### PR TITLE
feat: add auto-healing pipeline and surface curvature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -600,7 +600,15 @@ export {
 
 // ── Healing (functional) ──
 
-export { isShapeValid, healSolid, healFace, healWire, healShape } from './topology/healingFns.js';
+export {
+  isShapeValid,
+  healSolid,
+  healFace,
+  healWire,
+  healShape,
+  autoHeal,
+  type HealingReport,
+} from './topology/healingFns.js';
 
 // ── Operations (functional) ──
 
@@ -666,6 +674,9 @@ export {
   type VolumeProps,
   type SurfaceProps,
   type LinearProps,
+  measureCurvatureAt,
+  measureCurvatureAtMid,
+  type CurvatureResult,
 } from './measurement/measureFns.js';
 
 export {

--- a/src/kernel/measureOps.ts
+++ b/src/kernel/measureOps.ts
@@ -5,7 +5,7 @@
  * Used by OCCTAdapter - re-exported for backward compatibility.
  */
 
-import type { OpenCascadeInstance, OcShape } from './types.js';
+import type { OpenCascadeInstance, OcShape, OcType } from './types.js';
 
 const HASH_CODE_MAX = 2147483647;
 
@@ -142,6 +142,175 @@ export function classifyPointOnFace(
   if (state === topAbs.TopAbs_IN) return 'in';
   if (state === topAbs.TopAbs_ON) return 'on';
   return 'out';
+}
+
+// ---------------------------------------------------------------------------
+// Surface curvature
+// ---------------------------------------------------------------------------
+
+export interface CurvatureResult {
+  /** Mean curvature: H = (k1 + k2) / 2 */
+  mean: number;
+  /** Gaussian curvature: K = k1 * k2 */
+  gaussian: number;
+  /** Maximum principal curvature */
+  maxCurvature: number;
+  /** Minimum principal curvature */
+  minCurvature: number;
+  /** Direction of maximum curvature */
+  maxDirection: [number, number, number];
+  /** Direction of minimum curvature */
+  minDirection: [number, number, number];
+}
+
+/**
+ * Compute surface curvature at a (u, v) point on a face.
+ *
+ * Uses BRepAdaptor_Surface to get first and second derivatives,
+ * then computes principal curvatures from the shape operator
+ * (first and second fundamental forms).
+ */
+export function surfaceCurvature(
+  oc: OpenCascadeInstance,
+  face: OcShape,
+  u: number,
+  v: number
+): CurvatureResult {
+  const adaptor = new oc.BRepAdaptor_Surface_2(face, false);
+
+  // D2 outputs: point, first derivatives (D1U, D1V), second derivatives (D2U, D2V, D2UV)
+  const P = new oc.gp_Pnt_1();
+  const D1U = new oc.gp_Vec_1();
+  const D1V = new oc.gp_Vec_1();
+  const D2U = new oc.gp_Vec_1();
+  const D2V = new oc.gp_Vec_1();
+  const D2UV = new oc.gp_Vec_1();
+
+  adaptor.D2(u, v, P, D1U, D1V, D2U, D2V, D2UV);
+
+  // First fundamental form coefficients
+  const E = D1U.Dot(D1U);
+  const F = D1U.Dot(D1V);
+  const G = D1V.Dot(D1V);
+
+  // Surface normal
+  const N = D1U.Crossed(D1V);
+  const nLen = N.Magnitude();
+
+  let result: CurvatureResult;
+
+  if (nLen < 1e-15) {
+    // Degenerate point — curvature is undefined
+    result = {
+      mean: 0,
+      gaussian: 0,
+      maxCurvature: 0,
+      minCurvature: 0,
+      maxDirection: [1, 0, 0],
+      minDirection: [0, 1, 0],
+    };
+  } else {
+    N.Divide(nLen);
+
+    // Second fundamental form coefficients
+    const L = D2U.Dot(N);
+    const M = D2UV.Dot(N);
+    const N2 = D2V.Dot(N);
+
+    const denom = E * G - F * F;
+
+    if (Math.abs(denom) < 1e-15) {
+      // Singular first fundamental form — curvature undefined
+      P.delete();
+      D1U.delete();
+      D1V.delete();
+      D2U.delete();
+      D2V.delete();
+      D2UV.delete();
+      N.delete();
+      adaptor.delete();
+      return {
+        mean: 0,
+        gaussian: 0,
+        maxCurvature: 0,
+        minCurvature: 0,
+        maxDirection: [1, 0, 0],
+        minDirection: [0, 1, 0],
+      };
+    }
+
+    // Mean curvature: H = (EN2 - 2FM + GL) / (2 * denom)
+    const mean = (E * N2 - 2 * F * M + G * L) / (2 * denom);
+
+    // Gaussian curvature: K = (LN2 - M²) / denom
+    const gaussian = (L * N2 - M * M) / denom;
+
+    // Principal curvatures from H and K: k1,k2 = H ± sqrt(H² - K)
+    const disc = Math.max(0, mean * mean - gaussian);
+    const sqrtDisc = Math.sqrt(disc);
+    const k1 = mean + sqrtDisc;
+    const k2 = mean - sqrtDisc;
+
+    // Principal directions from the Weingarten map (shape operator)
+    // S = [[E,F],[F,G]]^-1 * [[L,M],[M,N2]]
+    // Eigenvectors in (u,v) parameter space → map to 3D via D1U, D1V
+    const a11 = (G * L - F * M) / denom;
+    const a12 = (G * M - F * N2) / denom;
+    const a21 = (E * M - F * L) / denom;
+    const a22 = (E * N2 - F * M) / denom;
+
+    // Eigenvectors for k1: (a11-k1)*du + a12*dv = 0
+    let du1: number, dv1: number;
+    if (Math.abs(a12) > 1e-15) {
+      du1 = a12;
+      dv1 = k1 - a11;
+    } else if (Math.abs(a21) > 1e-15) {
+      du1 = k1 - a22;
+      dv1 = a21;
+    } else {
+      du1 = 1;
+      dv1 = 0;
+    }
+
+    // Map to 3D: direction = du * D1U + dv * D1V, then normalize
+    const maxDir = computeDirection(D1U, D1V, du1, dv1);
+    const minDir = computeDirection(D1U, D1V, -dv1, du1); // Perpendicular in parameter space
+
+    result = {
+      mean,
+      gaussian,
+      maxCurvature: k1,
+      minCurvature: k2,
+      maxDirection: maxDir,
+      minDirection: minDir,
+    };
+  }
+
+  // Clean up OCCT objects
+  P.delete();
+  D1U.delete();
+  D1V.delete();
+  D2U.delete();
+  D2V.delete();
+  D2UV.delete();
+  N.delete();
+  adaptor.delete();
+
+  return result;
+}
+
+function computeDirection(
+  D1U: OcType,
+  D1V: OcType,
+  du: number,
+  dv: number
+): [number, number, number] {
+  const x = du * D1U.X() + dv * D1V.X();
+  const y = du * D1U.Y() + dv * D1V.Y();
+  const z = du * D1U.Z() + dv * D1V.Z();
+  const len = Math.sqrt(x * x + y * y + z * z);
+  if (len < 1e-15) return [1, 0, 0];
+  return [x / len, y / len, z / len];
 }
 
 // Re-export HASH_CODE_MAX for use by other modules

--- a/tests/fn-autoHeal.test.ts
+++ b/tests/fn-autoHeal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import { makeBox, makeSphere, autoHeal, isShapeValid } from '../src/index.js';
+import { unwrap } from '../src/core/result.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('autoHeal', () => {
+  it('returns valid shape unchanged', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    expect(isShapeValid(box)).toBe(true);
+
+    const result = unwrap(autoHeal(box));
+    expect(result.report.isValid).toBe(true);
+    expect(result.report.steps).toContain('Shape already valid');
+    expect(result.report.wiresHealed).toBe(0);
+    expect(result.report.facesHealed).toBe(0);
+    expect(result.report.solidHealed).toBe(false);
+  });
+
+  it('returns valid sphere unchanged', () => {
+    const sphere = makeSphere(5);
+    expect(isShapeValid(sphere)).toBe(true);
+
+    const result = unwrap(autoHeal(sphere));
+    expect(result.report.isValid).toBe(true);
+    expect(result.report.steps).toContain('Shape already valid');
+  });
+
+  it('report has expected structure', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = unwrap(autoHeal(box));
+
+    expect(result.report).toHaveProperty('isValid');
+    expect(result.report).toHaveProperty('wiresHealed');
+    expect(result.report).toHaveProperty('facesHealed');
+    expect(result.report).toHaveProperty('solidHealed');
+    expect(result.report).toHaveProperty('steps');
+    expect(Array.isArray(result.report.steps)).toBe(true);
+  });
+
+  it('returns shape from result', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = unwrap(autoHeal(box));
+
+    // Should return a valid shape
+    expect(result.shape).toBeDefined();
+    expect(isShapeValid(result.shape)).toBe(true);
+  });
+});

