### PR TITLE
fix: memory leaks on error paths and axis helpers

### DIFF
--- a/src/core/geometry.ts
+++ b/src/core/geometry.ts
@@ -93,36 +93,38 @@ export const makeAx3 = (center: Point, dir: Point, xDir?: Point): OcType => {
   const oc = getKernel().oc;
   const origin = asPnt(center);
   const direction = asDir(dir);
+  const xDirection = xDir ? asDir(xDir) : null;
 
-  let axis: OcType;
-  if (xDir) {
-    const xDirection = asDir(xDir);
-    axis = new oc.gp_Ax3_3(origin, direction, xDirection);
-    xDirection.delete();
-  } else {
-    axis = new oc.gp_Ax3_4(origin, direction);
+  try {
+    if (xDirection) {
+      return new oc.gp_Ax3_3(origin, direction, xDirection);
+    } else {
+      return new oc.gp_Ax3_4(origin, direction);
+    }
+  } finally {
+    origin.delete();
+    direction.delete();
+    if (xDirection) xDirection.delete();
   }
-  origin.delete();
-  direction.delete();
-  return axis;
 };
 
 export const makeAx2 = (center: Point, dir: Point, xDir?: Point): OcType => {
   const oc = getKernel().oc;
   const origin = asPnt(center);
   const direction = asDir(dir);
+  const xDirection = xDir ? asDir(xDir) : null;
 
-  let axis: OcType;
-  if (xDir) {
-    const xDirection = asDir(xDir);
-    axis = new oc.gp_Ax2_2(origin, direction, xDirection);
-    xDirection.delete();
-  } else {
-    axis = new oc.gp_Ax2_3(origin, direction);
+  try {
+    if (xDirection) {
+      return new oc.gp_Ax2_2(origin, direction, xDirection);
+    } else {
+      return new oc.gp_Ax2_3(origin, direction);
+    }
+  } finally {
+    origin.delete();
+    direction.delete();
+    if (xDirection) xDirection.delete();
   }
-  origin.delete();
-  direction.delete();
-  return axis;
 };
 
 export const makeAx1 = (center: Point, dir: Point): OcType => {

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -52,6 +52,7 @@ function buildCompoundOcInternal(shapes: OcType[]): OcType {
 function castToShape3D(shape: OcType, errorCode: string, errorMsg: string): Result<Shape3D> {
   const wrapped = castShape(shape);
   if (!isShape3D(wrapped)) {
+    wrapped[Symbol.dispose]();
     return err(typeCastError(errorCode, errorMsg));
   }
   return ok(wrapped);

--- a/src/topology/curveFns.ts
+++ b/src/topology/curveFns.ts
@@ -162,6 +162,7 @@ export function offsetWire2D(
   offsetter.delete();
 
   if (!isWireGuard(wrapped)) {
+    wrapped[Symbol.dispose]();
     return err(typeCastError('OFFSET_NOT_WIRE', 'Offset did not produce a Wire'));
   }
   return ok(wrapped);


### PR DESCRIPTION
## Summary

This PR addresses memory leak issues found during ongoing code review:

### Error Path Memory Leaks
- **curveFns.ts**: Dispose wrapped shape when `offsetWire2D` type check fails
- **booleanFns.ts**: Dispose wrapped shape when `castToShape3D` type check fails

### Axis Helper Cleanup
- **geometry.ts**: Refactor `makeAx3` and `makeAx2` to use try-finally pattern
  - Ensures origin, direction, and xDirection objects are properly deleted even if the axis constructor throws

## Test plan
- [x] All 1034 tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Layer boundary checks pass