### PR TITLE
feat: add optional metadata field to BrepError

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -95,42 +95,95 @@ export interface BrepError {
   readonly code: string;
   readonly message: string;
   readonly cause?: unknown;
+  readonly metadata?: Readonly<Record<string, unknown>>;
 }
 
 // ---------------------------------------------------------------------------
 // Constructors per kind
 // ---------------------------------------------------------------------------
 
-export function occtError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'OCCT_OPERATION', code, message, cause };
+function makeError(
+  kind: BrepErrorKind,
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  const base: BrepError = { kind, code, message, cause };
+  if (metadata) return { ...base, metadata };
+  return base;
 }
 
-export function validationError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'VALIDATION', code, message, cause };
+export function occtError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('OCCT_OPERATION', code, message, cause, metadata);
 }
 
-export function typeCastError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'TYPE_CAST', code, message, cause };
+export function validationError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('VALIDATION', code, message, cause, metadata);
 }
 
-export function sketcherStateError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'SKETCHER_STATE', code, message, cause };
+export function typeCastError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('TYPE_CAST', code, message, cause, metadata);
 }
 
-export function moduleInitError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'MODULE_INIT', code, message, cause };
+export function sketcherStateError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('SKETCHER_STATE', code, message, cause, metadata);
 }
 
-export function computationError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'COMPUTATION', code, message, cause };
+export function moduleInitError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('MODULE_INIT', code, message, cause, metadata);
 }
 
-export function ioError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'IO', code, message, cause };
+export function computationError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('COMPUTATION', code, message, cause, metadata);
 }
 
-export function queryError(code: string, message: string, cause?: unknown): BrepError {
-  return { kind: 'QUERY', code, message, cause };
+export function ioError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('IO', code, message, cause, metadata);
+}
+
+export function queryError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Record<string, unknown>
+): BrepError {
+  return makeError('QUERY', code, message, cause, metadata);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -63,6 +63,39 @@ describe('Error constructors', () => {
     const e = occtError('FUSE_FAILED', 'Fuse failed', original);
     expect(e.cause).toBe(original);
   });
+
+  it('metadata is undefined when not provided', () => {
+    const e = occtError('FUSE_FAILED', 'Fuse failed');
+    expect(e.metadata).toBeUndefined();
+  });
+
+  it('preserves metadata when provided', () => {
+    const meta = { operation: 'fuse', tolerance: 1e-3, inputTypes: ['solid', 'solid'] };
+    const e = occtError('FUSE_FAILED', 'Fuse failed', undefined, meta);
+    expect(e.metadata).toEqual(meta);
+    expect(e.metadata?.operation).toBe('fuse');
+    expect(e.metadata?.tolerance).toBe(1e-3);
+  });
+
+  it('all factory functions accept metadata', () => {
+    const meta = { step: 'build' };
+    expect(validationError('V1', 'msg', undefined, meta).metadata).toEqual(meta);
+    expect(typeCastError('T1', 'msg', undefined, meta).metadata).toEqual(meta);
+    expect(sketcherStateError('S1', 'msg', undefined, meta).metadata).toEqual(meta);
+    expect(moduleInitError('M1', 'msg', undefined, meta).metadata).toEqual(meta);
+    expect(computationError('C1', 'msg', undefined, meta).metadata).toEqual(meta);
+    expect(ioError('I1', 'msg', undefined, meta).metadata).toEqual(meta);
+    expect(queryError('Q1', 'msg', undefined, meta).metadata).toEqual(meta);
+  });
+
+  it('preserves both cause and metadata together', () => {
+    const cause = new Error('root');
+    const meta = { inputCount: 3 };
+    const e = computationError('BSPLINE_FAILED', 'failed', cause, meta);
+    expect(e.cause).toBe(cause);
+    expect(e.metadata).toEqual(meta);
+    expect(e.kind).toBe('COMPUTATION');
+  });
 });
 
 describe('BrepErrorCode', () => {


### PR DESCRIPTION
## Summary
- Extend `BrepError` interface with optional `metadata?: Readonly<Record<string, unknown>>`
- All error factory functions (`occtError`, `validationError`, etc.) now accept an optional metadata parameter
- Enables attaching context like operation name, input types, tolerances, step names
- Fully backward-compatible — existing callers work without changes

## Test plan
- [x] Metadata is undefined when not provided
- [x] Metadata is preserved when provided
- [x] All 8 factory functions accept and preserve metadata
- [x] Both cause and metadata work together
- [x] All 1041 existing tests still pass