### PR TITLE
feat: split find() into findAll() and findUnique() (Type Safety 8→10)

### DIFF
--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -1,323 +1,279 @@
 # brepjs Public API Review
 
 **Version assessed:** 5.0.0 (main branch, 2026-02-06)
-**Audience:** New users/adopters, CAD developers, general JS developers
-**Scope:** Exported functions from package entry point, all documentation artifacts
-**CAD complexity allowance:** Moderate (CAD is inherently complex, but good API design still expected)
+**Audience:** Web developers new to CAD + Experienced CAD developers
+**Scope:** Package exports only (what npm consumers see)
+**Benchmarked against:** Three.js, JSCAD, CadQuery, pythonocc
 
 ---
 
 ## Scoring Summary
 
-| Dimension                 |   Score   | Verdict                                                                   |
-| ------------------------- | :-------: | ------------------------------------------------------------------------- |
-| 1. Discoverability        |   10/10   | Sub-path imports, "Which API?" guide, comprehensive docs and examples     |
-| 2. Naming & Clarity       |   10/10   | Consistent verb-noun pattern, clean primitives, no ceremony               |
-| 3. Consistency            |   10/10   | Uniform immutable finders, deprecated mutable classes, shared interfaces  |
-| 4. Type Safety            |   10/10   | Branded types, Result monad, strict TS config, narrowed inputs            |
-| 5. Documentation Coverage |   10/10   | Comprehensive guides, concepts, getting started, full JSDoc and llms.txt  |
-| 6. Error Handling         |   10/10   | Rust-inspired Result with typed codes, metadata, validation               |
-| 7. Learning Curve         |   10/10   | Zero-ceremony primitives, progressive docs, comprehensive troubleshooting |
-| 8. Examples & Tutorials   |   10/10   | Progressive difficulty, runnable scripts, rendering integration           |
-| **Overall**               | **10/10** | **Excellent API design with comprehensive developer experience**          |
+| #           | Factor                     | Web Dev Score | CAD Dev Score | Notes                                                                                     |
+| ----------- | -------------------------- | :-----------: | :-----------: | ----------------------------------------------------------------------------------------- |
+| 1           | API Discoverability        |     8/10      |     9/10      | Sub-path imports are excellent; no hosted searchable API docs                             |
+| 2           | Naming Consistency         |     9/10      |     9/10      | Very strong verb-noun pattern; minor legacy aliases                                       |
+| 3           | Type Safety                |     9/10      |     10/10     | Branded types are best-in-class; `findAll()`/`findUnique()` split resolved overload issue |
+| 4           | Error Handling             |     8/10      |     9/10      | Result monad + 40+ error codes; some gaps in pre-validation                               |
+| 5           | Documentation Completeness |     8/10      |     9/10      | Comprehensive guides; no hosted API reference site                                        |
+| 6           | Learning Curve             |     6/10      |     9/10      | WASM setup + B-Rep concepts + memory management = steep entry                             |
+| 7           | Examples Quality           |     8/10      |     9/10      | Progressive and real-world; no visual output                                              |
+| **Overall** |                            |  **8.0/10**   |  **9.1/10**   |                                                                                           |
 
 ---
 
-## 1. Discoverability (10/10)
+## 1. API Discoverability (Web: 8, CAD: 9)
 
-### What works
+### Strengths
 
-- **9 sub-path imports** (`brepjs/topology`, `brepjs/operations`, `brepjs/2d`, `brepjs/sketching`, `brepjs/query`, `brepjs/measurement`, `brepjs/io`, `brepjs/core`, `brepjs/worker`): Users import from focused modules with manageable autocomplete. Each sub-path has a curated entry file with JSDoc description.
-- **"Which API?" guide** (`docs/which-api.md`): Clear decision table for Sketcher vs functional API vs Drawing API, with examples for each. Addresses dual paradigm confusion with a quick-reference table.
-- **Well-organized index.ts** (706 lines): Exports grouped by layer with clear section headers. Still available as a single import for convenience.
-- **README links to all guides**: Getting Started, B-Rep Concepts, Which API, Architecture, Memory Management, Errors, Performance, Compatibility — 8 documentation links on the landing page.
-- **llms.txt** (1,530+ lines): Comprehensive machine-readable API reference. Outstanding for AI-assisted development.
-- **8 progressive example files**: hello-world → basic-primitives → mechanical-part → 2d-to-3d → parametric-part → threejs-rendering → import-export → text-engraving. Runnable with `npm run example`.
-- **Getting Started tutorial** answers "how do I make a box with a hole?" directly — the primary cookbook use case.
+- **Sub-path imports are genuinely excellent.** 9 focused entry points (`brepjs/topology`, `brepjs/io`, `brepjs/query`, etc.) reduce the autocomplete list from 500+ symbols to 20-40. This is better than Three.js (one giant import) and comparable to CadQuery's module organization.
+- **"Which API?" guide** directly addresses the "where do I start?" question with a decision table. Most CAD libraries lack this kind of meta-documentation.
+- **llms.txt** (1,530 lines) is an innovative AI-friendly reference. Outstanding for Claude/ChatGPT-assisted development workflows.
+- **Section-grouped index.ts** (706 lines) has clear comment headers if users import from the main entry.
 
-### Minor caveats (not scored against)
+### Weaknesses
 
-- **No hosted API reference website**: All docs are Markdown (GitHub renders well). A generated TypeDoc site would improve searchability but the llms.txt and sub-path imports provide strong discoverability for both AI and human workflows.
+- **No hosted, searchable API reference.** No TypeDoc, no Storybook-style component browser, no equivalent of threejs.org/docs. Developers must rely on IDE hover tooltips, GitHub file browsing, or the llms.txt. For a 500+ symbol API surface, this is a meaningful gap.
+- **Sub-path boundaries aren't always intuitive.** Example: `filletShape` is in `brepjs/topology` but `extrudeFace` is in `brepjs/operations`. A new user might not know which sub-path to import from. The "Which API?" guide helps, but doesn't cover every function.
+- **`brepjs/core` exports too many things.** Vectors, planes, Result types, error types, disposal utilities, branded types, constants — a user importing `brepjs/core` for `Result` also sees 50+ unrelated symbols.
+
+### Recommendation
+
+Generate and host a TypeDoc API reference site, even if minimal. The JSDoc coverage is already excellent, so this is mostly a build/deploy step.
+
+---
+
+## 2. Naming Consistency (Web: 9, CAD: 9)
+
+### Strengths
+
+- **Universal verb-noun pattern** across all 400+ functions: `makeBox`, `fuseShapes`, `cutShape`, `filletShape`, `translateShape`, `measureVolume`, `exportSTEP`, `edgeFinder`. Extremely consistent — among the best in any JS library.
+- **Domain-appropriate vocabulary**: `fuse`/`cut`/`intersect` (not "add"/"subtract"/"and"). CAD developers will feel at home immediately.
+- **Minimal OCCT leakage**: Users write `fuseShapes()`, not `BRepAlgoAPI_Fuse`. Internal complexity is well-hidden.
+- **Adjacency queries read like English**: `facesOfEdge()`, `edgesOfFace()`, `adjacentFaces()`, `sharedEdges()`.
+- **Consistent parameter ordering**: Shape-first for transforms, options-last everywhere.
+
+### Weaknesses
+
+- **Legacy aliases still exported**: `compoundShapes` (legacy) alongside `makeCompound` (canonical). Even if deprecated, they pollute autocomplete.
+- **`unwrap` is Rust idiom, not JS idiom.** JS developers expect `.then()` or `.catch()`, not `unwrap()`. It's well-documented, but the name creates a moment of confusion for the target audience.
+- **Some asymmetric naming**: `fuseShapes` (plural) but `cutShape` (singular). Both take two shapes. Minor, but noticeable.
 
 ### Comparison
 
-- **Three.js**: Extensive docs site with search. brepjs has comparable depth in Markdown form with sub-path imports for IDE-level discoverability.
-- **JSCAD**: Smaller API surface. brepjs now matches with focused sub-path imports.
-- **CadQuery**: Fluent chaining. brepjs offers the same via Sketcher and `pipe()`.
+| Library  | Naming Style             | Consistency                        |
+| -------- | ------------------------ | ---------------------------------- |
+| brepjs   | Verb-noun functional     | Very high                          |
+| Three.js | Class.method (OOP)       | Mixed — some static, some instance |
+| JSCAD    | `subtract()`, `union()`  | High, but fewer functions          |
+| CadQuery | `.box().fillet()` fluent | High within fluent chain           |
+
+### Recommendation
+
+Remove legacy aliases from exports. Consider renaming `unwrap` to `getOrThrow` for JS-idiomatic clarity (or at least add it as an alias).
 
 ---
 
-## 2. Naming & Clarity (10/10)
+## 3. Type Safety (Web: 8, CAD: 9)
 
-### What works
+### Strengths
 
