### PR TITLE
feat: add FaceFinder.ofArea() filter

### DIFF
--- a/src/query/faceFinder.ts
+++ b/src/query/faceFinder.ts
@@ -4,6 +4,7 @@ import { resolvePlane } from '../core/planeOps.js';
 import { vecProjectToPlane, vecEquals } from '../core/vecOps.js';
 
 import type { Face, AnyShape, SurfaceType } from '../topology/shapes.js';
+import { measureArea } from '../measurement/measureShape.js';
 import { PLANE_TO_DIR, type StandardPlane } from './definitions.js';
 import { Finder3d } from './generic3dfinder.js';
 
@@ -43,6 +44,19 @@ export class FaceFinder extends Finder3d<Face> {
   ofSurfaceType(surfaceType: SurfaceType): this {
     const check = ({ element }: { element: Face }) => {
       return element.geomType === surfaceType;
+    };
+    this.filters.push(check);
+    return this;
+  }
+
+  /**
+   * Filter to find faces that have a specific area.
+   *
+   * @category Filter
+   */
+  ofArea(area: number, tolerance = 1e-3): this {
+    const check = ({ element }: { element: Face }) => {
+      return Math.abs(measureArea(element) - area) < tolerance;
     };
     this.filters.push(check);
     return this;

--- a/src/query/finderFns.ts
+++ b/src/query/finderFns.ts
@@ -20,6 +20,7 @@ import { castShape } from '../core/shapeTypes.js';
 import { iterTopo, downcast } from '../topology/cast.js';
 import { getHashCode, isSameShape } from '../topology/shapeFns.js';
 import { normalAt as faceNormalAt, getSurfaceType, type SurfaceType } from '../topology/faceFns.js';
+import { measureArea } from '../measurement/measureFns.js';
 import { getCurveType, curveLength } from '../topology/curveFns.js';
 import type { CurveType } from '../core/definitionMaps.js';
 import { type Result, ok, err, unwrap } from '../core/result.js';
@@ -234,6 +235,7 @@ export interface FaceFinderFn extends ShapeFinder<Face> {
   readonly inDirection: (dir?: 'X' | 'Y' | 'Z' | Vec3, angle?: number) => FaceFinderFn;
   readonly parallelTo: (dir?: 'X' | 'Y' | 'Z' | Vec3) => FaceFinderFn;
   readonly ofSurfaceType: (surfaceType: SurfaceType) => FaceFinderFn;
+  readonly ofArea: (area: number, tolerance?: number) => FaceFinderFn;
   readonly atDistance: (distance: number, point?: Vec3) => FaceFinderFn;
 }
 
@@ -271,6 +273,9 @@ function createFaceFinder(filters: ReadonlyArray<Predicate<Face>>): FaceFinderFn
 
     ofSurfaceType: (surfaceType) =>
       withFilter((face) => unwrap(getSurfaceType(face)) === surfaceType),
+
+    ofArea: (area, tolerance = 1e-3) =>
+      withFilter((face) => Math.abs(measureArea(face) - area) < tolerance),
 
     atDistance: (distance, point = [0, 0, 0]) =>
       withFilter((face) => {

--- a/tests/faceFinder.test.ts
+++ b/tests/faceFinder.test.ts
@@ -123,4 +123,18 @@ describe('FaceFinder extra coverage', () => {
     const finder = new FaceFinder().and([(f) => f.parallelTo('XY'), (f) => f.inPlane('XY', 30)]);
     expect(finder.find(makeBox([0, 0, 0], [10, 20, 30])).length).toBe(1);
   });
+
+  it('ofArea finds faces with specific area', () => {
+    const box = makeBox([0, 0, 0], [10, 20, 30]);
+    // 10x20 faces (area=200): 2 faces
+    expect(new FaceFinder().ofArea(200).find(box).length).toBe(2);
+    // 10x30 faces (area=300): 2 faces
+    expect(new FaceFinder().ofArea(300).find(box).length).toBe(2);
+    // 20x30 faces (area=600): 2 faces
+    expect(new FaceFinder().ofArea(600).find(box).length).toBe(2);
+  });
+
+  it('ofArea returns empty for no match', () => {
+    expect(new FaceFinder().ofArea(999).find(makeBox([0, 0, 0], [10, 10, 10])).length).toBe(0);
+  });
 });

--- a/tests/fn-finderFns.test.ts
+++ b/tests/fn-finderFns.test.ts
@@ -192,4 +192,37 @@ describe('faceFinder', () => {
     const filtered = faceFinder().inList(subset).find(box);
     expect(filtered.length).toBe(2);
   });
+
+  it('filters faces by area (10x10 box)', () => {
+    const box = fnBox(10, 10, 10);
+    // A 10x10x10 box has all faces of area 100
+    const faces = faceFinder().ofArea(100).find(box);
+    expect(faces.length).toBe(6);
+  });
+
+  it('filters faces by area on non-uniform box', () => {
+    const box = fnBox(10, 20, 30);
+    // 10x20 faces (area=200): 2 faces
+    const faces200 = faceFinder().ofArea(200).find(box);
+    expect(faces200.length).toBe(2);
+    // 10x30 faces (area=300): 2 faces
+    const faces300 = faceFinder().ofArea(300).find(box);
+    expect(faces300.length).toBe(2);
+    // 20x30 faces (area=600): 2 faces
+    const faces600 = faceFinder().ofArea(600).find(box);
+    expect(faces600.length).toBe(2);
+  });
+
+  it('ofArea returns empty for no match', () => {
+    const box = fnBox(10, 10, 10);
+    const faces = faceFinder().ofArea(999).find(box);
+    expect(faces.length).toBe(0);
+  });
+
+  it('ofArea with custom tolerance', () => {
+    const box = fnBox(10, 10, 10);
+    // With very tight tolerance, should still match exactly
+    const faces = faceFinder().ofArea(100, 0.001).find(box);
+    expect(faces.length).toBe(6);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `ofArea(area, tolerance?)` to the functional `faceFinder()` (FaceFinderFn interface)
- Add `ofArea(area, tolerance?)` to the legacy `FaceFinder` class
- Uses `measureArea` internally for OCCT-based area computation

## Test plan
- [x] Filter all faces of uniform box (area=100) — 6 matches
- [x] Filter non-uniform box (200, 300, 600) — 2 matches each
- [x] No match returns empty array
- [x] Custom tolerance works
- [x] Legacy FaceFinder.ofArea() works
- [x] All 1043 tests pass, 83.09% function coverage