### PR TITLE
chore: migrate poolOptions to top-level for Vitest 4

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,11 +7,7 @@ export default defineConfig({
     testTimeout: 30000,
     exclude: ['benchmarks/**', 'node_modules/**', 'site/**'],
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        execArgv: ['--max-old-space-size=6144'],
-      },
-    },
+    execArgv: ['--max-old-space-size=6144'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary
- Move `poolOptions.forks.execArgv` to top-level `execArgv` per Vitest 4 migration guide
- Eliminates the `DEPRECATED: test.poolOptions was removed in Vitest 4` warning

## Test plan
- [x] No deprecation warning on `npm run test`
- [x] All 1464 tests pass
- [x] Pre-commit hooks pass (lint, typecheck, coverage)