### PR TITLE
fix(site): use correct CodeQL inline suppression format

### DIFF
--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -198,7 +198,7 @@ function handleEval(id: string, code: string) {
   try {
     // Intentional: playground evaluates user-authored scripts in a sandboxed Web Worker
     // with no access to DOM, cookies, or storage.
-    const fn = new Function(code); // CodeQL [js/code-injection] Playground code execution
+    const fn = new Function(code); // codeql[js/code-injection] Playground evaluates user-authored scripts in sandboxed Web Worker
     let result = fn();
 
     // Restore console
@@ -338,7 +338,7 @@ function handleExportSTL(id: string, code: string) {
     if (lastEvalResult && lastEvalResult.length > 0) {
       result = lastEvalResult[0];
     } else {
-      const fn = new Function(code); // CodeQL [js/code-injection] Playground code execution
+      const fn = new Function(code); // codeql[js/code-injection] Playground evaluates user-authored scripts in sandboxed Web Worker
       result = fn();
     }
 
@@ -371,7 +371,7 @@ function handleExportSTEP(id: string, code: string) {
     if (lastEvalResult && lastEvalResult.length > 0) {
       result = lastEvalResult[0];
     } else {
-      const fn = new Function(code); // CodeQL [js/code-injection] Playground code execution
+      const fn = new Function(code); // codeql[js/code-injection] Playground evaluates user-authored scripts in sandboxed Web Worker
       result = fn();
     }
 


### PR DESCRIPTION
## Summary
- Fix CodeQL inline suppression comments from `// CodeQL [js/code-injection]` to `// codeql[js/code-injection]` (lowercase, no space before bracket) to match CodeQL's expected format
- Dismissed existing open alerts #13 and #14 as false positives — `new Function()` is intentional for the CAD playground worker, which runs in a sandboxed Web Worker

## Test plan
- [x] Verified 0 open code scanning alerts remain
- [x] Verified 0 open Dependabot alerts remain
- [x] Comment-only change — no runtime behavior affected