### PR TITLE
feat: add web worker protocol and helpers

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,7 +1,7 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/worker.ts'],
   project: ['src/**/*.ts'],
   ignore: ['src/**/*.test.ts'],
   ignoreDependencies: ['brepjs-opencascade'],

--- a/package.json
+++ b/package.json
@@ -59,6 +59,16 @@
         "types": "./dist/measurement.d.ts",
         "default": "./dist/measurement.cjs"
       }
+    },
+    "./worker": {
+      "import": {
+        "types": "./dist/worker.d.ts",
+        "default": "./dist/worker.js"
+      },
+      "require": {
+        "types": "./dist/worker.d.ts",
+        "default": "./dist/worker.cjs"
+      }
     }
   },
   "files": [

--- a/scripts/check-layer-boundaries.sh
+++ b/scripts/check-layer-boundaries.sh
@@ -25,7 +25,7 @@ get_layer() {
   case "$dir" in
     kernel|utils) echo 0 ;;
     core) echo 1 ;;
-    topology|2d|operations|query|measurement|io) echo 2 ;;
+    topology|2d|operations|query|measurement|io|worker) echo 2 ;;
     sketching|text|projection) echo 3 ;;
     *) echo -1 ;;
   esac

--- a/src/index.ts
+++ b/src/index.ts
@@ -668,3 +668,28 @@ export {
   projectEdges,
   type Camera,
 } from './projection/cameraFns.js';
+
+// ── Worker protocol ──
+
+export {
+  type WorkerRequest,
+  type InitRequest,
+  type OperationRequest,
+  type DisposeRequest,
+  type WorkerResponse,
+  type SuccessResponse,
+  type ErrorResponse,
+  isInitRequest,
+  isOperationRequest,
+  isDisposeRequest,
+  isSuccessResponse,
+  isErrorResponse,
+  type PendingTask,
+  type TaskQueue,
+  createTaskQueue,
+  enqueueTask,
+  dequeueTask,
+  pendingCount,
+  isQueueEmpty,
+  rejectAll,
+} from './worker/index.js';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,4 @@
+/**
+ * brepjs/worker -- Worker protocol and helpers.
+ */
+export * from './worker/index.js';

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Worker offloading utilities for brepjs.
+ *
+ * Provides protocol types and helpers for running CAD operations
+ * in Web Workers. Shapes are serialized as BREP strings for transfer.
+ */
+
+export {
+  type WorkerRequest,
+  type InitRequest,
+  type OperationRequest,
+  type DisposeRequest,
+  type WorkerResponse,
+  type SuccessResponse,
+  type ErrorResponse,
+  isInitRequest,
+  isOperationRequest,
+  isDisposeRequest,
+  isSuccessResponse,
+  isErrorResponse,
+} from './protocol.js';
+
+export {
+  type PendingTask,
+  type TaskQueue,
+  createTaskQueue,
+  enqueueTask,
+  dequeueTask,
+  pendingCount,
+  isEmpty as isQueueEmpty,
+  rejectAll,
+} from './taskQueue.js';

