### PR TITLE
fix(site): address PR #122 feedback

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -39,8 +39,9 @@ export default function PlaygroundPage() {
   const editorFormatFnRef = useMemo(() => ({ current: null as (() => void) | null }), []);
 
   // Layout persistence
-  const hLayout = useDefaultLayout({ id: 'playground-h', storage: localStorage });
-  const vLayout = useDefaultLayout({ id: 'playground-v', storage: localStorage });
+  const storage = typeof window !== 'undefined' ? localStorage : undefined;
+  const hLayout = useDefaultLayout({ id: 'playground-h', storage });
+  const vLayout = useDefaultLayout({ id: 'playground-v', storage });
 
   // Seed viewer with pre-computed mesh while WASM engine loads
   useEffect(() => {
@@ -121,11 +122,12 @@ export default function PlaygroundPage() {
       run: handleRun,
       share: handleShare,
       exportSTL: handleExportSTL,
+      exportSTEP: handleExportSTEP,
       formatCode: handleFormat,
       toggleOutput: toggleConsole,
       toggleViewer: toggleViewer,
     }),
-    [handleRun, handleShare, handleExportSTL, handleFormat, toggleConsole, toggleViewer],
+    [handleRun, handleShare, handleExportSTL, handleExportSTEP, handleFormat, toggleConsole, toggleViewer],
   );
 
   useKeyboardShortcuts(shortcutActions, shortcutDefs);

--- a/site/src/components/playground/Toolbar.tsx
+++ b/site/src/components/playground/Toolbar.tsx
@@ -60,7 +60,7 @@ export default function Toolbar({
         <button
           onClick={onExportSTEP}
           disabled={!engineReady}
-          title="Export STEP"
+          title={`Export STEP (${formatShortcut(SHORTCUTS.exportSTEP)})`}
           className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
         >
           STEP

--- a/site/src/components/shared/GradientBackground.tsx
+++ b/site/src/components/shared/GradientBackground.tsx
@@ -24,8 +24,8 @@ interface GradientBackgroundProps {
 }
 
 export default function GradientBackground({
-  colorTop = '#191920',
-  colorBottom = '#0c0c10',
+  colorTop = '#606068',
+  colorBottom = '#2e2e34',
 }: GradientBackgroundProps) {
   const matRef = useRef<THREE.ShaderMaterial>(null);
 

--- a/site/src/lib/shortcuts.ts
+++ b/site/src/lib/shortcuts.ts
@@ -10,6 +10,7 @@ export const SHORTCUTS: Record<string, ShortcutDef> = {
   run: { id: 'run', key: 'Enter', ctrl: true, shift: false, label: 'Run Code' },
   share: { id: 'share', key: 's', ctrl: true, shift: false, label: 'Share' },
   exportSTL: { id: 'exportSTL', key: 'e', ctrl: true, shift: false, label: 'Export STL' },
+  exportSTEP: { id: 'exportSTEP', key: 'e', ctrl: true, shift: true, label: 'Export STEP' },
   formatCode: { id: 'formatCode', key: 'f', ctrl: true, shift: true, label: 'Format Code' },
   toggleOutput: { id: 'toggleOutput', key: 'b', ctrl: true, shift: false, label: 'Toggle Console' },
   toggleViewer: { id: 'toggleViewer', key: '\\', ctrl: true, shift: false, label: 'Toggle Viewer' },


### PR DESCRIPTION
## Summary
- Guard `localStorage` access with `typeof window` check to prevent SSR crashes
- Add `Ctrl+Shift+E` keyboard shortcut for STEP export and include it in the tooltip
- Lighten gradient background to a mid-gray studio look (`#606068` → `#2e2e34`)

## Test plan
- [ ] Verify playground loads without errors
- [ ] Hover STEP button — tooltip should show shortcut
- [ ] Press Ctrl+Shift+E — should trigger STEP export
- [ ] Check 3D viewer background is a visible gray gradient