### PR TITLE
feat: add parametric history module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -621,6 +621,19 @@ export {
   type AssemblyNodeOptions,
 } from './operations/assemblyFns.js';
 
+export {
+  createHistory,
+  addStep,
+  undoLast,
+  findStep,
+  getShape as getHistoryShape,
+  stepCount,
+  stepsFrom,
+  registerShape,
+  type OperationStep,
+  type ModelHistory,
+} from './operations/historyFns.js';
+
 // ── Measurement (functional) ──
 
 export {

--- a/src/operations/historyFns.ts
+++ b/src/operations/historyFns.ts
@@ -1,0 +1,99 @@
+/**
+ * Parametric history — immutable operation log for shape construction.
+ *
+ * Records a sequence of operation steps. Each step captures the operation
+ * type, parameters, and references to input/output shapes by ID. The
+ * history is a pure data structure with no OCCT dependency.
+ */
+
+import type { AnyShape } from '../core/shapeTypes.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OperationStep {
+  readonly id: string;
+  readonly type: string; // e.g. 'extrude', 'fuse', 'fillet', etc.
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly inputIds: ReadonlyArray<string>;
+  readonly outputId: string;
+  readonly timestamp: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface ModelHistory {
+  readonly steps: ReadonlyArray<OperationStep>;
+  readonly shapes: ReadonlyMap<string, AnyShape>;
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+/** Create a new empty history. */
+export function createHistory(): ModelHistory {
+  return { steps: [], shapes: new Map() };
+}
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+/** Add a step and its output shape. Returns a new history. */
+export function addStep(
+  history: ModelHistory,
+  step: Omit<OperationStep, 'timestamp'>,
+  outputShape: AnyShape
+): ModelHistory {
+  const fullStep: OperationStep = { ...step, timestamp: Date.now() };
+  const shapes = new Map(history.shapes);
+  shapes.set(step.outputId, outputShape);
+  return { steps: [...history.steps, fullStep], shapes };
+}
+
+/** Remove the last step and clean up orphaned shapes. Returns a new history. */
+export function undoLast(history: ModelHistory): ModelHistory {
+  if (history.steps.length === 0) return history;
+  const steps = history.steps.slice(0, -1);
+  // Rebuild shapes map from remaining steps
+  const usedIds = new Set<string>();
+  for (const s of steps) {
+    usedIds.add(s.outputId);
+    for (const id of s.inputIds) usedIds.add(id);
+  }
+  const shapes = new Map<string, AnyShape>();
+  for (const [id, shape] of history.shapes) {
+    if (usedIds.has(id)) shapes.set(id, shape);
+  }
+  return { steps, shapes };
+}
+
+/** Find a step by its ID. */
+export function findStep(history: ModelHistory, stepId: string): OperationStep | undefined {
+  return history.steps.find((s) => s.id === stepId);
+}
+
+/** Retrieve a shape by its ID. */
+export function getShape(history: ModelHistory, shapeId: string): AnyShape | undefined {
+  return history.shapes.get(shapeId);
+}
+
+/** Return the number of steps in the history. */
+export function stepCount(history: ModelHistory): number {
+  return history.steps.length;
+}
+
+/** Return all steps from a given step ID onwards (inclusive). */
+export function stepsFrom(history: ModelHistory, stepId: string): ReadonlyArray<OperationStep> {
+  const idx = history.steps.findIndex((s) => s.id === stepId);
+  if (idx === -1) return [];
+  return history.steps.slice(idx);
+}
+
+/** Register an initial shape without an operation step. Returns a new history. */
+export function registerShape(history: ModelHistory, id: string, shape: AnyShape): ModelHistory {
+  const shapes = new Map(history.shapes);
+  shapes.set(id, shape);
+  return { ...history, shapes };
+}

--- a/tests/fn-historyFns.test.ts
+++ b/tests/fn-historyFns.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  makeCylinder,
+  castShape,
+  createHistory,
+  addStep,
+  undoLast,
+  findStep,
+  getHistoryShape,
+  stepCount,
+  stepsFrom,
+  registerShape,
+} from '../src/index.js';
+import type { Shape3D, ModelHistory } from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+function box(): Shape3D {
+  return castShape(makeBox([0, 0, 0], [10, 10, 10]).wrapped) as Shape3D;
+}
+
+function cyl(): Shape3D {
+  return castShape(makeCylinder(5, 20).wrapped) as Shape3D;
+}
+
+describe('createHistory', () => {
+  it('returns empty history', () => {
+    const h = createHistory();
+    expect(h.steps).toHaveLength(0);
+    expect(h.shapes.size).toBe(0);
+  });
+});
+
+describe('addStep', () => {
+  it('adds a step and stores the shape', () => {
+    const shape = box();
+    const h = addStep(
+      createHistory(),
+      {
+        id: 's1',
+        type: 'extrude',
+        parameters: { height: 10 },
+        inputIds: [],
+        outputId: 'shape-1',
+      },
+      shape
+    );
+    expect(h.steps).toHaveLength(1);
+    expect(h.steps[0]?.id).toBe('s1');
+    expect(h.steps[0]?.type).toBe('extrude');
+    expect(h.steps[0]?.parameters).toEqual({ height: 10 });
+    expect(h.steps[0]?.outputId).toBe('shape-1');
+    expect(h.steps[0]?.timestamp).toBeGreaterThan(0);
+    expect(h.shapes.get('shape-1')).toBe(shape);
+  });
+});
+
+describe('undoLast', () => {
+  it('removes last step and cleans up orphaned shapes', () => {
+    const shape1 = box();
+    const shape2 = cyl();
+    let h: ModelHistory = createHistory();
+    h = registerShape(h, 'base', shape1);
+    h = addStep(
+      h,
+      {
+        id: 's1',
+        type: 'extrude',
+        parameters: {},
+        inputIds: ['base'],
+        outputId: 'out-1',
+      },
+      shape1
+    );
+    h = addStep(
+      h,
+      {
+        id: 's2',
+        type: 'fuse',
+        parameters: {},
+        inputIds: ['out-1'],
+        outputId: 'out-2',
+      },
+      shape2
+    );
+
+    const undone = undoLast(h);
+    expect(undone.steps).toHaveLength(1);
+    // out-1 is still referenced by step s1, so it stays
+    expect(undone.shapes.has('out-1')).toBe(true);
+    // base is still referenced by step s1 inputIds
+    expect(undone.shapes.has('base')).toBe(true);
+    // out-2 is no longer referenced
+    expect(undone.shapes.has('out-2')).toBe(false);
+  });
+
+  it('returns same history when empty', () => {
+    const h = createHistory();
+    expect(undoLast(h)).toBe(h);
+  });
+});
+
+describe('findStep', () => {
+  it('finds existing step by ID', () => {
+    const shape = box();
+    const h = addStep(
+      createHistory(),
+      {
+        id: 'find-me',
+        type: 'box',
+        parameters: { w: 10 },
+        inputIds: [],
+        outputId: 'o1',
+      },
+      shape
+    );
+    const step = findStep(h, 'find-me');
+    expect(step).toBeDefined();
+    expect(step?.type).toBe('box');
+  });
+
+  it('returns undefined for missing ID', () => {
+    const h = createHistory();
+    expect(findStep(h, 'nope')).toBeUndefined();
+  });
+});
+
+describe('getHistoryShape', () => {
+  it('retrieves shape by ID', () => {
+    const shape = box();
+    const h = addStep(
+      createHistory(),
+      {
+        id: 's1',
+        type: 'box',
+        parameters: {},
+        inputIds: [],
+        outputId: 'my-shape',
+      },
+      shape
+    );
+    expect(getHistoryShape(h, 'my-shape')).toBe(shape);
+  });
+
+  it('returns undefined for missing ID', () => {
+    const h = createHistory();
+    expect(getHistoryShape(h, 'missing')).toBeUndefined();
+  });
+});
+
+describe('stepCount', () => {
+  it('returns correct count', () => {
+    const shape = box();
+    let h: ModelHistory = createHistory();
+    expect(stepCount(h)).toBe(0);
+    h = addStep(h, { id: 's1', type: 'a', parameters: {}, inputIds: [], outputId: 'o1' }, shape);
+    expect(stepCount(h)).toBe(1);
+    h = addStep(h, { id: 's2', type: 'b', parameters: {}, inputIds: [], outputId: 'o2' }, shape);
+    expect(stepCount(h)).toBe(2);
+  });
+});
+
+describe('stepsFrom', () => {
+  it('returns steps from given ID onwards', () => {
+    const shape = box();
+    let h: ModelHistory = createHistory();
+    h = addStep(h, { id: 's1', type: 'a', parameters: {}, inputIds: [], outputId: 'o1' }, shape);
+    h = addStep(h, { id: 's2', type: 'b', parameters: {}, inputIds: [], outputId: 'o2' }, shape);
+    h = addStep(h, { id: 's3', type: 'c', parameters: {}, inputIds: [], outputId: 'o3' }, shape);
+
+    const from = stepsFrom(h, 's2');
+    expect(from).toHaveLength(2);
+    expect(from[0]?.id).toBe('s2');
+    expect(from[1]?.id).toBe('s3');
+  });
+
+  it('returns empty array for missing ID', () => {
+    const h = createHistory();
+    expect(stepsFrom(h, 'nope')).toHaveLength(0);
+  });
+});
+
+describe('registerShape', () => {
+  it('adds initial shape without a step', () => {
+    const shape = box();
+    const h = registerShape(createHistory(), 'initial', shape);
+    expect(h.shapes.get('initial')).toBe(shape);
+    expect(h.steps).toHaveLength(0);
+  });
+});
+
+describe('multiple operations', () => {
+  it('builds up correctly with 3 steps', () => {
+    const s1 = box();
+    const s2 = cyl();
+    const s3 = box();
+    let h: ModelHistory = createHistory();
+    h = addStep(
+      h,
+      { id: 'a', type: 'box', parameters: { w: 10 }, inputIds: [], outputId: 'o-a' },
+      s1
+    );
+    h = addStep(
+      h,
+      { id: 'b', type: 'cyl', parameters: { r: 5 }, inputIds: ['o-a'], outputId: 'o-b' },
+      s2
+    );
+    h = addStep(
+      h,
+      { id: 'c', type: 'fuse', parameters: {}, inputIds: ['o-a', 'o-b'], outputId: 'o-c' },
+      s3
+    );
+
+    expect(stepCount(h)).toBe(3);
+    expect(h.shapes.size).toBe(3);
+    expect(getHistoryShape(h, 'o-a')).toBe(s1);
+    expect(getHistoryShape(h, 'o-b')).toBe(s2);
+    expect(getHistoryShape(h, 'o-c')).toBe(s3);
+  });
+});
+
+describe('immutability', () => {
+  it('original history is unchanged after addStep', () => {
+    const shape = box();
+    const original = createHistory();
+    const updated = addStep(
+      original,
+      {
+        id: 's1',
+        type: 'box',
+        parameters: {},
+        inputIds: [],
+        outputId: 'o1',
+      },
+      shape
+    );
+    expect(original.steps).toHaveLength(0);
+    expect(original.shapes.size).toBe(0);
+    expect(updated.steps).toHaveLength(1);
+  });
+
+  it('original history is unchanged after undoLast', () => {
+    const shape = box();
+    const h = addStep(
+      createHistory(),
+      {
+        id: 's1',
+        type: 'box',
+        parameters: {},
+        inputIds: [],
+        outputId: 'o1',
+      },
+      shape
+    );
+    const undone = undoLast(h);
+    expect(h.steps).toHaveLength(1);
+    expect(h.shapes.size).toBe(1);
+    expect(undone.steps).toHaveLength(0);
+  });
+
+  it('original history is unchanged after registerShape', () => {
+    const shape = box();
+    const original = createHistory();
+    const updated = registerShape(original, 'init', shape);
+    expect(original.shapes.size).toBe(0);
+    expect(updated.shapes.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- New `operations/historyFns.ts` module for tracking shape operation history
- Immutable data structure following the same pattern as `assemblyFns.ts`
- Records operation steps with type, parameters, and shape references
- Supports undo, find, replay (stepsFrom), and shape registration

## Test plan
- [x] Unit tests for all functions (create, add, undo, find, getShape, stepCount, stepsFrom, registerShape)
- [x] Immutability verification
- [x] TypeScript strict mode compliance
- [x] Boundary check passes
- [x] Knip (no unused exports)