### PR TITLE
feat: improve error handling and add deprecation tags

### DIFF
--- a/src/measurement/measureShape.ts
+++ b/src/measurement/measureShape.ts
@@ -11,18 +11,21 @@ class PhysicalProperties extends WrappingObj<OcType> {
   }
 }
 
+/** @deprecated Use measureVolumeProps() instead. */
 export class VolumePhysicalProperties extends PhysicalProperties {
   get volume(): number {
     return this.wrapped.Mass();
   }
 }
 
+/** @deprecated Use measureSurfaceProps() instead. */
 export class SurfacePhysicalProperties extends PhysicalProperties {
   get area(): number {
     return this.wrapped.Mass();
   }
 }
 
+/** @deprecated Use measureLinearProps() instead. */
 export class LinearPhysicalProperties extends PhysicalProperties {
   get length(): number {
     return this.wrapped.Mass();
@@ -74,6 +77,7 @@ export function measureLength(shape: AnyShape): number {
   return l;
 }
 
+/** @deprecated Use measureDistance() instead. */
 export class DistanceTool extends WrappingObj<OcType> {
   constructor() {
     const oc = getKernel().oc;
@@ -100,6 +104,7 @@ export function measureDistanceBetween(shape1: AnyShape, shape2: AnyShape): numb
   return dist;
 }
 
+/** @deprecated Use createDistanceQuery() instead. */
 export class DistanceQuery extends WrappingObj<OcType> {
   constructor(shape: AnyShape) {
     const oc = getKernel().oc;

--- a/src/topology/pipeFns.ts
+++ b/src/topology/pipeFns.ts
@@ -69,17 +69,17 @@ function createPipe<T extends AnyShape>(shape: T): ShapePipe<T> {
     apply: (fn) => createPipe(fn(shape)),
 
     fuse: (tool, options) => {
-      if (!isShape3D(shape)) throw new Error('fuse requires a 3D shape');
+      if (!isShape3D(shape)) throw new Error('pipe.fuse() requires a 3D shape');
       return createPipe(unwrap(fuseShapes(shape, tool, options)));
     },
 
     cut: (tool, options) => {
-      if (!isShape3D(shape)) throw new Error('cut requires a 3D shape');
+      if (!isShape3D(shape)) throw new Error('pipe.cut() requires a 3D shape');
       return createPipe(unwrap(cutShape(shape, tool, options)));
     },
 
     intersect: (tool) => {
-      if (!isShape3D(shape)) throw new Error('intersect requires a 3D shape');
+      if (!isShape3D(shape)) throw new Error('pipe.intersect() requires a 3D shape');
       return createPipe(unwrap(intersectShapes(shape, tool)));
     },
   };

--- a/src/topology/shapes.ts
+++ b/src/topology/shapes.ts
@@ -74,6 +74,7 @@ export type BooleanOperationOptions = {
 // ---------------------------------------------------------------------------
 
 export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
+  /** @deprecated Use cloneShape() instead. */
   clone(): this {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic constructor access
     return new (this.constructor as any)(unwrap(downcast(this.wrapped)));
@@ -102,6 +103,8 @@ export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
 
   /**
    * Simplifies the shape by removing unnecessary edges and faces.
+   *
+   * @deprecated Use simplifyShape() instead.
    */
   simplify(): this {
     const oc = getKernel().oc;
@@ -120,6 +123,7 @@ export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
   /**
    * Translates the shape by an arbitrary vector.
    *
+   * @deprecated Use translateShape() instead.
    * @category Shape Transformations
    */
   translate(xDist: number, yDist: number, zDist: number): this;
@@ -167,6 +171,7 @@ export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
   /**
    * Rotates the shape.
    *
+   * @deprecated Use rotateShape() instead.
    * @category Shape Transformations
    */
   rotate(angle: number, position: PointInput = [0, 0, 0], direction: PointInput = [0, 0, 1]): this {
@@ -182,6 +187,7 @@ export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
   /**
    * Mirrors the shape through a plane.
    *
+   * @deprecated Use mirrorShape() instead.
    * @category Shape Transformations
    */
   mirror(inputPlane?: Plane | PlaneName | PointInput, origin?: PointInput): this {
@@ -198,6 +204,7 @@ export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
   /**
    * Returns a scaled version of the shape.
    *
+   * @deprecated Use scaleShape() instead.
    * @category Shape Transformations
    */
   scale(scaleFactor: number, center: PointInput = [0, 0, 0]): this {
@@ -247,6 +254,7 @@ export class Shape<Type extends OcShape = OcShape> extends WrappingObj<Type> {
   /**
    * Exports the current shape as a set of triangles for rendering.
    *
+   * @deprecated Use meshShape() instead.
    * @category Shape Export
    */
   mesh({
@@ -811,6 +819,7 @@ export class _3DShape<Type extends OcShape = OcShape> extends Shape<Type> {
   /**
    * Builds a new shape out of the two fused shapes.
    *
+   * @deprecated Use fuseShapes() instead.
    * @category Shape Modifications
    */
   fuse(
@@ -836,6 +845,7 @@ export class _3DShape<Type extends OcShape = OcShape> extends Shape<Type> {
   /**
    * Builds a new shape by removing the tool from this shape.
    *
+   * @deprecated Use cutShape() instead.
    * @category Shape Modifications
    */
   cut(
@@ -861,6 +871,7 @@ export class _3DShape<Type extends OcShape = OcShape> extends Shape<Type> {
   /**
    * Builds a new shape by intersecting this shape and another.
    *
+   * @deprecated Use intersectShapes() instead.
    * @category Shape Modifications
    */
   intersect(tool: AnyShape, { simplify = false }: { simplify?: boolean } = {}): Result<Shape3D> {

--- a/tests/fn-interferenceFns.test.ts
+++ b/tests/fn-interferenceFns.test.ts
@@ -6,6 +6,7 @@ import {
   makeBox,
   makeSphere,
   translateShape,
+  unwrap,
 } from '../src/index.js';
 
 beforeAll(async () => {
@@ -17,7 +18,7 @@ describe('checkInterference', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
     const box2 = makeBox([5, 5, 5], [15, 15, 15]);
 
-    const result = checkInterference(box1, box2);
+    const result = unwrap(checkInterference(box1, box2));
     expect(result.hasInterference).toBe(true);
     expect(result.minDistance).toBeCloseTo(0, 5);
   });
@@ -26,7 +27,7 @@ describe('checkInterference', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
     const box2 = makeBox([10, 0, 0], [20, 10, 10]);
 
-    const result = checkInterference(box1, box2);
+    const result = unwrap(checkInterference(box1, box2));
     expect(result.hasInterference).toBe(true);
     expect(result.minDistance).toBeCloseTo(0, 5);
   });
@@ -35,7 +36,7 @@ describe('checkInterference', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
     const box2 = makeBox([20, 0, 0], [30, 10, 10]);
 
-    const result = checkInterference(box1, box2);
+    const result = unwrap(checkInterference(box1, box2));
     expect(result.hasInterference).toBe(false);
     expect(result.minDistance).toBeCloseTo(10, 3);
   });
@@ -44,7 +45,7 @@ describe('checkInterference', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
     const box2 = makeBox([20, 0, 0], [30, 10, 10]);
 
-    const result = checkInterference(box1, box2);
+    const result = unwrap(checkInterference(box1, box2));
     // Closest point on box1 should be near x=10, on box2 near x=20
     expect(result.pointOnShape1[0]).toBeCloseTo(10, 3);
     expect(result.pointOnShape2[0]).toBeCloseTo(20, 3);
@@ -54,7 +55,7 @@ describe('checkInterference', () => {
     const s1 = makeSphere(5);
     const s2 = translateShape(makeSphere(5), [3, 0, 0]);
 
-    const result = checkInterference(s1, s2);
+    const result = unwrap(checkInterference(s1, s2));
     expect(result.hasInterference).toBe(true);
     expect(result.minDistance).toBeCloseTo(0, 5);
   });
@@ -63,7 +64,7 @@ describe('checkInterference', () => {
     const s1 = makeSphere(5);
     const s2 = translateShape(makeSphere(5), [20, 0, 0]);
 
-    const result = checkInterference(s1, s2);
+    const result = unwrap(checkInterference(s1, s2));
     expect(result.hasInterference).toBe(false);
     expect(result.minDistance).toBeCloseTo(10, 2);
   });
@@ -73,11 +74,11 @@ describe('checkInterference', () => {
     const box2 = makeBox([10.005, 0, 0], [20, 10, 10]);
 
     // Default tolerance (1e-6) — should not detect interference
-    const strict = checkInterference(box1, box2);
+    const strict = unwrap(checkInterference(box1, box2));
     expect(strict.hasInterference).toBe(false);
 
     // Larger tolerance — should detect as interference
-    const lenient = checkInterference(box1, box2, 0.01);
+    const lenient = unwrap(checkInterference(box1, box2, 0.01));
     expect(lenient.hasInterference).toBe(true);
   });
 });
@@ -103,9 +104,9 @@ describe('checkAllInterferences', () => {
 
     const pairs = checkAllInterferences(shapes);
     expect(pairs).toHaveLength(1);
-    expect(pairs[0].i).toBe(0);
-    expect(pairs[0].j).toBe(1);
-    expect(pairs[0].result.hasInterference).toBe(true);
+    expect(pairs[0]!.i).toBe(0);
+    expect(pairs[0]!.j).toBe(1);
+    expect(pairs[0]!.result.hasInterference).toBe(true);
   });
 
   it('returns multiple pairs when multiple shapes interfere', () => {


### PR DESCRIPTION
## Summary
- Convert `checkInterference` to return `Result<InterferenceResult>` instead of throwing on failure
- Convert `createCamera`, `cameraLookAt`, `cameraFromPlane` to return `Result<Camera>` with structured error for zero-direction vectors
- Add `@deprecated` JSDoc tags to OO class methods in `Shape`, `_3DShape`, and measurement classes pointing to their functional API replacements

## Test plan
- [x] All interference tests updated to unwrap results
- [x] All camera tests updated to unwrap results
- [x] New test: `createCamera` returns error for zero-length direction vector
- [x] Deprecation tags trigger IDE warnings (verified via ESLint `@typescript-eslint/no-deprecated`)
- [x] All 1240 tests pass, function coverage 85.47% (≥83%)