### PR TITLE
chore: remove WrappingObj, fix lint warnings, update llms.txt

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,7 +1,6 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  entry: ['src/index.ts', 'src/worker.ts'],
   project: ['src/**/*.ts'],
   ignore: ['src/**/*.test.ts'],
   ignoreDependencies: ['brepjs-opencascade'],

--- a/llms.txt
+++ b/llms.txt
@@ -121,7 +121,7 @@ Drawing factory functions:
 - `drawText(text, {startX?, startY?, fontSize?, fontFamily?})` — Text outline (requires `loadFont()` first)
 - `drawPointsInterpolation(points, approxConfig?, {closeShape?})` — BSpline through Point2D[]. `approxConfig`: `{tolerance?, degMax?, degMin?, smoothing?}`
 - `drawParametricFunction(fn, {pointsCount?, start?, stop?, closeShape?}, approxConfig?)` — Parametric curve `fn: (t: number) => Point2D`
-- `drawProjection(shape, camera?)` — Project 3D shape to 2D. `camera`: `ProjectionPlane | ProjectionCamera` (default `'front'`). Returns `{visible: Drawing, hidden: Drawing}`
+- `drawProjection(shape, camera?)` — Project 3D shape to 2D. `camera`: `ProjectionPlane | Camera` (default `'front'`). Returns `{visible: Drawing, hidden: Drawing}`
 - `drawFaceOutline(face)` — Extract face outer wire as a 2D Drawing
 - `deserializeDrawing(data)` — Reconstruct from string produced by `drawing.serialize()`
 
@@ -587,16 +587,14 @@ projectPointOnFace(face, point): Result<{ uv, point, distance }>
 ```typescript
 import {
   measureVolume, measureArea, measureLength,
-  measureDistanceBetween
+  measureDistance
 } from 'brepjs';
 
 measureVolume(solid);                           // number
 measureArea(face);                              // number
 measureLength(edge);                            // number
-measureDistanceBetween(shape1, shape2);         // number
+measureDistance(shape1, shape2);                 // number
 ```
-
-Physical properties: `measureShapeVolumeProperties(shape)`, `measureShapeSurfaceProperties(shape)`, `measureShapeLinearProperties(shape)` — return objects with `centerOfMass` and the relevant measurement.
 
 Functional measurement API:
 ```typescript
@@ -883,35 +881,32 @@ import {
 Project 3D shapes to 2D for technical drawings:
 
 ```typescript
-import { drawProjection, ProjectionCamera, lookFromPlane } from 'brepjs';
+import { drawProjection, createCamera, cameraLookAt, unwrap } from 'brepjs';
 
 // Quick projection from a named plane
 const { visible, hidden } = drawProjection(shape, 'front');
 const svg = visible.toSVG();
 
 // Custom camera
-const camera = new ProjectionCamera()
-  .setPosition([100, 100, 100])
-  .lookAt([0, 0, 0]);
-const projected = drawProjection(shape, camera);
+const camera = unwrap(createCamera([100, 100, 100], [0, 0, -1]));
+const lookingAt = unwrap(cameraLookAt(camera, [0, 0, 0]));
+const projected = drawProjection(shape, lookingAt);
 ```
 
-Functional camera API:
+Camera API:
 ```typescript
-import { createCamera, cameraLookAt, cameraFromPlane, projectEdges, cameraToProjectionCamera } from 'brepjs';
+import { createCamera, cameraLookAt, cameraFromPlane, projectEdges } from 'brepjs';
 
 createCamera(position?, direction?, xAxis?): Result<Camera>
 cameraLookAt(camera, target): Result<Camera>
 cameraFromPlane(planeName): Result<Camera>
-cameraToProjectionCamera(camera): ProjectionCamera
 projectEdges(shape, camera, withHiddenLines?): { visible: Edge[], hidden: Edge[] }
 ```
 
 Additional projection helpers:
 ```typescript
-import { lookFromPlane, isProjectionPlane, makeProjectedEdges } from 'brepjs';
+import { isProjectionPlane, makeProjectedEdges } from 'brepjs';
 
