### PR TITLE
feat: chamfer with distance + angle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -486,6 +486,8 @@ export {
   type Bounds3D,
 } from './topology/shapeFns.js';
 
+export { chamferDistAngleShape } from './topology/chamferAngleFns.js';
+
 export {
   getCurveType as fnGetCurveType,
   curveStartPoint,

--- a/src/kernel/occtAdapter.ts
+++ b/src/kernel/occtAdapter.ts
@@ -67,6 +67,7 @@ import {
 import {
   fillet as _fillet,
   chamfer as _chamfer,
+  chamferDistAngle as _chamferDistAngle,
   shell as _shell,
   thicken as _thicken,
   offset as _offset,
@@ -196,6 +197,10 @@ export class OCCTAdapter implements KernelAdapter {
     distance: number | ((edge: OcShape) => number)
   ): OcShape {
     return _chamfer(this.oc, shape, edges, distance);
+  }
+
+  chamferDistAngle(shape: OcShape, edges: OcShape[], distance: number, angleDeg: number): OcShape {
+    return _chamferDistAngle(this.oc, shape, edges, distance, angleDeg);
   }
 
   shell(shape: OcShape, faces: OcShape[], thickness: number, tolerance = 1e-3): OcShape {

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -99,6 +99,7 @@ export interface KernelAdapter {
     edges: OcShape[],
     distance: number | ((edge: OcShape) => number)
   ): OcShape;
+  chamferDistAngle(shape: OcShape, edges: OcShape[], distance: number, angleDeg: number): OcShape;
   shell(shape: OcShape, faces: OcShape[], thickness: number, tolerance?: number): OcShape;
   thicken(shape: OcShape, thickness: number): OcShape;
   offset(shape: OcShape, distance: number, tolerance?: number): OcShape;

--- a/src/topology/chamferAngleFns.ts
+++ b/src/topology/chamferAngleFns.ts
@@ -1,0 +1,36 @@
+/**
+ * Chamfer with distance + angle — functional API.
+ *
+ * Provides chamferDistAngleShape() which chamfers edges using a distance
+ * measured along one face and an angle to determine the chamfer on the other.
+ */
+
+import { getKernel } from '../kernel/index.js';
+import type { AnyShape, Edge } from '../core/shapeTypes.js';
+import { castShape } from '../core/shapeTypes.js';
+import { downcast } from './cast.js';
+import { unwrap } from '../core/result.js';
+
+/**
+ * Chamfer edges of a shape using distance + angle.
+ *
+ * The distance is measured along the face that contains the edge, and the
+ * angle (in degrees) determines how the chamfer cuts into the adjacent face.
+ *
+ * @param shape   - The shape to chamfer
+ * @param edges   - Edges to chamfer
+ * @param distance - Chamfer distance along the face
+ * @param angleDeg - Chamfer angle in degrees (typically 0 < angle < 90)
+ * @returns A new shape with chamfered edges
+ */
+export function chamferDistAngleShape(
+  shape: AnyShape,
+  edges: Edge[],
+  distance: number,
+  angleDeg: number
+): AnyShape {
+  const kernel = getKernel();
+  const rawEdges = edges.map((e) => e.wrapped);
+  const raw = kernel.chamferDistAngle(shape.wrapped, rawEdges, distance, angleDeg);
+  return castShape(unwrap(downcast(raw)));
+}

--- a/tests/fn-chamferAngle.test.ts
+++ b/tests/fn-chamferAngle.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  chamferDistAngleShape,
+  isOk,
+  unwrap,
+  fnMeasureVolume,
+  fnIsShape3D,
+  getEdges,
+} from '../src/index.js';
+import { createSolid } from '../src/core/shapeTypes.js';
+import { getKernel } from '../src/kernel/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+function makeBox(w: number, h: number, d: number) {
+  const kernel = getKernel();
+  return createSolid(kernel.makeBox(w, h, d));
+}
+
+describe('chamferDistAngleShape', () => {
+  it('chamfers a single edge of a box with distance + angle', () => {
+    const box = makeBox(10, 10, 10);
+    const edges = getEdges(box);
+    expect(edges.length).toBe(12);
+
+    const result = chamferDistAngleShape(box, [edges[0]!], 1, 45);
+    expect(fnIsShape3D(result)).toBe(true);
+
+    // Chamfered box should have less volume than original
+    const origVol = fnMeasureVolume(box);
+    const chamfVol = fnMeasureVolume(result);
+    expect(chamfVol).toBeLessThan(origVol);
+    expect(chamfVol).toBeGreaterThan(0);
+  });
+
+  it('chamfers multiple edges', () => {
+    const box = makeBox(10, 10, 10);
+    const edges = getEdges(box);
+    const selected = edges.slice(0, 4);
+
+    const result = chamferDistAngleShape(box, selected, 1, 45);
+    expect(fnIsShape3D(result)).toBe(true);
+
+    const origVol = fnMeasureVolume(box);
+    const chamfVol = fnMeasureVolume(result);
+    expect(chamfVol).toBeLessThan(origVol);
+  });
+
+  it('uses different angles', () => {
+    const box = makeBox(20, 20, 20);
+    const edges = getEdges(box);
+
+    // A smaller angle should remove less material than a larger angle
+    // at the same distance
+    const result30 = chamferDistAngleShape(box, [edges[0]!], 2, 30);
+    const result60 = chamferDistAngleShape(box, [edges[0]!], 2, 60);
+
+    const vol30 = fnMeasureVolume(result30);
+    const vol60 = fnMeasureVolume(result60);
+
+    // Both should be valid and less than original
+    const origVol = fnMeasureVolume(box);
+    expect(vol30).toBeLessThan(origVol);
+    expect(vol60).toBeLessThan(origVol);
+    // Different angles produce different volumes
+    expect(vol30).not.toBeCloseTo(vol60, 0);
+  });
+
+  it('chamfers all 12 edges of a box', () => {
+    const box = makeBox(20, 20, 20);
+    const edges = getEdges(box);
+    expect(edges.length).toBe(12);
+
+    const result = chamferDistAngleShape(box, edges, 1, 45);
+    expect(fnIsShape3D(result)).toBe(true);
+
+    const origVol = fnMeasureVolume(box);
+    const chamfVol = fnMeasureVolume(result);
+    expect(chamfVol).toBeLessThan(origVol);
+    expect(chamfVol).toBeGreaterThan(origVol * 0.8); // Not too much removed
+  });
+
+  it('is immutable — does not modify original shape', () => {
+    const box = makeBox(10, 10, 10);
+    const origVol = fnMeasureVolume(box);
+    const edges = getEdges(box);
+
+    chamferDistAngleShape(box, [edges[0]!], 1, 45);
+    expect(fnMeasureVolume(box)).toBeCloseTo(origVol, 6);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `chamferDistAngle()` to the kernel layer using `BRepFilletAPI_MakeChamfer.AddDA`
- The function automatically finds the containing face for each edge via `TopExp_Explorer`
- Expose `chamferDistAngleShape()` in the functional API for distance + angle chamfering
- Add to `KernelAdapter` interface and `OCCTAdapter` implementation

## Test plan
- [x] Chamfer single edge with distance + angle
- [x] Chamfer multiple edges
- [x] Different angles produce different volumes
- [x] Chamfer all 12 edges of a box
- [x] Immutability — original shape not modified
- [x] All 1042 tests pass, 83.24% function coverage