### PR TITLE
feat: add immutable assembly graph for shape hierarchies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -589,6 +589,19 @@ export {
 
 export { linearPattern, circularPattern } from './operations/patternFns.js';
 
+export {
+  createAssemblyNode,
+  addChild,
+  removeChild,
+  updateNode,
+  findNode,
+  walkAssembly,
+  countNodes,
+  collectShapes,
+  type AssemblyNode,
+  type AssemblyNodeOptions,
+} from './operations/assemblyFns.js';
+
 // ── Measurement (functional) ──
 
 export {

--- a/src/operations/assemblyFns.ts
+++ b/src/operations/assemblyFns.ts
@@ -1,0 +1,127 @@
+/**
+ * Assembly graph — tree structure for managing shape hierarchies.
+ *
+ * An assembly is a tree of nodes. Each node has an optional shape,
+ * a local transform (translation + rotation), optional metadata,
+ * and child nodes. This is a pure data structure with no OCCT calls.
+ *
+ * Usage:
+ *   const asm = createAssemblyNode('root')
+ *     |> addChild(_, createAssemblyNode('part-a', { shape: boxShape, translate: [10, 0, 0] }))
+ *     |> addChild(_, createAssemblyNode('part-b', { shape: cylShape }));
+ */
+
+import type { Vec3 } from '../core/types.js';
+import type { AnyShape } from '../core/shapeTypes.js';
+
+// ---------------------------------------------------------------------------
+// Assembly types
+// ---------------------------------------------------------------------------
+
+export interface AssemblyNode {
+  readonly name: string;
+  readonly shape?: AnyShape;
+  readonly translate?: Vec3;
+  readonly rotate?: { angle: number; axis?: Vec3 };
+  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly children: ReadonlyArray<AssemblyNode>;
+}
+
+export interface AssemblyNodeOptions {
+  shape?: AnyShape;
+  translate?: Vec3;
+  rotate?: { angle: number; axis?: Vec3 };
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+/** Create a new assembly node. */
+export function createAssemblyNode(name: string, options: AssemblyNodeOptions = {}): AssemblyNode {
+  const node: AssemblyNode = { name, children: [] };
+  if (options.shape !== undefined) (node as { shape: AnyShape }).shape = options.shape;
+  if (options.translate !== undefined) (node as { translate: Vec3 }).translate = options.translate;
+  if (options.rotate !== undefined)
+    (node as { rotate: { angle: number; axis?: Vec3 } }).rotate = options.rotate;
+  if (options.metadata !== undefined)
+    (node as { metadata: Record<string, unknown> }).metadata = options.metadata;
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Immutable tree operations
+// ---------------------------------------------------------------------------
+
+/** Add a child node. Returns a new parent node. */
+export function addChild(parent: AssemblyNode, child: AssemblyNode): AssemblyNode {
+  return { ...parent, children: [...parent.children, child] };
+}
+
+/** Remove a child by name (first match). Returns a new parent node. */
+export function removeChild(parent: AssemblyNode, childName: string): AssemblyNode {
+  const idx = parent.children.findIndex((c) => c.name === childName);
+  if (idx === -1) return parent;
+  const children = [...parent.children];
+  children.splice(idx, 1);
+  return { ...parent, children };
+}
+
+/** Update a node's properties. Returns a new node. */
+export function updateNode(
+  node: AssemblyNode,
+  updates: Partial<AssemblyNodeOptions>
+): AssemblyNode {
+  return {
+    ...node,
+    ...(updates.shape !== undefined ? { shape: updates.shape } : {}),
+    ...(updates.translate !== undefined ? { translate: updates.translate } : {}),
+    ...(updates.rotate !== undefined ? { rotate: updates.rotate } : {}),
+    ...(updates.metadata !== undefined ? { metadata: updates.metadata } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Traversal
+// ---------------------------------------------------------------------------
+
+/** Find a node by name (depth-first). Returns undefined if not found. */
+export function findNode(root: AssemblyNode, name: string): AssemblyNode | undefined {
+  if (root.name === name) return root;
+  for (const child of root.children) {
+    const found = findNode(child, name);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** Walk the tree depth-first, calling visitor for each node. */
+export function walkAssembly(
+  root: AssemblyNode,
+  visitor: (node: AssemblyNode, depth: number) => void,
+  depth = 0
+): void {
+  visitor(root, depth);
+  for (const child of root.children) {
+    walkAssembly(child, visitor, depth + 1);
+  }
+}
+
+/** Count all nodes in the tree. */
+export function countNodes(root: AssemblyNode): number {
+  let count = 1;
+  for (const child of root.children) {
+    count += countNodes(child);
+  }
+  return count;
+}
+
+/** Collect all shapes in the tree (depth-first). */
+export function collectShapes(root: AssemblyNode): AnyShape[] {
+  const shapes: AnyShape[] = [];
+  walkAssembly(root, (node) => {
+    if (node.shape) shapes.push(node.shape);
+  });
+  return shapes;
+}

--- a/tests/fn-assemblyFns.test.ts
+++ b/tests/fn-assemblyFns.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  makeCylinder,
+  castShape,
+  createAssemblyNode,
+  addChild,
+  removeChild,
+  updateNode,
+  findNode,
+  walkAssembly,
+  countNodes,
+  collectShapes,
+} from '../src/index.js';
+import type { Shape3D } from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+function box(): Shape3D {
+  return castShape(makeBox([0, 0, 0], [10, 10, 10]).wrapped) as Shape3D;
+}
+
+function cyl(): Shape3D {
+  return castShape(makeCylinder(5, 20).wrapped) as Shape3D;
+}
+
+describe('createAssemblyNode', () => {
+  it('creates a node with just a name', () => {
+    const node = createAssemblyNode('root');
+    expect(node.name).toBe('root');
+    expect(node.children).toHaveLength(0);
+    expect(node.shape).toBeUndefined();
+  });
+
+  it('creates a node with a shape', () => {
+    const shape = box();
+    const node = createAssemblyNode('part', { shape });
+    expect(node.shape).toBe(shape);
+  });
+
+  it('creates a node with transform and metadata', () => {
+    const node = createAssemblyNode('part', {
+      translate: [10, 20, 30],
+      rotate: { angle: 45, axis: [0, 0, 1] },
+      metadata: { material: 'steel' },
+    });
+    expect(node.translate).toEqual([10, 20, 30]);
+    expect(node.rotate).toEqual({ angle: 45, axis: [0, 0, 1] });
+    expect(node.metadata).toEqual({ material: 'steel' });
+  });
+});
+
+describe('addChild / removeChild', () => {
+  it('adds a child to a node', () => {
+    const root = createAssemblyNode('root');
+    const child = createAssemblyNode('child');
+    const updated = addChild(root, child);
+    expect(updated.children).toHaveLength(1);
+    expect(updated.children[0]?.name).toBe('child');
+    // Original is unchanged
+    expect(root.children).toHaveLength(0);
+  });
+
+  it('removes a child by name', () => {
+    const root = addChild(
+      addChild(createAssemblyNode('root'), createAssemblyNode('a')),
+      createAssemblyNode('b')
+    );
+    const updated = removeChild(root, 'a');
+    expect(updated.children).toHaveLength(1);
+    expect(updated.children[0]?.name).toBe('b');
+  });
+
+  it('returns same node if child not found', () => {
+    const root = createAssemblyNode('root');
+    const updated = removeChild(root, 'nonexistent');
+    expect(updated).toBe(root);
+  });
+});
+
+describe('updateNode', () => {
+  it('updates translate', () => {
+    const node = createAssemblyNode('part');
+    const updated = updateNode(node, { translate: [1, 2, 3] });
+    expect(updated.translate).toEqual([1, 2, 3]);
+    expect(updated.name).toBe('part');
+  });
+
+  it('updates metadata', () => {
+    const node = createAssemblyNode('part');
+    const updated = updateNode(node, { metadata: { weight: 5 } });
+    expect(updated.metadata).toEqual({ weight: 5 });
+  });
+});
+
+describe('findNode', () => {
+  it('finds root by name', () => {
+    const root = createAssemblyNode('root');
+    expect(findNode(root, 'root')).toBe(root);
+  });
+
+  it('finds nested child', () => {
+    const grandchild = createAssemblyNode('gc');
+    const child = addChild(createAssemblyNode('child'), grandchild);
+    const root = addChild(createAssemblyNode('root'), child);
+    const found = findNode(root, 'gc');
+    expect(found?.name).toBe('gc');
+  });
+
+  it('returns undefined when not found', () => {
+    const root = createAssemblyNode('root');
+    expect(findNode(root, 'missing')).toBeUndefined();
+  });
+});
+
+describe('walkAssembly', () => {
+  it('visits all nodes in order', () => {
+    const root = addChild(
+      addChild(createAssemblyNode('root'), createAssemblyNode('a')),
+      createAssemblyNode('b')
+    );
+    const names: string[] = [];
+    walkAssembly(root, (node) => names.push(node.name));
+    expect(names).toEqual(['root', 'a', 'b']);
+  });
+
+  it('reports correct depth', () => {
+    const grandchild = createAssemblyNode('gc');
+    const child = addChild(createAssemblyNode('child'), grandchild);
+    const root = addChild(createAssemblyNode('root'), child);
+    const depths: number[] = [];
+    walkAssembly(root, (_, d) => depths.push(d));
+    expect(depths).toEqual([0, 1, 2]);
+  });
+});
+
+describe('countNodes', () => {
+  it('counts single node', () => {
+    expect(countNodes(createAssemblyNode('root'))).toBe(1);
+  });
+
+  it('counts nested tree', () => {
+    const root = addChild(
+      addChild(createAssemblyNode('root'), createAssemblyNode('a')),
+      addChild(createAssemblyNode('b'), createAssemblyNode('c'))
+    );
+    expect(countNodes(root)).toBe(4);
+  });
+});
+
+describe('collectShapes', () => {
+  it('collects shapes from tree', () => {
+    const boxShape = box();
+    const cylShape = cyl();
+    const root = addChild(
+      addChild(createAssemblyNode('root'), createAssemblyNode('box', { shape: boxShape })),
+      createAssemblyNode('cyl', { shape: cylShape })
+    );
+    const shapes = collectShapes(root);
+    expect(shapes).toHaveLength(2);
+    expect(shapes[0]).toBe(boxShape);
+    expect(shapes[1]).toBe(cylShape);
+  });
+
+  it('skips nodes without shapes', () => {
+    const root = addChild(createAssemblyNode('root'), createAssemblyNode('empty'));
+    expect(collectShapes(root)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds tree-based assembly structure for managing shape hierarchies
- `createAssemblyNode()`, `addChild()`, `removeChild()`, `updateNode()` for tree construction
- `findNode()`, `walkAssembly()`, `countNodes()`, `collectShapes()` for traversal
- All operations are immutable — returns new nodes without modifying originals
- Pure data structure, no OCCT calls required

## Test plan
- [x] 17 tests: construction, tree ops, traversal, shape collection
- [x] All 1054 tests pass, 83.17% function coverage
- [x] typecheck, lint, boundaries, knip all pass