### PR TITLE
chore(site): update brepjs dependency to ^7.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4170,9 +4170,9 @@
       }
     },
     "node_modules/brepjs": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/brepjs/-/brepjs-4.29.0.tgz",
-      "integrity": "sha512-C7kbgOPYsqTqu1tlFBaiM5jCxa2opbn1tql8QNXafFhJ0cAqDMrhi3815r4IfgBpfeP/QsazqT65CiV1ufzOLw==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/brepjs/-/brepjs-7.4.2.tgz",
+      "integrity": "sha512-pT8lzq99SadQnT4qmq1WgFCPm2gcyjeBzlUSyPmV+9DHs4/UKodeX6mREJktII2nqsDaBsC0tvNFulSsV8IT7Q==",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -9513,7 +9513,7 @@
         "@monaco-editor/react": "4.7.0",
         "@react-three/drei": "10.7.7",
         "@react-three/fiber": "9.5.0",
-        "brepjs": "^4.29.0",
+        "brepjs": "^7.4.2",
         "brepjs-opencascade": "*",
         "lz-string": "1.5.0",
         "monaco-editor": "0.55.1",

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,7 @@
     "@monaco-editor/react": "4.7.0",
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.5.0",
-    "brepjs": "^4.29.0",
+    "brepjs": "^7.4.2",
     "brepjs-opencascade": "*",
     "lz-string": "1.5.0",
     "monaco-editor": "0.55.1",


### PR DESCRIPTION
## Summary
- Updates the site's `brepjs` dependency from `^4.29.0` to `^7.4.2` (latest)
- The site was 3 major versions behind the published package

## Test plan
- [x] `npm install` completes cleanly with no vulnerabilities
- [ ] Verify site builds successfully with the updated dependency