### PR TITLE
fix: align hashPoint precision with PRECISION_INTERSECTION

### DIFF
--- a/src/2d/blueprints/booleanOperations.ts
+++ b/src/2d/blueprints/booleanOperations.ts
@@ -60,7 +60,8 @@ const rotateToStartAtSegment = (curves: Curve2D[], segment: Curve2D) => {
 };
 
 // Hash a point for Set/Map lookup (uses precision rounding for fuzzy matching)
-const hashPoint = (p: Point2D): string => `${p[0].toFixed(6)},${p[1].toFixed(6)}`;
+// Must match PRECISION_INTERSECTION (1e-9) to avoid hash collisions for nearly-equal points
+const hashPoint = (p: Point2D): string => `${p[0].toFixed(9)},${p[1].toFixed(9)}`;
 
 // Hash a segment by both orientations for bidirectional lookup
 const hashSegment = (first: Point2D, last: Point2D): string => {


### PR DESCRIPTION
## Summary
- Fixed precision mismatch in `hashPoint` function that could break O(1) lookup optimization
- Changed from `toFixed(6)` to `toFixed(9)` to match `PRECISION_INTERSECTION` (1e-9)

## Background
The `hashPoint` function used 6 decimal places but `samePoint` uses `PRECISION_INTERSECTION` (1e-9). Two points within 1e-9 could hash to different values, potentially breaking the O(1) lookup optimization added in PR #32.

## Test plan
- [x] All 1037 tests pass
- [x] Lint and typecheck pass

Addresses review comment from PR #32.

---

Note: PR #28 review comment about `ProjectionCamera.ts` was investigated and found to be a false positive - the original code is correct because `xAxis` is intentionally not registered (it's the return value), and `normalize()` mutates in place.