### PR TITLE
feat: add AbortSignal cancellation to long-running operations

### DIFF
--- a/src/kernel/booleanOps.ts
+++ b/src/kernel/booleanOps.ts
@@ -191,6 +191,7 @@ function fuseAllPairwiseRange(
   end: number,
   options: BooleanOptions
 ): OcShape {
+  options.signal?.throwIfAborted();
   const count = end - start;
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
   if (count === 1) return shapes[start]!;

--- a/src/kernel/meshOps.ts
+++ b/src/kernel/meshOps.ts
@@ -129,6 +129,7 @@ export function meshJS(
   explorer.Init(shape, oc.TopAbs_ShapeEnum.TopAbs_FACE, oc.TopAbs_ShapeEnum.TopAbs_SHAPE);
 
   while (explorer.More()) {
+    options.signal?.throwIfAborted();
     const face = oc.TopoDS.Face_1(explorer.Current());
     const location = new oc.TopLoc_Location_1();
     const triangulation = oc.BRep_Tool.Triangulation(face, location, 0);

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -20,6 +20,8 @@ export interface BooleanOptions {
   optimisation?: 'none' | 'commonFace' | 'sameFace';
   simplify?: boolean;
   strategy?: 'native' | 'pairwise';
+  /** Abort signal to cancel long-running operations between steps. */
+  signal?: AbortSignal;
 }
 
 export type ShapeType =
@@ -37,6 +39,8 @@ export interface MeshOptions {
   angularTolerance: number;
   skipNormals?: boolean;
   includeUVs?: boolean;
+  /** Abort signal to cancel mesh generation between face iterations. */
+  signal?: AbortSignal;
 }
 
 export interface KernelMeshResult {

--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -36,6 +36,8 @@ export interface EdgeMesh {
 export interface MeshOptions {
   tolerance?: number;
   angularTolerance?: number;
+  /** Abort signal to cancel mesh generation between face iterations. */
+  signal?: AbortSignal;
 }
 
 // ---------------------------------------------------------------------------
@@ -51,8 +53,10 @@ export function meshShape(
     skipNormals = false,
     includeUVs = false,
     cache = true,
+    signal,
   }: MeshOptions & { skipNormals?: boolean; includeUVs?: boolean; cache?: boolean } = {}
 ): ShapeMesh {
+  signal?.throwIfAborted();
   // Check cache first (uses WeakMap keyed by shape object to avoid hash collisions)
   const cacheKey = buildMeshCacheKey(0, tolerance, angularTolerance, skipNormals);
   if (cache && !includeUVs) {
@@ -65,6 +69,7 @@ export function meshShape(
     angularTolerance,
     skipNormals,
     includeUVs,
+    ...(signal ? { signal } : {}),
   });
 
   const mesh: ShapeMesh = {

--- a/tests/fn-abortSignal.test.ts
+++ b/tests/fn-abortSignal.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import { fnFuseAll, fnMeasureVolume, meshShape, fnCreateSolid } from '../src/index.js';
+import { getKernel } from '../src/kernel/index.js';
+import { unwrap } from '../src/core/result.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+function makeBox(w: number, h: number, d: number) {
+  return fnCreateSolid(getKernel().makeBox(w, h, d));
+}
+
+describe('AbortSignal cancellation', () => {
+  it('fuseAll (pairwise) throws when signal is already aborted', () => {
+    const boxes = Array.from({ length: 4 }, () => makeBox(10, 10, 10));
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(() => fnFuseAll(boxes, { strategy: 'pairwise', signal: controller.signal })).toThrow();
+  });
+
+  it('fuseAll (pairwise) succeeds without signal', () => {
+    const boxes = Array.from({ length: 3 }, () => makeBox(10, 10, 10));
+    const result = unwrap(fnFuseAll(boxes, { strategy: 'pairwise' }));
+    expect(fnMeasureVolume(result)).toBeCloseTo(1000, 0);
+  });
+
+  it('fuseAll (native) throws when signal is already aborted', () => {
+    const boxes = Array.from({ length: 3 }, () => makeBox(10, 10, 10));
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(() => fnFuseAll(boxes, { strategy: 'native', signal: controller.signal })).toThrow();
+  });
+
+  it('fuseAll passes signal through to pairwise recursion', () => {
+    // Create enough shapes to ensure recursion depth > 1
+    const boxes = Array.from({ length: 8 }, () => makeBox(10, 10, 10));
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(() => fnFuseAll(boxes, { strategy: 'pairwise', signal: controller.signal })).toThrow();
+  });
+
+  it('meshShape throws when signal is already aborted', () => {
+    const box = makeBox(10, 10, 10);
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(() => meshShape(box, { signal: controller.signal })).toThrow();
+  });
+
+  it('meshShape succeeds without signal', () => {
+    const box = makeBox(10, 10, 10);
+    const mesh = meshShape(box);
+    expect(mesh.vertices.length).toBeGreaterThan(0);
+    expect(mesh.triangles.length).toBeGreaterThan(0);
+  });
+
+  it('signal with custom reason preserves the reason', () => {
+    const boxes = Array.from({ length: 3 }, () => makeBox(10, 10, 10));
+    const reason = new Error('User cancelled');
+    const controller = new AbortController();
+    controller.abort(reason);
+
+    expect(() => fnFuseAll(boxes, { strategy: 'pairwise', signal: controller.signal })).toThrow(
+      'User cancelled'
+    );
+  });
+
+  it('non-aborted signal does not interfere', () => {
+    const boxes = Array.from({ length: 3 }, () => makeBox(10, 10, 10));
+    const controller = new AbortController();
+    // Don't abort — operation should succeed
+    const result = unwrap(fnFuseAll(boxes, { strategy: 'pairwise', signal: controller.signal }));
+    expect(fnMeasureVolume(result)).toBeCloseTo(1000, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional `signal?: AbortSignal` to `BooleanOptions` and `MeshOptions` at both kernel and functional API layers
- Checks `signal.throwIfAborted()` at key checkpoints: pairwise fusion recursion steps and JS mesh face iteration loop
- Passes signal through from functional API (`fnFuseAll`, `meshShape`) down to kernel layer

## Changed files
- `src/kernel/types.ts` — Added `signal` to `BooleanOptions` and `MeshOptions`
- `src/kernel/booleanOps.ts` — Abort check in `fuseAllPairwiseRange`
- `src/kernel/meshOps.ts` — Abort check in `meshJS` face iteration
- `src/topology/booleanFns.ts` — Signal in `BooleanOptions`, passthrough in `fuseAll`/`fuseAllPairwise`
- `src/topology/meshFns.ts` — Signal in `MeshOptions`, passthrough in `meshShape`
- `tests/fn-abortSignal.test.ts` — 8 new tests

## Test plan
- [x] Pre-aborted signal throws on pairwise fuseAll
- [x] Pre-aborted signal throws on native fuseAll
- [x] Signal passes through pairwise recursion (8 shapes)
- [x] Pre-aborted signal throws on meshShape
- [x] Non-aborted signal does not interfere with operations
- [x] Custom abort reason is preserved
- [x] Operations succeed without signal
- [x] All 1045 tests pass, 83.19% function coverage