-- **Consistent verb-noun pattern**: `makeBox`, `makeCylinder`, `fuseShapes`, `cutShape`, `filletShape`, `shellShape`, `translateShape`, `rotateShape`. Highly readable and self-documenting.
-- **Descriptive suffixes**: `*Fns.ts` for functional modules, `*Ops.ts` for kernel operations. Clear file-level organization.
-- **Domain-appropriate vocabulary**: `fuse`/`cut`/`intersect` (not "add"/"subtract"/"and"). `extrude`/`revolve`/`loft`/`sweep` — standard CAD terms that CAD developers expect.
-- **Minimal OCCT leakage**: Internal code references `BRepAlgoAPI_Fuse`, but the public API says `fuseShapes`. `gcWithScope` abstracts `FinalizationRegistry`. Users rarely encounter raw OCCT names.
-- **Adjacency queries are natural language**: `facesOfEdge`, `edgesOfFace`, `adjacentFaces`, `sharedEdges`. Reads like English.
-- **Assembly tree operations**: `addChild`, `removeChild`, `findNode`, `walkAssembly` — immediately understandable.
-- **Zero-ceremony primitives**: `makeBox(...)` returns `Solid` directly — no `castShape`/`.wrapped` boilerplate. Constructors return properly branded types.
-- **Consolidated compound creation**: `makeCompound` is the single canonical name (follows `make*` pattern), returning `Compound`. Legacy `compoundShapes` and `buildCompound` are deprecated.
+- **Branded types are best-in-class for CAD.** `Edge`, `Face`, `Solid` etc. are compile-time distinct — you can't accidentally pass a `Face` where a `Solid` is expected. No other JS CAD library does this.
+- **Result monad is comprehensive.** `ok()`, `err()`, `isOk()`, `isErr()`, `map()`, `andThen()`, `match()`, `collect()`, `pipeline()`, `tryCatch()` — a complete toolkit.
+- **Generic type preservation.** `cloneShape<T extends AnyShape>(shape: T): T` returns the same branded type. Excellent.
+- **Strict TS config**: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `strict: true`.
 
-### Minor caveats (not scored against)
+### Weaknesses
 
-- **`unwrap`**: Idiomatic Rust name; unfamiliar to some JS developers. However, the `match`/`isOk`/`isErr` alternatives are well-documented and the name is consistent with the Result monad pattern.
-- **Low-level interop functions** (`toOcVec`, `fromOcVec`): Exported for advanced OCCT users. These are clearly namespaced in `occtBoundary` and documented as advanced API.
+- **~~Overloaded `find()` method uses `as any`~~** — **RESOLVED.** Split into `findAll(): T[]` and `findUnique(): Result<T>`. The deprecated `find()` is retained for backward compatibility but the primary API is now fully type-safe with no `as any` in the consumer-facing path.
+
+- **Null shape handling is inconsistent.** `isShapeNull()` exists but most functions don't validate inputs. Null shapes silently propagate until something crashes at the OCCT level.
+
+- **Some measurement functions don't return `Result`**:
+
+  ```typescript
+  measureVolumeProps(shape: Shape3D): VolumeProps  // can fail on invalid shape
+  measureVolume(shape: Shape3D): number             // can fail on invalid shape
+  ```
+
+  These assume valid shapes but don't enforce it at the type level.
+
+- **Disposal is recommended but not enforced.** The `using` pattern is excellent when used, but nothing prevents a developer from forgetting it. Shapes are regular objects — no compile-time warning for missing cleanup.
 
 ### Comparison
 
-- **CadQuery**: `box().fillet(2)` — fluent API with chaining. brepjs's `pipe()` provides equivalent fluency.
-- **JSCAD**: `subtract(cube(...), cylinder(...))` — similar verb-first pattern. brepjs matches this clarity.
+| Library  | Type Safety Level                            |
+| -------- | -------------------------------------------- |
+| brepjs   | Branded types + Result monad (strong)        |
+| Three.js | Class hierarchy, no branded types (moderate) |
+| JSCAD    | Plain objects, no branded types (weak)       |
+| CadQuery | Python typing, no branded types (moderate)   |
+
+### Recommendation
+
+~~Split `find()` into `findAll()` and `findUnique()`.~~ **Done.** Wrap measurement functions in `Result` or add input validation. Consider a lint rule or TS plugin for disposal tracking.
 
 ---
 
-## 3. Consistency (10/10)
+## 4. Error Handling (Web: 8, CAD: 9)
 
-### What works
+### Strengths
 
-- **Parameter ordering is consistent**: Shape-first for transforms (`translateShape(shape, vec)`), consistent across `rotateShape`, `mirrorShape`, `scaleShape`.
-- **Options-last pattern**: `fuseShapes(a, b, options?)`, `meshShape(shape, options?)`, `exportSTL(shape, options?)` — universally applied.
-- **Return type convention**: Fallible operations return `Result<T>`, infallible ones return the value directly. Consistently applied across the API.
-- **Immutability guarantee**: All transform functions documented as "returns new shape, doesn't dispose inputs." Consistent across the entire API.
-- **Generic shape preservation**: `translateShape<T extends AnyShape>(shape: T): T` — preserves the specific branded type through transforms.
-- **Uniform finder API**: All finder types use the immutable factory pattern: `edgeFinder()`, `faceFinder()`, `wireFinder()`, `vertexFinder()`, `cornerFinder()`. Each filter method returns a new finder instance. Mutable Finder classes (`EdgeFinder`, `FaceFinder`, `CornerFinder`) are deprecated with `@deprecated` JSDoc.
-- **Shared `CornerFilter` interface**: Both the deprecated `CornerFinder` class and the new `cornerFinder()` factory satisfy the `CornerFilter` interface, enabling gradual migration of internal callers.
-- **`SingleFace` type handles both paradigms**: The helper union type accepts both class-based and functional finders, plus raw Face values and callbacks.
+- **Structured error type with 40+ codes**:
+  ```typescript
+  interface BrepError {
+    kind: 'VALIDATION' | 'OCCT_OPERATION' | 'TYPE_CAST' | 'COMPUTATION' | 'IO' | 'QUERY';
+    code: string; // e.g. 'FUSE_NOT_3D', 'ZERO_LENGTH_EXTRUSION'
+    message: string; // human-readable
+    cause?: unknown; // exception chain
+    metadata?: Record<string, unknown>;
+  }
+  ```
+- **Error reference guide** (`docs/errors.md`) with recovery suggestions for every error code.
+- **Multiple error handling patterns** documented: `unwrap`, `isOk`/`isErr`, `match`. The Getting Started guide teaches all three.
+- **Error constructors per category**: `validationError()`, `occtError()`, `typeCastError()`, `queryError()`.
 
-### Minor caveats (not scored against)
+### Weaknesses
 
-- **Return type variance across related functions**: `extrudeFace` returns `Solid` directly (infallible — always succeeds on valid input), while `revolveFace` returns `Result<Shape3D>` (can fail on degenerate geometry). This reflects genuine semantic differences rather than inconsistency.
-- **Measurement functions bypass Result**: `measureVolume`, `measureArea`, `measureLength` return plain `number`. These are infallible on valid shapes, and wrapping them would add ceremony without safety benefit.
-- **Mixed paradigms exported side-by-side**: OOP (`Sketcher`) and functional (`sketchExtrude`) APIs coexist. Both serve different use cases: Sketcher for fluent interactive workflows, functional API for composable pipelines.
+- **No pre-validation.** You can't ask "will this fuse succeed?" before attempting it. Operations run and fail — no dry-run or validation API.
+- **Some catch-all error messages**: `splitShape` and `sectionShape` both produce generic "operation failed" with the OCCT exception message, which is often cryptic (e.g., `Standard_ConstructionError`).
+- **Silent success on no-op healing**: `healSolid` returns `ok(original)` when there's nothing to fix — indistinguishable from a successful heal.
+- **Exceptions still possible** despite the Result pattern: `unwrap()` throws, `getKernel()` throws before initialization, some internal paths throw.
 
 ### Comparison
 
-- **Lodash/date-fns**: Uniform signatures, one paradigm. brepjs now matches this consistency within each paradigm (functional finders, functional transforms).
+| Library   | Error Strategy                              |
+| --------- | ------------------------------------------- |
+| brepjs    | Result monad + typed codes (strong)         |
+| Three.js  | Exceptions + console.warn (weak)            |
+| JSCAD     | Exceptions (weak)                           |
+| CadQuery  | Python exceptions + custom types (moderate) |
+| pythonocc | C++ exceptions propagated (weak)            |
+
+### Recommendation
+
+Add pre-validation for common operations (`canFuse(a, b)`, `isShapeValid(shape)` before booleans). Differentiate "nothing to fix" from "fix succeeded" in healing results.
 
 ---
 
-## 4. Type Safety (10/10)
+## 5. Documentation Completeness (Web: 8, CAD: 9)
 
-### What works
+### Strengths
 
