### PR TITLE
chore(site): configure Vercel deployment

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 public/wasm/
+.vercel
+.env*.local

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "cd .. && npm install --ignore-scripts && cd site && npm install --ignore-scripts",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "headers": [


### PR DESCRIPTION
## Summary
- Add `installCommand` to `site/vercel.json` that installs root dependencies (with `--ignore-scripts` to skip husky) before site dependencies, fixing the Vercel build
- Update `site/.gitignore` for `.vercel` directory and `.env*.local` files

## Context
Deployed the site to the **collective-context** Vercel team as the **brepjs** project. The build was failing because:
1. The root `prepare` script runs `husky`, which isn't available in Vercel's build environment
2. The site's `file:..` dependency on brepjs requires root-level `node_modules` for transitive deps like `opentype.js`

Production URL: https://www.brepjs.dev

## Test plan
- [x] Verified successful production deployment on Vercel
- [x] All pre-commit checks pass (lint, typecheck, tests)