### PR TITLE
feat(site): update playground examples to v5 API

### DIFF
--- a/site/scripts/test-examples.ts
+++ b/site/scripts/test-examples.ts
@@ -31,9 +31,11 @@ for (const ex of examples) {
 
     // Try to mesh it (same as worker)
     const fnShape =
-      result && typeof result === 'object' && 'wrapped' in result
-        ? brepjs.castShape(result.wrapped)
-        : result;
+      result && typeof result === 'object' && '__wrapped' in result
+        ? (result as unknown as { val: unknown }).val
+        : result && typeof result === 'object' && 'wrapped' in result
+          ? brepjs.castShape(result.wrapped)
+          : result;
 
     const shapeMesh = brepjs.meshShape(fnShape, { tolerance: 0.1, angularTolerance: 0.5 });
     const edgeMesh = brepjs.meshShapeEdges(fnShape, { tolerance: 0.1, angularTolerance: 0.5 });

--- a/site/src/lib/constants.ts
+++ b/site/src/lib/constants.ts
@@ -8,29 +8,21 @@ const colR  = 12;   // column radius
 const thick = 4;    // tread thickness
 
 // Central column + landing pad
-const column = makeCylinder(colR, steps * rise + thick);
-const landing = makeCylinder(colR + width, thick);
-let shape = unwrap(fuseShape(column, landing));
+const column = cylinder(colR, steps * rise + thick);
+const landing = cylinder(colR + width, thick);
+let stair = unwrap(fuse(column, landing));
 
 // Spiral treads with railing posts
 for (let i = 0; i < steps; i++) {
-  const tread = makeBox(
-    [0, -depth / 2, 0],
-    [colR + width, depth / 2, thick]
-  );
-  const post = translateShape(
-    makeCylinder(1.5, 90),
-    [colR + width - 4, 0, thick]
-  );
-  const step = unwrap(fuseShape(tread, post));
-  const placed = translateShape(step, [0, 0, rise * (i + 1)]);
-  const rotated = rotateShape(placed, twist * i);
-  shape = unwrap(fuseShape(shape, rotated));
+  const tread = translate(box(colR + width, depth, thick), [0, -depth / 2, 0]);
+  const post = translate(cylinder(1.5, 90), [colR + width - 4, 0, thick]);
+  const step = unwrap(fuse(tread, post));
+  const placed = translate(step, [0, 0, rise * (i + 1)]);
+  const rotated = rotate(placed, twist * i);
+  stair = unwrap(fuse(stair, rotated));
 }
 
-return shape;`;
+return stair;`;
 
 export const DEFAULT_CODE = `// A filleted box
-const box = makeBox([0, 0, 0], [40, 30, 20]);
-const filleted = unwrap(filletShape(box, undefined, 3));
-return filleted;`;
+return shape(box(40, 30, 20)).fillet(3).val;`;

--- a/site/src/lib/examples.ts
+++ b/site/src/lib/examples.ts
@@ -15,8 +15,7 @@ export const examples: Example[] = [
     description: 'A basic box primitive — the simplest possible shape.',
     category: 'Primitives',
     code: `// A simple 40×30×20 box
-const box = makeBox([0, 0, 0], [40, 30, 20]);
-return box;`,
+return box(40, 30, 20);`,
   },
   {
     id: 'filleted-box',
@@ -24,9 +23,7 @@ return box;`,
     description: 'Round all edges of a box with a fillet radius.',
     category: 'Operations',
     code: `// Create a box and fillet all edges
-const box = makeBox([0, 0, 0], [40, 30, 20]);
-const filleted = unwrap(filletShape(box, undefined, 3));
-return filleted;`,
+return shape(box(40, 30, 20)).fillet(3).val;`,
   },
   {
     id: 'boolean-subtraction',
@@ -34,13 +31,8 @@ return filleted;`,
     description: 'Cut a cylinder from a box to create a hole.',
     category: 'Booleans',
     code: `// Box with a cylindrical hole
-const box = makeBox([0, 0, 0], [40, 40, 20]);
-const cyl = translateShape(
-  makeCylinder(10, 30),
-  [20, 20, -5]
-);
-const result = unwrap(cutShape(box, cyl));
-return result;`,
+const hole = cylinder(10, 30, { at: [20, 20, -5] });
+return shape(box(40, 40, 20)).cut(hole).val;`,
   },
   {
     id: 'chamfered-box',
@@ -48,9 +40,7 @@ return result;`,
     description: 'Apply chamfers to all edges of a box — compare with the filleted box.',
     category: 'Operations',
     code: `// Chamfer every edge of a box
-const box = makeBox([0, 0, 0], [40, 30, 20]);
-const chamfered = unwrap(chamferShape(box, undefined, 3));
-return chamfered;`,
+return shape(box(40, 30, 20)).chamfer(3).val;`,
   },
   {
     id: 'extruded-l-shape',
@@ -66,9 +56,7 @@ const sketch = new Sketcher()
   .lineTo([0, 40])
   .close();
 
-const face = sketch.face();
-const solid = basicFaceExtrusion(face, [0, 0, 15]);
-return solid;`,
+return shape(sketch.face()).extrude(15).val;`,
   },
   {
     id: 'revolved-profile',
@@ -86,9 +74,7 @@ const sketch = new Sketcher(plane)
   .lineTo([0, 60])
   .close();
 
-const face = sketch.face();
-const vase = unwrap(revolveFace(face));
-return vase;`,
+return shape(sketch.face()).revolve().val;`,
   },
   {
     id: 'sphere-with-holes',
@@ -96,28 +82,13 @@ return vase;`,
     description: 'Subtract cylinders from a sphere along three axes.',
     category: 'Booleans',
     code: `// Sphere with holes along X, Y, and Z axes
-let shape = makeSphere(25);
-const hole = makeCylinder(8, 60);
+const hole = cylinder(8, 60, { at: [0, 0, -30] });
 
-// Z-axis hole
-const holeZ = translateShape(hole, [0, 0, -30]);
-shape = unwrap(cutShape(shape, holeZ));
-
-// X-axis hole
-const holeX = rotateShape(
-  translateShape(hole, [0, 0, -30]),
-  90, [0, 0, 0], [0, 1, 0]
-);
-shape = unwrap(cutShape(shape, holeX));
-
-// Y-axis hole
-const holeY = rotateShape(
-  translateShape(hole, [0, 0, -30]),
-  90, [0, 0, 0], [1, 0, 0]
-);
-shape = unwrap(cutShape(shape, holeY));
-
-return shape;`,
+return shape(sphere(25))
+  .cut(hole)                                         // Z-axis
+  .cut(rotate(hole, 90, { axis: [0, 1, 0] }))       // X-axis
+  .cut(rotate(hole, 90, { axis: [1, 0, 0] }))       // Y-axis
+  .val;`,
   },
   {
     id: 'spiral-staircase',


### PR DESCRIPTION
## Summary

- Migrate all 8 playground examples from v4 API names (`makeBox`, `makeCylinder`, `fuseShape`, etc.) to v5 short names (`box`, `cylinder`, `fuse`, etc.) with fluent `shape()` chaining
- Add `__wrapped` detection in cad worker and test scripts to handle fluent wrapper objects returned by `shape().val`
- Fix `fnExportSTEP` → `exportSTEP` bug in STEP export handler
- Rewrite `precompute-hero-mesh.ts` with v5 imports and branded types (no more `castShape` calls)

## Test plan

- [x] `npx tsx scripts/test-examples.ts` — all 8 examples produce meshes
- [x] `npx tsx scripts/precompute-hero-mesh.ts` — generates hero-mesh.json (251.5 KB)
- [x] Site typecheck passes (`tsc -b`)
- [x] Lint passes
- [x] Pre-commit hooks pass (coverage ≥ 83%)