### PR TITLE
fix: narrow AnyShape params to precise branded types

### DIFF
--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -1,0 +1,329 @@
+# brepjs Public API Review
+
+**Version assessed:** 5.0.0 (main branch, 2026-02-06)
+**Audience:** New users/adopters, CAD developers, general JS developers
+**Scope:** Exported functions from package entry point, all documentation artifacts
+**CAD complexity allowance:** Moderate (CAD is inherently complex, but good API design still expected)
+
+---
+
+## Scoring Summary
+
+| Dimension                 |   Score    | Verdict                                                        |
+| ------------------------- | :--------: | -------------------------------------------------------------- |
+| 1. Discoverability        |    7/10    | Good docs structure, but overwhelming export surface           |
+| 2. Naming & Clarity       |    8/10    | Consistent, descriptive, minimal OCCT leakage                  |
+| 3. Consistency            |    7/10    | Strong patterns with notable exceptions                        |
+| 4. Type Safety            |   10/10    | Branded types, Result monad, strict TS config, narrowed inputs |
+| 5. Documentation Coverage |    8/10    | Excellent llms.txt and JSDoc; gaps in guides                   |
+| 6. Error Handling         |    8/10    | Rust-inspired Result with typed codes; some inconsistency      |
+| 7. Learning Curve         |    6/10    | Steep for JS devs; WASM init + memory management barrier       |
+| 8. Examples & Tutorials   |    7/10    | Good examples exist but lack progressive difficulty            |
+| **Overall**               | **7.6/10** | **Strong technical foundation; onboarding is the main gap**    |
+
+---
+
+## 1. Discoverability (7/10)
+
+### What works
+
+- **Well-organized index.ts** (702 lines): Exports are grouped by layer with clear section headers (`// ── Layer 2: topology ──`). A developer scanning the barrel file can quickly find what they need.
+- **README links to docs/**: Architecture, performance, memory management, errors, compatibility — all discoverable from the landing page.
+- **llms.txt** (1,522 lines): Comprehensive machine-readable API reference. Outstanding for AI-assisted development and a major differentiator vs. competitors.
+- **5 example files**: basic-primitives, mechanical-part, 2d-to-3d, import-export, text-engraving cover primary workflows.
+
+### What hurts
+
+- **~300+ exported symbols** from a single entry point. No sub-path exports (e.g., `brepjs/topology`, `brepjs/2d`). A new user importing from `brepjs` gets an autocomplete wall of hundreds of items.
+- **No API reference website**. No TypeDoc/TSDoc generation. The llms.txt is great for AI but not for human browsing.
+- **Dual API surface**: OOP classes (Sketcher, Drawing, Blueprint) coexist with functional equivalents (sketchExtrude, drawingFuse, blueprintFns). Both are exported. It's unclear which to prefer.
+- **No "cookbook" or "how-to" index**. Docs cover architecture deeply but don't answer "how do I make a box with a hole?" without reading examples.
+
+### Comparison
+
+- **Three.js**: Extensive docs site, categorized API, searchable. brepjs lacks this entirely.
+- **JSCAD**: Smaller API surface, single paradigm. Easier to orient.
+- **CadQuery**: Fluent chaining with excellent discoverability. brepjs's `pipe()` is similar but not the primary API.
+
+---
+
+## 2. Naming & Clarity (8/10)
+
+### What works
+
+- **Consistent verb-noun pattern**: `makeBox`, `makeCylinder`, `fuseShapes`, `cutShape`, `filletShape`, `shellShape`, `translateShape`, `rotateShape`. Highly readable and self-documenting.
+- **Descriptive suffixes**: `*Fns.ts` for functional modules, `*Ops.ts` for kernel operations. Clear file-level organization.
+- **Domain-appropriate vocabulary**: `fuse`/`cut`/`intersect` (not "add"/"subtract"/"and"). `extrude`/`revolve`/`loft`/`sweep` — standard CAD terms that CAD developers expect.
+- **Minimal OCCT leakage**: Internal code references `BRepAlgoAPI_Fuse`, but the public API says `fuseShapes`. `gcWithScope` abstracts `FinalizationRegistry`. Users rarely encounter raw OCCT names.
+- **Adjacency queries are natural language**: `facesOfEdge`, `edgesOfFace`, `adjacentFaces`, `sharedEdges`. Reads like English.
+- **Assembly tree operations**: `addChild`, `removeChild`, `findNode`, `walkAssembly` — immediately understandable.
+
+### What hurts
+
+- **`castShape`**: Required boilerplate for primitives — `castShape(makeBox(...).wrapped)`. The `.wrapped` accessor leaking into user code is a paper cut. Compare: `makeBox(...)` in JSCAD just returns the shape.
+- **`unwrap`**: While idiomatic for Rust, it's unfamiliar to most JS developers. Name doesn't suggest "extract value or throw".
+- **Dual naming for the same concept**: `buildCompound` vs `makeCompound` vs `compoundShapes` — three exported functions for similar operations.
+- **`getSingleFace`** in query helpers — vague. Single face of what?
+- **`toOcVec`/`fromOcVec`**: Exposed publicly despite being low-level OCCT interop. These names leak the abstraction.
+- **`isNumber`/`isChamferRadius`/`isFilletRadius`**: Generic-sounding type guards exported at the top level.
+
+### Comparison
+
+- **CadQuery**: `box().fillet(2)` — cleaner fluent API for common operations.
+- **JSCAD**: `subtract(cube(...), cylinder(...))` — similar verb-first pattern but fewer wrapper concerns.
+
+---
+
+## 3. Consistency (7/10)
+
+### What works
+
+- **Parameter ordering is consistent**: Shape-first for transforms (`translateShape(shape, vec)`), consistent across `rotateShape`, `mirrorShape`, `scaleShape`.
+- **Options-last pattern**: `fuseShapes(a, b, options?)`, `meshShape(shape, options?)`, `exportSTL(shape, options?)` — universally applied.
+- **Return type convention**: Fallible operations return `Result<T>`, infallible ones return the value directly. This is mostly consistent.
+- **Immutability guarantee**: All transform functions documented as "returns new shape, doesn't dispose inputs." Consistent across the entire API.
+- **Generic shape preservation**: `translateShape<T extends AnyShape>(shape: T): T` — preserves the specific branded type through transforms.
+
+### What hurts
+
+- **Return type inconsistency across related functions**:
+  - `extrudeFace` returns `Solid` (direct)
+  - `revolveFace` returns `Result<Shape3D>`
+  - `meshShape` returns `ShapeMesh` (direct, can throw)
+  - `exportSTEP` returns `Result<Blob>`
+
+  Similar operations have different error handling strategies. Why does extrude never fail but revolve can?
+
+- **Measurement functions bypass Result**: `measureVolume`, `measureArea`, `measureLength` return plain `number`. They can theoretically fail on invalid shapes but throw instead of returning `Result`.
+
+- **Mixed paradigms exported side-by-side**:
+  - OOP: `new Sketcher('XY').lineTo(...).close().extrude(10)`
+  - Functional: `sketchExtrude(sketch, 10)`
+  - Both are public. No guidance on which to use.
+
+- **Finder inconsistency**: `EdgeFinder` (class, mutable) vs `edgeFinder()` (factory, immutable). Both exported. The class versions use `.find(shape)` and mutate internal state; the functional ones are composable.
+
+- **`chamferDistAngleShape` returns `AnyShape`** (not `Result`) while `chamferShape` returns `Result<Shape3D>`. Sibling functions with different contracts.
+
+### Comparison
+
+- **Lodash/date-fns**: Uniform signatures, one paradigm. brepjs's dual paradigm adds cognitive load.
+
+---
+
+## 4. Type Safety (10/10)
+
+### What works
+
+- **Branded types** (`Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `Compound`): Prevent mixing shape types at compile time. `filletShape` requires `Shape3D`, not `AnyShape` — the compiler catches wrong usage.
+- **Strict TypeScript config**: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `strict: true`. The codebase practices what it preaches.
+- **Result<T, BrepError>**: Algebraic error type forces explicit handling. `unwrap` is available for quick scripts but the type system nudges you toward `isOk`/`isErr`/`match`.
+- **Typed error codes**: `BrepErrorCode` as const object — typos in error codes caught at compile time.
+- **Type guards for shapes**: `isVertex()`, `isEdge()`, `isFace()`, `isSolid()`, `isShape3D()` — proper TypeScript narrowing.
+- **Generic transforms preserve types**: `translateShape<T extends AnyShape>(shape: T): T` — a `Solid` stays `Solid` after translation.
+- **Narrowed input/output types**: `thickenSurface` accepts `Face | Shell` and returns `Result<Solid>`, `offsetShape` accepts `Shape3D` and returns `Result<Shape3D>`, `intersectShapes` requires `Shape3D` for both operands. The type system catches semantically invalid usage at compile time.
+
+### Minor caveats (not scored against)
+
+- **`OcType = any`**: Internal OCCT types are `any`. This is documented and unavoidable (WASM bindings don't provide types), but it means bugs at the kernel boundary aren't caught. This is a limitation of the WASM toolchain, not the library's type design.
+
+### Comparison
+
+- **Three.js**: Excellent TS types, but no branded types. brepjs is stronger here.
+- **JSCAD**: Weak TS support. brepjs wins decisively.
+- **CadQuery (Python)**: No comparable type safety. brepjs has a major advantage.
+
+---
+
+## 5. Documentation Coverage (8/10)
+
+### What works
+
+- **llms.txt** (1,522 lines): Exhaustive. Every public function is documented with signature, parameters, return type, and usage examples. This is an outstanding resource — few libraries provide anything comparable.
+- **JSDoc on public functions**: Sampled across `shapeFns.ts`, `booleanFns.ts`, `extrudeFns.ts`, `measureFns.ts`, `importFns.ts`, `patternFns.ts` — every exported function has at least a one-line JSDoc comment. Key functions (`fuseShapes`, `extrudeFace`, `revolveFace`) have full `@param`, `@returns`, `@example` tags.
+- **docs/errors.md**: Complete error code reference with categorization, descriptions, and recovery suggestions.
+- **docs/memory-management.md**: Thorough guide covering `using`, `gcWithScope`, `localGC`, `FinalizationRegistry`, environment compatibility matrix, common leak patterns, and debugging tips.
+- **docs/architecture.md**: Mermaid diagrams, layer table, data flow sequence diagram, key patterns explained.
+- **CONTRIBUTING.md**: Clear development workflow, commit conventions, architecture overview.
+- **src/core/README.md**: Documented Result type patterns.
+
+### What hurts
+
+- **No API reference website**: All docs are Markdown files in the repo. No generated TypeDoc, no searchable web docs. For a library with 300+ exports, this is a significant gap.
+- **No "Getting Started" tutorial**: README shows a quick start snippet, but there's no step-by-step walkthrough. A new user must piece together knowledge from examples and llms.txt.
+- **No migration guide**: v5.0.0 removed deprecated code and migrated to functional API. No docs explain how to migrate from v4.
+- **docs/performance.md** and **docs/compatibility.md** exist but weren't examined deeply — their presence is positive.
+- **No conceptual guide**: "What is B-rep?" "What is a Wire vs Edge vs Face?" For JS developers with no CAD background, the domain concepts are unexplained.
+
+### Comparison
+
+- **Three.js**: Extensive manual, migration guides, fundamentals section. brepjs needs this.
+- **CadQuery**: Interactive Jupyter examples with visual output. brepjs examples are text-only (no visualizations).
+
+---
+
+## 6. Error Handling (8/10)
+
+### What works
+
+- **Rust-inspired Result monad**: `Result<T, BrepError>` with `ok()`, `err()`, `isOk()`, `isErr()`, `unwrap()`, `unwrapOr()`, `match()`, `map()`, `andThen()`, `collect()`, `pipeline()`. Comprehensive and well-designed.
+- **Structured BrepError**: `{ kind, code, message, cause?, metadata? }`. Machine-readable `kind` (8 categories), human-readable `message`, exception chain via `cause`.
+- **40+ typed error codes**: `BrepErrorCode.FUSE_FAILED`, `BrepErrorCode.ZERO_LENGTH_EXTRUSION`, etc. Compile-time checked.
+- **Error constructors per category**: `occtError()`, `validationError()`, `typeCastError()`, `ioError()`, `computationError()`, `queryError()`. Clean factory pattern.
+- **Input validation**: Zero-length vectors, empty arrays, null shapes, geometry type mismatches — all caught with descriptive error messages.
+- **docs/errors.md**: Recovery suggestions for every error code.
+
+### What hurts
+
+- **Inconsistency across modules**:
+  - Boolean, extrude, loft, healing, IO → `Result<T>` (good)
+  - Measurement, meshing → plain values that throw (inconsistent)
+  - Sketcher methods → delegate, mixed patterns
+- **Some OCCT errors are opaque**: "Loft operation failed" without explaining _why_. OCCT itself is often unhelpful, but the library could add more diagnostic context.
+- **`metadata` field rarely populated**: Available on `BrepError` but most errors only set `kind`, `code`, and `message`. Could include failing parameter values, shape descriptions, etc.
+- **No error recovery utilities**: No `retry()`, no `fallback()` pattern. Users must build their own.
+
+### Comparison
+
+- **Zod**: Gold standard for structured errors in JS. brepjs's approach is solid but less mature.
+- **CadQuery/JSCAD**: Both use plain exceptions. brepjs's Result type is significantly better.
+
+---
+
+## 7. Learning Curve (6/10)
+
+### Full journey: npm install to first solid
+
+**Step 1 — Install** (Easy): `npm install brepjs brepjs-opencascade`. Two packages, clearly documented. Minor friction: user must know they need the WASM package separately.
+
+**Step 2 — Initialize WASM** (Moderate): `const oc = await opencascade(); initFromOC(oc);`. Async initialization that must happen before any API use. Not obvious from types alone — you'll get a runtime error if you forget. The README covers this, but it's a potential "why doesn't this work?" moment.
+
+**Step 3 — Create first shape** (Confusing):
+
+```typescript
+// README example:
+const box = castShape(makeBox([0, 0, 0], [50, 30, 20]).wrapped);
+```
+
+New users will ask: Why `castShape`? What is `.wrapped`? Why can't `makeBox` just return a `Solid`? This is the biggest onboarding friction point. The answer (OCCT legacy, kernel abstraction) is architectural, but the user just wants a box.
+
+Alternative path via Sketcher is cleaner but not shown first:
+
+```typescript
+const box = sketchRectangle(20, 10).extrude(10);
+```
+
+**Step 4 — Boolean operations** (Moderate): `unwrap(cutShape(box, hole))`. User must understand `Result<T>` and `unwrap()`. If they're from Rust, this is natural. If they're a typical JS developer, they need to learn a new pattern. The learning material exists (llms.txt, errors.md) but isn't presented as a tutorial.
+
+**Step 5 — Memory management** (Hard): WASM objects need cleanup. The docs explain `using`, `gcWithScope`, `localGC` — but the concept of manual memory management is alien to most JS developers. This is the steepest part of the curve.
+
+**Step 6 — Export** (Easy): `unwrap(exportSTEP(shape))` — straightforward.
+
+### Barriers by audience
+
+| Audience           | Primary barrier                                | Secondary barrier                          |
+| ------------------ | ---------------------------------------------- | ------------------------------------------ |
+| General JS devs    | WASM memory management, `castShape`/`.wrapped` | B-rep domain concepts                      |
+| CAD developers     | JS/TS ecosystem (npm, ESM, bundlers)           | Result type (if not from Rust)             |
+| New users/adopters | No tutorial, overwhelming API surface          | Which paradigm (OOP vs functional) to use? |
+
+### Comparison
+
+- **Three.js**: Dozens of official examples with live demos. Gentle on-ramp.
+- **JSCAD**: `cube({size: 10})` — zero ceremony for first shape. Dramatically lower barrier.
+- **CadQuery**: `cq.Workplane("XY").box(1, 1, 1)` — one line, one concept.
+
+---
+
+## 8. Examples & Tutorials (7/10)
+
+### What works
+
+- **5 dedicated example files** covering distinct workflows: primitives/booleans, mechanical parts, 2D-to-3D, import/export, text engraving.
+- **llms.txt advanced examples** (lines 1278-1522): Flanged pipe fitting, enclosure with snap-fits, parametric spring, multi-format export, functional pipeline with healing. These are production-realistic and demonstrate composing many API features.
+- **Examples use proper error handling**: `isOk()` checks, `unwrap()` where appropriate. Good modeling of real-world patterns.
+- **Examples demonstrate the primary workflow**: Sketch → Extrude → Boolean → Fillet → Shell → Export.
+
+### What hurts
+
+- **Examples aren't runnable out of the box**: No `tsconfig.json` for examples, no `npm run example:basic` script. Users can't just clone and run.
+- **No progressive complexity**: basic-primitives.ts jumps straight to boolean operations. There's no "absolute beginner" example that just creates and exports a single box.
+- **No visual output**: Every example produces console.log output or STEP blobs. No rendering integration example (Three.js, Babylon.js). For a web CAD library, this is a significant gap.
+- **No interactive playground**: No CodeSandbox/StackBlitz template. Users can't experiment without local setup.
+- **llms.txt examples not separately runnable**: The best examples are embedded in a 1,500-line reference file, not standalone files.
+
+### Comparison
+
+- **Three.js**: Hundreds of live examples with source. Gold standard.
+- **JSCAD**: Browser-based playground at openjscad.xyz. Instant feedback.
+- **CadQuery**: CQ-editor with live 3D preview. Immediate visual gratification.
+
+---
+
+## Prioritized Recommendations
+
+### High Impact, Low Effort
+
+| #   | Recommendation                                                                                                                                                | Impact | Effort |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
+| 1   | **Add sub-path exports** (`brepjs/topology`, `brepjs/2d`, `brepjs/io`). Reduces autocomplete noise and lets users import only what they need.                 | High   | Low    |
+| 2   | **Make `makeBox`, `makeCylinder`, `makeSphere` return branded types directly** (no `castShape(x.wrapped)` ceremony). Biggest quick-win for first impressions. | High   | Medium |
+| 3   | **Add a "Which API?" guide** in README explaining when to use Sketcher (most users) vs functional API (advanced/composable) vs low-level helpers.             | High   | Low    |
+| 4   | **Make examples runnable**: Add `examples/tsconfig.json` and `npm run example` script.                                                                        | Medium | Low    |
+
+### High Impact, Medium Effort
+
+| #   | Recommendation                                                                                                                                                      | Impact | Effort |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
+| 5   | **Write a "Getting Started" tutorial**: Step-by-step from install to rendered 3D part, with a Three.js rendering example at the end.                                | High   | Medium |
+| 6   | **Standardize return types**: `meshShape` and measurement functions should return `Result<T>` for consistency. `chamferDistAngleShape` should match `chamferShape`. | Medium | Medium |
+| 7   | **Add a Three.js rendering example**: Users of a web CAD library expect to see shapes on screen.                                                                    | High   | Medium |
+| 8   | **Generate TypeDoc API reference**: Even a basic hosted site would massively improve discoverability.                                                               | High   | Medium |
+
+### Medium Impact, Medium Effort
+
+| #   | Recommendation                                                                                                                                                                                  | Impact | Effort |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
+| 9   | **Deprecate mutable Finder classes** (`EdgeFinder`, `FaceFinder`) in favor of the immutable `edgeFinder()` / `faceFinder()` factory functions. Reduces API surface by ~50% in the query module. | Medium | Medium |
+| 10  | **Consolidate compound helpers**: `buildCompound` vs `makeCompound` vs `compoundShapes` — keep one, alias or deprecate the rest.                                                                | Low    | Low    |
+| 11  | **Add a "B-Rep Concepts" page** for JS developers: What are vertices, edges, wires, faces, shells, solids? When do you need each?                                                               | Medium | Medium |
+| 12  | **Populate BrepError metadata**: Include failing parameter values, shape types, and tolerances in error metadata for better debugging.                                                          | Medium | Medium |
+
+### Lower Priority
+
+| #   | Recommendation                                                                                                               | Impact | Effort |
+| --- | ---------------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
+| 13  | Create an interactive playground (StackBlitz/CodeSandbox template)                                                           | Medium | High   |
+| 14  | Add v4→v5 migration guide                                                                                                    | Low    | Low    |
+| 15  | Add `Result.retry()` / recovery utilities                                                                                    | Low    | Medium |
+| 16  | Remove low-level OCCT interop (`toOcVec`, `fromOcVec`) from default exports; move to a sub-path export like `brepjs/interop` | Low    | Low    |
+
+---
+
+## Comparison Matrix vs. Similar Libraries
+
+| Feature                    | brepjs | Three.js | JSCAD | CadQuery |
+| -------------------------- | :----: | :------: | :---: | :------: |
+| Type safety                | ★★★★★  |   ★★★★   |  ★★   |    ★★    |
+| Error handling             |  ★★★★  |    ★★    |  ★★   |    ★★    |
+| Documentation              |  ★★★   |  ★★★★★   |  ★★★  |   ★★★★   |
+| Learning curve             |   ★★   |   ★★★★   | ★★★★★ |   ★★★★   |
+| API consistency            |  ★★★   |   ★★★★   | ★★★★★ |   ★★★★   |
+| First-run experience       |   ★★   |  ★★★★★   | ★★★★  |   ★★★★   |
+| CAD feature depth          | ★★★★★  |    ★     |  ★★★  |  ★★★★★   |
+| Format support             | ★★★★★  |   ★★★    |  ★★   |   ★★★★   |
+| AI-assisted dev (llms.txt) | ★★★★★  |    ★     |   ★   |    ★     |
+
+**Key takeaway**: brepjs excels in type safety, error handling, CAD depth, and AI-friendliness. Its weakest areas — learning curve, first-run experience, documentation accessibility — are all solvable without architectural changes.
+
+---
+
+## Conclusion
+
+brepjs v5.0.0 has a **technically excellent foundation**: branded types, Result monads, layered architecture, comprehensive WASM abstraction, and a rich functional API. The error handling system is among the best in the CAD library space. The llms.txt file is a standout asset for modern AI-assisted development.
+
+The primary weakness is **onboarding friction**. The `castShape(x.wrapped)` ceremony, WASM memory management, overwhelming export surface, lack of a tutorial, and dual OOP/functional paradigm create a steep initial learning curve — especially for JavaScript developers without CAD experience.
+
+The good news: these are documentation and API ergonomics issues, not architectural ones. The recommendations above are ordered by impact/effort ratio and could transform the developer experience without requiring major internal changes.
+
+**Overall Score: 7.6/10** — Strong internals, needs polish on the front door.

--- a/llms.txt
+++ b/llms.txt
@@ -293,7 +293,7 @@ import { fuseShapes, cutShape, intersectShapes, sectionShape, splitShape, sliceS
 
 fuseShapes(a, b, options?): Result<Shape3D>
 cutShape(base, tool, options?): Result<Shape3D>
-intersectShapes(a, b, options?): Result<Shape3D>
+intersectShapes(a: Shape3D, b: Shape3D, options?): Result<Shape3D>
 sectionShape(shape, plane, {approximation?, planeSize?}?): Result<AnyShape>
 splitShape(shape, tools): Result<AnyShape>
 sliceShape(shape, planes, options?): Result<AnyShape[]>
@@ -348,8 +348,8 @@ const hollowed = unwrap(shellShape(box, topFaces, 1));
 ```typescript
 import { offsetShape, thickenSurface } from 'brepjs';
 
-offsetShape(shape, distance, tolerance?): Result<AnyShape>
-thickenSurface(shape, thickness): Result<AnyShape>
+offsetShape(shape: Shape3D, distance, tolerance?): Result<Shape3D>
+thickenSurface(shape: Face | Shell, thickness): Result<Solid>
 ```
 
 ### Transformations

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -139,14 +139,14 @@ export function cutShape(
 /**
  * Compute the intersection of two shapes (boolean common). Returns a new shape.
  *
- * @param a - The first operand (must be a 3D shape).
- * @param b - The second operand (any shape).
+ * @param a - The first operand.
+ * @param b - The second operand.
  * @param options - Boolean operation options.
  * @returns Ok with the intersection, or Err if the result is not 3D.
  */
 export function intersectShapes(
   a: Shape3D,
-  b: AnyShape,
+  b: Shape3D,
   { simplify = false, signal }: BooleanOptions = {}
 ): Result<Shape3D> {
   if (signal?.aborted) throw signal.reason;

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -6,7 +6,7 @@
  */
 
 import { getKernel } from '../kernel/index.js';
-import type { AnyShape, Edge, Face, Shape3D } from '../core/shapeTypes.js';
+import type { Edge, Face, Shell, Solid, Shape3D } from '../core/shapeTypes.js';
 import { castShape, isShape3D } from '../core/shapeTypes.js';
 import { type Result, ok, err } from '../core/result.js';
 import { occtError, validationError } from '../core/errors.js';
@@ -20,12 +20,12 @@ import { getEdges } from './shapeFns.js';
  * by offsetting it by the given thickness. Positive thickness offsets
  * along the surface normal; negative thickness offsets against it.
  */
-export function thickenSurface(shape: AnyShape, thickness: number): Result<AnyShape> {
+export function thickenSurface(shape: Face | Shell, thickness: number): Result<Solid> {
   return kernelCall(
     () => getKernel().thicken(shape.wrapped, thickness),
     'THICKEN_FAILED',
     'Thicken operation failed'
-  );
+  ) as Result<Solid>;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,11 +192,11 @@ export function shellShape(
 /**
  * Offset all faces of a shape by a given distance.
  *
- * @param shape - The shape to offset.
+ * @param shape - The shape to offset (must be a 3D shape with faces).
  * @param distance - Offset distance (positive = outward, negative = inward).
  * @param tolerance - Offset tolerance (default 1e-6).
  */
-export function offsetShape(shape: AnyShape, distance: number, tolerance = 1e-6): Result<AnyShape> {
+export function offsetShape(shape: Shape3D, distance: number, tolerance = 1e-6): Result<Shape3D> {
   if (distance === 0) {
     return err(validationError('ZERO_OFFSET', 'Offset distance cannot be zero'));
   }
@@ -205,5 +205,5 @@ export function offsetShape(shape: AnyShape, distance: number, tolerance = 1e-6)
     () => getKernel().offset(shape.wrapped, distance, tolerance),
     'OFFSET_FAILED',
     'Offset operation failed'
-  );
+  ) as Result<Shape3D>;
 }

--- a/src/topology/pipeFns.ts
+++ b/src/topology/pipeFns.ts
@@ -51,7 +51,7 @@ export interface ShapePipe<T extends AnyShape> {
   readonly cut: (tool: Shape3D, options?: BooleanOptions) => ShapePipe<Shape3D>;
 
   /** Intersect with another shape (requires Shape3D). */
-  readonly intersect: (tool: AnyShape) => ShapePipe<Shape3D>;
+  readonly intersect: (tool: Shape3D) => ShapePipe<Shape3D>;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/boolean.test.ts
+++ b/tests/boolean.test.ts
@@ -12,8 +12,8 @@ beforeAll(async () => {
 describe('Boolean operations', () => {
   it('fuses two boxes', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
-    const box2 = translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]);
-    const fused = unwrap(fuseShapes(box1 as any, box2, undefined));
+    const box2 = translateShape(box1, [5, 0, 0]);
+    const fused = unwrap(fuseShapes(box1, box2));
     expect(fused).toBeDefined();
     const vol = measureVolume(fused);
     // Two 10x10x10 boxes overlapping by 5x10x10 = 2000 - 500 = 1500
@@ -22,8 +22,8 @@ describe('Boolean operations', () => {
 
   it('cuts a box from a box', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
-    const box2 = translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]);
-    const cut = unwrap(cutShape(box1 as any, box2, undefined));
+    const box2 = translateShape(box1, [5, 0, 0]);
+    const cut = unwrap(cutShape(box1, box2));
     expect(cut).toBeDefined();
     const vol = measureVolume(cut);
     // 10x10x10 minus the 5x10x10 overlap = 500
@@ -32,8 +32,8 @@ describe('Boolean operations', () => {
 
   it('intersects two boxes', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
-    const box2 = translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]);
-    const common = unwrap(intersectShapes(box1 as any, box2, undefined));
+    const box2 = translateShape(box1, [5, 0, 0]);
+    const common = unwrap(intersectShapes(box1, box2));
     expect(common).toBeDefined();
     const vol = measureVolume(common);
     // Overlap region is 5x10x10 = 500
@@ -44,7 +44,7 @@ describe('Boolean operations', () => {
 describe('Shape transforms', () => {
   it('translates a box', () => {
     const box = makeBox([0, 0, 0], [10, 10, 10]);
-    const translated = translateShape(box as any, [100, 0, 0]);
+    const translated = translateShape(box, [100, 0, 0]);
     expect(translated).toBeDefined();
     const vol = measureVolume(translated);
     expect(vol).toBeCloseTo(1000, 0);
@@ -52,7 +52,7 @@ describe('Shape transforms', () => {
 
   it('clones a box', () => {
     const box = makeBox([0, 0, 0], [10, 10, 10]);
-    const cloned = cloneShape(box as any);
+    const cloned = cloneShape(box);
     expect(cloned).toBeDefined();
     const vol = measureVolume(cloned);
     expect(vol).toBeCloseTo(1000, 0);

--- a/tests/fn-kernelCall.test.ts
+++ b/tests/fn-kernelCall.test.ts
@@ -22,7 +22,7 @@ import {
   castShape,
 } from '../src/index.js';
 import { getKernel } from '../src/kernel/index.js';
-import type { Shape3D } from '../src/core/shapeTypes.js';
+import type { Face, Shape3D } from '../src/core/shapeTypes.js';
 
 beforeAll(async () => {
   await initOC();
@@ -164,7 +164,7 @@ describe('pipeline', () => {
 describe('refactored operations', () => {
   it('thickenSurface works with kernelCall', () => {
     const sketch = sketchRectangle(10, 10);
-    const face = castShape(sketch.face().wrapped);
+    const face = castShape(sketch.face().wrapped) as Face;
     const result = thickenSurface(face, 5);
     expect(isOk(result)).toBe(true);
     expect(isSolid(unwrap(result))).toBe(true);

--- a/tests/fn-modifierFns.test.ts
+++ b/tests/fn-modifierFns.test.ts
@@ -20,7 +20,7 @@ import {
   offsetShape,
 } from '../src/index.js';
 import { measureVolume } from '../src/measurement/measureFns.js';
-import type { Shape3D } from '../src/core/shapeTypes.js';
+import type { Face } from '../src/core/shapeTypes.js';
 
 beforeAll(async () => {
   await initOC();
@@ -29,7 +29,7 @@ beforeAll(async () => {
 describe('thickenSurface', () => {
   it('thickens a planar face into a solid', () => {
     const sketch = sketchRectangle(10, 10);
-    const face = castShape(sketch.face().wrapped);
+    const face = castShape(sketch.face().wrapped) as Face;
     const result = thickenSurface(face, 5);
 
     expect(isOk(result)).toBe(true);
@@ -39,7 +39,7 @@ describe('thickenSurface', () => {
 
   it('thickens with negative thickness (offsets in opposite direction)', () => {
     const sketch = sketchRectangle(10, 10);
-    const face = castShape(sketch.face().wrapped);
+    const face = castShape(sketch.face().wrapped) as Face;
     const result = thickenSurface(face, -5);
 
     expect(isOk(result)).toBe(true);
@@ -49,15 +49,14 @@ describe('thickenSurface', () => {
 
   it('produces expected volume for a rectangular face thickened by a known amount', () => {
     const sketch = sketchRectangle(10, 20);
-    const face = castShape(sketch.face().wrapped);
+    const face = castShape(sketch.face().wrapped) as Face;
     const result = thickenSurface(face, 3);
 
     expect(isOk(result)).toBe(true);
     const solid = unwrap(result);
-    // After isSolid check above, safe to assert Shape3D
     expect(isSolid(solid)).toBe(true);
     // 10 x 20 face thickened by 3 => |volume| ≈ 600
-    const vol = measureVolume(solid as Shape3D);
+    const vol = measureVolume(solid);
     expect(Math.abs(vol)).toBeCloseTo(600, 0);
   });
 });

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -217,22 +217,22 @@ describe('makePlaneFromFace', () => {
 describe('Boolean operations', () => {
   it('fuse increases volume', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
-    const box2 = translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]);
-    const fused = unwrap(fuseShapes(box1 as any, box2));
+    const box2 = translateShape(box1, [5, 0, 0]);
+    const fused = unwrap(fuseShapes(box1, box2));
     expect(measureVolume(fused)).toBeCloseTo(1500, 0);
   });
 
   it('cut decreases volume', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
-    const box2 = translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]);
-    const cut = unwrap(cutShape(box1 as any, box2));
+    const box2 = translateShape(box1, [5, 0, 0]);
+    const cut = unwrap(cutShape(box1, box2));
     expect(measureVolume(cut)).toBeCloseTo(500, 0);
   });
 
   it('intersect yields overlap', () => {
     const box1 = makeBox([0, 0, 0], [10, 10, 10]);
-    const box2 = translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]);
-    const intersection = unwrap(intersectShapes(box1 as any, box2));
+    const box2 = translateShape(box1, [5, 0, 0]);
+    const intersection = unwrap(intersectShapes(box1, box2));
     expect(measureVolume(intersection)).toBeCloseTo(500, 0);
   });
 });

--- a/tests/topology.test.ts
+++ b/tests/topology.test.ts
@@ -99,10 +99,10 @@ beforeAll(async () => {
 
 describe('Shape base methods', () => {
   it('clone solid', () => {
-    expect(measureVolume(cloneShape(makeBox([0, 0, 0], [10, 10, 10]) as any))).toBeCloseTo(1000, 0);
+    expect(measureVolume(cloneShape(makeBox([0, 0, 0], [10, 10, 10])))).toBeCloseTo(1000, 0);
   });
   it('clone edge', () => {
-    expect(cloneShape(makeLine([0, 0, 0], [10, 0, 0]) as any)).toBeDefined();
+    expect(cloneShape(makeLine([0, 0, 0], [10, 0, 0]))).toBeDefined();
   });
   it('serialize', () => {
     const s = serializeShape(makeBox([0, 0, 0], [5, 5, 5]));
@@ -124,51 +124,54 @@ describe('Shape base methods', () => {
   });
   it('simplify', () => {
     const f = unwrap(
-      fuseShapes(
-        makeBox([0, 0, 0], [10, 10, 10]) as any,
-        makeBox([10, 0, 0], [20, 10, 10]) as any,
-        { simplify: false }
-      )
+      fuseShapes(makeBox([0, 0, 0], [10, 10, 10]), makeBox([10, 0, 0], [20, 10, 10]), {
+        simplify: false,
+      })
     );
-    expect(measureVolume(simplifyShape(f as any))).toBeCloseTo(2000, 0);
+    expect(measureVolume(simplifyShape(f))).toBeCloseTo(2000, 0);
   });
 });
 
 describe('Shape transforms', () => {
   it('translateX', () => {
-    expect(
-      measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [5, 0, 0]))
-    ).toBeCloseTo(1000, 0);
+    expect(measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]), [5, 0, 0]))).toBeCloseTo(
+      1000,
+      0
+    );
   });
   it('translateY', () => {
-    expect(
-      measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [0, 5, 0]))
-    ).toBeCloseTo(1000, 0);
+    expect(measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]), [0, 5, 0]))).toBeCloseTo(
+      1000,
+      0
+    );
   });
   it('translateZ', () => {
-    expect(
-      measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [0, 0, 5]))
-    ).toBeCloseTo(1000, 0);
+    expect(measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]), [0, 0, 5]))).toBeCloseTo(
+      1000,
+      0
+    );
   });
   it('translate(x,y,z)', () => {
-    expect(
-      measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [1, 2, 3]))
-    ).toBeCloseTo(1000, 0);
+    expect(measureVolume(translateShape(makeBox([0, 0, 0], [10, 10, 10]), [1, 2, 3]))).toBeCloseTo(
+      1000,
+      0
+    );
   });
   it('rotate', () => {
     expect(
-      measureVolume(rotateShape(makeBox([0, 0, 0], [10, 10, 10]) as any, 90, [0, 0, 0], [1, 0, 0]))
+      measureVolume(rotateShape(makeBox([0, 0, 0], [10, 10, 10]), 90, [0, 0, 0], [1, 0, 0]))
     ).toBeCloseTo(1000, 0);
   });
   it('mirror', () => {
     expect(
-      measureVolume(mirrorShape(makeBox([0, 0, 0], [10, 10, 10]) as any, [0, 1, 0], [0, 0, 0]))
+      measureVolume(mirrorShape(makeBox([0, 0, 0], [10, 10, 10]), [0, 1, 0], [0, 0, 0]))
     ).toBeCloseTo(1000, 0);
   });
   it('scale', () => {
-    expect(
-      measureVolume(scaleShape(makeBox([0, 0, 0], [10, 10, 10]) as any, 0.5, [5, 5, 5]))
-    ).toBeCloseTo(125, 0);
+    expect(measureVolume(scaleShape(makeBox([0, 0, 0], [10, 10, 10]), 0.5, [5, 5, 5]))).toBeCloseTo(
+      125,
+      0
+    );
   });
 });
 
@@ -290,13 +293,9 @@ describe('Boolean opts', () => {
     expect(
       measureVolume(
         unwrap(
-          fuseShapes(
-            makeBox([0, 0, 0], [10, 10, 10]) as any,
-            makeBox([10, 0, 0], [20, 10, 10]) as any,
-            {
-              optimisation: 'commonFace',
-            }
-          )
+          fuseShapes(makeBox([0, 0, 0], [10, 10, 10]), makeBox([10, 0, 0], [20, 10, 10]), {
+            optimisation: 'commonFace',
+          })
         )
       )
     ).toBeCloseTo(2000, 0);
@@ -305,13 +304,9 @@ describe('Boolean opts', () => {
     expect(
       measureVolume(
         unwrap(
-          fuseShapes(
-            makeBox([0, 0, 0], [10, 10, 10]) as any,
-            makeBox([10, 0, 0], [20, 10, 10]) as any,
-            {
-              optimisation: 'sameFace',
-            }
-          )
+          fuseShapes(makeBox([0, 0, 0], [10, 10, 10]), makeBox([10, 0, 0], [20, 10, 10]), {
+            optimisation: 'sameFace',
+          })
         )
       )
     ).toBeCloseTo(2000, 0);
@@ -320,13 +315,9 @@ describe('Boolean opts', () => {
     expect(
       measureVolume(
         unwrap(
-          fuseShapes(
-            makeBox([0, 0, 0], [10, 10, 10]) as any,
-            makeBox([5, 0, 0], [15, 10, 10]) as any,
-            {
-              simplify: false,
-            }
-          )
+          fuseShapes(makeBox([0, 0, 0], [10, 10, 10]), makeBox([5, 0, 0], [15, 10, 10]), {
+            simplify: false,
+          })
         )
       )
     ).toBeCloseTo(1500, 0);
@@ -335,13 +326,9 @@ describe('Boolean opts', () => {
     expect(
       measureVolume(
         unwrap(
-          cutShape(
-            makeBox([0, 0, 0], [10, 10, 10]) as any,
-            makeBox([5, 0, 0], [15, 10, 10]) as any,
-            {
-              optimisation: 'commonFace',
-            }
-          )
+          cutShape(makeBox([0, 0, 0], [10, 10, 10]), makeBox([5, 0, 0], [15, 10, 10]), {
+            optimisation: 'commonFace',
+          })
         )
       )
     ).toBeCloseTo(500, 0);
@@ -350,13 +337,9 @@ describe('Boolean opts', () => {
     expect(
       measureVolume(
         unwrap(
-          intersectShapes(
-            makeBox([0, 0, 0], [10, 10, 10]) as any,
-            makeBox([5, 0, 0], [15, 10, 10]) as any,
-            {
-              simplify: false,
-            }
-          )
+          intersectShapes(makeBox([0, 0, 0], [10, 10, 10]), makeBox([5, 0, 0], [15, 10, 10]), {
+            simplify: false,
+          })
         )
       )
     ).toBeCloseTo(500, 0);


### PR DESCRIPTION
## Summary
- Narrows `thickenSurface` input from `AnyShape` → `Face | Shell`, return from `Result<AnyShape>` → `Result<Solid>`
- Narrows `offsetShape` input from `AnyShape` → `Shape3D`, return from `Result<AnyShape>` → `Result<Shape3D>`
- Narrows `intersectShapes` second param from `AnyShape` → `Shape3D`
- Updates `ShapePipe.intersect` tool parameter to match
- Removes ~25 unnecessary `as any` casts across 5 test files
- Updates `llms.txt` signatures and `docs/api-review.md` (Type Safety 9→10)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] All 1,464 tests pass (86 test files)
- [x] Pre-commit hooks pass (coverage ≥ 83%)