-lookFromPlane(projectionPlane): ProjectionCamera   // Create camera from named plane (e.g. 'front', 'XY')
 isProjectionPlane(plane): plane is ProjectionPlane  // Type guard for ProjectionPlane strings
 makeProjectedEdges(shape, camera, withHiddenLines?): { visible: Edge[], hidden: Edge[] }  // HLR projection
 ```
@@ -1052,13 +1047,13 @@ const grouped = toGroupedBufferGeometryData(mesh);
 OCCT objects are allocated in WASM memory and must be cleaned up:
 
 ```typescript
-import { gcWithScope, localGC, GCWithScope } from 'brepjs';
+import { withScope, localGC, createHandle, createOcHandle } from 'brepjs';
 
 // Scope-based cleanup (preferred)
-const result = gcWithScope(() => {
-  const a = sketchCircle(10).extrude(20);
-  const b = sketchCircle(5).extrude(30);
-  return unwrap(cutShape(a, b));  // Returned shape survives the scope
+const result = withScope((scope) => {
+  const a = scope.register(someOcctObject);
+  // a is auto-deleted when scope ends
+  return finalShape;  // returned value survives the scope
 });
 
 // Manual cleanup
@@ -1069,25 +1064,13 @@ try {
 } finally {
   cleanup();
 }
-```
-
-Functional API with `Symbol.dispose`:
-```typescript
-import { withScope, DisposalScope, createHandle, createOcHandle } from 'brepjs';
-
-// Automatic disposal of intermediates
-const result = withScope((scope) => {
-  const handle = scope.register(ocObject);
-  // handle.value for access; auto-deleted when scope ends
-  return finalShape;  // survives the scope
-});
 
 // Explicit handle management
 const handle = createHandle(ocShape);     // ShapeHandle: { wrapped, disposed, [Symbol.dispose] }
 const ocHandle = createOcHandle(ocObj);   // OcHandle<T>: { value, disposed, [Symbol.dispose] }
 ```
 
-`GCWithScope` is a deprecated alias for `gcWithScope`. `gcWithObject(obj)` registers objects on an existing WASM object for lifecycle tracking.
+`gcWithScope()` returns a register function that ties cleanup to FinalizationRegistry (GC-based). `gcWithObject(obj)` registers objects on an existing object for lifecycle tracking. `withScope` / `localGC` are preferred for deterministic cleanup.
 
 ## Error Handling
 

--- a/src/core/disposal.ts
+++ b/src/core/disposal.ts
@@ -189,6 +189,20 @@ export function withScope<T>(fn: (scope: DisposalScope) => T): T {
 }
 
 // ---------------------------------------------------------------------------
+// FinalizationRegistry helpers for non-branded wrappers (e.g. Curve2D)
+// ---------------------------------------------------------------------------
+
+/** Register `deletable` for GC cleanup when `owner` is collected. */
+export function registerForCleanup(owner: object, deletable: Deletable): void {
+  registry.register(owner, deletable, deletable);
+}
+
+/** Unregister a previously-registered deletable (call before manual delete). */
+export function unregisterFromCleanup(deletable: Deletable): void {
+  registry.unregister(deletable);
+}
+
+// ---------------------------------------------------------------------------
 // GC helpers (backwards-compatible)
 // ---------------------------------------------------------------------------
 

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -1,8 +1,5 @@
 /**
- * Memory management utilities.
- *
- * This module provides the new disposal system and backward-compatible
- * WrappingObj for classes being migrated.
+ * Memory management utilities — re-export hub for disposal.ts.
  */
 
 export type { Deletable } from './disposal.js';
@@ -14,66 +11,8 @@ export {
   gcWithScope,
   gcWithObject,
   localGC,
+  registerForCleanup,
+  unregisterFromCleanup,
   type ShapeHandle,
   type OcHandle,
 } from './disposal.js';
-
-// ---------------------------------------------------------------------------
-// Legacy WrappingObj — kept during migration, will be removed
-// ---------------------------------------------------------------------------
-
-import type { OpenCascadeInstance } from '../kernel/types.js';
-import { getKernel } from '../kernel/index.js';
-import type { Deletable } from './disposal.js';
-
-// FinalizationRegistry polyfill is installed by disposal.ts (imported above via re-exports).
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- FinalizationRegistry generic typing
-const deletableRegistry = new (globalThis as any).FinalizationRegistry((heldValue: Deletable) => {
-  try {
-    heldValue.delete();
-  } catch {
-    // Object was already deleted manually or via another GC path — this is expected
-    // and not an error. OCCT objects can be deleted multiple times safely.
-  }
-});
-
-/**
- * Legacy wrapper for OCCT objects with FinalizationRegistry-based GC.
- *
- * @remarks Prefer {@link createHandle} + branded shape types for new code.
- * @deprecated Use `createHandle()` from `disposal.ts` instead.
- */
-export class WrappingObj<Type extends Deletable> {
-  protected oc: OpenCascadeInstance;
-  private _wrapped: Type | null;
-
-  constructor(wrapped: Type) {
-    this.oc = getKernel().oc;
-    deletableRegistry.register(this, wrapped, wrapped);
-    this._wrapped = wrapped;
-  }
-
-  get wrapped(): Type {
-    if (this._wrapped === null) throw new Error('This object has been deleted');
-    return this._wrapped;
-  }
-
-  set wrapped(newWrapped: Type) {
-    if (this._wrapped) {
-      deletableRegistry.unregister(this._wrapped);
-      this._wrapped.delete();
-    }
-
-    deletableRegistry.register(this, newWrapped, newWrapped);
-    this._wrapped = newWrapped;
-  }
-
-  delete(): void {
-    if (this._wrapped) {
-      deletableRegistry.unregister(this._wrapped);
-      this._wrapped.delete();
-      this._wrapped = null;
-    }
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export {
 
 export { DEG2RAD, RAD2DEG, HASH_CODE_MAX } from './core/constants.js';
 
-export { WrappingObj, gcWithScope, gcWithObject, localGC, type Deletable } from './core/memory.js';
+export { gcWithScope, gcWithObject, localGC, type Deletable } from './core/memory.js';
 
 // Legacy type exports (kept for compatibility)
 export { isPoint, type Point } from './core/geometry.js';

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,17 +1,5 @@
-import { describe, expect, it, beforeAll } from 'vitest';
-import { initOC } from './setup.js';
-import {
-  WrappingObj,
-  gcWithScope,
-  gcWithObject,
-  localGC,
-  type Deletable,
-} from '../src/core/memory.js';
-import { makeBox } from '../src/index.js';
-
-beforeAll(async () => {
-  await initOC();
-}, 30000);
+import { describe, expect, it } from 'vitest';
+import { gcWithScope, gcWithObject, localGC, type Deletable } from '../src/core/memory.js';
 
 /** Simple mock deletable for unit-level tests. */
 function mockDeletable(): Deletable & { deleted: boolean } {
@@ -80,25 +68,5 @@ describe('gcWithObject', () => {
     const obj = mockDeletable();
     const result = r(obj);
     expect(result).toBe(obj);
-  });
-});
-
-describe('WrappingObj', () => {
-  it('wraps an OCCT shape and exposes it via .wrapped', () => {
-    const box = makeBox([0, 0, 0], [10, 10, 10]);
-    expect(box.wrapped).toBeDefined();
-  });
-
-  it('throws after delete', () => {
-    const box = makeBox([0, 0, 0], [5, 5, 5]);
-    box.delete();
-    expect(() => box.wrapped).toThrow('Shape handle has been disposed');
-  });
-
-  it('tracks disposed state', () => {
-    const box = makeBox([0, 0, 0], [5, 5, 5]);
-    expect(box.disposed).toBe(false);
-    box.delete();
-    expect(box.disposed).toBe(true);
   });
 });

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -164,7 +164,6 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'Sketch',
   'Sketcher',
   'Sketches',
-  'WrappingObj',
   'addChild',
   'addHolesInFace',
   'addStep',


### PR DESCRIPTION
## Summary
- Migrate `BoundingBox2d` and `Curve2D` off deprecated `WrappingObj` to composition with new `registerForCleanup`/`unregisterFromCleanup` helpers in `disposal.ts`
- Remove `WrappingObj` class from `memory.ts` and public API exports
- Fix knip config: remove redundant entry patterns (resolves 2 configuration hints)
- Update `llms.txt`: remove stale references to `ProjectionCamera`, `lookFromPlane`, `cameraToProjectionCamera`, `GCWithScope`, `measureDistanceBetween`

## Test plan
- [x] All 86 test files pass (1464 tests)
- [x] Zero lint errors/warnings
- [x] Typecheck passes
- [x] Knip clean (no hints)
- [x] Layer boundaries pass
- [x] Format check passes
- [x] Pre-commit hook passes (coverage ≥ 83%)