### PR TITLE
feat: add healing ops, point-in-face, and splitter to kernel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -526,6 +526,7 @@ export {
   uvCoordinates as fnUvCoordinates,
   normalAt as fnNormalAt,
   faceCenter,
+  classifyPointOnFace,
   outerWire as fnOuterWire,
   innerWires as fnInnerWires,
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- re-export for backward compat
@@ -566,6 +567,7 @@ export {
   cutShape,
   intersectShapes,
   sectionShape,
+  splitShape,
   fuseAll as fnFuseAll,
   cutAll as fnCutAll,
   buildCompound as fnBuildCompound,

--- a/src/kernel/booleanOps.ts
+++ b/src/kernel/booleanOps.ts
@@ -252,6 +252,38 @@ export function fuseAll(
 }
 
 /**
+ * Splits a shape using one or more tool shapes via BRepAlgoAPI_Splitter.
+ * The result contains all the pieces from the split.
+ */
+export function split(oc: OpenCascadeInstance, shape: OcShape, tools: OcShape[]): OcShape {
+  if (!oc.BRepAlgoAPI_Splitter) {
+    throw new Error('BRepAlgoAPI_Splitter not available in this WASM build');
+  }
+
+  const argList = new oc.TopTools_ListOfShape_1();
+  argList.Append_1(shape);
+
+  const toolList = new oc.TopTools_ListOfShape_1();
+  for (const tool of tools) {
+    toolList.Append_1(tool);
+  }
+
+  const splitter = new oc.BRepAlgoAPI_Splitter();
+  splitter.SetArguments(argList);
+  splitter.SetTools(toolList);
+
+  const progress = new oc.Message_ProgressRange_1();
+  splitter.Build(progress);
+
+  const result = splitter.Shape();
+  splitter.delete();
+  progress.delete();
+  argList.delete();
+  toolList.delete();
+  return result;
+}
+
+/**
  * Cuts all tool shapes from a base shape using C++ batch operation.
  */
 function cutAllBatch(

--- a/src/kernel/healingOps.ts
+++ b/src/kernel/healingOps.ts
@@ -1,0 +1,54 @@
+/**
+ * Shape healing operations for OCCT.
+ *
+ * Provides solid, face, and wire healing using ShapeFix_Solid/Face/Wire.
+ * Used by OCCTAdapter — follows the established ops file pattern.
+ */
+
+import type { OpenCascadeInstance, OcShape } from './types.js';
+
+/**
+ * Heals a solid shape using ShapeFix_Solid.
+ * Returns the healed solid, or null if the fixer produced a null result.
+ */
+export function healSolid(oc: OpenCascadeInstance, shape: OcShape): OcShape | null {
+  const fixer = new oc.ShapeFix_Solid_2(shape);
+  const progress = new oc.Message_ProgressRange_1();
+  fixer.Perform(progress);
+  progress.delete();
+  const result = fixer.Solid();
+  fixer.delete();
+  if (result.IsNull()) return null;
+  return result;
+}
+
+/**
+ * Heals a face shape using ShapeFix_Face.
+ * Returns the healed face.
+ */
+export function healFace(oc: OpenCascadeInstance, shape: OcShape): OcShape {
+  const fixer = new oc.ShapeFix_Face_2(shape);
+  fixer.Perform();
+  const result = fixer.Face();
+  fixer.delete();
+  return result;
+}
+
+/**
+ * Heals a wire using ShapeFix_Wire.
+ * If a face is provided, it's used for surface context.
+ * Returns the healed wire.
+ */
+export function healWire(oc: OpenCascadeInstance, wire: OcShape, face?: OcShape): OcShape {
+  let fixer;
+  if (face) {
+    fixer = new oc.ShapeFix_Wire_2(wire, face, 1e-6);
+  } else {
+    fixer = new oc.ShapeFix_Wire_1();
+    fixer.Load_1(wire);
+  }
+  fixer.Perform();
+  const result = fixer.Wire();
+  fixer.delete();
+  return result;
+}

--- a/src/kernel/measureOps.ts
+++ b/src/kernel/measureOps.ts
@@ -118,5 +118,31 @@ export function distance(
   return result;
 }
 
+/**
+ * Classifies a point (given in UV space) relative to a face boundary.
+ * Returns 'in', 'on', or 'out'.
+ */
+export function classifyPointOnFace(
+  oc: OpenCascadeInstance,
+  face: OcShape,
+  u: number,
+  v: number,
+  tolerance = 1e-6
+): 'in' | 'on' | 'out' {
+  if (!oc.BRepClass_FaceClassifier) {
+    throw new Error('BRepClass_FaceClassifier not available in this WASM build');
+  }
+  const pnt2d = new oc.gp_Pnt2d_3(u, v);
+  const classifier = new oc.BRepClass_FaceClassifier_3(face, pnt2d, tolerance);
+  const state = classifier.State();
+  pnt2d.delete();
+  classifier.delete();
+
+  const topAbs = oc.TopAbs_State;
+  if (state === topAbs.TopAbs_IN) return 'in';
+  if (state === topAbs.TopAbs_ON) return 'on';
+  return 'out';
+}
+
 // Re-export HASH_CODE_MAX for use by other modules
 export { HASH_CODE_MAX };

--- a/src/kernel/occtAdapter.ts
+++ b/src/kernel/occtAdapter.ts
@@ -25,6 +25,7 @@ import {
   centerOfMass as _centerOfMass,
   boundingBox as _boundingBox,
   distance as _distance,
+  classifyPointOnFace as _classifyPointOnFace,
 } from './measureOps.js';
 import {
   transform as _transform,
@@ -43,6 +44,7 @@ import {
   cutAll as _cutAll,
   buildCompound as _buildCompound,
   applyGlue as _applyGlue,
+  split as _split,
 } from './booleanOps.js';
 import { mesh as _mesh, meshEdges as _meshEdges } from './meshOps.js';
 import {
@@ -70,6 +72,11 @@ import {
   loft as _loft,
   sweep as _sweep,
 } from './sweepOps.js';
+import {
+  healSolid as _healSolid,
+  healFace as _healFace,
+  healWire as _healWire,
+} from './healingOps.js';
 import {
   fillet as _fillet,
   chamfer as _chamfer,
@@ -352,6 +359,18 @@ export class OCCTAdapter implements KernelAdapter {
     return _sew(this.oc, shapes, tolerance);
   }
 
+  healSolid(shape: OcShape): OcShape | null {
+    return _healSolid(this.oc, shape);
+  }
+
+  healFace(shape: OcShape): OcShape {
+    return _healFace(this.oc, shape);
+  }
+
+  healWire(wire: OcShape, face?: OcShape): OcShape {
+    return _healWire(this.oc, wire, face);
+  }
+
   // --- 2D offset ---
 
   offsetWire2D(wire: OcShape, offset: number, joinType?: number): OcShape {
@@ -362,5 +381,17 @@ export class OCCTAdapter implements KernelAdapter {
 
   distance(shape1: OcShape, shape2: OcShape): DistanceResult {
     return _distance(this.oc, shape1, shape2);
+  }
+
+  // --- Classification ---
+
+  classifyPointOnFace(face: OcShape, u: number, v: number, tolerance = 1e-6): 'in' | 'on' | 'out' {
+    return _classifyPointOnFace(this.oc, face, u, v, tolerance);
+  }
+
+  // --- Splitting ---
+
+  split(shape: OcShape, tools: OcShape[]): OcShape {
+    return _split(this.oc, shape, tools);
   }
 }

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -173,10 +173,19 @@ export interface KernelAdapter {
   // --- Validation & repair ---
   isValid(shape: OcShape): boolean;
   sew(shapes: OcShape[], tolerance?: number): OcShape;
+  healSolid(shape: OcShape): OcShape | null;
+  healFace(shape: OcShape): OcShape;
+  healWire(wire: OcShape, face?: OcShape): OcShape;
 
   // --- 2D offset ---
   offsetWire2D(wire: OcShape, offset: number, joinType?: number): OcShape;
 
   // --- Distance ---
   distance(shape1: OcShape, shape2: OcShape): DistanceResult;
+
+  // --- Classification ---
+  classifyPointOnFace(face: OcShape, u: number, v: number, tolerance?: number): 'in' | 'on' | 'out';
+
+  // --- Splitting ---
+  split(shape: OcShape, tools: OcShape[]): OcShape;
 }

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -311,6 +311,33 @@ export function sectionShape(
 }
 
 // ---------------------------------------------------------------------------
+// Splitting
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a shape with one or more tool shapes using BRepAlgoAPI_Splitter.
+ * Returns all pieces from the split as a compound.
+ */
+export function splitShape(shape: AnyShape, tools: AnyShape[]): Result<AnyShape> {
+  if (tools.length === 0) return ok(shape);
+
+  try {
+    const result = getKernel().split(
+      shape.wrapped,
+      tools.map((t) => t.wrapped)
+    );
+    return ok(castShape(result));
+  } catch (e) {
+    return err(
+      occtError(
+        'SPLIT_FAILED',
+        `Split operation failed: ${e instanceof Error ? e.message : String(e)}`
+      )
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Compound building
 // ---------------------------------------------------------------------------
 

--- a/src/topology/faceFns.ts
+++ b/src/topology/faceFns.ts
@@ -186,6 +186,25 @@ export function faceCenter(face: Face): Vec3 {
 }
 
 // ---------------------------------------------------------------------------
+// Point classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a 3D point's position relative to a face boundary.
+ * Projects the point onto the face's surface and classifies the UV result.
+ *
+ * @returns 'in' if inside, 'on' if on the boundary, 'out' if outside
+ */
+export function classifyPointOnFace(
+  face: Face,
+  point: PointInput,
+  tolerance = 1e-6
+): 'in' | 'on' | 'out' {
+  const [u, v] = uvCoordinates(face, point);
+  return getKernel().classifyPointOnFace(face.wrapped, u, v, tolerance);
+}
+
+// ---------------------------------------------------------------------------
 // Wire extraction from faces
 // ---------------------------------------------------------------------------
 

--- a/src/topology/healingFns.ts
+++ b/src/topology/healingFns.ts
@@ -37,14 +37,8 @@ export function healSolid(solid: Solid): Result<Solid> {
   }
 
   try {
-    const oc = getKernel().oc;
-    const fixer = new oc.ShapeFix_Solid_2(solid.wrapped);
-    const progress = new oc.Message_ProgressRange_1();
-    fixer.Perform(progress);
-    progress.delete();
-    const result = fixer.Solid();
-    fixer.delete();
-    if (result.IsNull()) {
+    const result = getKernel().healSolid(solid.wrapped);
+    if (!result) {
       // Perform may return null solid if there's nothing to fix — return original
       return ok(solid);
     }
@@ -69,11 +63,7 @@ export function healFace(face: Face): Result<Face> {
   }
 
   try {
-    const oc = getKernel().oc;
-    const fixer = new oc.ShapeFix_Face_2(face.wrapped);
-    fixer.Perform();
-    const result = fixer.Face();
-    fixer.delete();
+    const result = getKernel().healFace(face.wrapped);
     const cast = castShape(result);
     if (!isFace(cast)) {
       return err(occtError('HEAL_RESULT_NOT_FACE', 'Healed result is not a face'));
@@ -96,21 +86,7 @@ export function healWire(wire: Wire, face?: Face): Result<Wire> {
   }
 
   try {
-    const oc = getKernel().oc;
-    let fixer;
-    if (face) {
-      fixer = new oc.ShapeFix_Wire_2(
-        wire.wrapped,
-        face.wrapped,
-        1e-6 // default precision
-      );
-    } else {
-      fixer = new oc.ShapeFix_Wire_1();
-      fixer.Load_1(wire.wrapped);
-    }
-    fixer.Perform();
-    const result = fixer.Wire();
-    fixer.delete();
+    const result = getKernel().healWire(wire.wrapped, face?.wrapped);
     const cast = castShape(result);
     if (!isWire(cast)) {
       return err(occtError('HEAL_RESULT_NOT_WIRE', 'Healed result is not a wire'));

--- a/tests/fn-kernelExpansion.test.ts
+++ b/tests/fn-kernelExpansion.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  makeBox,
+  getFaces,
+  getEdges,
+  classifyPointOnFace,
+  splitShape,
+  translateShape,
+  isOk,
+  isErr,
+  unwrap,
+  castShape,
+  sketchRectangle,
+} from '../src/index.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- WASM availability check
+let oc: any;
+
+beforeAll(async () => {
+  oc = await initOC();
+}, 30000);
+
+describe('classifyPointOnFace', () => {
+  it('classifies a point inside a face as "in"', () => {
+    if (!oc.BRepClass_FaceClassifier) return; // skip if not in WASM build
+    const rect = sketchRectangle(10, 10);
+    const face = getFaces(castShape(rect.face().wrapped))[0]!;
+    const result = classifyPointOnFace(face, [0, 0, 0]);
+    expect(result).toBe('in');
+  });
+
+  it('classifies a point outside a face as "out"', () => {
+    if (!oc.BRepClass_FaceClassifier) return;
+    const rect = sketchRectangle(10, 10);
+    const face = getFaces(castShape(rect.face().wrapped))[0]!;
+    const result = classifyPointOnFace(face, [100, 100, 0]);
+    expect(result).toBe('out');
+  });
+
+  it('classifies a point on the boundary as "on"', () => {
+    if (!oc.BRepClass_FaceClassifier) return;
+    const rect = sketchRectangle(10, 10);
+    const face = getFaces(castShape(rect.face().wrapped))[0]!;
+    const result = classifyPointOnFace(face, [5, 0, 0]);
+    expect(result).toBe('on');
+  });
+
+  it('throws when BRepClass_FaceClassifier is unavailable', () => {
+    if (oc.BRepClass_FaceClassifier) return; // skip if available
+    const rect = sketchRectangle(10, 10);
+    const face = getFaces(castShape(rect.face().wrapped))[0]!;
+    expect(() => classifyPointOnFace(face, [0, 0, 0])).toThrow(
+      'BRepClass_FaceClassifier not available'
+    );
+  });
+});
+
+describe('splitShape', () => {
+  it('returns the original shape when no tools provided', () => {
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const result = splitShape(box, []);
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('splits a box with a planar face', () => {
+    if (!oc.BRepAlgoAPI_Splitter) return; // skip if not in WASM build
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const rect = sketchRectangle(100, 100);
+    const face = rect.face();
+    const tool = translateShape(face, [0, 0, 5]);
+
+    const result = splitShape(box, [tool]);
+    expect(isOk(result)).toBe(true);
+    const edges = getEdges(unwrap(result));
+    expect(edges.length).toBeGreaterThan(0);
+  });
+
+  it('returns error when BRepAlgoAPI_Splitter is unavailable', () => {
+    if (oc.BRepAlgoAPI_Splitter) return; // skip if available
+    const box = makeBox([0, 0, 0], [10, 10, 10]);
+    const rect = sketchRectangle(10, 10);
+    const tool = translateShape(rect.face(), [0, 0, 5]);
+    const result = splitShape(box, [tool]);
+    expect(isErr(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add kernel healing ops (`healSolid`, `healFace`, `healWire`) using `ShapeFix_Solid/Face/Wire`
- Add `classifyPointOnFace` using `BRepClass_FaceClassifier` with runtime WASM guard
- Add `splitShape` using `BRepAlgoAPI_Splitter` with runtime WASM guard
- Refactor topology healing functions to delegate to kernel layer
- Export new functions from `src/index.ts`

Re-creation of #95 after branch conflict from #94 merge.

## Test plan
- [x] Point-in-face classification (inside, outside, on-edge)
- [x] Split box with bisecting plane → valid result
- [x] Runtime guards for unavailable WASM classes
- [x] All tests pass, function coverage ≥83%