### PR TITLE
refactor: migrate disposal patterns to gcWithScope

### DIFF
--- a/src/sketching/Sketcher.ts
+++ b/src/sketching/Sketcher.ts
@@ -292,7 +292,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
     longAxis = false,
     sweep = false
   ): this {
-    const [, gc] = localGC();
     const [startX, startY] = planeToLocal(this.plane, this.pointer);
 
     let rotationAngle = rotation;
@@ -335,7 +334,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
 
     this.pendingEdges.push(arc);
     this._updatePointer(planeToWorld(this.plane, end));
-    gc();
     return this;
   }
 

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -332,39 +332,36 @@ function makeSectionFace(plane: Plane, size: number): OcType {
     vecAdd(vecAdd(o, nhx), hy),
   ];
 
+  const r = gcWithScope();
+
   // Build 4 OCCT points
-  const pts = corners.map((c) => new oc.gp_Pnt_3(c[0], c[1], c[2]));
+  const pts = corners.map((c) => r(new oc.gp_Pnt_3(c[0], c[1], c[2])));
 
   // Build 4 edges forming a closed rectangle
   const edges = [
-    new oc.BRepBuilderAPI_MakeEdge_3(pts[0], pts[1]),
-    new oc.BRepBuilderAPI_MakeEdge_3(pts[1], pts[2]),
-    new oc.BRepBuilderAPI_MakeEdge_3(pts[2], pts[3]),
-    new oc.BRepBuilderAPI_MakeEdge_3(pts[3], pts[0]),
+    r(new oc.BRepBuilderAPI_MakeEdge_3(pts[0], pts[1])),
+    r(new oc.BRepBuilderAPI_MakeEdge_3(pts[1], pts[2])),
+    r(new oc.BRepBuilderAPI_MakeEdge_3(pts[2], pts[3])),
+    r(new oc.BRepBuilderAPI_MakeEdge_3(pts[3], pts[0])),
   ];
 
   // Build wire from edges
-  const wireBuilder = new oc.BRepBuilderAPI_MakeWire_1();
+  const wireBuilder = r(new oc.BRepBuilderAPI_MakeWire_1());
   for (const e of edges) {
     const edge = e.Edge();
     wireBuilder.Add_1(edge);
     edge.delete();
   }
-  const progress = new oc.Message_ProgressRange_1();
+  const progress = r(new oc.Message_ProgressRange_1());
   wireBuilder.Build(progress);
   const wire = wireBuilder.Wire();
 
   // Build planar face from wire
-  const faceBuilder = new oc.BRepBuilderAPI_MakeFace_15(wire, true);
+  const faceBuilder = r(new oc.BRepBuilderAPI_MakeFace_15(wire, true));
   const face = faceBuilder.Face();
 
-  // Cleanup temporaries
-  faceBuilder.delete();
+  // Cleanup wire (other temporaries cleaned via gcWithScope)
   wire.delete();
-  wireBuilder.delete();
-  progress.delete();
-  for (const e of edges) e.delete();
-  for (const p of pts) p.delete();
 
   return face;
 }

--- a/src/topology/primitiveFns.ts
+++ b/src/topology/primitiveFns.ts
@@ -49,7 +49,7 @@ import {
   makePolygon as _makePolygon,
 } from './shapeHelpers.js';
 import { getKernel } from '../kernel/index.js';
-import { localGC } from '../core/memory.js';
+import { gcWithScope } from '../core/disposal.js';
 import { createSolid } from '../core/shapeTypes.js';
 import { translate } from './shapeFns.js';
 
