### PR TITLE
feat: add Three.js BufferGeometry helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -531,6 +531,15 @@ export { clearMeshCache } from './topology/meshCache.js';
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- Public API, kept for backward compatibility
 export { setMeshCacheSize } from './topology/meshCache.js';
 
+// ── Three.js integration ──
+
+export {
+  toBufferGeometryData,
+  toLineGeometryData,
+  type BufferGeometryData,
+  type LineGeometryData,
+} from './topology/threeHelpers.js';
+
 // ── Boolean operations (functional) ──
 
 export {

--- a/src/topology/index.ts
+++ b/src/topology/index.ts
@@ -173,3 +173,10 @@ export {
   buildCompound as fnBuildCompound,
   type BooleanOptions,
 } from './booleanFns.js';
+
+export {
+  toBufferGeometryData,
+  toLineGeometryData,
+  type BufferGeometryData,
+  type LineGeometryData,
+} from './threeHelpers.js';

--- a/src/topology/threeHelpers.ts
+++ b/src/topology/threeHelpers.ts
@@ -1,0 +1,66 @@
+/**
+ * Three.js integration helpers.
+ *
+ * Converts brepjs mesh data into typed arrays suitable for
+ * THREE.BufferGeometry.setAttribute(). No three.js dependency required.
+ */
+
+import type { ShapeMesh, EdgeMesh } from './meshFns.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Data ready to be used with THREE.BufferGeometry. */
+export interface BufferGeometryData {
+  /** Flat float array of vertex positions (x,y,z interleaved). */
+  position: Float32Array;
+  /** Flat float array of vertex normals (x,y,z interleaved). */
+  normal: Float32Array;
+  /** Triangle index array (3 indices per triangle). */
+  index: Uint32Array;
+}
+
+/** Line segment data ready for THREE.LineSegments or THREE.Line. */
+export interface LineGeometryData {
+  /** Flat float array of line vertex positions (x,y,z interleaved). */
+  position: Float32Array;
+}
+
+// ---------------------------------------------------------------------------
+// Conversion functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a ShapeMesh into BufferGeometry-compatible typed arrays.
+ *
+ * The returned arrays can be used directly with Three.js:
+ * ```ts
+ * const geo = new THREE.BufferGeometry();
+ * geo.setAttribute('position', new THREE.BufferAttribute(data.position, 3));
+ * geo.setAttribute('normal', new THREE.BufferAttribute(data.normal, 3));
+ * geo.setIndex(new THREE.BufferAttribute(data.index, 1));
+ * ```
+ */
+export function toBufferGeometryData(mesh: ShapeMesh): BufferGeometryData {
+  return {
+    position: mesh.vertices,
+    normal: mesh.normals,
+    index: mesh.triangles,
+  };
+}
+
+/**
+ * Convert an EdgeMesh into position data for THREE.LineSegments.
+ *
+ * ```ts
+ * const geo = new THREE.BufferGeometry();
+ * geo.setAttribute('position', new THREE.BufferAttribute(data.position, 3));
+ * const lines = new THREE.LineSegments(geo, material);
+ * ```
+ */
+export function toLineGeometryData(mesh: EdgeMesh): LineGeometryData {
+  return {
+    position: new Float32Array(mesh.lines),
+  };
+}

--- a/tests/fn-threeHelpers.test.ts
+++ b/tests/fn-threeHelpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  castShape,
+  meshShape,
+  meshShapeEdges,
+  toBufferGeometryData,
+  toLineGeometryData,
+} from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('toBufferGeometryData', () => {
+  it('converts a box mesh to BufferGeometry-compatible data', () => {
+    const box = castShape(makeBox([0, 0, 0], [10, 10, 10]).wrapped);
+    const mesh = meshShape(box, { tolerance: 0.1, angularTolerance: 0.5 });
+    const data = toBufferGeometryData(mesh);
+
+    // Should have position, normal, and index arrays
+    expect(data.position).toBeInstanceOf(Float32Array);
+    expect(data.normal).toBeInstanceOf(Float32Array);
+    expect(data.index).toBeInstanceOf(Uint32Array);
+
+    // Positions and normals should have same length (3 floats per vertex)
+    expect(data.position.length).toBe(data.normal.length);
+    expect(data.position.length).toBeGreaterThan(0);
+
+    // Position length must be divisible by 3
+    expect(data.position.length % 3).toBe(0);
+
+    // Index length must be divisible by 3 (triangles)
+    expect(data.index.length % 3).toBe(0);
+    expect(data.index.length).toBeGreaterThan(0);
+  });
+
+  it('returns same underlying typed arrays (zero-copy)', () => {
+    const box = castShape(makeBox([0, 0, 0], [5, 5, 5]).wrapped);
+    const mesh = meshShape(box, { tolerance: 0.1, angularTolerance: 0.5 });
+    const data = toBufferGeometryData(mesh);
+
+    // Should reference the same buffers (no copy)
+    expect(data.position.buffer).toBe(mesh.vertices.buffer);
+    expect(data.normal.buffer).toBe(mesh.normals.buffer);
+    expect(data.index.buffer).toBe(mesh.triangles.buffer);
+  });
+
+  it('vertex count matches normals count', () => {
+    const box = castShape(makeBox([0, 0, 0], [10, 20, 30]).wrapped);
+    const mesh = meshShape(box, { tolerance: 0.1, angularTolerance: 0.5 });
+    const data = toBufferGeometryData(mesh);
+
+    const vertexCount = data.position.length / 3;
+    const normalCount = data.normal.length / 3;
+    expect(vertexCount).toBe(normalCount);
+  });
+});
+
+describe('toLineGeometryData', () => {
+  it('converts edge mesh to line geometry data', () => {
+    const box = castShape(makeBox([0, 0, 0], [10, 10, 10]).wrapped);
+    const edgeMesh = meshShapeEdges(box, { tolerance: 0.1, angularTolerance: 0.5 });
+    const data = toLineGeometryData(edgeMesh);
+
+    expect(data.position).toBeInstanceOf(Float32Array);
+    expect(data.position.length).toBeGreaterThan(0);
+    // 3 floats per point
+    expect(data.position.length % 3).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `toBufferGeometryData()` to convert ShapeMesh into `{position, normal, index}` typed arrays
- Add `toLineGeometryData()` to convert EdgeMesh into `{position}` for line rendering
- Zero-copy where possible (returns same underlying Float32Array/Uint32Array buffers)
- No three.js dependency — just data formatting for easy integration

## Test plan
- [x] Box mesh converts to valid BufferGeometry data (correct array types, divisible by 3)
- [x] Zero-copy verified (same buffer references)
- [x] Vertex count matches normal count
- [x] Edge mesh converts to valid line geometry data
- [x] All 1041 existing tests still pass