### PR TITLE
feat: add slicing, measurement aliases, topo caching, AbortSignal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -568,6 +568,7 @@ export {
   intersectShapes,
   sectionShape,
   splitShape,
+  sliceShape,
   fuseAll as fnFuseAll,
   cutAll as fnCutAll,
   buildCompound as fnBuildCompound,
@@ -649,6 +650,9 @@ export {
   measureSurfaceProps,
   measureLinearProps,
   type PhysicalProps,
+  type VolumeProps,
+  type SurfaceProps,
+  type LinearProps,
 } from './measurement/measureFns.js';
 
 export {

--- a/src/measurement/measureFns.ts
+++ b/src/measurement/measureFns.ts
@@ -17,44 +17,65 @@ export interface PhysicalProps {
   readonly centerOfMass: Vec3;
 }
 
+/** Volume properties with a domain-specific `volume` alias. */
+export interface VolumeProps extends PhysicalProps {
+  readonly volume: number;
+}
+
+/** Surface properties with a domain-specific `area` alias. */
+export interface SurfaceProps extends PhysicalProps {
+  readonly area: number;
+}
+
+/** Linear properties with a domain-specific `length` alias. */
+export interface LinearProps extends PhysicalProps {
+  readonly length: number;
+}
+
 /** Measure volume properties of a 3D shape. */
-export function measureVolumeProps(shape: Shape3D): PhysicalProps {
+export function measureVolumeProps(shape: Shape3D): VolumeProps {
   const oc = getKernel().oc;
   const r = gcWithScope();
 
   const props = r(new oc.GProp_GProps_1());
   oc.BRepGProp.VolumeProperties_1(shape.wrapped, props, false, false, false);
   const pnt = r(props.CentreOfMass());
+  const m = props.Mass();
   return {
-    mass: props.Mass(),
+    mass: m,
+    volume: m,
     centerOfMass: [pnt.X(), pnt.Y(), pnt.Z()],
   };
 }
 
 /** Measure surface properties of a face or 3D shape. */
-export function measureSurfaceProps(shape: Face | Shape3D): PhysicalProps {
+export function measureSurfaceProps(shape: Face | Shape3D): SurfaceProps {
   const oc = getKernel().oc;
   const r = gcWithScope();
 
   const props = r(new oc.GProp_GProps_1());
   oc.BRepGProp.SurfaceProperties_1(shape.wrapped, props, false, false);
   const pnt = r(props.CentreOfMass());
+  const m = props.Mass();
   return {
-    mass: props.Mass(),
+    mass: m,
+    area: m,
     centerOfMass: [pnt.X(), pnt.Y(), pnt.Z()],
   };
 }
 
 /** Measure linear properties of any shape. */
-export function measureLinearProps(shape: AnyShape): PhysicalProps {
+export function measureLinearProps(shape: AnyShape): LinearProps {
   const oc = getKernel().oc;
   const r = gcWithScope();
 
   const props = r(new oc.GProp_GProps_1());
   oc.BRepGProp.LinearProperties(shape.wrapped, props, false, false);
   const pnt = r(props.CentreOfMass());
+  const m = props.Mass();
   return {
-    mass: props.Mass(),
+    mass: m,
+    length: m,
     centerOfMass: [pnt.X(), pnt.Y(), pnt.Z()],
   };
 }

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -135,28 +135,51 @@ export function scaleShape<T extends AnyShape>(
 }
 
 // ---------------------------------------------------------------------------
-// Topology queries
+// Topology queries (with lazy caching)
 // ---------------------------------------------------------------------------
 
-/** Get all edges of a shape as branded Edge handles. */
+const topoCache = new WeakMap<object, { edges?: Edge[]; faces?: Face[]; wires?: Wire[] }>();
+
+function getOrCreateCache(shape: AnyShape): { edges?: Edge[]; faces?: Face[]; wires?: Wire[] } {
+  let entry = topoCache.get(shape.wrapped);
+  if (!entry) {
+    entry = {};
+    topoCache.set(shape.wrapped, entry);
+  }
+  return entry;
+}
+
+/** Get all edges of a shape as branded Edge handles. Results are cached per shape. */
 export function getEdges(shape: AnyShape): Edge[] {
-  return Array.from(iterTopo(shape.wrapped, 'edge')).map(
+  const cache = getOrCreateCache(shape);
+  if (cache.edges) return cache.edges;
+  const edges = Array.from(iterTopo(shape.wrapped, 'edge')).map(
     (e) => castShape(unwrap(downcast(e))) as Edge
   );
+  cache.edges = edges;
+  return edges;
 }
 
-/** Get all faces of a shape as branded Face handles. */
+/** Get all faces of a shape as branded Face handles. Results are cached per shape. */
 export function getFaces(shape: AnyShape): Face[] {
-  return Array.from(iterTopo(shape.wrapped, 'face')).map(
+  const cache = getOrCreateCache(shape);
+  if (cache.faces) return cache.faces;
+  const faces = Array.from(iterTopo(shape.wrapped, 'face')).map(
     (e) => castShape(unwrap(downcast(e))) as Face
   );
+  cache.faces = faces;
+  return faces;
 }
 
-/** Get all wires of a shape as branded Wire handles. */
+/** Get all wires of a shape as branded Wire handles. Results are cached per shape. */
 export function getWires(shape: AnyShape): Wire[] {
-  return Array.from(iterTopo(shape.wrapped, 'wire')).map(
+  const cache = getOrCreateCache(shape);
+  if (cache.wires) return cache.wires;
+  const wires = Array.from(iterTopo(shape.wrapped, 'wire')).map(
     (e) => castShape(unwrap(downcast(e))) as Wire
   );
+  cache.wires = wires;
+  return wires;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/fn-functionalApi.test.ts
+++ b/tests/fn-functionalApi.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  makeLine,
+  sketchRectangle,
+  sliceShape,
+  measureVolumeProps,
+  measureSurfaceProps,
+  measureLinearProps,
+  getEdges,
+  getFaces,
+  getWires,
+  fuseShapes,
+  isOk,
+  unwrap,
+  castShape,
+  createPlane,
+} from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('sliceShape', () => {
+  it('slices a box with multiple XY planes at different Z heights', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const planes = [
+      createPlane([0, 0, 3], null, [0, 0, 1]),
+      createPlane([0, 0, 5], null, [0, 0, 1]),
+      createPlane([0, 0, 7], null, [0, 0, 1]),
+    ];
+    const result = sliceShape(box, planes);
+    expect(isOk(result)).toBe(true);
+    const sections = unwrap(result);
+    expect(sections).toHaveLength(3);
+  });
+
+  it('returns ok for empty planes array', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = sliceShape(box, []);
+    expect(isOk(result)).toBe(true);
+    expect(unwrap(result)).toHaveLength(0);
+  });
+});
+
+describe('VolumeProps / SurfaceProps / LinearProps aliases', () => {
+  it('measureVolumeProps returns volume alias', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const props = measureVolumeProps(castShape(box.wrapped));
+    expect(props.volume).toBeCloseTo(1000, 0);
+    expect(props.volume).toBe(props.mass);
+  });
+
+  it('measureSurfaceProps returns area alias', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const props = measureSurfaceProps(castShape(box.wrapped));
+    expect(props.area).toBeCloseTo(600, 0);
+    expect(props.area).toBe(props.mass);
+  });
+
+  it('measureLinearProps returns length alias', () => {
+    const line = makeLine([0, 0, 0], [10, 0, 0]);
+    const props = measureLinearProps(castShape(line.wrapped));
+    expect(props.length).toBeCloseTo(10, 2);
+    expect(props.length).toBe(props.mass);
+  });
+});
+
+describe('topo caching', () => {
+  it('getEdges returns same array reference on second call', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const edges1 = getEdges(box);
+    const edges2 = getEdges(box);
+    expect(edges1).toBe(edges2);
+    expect(edges1.length).toBe(12);
+  });
+
+  it('getFaces returns same array reference on second call', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces1 = getFaces(box);
+    const faces2 = getFaces(box);
+    expect(faces1).toBe(faces2);
+    expect(faces1.length).toBe(6);
+  });
+
+  it('getWires returns same array reference on second call', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const wires1 = getWires(box);
+    const wires2 = getWires(box);
+    expect(wires1).toBe(wires2);
+  });
+
+  it('different shapes have independent caches', () => {
+    const box1 = makeBox([0, 0, 0], [10, 10, 10]);
+    const box2 = makeBox([0, 0, 0], [5, 5, 5]);
+    const edges1 = getEdges(box1);
+    const edges2 = getEdges(box2);
+    expect(edges1).not.toBe(edges2);
+  });
+});
+
+describe('AbortSignal pre-check', () => {
+  it('fuseShapes throws on pre-aborted signal', () => {
+    const box1 = castShape(makeBox([0, 0, 0], [10, 10, 10]).wrapped);
+    const box2 = castShape(makeBox([5, 5, 5], [15, 15, 15]).wrapped);
+    const controller = new AbortController();
+    controller.abort();
+    expect(() => fuseShapes(box1, box2, { signal: controller.signal })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- **sliceShape**: batch cross-section a shape with multiple planes, returning one result per plane
- **VolumeProps/SurfaceProps/LinearProps**: domain-specific aliases (`volume`, `area`, `length`) alongside `mass` for clearer API
- **Topo cache**: WeakMap-based caching for `getEdges`/`getFaces`/`getWires` — repeated calls return the same array ref
- **AbortSignal**: pre-check cancellation in `fuseShapes`, `cutShape`, `intersectShapes`
- **Dedup**: remove local `applyGlue` copy in `booleanFns.ts`, import from `shapeBooleans.ts`

## Test plan
- [x] All 1249 tests pass (73 files)
- [x] New tests: sliceShape (3 planes → 3 sections), measurement prop aliases, cache identity, AbortSignal pre-abort
- [x] typecheck, lint, boundaries, knip, coverage all pass