### PR TITLE
perf: optimize OCCT engine internals

### DIFF
--- a/src/kernel/curveOps.ts
+++ b/src/kernel/curveOps.ts
@@ -34,12 +34,13 @@ export function interpolatePoints(
 
   // Use high-precision approximation to effectively interpolate
   const pnts = new oc.TColgp_Array1OfPnt_2(1, points.length);
+  const reusePnt = new oc.gp_Pnt_1();
   let idx = 1;
   for (const pt of points) {
-    const pnt = new oc.gp_Pnt_3(pt[0], pt[1], pt[2]);
-    pnts.SetValue(idx++, pnt);
-    pnt.delete();
+    reusePnt.SetCoord_2(pt[0], pt[1], pt[2]);
+    pnts.SetValue(idx++, reusePnt);
   }
+  reusePnt.delete();
 
   const splineBuilder = new oc.GeomAPI_PointsToBSpline_2(
     pnts,
@@ -77,12 +78,13 @@ export function approximatePoints(
   const { tolerance = 1e-3, degMin = 1, degMax = 6, smoothing = null } = options;
 
   const pnts = new oc.TColgp_Array1OfPnt_2(1, points.length);
+  const reusePnt = new oc.gp_Pnt_1();
   let idx = 1;
   for (const pt of points) {
-    const pnt = new oc.gp_Pnt_3(pt[0], pt[1], pt[2]);
-    pnts.SetValue(idx++, pnt);
-    pnt.delete();
+    reusePnt.SetCoord_2(pt[0], pt[1], pt[2]);
+    pnts.SetValue(idx++, reusePnt);
   }
+  reusePnt.delete();
 
   let splineBuilder: OcType;
   if (smoothing) {


### PR DESCRIPTION
## Summary
- **Skip redundant meshing**: `meshEdgesJS` and `exportSTL` now check for existing triangulation before creating `BRepMesh_IncrementalMesh`, avoiding redundant work when `mesh()` was already called
- **Hash-based edge→face lookup**: Chamfer operations build a `Map<hash, face>` once instead of iterating all faces per edge (O(1) vs O(edges × faces × edges_per_face))
- **Pool gp_Pnt in curve construction**: Reuse a single `gp_Pnt` with `SetCoord()` instead of alloc/delete per point in `interpolatePoints` and `approximatePoints`
- **Pool transform objects in patterns**: Linear and circular patterns reuse `gp_Trsf`/`gp_Vec`/`gp_Ax1` across loop iterations instead of creating/deleting per copy

## Test plan
- [x] All 1590 tests pass
- [x] TypeScript strict check passes
- [x] ESLint clean
- [x] Layer boundary check passes
- [x] Knip unused code check passes