### PR TITLE
chore: bump brepjs-opencascade to 0.1.1

### DIFF
--- a/packages/brepjs-opencascade/package.json
+++ b/packages/brepjs-opencascade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brepjs-opencascade",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCascade.js custom WASM build for brepjs",
   "license": "MIT",
   "main": "src/brepjs_single.js",


### PR DESCRIPTION
Version bump after manual npm publish.