### PR TITLE
docs: configure Context7 indexing for API documentation

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,20 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/andymai/brepjs",
-  "public_key": "pk_WmPUK3NlUHZYB3un8SqbQ"
+  "public_key": "pk_WmPUK3NlUHZYB3un8SqbQ",
+  "projectTitle": "brepjs",
+  "description": "Web CAD library built on OpenCascade — create, combine, and export 3D shapes with a functional TypeScript API and WASM-powered B-Rep kernel.",
+  "folders": [
+    "docs",
+    "llms.txt"
+  ],
+  "excludeFolders": [],
+  "excludeFiles": [],
+  "rules": [
+    "Always initialize the WASM kernel before using any brepjs function: `const oc = await opencascade(); initFromOC(oc);`",
+    "Boolean operations (fuseShape, cutShape, intersectShape) return Result<Shape3D> — use unwrap() for scripts or isOk()/match() for production error handling",
+    "Use sub-path imports for focused autocomplete: brepjs/topology, brepjs/operations, brepjs/sketching, brepjs/2d, brepjs/query, brepjs/measurement, brepjs/io",
+    "WASM objects are not garbage collected — use `using` keyword (TS 5.9+) or gcWithScope()/localGC() for memory management",
+    "Peer dependency brepjs-opencascade must be installed separately: `npm install brepjs brepjs-opencascade`"
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds indexing configuration to `context7.json` so Context7 indexes only `docs/` and `llms.txt` instead of the entire repository
- Adds 5 rules for AI assistants covering WASM init, Result handling, sub-path imports, memory management, and peer dependency installation
- Preserves existing ownership fields (`url`, `public_key`)

## Test plan
- [x] JSON is well-formed (validated with Node.js)
- [x] All fields match the [Context7 JSON Schema](https://context7.com/schema/context7.json)
- [x] `docs/` directory and `llms.txt` exist at expected paths