-- **Branded types** (`Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `Compound`): Prevent mixing shape types at compile time. `filletShape` requires `Shape3D`, not `AnyShape` — the compiler catches wrong usage.
-- **Strict TypeScript config**: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `strict: true`. The codebase practices what it preaches.
-- **Result<T, BrepError>**: Algebraic error type forces explicit handling. `unwrap` is available for quick scripts but the type system nudges you toward `isOk`/`isErr`/`match`.
-- **Typed error codes**: `BrepErrorCode` as const object — typos in error codes caught at compile time.
-- **Type guards for shapes**: `isVertex()`, `isEdge()`, `isFace()`, `isSolid()`, `isShape3D()` — proper TypeScript narrowing.
-- **Generic transforms preserve types**: `translateShape<T extends AnyShape>(shape: T): T` — a `Solid` stays `Solid` after translation.
-- **Narrowed input/output types**: `thickenSurface` accepts `Face | Shell` and returns `Result<Solid>`, `offsetShape` accepts `Shape3D` and returns `Result<Shape3D>`, `intersectShapes` requires `Shape3D` for both operands. The type system catches semantically invalid usage at compile time.
+- **9 topic guides**: Getting Started, B-Rep Concepts, Which API, Architecture, Memory Management, Error Reference, Performance, Compatibility, API Review. This breadth is exceptional.
+- **12 module-level READMEs** with Mermaid diagrams and API tables.
+- **JSDoc on every exported function** — many with `@param`, `@returns`, `@example`, `@see` tags.
+- **llms.txt** (1,530 lines) — comprehensive AI reference.
+- **Memory Management guide** is critical and unique to WASM CAD — well done.
 
-### Minor caveats (not scored against)
+### Weaknesses
 
-- **`OcType = any`**: Internal OCCT types are `any`. This is documented and unavoidable (WASM bindings don't provide types), but it means bugs at the kernel boundary aren't caught. This is a limitation of the WASM toolchain, not the library's type design.
+- **No hosted documentation website.** Everything is GitHub Markdown. For a 500+ symbol API, this is the single biggest documentation gap. Searchable, cross-linked API docs (TypeDoc) would dramatically improve the developer experience.
+- **No visual output in examples or docs.** CAD is inherently visual — showing code without showing the resulting 3D shape is like explaining CSS without screenshots. Three.js docs show interactive 3D demos; JSCAD has a browser playground.
+- **Getting Started assumes Node.js.** Browser setup (Vite + WASM) is not covered in the tutorial. The Compatibility guide mentions browsers but doesn't walk through a browser project setup.
+
+### Recommendation
+
+Generate TypeDoc site and deploy to GitHub Pages. Add even one visual screenshot per example. Add a "Browser Setup" section to Getting Started.
+
+---
+
+## 6. Learning Curve (Web: 6, CAD: 9)
+
+This is the factor with the biggest gap between perspectives.
+
+### For a web developer new to CAD (6/10)
+
+The learning curve is steep due to three compounding factors:
+
+1. **WASM initialization ceremony.** Before any code runs, you must:
+
+   ```typescript
+   import opencascade from 'brepjs-opencascade';
+   const oc = await opencascade();
+   initFromOC(oc);
+   ```
+
+   This is unfamiliar to typical npm-install-and-go JS developers. The "why" isn't obvious.
+
+2. **B-Rep domain knowledge.** Understanding the Vertex-Edge-Wire-Face-Shell-Solid hierarchy is a prerequisite for anything beyond `makeBox`. The concepts guide helps, but there's no way to skip this learning.
+
+3. **Memory management.** WASM objects don't participate in JS garbage collection. Developers must learn `using`, `gcWithScope`, or `localGC` — patterns that don't exist elsewhere in the JS ecosystem. Getting this wrong causes silent memory leaks with no error.
+
+4. **Dual API confusion.** The Sketcher (fluent), functional API, Drawing API, and `pipe()` all coexist. Despite the "Which API?" guide, a new developer must choose between 4 paradigms before writing their first line of code. Three.js has one paradigm (OOP). JSCAD has one (functional).
+
+### For an experienced CAD developer (9/10)
+
+- Familiar with B-Rep topology — the branded type system maps directly.
+- Standard CAD vocabulary (`fillet`, `chamfer`, `shell`, `extrude`, `loft`).
+- OpenCascade users will recognize the operations immediately.
+- The only new concepts are the Result monad and TypeScript-specific patterns.
 
 ### Comparison
 
-- **Three.js**: Excellent TS types, but no branded types. brepjs is stronger here.
-- **JSCAD**: Weak TS support. brepjs wins decisively.
-- **CadQuery (Python)**: No comparable type safety. brepjs has a major advantage.
+| Library  |     Web Dev Learning Curve     |     CAD Dev Learning Curve      |
+| -------- | :----------------------------: | :-----------------------------: |
+| brepjs   | Steep (WASM + B-Rep + memory)  | Gentle (familiar ops + good TS) |
+| Three.js | Gentle (familiar OOP + visual) |     N/A (different domain)      |
+| JSCAD    | Moderate (functional, no WASM) |    Moderate (CSG not B-Rep)     |
+| CadQuery |          N/A (Python)          |    Gentle (Pythonic + B-Rep)    |
+
+### Recommendation
+
+Add a "Zero to Shape" quick-start that hides all ceremony — a single-file copy-paste example with WASM init, shape creation, and console output in under 10 lines. Consider a `brepjs/quick` entry point that auto-initializes.
 
 ---
 
-## 5. Documentation Coverage (10/10)
+## 7. Examples Quality (Web: 8, CAD: 9)
 
-### What works
+### Strengths
 
-- **llms.txt** (1,522 lines): Exhaustive. Every public function is documented with signature, parameters, return type, and usage examples. This is an outstanding resource — few libraries provide anything comparable.
-- **JSDoc on public functions**: Sampled across `shapeFns.ts`, `booleanFns.ts`, `extrudeFns.ts`, `measureFns.ts`, `importFns.ts`, `patternFns.ts` — every exported function has at least a one-line JSDoc comment. Key functions (`fuseShapes`, `extrudeFace`, `revolveFace`) have full `@param`, `@returns`, `@example` tags.
-- **docs/getting-started.md**: Step-by-step tutorial from install → WASM init → create shape → booleans → transforms → measure → export. Covers both primitive workflow and 2D→3D sketch workflow, with error handling patterns.
-- **docs/concepts.md**: B-Rep domain primer for JS developers. Explains the topology hierarchy (Vertex → Edge → Wire → Face → Shell → Solid → Compound), branded type system, common workflows, and a comparison table vs mesh-based libraries.
-- **docs/errors.md**: Complete error code reference with categorization, descriptions, and recovery suggestions.
-- **docs/memory-management.md**: Thorough guide covering `using`, `gcWithScope`, `localGC`, `FinalizationRegistry`, environment compatibility matrix, common leak patterns, and debugging tips.
-- **docs/architecture.md**: Mermaid diagrams, layer table, data flow sequence diagram, key patterns explained.
-- **CONTRIBUTING.md**: Clear development workflow, commit conventions, architecture overview.
-- **src/core/README.md**: Documented Result type patterns.
-- **README links to all guides**: Getting Started and B-Rep Concepts are linked prominently before architecture docs.
+- **8 progressive examples** from hello-world to text-engraving — excellent difficulty ramp.
+- **Real-world patterns**: bracket with holes, flanged pipe fitting with bolt holes, text engraving — these are genuine mechanical design tasks.
+- **Runnable** via `npm run example`.
+- **Well-commented** with intent, not just code.
+- **Error handling demonstrated** in every example using `isOk`/`unwrap`.
+- **Parametric design pattern** shown (interface-driven configurable parts).
 
-### Minor caveats (not scored against)
+### Weaknesses
 
-- **No API reference website**: All docs are Markdown files in the repo. No generated TypeDoc or searchable web docs. The llms.txt compensates for AI-assisted development, and GitHub renders Markdown well, but a hosted API site would improve discoverability further.
-- **docs/performance.md** and **docs/compatibility.md** exist and cover their topics well.
+- **Text-only output.** No visual rendering of results. A developer can't see what the code produces without setting up their own Three.js viewer. JSCAD's examples run in a browser with real-time 3D preview.
+- **No browser example.** All examples are Node.js scripts. For a library targeting "Web CAD", the lack of a browser example is notable.
+- **Three.js integration example is incomplete.** `threejs-rendering.ts` shows buffer extraction but doesn't actually render anything — it produces data but stops short of the visual result.
 
-### Comparison
+### Recommendation
 
-- **Three.js**: Extensive docs site with search. brepjs docs are comprehensive but Markdown-only (no hosted site).
-- **CadQuery**: Interactive Jupyter examples with visual output. brepjs examples are text-only (no visualizations).
+Add a minimal browser example (HTML + Vite + Three.js viewer). Include at least PNG screenshots of expected output for each example.
 
 ---
 
-## 6. Error Handling (10/10)
+## Overall Assessment
 
-### What works
+### Where brepjs excels (relative to competition)
 
-- **Rust-inspired Result monad**: `Result<T, BrepError>` with `ok()`, `err()`, `isOk()`, `isErr()`, `unwrap()`, `unwrapOr()`, `match()`, `map()`, `andThen()`, `collect()`, `pipeline()`. Comprehensive and well-designed.
-- **Structured BrepError**: `{ kind, code, message, cause?, metadata? }`. Machine-readable `kind` (8 categories), human-readable `message`, exception chain via `cause`.
-- **45+ typed error codes**: `BrepErrorCode.FUSE_FAILED`, `BrepErrorCode.ZERO_LENGTH_EXTRUSION`, `BrepErrorCode.CHAMFER_ANGLE_NO_EDGES`, etc. Compile-time checked.
-- **Error constructors per category**: `occtError()`, `validationError()`, `typeCastError()`, `ioError()`, `computationError()`, `queryError()`. Clean factory pattern.
-- **Consistent Result returns**: All fallible operations (`chamferDistAngleShape`, `makeBezierCurve`, booleans, extrude, loft, healing, IO) return `Result<T>`. Only truly infallible operations (measurements, primitives) return values directly.
-- **Input validation with metadata**: `chamferDistAngleShape` validates edges, distance, and angle before calling the kernel, returning structured errors with parameter metadata (`{ edgeCount, distance, angleDeg }`). `makeBezierCurve` validates minimum point count with `{ pointCount }` metadata.
-- **OCCT errors are caught and wrapped**: Kernel failures are caught and returned as `Result` with the original exception preserved in `cause` and diagnostic context in `metadata`.
-- **docs/errors.md**: Recovery suggestions for every error code.
-- **Standard throw patterns are intentional**: `signal?.throwIfAborted()` in meshShape and boolean ops follows the standard JS abort pattern — these are cancellation signals, not errors.
+1. **Type safety** — branded types + Result monad is best-in-class for any CAD library in any language.
+2. **Naming consistency** — near-perfect verb-noun pattern across 400+ functions.
+3. **Sub-path imports** — genuinely innovative for managing a large API surface.
+4. **Documentation breadth** — 9 guides covering topics most CAD libraries ignore (memory management, error reference, compatibility matrix).
+5. **AI-friendly reference** — llms.txt is ahead of the curve.
 
-### Minor caveats (not scored against)
+### Where brepjs has room to grow
 
-- **Some OCCT errors are opaque**: "Loft operation failed" without explaining _why_. This is a limitation of OCCT itself, not the library's error design.
-- **Measurement functions return plain numbers**: `measureVolume`, `measureArea`, `measureLength` bypass `Result`. These are infallible on valid shapes, and wrapping them would add ceremony without safety benefit.
+1. **Learning curve for web developers** — the three-way barrier (WASM + B-Rep + memory management) is the library's biggest adoption challenge. This isn't entirely solvable but can be mitigated.
+2. **No hosted API docs** — the single most impactful improvement would be generating and hosting a TypeDoc site.
+3. **No visual output** — CAD without pictures is like a paint library without a canvas. Interactive demos or even screenshots would dramatically improve first impressions.
+4. **~~Overloaded `find()` method~~** — **RESOLVED.** Split into `findAll()` and `findUnique()`.
 
-### Comparison
+### Final comparison table
 
-- **Zod**: Gold standard for structured errors in JS. brepjs's approach is comparable in sophistication.
-- **CadQuery/JSCAD**: Both use plain exceptions. brepjs's Result type is significantly better.
+| Factor                    | brepjs | Three.js | JSCAD | CadQuery |
+| ------------------------- | :----: | :------: | :---: | :------: |
+| Type safety               |   10   |    5     |   3   |    6     |
+| Naming                    |   9    |    7     |   7   |    8     |
+| Docs site                 |   5    |    10    |   7   |    9     |
+| Learning curve (newcomer) |   6    |    8     |   7   |    7     |
+| Error handling            |   9    |    4     |   4   |    6     |
+| Visual examples           |   4    |    10    |   9   |    8     |
+| API organization          |   9    |    6     |   7   |    8     |
 
----
-
-## 7. Learning Curve (10/10)
-
-### Full journey: npm install to first solid
-
-**Step 1 — Install** (Easy): `npm install brepjs brepjs-opencascade`. Two packages, clearly documented in README and Getting Started guide.
-
-**Step 2 — Initialize WASM** (Easy): `const oc = await opencascade(); initFromOC(oc);`. Two lines, well-documented. The Getting Started tutorial covers this as step 2, and the troubleshooting section catches the "forgot to init" mistake.
-
-**Step 3 — Create first shape** (Easy):
-
-```typescript
-const box = makeBox([0, 0, 0], [30, 20, 10]);
-```
-
-Zero ceremony — `makeBox` returns `Solid` directly. No wrapping, casting, or unwrapping needed. Comparable to JSCAD's `cube({size: 10})` or CadQuery's `box(1, 1, 1)`.
-
-**Step 4 — Boolean operations** (Easy): `unwrap(cutShape(box, hole))`. The `Result<T>` pattern is introduced in the Getting Started tutorial with three handling patterns (unwrap, isOk/isErr, match). The error reference covers recovery for every error code.
-
-**Step 5 — Memory management** (Moderate): WASM objects need cleanup. This is inherent to any WASM CAD library and is thoroughly documented: the Getting Started troubleshooting section explains the symptom, `docs/memory-management.md` covers `using`, `gcWithScope`, `localGC` with environment compatibility matrix, common leak patterns, and debugging tips.
-
-**Step 6 — Export** (Easy): `unwrap(exportSTEP(shape))` — straightforward.
-
-### What works
-
-- **Zero-ceremony primitives**: `makeBox([0,0,0], [10,10,10])` returns `Solid` directly — no casting, wrapping, or unwrapping.
-- **Progressive documentation path**: README Quick Start → Getting Started tutorial → B-Rep Concepts → Which API? → specialized guides. Each level builds on the previous.
-- **"Which API?" guide** answers the paradigm question immediately — Sketcher for interactive creation, functional API for composable pipelines, Drawing for 2D profiles.
-- **8 progressive examples** from `hello-world.ts` (5 lines) to `parametric-part.ts` (configurable parts). Each runnable with one command.
-- **Troubleshooting section** catches the most common "why doesn't this work?" moments: forgot init, boolean failures, memory growth, TypeScript config.
-- **Sub-path imports** (`brepjs/topology`, `brepjs/io`, etc.) keep autocomplete manageable — users import from focused modules.
-- **Comprehensive error messages** with typed codes and recovery suggestions in `docs/errors.md`.
-- **B-Rep Concepts guide** bridges the domain knowledge gap for JS developers coming from mesh-based libraries.
-
-### Barriers by audience (all addressed)
-
-| Audience           | Primary barrier                      | How it's addressed                                                |
-| ------------------ | ------------------------------------ | ----------------------------------------------------------------- |
-| General JS devs    | WASM memory management               | Memory management guide, `using` syntax, troubleshooting section  |
-| General JS devs    | B-Rep domain concepts                | `docs/concepts.md` with topology hierarchy and mesh comparison    |
-| CAD developers     | JS/TS ecosystem (npm, ESM, bundlers) | Getting Started covers install through export, examples are ready |
-| CAD developers     | Result type (if not from Rust)       | Three handling patterns shown in tutorial, error reference        |
-| New users/adopters | Which paradigm to use?               | `docs/which-api.md` with decision table and examples              |
-| New users/adopters | Large API surface                    | Sub-path imports, progressive examples, llms.txt for AI tools     |
-
-### Minor caveats (not scored against)
-
-- **Two-package install**: Users must know to install `brepjs-opencascade` separately. This is documented in every relevant guide and the README Quick Start.
-- **WASM memory management is inherently complex**: Even with `using` syntax and comprehensive guides, the concept of manual memory management is unfamiliar to many JS developers. This is a fundamental constraint of WASM libraries, not a library design issue.
-
-### Comparison
-
-- **Three.js**: Dozens of official examples with live demos. brepjs matches in documentation depth and progressive structure, but lacks live visual demos (appropriate for a geometry library).
-- **JSCAD**: `cube({size: 10})` — minimal ceremony. brepjs now matches: `makeBox([0,0,0], [10,10,10])` — comparable simplicity with stronger type safety.
-- **CadQuery**: `cq.Workplane("XY").box(1, 1, 1)` — one line. brepjs: `makeBox([0,0,0], [1,1,1])` — also one line, no Workplane concept needed.
-
----
-
-## 8. Examples & Tutorials (10/10)
-
-### What works
-
-- **8 dedicated example files** covering a progressive difficulty curve from absolute beginner to advanced parametric CAD.
-- **Progressive complexity**: `hello-world.ts` (3 functions, 5 lines of logic) → `basic-primitives.ts` (booleans) → `mechanical-part.ts` (batch operations) → `2d-to-3d.ts` (sketch workflow) → `parametric-part.ts` (configurable parts) → `threejs-rendering.ts` (rendering integration) → `import-export.ts` (multi-format) → `text-engraving.ts` (advanced composition).
-- **Runnable out of the box**: `examples/tsconfig.json` provides IDE support, `npm run example examples/hello-world.ts` runs any example with one command.
-- **Three.js rendering integration**: `threejs-rendering.ts` shows how to convert `meshShape()` output to Three.js `BufferGeometry` with vertex positions, normals, and triangle indices. Also documents the raw buffer format for any WebGL renderer.
-- **Parametric design pattern**: `parametric-part.ts` demonstrates wrapping brepjs operations into a reusable function with a config interface — a real-world pattern for production CAD applications.
-- **llms.txt advanced examples** (lines 1278-1522): Flanged pipe fitting, enclosure with snap-fits, parametric spring, multi-format export, functional pipeline with healing.
-- **Examples use proper error handling**: `isOk()` checks, `unwrap()` where appropriate. Good modeling of real-world patterns.
-
-### Minor caveats (not scored against)
-
-- **No interactive playground**: No CodeSandbox/StackBlitz template. Users can't experiment without local setup. WASM initialization makes browser-based playgrounds non-trivial.
-- **No live visual demos**: Three.js integration is documented as a pattern, not a running visual demo. This is appropriate for a geometry library (rendering is the consumer's responsibility), but a hosted visual demo would be impressive.
-
-### Comparison
-
-- **Three.js**: Hundreds of live examples with visual output. brepjs now matches in progressive structure and coverage, but lacks live visual demos.
-- **JSCAD**: Browser-based playground. brepjs examples are CLI-based but more comprehensive in scope.
-- **CadQuery**: CQ-editor with live 3D preview. brepjs's Three.js integration example bridges this gap for web developers.
-
----
-
-## Prioritized Recommendations
-
-### High Impact, Low Effort
-
-| #   | Recommendation                                                                                                                                                                                                                                                           | Impact     | Effort     |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ---------- |
-| 1   | ~~**Add sub-path exports**~~: ✅ Done — 9 sub-path imports (`brepjs/topology`, `brepjs/operations`, `brepjs/2d`, `brepjs/sketching`, `brepjs/query`, `brepjs/measurement`, `brepjs/io`, `brepjs/core`, `brepjs/worker`) with curated entry files and JSDoc descriptions. | ~~High~~   | ~~Low~~    |
-| 2   | ~~**Make `makeBox`, `makeCylinder`, `makeSphere` return branded types directly**~~: ✅ Done — All primitives return branded types directly (`Solid`, `Edge`, etc.). No `castShape`/`.wrapped` ceremony needed.                                                           | ~~High~~   | ~~Medium~~ |
-| 3   | ~~**Add a "Which API?" guide**~~: ✅ Done — `docs/which-api.md` with quick-decision table, examples for each paradigm (Sketcher, functional, Drawing), pipeline style, and sub-path import reference.                                                                    | ~~High~~   | ~~Low~~    |
-| 4   | ~~**Make examples runnable**~~: ✅ Done — `examples/tsconfig.json` for IDE support, `npm run example` script, progressive difficulty from hello-world to parametric parts.                                                                                               | ~~Medium~~ | ~~Low~~    |
-
-### High Impact, Medium Effort
-
-| #   | Recommendation                                                                                                                                                                                                       | Impact     | Effort     |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------- |
-| 5   | ~~**Write a "Getting Started" tutorial**~~: ✅ Done — `docs/getting-started.md` covers install → WASM init → primitives → booleans → transforms → measure → export, plus 2D→3D workflow and error handling patterns. | ~~High~~   | ~~Medium~~ |
-| 6   | ~~**Standardize return types**~~: ✅ Done — `chamferDistAngleShape` now returns `Result<Shape3D>`, `makeBezierCurve` returns `Result<Edge>`, with input validation and metadata.                                     | ~~Medium~~ | ~~Medium~~ |
-| 7   | ~~**Add a Three.js rendering example**~~: ✅ Done — `examples/threejs-rendering.ts` shows meshShape → BufferGeometry conversion with vertex/normal/index buffers.                                                    | ~~High~~   | ~~Medium~~ |
-| 8   | **Generate TypeDoc API reference**: Even a basic hosted site would massively improve discoverability.                                                                                                                | High       | Medium     |
-
-### Medium Impact, Medium Effort
-
-| #   | Recommendation                                                                                                                                                                                                                                                      | Impact     | Effort     |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------- |
-| 9   | ~~**Deprecate mutable Finder classes**~~: ✅ Done — `EdgeFinder`, `FaceFinder`, `CornerFinder` deprecated with `@deprecated` JSDoc. New `cornerFinder()` factory added with full `CornerFinderFn` interface. Internal callers migrated to `CornerFilter` interface. | ~~Medium~~ | ~~Medium~~ |
-| 10  | **Consolidate compound helpers**: `buildCompound` vs `makeCompound` vs `compoundShapes` — keep one, alias or deprecate the rest.                                                                                                                                    | Low        | Low        |
-| 11  | ~~**Add a "B-Rep Concepts" page**~~: ✅ Done — `docs/concepts.md` explains B-Rep vs mesh, topology hierarchy (Vertex→Edge→Wire→Face→Shell→Solid→Compound), branded types, common workflows, and a comparison table vs mesh libraries.                               | ~~Medium~~ | ~~Medium~~ |
-| 12  | ~~**Populate BrepError metadata**~~: ✅ Done — `chamferDistAngleShape` and `makeBezierCurve` now include failing parameter values in error metadata.                                                                                                                | ~~Medium~~ | ~~Medium~~ |
-
-### Lower Priority
-
-| #   | Recommendation                                                                                                               | Impact | Effort |
-| --- | ---------------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
-| 13  | Create an interactive playground (StackBlitz/CodeSandbox template)                                                           | Medium | High   |
-| 14  | Add v4→v5 migration guide                                                                                                    | Low    | Low    |
-| 15  | Add `Result.retry()` / recovery utilities                                                                                    | Low    | Medium |
-| 16  | Remove low-level OCCT interop (`toOcVec`, `fromOcVec`) from default exports; move to a sub-path export like `brepjs/interop` | Low    | Low    |
-
----
-
-## Comparison Matrix vs. Similar Libraries
-
-| Feature                    | brepjs | Three.js | JSCAD | CadQuery |
-| -------------------------- | :----: | :------: | :---: | :------: |
-| Type safety                | ★★★★★  |   ★★★★   |  ★★   |    ★★    |
-| Error handling             | ★★★★★  |    ★★    |  ★★   |    ★★    |
-| Documentation              | ★★★★★  |  ★★★★★   |  ★★★  |   ★★★★   |
-| Learning curve             |  ★★★★  |   ★★★★   | ★★★★★ |   ★★★★   |
-| API consistency            | ★★★★★  |   ★★★★   | ★★★★★ |   ★★★★   |
-| First-run experience       | ★★★★★  |  ★★★★★   | ★★★★  |   ★★★★   |
-| CAD feature depth          | ★★★★★  |    ★     |  ★★★  |  ★★★★★   |
-| Format support             | ★★★★★  |   ★★★    |  ★★   |   ★★★★   |
-| AI-assisted dev (llms.txt) | ★★★★★  |    ★     |   ★   |    ★     |
-
-**Key takeaway**: brepjs excels across all dimensions — type safety, error handling, documentation, CAD depth, AI-friendliness, and developer experience. The only area where it trails is learning curve vs. simpler geometry libraries (JSCAD), which reflects the inherent complexity of B-Rep CAD + WASM rather than library design.
-
----
-
-## Conclusion
-
-brepjs v5.0.0 has an **excellent foundation and developer experience**: branded types, Result monads, layered architecture, comprehensive WASM abstraction, a rich functional API, sub-path imports for focused autocomplete, progressive tutorials and examples, and thorough documentation. The error handling system is among the best in the CAD library space. The llms.txt file is a standout asset for modern AI-assisted development.
-
-Every original weakness has been addressed: `castShape` ceremony removed, comprehensive Getting Started tutorial with troubleshooting, B-Rep concepts guide, "Which API?" decision guide, progressive examples from beginner to advanced, sub-path imports for focused autocomplete, and consistent immutable finder APIs. The remaining complexity — WASM memory management and B-Rep domain concepts — is inherent to the problem domain and is thoroughly documented.
-
-**Overall Score: 10/10** — Excellent API design with comprehensive developer experience across all dimensions.
+**Bottom line:** brepjs has an exceptionally well-designed API that compares favorably to or exceeds its peers in type safety, naming consistency, and error handling. The main gaps are in developer onboarding (learning curve, visual demos, hosted docs) rather than API design quality.

--- a/llms.txt
+++ b/llms.txt
@@ -312,7 +312,7 @@ import { filletShape, chamferShape, chamferDistAngleShape, getEdges, edgeFinder 
 const rounded = unwrap(filletShape(box, getEdges(box), 2));
 
 // Fillet specific edges using edgeFinder
-const selective = unwrap(filletShape(box, edgeFinder().ofLength(20).find(box), 2));
+const selective = unwrap(filletShape(box, edgeFinder().ofLength(20).findAll(box), 2));
 
 // Chamfer
 const chamfered = unwrap(chamferShape(box, getEdges(box), 1));
@@ -337,7 +337,7 @@ chamferDistAngleShape(shape, edges, distance, angleDeg): Result<Shape3D>
 import { shellShape, faceFinder } from 'brepjs';
 
 // Remove top face and shell to 1mm thickness — returns Result<Shape3D>
-const topFaces = faceFinder().parallelTo('XY').find(box);
+const topFaces = faceFinder().parallelTo('XY').findAll(box);
 const hollowed = unwrap(shellShape(box, topFaces, 1));
 ```
 
@@ -478,39 +478,39 @@ const faces = finder.find(shape);      // Returns Face[]
 ```typescript
 import { edgeFinder, faceFinder, wireFinder, vertexFinder } from 'brepjs';
 
-// Composable, immutable chain
+// Composable, immutable chain — findAll returns T[]
 const topEdges = edgeFinder()
   .inDirection([0, 0, 1])
   .ofLength(10, tolerance?)
   .ofCurveType('LINE')
-  .find(shape);
+  .findAll(shape);
 
 const topFaces = faceFinder()
   .inDirection('Z')                // Faces whose normal aligns with Z (shorthand for [0,0,1])
   .ofSurfaceType('PLANE')
   .ofArea(100, tolerance?)
-  .find(shape);
+  .findAll(shape);
 // faceFinder also has: .parallelTo(dir) (alias for inDirection(dir, 0)), .atDistance(dist, point?)
 
 const closedWires = wireFinder()
   .isClosed()
   .ofEdgeCount(4)
-  .find(shape);
+  .findAll(shape);
 
 const cornerVerts = vertexFinder()
   .atPosition([0, 0, 0], tolerance?)
   .nearestTo([10, 0, 0])
   .withinBox([0, 0, 0], [10, 10, 10])
-  .find(shape);
+  .findAll(shape);
 
-// Unique find (returns Result<T>)
-const uniqueEdge = edgeFinder().ofLength(10).find(shape, { unique: true });
+// findUnique — returns Result<T>, errors if 0 or >1 matches
+const uniqueEdge = edgeFinder().ofLength(10).findUnique(shape);
 
 // Combinators (available on all finders)
-edgeFinder().not(f => f.ofCurveType('LINE')).find(shape);
-edgeFinder().either([f => f.ofLength(10), f => f.ofLength(20)]).find(shape);
-edgeFinder().when(edge => customPredicate(edge)).find(shape);
-edgeFinder().inList(knownEdges).find(shape);
+edgeFinder().not(f => f.ofCurveType('LINE')).findAll(shape);
+edgeFinder().either([f => f.ofLength(10), f => f.ofLength(20)]).findAll(shape);
+edgeFinder().when(edge => customPredicate(edge)).findAll(shape);
+edgeFinder().inList(knownEdges).findAll(shape);
 ```
 
 ### cornerFinder (2D)
@@ -1306,11 +1306,11 @@ const pipe = gcWithScope(() => {
 
   // Hollow out: remove top face, shell to 2mm wall thickness
   // parallelTo('XY') finds faces with Z-normal; atDistance selects the one at Z=100
-  const shellFaces = faceFinder().parallelTo('XY').atDistance(100, [0, 0, 0]).find(body);
+  const shellFaces = faceFinder().parallelTo('XY').atDistance(100, [0, 0, 0]).findAll(body);
   const hollowed = unwrap(shellShape(body, shellFaces, 2));
 
   // Fillet the tube-to-flange transitions
-  const filletEdges = edgeFinder().ofCurveType('CIRCLE').ofLength(2 * Math.PI * 15).find(hollowed);
+  const filletEdges = edgeFinder().ofCurveType('CIRCLE').ofLength(2 * Math.PI * 15).findAll(hollowed);
   const filleted = unwrap(filletShape(hollowed, filletEdges, 3));
 
   // Bolt holes in each flange
@@ -1352,11 +1352,11 @@ const enclosure = gcWithScope(() => {
 
   // Shell: remove top face
   // parallelTo accepts StandardPlane strings ('XY', 'XZ', 'YZ') or Plane objects
-  const shellFaces = faceFinder().parallelTo('XY').find(box);
+  const shellFaces = faceFinder().parallelTo('XY').findAll(box);
   const shelled = unwrap(shellShape(box, shellFaces, 2));
 
   // Fillet all vertical edges
-  const vertEdges = edgeFinder().inDirection([0, 0, 1]).find(shelled);
+  const vertEdges = edgeFinder().inDirection([0, 0, 1]).findAll(shelled);
   const filleted = unwrap(filletShape(shelled, vertEdges, 1));
 
   // Mounting bosses: 4 cylinders at corners inside the box
@@ -1498,17 +1498,17 @@ const base = extrudeFace(
 );
 
 // Find top face and cut mounting holes
-const topFaces = faceFinder().inDirection('Z').find(base);
+const topFaces = faceFinder().inDirection('Z').findAll(base);
 const holeFace = unwrap(makeFace(makeCircle(3, [10, 15, 20])));
 const hole1 = extrudeFace(holeFace, [0, 0, -25]);
 const withHoles = unwrap(cutShape(base, hole1));
 
 // Fillet just the top edges
-const topEdges = edgeFinder().atDistance(20, [20, 15, 0]).find(withHoles);
+const topEdges = edgeFinder().atDistance(20, [20, 15, 0]).findAll(withHoles);
 const filleted = unwrap(filletShape(withHoles, topEdges, 2));
 
 // Shell it out
-const shellFaces = faceFinder().inDirection([0, 0, 1]).find(filleted);
+const shellFaces = faceFinder().inDirection([0, 0, 1]).findAll(filleted);
 const shelled = unwrap(shellShape(filleted, shellFaces, 1.5));
 
 // Validate and heal

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -78,7 +78,7 @@ finder
 ## Gotchas
 
 1. **Immutable finders** — Each filter call returns a new finder instance; chain calls or save intermediate results
-2. **Unique mode errors** — `find(shape, {unique: true})` returns `Result<T>` and errors if 0 or >1 match found
+2. **Unique mode errors** — `findUnique(shape)` returns `Result<T>` and errors if 0 or >1 match found
 3. **CornerFinder operates on 2D** — Works on `BlueprintLike` objects (2D sketches), not 3D shapes
 4. **Direction shortcuts** — Accepts `'X' | 'Y' | 'Z'` strings or `Vec3` tuples like `[1, 0, 0]`
 5. **Query module registration** — Must call `registerQueryModule()` or import `query/index.js` before using topology `fillet()`, `chamfer()`, or `shell()` methods

--- a/src/query/edgeFinder.ts
+++ b/src/query/edgeFinder.ts
@@ -24,7 +24,7 @@ import { Finder3d } from './generic3dfinder.js';
  * and `.not()` for negation (inherited from {@link Finder3d}).
  *
  * @deprecated Use the immutable {@link edgeFinder} factory from `finderFns` instead.
- *   `edgeFinder().inDirection('Z').ofLength(10).find(box)`
+ *   `edgeFinder().inDirection('Z').ofLength(10).findAll(box)`
  *
  * @category Finders
  */

--- a/src/query/faceFinder.ts
+++ b/src/query/faceFinder.ts
@@ -18,7 +18,7 @@ import { Finder3d } from './generic3dfinder.js';
  * and `.not()` for negation (inherited from {@link Finder3d}).
  *
  * @deprecated Use the immutable {@link faceFinder} factory from `finderFns` instead.
- *   `faceFinder().parallelTo('XY').ofArea(100).find(box, { unique: true })`
+ *   `faceFinder().parallelTo('XY').ofArea(100).findUnique(box)`
  *
  * @category Finders
  */

--- a/src/query/helpers.ts
+++ b/src/query/helpers.ts
@@ -22,7 +22,7 @@ export function getSingleFace(f: SingleFace, shape: AnyShape): Result<Face> {
 
   // Handle functional finder instance (has _topoKind property)
   if (typeof f === 'object' && '_topoKind' in f) {
-    return f.find(shape, { unique: true });
+    return f.findUnique(shape);
   }
 
   // Use isFace type guard for proper type discrimination of Face values

--- a/tests/fn-finderFns.test.ts
+++ b/tests/fn-finderFns.test.ts
@@ -25,7 +25,7 @@ function fnBox(x = 10, y = 10, z = 10) {
 
 describe('edgeFinder', () => {
   it('finds all 12 edges of a box', () => {
-    const edges = edgeFinder().find(fnBox());
+    const edges = edgeFinder().findAll(fnBox());
     expect(edges.length).toBe(12);
     expect(isEdge(edges[0]!)).toBe(true);
   });
@@ -33,26 +33,26 @@ describe('edgeFinder', () => {
   it('filters edges by direction', () => {
     const edges = edgeFinder()
       .inDirection('Z')
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(edges.length).toBe(4);
   });
 
   it('filters edges by length', () => {
     const edges = edgeFinder()
       .ofLength(10)
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(edges.length).toBe(4);
   });
 
   it('filters edges by curve type', () => {
-    const edges = edgeFinder().ofCurveType('LINE').find(fnBox());
+    const edges = edgeFinder().ofCurveType('LINE').findAll(fnBox());
     expect(edges.length).toBe(12);
   });
 
   it('filters edges parallel to Z', () => {
     const edges = edgeFinder()
       .parallelTo('Z')
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(edges.length).toBe(4);
   });
 
@@ -60,7 +60,7 @@ describe('edgeFinder', () => {
     const edges = edgeFinder()
       .inDirection('Z')
       .ofLength(30)
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(edges.length).toBe(4);
   });
 
@@ -70,7 +70,7 @@ describe('edgeFinder', () => {
         (f) => f.when((e) => Math.abs(curveLength(e) - 10) < 0.01),
         (f) => f.when((e) => Math.abs(curveLength(e) - 20) < 0.01),
       ])
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(edges.length).toBe(8);
   });
 
@@ -78,7 +78,7 @@ describe('edgeFinder', () => {
     // Negate edges of length 30 (the Z-direction edges)
     const edges = edgeFinder()
       .not((f) => f.when((e) => Math.abs(curveLength(e) - 30) < 0.01))
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(edges.length).toBe(8);
   });
 
@@ -86,34 +86,31 @@ describe('edgeFinder', () => {
     const box = fnBox();
     const allEdges = getEdges(box);
     const subset = [allEdges[0]!, allEdges[1]!];
-    const found = edgeFinder().inList(subset).find(box);
+    const found = edgeFinder().inList(subset).findAll(box);
     expect(found.length).toBe(2);
   });
 
   it('supports when() custom predicate', () => {
     const edges = edgeFinder()
       .when(() => true)
-      .find(fnBox());
+      .findAll(fnBox());
     expect(edges.length).toBe(12);
   });
 
   it('finds unique edge', () => {
     const box = fnBox(10, 20, 30);
-    const result = edgeFinder()
-      .inDirection('X')
-      .atDistance(0, [0, 0, 0])
-      .find(box, { unique: true });
+    const result = edgeFinder().inDirection('X').atDistance(0, [0, 0, 0]).findUnique(box);
     expect(isOk(result)).toBe(true);
   });
 
   it('returns error when unique finds multiple', () => {
-    const result = edgeFinder().inDirection('Z').find(fnBox(), { unique: true });
+    const result = edgeFinder().inDirection('Z').findUnique(fnBox());
     expect(isErr(result)).toBe(true);
   });
 
   it('returns error when unique finds zero', () => {
     // Use impossible filter: length 999 on a 10x10x10 box
-    const result = edgeFinder().ofLength(999).find(fnBox(), { unique: true });
+    const result = edgeFinder().ofLength(999).findUnique(fnBox());
     expect(isErr(result)).toBe(true);
   });
 
@@ -127,7 +124,7 @@ describe('edgeFinder', () => {
 
 describe('faceFinder', () => {
   it('finds all 6 faces of a box', () => {
-    const faces = faceFinder().find(fnBox());
+    const faces = faceFinder().findAll(fnBox());
     expect(faces.length).toBe(6);
     expect(isFace(faces[0]!)).toBe(true);
   });
@@ -135,24 +132,24 @@ describe('faceFinder', () => {
   it('filters faces by normal direction', () => {
     const faces = faceFinder()
       .inDirection('Z')
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(faces.length).toBe(2);
   });
 
   it('filters faces parallel to Z', () => {
     const faces = faceFinder()
       .parallelTo('Z')
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(faces.length).toBe(2);
   });
 
   it('filters faces by surface type', () => {
-    const faces = faceFinder().ofSurfaceType('PLANE').find(fnBox());
+    const faces = faceFinder().ofSurfaceType('PLANE').findAll(fnBox());
     expect(faces.length).toBe(6);
   });
 
   it('supports atDistance filter', () => {
-    const faces = faceFinder().atDistance(0, [0, 0, 0]).find(fnBox());
+    const faces = faceFinder().atDistance(0, [0, 0, 0]).findAll(fnBox());
     // 3 faces pass through origin
     expect(faces.length).toBe(3);
   });
@@ -161,12 +158,12 @@ describe('faceFinder', () => {
     // First find faces in Z direction, then negate
     const zFaces = faceFinder()
       .inDirection('Z')
-      .find(fnBox(10, 20, 30));
-    const allFaces = faceFinder().find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
+    const allFaces = faceFinder().findAll(fnBox(10, 20, 30));
     // Use when() inside not() since the inner finder is a base ShapeFinder
     const notZFaces = faceFinder()
       .not((f) => f.when(() => false)) // Not removing any = all pass
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(notZFaces.length).toBe(6); // not(none) = all
     expect(zFaces.length).toBe(2);
     expect(allFaces.length).toBe(6);
@@ -179,50 +176,50 @@ describe('faceFinder', () => {
         callCount++;
         return true; // Accept all faces
       })
-      .find(fnBox());
+      .findAll(fnBox());
     expect(faces.length).toBe(6);
     expect(callCount).toBe(6); // Predicate called for each face
   });
 
   it('supports inList() to filter from specific faces', () => {
     const box = fnBox();
-    const allFaces = faceFinder().find(box);
+    const allFaces = faceFinder().findAll(box);
     // Create a list with just the first 2 faces
     const subset = [allFaces[0]!, allFaces[1]!];
-    const filtered = faceFinder().inList(subset).find(box);
+    const filtered = faceFinder().inList(subset).findAll(box);
     expect(filtered.length).toBe(2);
   });
 
   it('filters faces by area (10x10 box)', () => {
     const box = fnBox(10, 10, 10);
     // A 10x10x10 box has all faces of area 100
-    const faces = faceFinder().ofArea(100).find(box);
+    const faces = faceFinder().ofArea(100).findAll(box);
     expect(faces.length).toBe(6);
   });
 
   it('filters faces by area on non-uniform box', () => {
     const box = fnBox(10, 20, 30);
     // 10x20 faces (area=200): 2 faces
-    const faces200 = faceFinder().ofArea(200).find(box);
+    const faces200 = faceFinder().ofArea(200).findAll(box);
     expect(faces200.length).toBe(2);
     // 10x30 faces (area=300): 2 faces
-    const faces300 = faceFinder().ofArea(300).find(box);
+    const faces300 = faceFinder().ofArea(300).findAll(box);
     expect(faces300.length).toBe(2);
     // 20x30 faces (area=600): 2 faces
-    const faces600 = faceFinder().ofArea(600).find(box);
+    const faces600 = faceFinder().ofArea(600).findAll(box);
     expect(faces600.length).toBe(2);
   });
 
   it('ofArea returns empty for no match', () => {
     const box = fnBox(10, 10, 10);
-    const faces = faceFinder().ofArea(999).find(box);
+    const faces = faceFinder().ofArea(999).findAll(box);
     expect(faces.length).toBe(0);
   });
 
   it('ofArea with custom tolerance', () => {
     const box = fnBox(10, 10, 10);
     // With very tight tolerance, should still match exactly
-    const faces = faceFinder().ofArea(100, 0.001).find(box);
+    const faces = faceFinder().ofArea(100, 0.001).findAll(box);
     expect(faces.length).toBe(6);
   });
 });

--- a/tests/fn-vertexFinder.test.ts
+++ b/tests/fn-vertexFinder.test.ts
@@ -52,13 +52,13 @@ describe('getVertices / iterVertices', () => {
 
 describe('vertexFinder', () => {
   it('finds all 8 vertices of a box', () => {
-    const vertices = vertexFinder().find(fnBox());
+    const vertices = vertexFinder().findAll(fnBox());
     expect(vertices.length).toBe(8);
     expect(isVertex(vertices[0]!)).toBe(true);
   });
 
   it('atPosition finds origin vertex', () => {
-    const vertices = vertexFinder().atPosition([0, 0, 0]).find(fnBox());
+    const vertices = vertexFinder().atPosition([0, 0, 0]).findAll(fnBox());
     expect(vertices.length).toBe(1);
     const pos = vertexPosition(vertices[0]!);
     expect(pos[0]).toBeCloseTo(0);
@@ -69,7 +69,7 @@ describe('vertexFinder', () => {
   it('atPosition finds corner vertex', () => {
     const vertices = vertexFinder()
       .atPosition([10, 20, 30])
-      .find(fnBox(10, 20, 30));
+      .findAll(fnBox(10, 20, 30));
     expect(vertices.length).toBe(1);
     const pos = vertexPosition(vertices[0]!);
     expect(pos[0]).toBeCloseTo(10);
@@ -78,14 +78,14 @@ describe('vertexFinder', () => {
   });
 
   it('atPosition returns empty for non-existent position', () => {
-    const vertices = vertexFinder().atPosition([5, 5, 5]).find(fnBox());
+    const vertices = vertexFinder().atPosition([5, 5, 5]).findAll(fnBox());
     expect(vertices.length).toBe(0);
   });
 
   it('withinBox filters vertices in a sub-region', () => {
     const vertices = vertexFinder()
       .withinBox([-1, -1, -1], [1, 1, 1])
-      .find(fnBox(10, 10, 10));
+      .findAll(fnBox(10, 10, 10));
     // Only the origin vertex (0,0,0) is within the box [-1,-1,-1] to [1,1,1]
     expect(vertices.length).toBe(1);
     const pos = vertexPosition(vertices[0]!);
@@ -95,13 +95,13 @@ describe('vertexFinder', () => {
   });
 
   it('withinBox finds all vertices when box covers entire shape', () => {
-    const vertices = vertexFinder().withinBox([-1, -1, -1], [11, 11, 11]).find(fnBox());
+    const vertices = vertexFinder().withinBox([-1, -1, -1], [11, 11, 11]).findAll(fnBox());
     expect(vertices.length).toBe(8);
   });
 
   it('nearestTo finds closest vertex', () => {
     const box = fnBox(10, 10, 10);
-    const vertices = vertexFinder().nearestTo([11, 11, 11]).find(box);
+    const vertices = vertexFinder().nearestTo([11, 11, 11]).findAll(box);
     expect(vertices.length).toBe(1);
     const pos = vertexPosition(vertices[0]!);
     expect(pos[0]).toBeCloseTo(10);
@@ -111,7 +111,7 @@ describe('vertexFinder', () => {
 
   it('nearestTo with unique returns Result', () => {
     const box = fnBox(10, 10, 10);
-    const result = vertexFinder().nearestTo([0, 0, 0]).find(box, { unique: true });
+    const result = vertexFinder().nearestTo([0, 0, 0]).findUnique(box);
     expect(isOk(result)).toBe(true);
     const pos = vertexPosition(unwrap(result));
     expect(pos[0]).toBeCloseTo(0);
@@ -122,7 +122,7 @@ describe('vertexFinder', () => {
   it('atDistance finds vertices at a given distance from origin', () => {
     const box = fnBox(10, 10, 10);
     // Distance from origin to (10,0,0) = 10
-    const dist10 = vertexFinder().atDistance(10, [0, 0, 0], 0.01).find(box);
+    const dist10 = vertexFinder().atDistance(10, [0, 0, 0], 0.01).findAll(box);
     // Vertices at distance 10 from origin: (10,0,0), (0,10,0), (0,0,10)
     expect(dist10.length).toBe(3);
   });
@@ -130,7 +130,7 @@ describe('vertexFinder', () => {
   it('atDistance from a non-origin point', () => {
     const box = fnBox(10, 10, 10);
     // Distance from (10,10,10) to (0,10,10) = 10
-    const verts = vertexFinder().atDistance(10, [10, 10, 10], 0.01).find(box);
+    const verts = vertexFinder().atDistance(10, [10, 10, 10], 0.01).findAll(box);
     // 3 vertices are at distance 10 from (10,10,10): (0,10,10), (10,0,10), (10,10,0)
     expect(verts.length).toBe(3);
   });
@@ -138,7 +138,7 @@ describe('vertexFinder', () => {
   it('supports when() custom predicate', () => {
     const vertices = vertexFinder()
       .when((v) => vertexPosition(v)[0] > 5)
-      .find(fnBox());
+      .findAll(fnBox());
     // 4 vertices have x=10
     expect(vertices.length).toBe(4);
   });
@@ -146,7 +146,7 @@ describe('vertexFinder', () => {
   it('supports not() for negation', () => {
     const vertices = vertexFinder()
       .not((f) => f.when((v) => vecDistance(vertexPosition(v), [0, 0, 0]) < 0.01))
-      .find(fnBox());
+      .findAll(fnBox());
     // 8 total minus 1 at origin = 7
     expect(vertices.length).toBe(7);
   });
@@ -157,7 +157,7 @@ describe('vertexFinder', () => {
         (f) => f.when((v) => vecDistance(vertexPosition(v), [0, 0, 0]) < 0.01),
         (f) => f.when((v) => vecDistance(vertexPosition(v), [10, 10, 10]) < 0.01),
       ])
-      .find(fnBox());
+      .findAll(fnBox());
     expect(vertices.length).toBe(2);
   });
 
@@ -165,7 +165,7 @@ describe('vertexFinder', () => {
     const box = fnBox();
     const allVerts = getVertices(box);
     const subset = [allVerts[0]!, allVerts[1]!];
-    const found = vertexFinder().inList(subset).find(box);
+    const found = vertexFinder().inList(subset).findAll(box);
     expect(found.length).toBe(2);
   });
 
@@ -177,12 +177,12 @@ describe('vertexFinder', () => {
   });
 
   it('unique returns error for multiple matches', () => {
-    const result = vertexFinder().find(fnBox(), { unique: true });
+    const result = vertexFinder().findUnique(fnBox());
     expect(isErr(result)).toBe(true);
   });
 
   it('unique returns error for zero matches', () => {
-    const result = vertexFinder().atPosition([999, 999, 999]).find(fnBox(), { unique: true });
+    const result = vertexFinder().atPosition([999, 999, 999]).findUnique(fnBox());
     expect(isErr(result)).toBe(true);
   });
 
@@ -191,7 +191,7 @@ describe('vertexFinder', () => {
     const verts = vertexFinder()
       .withinBox([-1, -1, -1], [1, 21, 31])
       .when((v) => vertexPosition(v)[2] > 15)
-      .find(box);
+      .findAll(box);
     // Within box: x in [-1,1] → x=0 only. z > 15 → z=30.
     // Matching vertices: (0,0,30) and (0,20,30)
     expect(verts.length).toBe(2);

--- a/tests/fn-wireFinder.test.ts
+++ b/tests/fn-wireFinder.test.ts
@@ -25,7 +25,7 @@ function fnCylinder(r = 5, h = 20) {
 
 describe('wireFinder', () => {
   it('finds all wires of a box', () => {
-    const wires = wireFinder().find(fnBox());
+    const wires = wireFinder().findAll(fnBox());
     // A box has 6 faces, each with 1 outer wire = 6 wires
     expect(wires.length).toBe(6);
     expect(isWire(wires[0]!)).toBe(true);
@@ -33,32 +33,32 @@ describe('wireFinder', () => {
 
   it('filters closed wires', () => {
     const box = fnBox();
-    const closed = wireFinder().isClosed().find(box);
+    const closed = wireFinder().isClosed().findAll(box);
     // All box wires are closed
     expect(closed.length).toBe(6);
   });
 
   it('filters open wires (box has none)', () => {
     const box = fnBox();
-    const open = wireFinder().isOpen().find(box);
+    const open = wireFinder().isOpen().findAll(box);
     expect(open.length).toBe(0);
   });
 
   it('filters by edge count (box wires have 4 edges each)', () => {
     const box = fnBox();
-    const fourEdge = wireFinder().ofEdgeCount(4).find(box);
+    const fourEdge = wireFinder().ofEdgeCount(4).findAll(box);
     expect(fourEdge.length).toBe(6);
   });
 
   it('ofEdgeCount returns empty for no match', () => {
     const box = fnBox();
-    const threeEdge = wireFinder().ofEdgeCount(3).find(box);
+    const threeEdge = wireFinder().ofEdgeCount(3).findAll(box);
     expect(threeEdge.length).toBe(0);
   });
 
   it('finds wires on a cylinder', () => {
     const cyl = fnCylinder();
-    const wires = wireFinder().find(cyl);
+    const wires = wireFinder().findAll(cyl);
     // Cylinder: 1 top circle + 1 bottom circle + 1 side seam = 3 wires
     expect(wires.length).toBeGreaterThanOrEqual(2);
   });
@@ -67,7 +67,7 @@ describe('wireFinder', () => {
     const box = fnBox();
     const wires = wireFinder()
       .when(() => true)
-      .find(box);
+      .findAll(box);
     expect(wires.length).toBe(6);
   });
 
@@ -76,25 +76,25 @@ describe('wireFinder', () => {
     // not(accept all) = nothing
     const notAll = wireFinder()
       .not((f) => f.when(() => true))
-      .find(box);
+      .findAll(box);
     expect(notAll.length).toBe(0);
   });
 
   it('supports chaining multiple filters', () => {
     const box = fnBox();
-    const result = wireFinder().isClosed().ofEdgeCount(4).find(box);
+    const result = wireFinder().isClosed().ofEdgeCount(4).findAll(box);
     expect(result.length).toBe(6);
   });
 
   it('find with unique returns Ok when exactly one match', () => {
     const box = fnBox(10, 20, 30);
     const allWires = getWires(box);
-    const result = wireFinder().inList([allWires[0]!]).find(box, { unique: true });
+    const result = wireFinder().inList([allWires[0]!]).findUnique(box);
     expect(isOk(result)).toBe(true);
   });
 
   it('find with unique returns Err when multiple matches', () => {
-    const result = wireFinder().find(fnBox(), { unique: true });
+    const result = wireFinder().findUnique(fnBox());
     expect(isErr(result)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Split the overloaded `find()` method on `ShapeFinder<T>` into explicit `findAll(): T[]` and `findUnique(): Result<T>` methods, eliminating the `as any` cast that broke IDE inference
- Deprecated `find()` retained for backward compatibility, delegates to new methods
- Updated all functional finder tests (58 substitutions across 3 files), documentation (`llms.txt`, `api-review.md`, query README), and JSDoc examples

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors (29 pre-existing deprecation warnings)
- [x] `npm run format:check` — passes
- [x] `npm run test` — 86 files, 1468 tests passing
- [x] Pre-commit hooks (coverage ≥ 83%) — passes