### PR TITLE
ci: pin to ubuntu-22.04 to fix WASM memory errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Tests `makeNonPlanarFace` and `makeEllipsoid` fail consistently on `ubuntu-24.04` (ubuntu-latest) with WASM memory access errors. Pinning to `ubuntu-22.04` to test if older glibc/kernel resolves the issue.