### PR TITLE
refactor: standardize on gcWithScope naming convention

### DIFF
--- a/src/2d/blueprints/Blueprint.ts
+++ b/src/2d/blueprints/Blueprint.ts
@@ -31,7 +31,7 @@ import { DEG2RAD } from '../../core/constants.js';
 import type { DrawingInterface, SketchData } from './lib.js';
 import round5 from '../../utils/round5.js';
 import { asSVG, viewbox } from './svg.js';
-import { GCWithScope } from '../../core/memory.js';
+import { gcWithScope } from '../../core/memory.js';
 import type { SingleFace } from '../../query/helpers.js';
 import { getSingleFace } from '../../query/helpers.js';
 
@@ -203,7 +203,7 @@ export default class Blueprint implements DrawingInterface {
     } = {}
   ) {
     const oc = getKernel().oc;
-    const gc = GCWithScope();
+    const gc = gcWithScope();
 
     const foundFace = unwrap(getSingleFace(face, shape));
     const hole = this.subFace(foundFace, origin);
@@ -227,7 +227,7 @@ export default class Blueprint implements DrawingInterface {
   }
 
   toSVGPathD() {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const bp = this.clone().mirror([1, 0], [0, 0], 'plane');
 
     const compatibleCurves = approximateAsSvgCompatibleCurve(bp.curves);

--- a/src/2d/curves.ts
+++ b/src/2d/curves.ts
@@ -1,6 +1,6 @@
 import type { OcType } from '../kernel/types.js';
 import { getKernel } from '../kernel/index.js';
-import { GCWithScope, localGC, WrappingObj } from '../core/memory.js';
+import { gcWithScope, localGC, WrappingObj } from '../core/memory.js';
 import type { Plane } from '../core/geometry.js';
 import { makeAx2 } from '../core/geometry.js';
 import type { Face } from '../topology/shapes.js';
@@ -206,7 +206,7 @@ export function curvesAsEdgesOnFace(
 
 export function edgeToCurve(e: Edge, face: Face): Curve2D {
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const adaptor = r(new oc.BRepAdaptor_Curve2d_2(e.wrapped, face.wrapped));
 

--- a/src/2d/lib/BoundingBox2d.ts
+++ b/src/2d/lib/BoundingBox2d.ts
@@ -1,4 +1,4 @@
-import { WrappingObj, GCWithScope } from '../../core/memory.js';
+import { WrappingObj, gcWithScope } from '../../core/memory.js';
 import { getKernel } from '../../kernel/index.js';
 import type { OcType } from '../../kernel/types.js';
 
@@ -69,7 +69,7 @@ export class BoundingBox2d extends WrappingObj<OcType> {
   }
 
   containsPoint(other: Point2D): boolean {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const point = r(pnt(other));
     return !this.wrapped.IsOut_1(point);
   }

--- a/src/2d/lib/Curve2D.ts
+++ b/src/2d/lib/Curve2D.ts
@@ -6,7 +6,7 @@ import { type Result, ok, err, unwrap } from '../../core/result.js';
 import { computationError } from '../../core/errors.js';
 import precisionRound from '../../utils/precisionRound.js';
 import { getKernel } from '../../kernel/index.js';
-import { GCWithScope, localGC, WrappingObj } from '../../core/memory.js';
+import { gcWithScope, localGC, WrappingObj } from '../../core/memory.js';
 import zip from '../../utils/zip.js';
 
 import { BoundingBox2d } from './BoundingBox2d.js';
@@ -102,7 +102,7 @@ export class Curve2D extends WrappingObj<OcType> {
 
   private distanceFromPoint(point: Point2D): number {
     const oc = getKernel().oc;
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const projector = r(new oc.Geom2dAPI_ProjectPointOnCurve_2(r(pnt(point)), this.wrapped));
 
@@ -123,7 +123,7 @@ export class Curve2D extends WrappingObj<OcType> {
 
   private distanceFromCurve(curve: Curve2D): number {
     const oc = getKernel().oc;
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     let curveDistance = Infinity;
     const projector = r(
@@ -167,7 +167,7 @@ export class Curve2D extends WrappingObj<OcType> {
 
   parameter(point: Point2D, precision = 1e-9): Result<number> {
     const oc = getKernel().oc;
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     let lowerDistance;
     let lowerDistanceParameter;
@@ -220,7 +220,7 @@ export class Curve2D extends WrappingObj<OcType> {
 
   splitAt(points: Point2D[] | number[], precision = 1e-9): Curve2D[] {
     const oc = getKernel().oc;
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     let parameters = points.map((point: Point2D | number) => {
       if (isPoint2D(point)) return unwrap(this.parameter(point, precision));

--- a/src/2d/lib/approximations.ts
+++ b/src/2d/lib/approximations.ts
@@ -3,7 +3,7 @@ import { findCurveType } from '../../core/definitionMaps.js';
 import { unwrap } from '../../core/result.js';
 import { bug } from '../../core/errors.js';
 import { getKernel } from '../../kernel/index.js';
-import { GCWithScope } from '../../core/memory.js';
+import { gcWithScope } from '../../core/memory.js';
 import { Curve2D } from './Curve2D.js';
 import { samePoint } from './vectorOperations.js';
 
@@ -14,7 +14,7 @@ export const approximateAsBSpline = (
   maxSegments = 200
 ): Curve2D => {
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const continuities: Record<string, OcType> = {
     C0: oc.GeomAbs_Shape.GeomAbs_C0,
@@ -74,7 +74,7 @@ export function approximateAsSvgCompatibleCurve(
     maxSegments: 300,
   }
 ): Curve2D[] {
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   return curves.flatMap((curve) => {
     const adaptor = r(curve.adaptor());

--- a/src/2d/lib/makeCurves.ts
+++ b/src/2d/lib/makeCurves.ts
@@ -1,6 +1,6 @@
 import type { OcType } from '../../kernel/types.js';
 import { getKernel } from '../../kernel/index.js';
-import { GCWithScope, localGC } from '../../core/memory.js';
+import { gcWithScope, localGC } from '../../core/memory.js';
 import { type Result, ok, err } from '../../core/result.js';
 import { computationError } from '../../core/errors.js';
 
@@ -250,7 +250,7 @@ export function make2dInerpolatedBSplineCurve(
     degMin?: number;
   } = {}
 ): Result<Curve2D> {
-  const r = GCWithScope();
+  const r = gcWithScope();
   const oc = getKernel().oc;
 
   const pnts = r(new oc.TColgp_Array1OfPnt2d_2(1, points.length));

--- a/src/2d/lib/offset.ts
+++ b/src/2d/lib/offset.ts
@@ -1,5 +1,5 @@
 import { getKernel } from '../../kernel/index.js';
-import { GCWithScope } from '../../core/memory.js';
+import { gcWithScope } from '../../core/memory.js';
 import { approximateAsBSpline } from './approximations.js';
 import { Curve2D } from './Curve2D.js';
 import type { Point2D } from './definitions.js';
@@ -25,7 +25,7 @@ export const make2dOffset = (
   curve: Curve2D,
   offset: number
 ): Curve2D | { collapsed: true; firstPoint: Point2D; lastPoint: Point2D } => {
-  const r = GCWithScope();
+  const r = gcWithScope();
   const curveType = curve.geomType;
 
   if (curveType === 'CIRCLE') {

--- a/src/core/geometry.ts
+++ b/src/core/geometry.ts
@@ -55,7 +55,7 @@ export {
 // ── Legacy imports ──
 
 import { WrappingObj } from './memory.js';
-import { GCWithScope } from './memory.js';
+import { gcWithScope } from './memory.js';
 import { DEG2RAD, RAD2DEG } from './constants.js';
 import { getKernel } from '../kernel/index.js';
 import type { OpenCascadeInstance, OcType } from '../kernel/types.js';
@@ -339,7 +339,7 @@ export class Transformation extends WrappingObj<OcType> {
   }
 
   mirror(inputPlane: Plane | PlaneName | Point = 'YZ', inputOrigin?: Point): this {
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     let origin: Point;
     let direction: Point;
@@ -370,7 +370,7 @@ export class Transformation extends WrappingObj<OcType> {
   }
 
   coordSystemChange(fromSystem: CoordSystem, toSystem: CoordSystem): this {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const fromAx = r(
       fromSystem === 'reference'
         ? new this.oc.gp_Ax3_1()

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -11,12 +11,15 @@ export {
   createOcHandle,
   DisposalScope,
   withScope,
-  gcWithScope as GCWithScope,
-  gcWithObject as GCWithObject,
+  gcWithScope,
+  gcWithObject,
   localGC,
   type ShapeHandle,
   type OcHandle,
 } from './disposal.js';
+
+// Legacy aliases (deprecated) — use gcWithScope and gcWithObject instead
+export { gcWithScope as GCWithScope, gcWithObject as GCWithObject } from './disposal.js';
 
 // ---------------------------------------------------------------------------
 // Legacy WrappingObj — kept during migration, will be removed

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,16 @@ export {
 
 export { DEG2RAD, RAD2DEG, HASH_CODE_MAX } from './core/constants.js';
 
-export { WrappingObj, GCWithScope, GCWithObject, localGC, type Deletable } from './core/memory.js';
+export {
+  WrappingObj,
+  gcWithScope,
+  gcWithObject,
+  localGC,
+  type Deletable,
+  // Deprecated aliases — use gcWithScope and gcWithObject instead
+  GCWithScope,
+  GCWithObject,
+} from './core/memory.js';
 
 export {
   Vector,

--- a/src/measurement/measureShape.ts
+++ b/src/measurement/measureShape.ts
@@ -1,11 +1,11 @@
 import { getKernel } from '../kernel/index.js';
 import type { OcType } from '../kernel/types.js';
-import { GCWithScope, WrappingObj, localGC } from '../core/memory.js';
+import { gcWithScope, WrappingObj, localGC } from '../core/memory.js';
 import type { AnyShape, Face, Shape3D } from '../topology/shapes.js';
 
 class PhysicalProperties extends WrappingObj<OcType> {
   get centerOfMass(): [number, number, number] {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const pnt = r(this.wrapped.CentreOfMass());
     return [pnt.X(), pnt.Y(), pnt.Z()];
   }

--- a/src/operations/batchBooleans.ts
+++ b/src/operations/batchBooleans.ts
@@ -1,5 +1,5 @@
 import { getKernel } from '../kernel/index.js';
-import { GCWithScope } from '../core/memory.js';
+import { gcWithScope } from '../core/memory.js';
 import type { OcType } from '../kernel/types.js';
 import { applyGlue, buildCompoundOc, type BooleanOperationOptions } from '../topology/shapes.js';
 import { type Result, ok, err } from '../core/result.js';
@@ -23,7 +23,7 @@ export function fuseAllShapes(
   // Pairwise fallback: recursive divide-and-conquer
   // Defer simplification to the final fuse — intermediate simplification is wasted work
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const mid = Math.ceil(shapes.length / 2);
   const leftResult = fuseAllShapes(shapes.slice(0, mid), {
@@ -54,7 +54,7 @@ export function cutAllShapes(
   if (tools.length === 0) return ok(base);
 
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const toolCompound = r(buildCompoundOc(tools));
 

--- a/src/operations/exporters.ts
+++ b/src/operations/exporters.ts
@@ -1,6 +1,6 @@
 import type { OcType } from '../kernel/types.js';
 import { getKernel } from '../kernel/index.js';
-import { GCWithScope, WrappingObj } from '../core/memory.js';
+import { gcWithScope, WrappingObj } from '../core/memory.js';
 import { uuidv } from '../utils/uuid.js';
 import type { AnyShape } from '../topology/shapes.js';
 import { type Result, ok, err } from '../core/result.js';
@@ -81,7 +81,7 @@ export function exportSTEP(
   { unit, modelUnit }: { unit?: SupportedUnit; modelUnit?: SupportedUnit } = {}
 ): Result<Blob> {
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const doc = createAssembly(shapes);
 

--- a/src/projection/makeProjectedEdges.ts
+++ b/src/projection/makeProjectedEdges.ts
@@ -1,6 +1,6 @@
 import { getKernel } from '../kernel/index.js';
 import type { OcType } from '../kernel/types.js';
-import { GCWithScope } from '../core/memory.js';
+import { gcWithScope } from '../core/memory.js';
 import { cast } from '../topology/cast.js';
 import { unwrap } from '../core/result.js';
 import type { Edge, AnyShape } from '../topology/shapes.js';
@@ -17,7 +17,7 @@ export function makeProjectedEdges(
   withHiddenLines = true
 ): { visible: Edge[]; hidden: Edge[] } {
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const hiddenLineRemoval = r(new oc.HLRBRep_Algo_1());
   hiddenLineRemoval.Add_2(shape.wrapped, 0);

--- a/src/topology/shapeHelpers.ts
+++ b/src/topology/shapeHelpers.ts
@@ -1,6 +1,6 @@
 import type { OcType } from '../kernel/types.js';
 import { getKernel } from '../kernel/index.js';
-import { GCWithScope, localGC, WrappingObj } from '../core/memory.js';
+import { gcWithScope, localGC, WrappingObj } from '../core/memory.js';
 import { asPnt, makeAx2, makeAx3, makeAx1, Vector, type Point } from '../core/geometry.js';
 import { cast, downcast } from './cast.js';
 import { type Result, ok, err, unwrap, andThen } from '../core/result.js';
@@ -391,7 +391,7 @@ export const makeSphere = (radius: number): Solid => {
 class EllipsoidTransform extends WrappingObj<OcType> {
   constructor(x: number, y: number, z: number) {
     const oc = getKernel().oc;
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const xyRatio = Math.sqrt((x * y) / z);
     const xzRatio = x / xyRatio;
@@ -416,7 +416,7 @@ class EllipsoidTransform extends WrappingObj<OcType> {
 
   applyToPoint(p: OcType): OcType {
     const oc = getKernel().oc;
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const coords = r(p.XYZ());
     this.wrapped.Transforms_1(coords);
@@ -446,7 +446,7 @@ function convertToJSArray(arrayOfPoints: OcType): OcType[][] {
  */
 export const makeEllipsoid = (aLength: number, bLength: number, cLength: number): Solid => {
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const sphere = r(new oc.gp_Sphere_1());
   sphere.SetRadius(1);
@@ -556,7 +556,7 @@ export const makeCompound = compoundShapes;
 
 function _weld(facesOrShells: Array<Face | Shell>): AnyShape {
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const shellBuilder = r(new oc.BRepBuilderAPI_Sewing(1e-6, true, true, true, false));
 
@@ -597,7 +597,7 @@ export function weldShellsAndFaces(
  * @category Solids
  */
 export function makeSolid(facesOrShells: Array<Face | Shell>): Result<Solid> {
-  const r = GCWithScope();
+  const r = gcWithScope();
   const oc = getKernel().oc;
   const shell = _weld(facesOrShells);
   return andThen(cast(r(new oc.ShapeFix_Solid_1()).SolidFromShell(shell.wrapped)), (solid) => {

--- a/src/topology/shapes.ts
+++ b/src/topology/shapes.ts
@@ -1,6 +1,6 @@
 import type { OcShape, OcType } from '../kernel/types.js';
 import { getKernel } from '../kernel/index.js';
-import { WrappingObj, GCWithScope, type Deletable } from '../core/memory.js';
+import { WrappingObj, gcWithScope, type Deletable } from '../core/memory.js';
 import { meshShapeEdges as _meshShapeEdges } from './meshFns.js';
 import {
   Vector,
@@ -758,7 +758,7 @@ export class Face extends Shape {
   }
 
   uvCoordinates(point: Point): [number, number] {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const surface = r(this.oc.BRep_Tool.Surface_2(this.wrapped));
 
     const projectedPoint = r(
@@ -781,7 +781,7 @@ export class Face extends Shape {
     let u = 0;
     let v = 0;
 
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     if (!locationVector) {
       const { uMin, uMax, vMin, vMax } = this.UVBounds;
@@ -828,7 +828,7 @@ export class Face extends Shape {
    * @internal
    */
   triangulation(index0 = 0, skipNormals = false): FaceTriangulation | null {
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const aLocation = r(new this.oc.TopLoc_Location_1());
     const triangulationHandle = r(this.oc.BRep_Tool.Triangulation(this.wrapped, aLocation, 0));
@@ -906,7 +906,7 @@ export class _3DShape<Type extends Deletable = OcShape> extends Shape<Type> {
     other: Shape3D,
     { optimisation = 'none', simplify = false }: BooleanOperationOptions = {}
   ): Result<Shape3D> {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const progress = r(new this.oc.Message_ProgressRange_1());
     const newBody = r(new this.oc.BRepAlgoAPI_Fuse_3(this.wrapped, other.wrapped, progress));
     applyGlue(newBody, optimisation);
@@ -931,7 +931,7 @@ export class _3DShape<Type extends Deletable = OcShape> extends Shape<Type> {
     tool: Shape3D,
     { optimisation = 'none', simplify = false }: BooleanOperationOptions = {}
   ): Result<Shape3D> {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const progress = r(new this.oc.Message_ProgressRange_1());
     const cutter = r(new this.oc.BRepAlgoAPI_Cut_3(this.wrapped, tool.wrapped, progress));
     applyGlue(cutter, optimisation);
@@ -953,7 +953,7 @@ export class _3DShape<Type extends Deletable = OcShape> extends Shape<Type> {
    * @category Shape Modifications
    */
   intersect(tool: AnyShape, { simplify = false }: { simplify?: boolean } = {}): Result<Shape3D> {
-    const r = GCWithScope();
+    const r = gcWithScope();
     const progress = r(new this.oc.Message_ProgressRange_1());
     const intersector = r(new this.oc.BRepAlgoAPI_Common_3(this.wrapped, tool.wrapped, progress));
     intersector.Build(progress);
@@ -1000,7 +1000,7 @@ export class _3DShape<Type extends Deletable = OcShape> extends Shape<Type> {
       filter = thicknessOrConfig.filter;
     }
 
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const filteredFaces = filter.find(this as unknown as AnyShape);
     const facesToRemove = r(new this.oc.TopTools_ListOfShape_1());
@@ -1090,7 +1090,7 @@ export class _3DShape<Type extends Deletable = OcShape> extends Shape<Type> {
     radiusConfig: RadiusConfig<FilletRadius>,
     filter?: (e: EdgeFinder) => EdgeFinder
   ): Result<Shape3D> {
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const filletBuilder = r(
       new this.oc.BRepFilletAPI_MakeFillet(
@@ -1136,7 +1136,7 @@ export class _3DShape<Type extends Deletable = OcShape> extends Shape<Type> {
     radiusConfig: RadiusConfig<ChamferRadius>,
     filter?: (e: EdgeFinder) => EdgeFinder
   ): Result<Shape3D> {
-    const r = GCWithScope();
+    const r = gcWithScope();
 
     const chamferBuilder = r(new this.oc.BRepFilletAPI_MakeChamfer(this.wrapped));
 
@@ -1294,7 +1294,7 @@ export function cutAll(
   if (tools.length === 0) return ok(base);
 
   const oc = getKernel().oc;
-  const r = GCWithScope();
+  const r = gcWithScope();
 
   const toolCompound = r(buildCompound(tools));
 


### PR DESCRIPTION
## Summary

Standardizes the codebase on `gcWithScope` (camelCase) naming convention for GC helper functions, following JavaScript/TypeScript conventions.

### Changes

- Renamed all internal usages of `GCWithScope` to `gcWithScope` (16 files)
- Renamed all internal usages of `GCWithObject` to `gcWithObject`
- Preserved `GCWithScope` and `GCWithObject` as deprecated export aliases for backwards compatibility

### Backwards Compatibility

External consumers using `GCWithScope` or `GCWithObject` will continue to work. The PascalCase names are now marked as deprecated aliases that re-export the camelCase versions.

### Migration Path

```typescript
// Old (deprecated but still works)
import { GCWithScope } from 'brepjs';
const r = GCWithScope();

// New (preferred)
import { gcWithScope } from 'brepjs';
const r = gcWithScope();
```

## Test plan

- [x] All 1037 tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Layer boundary checks pass