### PR TITLE
fix(ci): pin ytt to v0.50.0 for opencascade build

### DIFF
--- a/.github/workflows/publish-opencascade.yml
+++ b/.github/workflows/publish-opencascade.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install ytt
         run: |
-          curl -fsSL -o ytt https://github.com/carvel-dev/ytt/releases/latest/download/ytt-linux-amd64
+          curl -fsSL -o ytt https://github.com/carvel-dev/ytt/releases/download/v0.50.0/ytt-linux-amd64
           chmod +x ytt
           sudo mv ytt /usr/local/bin/
 


### PR DESCRIPTION
## Summary
- Pin ytt to v0.50.0 instead of latest — v0.53.0 has stricter YAML parsing that rejects the embedded C++ code in `defaults.yml`

## Test plan
- [ ] Re-trigger publish-opencascade workflow after merge