--- a/tests/fn-curvature.test.ts
+++ b/tests/fn-curvature.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  makeSphere,
+  getFaces,
+  measureCurvatureAt,
+  measureCurvatureAtMid,
+} from '../src/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('measureCurvatureAt', () => {
+  it('plane face has zero curvature', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+    expect(faces.length).toBe(6);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- 6 faces
+    const face = faces[0]!;
+    const result = measureCurvatureAt(face, 0.5, 0.5);
+
+    expect(result.mean).toBeCloseTo(0, 5);
+    expect(result.gaussian).toBeCloseTo(0, 5);
+    expect(result.maxCurvature).toBeCloseTo(0, 5);
+    expect(result.minCurvature).toBeCloseTo(0, 5);
+  });
+
+  it('sphere face has constant positive curvature', () => {
+    const sphere = makeSphere(5);
+    const faces = getFaces(sphere);
+    expect(faces.length).toBeGreaterThan(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- at least 1 face
+    const face = faces[0]!;
+    const result = measureCurvatureAtMid(face);
+
+    // Sphere of radius R: |k1| = |k2| = 1/R, |mean| = 1/R, gaussian = 1/R²
+    // Sign depends on surface normal orientation (inward vs outward)
+    const expectedK = 1 / 5;
+    expect(Math.abs(result.mean)).toBeCloseTo(expectedK, 3);
+    expect(result.gaussian).toBeCloseTo(expectedK * expectedK, 3);
+    expect(Math.abs(result.maxCurvature)).toBeCloseTo(expectedK, 3);
+    expect(Math.abs(result.minCurvature)).toBeCloseTo(expectedK, 3);
+  });
+
+  it('returns direction vectors', () => {
+    const sphere = makeSphere(5);
+    const faces = getFaces(sphere);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- at least 1 face
+    const face = faces[0]!;
+    const result = measureCurvatureAtMid(face);
+
+    // Direction vectors should be unit vectors
+    const maxLen = Math.sqrt(
+      result.maxDirection[0] ** 2 + result.maxDirection[1] ** 2 + result.maxDirection[2] ** 2
+    );
+    const minLen = Math.sqrt(
+      result.minDirection[0] ** 2 + result.minDirection[1] ** 2 + result.minDirection[2] ** 2
+    );
+    expect(maxLen).toBeCloseTo(1, 3);
+    expect(minLen).toBeCloseTo(1, 3);
+  });
+});
+
+describe('measureCurvatureAtMid', () => {
+  it('works on box faces', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const faces = getFaces(box);
+
+    for (const face of faces) {
+      const result = measureCurvatureAtMid(face);
+      // All box faces are planar — zero curvature
+      expect(result.mean).toBeCloseTo(0, 5);
+      expect(result.gaussian).toBeCloseTo(0, 5);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add surface curvature measurement using `BRepAdaptor_Surface` D2 derivatives and first/second fundamental forms — computes mean, Gaussian, and principal curvatures with directions
- Add `measureCurvatureAt(face, u, v)` and `measureCurvatureAtMid(face)` to the functional measurement API
- Add `autoHeal(shape)` pipeline that validates shape, then iterates sub-shapes bottom-up (wires → faces → solid), applying appropriate fixers, returning a `HealingReport` with what was healed

## Test plan
- [x] Plane face (box) → zero curvature (mean, Gaussian, principal all ~0)
- [x] Sphere face → constant curvature (|mean| = 1/R, Gaussian = 1/R²)
- [x] Curvature directions are unit vectors
- [x] `measureCurvatureAtMid` works on all box faces
- [x] `autoHeal` on valid shape returns no-op report with "Shape already valid"
- [x] `autoHeal` report has correct structure (isValid, wiresHealed, facesHealed, solidHealed, steps)
- [x] All 1247 tests pass, function coverage 85.52% (≥83%)