### PR TITLE
docs: update documentation for v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,21 +81,18 @@ Layer 0: kernel/, utils/                     (WASM bindings)
 
 See [docs/architecture.md](./docs/architecture.md) for the full diagram.
 
-## API Styles
+## API Style
 
-brepjs supports two API styles:
+brepjs uses an immutable functional API:
 
-**Functional API (recommended):**
 ```typescript
 const box = castShape(makeBox([0, 0, 0], [10, 10, 10]).wrapped);
 const moved = translateShape(box, [5, 0, 0]); // Returns new shape
 ```
 
-**Legacy class API:**
-```typescript
-const box = makeBox([10, 10, 10]);
-box.translate([5, 0, 0]); // Mutates in place
-```
+## Projects Using brepjs
+
+- [Gridfinity Layout Tool](https://github.com/andymai/gridfinity-layout-tool) — Web-based layout generator for Gridfinity storage systems
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.x     | :white_check_mark: |
-| 1.x     | :x:                |
-| < 1.0   | :x:                |
+| 4.x     | :white_check_mark: |
+| 3.x     | :x:                |
+| < 3.0   | :x:                |
 
-Only the current major version (2.x) receives security updates. We recommend upgrading to the latest version.
+Only the current major version (4.x) receives security updates. We recommend upgrading to the latest version.
 
 ## Reporting a Vulnerability
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,41 +80,41 @@ graph TB
 
 No internal imports allowed.
 
-| Module | Purpose |
-|--------|---------|
-| `kernel/` | WASM adapter, OCCT bindings |
-| `utils/` | Pure utilities (no dependencies) |
+| Module    | Purpose                          |
+| --------- | -------------------------------- |
+| `kernel/` | WASM adapter, OCCT bindings      |
+| `utils/`  | Pure utilities (no dependencies) |
 
 ### Layer 1: Core
 
 Imports kernel/utils only.
 
-| Module | Purpose |
-|--------|---------|
+| Module  | Purpose                                                       |
+| ------- | ------------------------------------------------------------- |
 | `core/` | Memory management, types, geometry primitives, error handling |
 
 ### Layer 2: Domain
 
 Imports layers 0-1 and each other.
 
-| Module | Purpose |
-|--------|---------|
-| `topology/` | Shape classes, boolean operations, casting |
-| `operations/` | Extrusion, loft, sweep, batch operations |
-| `2d/` | Blueprints, curves, 2D operations |
-| `query/` | Shape finders (face, edge, corner) |
-| `measurement/` | Volume, area, length, distance |
-| `io/` | STEP/STL import/export |
+| Module         | Purpose                                    |
+| -------------- | ------------------------------------------ |
+| `topology/`    | Shape classes, boolean operations, casting |
+| `operations/`  | Extrusion, loft, sweep, batch operations   |
+| `2d/`          | Blueprints, curves, 2D operations          |
+| `query/`       | Shape finders (face, edge, corner)         |
+| `measurement/` | Volume, area, length, distance             |
+| `io/`          | STEP/STL import/export                     |
 
 ### Layer 3: High-Level API
 
 Imports all lower layers.
 
-| Module | Purpose |
-|--------|---------|
-| `sketching/` | Sketcher API, sketch-to-shape workflows |
-| `text/` | Text blueprints from fonts |
-| `projection/` | Camera and projection utilities |
+| Module        | Purpose                                 |
+| ------------- | --------------------------------------- |
+| `sketching/`  | Sketcher API, sketch-to-shape workflows |
+| `text/`       | Text blueprints from fonts              |
+| `projection/` | Camera and projection utilities         |
 
 ## Data Flow
 
@@ -141,18 +141,13 @@ sequenceDiagram
 
 ## Key Patterns
 
-### 1. Dual API
+### 1. Functional API
 
-Both class-based (legacy) and functional APIs:
+brepjs uses an immutable functional API:
 
 ```typescript
-// Legacy (mutates)
-const shape = makeBox([10, 10, 10]);
-shape.translate([5, 0, 0]);
-
-// Functional (immutable)
 const shape = castShape(makeBox([10, 10, 10]).wrapped);
-const moved = translateShape(shape, [5, 0, 0]);
+const moved = translateShape(shape, [5, 0, 0]); // Returns new shape
 ```
 
 ### 2. Result Types

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,34 +2,34 @@
 
 ## Runtime Environments
 
-| Environment | Tested | Notes |
-|-------------|--------|-------|
-| Node.js 24 | ✅ Primary | CI tested |
-| Node.js 22 | ✅ | LTS |
-| Node.js 20 | ✅ | LTS, Symbol.dispose support |
-| Node.js 18 | ⚠️ | Works, no Symbol.dispose |
-| Deno | 🔲 | Untested |
-| Bun | 🔲 | Untested |
+| Environment | Tested     | Notes                       |
+| ----------- | ---------- | --------------------------- |
+| Node.js 24  | ✅ Primary | CI tested                   |
+| Node.js 22  | ✅         | LTS                         |
+| Node.js 20  | ✅         | LTS, Symbol.dispose support |
+| Node.js 18  | ⚠️         | Works, no Symbol.dispose    |
+| Deno        | 🔲         | Untested                    |
+| Bun         | 🔲         | Untested                    |
 
 ## Browsers
 
-| Browser | Tested | Notes |
-|---------|--------|-------|
-| Chrome 117+ | ✅ | Full support |
-| Firefox 115+ | ✅ | Full support |
-| Safari 16.4+ | ✅ | Full support |
-| Edge (Chromium) | ✅ | Same as Chrome |
-| Safari < 16.4 | ⚠️ | May need polyfills |
-| IE 11 | ❌ | Not supported |
+| Browser         | Tested | Notes              |
+| --------------- | ------ | ------------------ |
+| Chrome 117+     | ✅     | Full support       |
+| Firefox 115+    | ✅     | Full support       |
+| Safari 16.4+    | ✅     | Full support       |
+| Edge (Chromium) | ✅     | Same as Chrome     |
+| Safari < 16.4   | ⚠️     | May need polyfills |
+| IE 11           | ❌     | Not supported      |
 
 ## TypeScript
 
-| Version | Support |
-|---------|---------|
-| 5.9+ | ✅ Recommended |
-| 5.2-5.8 | ✅ Full support |
-| 5.0-5.1 | ⚠️ Missing Symbol.dispose types |
-| < 5.0 | ❌ Not tested |
+| Version | Support                    |
+| ------- | -------------------------- |
+| 5.9+    | ✅ Required                |
+| 5.2-5.8 | ❌ Not supported (v4.0.0+) |
+| 5.0-5.1 | ❌ Not supported           |
+| < 5.0   | ❌ Not supported           |
 
 ### tsconfig.json Requirements
 
@@ -47,20 +47,21 @@
 
 ## Bundlers
 
-| Bundler | Tested | Notes |
-|---------|--------|-------|
-| Vite 7 | ✅ Primary | Used in development |
-| Vite 5-6 | ✅ | Works |
-| esbuild | ✅ | Direct usage |
-| Webpack 5 | ⚠️ | Requires externals config |
-| Rollup | ⚠️ | Requires externals config |
-| Parcel | 🔲 | Untested |
+| Bundler   | Tested     | Notes                     |
+| --------- | ---------- | ------------------------- |
+| Vite 7    | ✅ Primary | Used in development       |
+| Vite 5-6  | ✅         | Works                     |
+| esbuild   | ✅         | Direct usage              |
+| Webpack 5 | ⚠️         | Requires externals config |
+| Rollup    | ⚠️         | Requires externals config |
+| Parcel    | 🔲         | Untested                  |
 
 ### WASM External
 
 The `brepjs-opencascade` WASM module must be external:
 
 **Vite:**
+
 ```typescript
 // vite.config.ts
 export default defineConfig({
@@ -71,6 +72,7 @@ export default defineConfig({
 ```
 
 **Webpack:**
+
 ```javascript
 // webpack.config.js
 module.exports = {
@@ -84,19 +86,20 @@ module.exports = {
 
 brepjs requires WebAssembly support:
 
-| Feature | Required |
-|---------|----------|
-| Basic WASM | ✅ |
+| Feature         | Required                        |
+| --------------- | ------------------------------- |
+| Basic WASM      | ✅                              |
 | WASM Exceptions | ✅ (for brepjs-with-exceptions) |
-| WASM BigInt | ✅ |
-| WASM Threads | ❌ Not used |
-| WASM SIMD | ❌ Not used |
+| WASM BigInt     | ✅                              |
+| WASM Threads    | ✅ (for brepjs_multi variant)   |
+| WASM SIMD       | ❌ Not used                     |
 
 ### WASM Module Variants
 
-| Module | Size | Features |
-|--------|------|----------|
-| `brepjs_single` | ~15 MB | Standard, no exceptions |
+| Module                   | Size   | Features                                 |
+| ------------------------ | ------ | ---------------------------------------- |
+| `brepjs_single`          | ~15 MB | Standard, single-threaded, no exceptions |
+| `brepjs_multi`           | ~16 MB | Multi-threaded variant                   |
 | `brepjs_with_exceptions` | ~17 MB | C++ exceptions for better error messages |
 
 ## Known Limitations
@@ -107,11 +110,11 @@ brepjs requires WebAssembly support:
 - Complex models may require memory tuning
 - Node.js: Use `--max-old-space-size=4096`
 
-### 2. Single-Threaded
+### 2. Threading
 
-- OCCT operations are single-threaded
-- Long operations block the main thread
-- Consider Web Workers for heavy computation
+- Default (`brepjs_single`): OCCT operations are single-threaded and block the main thread
+- Multi-threaded (`brepjs_multi`): Parallel operations available, requires SharedArrayBuffer and cross-origin isolation
+- Consider Web Workers for heavy computation in single-threaded mode
 
 ### 3. No SSR Support
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,6 +1,6 @@
 # Error Reference
 
-brepjs uses the `Result<T, BrepError>` pattern for fallible operations. This document lists all error codes and their meanings.
+brepjs uses the `Result<T, BrepError>` pattern for all fallible operations (v4.0.0+). This document lists all error codes and their meanings.
 
 ## Error Structure
 
@@ -56,76 +56,76 @@ const value = unwrap(result);
 
 Errors from OpenCascade operations.
 
-| Code | Description | Recovery |
-|------|-------------|----------|
-| `BSPLINE_FAILED` | B-spline curve construction failed | Check control points are valid |
+| Code                | Description                        | Recovery                         |
+| ------------------- | ---------------------------------- | -------------------------------- |
+| `BSPLINE_FAILED`    | B-spline curve construction failed | Check control points are valid   |
 | `FACE_BUILD_FAILED` | Face construction from wire failed | Ensure wire is closed and planar |
 
 ### VALIDATION
 
 Input validation errors.
 
-| Code | Description | Recovery |
-|------|-------------|----------|
-| `CHAMFER_NO_EDGES` | Chamfer called with no edges | Provide at least one edge |
-| `ELLIPSE_RADII` | Invalid ellipse radii | Ensure major >= minor > 0 |
-| `FILLET_NO_EDGES` | Fillet called with no edges | Provide at least one edge |
-| `FUSE_ALL_EMPTY` | fuseAll called with empty array | Provide at least one shape |
-| `POLYGON_MIN_POINTS` | Polygon requires 3+ points | Provide at least 3 points |
-| `UNKNOWN_PLANE` | Unknown named plane | Use valid plane name (XY, YZ, ZX, etc.) |
-| `UNSUPPORTED_PROFILE` | Extrusion profile not supported | Use supported profile type |
+| Code                  | Description                     | Recovery                                |
+| --------------------- | ------------------------------- | --------------------------------------- |
+| `CHAMFER_NO_EDGES`    | Chamfer called with no edges    | Provide at least one edge               |
+| `ELLIPSE_RADII`       | Invalid ellipse radii           | Ensure major >= minor > 0               |
+| `FILLET_NO_EDGES`     | Fillet called with no edges     | Provide at least one edge               |
+| `FUSE_ALL_EMPTY`      | fuseAll called with empty array | Provide at least one shape              |
+| `POLYGON_MIN_POINTS`  | Polygon requires 3+ points      | Provide at least 3 points               |
+| `UNKNOWN_PLANE`       | Unknown named plane             | Use valid plane name (XY, YZ, ZX, etc.) |
+| `UNSUPPORTED_PROFILE` | Extrusion profile not supported | Use supported profile type              |
 
 ### TYPE_CAST
 
 Type conversion and shape casting errors.
 
-| Code | Description | Recovery |
-|------|-------------|----------|
-| `NO_WRAPPER` | Shape has no wrapper object | Re-cast the shape |
-| `NULL_SHAPE` | Shape is null | Check upstream operation succeeded |
-| `OFFSET_NOT_WIRE` | Offset result is not a wire | Check offset parameters |
-| `SOLID_BUILD_FAILED` | Solid construction failed | Ensure shell is closed |
-| `SWEEP_END_NOT_WIRE` | Sweep end section is not a wire | Provide wire for end section |
-| `SWEEP_START_NOT_WIRE` | Sweep start section is not a wire | Provide wire for start section |
-| `UNKNOWN_CURVE_TYPE` | Unrecognized curve type | Check curve is valid |
-| `UNKNOWN_SURFACE_TYPE` | Unrecognized surface type | Check surface is valid |
-| `WELD_NOT_SHELL` | Weld result is not a shell | Check faces are compatible |
+| Code                   | Description                       | Recovery                           |
+| ---------------------- | --------------------------------- | ---------------------------------- |
+| `NO_WRAPPER`           | Shape has no wrapper object       | Re-cast the shape                  |
+| `NULL_SHAPE`           | Shape is null                     | Check upstream operation succeeded |
+| `OFFSET_NOT_WIRE`      | Offset result is not a wire       | Check offset parameters            |
+| `SOLID_BUILD_FAILED`   | Solid construction failed         | Ensure shell is closed             |
+| `SWEEP_END_NOT_WIRE`   | Sweep end section is not a wire   | Provide wire for end section       |
+| `SWEEP_START_NOT_WIRE` | Sweep start section is not a wire | Provide wire for start section     |
+| `UNKNOWN_CURVE_TYPE`   | Unrecognized curve type           | Check curve is valid               |
+| `UNKNOWN_SURFACE_TYPE` | Unrecognized surface type         | Check surface is valid             |
+| `WELD_NOT_SHELL`       | Weld result is not a shell        | Check faces are compatible         |
 
 ### COMPUTATION
 
 Computational/algorithmic failures.
 
-| Code | Description | Recovery |
-|------|-------------|----------|
-| `INTERSECTION_FAILED` | Curve/surface intersection failed | Check geometry validity |
-| `PARAMETER_NOT_FOUND` | Curve parameter not found | Check point is on curve |
-| `SELF_INTERSECTION_FAILED` | Self-intersection detection failed | Simplify geometry |
+| Code                       | Description                        | Recovery                |
+| -------------------------- | ---------------------------------- | ----------------------- |
+| `INTERSECTION_FAILED`      | Curve/surface intersection failed  | Check geometry validity |
+| `PARAMETER_NOT_FOUND`      | Curve parameter not found          | Check point is on curve |
+| `SELF_INTERSECTION_FAILED` | Self-intersection detection failed | Simplify geometry       |
 
 ### IO
 
 File import/export errors.
 
-| Code | Description | Recovery |
-|------|-------------|----------|
-| `STEP_EXPORT_FAILED` | STEP file export failed | Check shape is valid |
+| Code                   | Description              | Recovery                          |
+| ---------------------- | ------------------------ | --------------------------------- |
+| `STEP_EXPORT_FAILED`   | STEP file export failed  | Check shape is valid              |
 | `STEP_FILE_READ_ERROR` | Could not read STEP file | Check file exists and is readable |
-| `STEP_IMPORT_FAILED` | STEP file import failed | Check file format |
-| `STL_EXPORT_FAILED` | STL file export failed | Check shape has valid mesh |
-| `STL_FILE_READ_ERROR` | Could not read STL file | Check file exists and is readable |
-| `STL_IMPORT_FAILED` | STL file import failed | Check file format |
+| `STEP_IMPORT_FAILED`   | STEP file import failed  | Check file format                 |
+| `STL_EXPORT_FAILED`    | STL file export failed   | Check shape has valid mesh        |
+| `STL_FILE_READ_ERROR`  | Could not read STL file  | Check file exists and is readable |
+| `STL_IMPORT_FAILED`    | STL file import failed   | Check file format                 |
 
 ### QUERY
 
 Shape query and finder errors.
 
-| Code | Description | Recovery |
-|------|-------------|----------|
+| Code                | Description                   | Recovery                               |
+| ------------------- | ----------------------------- | -------------------------------------- |
 | `FINDER_NOT_UNIQUE` | Finder expected unique result | Refine filters or remove unique option |
 
 ## Creating Custom Errors
 
 ```typescript
-import { validationError, err } from 'brepjs';
+import { validationError, err, ok } from 'brepjs';
 
 function myOperation(value: number): Result<number> {
   if (value < 0) {

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -27,8 +27,10 @@ The `using` declaration automatically disposes objects when they go out of scope
 
 ### Requirements
 
-- TypeScript 5.2+ with `"lib": ["ES2022", "ESNext.Disposable"]`
+- TypeScript 5.9+ with `"lib": ["ES2022", "ESNext.Disposable"]`
 - Node.js 20+ or modern browsers
+
+> **Note:** TypeScript 5.9 is required for proper `using` syntax support in brepjs v4.0.0+.
 
 ### Polyfill
 
@@ -80,6 +82,7 @@ const shape = makeBox([10, 10, 10]);
 ```
 
 **Warning**: Relying on FinalizationRegistry is not recommended because:
+
 - GC timing is unpredictable
 - Memory pressure may build up before cleanup
 - Not all environments support it
@@ -99,14 +102,14 @@ try {
 
 ## Environment Compatibility
 
-| Environment | Symbol.dispose | FinalizationRegistry | Recommendation |
-|-------------|----------------|----------------------|----------------|
-| Node.js 20+ | ✅ | ✅ | Use `using` declaration |
-| Node.js 18-19 | ❌ | ✅ | Use `gcWithScope` |
-| Chrome 117+ | ✅ | ✅ | Use `using` declaration |
-| Firefox 115+ | ✅ | ✅ | Use `using` declaration |
-| Safari 16.4+ | ✅ | ✅ | Use `using` declaration |
-| Older browsers | ❌ | ⚠️ | Use `gcWithScope` + polyfill |
+| Environment    | Symbol.dispose | FinalizationRegistry | Recommendation               |
+| -------------- | -------------- | -------------------- | ---------------------------- |
+| Node.js 20+    | ✅             | ✅                   | Use `using` declaration      |
+| Node.js 18-19  | ❌             | ✅                   | Use `gcWithScope`            |
+| Chrome 117+    | ✅             | ✅                   | Use `using` declaration      |
+| Firefox 115+   | ✅             | ✅                   | Use `using` declaration      |
+| Safari 16.4+   | ✅             | ✅                   | Use `using` declaration      |
+| Older browsers | ❌             | ⚠️                   | Use `gcWithScope` + polyfill |
 
 ### Checking Support
 
@@ -156,7 +159,7 @@ for (let i = 0; i < 100; i++) {
 // ✅ Clear when done
 shapes.length = 0;
 // Or explicitly dispose each
-shapes.forEach(s => s[Symbol.dispose]?.());
+shapes.forEach((s) => s[Symbol.dispose]?.());
 ```
 
 ### 3. Event Handlers Holding References
@@ -214,10 +217,10 @@ console.log(`Active shapes: ${activeShapes}`);
 
 ## Summary
 
-| Scenario | Recommended Approach |
-|----------|---------------------|
-| Simple temporary | `using shape = makeShape()` |
-| Multiple temporaries | `const r = gcWithScope()` |
-| Long-lived objects | Store reference, dispose when done |
-| Loops | `using` in loop body |
-| Legacy code | `try/finally` with `delete()` |
+| Scenario             | Recommended Approach               |
+| -------------------- | ---------------------------------- |
+| Simple temporary     | `using shape = makeShape()`        |
+| Multiple temporaries | `const r = gcWithScope()`          |
+| Long-lived objects   | Store reference, dispose when done |
+| Loops                | `using` in loop body               |
+| Legacy code          | `try/finally` with `delete()`      |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,6 +24,7 @@ function buildComplexShape() {
 ```
 
 **Key patterns:**
+
 - Wrap intermediate OCCT objects with `r()` to register them for cleanup
 - Objects returned from the function escape the scope and remain valid
 - Cleanup happens automatically when the scope exits
@@ -41,7 +42,7 @@ try {
   box.delete();
 }
 
-// ✅ Modern pattern — automatic cleanup
+// ✅ Modern pattern — automatic cleanup (requires TypeScript 5.9+)
 using box = makeBox([10, 10, 10]);
 doSomething(box);
 ```
@@ -101,17 +102,18 @@ clearMeshCache();
 ```
 
 **Mesh options affecting cache:**
+
 - `linearDeflection`: Maximum chord height (smaller = finer mesh)
 - `angularDeflection`: Maximum angle between adjacent normals
 
 ### Mesh Quality vs. Performance
 
-| linearDeflection | Use Case | Relative Speed |
-|------------------|----------|----------------|
-| 0.5 | Preview/bounding box | ~1x |
-| 0.1 | Interactive display | ~5x |
-| 0.01 | High-quality render | ~50x |
-| 0.001 | CAM/precision | ~500x |
+| linearDeflection | Use Case             | Relative Speed |
+| ---------------- | -------------------- | -------------- |
+| 0.5              | Preview/bounding box | ~1x            |
+| 0.1              | Interactive display  | ~5x            |
+| 0.01             | High-quality render  | ~50x           |
+| 0.001            | CAM/precision        | ~500x          |
 
 ## Query Operations
 
@@ -160,9 +162,13 @@ import { bench, printResults, type BenchResult } from './harness.js';
 const results: BenchResult[] = [];
 
 results.push(
-  await bench('operation name', () => {
-    // Operation to benchmark
-  }, { warmup: 3, iterations: 10 })
+  await bench(
+    'operation name',
+    () => {
+      // Operation to benchmark
+    },
+    { warmup: 3, iterations: 10 }
+  )
 );
 
 printResults(results);


### PR DESCRIPTION
## Summary

- Update SECURITY.md version matrix (4.x now supported, 3.x and below not supported)
- Update TypeScript requirement from 5.2+ to 5.9+ (required for v4.0.0+)
- Add `brepjs_multi` multi-threaded WASM variant to compatibility docs
- Replace dual API documentation with functional-only API (legacy class API removed in v4.0.0)
- Add v4.0.0 context to Result pattern documentation in errors.md
- Add missing `ok` import to custom errors example
- Add "Projects Using brepjs" section with Gridfinity Layout Tool

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] All tests pass