### PR TITLE
feat: shape healing and validation functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -575,6 +575,10 @@ export {
 
 export { thickenSurface, filletShape, chamferShape, shellShape, offsetShape } from './topology/modifierFns.js';
 
+// ── Healing (functional) ──
+
+export { isShapeValid, healSolid, healFace, healWire, healShape } from './topology/healingFns.js';
+
 // ── Operations (functional) ──
 
 export {

--- a/src/topology/healingFns.ts
+++ b/src/topology/healingFns.ts
@@ -1,0 +1,146 @@
+/**
+ * Shape healing and validation functions.
+ *
+ * Uses ShapeFix_Solid, ShapeFix_Face, ShapeFix_Wire, and BRepCheck_Analyzer
+ * to validate and repair shapes.
+ */
+
+import { getKernel } from '../kernel/index.js';
+import type { AnyShape, Face, Wire, Solid } from '../core/shapeTypes.js';
+import { castShape, isSolid, isFace, isWire } from '../core/shapeTypes.js';
+import { type Result, ok, err } from '../core/result.js';
+import { occtError, validationError } from '../core/errors.js';
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a shape is valid according to OCCT geometry and topology checks.
+ */
+export function isShapeValid(shape: AnyShape): boolean {
+  const oc = getKernel().oc;
+  const analyzer = new oc.BRepCheck_Analyzer(shape.wrapped, true, false);
+  const valid = analyzer.IsValid_2();
+  analyzer.delete();
+  return valid;
+}
+
+// ---------------------------------------------------------------------------
+// Healing
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to heal/fix a solid shape.
+ *
+ * Uses ShapeFix_Solid to repair topology issues like gaps, wrong orientation, etc.
+ */
+export function healSolid(solid: Solid): Result<Solid> {
+  if (!isSolid(solid)) {
+    return err(validationError('NOT_A_SOLID', 'Input shape is not a solid'));
+  }
+
+  try {
+    const oc = getKernel().oc;
+    const fixer = new oc.ShapeFix_Solid_2(solid.wrapped);
+    const progress = new oc.Message_ProgressRange_1();
+    fixer.Perform(progress);
+    progress.delete();
+    const result = fixer.Solid();
+    fixer.delete();
+    if (result.IsNull()) {
+      // Perform may return null solid if there's nothing to fix — return original
+      return ok(solid);
+    }
+    const cast = castShape(result);
+    if (!isSolid(cast)) {
+      return err(occtError('HEAL_RESULT_NOT_SOLID', 'Healed result is not a solid'));
+    }
+    return ok(cast);
+  } catch (e) {
+    return err(occtError('HEAL_SOLID_FAILED', 'Solid healing failed', e));
+  }
+}
+
+/**
+ * Attempt to heal/fix a face.
+ *
+ * Uses ShapeFix_Face to repair wire ordering, orientation, and geometry issues.
+ */
+export function healFace(face: Face): Result<Face> {
+  if (!isFace(face)) {
+    return err(validationError('NOT_A_FACE', 'Input shape is not a face'));
+  }
+
+  try {
+    const oc = getKernel().oc;
+    const fixer = new oc.ShapeFix_Face_2(face.wrapped);
+    fixer.Perform();
+    const result = fixer.Face();
+    fixer.delete();
+    const cast = castShape(result);
+    if (!isFace(cast)) {
+      return err(occtError('HEAL_RESULT_NOT_FACE', 'Healed result is not a face'));
+    }
+    return ok(cast);
+  } catch (e) {
+    return err(occtError('HEAL_FACE_FAILED', 'Face healing failed', e));
+  }
+}
+
+/**
+ * Attempt to heal/fix a wire.
+ *
+ * Uses ShapeFix_Wire to repair edge connectivity, gaps, and self-intersections.
+ * Requires a face for surface context; pass `undefined` to use a default planar context.
+ */
+export function healWire(wire: Wire, face?: Face): Result<Wire> {
+  if (!isWire(wire)) {
+    return err(validationError('NOT_A_WIRE', 'Input shape is not a wire'));
+  }
+
+  try {
+    const oc = getKernel().oc;
+    let fixer;
+    if (face) {
+      fixer = new oc.ShapeFix_Wire_2(
+        wire.wrapped,
+        face.wrapped,
+        1e-6 // default precision
+      );
+    } else {
+      fixer = new oc.ShapeFix_Wire_1();
+      fixer.Load_1(wire.wrapped);
+    }
+    fixer.Perform();
+    const result = fixer.Wire();
+    fixer.delete();
+    const cast = castShape(result);
+    if (!isWire(cast)) {
+      return err(occtError('HEAL_RESULT_NOT_WIRE', 'Healed result is not a wire'));
+    }
+    return ok(cast);
+  } catch (e) {
+    return err(occtError('HEAL_WIRE_FAILED', 'Wire healing failed', e));
+  }
+}
+
+/**
+ * Attempt to heal any shape by dispatching to the appropriate fixer.
+ *
+ * Supports solids, faces, and wires. For other shape types, returns the
+ * input unchanged.
+ */
+export function healShape<T extends AnyShape>(shape: T): Result<T> {
+  if (isSolid(shape)) {
+    return healSolid(shape) as Result<T>;
+  }
+  if (isFace(shape)) {
+    return healFace(shape) as Result<T>;
+  }
+  if (isWire(shape)) {
+    return healWire(shape) as Result<T>;
+  }
+  // For unsupported types, return the shape as-is
+  return ok(shape);
+}

--- a/tests/fn-healingFns.test.ts
+++ b/tests/fn-healingFns.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  makeSphere,
+  getEdges,
+  getFaces,
+  getWires,
+  isShapeValid,
+  healSolid,
+  healFace,
+  healWire,
+  healShape,
+  isOk,
+  unwrap,
+  fnMeasureVolume,
+  fnMeasureArea,
+  fnIsSolid,
+  fnIsFace,
+  fnIsWire,
+} from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('isShapeValid', () => {
+  it('returns true for a valid box', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    expect(isShapeValid(box)).toBe(true);
+  });
+
+  it('returns true for a valid sphere', () => {
+    const sphere = makeSphere(5);
+    expect(isShapeValid(sphere)).toBe(true);
+  });
+
+  it('returns true for a valid face', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    expect(isShapeValid(faces[0]!)).toBe(true);
+  });
+});
+
+describe('healSolid', () => {
+  it('heals a valid solid (no-op)', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = healSolid(box);
+    expect(isOk(result)).toBe(true);
+    const healed = unwrap(result);
+    expect(fnIsSolid(healed)).toBe(true);
+    // Volume should be preserved
+    const vol = fnMeasureVolume(healed);
+    expect(vol).toBeCloseTo(1000, 0);
+  });
+
+  it('heals a sphere solid', () => {
+    const sphere = makeSphere(5);
+    const result = healSolid(sphere);
+    // ShapeFix_Solid may or may not successfully heal a sphere
+    // (spheres have special topology), but it should not crash
+    if (isOk(result)) {
+      expect(fnIsSolid(unwrap(result))).toBe(true);
+    }
+  });
+});
+
+describe('healFace', () => {
+  it('heals a valid face (no-op)', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    const result = healFace(faces[0]!);
+    expect(isOk(result)).toBe(true);
+    const healed = unwrap(result);
+    expect(fnIsFace(healed)).toBe(true);
+  });
+
+  it('preserves face area', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    const originalArea = fnMeasureArea(faces[0]!);
+    const healed = unwrap(healFace(faces[0]!));
+    const healedArea = fnMeasureArea(healed);
+    expect(healedArea).toBeCloseTo(originalArea, 2);
+  });
+});
+
+describe('healWire', () => {
+  it('heals a valid wire (no-op)', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const wires = getWires(box);
+    const result = healWire(wires[0]!);
+    expect(isOk(result)).toBe(true);
+    expect(fnIsWire(unwrap(result))).toBe(true);
+  });
+
+  it('heals a wire with face context', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    const wires = getWires(faces[0]!);
+    const result = healWire(wires[0]!, faces[0]!);
+    expect(isOk(result)).toBe(true);
+    expect(fnIsWire(unwrap(result))).toBe(true);
+  });
+});
+
+describe('healShape', () => {
+  it('dispatches to healSolid for solids', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = healShape(box);
+    expect(isOk(result)).toBe(true);
+    expect(fnIsSolid(unwrap(result))).toBe(true);
+  });
+
+  it('dispatches to healFace for faces', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    const result = healShape(faces[0]!);
+    expect(isOk(result)).toBe(true);
+    expect(fnIsFace(unwrap(result))).toBe(true);
+  });
+
+  it('dispatches to healWire for wires', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const wires = getWires(box);
+    const result = healShape(wires[0]!);
+    expect(isOk(result)).toBe(true);
+    expect(fnIsWire(unwrap(result))).toBe(true);
+  });
+
+  it('returns ok for unsupported shape types (passthrough)', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    // An edge is neither solid, face, nor wire — should passthrough
+    const edges = getEdges(box);
+    const result = healShape(edges[0]!);
+    expect(isOk(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds standalone `Result`-returning functions for shape healing and validation
- `isShapeValid(shape)`: check shape validity via `BRepCheck_Analyzer`
- `healSolid(solid)`: repair solid topology using `ShapeFix_Solid`
- `healFace(face)`: repair face geometry using `ShapeFix_Face`
- `healWire(wire, face?)`: repair wire connectivity using `ShapeFix_Wire`
- `healShape(shape)`: auto-dispatch to appropriate healer based on shape type

## Test plan
- [x] `isShapeValid` — validates box, sphere, and individual faces
- [x] `healSolid` — heals valid box (preserves volume), handles sphere gracefully
- [x] `healFace` — heals valid face (preserves area)
- [x] `healWire` — heals wire with and without face context
- [x] `healShape` — dispatches to correct healer, passthrough for unsupported types
- [x] 13 new tests, 1050 total pass
- [x] Function coverage 83.1%
- [x] Typecheck, lint, check:boundaries, knip all pass