### PR TITLE
fix: memory leaks and code quality improvements

### DIFF
--- a/src/sketching/Sketch.ts
+++ b/src/sketching/Sketch.ts
@@ -58,8 +58,7 @@ export default class Sketch implements SketchInterface {
 
   set baseFace(newFace: Face | null | undefined) {
     if (this._baseFace) this._baseFace.delete();
-    if (!newFace) this._baseFace = newFace;
-    else this._baseFace = newFace.clone();
+    this._baseFace = newFace ? newFace.clone() : newFace;
   }
 
   delete(): void {

--- a/src/sketching/Sketcher2d.ts
+++ b/src/sketching/Sketcher2d.ts
@@ -490,7 +490,7 @@ export class BaseSketcher2d {
       (c) => new Curve2D(c.innerCurve.Mirrored_2(mirrorAxis))
     );
     mirroredCurves.reverse();
-    mirroredCurves.map((c) => {
+    mirroredCurves.forEach((c) => {
       c.reverse();
     });
     this.pendingCurves.push(...mirroredCurves);


### PR DESCRIPTION
## Summary

### Memory leak fixes
- Fix memory leaks in `edgeFinder.atDistance()` and `faceFinder.atDistance()` - OCCT objects (vertex, distance tool) were created once when the filter was built but never deleted. Now uses `gcWithScope()` to properly clean up after each filter evaluation.

### Code quality improvements
- Change `.map()` to `.forEach()` in `Sketcher2d.ts` when used for side effects only - clearer intent since return values were discarded
- Simplify `Sketch.baseFace` setter logic - remove redundant conditional by using ternary operator

## Test plan

- [x] All 1034 tests pass
- [x] TypeScript type checking passes  
- [x] ESLint passes
- [x] Layer boundary checks pass