### PR TITLE
fix: add EmscriptenModuleConfig to WASM init type declarations

### DIFF
--- a/packages/brepjs-opencascade/src/brepjs_single.d.ts
+++ b/packages/brepjs-opencascade/src/brepjs_single.d.ts
@@ -9119,6 +9119,12 @@ export type OpenCascadeInstance = {FS: typeof FS} & {
   MeshExtractor: typeof MeshExtractor;
 };
 
-declare function init(): Promise<OpenCascadeInstance>;
+/** Emscripten module configuration passed to the WASM factory function. */
+interface EmscriptenModuleConfig {
+  locateFile?: (path: string) => string;
+  mainScriptUrlOrBlob?: string;
+}
+
+declare function init(config?: EmscriptenModuleConfig): Promise<OpenCascadeInstance>;
 
 export default init;

--- a/packages/brepjs-opencascade/src/brepjs_threaded.d.ts
+++ b/packages/brepjs-opencascade/src/brepjs_threaded.d.ts
@@ -9092,6 +9092,12 @@ export type OpenCascadeInstance = {FS: typeof FS} & {
   TopologyExtractor: typeof TopologyExtractor;
 };
 
-declare function init(): Promise<OpenCascadeInstance>;
+/** Emscripten module configuration passed to the WASM factory function. */
+interface EmscriptenModuleConfig {
+  locateFile?: (path: string) => string;
+  mainScriptUrlOrBlob?: string;
+}
+
+declare function init(config?: EmscriptenModuleConfig): Promise<OpenCascadeInstance>;
 
 export default init;

--- a/packages/brepjs-opencascade/src/brepjs_with_exceptions.d.ts
+++ b/packages/brepjs-opencascade/src/brepjs_with_exceptions.d.ts
@@ -9142,6 +9142,12 @@ export type OpenCascadeInstance = {FS: typeof FS} & {
   OCJS: typeof OCJS;
 };
 
-declare function init(): Promise<OpenCascadeInstance>;
+/** Emscripten module configuration passed to the WASM factory function. */
+interface EmscriptenModuleConfig {
+  locateFile?: (path: string) => string;
+  mainScriptUrlOrBlob?: string;
+}
+
+declare function init(config?: EmscriptenModuleConfig): Promise<OpenCascadeInstance>;
 
 export default init;


### PR DESCRIPTION
## Summary

- Add optional `EmscriptenModuleConfig` parameter to the `init()` function type declarations in all three WASM build variants (single, threaded, with_exceptions)
- The Emscripten factory functions already accept `locateFile` and `mainScriptUrlOrBlob` at runtime, but the `.d.ts` files declared `init()` with no parameters
- This forced consumers (e.g. gridfinity-layout-tool) to use `as unknown as` double casts to pass config

## Test plan

- [x] TypeScript compiles cleanly
- [x] All existing tests pass
- [x] Change is additive (optional parameter) — fully backward compatible