--- a/src/worker/protocol.ts
+++ b/src/worker/protocol.ts
@@ -1,0 +1,71 @@
+/**
+ * Worker communication protocol for offloading CAD operations.
+ *
+ * Messages are sent between the main thread and worker threads.
+ * Shapes are transferred as BREP-serialized strings.
+ */
+
+// ---------------------------------------------------------------------------
+// Message types
+// ---------------------------------------------------------------------------
+
+export interface WorkerRequest {
+  readonly id: string;
+  readonly type: 'init' | 'operation' | 'dispose';
+}
+
+export interface InitRequest extends WorkerRequest {
+  readonly type: 'init';
+  readonly wasmUrl?: string;
+}
+
+export interface OperationRequest extends WorkerRequest {
+  readonly type: 'operation';
+  readonly operation: string;
+  readonly shapesBrep: ReadonlyArray<string>;
+  readonly parameters: Readonly<Record<string, unknown>>;
+}
+
+export interface DisposeRequest extends WorkerRequest {
+  readonly type: 'dispose';
+}
+
+export interface WorkerResponse {
+  readonly id: string;
+  readonly success: boolean;
+}
+
+export interface SuccessResponse extends WorkerResponse {
+  readonly success: true;
+  readonly resultBrep?: string;
+  readonly resultData?: unknown;
+}
+
+export interface ErrorResponse extends WorkerResponse {
+  readonly success: false;
+  readonly error: string;
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isInitRequest(msg: WorkerRequest): msg is InitRequest {
+  return msg.type === 'init';
+}
+
+export function isOperationRequest(msg: WorkerRequest): msg is OperationRequest {
+  return msg.type === 'operation';
+}
+
+export function isDisposeRequest(msg: WorkerRequest): msg is DisposeRequest {
+  return msg.type === 'dispose';
+}
+
+export function isSuccessResponse(msg: WorkerResponse): msg is SuccessResponse {
+  return msg.success;
+}
+
+export function isErrorResponse(msg: WorkerResponse): msg is ErrorResponse {
+  return !msg.success;
+}

--- a/src/worker/taskQueue.ts
+++ b/src/worker/taskQueue.ts
@@ -1,0 +1,57 @@
+/**
+ * Task queue for managing pending worker operations.
+ * Pure data structure -- no Worker API dependency.
+ */
+
+export interface PendingTask<T = unknown> {
+  readonly id: string;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason: unknown) => void;
+  readonly createdAt: number;
+}
+
+export interface TaskQueue<T = unknown> {
+  readonly pending: ReadonlyMap<string, PendingTask<T>>;
+}
+
+/** Create an empty task queue. */
+export function createTaskQueue<T = unknown>(): TaskQueue<T> {
+  return { pending: new Map() };
+}
+
+/** Add a task to the queue. Returns the updated queue. */
+export function enqueueTask<T>(queue: TaskQueue<T>, task: PendingTask<T>): TaskQueue<T> {
+  const pending = new Map(queue.pending);
+  pending.set(task.id, task);
+  return { pending };
+}
+
+/** Remove and return a task from the queue. */
+export function dequeueTask<T>(
+  queue: TaskQueue<T>,
+  taskId: string
+): { queue: TaskQueue<T>; task: PendingTask<T> | undefined } {
+  const task = queue.pending.get(taskId);
+  if (!task) return { queue, task: undefined };
+  const pending = new Map(queue.pending);
+  pending.delete(taskId);
+  return { queue: { pending }, task };
+}
+
+/** Get the number of pending tasks. */
+export function pendingCount<T>(queue: TaskQueue<T>): number {
+  return queue.pending.size;
+}
+
+/** Check if the queue has no pending tasks. */
+export function isEmpty<T>(queue: TaskQueue<T>): boolean {
+  return queue.pending.size === 0;
+}
+
+/** Reject all pending tasks with the given reason. */
+export function rejectAll<T>(queue: TaskQueue<T>, reason: unknown): TaskQueue<T> {
+  for (const task of queue.pending.values()) {
+    task.reject(reason);
+  }
+  return { pending: new Map() };
+}

