### PR TITLE
feat: functional modifier operations (fillet, chamfer, shell, offset)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -564,7 +564,7 @@ export {
 
 // ── Modifier operations (functional) ──
 
-export { thickenSurface } from './topology/modifierFns.js';
+export { thickenSurface, filletShape, chamferShape, shellShape, offsetShape } from './topology/modifierFns.js';
 
 // ── Operations (functional) ──
 

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -6,10 +6,11 @@
  */
 
 import { getKernel } from '../kernel/index.js';
-import type { AnyShape } from '../core/shapeTypes.js';
-import { castShape } from '../core/shapeTypes.js';
+import type { AnyShape, Edge, Face, Shape3D } from '../core/shapeTypes.js';
+import { castShape, isShape3D } from '../core/shapeTypes.js';
 import { type Result, ok, err } from '../core/result.js';
-import { occtError } from '../core/errors.js';
+import { occtError, validationError } from '../core/errors.js';
+import { getEdges } from './shapeFns.js';
 
 /**
  * Thickens a surface (face or shell) into a solid by offsetting it.
@@ -30,5 +31,178 @@ export function thickenSurface(shape: AnyShape, thickness: number): Result<AnySh
         `Thicken operation failed: ${e instanceof Error ? e.message : String(e)}`
       )
     );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fillet
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a fillet (rounded edge) to selected edges of a 3D shape.
+ *
+ * @param shape - The shape to modify.
+ * @param edges - Edges to fillet. Pass `undefined` to fillet all edges.
+ * @param radius - Constant radius or per-edge callback.
+ */
+export function filletShape(
+  shape: Shape3D,
+  edges: ReadonlyArray<Edge> | undefined,
+  radius: number | ((edge: Edge) => number | null)
+): Result<Shape3D> {
+  if (typeof radius === 'number' && radius <= 0) {
+    return err(validationError('INVALID_FILLET_RADIUS', 'Fillet radius must be positive'));
+  }
+
+  const selectedEdges = edges ?? getEdges(shape);
+  if (selectedEdges.length === 0) {
+    return err(validationError('NO_EDGES', 'No edges found for fillet'));
+  }
+
+  try {
+    const kernel = getKernel();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel expects OcShape callback
+    const kernelRadius: any =
+      typeof radius === 'function'
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel expects OcShape callback
+          (ocEdge: any) => {
+            const edgeWrapped = castShape(ocEdge) as Edge;
+            return radius(edgeWrapped) ?? 0;
+          }
+        : radius;
+
+    const result = kernel.fillet(
+      shape.wrapped,
+      selectedEdges.map((e) => e.wrapped),
+      kernelRadius
+    );
+
+    const cast = castShape(result);
+    if (!isShape3D(cast)) {
+      return err(occtError('FILLET_RESULT_NOT_3D', 'Fillet result is not a 3D shape'));
+    }
+    return ok(cast);
+  } catch (e) {
+    return err(occtError('FILLET_FAILED', 'Fillet operation failed', e));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chamfer
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a chamfer (beveled edge) to selected edges of a 3D shape.
+ *
+ * @param shape - The shape to modify.
+ * @param edges - Edges to chamfer. Pass `undefined` to chamfer all edges.
+ * @param distance - Chamfer distance or per-edge callback.
+ */
+export function chamferShape(
+  shape: Shape3D,
+  edges: ReadonlyArray<Edge> | undefined,
+  distance: number | ((edge: Edge) => number | null)
+): Result<Shape3D> {
+  if (typeof distance === 'number' && distance <= 0) {
+    return err(validationError('INVALID_CHAMFER_DISTANCE', 'Chamfer distance must be positive'));
+  }
+
+  const selectedEdges = edges ?? getEdges(shape);
+  if (selectedEdges.length === 0) {
+    return err(validationError('NO_EDGES', 'No edges found for chamfer'));
+  }
+
+  try {
+    const kernel = getKernel();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel expects OcShape callback
+    const kernelDistance: any =
+      typeof distance === 'function'
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel expects OcShape callback
+          (ocEdge: any) => {
+            const edgeWrapped = castShape(ocEdge) as Edge;
+            return distance(edgeWrapped) ?? 0;
+          }
+        : distance;
+
+    const result = kernel.chamfer(
+      shape.wrapped,
+      selectedEdges.map((e) => e.wrapped),
+      kernelDistance
+    );
+
+    const cast = castShape(result);
+    if (!isShape3D(cast)) {
+      return err(occtError('CHAMFER_RESULT_NOT_3D', 'Chamfer result is not a 3D shape'));
+    }
+    return ok(cast);
+  } catch (e) {
+    return err(occtError('CHAMFER_FAILED', 'Chamfer operation failed', e));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shell
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a hollow shell by removing faces and offsetting remaining walls.
+ *
+ * @param shape - The solid to hollow out.
+ * @param faces - Faces to remove.
+ * @param thickness - Wall thickness.
+ * @param tolerance - Shell operation tolerance (default 1e-3).
+ */
+export function shellShape(
+  shape: Shape3D,
+  faces: ReadonlyArray<Face>,
+  thickness: number,
+  tolerance = 1e-3
+): Result<Shape3D> {
+  if (thickness <= 0) {
+    return err(validationError('INVALID_THICKNESS', 'Shell thickness must be positive'));
+  }
+  if (faces.length === 0) {
+    return err(validationError('NO_FACES', 'At least one face must be specified for shell'));
+  }
+
+  try {
+    const result = getKernel().shell(
+      shape.wrapped,
+      faces.map((f) => f.wrapped),
+      thickness,
+      tolerance
+    );
+
+    const cast = castShape(result);
+    if (!isShape3D(cast)) {
+      return err(occtError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
+    }
+    return ok(cast);
+  } catch (e) {
+    return err(occtError('SHELL_FAILED', 'Shell operation failed', e));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Offset
+// ---------------------------------------------------------------------------
+
+/**
+ * Offset all faces of a shape by a given distance.
+ *
+ * @param shape - The shape to offset.
+ * @param distance - Offset distance (positive = outward, negative = inward).
+ * @param tolerance - Offset tolerance (default 1e-6).
+ */
+export function offsetShape(shape: AnyShape, distance: number, tolerance = 1e-6): Result<AnyShape> {
+  if (distance === 0) {
+    return err(validationError('ZERO_OFFSET', 'Offset distance cannot be zero'));
+  }
+
+  try {
+    const result = getKernel().offset(shape.wrapped, distance, tolerance);
+    return ok(castShape(result));
+  } catch (e) {
+    return err(occtError('OFFSET_FAILED', 'Offset operation failed', e));
   }
 }

--- a/tests/fn-modifierFns.test.ts
+++ b/tests/fn-modifierFns.test.ts
@@ -5,8 +5,19 @@ import {
   thickenSurface,
   castShape,
   fnIsSolid,
+  makeBox,
+  makeSphere,
+  getEdges,
+  getFaces,
+  fnMeasureVolume,
+  fnMeasureArea,
   isOk,
+  isErr,
   unwrap,
+  filletShape,
+  chamferShape,
+  shellShape,
+  offsetShape,
 } from '../src/index.js';
 import { measureVolume } from '../src/measurement/measureFns.js';
 import type { Shape3D } from '../src/core/shapeTypes.js';
@@ -48,5 +59,128 @@ describe('thickenSurface', () => {
     // 10 x 20 face thickened by 3 => |volume| ≈ 600
     const vol = measureVolume(solid as Shape3D);
     expect(Math.abs(vol)).toBeCloseTo(600, 0);
+  });
+});
+
+describe('filletShape', () => {
+  it('fillets all edges of a box with constant radius', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = filletShape(box, undefined, 1);
+    expect(isOk(result)).toBe(true);
+    const filleted = unwrap(result);
+    const vol = fnMeasureVolume(filleted);
+    expect(vol).toBeLessThan(1000);
+    expect(vol).toBeGreaterThan(800);
+  });
+
+  it('fillets specific edges', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const edges = getEdges(box);
+    const result = filletShape(box, [edges[0]], 1);
+    expect(isOk(result)).toBe(true);
+    const vol = fnMeasureVolume(unwrap(result));
+    // Single edge fillet removes less material
+    expect(vol).toBeLessThan(1000);
+    expect(vol).toBeGreaterThan(990);
+  });
+
+  it('returns error for zero radius', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = filletShape(box, undefined, 0);
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('returns error for negative radius', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = filletShape(box, undefined, -1);
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('supports per-edge callback', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const edges = getEdges(box);
+    let callCount = 0;
+    const result = filletShape(box, edges.slice(0, 2), () => {
+      callCount++;
+      return 1;
+    });
+    expect(isOk(result)).toBe(true);
+    expect(callCount).toBe(2);
+  });
+});
+
+describe('chamferShape', () => {
+  it('chamfers all edges of a box', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = chamferShape(box, undefined, 1);
+    expect(isOk(result)).toBe(true);
+    const vol = fnMeasureVolume(unwrap(result));
+    expect(vol).toBeLessThan(1000);
+    expect(vol).toBeGreaterThan(800);
+  });
+
+  it('chamfers specific edges', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const edges = getEdges(box);
+    const result = chamferShape(box, [edges[0]], 1);
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('returns error for zero distance', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = chamferShape(box, undefined, 0);
+    expect(isErr(result)).toBe(true);
+  });
+});
+
+describe('shellShape', () => {
+  it('hollows a box by removing one face', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    const result = shellShape(box, [faces[0]], 1);
+    expect(isOk(result)).toBe(true);
+    const vol = fnMeasureVolume(unwrap(result));
+    // Shell removes interior, leaving walls of thickness 1
+    expect(vol).toBeLessThan(1000);
+    expect(vol).toBeGreaterThan(200);
+  });
+
+  it('returns error for zero thickness', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    const result = shellShape(box, [faces[0]], 0);
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('returns error for empty faces list', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = shellShape(box, [], 1);
+    expect(isErr(result)).toBe(true);
+  });
+});
+
+describe('offsetShape', () => {
+  it('offsets a sphere outward', () => {
+    const sphere = makeSphere(5);
+    const originalArea = fnMeasureArea(sphere);
+    const result = offsetShape(sphere, 1);
+    expect(isOk(result)).toBe(true);
+    const area = fnMeasureArea(unwrap(result));
+    expect(area).toBeGreaterThan(originalArea);
+  });
+
+  it('offsets a sphere inward', () => {
+    const sphere = makeSphere(5);
+    const originalArea = fnMeasureArea(sphere);
+    const result = offsetShape(sphere, -1);
+    expect(isOk(result)).toBe(true);
+    const area = fnMeasureArea(unwrap(result));
+    expect(area).toBeLessThan(originalArea);
+  });
+
+  it('returns error for zero distance', () => {
+    const sphere = makeSphere(5);
+    const result = offsetShape(sphere, 0);
+    expect(isErr(result)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds standalone `Result`-returning functions for shape modification: `filletShape`, `chamferShape`, `shellShape`, `offsetShape`
- Functions accept branded types (`Shape3D`, `Edge`, `Face`) and return `Result<Shape3D>` or `Result<AnyShape>`
- Input validation for radius/distance/thickness with typed error codes
- Fillet and chamfer support per-edge callback for variable sizing

## Test plan
- [x] `filletShape` — all edges, specific edges, per-edge callback, zero/negative radius errors
- [x] `chamferShape` — all edges, specific edges, zero distance error
- [x] `shellShape` — hollow box, zero thickness error, empty faces error
- [x] `offsetShape` — outward/inward sphere offset, zero distance error
- [x] 14 new tests, 1051 total pass
- [x] Function coverage 83.68%
- [x] Typecheck, lint, check:boundaries, knip all pass