### PR TITLE
feat: add Wavefront OBJ export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,7 @@ export {
 // ── Layer 2: io ──
 
 export { importSTEP, importSTL } from './io/importers.js';
+export { exportOBJ } from './io/objExportFns.js';
 
 // ── Layer 3: sketching ──
 

--- a/src/io/objExportFns.ts
+++ b/src/io/objExportFns.ts
@@ -1,0 +1,66 @@
+/**
+ * Wavefront OBJ export from ShapeMesh data.
+ * Pure string formatting — no OCCT dependency.
+ */
+
+import type { ShapeMesh } from '../topology/meshFns.js';
+
+/** Read a vec3 from a typed array at the given vertex index. */
+function vec3At(arr: Float32Array, i: number): [number, number, number] {
+  const off = i * 3;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
+  return [arr[off]!, arr[off + 1]!, arr[off + 2]!];
+}
+
+/** Read a triangle's three vertex indices from the triangles array. */
+function triAt(arr: Uint32Array, offset: number): [number, number, number] {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
+  return [arr[offset]!, arr[offset + 1]!, arr[offset + 2]!];
+}
+
+/**
+ * Export a ShapeMesh as a Wavefront OBJ string.
+ *
+ * The mesh should be obtained from `meshShape()`.
+ */
+export function exportOBJ(mesh: ShapeMesh): string {
+  const lines: string[] = ['# brepjs OBJ export'];
+
+  // Vertices
+  const vertCount = mesh.vertices.length / 3;
+  for (let i = 0; i < vertCount; i++) {
+    const [x, y, z] = vec3At(mesh.vertices, i);
+    lines.push(`v ${x} ${y} ${z}`);
+  }
+
+  // Normals
+  const normalCount = mesh.normals.length / 3;
+  for (let i = 0; i < normalCount; i++) {
+    const [nx, ny, nz] = vec3At(mesh.normals, i);
+    lines.push(`vn ${nx} ${ny} ${nz}`);
+  }
+
+  // Faces (triangles) — faceGroups use index offsets into the triangles array
+  const pushTri = (offset: number) => {
+    const [a, b, c] = triAt(mesh.triangles, offset);
+    // OBJ indices are 1-based; vertex and normal share the same index
+    lines.push(`f ${a + 1}//${a + 1} ${b + 1}//${b + 1} ${c + 1}//${c + 1}`);
+  };
+
+  if (mesh.faceGroups.length > 0) {
+    for (const group of mesh.faceGroups) {
+      lines.push(`g face_${group.faceId}`);
+      const triCount = group.count / 3;
+      for (let t = 0; t < triCount; t++) {
+        pushTri(group.start + t * 3);
+      }
+    }
+  } else {
+    const triCount = mesh.triangles.length / 3;
+    for (let t = 0; t < triCount; t++) {
+      pushTri(t * 3);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}

--- a/tests/objExport.test.ts
+++ b/tests/objExport.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import { makeBox, meshShape, exportOBJ } from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('exportOBJ', () => {
+  it('exports a box mesh to OBJ format', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const mesh = meshShape(box);
+    const obj = exportOBJ(mesh);
+
+    expect(obj).toContain('# brepjs OBJ export');
+
+    const lines = obj.split('\n');
+    const vLines = lines.filter((l) => l.startsWith('v '));
+    expect(vLines.length).toBe(mesh.vertices.length / 3);
+
+    const vnLines = lines.filter((l) => l.startsWith('vn '));
+    expect(vnLines.length).toBe(mesh.normals.length / 3);
+
+    const fLines = lines.filter((l) => l.startsWith('f '));
+    expect(fLines.length).toBe(mesh.triangles.length / 3);
+
+    const gLines = lines.filter((l) => l.startsWith('g '));
+    expect(gLines.length).toBeGreaterThan(0);
+  });
+
+  it('uses 1-based indices', () => {
+    const box = makeBox([0, 0, 0], [1, 1, 1]);
+    const mesh = meshShape(box);
+    const obj = exportOBJ(mesh);
+
+    const fLines = obj.split('\n').filter((l) => l.startsWith('f '));
+    for (const line of fLines) {
+      const indices = line.match(/\d+/g)?.map(Number) ?? [];
+      for (const idx of indices) {
+        expect(idx).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('ends with a newline', () => {
+    const box = makeBox([0, 0, 0], [5, 5, 5]);
+    const mesh = meshShape(box);
+    const obj = exportOBJ(mesh);
+    expect(obj.endsWith('\n')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- New `io/objExportFns.ts` with `exportOBJ(mesh)` function
- Converts `ShapeMesh` (from `meshShape()`) to Wavefront OBJ text format
- Pure string formatting — no OCCT dependency
- Supports vertices, normals, face groups, 1-based indexing

## Test plan
- [x] Export box mesh, verify vertex/normal/face counts
- [x] Verify 1-based indices (no zero references)
- [x] TypeScript, lint, boundary checks pass