@@ -77,19 +77,14 @@ export interface BoxOptions {
  */
 export function box(width: number, depth: number, height: number, options?: BoxOptions): Solid {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const maker = r(new oc.BRepPrimAPI_MakeBox_2(width, depth, height));
-  let solid = createSolid(maker.Solid());
-  gc();
+  const solid = createSolid(maker.Solid());
 
   const center = options?.at ?? (options?.centered ? ([0, 0, 0] as Vec3) : undefined);
   if (center) {
-    solid = translate(solid, [
-      center[0] - width / 2,
-      center[1] - depth / 2,
-      center[2] - height / 2,
-    ]);
+    return translate(solid, [center[0] - width / 2, center[1] - depth / 2, center[2] - height / 2]);
   }
   return solid;
 }

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -11,6 +11,7 @@ import { toOcVec, toOcPnt, makeOcAx1, makeOcAx2 } from '../core/occtBoundary.js'
 import { HASH_CODE_MAX, DEG2RAD } from '../core/constants.js';
 import { downcast, iterTopo } from './cast.js';
 import { unwrap } from '../core/result.js';
+import { gcWithScope } from '../core/disposal.js';
 
 // ---------------------------------------------------------------------------
 // Identity / introspection
@@ -50,11 +51,10 @@ export function isEqualShape(a: AnyShape, b: AnyShape): boolean {
 /** Simplify a shape by merging same-domain faces/edges. Returns a new shape. */
 export function simplify<T extends AnyShape>(shape: T): T {
   const oc = getKernel().oc;
-  const upgrader = new oc.ShapeUpgrade_UnifySameDomain_2(shape.wrapped, true, true, false);
+  const r = gcWithScope();
+  const upgrader = r(new oc.ShapeUpgrade_UnifySameDomain_2(shape.wrapped, true, true, false));
   upgrader.Build();
-  const result = castShape(upgrader.Shape()) as T;
-  upgrader.delete();
-  return result;
+  return castShape(upgrader.Shape()) as T;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/topology/solidBuilders.ts
+++ b/src/topology/solidBuilders.ts
@@ -5,7 +5,7 @@
 
 import type { OcType } from '../kernel/types.js';
 import { getKernel } from '../kernel/index.js';
-import { gcWithScope, localGC } from '../core/memory.js';
+import { gcWithScope } from '../core/disposal.js';
 import { toOcPnt, makeOcAx1, makeOcAx2 } from '../core/occtBoundary.js';
 import type { Vec3 } from '../core/types.js';
 import { type Result, ok, err, andThen, unwrap } from '../core/result.js';
@@ -41,13 +41,11 @@ export function makeCylinder(
   direction: Vec3 = [0, 0, 1]
 ): Solid {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const axis = r(makeOcAx2(location, direction));
   const cylinder = r(new oc.BRepPrimAPI_MakeCylinder_3(axis, radius, height));
-  const solid = createSolid(cylinder.Shape());
-  gc();
-  return solid;
+  return createSolid(cylinder.Shape());
 }
 
 /**
@@ -57,12 +55,10 @@ export function makeCylinder(
  */
 export function makeSphere(radius: number): Solid {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const sphereMaker = r(new oc.BRepPrimAPI_MakeSphere_1(radius));
-  const sphere = createSolid(sphereMaker.Shape());
-  gc();
-  return sphere;
+  return createSolid(sphereMaker.Shape());
 }
 
 /**
@@ -78,13 +74,11 @@ export function makeCone(
   direction: Vec3 = [0, 0, 1]
 ): Solid {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const axis = r(makeOcAx2(location, direction));
   const coneMaker = r(new oc.BRepPrimAPI_MakeCone_3(axis, radius1, radius2, height));
-  const solid = createSolid(coneMaker.Shape());
-  gc();
-  return solid;
+  return createSolid(coneMaker.Shape());
 }
 
 /**
@@ -99,13 +93,11 @@ export function makeTorus(
   direction: Vec3 = [0, 0, 1]
 ): Solid {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const axis = r(makeOcAx2(location, direction));
   const torusMaker = r(new oc.BRepPrimAPI_MakeTorus_5(axis, majorRadius, minorRadius));
-  const solid = createSolid(torusMaker.Shape());
-  gc();
-  return solid;
+  return createSolid(torusMaker.Shape());
 }
 
 // ---------------------------------------------------------------------------
@@ -215,27 +207,22 @@ export function makeEllipsoid(aLength: number, bLength: number, cLength: number)
  */
 export function makeBox(corner1: Vec3, corner2: Vec3): Solid {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const p1 = r(toOcPnt(corner1));
   const p2 = r(toOcPnt(corner2));
   const boxMaker = r(new oc.BRepPrimAPI_MakeBox_4(p1, p2));
-  const box = createSolid(boxMaker.Solid());
-  gc();
-  return box;
+  return createSolid(boxMaker.Solid());
 }
 
 /** Create a vertex at a 3D point. */
 export function makeVertex(point: Vec3): Vertex {
   const oc = getKernel().oc;
-  const [r, gc] = localGC();
+  const r = gcWithScope();
 
   const pnt = r(toOcPnt(point));
   const vertexMaker = r(new oc.BRepBuilderAPI_MakeVertex(pnt));
-  const vertex = vertexMaker.Vertex();
-  gc();
-
-  return createVertex(vertex);
+  return createVertex(vertexMaker.Vertex());
 }
 
 /**


### PR DESCRIPTION
## Summary
- Migrate 26 functions across 8 files from manual `.delete()` chains and `localGC()` to `gcWithScope()` for exception-safe OCCT handle cleanup
- Rewrite `FinalizationRegistry` polyfill with proper typing, eliminating 4 `eslint-disable` comments
- Fix potential memory leaks in `makeSectionFace`, `simplify`, and all `curveFns` where exceptions between allocation and `.delete()` would leak WASM objects

## Test plan
- [x] All 1590 tests pass (verified after each round of changes)
- [x] Pre-commit hooks pass (lint, typecheck, boundaries, coverage)
- [ ] Verify no regressions in OCCT memory usage under sustained workloads