### PR TITLE
feat: add vertex finder and topology query functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -480,9 +480,11 @@ export {
   getEdges,
   getFaces,
   getWires,
+  getVertices,
   iterEdges,
   iterFaces,
   iterWires,
+  iterVertices,
   getBounds,
   vertexPosition,
   type Bounds3D,
@@ -676,9 +678,11 @@ export {
   edgeFinder,
   faceFinder,
   wireFinder,
+  vertexFinder,
   type EdgeFinderFn,
   type FaceFinderFn,
   type WireFinderFn,
+  type VertexFinderFn,
   type ShapeFinder,
 } from './query/finderFns.js';
 

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -182,6 +182,13 @@ export function getWires(shape: AnyShape): Wire[] {
   return wires;
 }
 
+/** Get all vertices of a shape as branded Vertex handles. */
+export function getVertices(shape: AnyShape): Vertex[] {
+  return Array.from(iterTopo(shape.wrapped, 'vertex')).map(
+    (e) => castShape(unwrap(downcast(e))) as Vertex
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Lazy topology iterators (generators)
 // ---------------------------------------------------------------------------
@@ -204,6 +211,13 @@ export function* iterFaces(shape: AnyShape): Generator<Face> {
 export function* iterWires(shape: AnyShape): Generator<Wire> {
   for (const w of iterTopo(shape.wrapped, 'wire')) {
     yield castShape(unwrap(downcast(w))) as Wire;
+  }
+}
+
+/** Lazily iterate vertices of a shape, yielding branded Vertex handles one at a time. */
+export function* iterVertices(shape: AnyShape): Generator<Vertex> {
+  for (const v of iterTopo(shape.wrapped, 'vertex')) {
+    yield castShape(unwrap(downcast(v))) as Vertex;
   }
 }
 

--- a/tests/fn-vertexFinder.test.ts
+++ b/tests/fn-vertexFinder.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  castShape,
+  vertexFinder,
+  getVertices,
+  vertexPosition,
+  fnIsVertex,
+  isOk,
+  isErr,
+  unwrap,
+  iterVertices,
+} from '../src/index.js';
+import { vecDistance } from '../src/core/vecOps.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+function fnBox(x = 10, y = 10, z = 10) {
+  return castShape(makeBox([0, 0, 0], [x, y, z]).wrapped);
+}
+
+describe('getVertices / iterVertices', () => {
+  it('finds all 8 vertices of a box', () => {
+    const vertices = getVertices(fnBox());
+    expect(vertices.length).toBe(8);
+    expect(fnIsVertex(vertices[0]!)).toBe(true);
+  });
+
+  it('iterVertices yields the same count', () => {
+    const box = fnBox();
+    const fromIter = [...iterVertices(box)];
+    const fromArray = getVertices(box);
+    expect(fromIter.length).toBe(fromArray.length);
+  });
+
+  it('vertex positions are within box bounds', () => {
+    const vertices = getVertices(fnBox(10, 20, 30));
+    for (const v of vertices) {
+      const pos = vertexPosition(v);
+      expect(pos[0]).toBeGreaterThanOrEqual(-0.001);
+      expect(pos[0]).toBeLessThanOrEqual(10.001);
+      expect(pos[1]).toBeGreaterThanOrEqual(-0.001);
+      expect(pos[1]).toBeLessThanOrEqual(20.001);
+      expect(pos[2]).toBeGreaterThanOrEqual(-0.001);
+      expect(pos[2]).toBeLessThanOrEqual(30.001);
+    }
+  });
+});
+
+describe('vertexFinder', () => {
+  it('finds all 8 vertices of a box', () => {
+    const vertices = vertexFinder().find(fnBox());
+    expect(vertices.length).toBe(8);
+    expect(fnIsVertex(vertices[0]!)).toBe(true);
+  });
+
+  it('atPosition finds origin vertex', () => {
+    const vertices = vertexFinder().atPosition([0, 0, 0]).find(fnBox());
+    expect(vertices.length).toBe(1);
+    const pos = vertexPosition(vertices[0]!);
+    expect(pos[0]).toBeCloseTo(0);
+    expect(pos[1]).toBeCloseTo(0);
+    expect(pos[2]).toBeCloseTo(0);
+  });
+
+  it('atPosition finds corner vertex', () => {
+    const vertices = vertexFinder()
+      .atPosition([10, 20, 30])
+      .find(fnBox(10, 20, 30));
+    expect(vertices.length).toBe(1);
+    const pos = vertexPosition(vertices[0]!);
+    expect(pos[0]).toBeCloseTo(10);
+    expect(pos[1]).toBeCloseTo(20);
+    expect(pos[2]).toBeCloseTo(30);
+  });
+
+  it('atPosition returns empty for non-existent position', () => {
+    const vertices = vertexFinder().atPosition([5, 5, 5]).find(fnBox());
+    expect(vertices.length).toBe(0);
+  });
+
+  it('withinBox filters vertices in a sub-region', () => {
+    const vertices = vertexFinder()
+      .withinBox([-1, -1, -1], [1, 1, 1])
+      .find(fnBox(10, 10, 10));
+    // Only the origin vertex (0,0,0) is within the box [-1,-1,-1] to [1,1,1]
+    expect(vertices.length).toBe(1);
+    const pos = vertexPosition(vertices[0]!);
+    expect(pos[0]).toBeCloseTo(0);
+    expect(pos[1]).toBeCloseTo(0);
+    expect(pos[2]).toBeCloseTo(0);
+  });
+
+  it('withinBox finds all vertices when box covers entire shape', () => {
+    const vertices = vertexFinder().withinBox([-1, -1, -1], [11, 11, 11]).find(fnBox());
+    expect(vertices.length).toBe(8);
+  });
+
+  it('nearestTo finds closest vertex', () => {
+    const box = fnBox(10, 10, 10);
+    const vertices = vertexFinder().nearestTo([11, 11, 11]).find(box);
+    expect(vertices.length).toBe(1);
+    const pos = vertexPosition(vertices[0]!);
+    expect(pos[0]).toBeCloseTo(10);
+    expect(pos[1]).toBeCloseTo(10);
+    expect(pos[2]).toBeCloseTo(10);
+  });
+
+  it('nearestTo with unique returns Result', () => {
+    const box = fnBox(10, 10, 10);
+    const result = vertexFinder().nearestTo([0, 0, 0]).find(box, { unique: true });
+    expect(isOk(result)).toBe(true);
+    const pos = vertexPosition(unwrap(result));
+    expect(pos[0]).toBeCloseTo(0);
+    expect(pos[1]).toBeCloseTo(0);
+    expect(pos[2]).toBeCloseTo(0);
+  });
+
+  it('atDistance finds vertices at a given distance from origin', () => {
+    const box = fnBox(10, 10, 10);
+    // Distance from origin to (10,0,0) = 10
+    const dist10 = vertexFinder().atDistance(10, [0, 0, 0], 0.01).find(box);
+    // Vertices at distance 10 from origin: (10,0,0), (0,10,0), (0,0,10)
+    expect(dist10.length).toBe(3);
+  });
+
+  it('atDistance from a non-origin point', () => {
+    const box = fnBox(10, 10, 10);
+    // Distance from (10,10,10) to (0,10,10) = 10
+    const verts = vertexFinder().atDistance(10, [10, 10, 10], 0.01).find(box);
+    // 3 vertices are at distance 10 from (10,10,10): (0,10,10), (10,0,10), (10,10,0)
+    expect(verts.length).toBe(3);
+  });
+
+  it('supports when() custom predicate', () => {
+    const vertices = vertexFinder()
+      .when((v) => vertexPosition(v)[0] > 5)
+      .find(fnBox());
+    // 4 vertices have x=10
+    expect(vertices.length).toBe(4);
+  });
+
+  it('supports not() for negation', () => {
+    const vertices = vertexFinder()
+      .not((f) => f.when((v) => vecDistance(vertexPosition(v), [0, 0, 0]) < 0.01))
+      .find(fnBox());
+    // 8 total minus 1 at origin = 7
+    expect(vertices.length).toBe(7);
+  });
+
+  it('supports either() for OR logic', () => {
+    const vertices = vertexFinder()
+      .either([
+        (f) => f.when((v) => vecDistance(vertexPosition(v), [0, 0, 0]) < 0.01),
+        (f) => f.when((v) => vecDistance(vertexPosition(v), [10, 10, 10]) < 0.01),
+      ])
+      .find(fnBox());
+    expect(vertices.length).toBe(2);
+  });
+
+  it('supports inList filter', () => {
+    const box = fnBox();
+    const allVerts = getVertices(box);
+    const subset = [allVerts[0]!, allVerts[1]!];
+    const found = vertexFinder().inList(subset).find(box);
+    expect(found.length).toBe(2);
+  });
+
+  it('shouldKeep works on individual elements', () => {
+    const finder = vertexFinder().atPosition([0, 0, 0]);
+    const verts = getVertices(fnBox());
+    const kept = verts.filter((v) => finder.shouldKeep(v));
+    expect(kept.length).toBe(1);
+  });
+
+  it('unique returns error for multiple matches', () => {
+    const result = vertexFinder().find(fnBox(), { unique: true });
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('unique returns error for zero matches', () => {
+    const result = vertexFinder().atPosition([999, 999, 999]).find(fnBox(), { unique: true });
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('combines multiple filters', () => {
+    const box = fnBox(10, 20, 30);
+    const verts = vertexFinder()
+      .withinBox([-1, -1, -1], [1, 21, 31])
+      .when((v) => vertexPosition(v)[2] > 15)
+      .find(box);
+    // Within box: x in [-1,1] → x=0 only. z > 15 → z=30.
+    // Matching vertices: (0,0,30) and (0,20,30)
+    expect(verts.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `getVertices()` and `iterVertices()` to `shapeFns.ts` following the existing `getEdges`/`iterEdges` pattern for extracting branded `Vertex` handles
- Add `vertexFinder()` to the immutable finder API (`finderFns.ts`) with position-based filters: `atPosition`, `withinBox`, `nearestTo`, and `atDistance`
- Export all new functions and the `VertexFinderFn` type from the public API

## Test plan
- [x] `getVertices` finds all 8 vertices of a box
- [x] `iterVertices` yields the same count
- [x] All vertex positions are within expected bounds
- [x] `atPosition` finds exact vertex, returns empty for non-existent
- [x] `withinBox` filters by axis-aligned bounding box
- [x] `nearestTo` returns closest vertex (normal and `unique` mode)
- [x] `atDistance` filters vertices at a given distance from a point
- [x] Composition: `when`, `not`, `either`, `inList`, `shouldKeep`
- [x] `unique` mode returns `Result<T>` errors for 0 and >1 matches
- [x] Combined filters (withinBox + when) work together
- [x] All 1260 tests pass, function coverage 85.48% (≥83%)