### PR TITLE
fix: use recursive pairwise fuse in fuseAll instead of compounds

### DIFF
--- a/src/kernel/occtAdapter.ts
+++ b/src/kernel/occtAdapter.ts
@@ -69,9 +69,13 @@ export class OCCTAdapter implements KernelAdapter {
     if (shapes.length === 0) throw new Error('fuseAll requires at least one shape');
     if (shapes.length === 1) return shapes[0];
 
+    // Recursive pairwise fuse: divide-and-conquer using actual boolean fuse
+    // at each level. Using compounds here would be incorrect when shapes within
+    // the same compound intersect each other (OCCT expects non-self-intersecting
+    // input shapes for BRepAlgoAPI_Fuse).
     const mid = Math.ceil(shapes.length / 2);
-    const left = this._buildCompound(shapes.slice(0, mid));
-    const right = this._buildCompound(shapes.slice(mid));
+    const left = this.fuseAll(shapes.slice(0, mid), options);
+    const right = this.fuseAll(shapes.slice(mid), options);
     return this.fuse(left, right, options);
   }
 


### PR DESCRIPTION
## Summary

- All four `fuseAll` implementations used `_buildCompound` / `TopoDS_Compound` to group shapes before fusing. When shapes within the same compound intersect each other (e.g., crossing divider walls in a grid bin), OCCT produces incorrect boolean results because `BRepAlgoAPI_Fuse` expects non-self-intersecting input operands.
- Replaced compound-based approach with recursive divide-and-conquer pairwise fuse in all four call sites: `occtAdapter.ts`, `shapes.ts`, `booleanFns.ts`, `batchBooleans.ts`.

## Test plan

- [x] All 1008 brepjs tests pass
- [x] Verified with a reproduction case: 3 crossing divider walls fused with a shelled box now produce 252 triangles (previously 56 — geometry was missing)
- [x] Downstream gridfinity-layout-tool integration tests (21 scenarios) all pass with linked fix