--- a/tests/fn-workerProtocol.test.ts
+++ b/tests/fn-workerProtocol.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isInitRequest,
+  isOperationRequest,
+  isDisposeRequest,
+  isSuccessResponse,
+  isErrorResponse,
+  createTaskQueue,
+  enqueueTask,
+  dequeueTask,
+  pendingCount,
+  isQueueEmpty,
+  rejectAll,
+} from '../src/worker/index.js';
+import type {
+  InitRequest,
+  OperationRequest,
+  DisposeRequest,
+  SuccessResponse,
+  ErrorResponse,
+} from '../src/worker/index.js';
+
+describe('protocol type guards', () => {
+  it('identifies init request', () => {
+    const msg: InitRequest = { id: '1', type: 'init' };
+    expect(isInitRequest(msg)).toBe(true);
+    expect(isOperationRequest(msg)).toBe(false);
+    expect(isDisposeRequest(msg)).toBe(false);
+  });
+
+  it('identifies operation request', () => {
+    const msg: OperationRequest = {
+      id: '2',
+      type: 'operation',
+      operation: 'fuse',
+      shapesBrep: ['brep1', 'brep2'],
+      parameters: {},
+    };
+    expect(isOperationRequest(msg)).toBe(true);
+    expect(isInitRequest(msg)).toBe(false);
+  });
+
+  it('identifies dispose request', () => {
+    const msg: DisposeRequest = { id: '3', type: 'dispose' };
+    expect(isDisposeRequest(msg)).toBe(true);
+  });
+
+  it('identifies success response', () => {
+    const msg: SuccessResponse = { id: '1', success: true, resultBrep: 'data' };
+    expect(isSuccessResponse(msg)).toBe(true);
+    expect(isErrorResponse(msg)).toBe(false);
+  });
+
+  it('identifies error response', () => {
+    const msg: ErrorResponse = { id: '1', success: false, error: 'fail' };
+    expect(isErrorResponse(msg)).toBe(true);
+    expect(isSuccessResponse(msg)).toBe(false);
+  });
+});
+
+describe('task queue', () => {
+  it('creates empty queue', () => {
+    const q = createTaskQueue();
+    expect(pendingCount(q)).toBe(0);
+    expect(isQueueEmpty(q)).toBe(true);
+  });
+
+  it('enqueues and dequeues a task', () => {
+    let resolved = false;
+    const task = {
+      id: 'task-1',
+      resolve: () => {
+        resolved = true;
+      },
+      reject: () => {},
+      createdAt: Date.now(),
+    };
+    const q1 = enqueueTask(createTaskQueue(), task);
+    expect(pendingCount(q1)).toBe(1);
+    expect(isQueueEmpty(q1)).toBe(false);
+
+    const { queue: q2, task: found } = dequeueTask(q1, 'task-1');
+    expect(found).toBeDefined();
+    expect(found?.id).toBe('task-1');
+    expect(pendingCount(q2)).toBe(0);
+
+    found?.resolve(undefined);
+    expect(resolved).toBe(true);
+  });
+
+  it('dequeue returns undefined for missing task', () => {
+    const q = createTaskQueue();
+    const { queue, task } = dequeueTask(q, 'nonexistent');
+    expect(task).toBeUndefined();
+    expect(queue).toBe(q);
+  });
+
+  it('rejectAll rejects all pending tasks', () => {
+    const errors: unknown[] = [];
+    const t1 = { id: '1', resolve: () => {}, reject: (e: unknown) => errors.push(e), createdAt: 0 };
+    const t2 = { id: '2', resolve: () => {}, reject: (e: unknown) => errors.push(e), createdAt: 0 };
+
+    let q = createTaskQueue();
+    q = enqueueTask(q, t1);
+    q = enqueueTask(q, t2);
+
+    const q2 = rejectAll(q, 'terminated');
+    expect(isQueueEmpty(q2)).toBe(true);
+    expect(errors).toEqual(['terminated', 'terminated']);
+  });
+
+  it('queue is immutable', () => {
+    const q1 = createTaskQueue();
+    const task = { id: '1', resolve: () => {}, reject: () => {}, createdAt: 0 };
+    const q2 = enqueueTask(q1, task);
+    expect(pendingCount(q1)).toBe(0);
+    expect(pendingCount(q2)).toBe(1);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         core: resolve(__dirname, 'src/core.ts'),
         query: resolve(__dirname, 'src/query.ts'),
         measurement: resolve(__dirname, 'src/measurement.ts'),
+        worker: resolve(__dirname, 'src/worker.ts'),
       },
       formats: ['es', 'cjs'],
     },


### PR DESCRIPTION
## Summary
- New `worker/` module with typed message protocol for worker communication
- Task queue for managing pending async operations
- Subpath export at `brepjs/worker` for tree-shaking
- Protocol supports init, operation dispatch, and dispose lifecycle
- Shapes transferred as BREP-serialized strings (using existing serializeShape/deserializeShape)

## Test plan
- [x] Protocol type guard tests (5 tests)
- [x] Task queue CRUD tests (5 tests)
- [x] Immutability verification
- [x] TypeScript strict mode compliance
- [x] Boundary check passes
- [x] Knip (no unused exports)