### PR TITLE
fix(ci): use checked-in build-config instead of running ytt

### DIFF
--- a/.github/workflows/publish-opencascade.yml
+++ b/.github/workflows/publish-opencascade.yml
@@ -18,16 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ytt
-        run: |
-          curl -fsSL -o ytt https://github.com/carvel-dev/ytt/releases/download/v0.50.0/ytt-linux-amd64
-          chmod +x ytt
-          sudo mv ytt /usr/local/bin/
-
-      - name: Generate build config
-        working-directory: packages/brepjs-opencascade
-        run: ytt -f build-source/ --output-files build-config
-
       - name: Build single (no exceptions)
         working-directory: packages/brepjs-opencascade/build-config
         run: |


### PR DESCRIPTION
## Summary
- Remove ytt install and config generation steps from the publish-opencascade workflow
- The `build-config/` directory already has the generated YAML files checked in
- ytt fails in CI because it can't parse the embedded C++ code in `defaults.yml`

## Test plan
- [ ] Re-trigger publish-opencascade workflow after merge