### PR TITLE
feat: add subpath exports for core, query, and measurement

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,46 @@
   "type": "module",
   "main": "./dist/brepjs.cjs",
   "module": "./dist/brepjs.js",
-  "types": "./dist/brepjs.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/brepjs.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/brepjs.js"
       },
       "require": {
-        "types": "./dist/brepjs.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/brepjs.cjs"
+      }
+    },
+    "./core": {
+      "import": {
+        "types": "./dist/core.d.ts",
+        "default": "./dist/core.js"
+      },
+      "require": {
+        "types": "./dist/core.d.ts",
+        "default": "./dist/core.cjs"
+      }
+    },
+    "./query": {
+      "import": {
+        "types": "./dist/query.d.ts",
+        "default": "./dist/query.js"
+      },
+      "require": {
+        "types": "./dist/query.d.ts",
+        "default": "./dist/query.cjs"
+      }
+    },
+    "./measurement": {
+      "import": {
+        "types": "./dist/measurement.d.ts",
+        "default": "./dist/measurement.js"
+      },
+      "require": {
+        "types": "./dist/measurement.d.ts",
+        "default": "./dist/measurement.cjs"
       }
     }
   },

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,109 @@
+/**
+ * brepjs/core — Core types, vectors, results, and plane operations.
+ * Lightweight subpath export with no OCCT dependency.
+ */
+
+export type { Vec3, Vec2, PointInput, Direction as DirectionInput } from './core/types.js';
+export { toVec3, toVec2, resolveDirection } from './core/types.js';
+
+export {
+  vecAdd,
+  vecSub,
+  vecScale,
+  vecNegate,
+  vecDot,
+  vecCross,
+  vecLength,
+  vecLengthSq,
+  vecDistance,
+  vecNormalize,
+  vecEquals,
+  vecIsZero,
+  vecAngle,
+  vecProjectToPlane,
+  vecRotate,
+  vecRepr,
+} from './core/vecOps.js';
+
+export {
+  ok,
+  err,
+  OK,
+  isOk,
+  isErr,
+  map,
+  mapErr,
+  andThen,
+  flatMap,
+  unwrap,
+  unwrapOr,
+  unwrapOrElse,
+  unwrapErr,
+  match,
+  collect,
+  tryCatch,
+  tryCatchAsync,
+  type Result,
+  type Ok,
+  type Err,
+  type Unit,
+} from './core/result.js';
+
+export {
+  type BrepError,
+  type BrepErrorKind,
+  occtError,
+  validationError,
+  typeCastError,
+  sketcherStateError,
+  moduleInitError,
+  computationError,
+  ioError,
+  queryError,
+  bug,
+  BrepBugError,
+} from './core/errors.js';
+
+export { DEG2RAD, RAD2DEG, HASH_CODE_MAX } from './core/constants.js';
+
+export type { Plane as FnPlane, PlaneName as FnPlaneName, PlaneInput } from './core/planeTypes.js';
+
+export {
+  createPlane,
+  createNamedPlane,
+  resolvePlane,
+  translatePlane,
+  pivotPlane,
+} from './core/planeOps.js';
+
+export type {
+  ShapeKind,
+  Vertex,
+  Edge,
+  Wire,
+  Face,
+  Shell,
+  Solid,
+  CompSolid,
+  Compound,
+  AnyShape,
+  Shape1D,
+  Shape3D,
+} from './core/shapeTypes.js';
+
+export {
+  castShape,
+  getShapeKind,
+  isVertex,
+  isEdge,
+  isWire,
+  isFace,
+  isShell,
+  isSolid,
+  isCompound,
+  isShape3D,
+  isShape1D,
+} from './core/shapeTypes.js';
+
+export type { ShapeHandle, OcHandle } from './core/disposal.js';
+export { createHandle, createOcHandle, DisposalScope, withScope } from './core/disposal.js';

--- a/src/measurement.ts
+++ b/src/measurement.ts
@@ -1,0 +1,15 @@
+/**
+ * brepjs/measurement — Shape measurement functions.
+ */
+
+export {
+  measureVolume,
+  measureArea,
+  measureLength,
+  measureDistance,
+  createDistanceQuery,
+  measureVolumeProps,
+  measureSurfaceProps,
+  measureLinearProps,
+  type PhysicalProps,
+} from './measurement/measureFns.js';

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,17 @@
+/**
+ * brepjs/query — Shape query finders.
+ */
+
+export {
+  edgeFinder,
+  faceFinder,
+  type EdgeFinderFn,
+  type FaceFinderFn,
+  type ShapeFinder,
+} from './query/finderFns.js';
+
+export { EdgeFinder } from './query/edgeFinder.js';
+export { FaceFinder } from './query/faceFinder.js';
+export { CornerFinder, type Corner } from './query/cornerFinder.js';
+export { getSingleFace, type SingleFace } from './query/helpers.js';
+export { combineFinderFilters, type FilterFcn } from './query/index.js';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,17 +5,20 @@ import { resolve } from 'path';
 export default defineConfig({
   plugins: [
     dts({
-      rollupTypes: true,
+      rollupTypes: false,
     }),
   ],
   build: {
     target: 'es2022',
     minify: false,
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'brepjs',
+      entry: {
+        brepjs: resolve(__dirname, 'src/index.ts'),
+        core: resolve(__dirname, 'src/core.ts'),
+        query: resolve(__dirname, 'src/query.ts'),
+        measurement: resolve(__dirname, 'src/measurement.ts'),
+      },
       formats: ['es', 'cjs'],
-      fileName: 'brepjs',
     },
     rollupOptions: {
       external: ['brepjs-opencascade', 'opentype.js'],


### PR DESCRIPTION
## Summary
- Add `brepjs/core`, `brepjs/query`, and `brepjs/measurement` subpath exports with barrel files
- Configure multi-entry Vite build producing separate ESM, CJS, and DTS outputs per subpath
- Fix main `types` field to point to correct `./dist/index.d.ts`

## Test plan
- [ ] Verify `npm run build` produces all entry outputs (brepjs, core, query, measurement × es/cjs)
- [ ] Verify DTS files generated for each subpath entry
- [ ] Confirm existing test suite passes (1037 tests, 83% function coverage)
- [ ] Test import from `brepjs/core` in a consuming project