### PR TITLE
fix(site): remove broken playground demos, improve mesh quality

### DIFF
--- a/scripts/generate-example-previews.ts
+++ b/scripts/generate-example-previews.ts
@@ -1,7 +1,7 @@
 /**
  * Generates styled SVG preview images for the README gallery.
  *
- * Initializes WASM, builds 5 representative shapes, projects them to 2D,
+ * Initializes WASM, builds 3 representative shapes, projects them to 2D,
  * and writes styled SVG files to docs/images/examples/.
  *
  * Usage: npx tsx scripts/generate-example-previews.ts
@@ -35,7 +35,6 @@ initFromOC(oc);
 const {
   box,
   cylinder,
-  cut,
   fuse,
   shell,
   intersect,
@@ -86,36 +85,6 @@ function flatPaths(raw: string[] | string[][]): string[] {
 }
 
 // ── Shape builders ──────────────────────────────────────────────────────
-
-function buildGameDie(): string {
-  const size = 20, r = 2.5, depth = 2, s = 5;
-  const H = size / 2;
-
-  let die = shape(box(size, size, size, { centered: true })).fillet(3).val;
-
-  function cutPip(x: number, y: number, z: number, axis: [number, number, number]) {
-    const c = cylinder(r, depth + 2, { at: [x, y, z], axis, centered: true });
-    die = unwrap(cut(die, c));
-  }
-
-  cutPip(0, 0, H, [0, 0, 1]);
-  for (const dx of [-s, s])
-    for (const dy of [-s, 0, s])
-      cutPip(dx, dy, -H, [0, 0, 1]);
-  cutPip(H, -s, s, [1, 0, 0]);
-  cutPip(H, s, -s, [1, 0, 0]);
-  cutPip(-H, 0, 0, [1, 0, 0]);
-  for (const [dy, dz] of [[-s, -s], [s, -s], [-s, s], [s, s]] as [number, number][])
-    cutPip(-H, dy, dz, [1, 0, 0]);
-  for (const [dx, dz] of [[-s, -s], [0, 0], [s, s]] as [number, number][])
-    cutPip(dx, H, dz, [0, 1, 0]);
-  for (const [dx, dz] of [[-s, -s], [s, -s], [-s, s], [s, s]] as [number, number][])
-    cutPip(dx, -H, dz, [0, 1, 0]);
-
-  const proj = drawProjection(die, 'front');
-  const paths = flatPaths(proj.visible.toSVGPaths());
-  return styledSVG(proj.visible.toSVGViewBox(3), paths);
-}
 
 function buildPenCup(): string {
   let cup = sketchRoundedRectangle(50, 35, 8).extrude(80);
@@ -183,7 +152,6 @@ function buildCompartmentTray(): string {
 mkdirSync(OUT_DIR, { recursive: true });
 
 const previews: [string, () => string][] = [
-  ['game-die.svg', buildGameDie],
   ['pen-cup.svg', buildPenCup],
   ['lofted-vase.svg', buildLoftedVase],
   ['compartment-tray.svg', buildCompartmentTray],

--- a/site/src/lib/examples.ts
+++ b/site/src/lib/examples.ts
@@ -4,7 +4,7 @@ export interface Example {
   id: string;
   title: string;
   description: string;
-  category: 'organic' | 'architectural' | 'practical' | 'gaming';
+  category: 'organic' | 'architectural' | 'practical';
   code: string;
   cameraPosition?: [number, number, number];
   cameraTarget?: [number, number, number];
@@ -19,45 +19,6 @@ export const examples: Example[] = [
     category: 'architectural',
     code: HERO_CODE,
     autoRotateSpeed: 0.3,
-  },
-  {
-    id: 'game-die',
-    title: 'Game Die',
-    description: 'Rounded cube with dot indentations on all six faces.',
-    category: 'gaming',
-    code: `// Six-sided die (mm)
-const size = 20, r = 2.5, depth = 2, gap = 5;
-const H = size / 2;
-
-let die = shape(box(size, size, size, { centered: true })).fillet(3).val;
-
-// Cut a single pip: cylinder starts outside the face, goes inward
-function cutPip(x, y, z, axis) {
-  const c = cylinder(r, depth + 2, { at: [x, y, z], axis, centered: true });
-  die = unwrap(cut(die, c));
-}
-
-// Face 1 (+Z): center
-cutPip(0, 0, H, [0,0,1]);
-// Face 6 (-Z): 2×3
-for (const dx of [-gap, gap])
-  for (const dy of [-gap, 0, gap])
-    cutPip(dx, dy, -H, [0,0,1]);
-// Face 2 (+X): diagonal pair
-cutPip(H, -gap, gap, [1,0,0]);
-cutPip(H, gap, -gap, [1,0,0]);
-// Face 5 (-X): center + 4 corners
-cutPip(-H, 0, 0, [1,0,0]);
-for (const [dy, dz] of [[-gap,-gap],[gap,-gap],[-gap,gap],[gap,gap]])
-  cutPip(-H, dy, dz, [1,0,0]);
-// Face 3 (+Y): diagonal triple
-for (const [dx, dz] of [[-gap,-gap],[0,0],[gap,gap]])
-  cutPip(dx, H, dz, [0,1,0]);
-// Face 4 (-Y): 4 corners
-for (const [dx, dz] of [[-gap,-gap],[gap,-gap],[-gap,gap],[gap,gap]])
-  cutPip(dx, -H, dz, [0,1,0]);
-
-return die;`,
   },
   {
     id: 'pen-cup',

--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -252,8 +252,8 @@ function handleEval(id: string, code: string) {
               ? brepjs.castShape(shape.wrapped)
               : shape;
 
-        const shapeMesh = brepjs.mesh(fnShape, { tolerance: 0.1, angularTolerance: 0.5 });
-        const edgeMesh = brepjs.meshEdges(fnShape, { tolerance: 0.1, angularTolerance: 0.5 });
+        const shapeMesh = brepjs.mesh(fnShape, { tolerance: 0.1, angularTolerance: 0.2 });
+        const edgeMesh = brepjs.meshEdges(fnShape, { tolerance: 0.1, angularTolerance: 0.2 });
 
         const bufData = brepjs.toBufferGeometryData(shapeMesh);
         const lineData = brepjs.toLineGeometryData(edgeMesh);


### PR DESCRIPTION
## Summary
- **Game die**: removed — recessed spherical pips are invisible with smooth-shaded material regardless of tessellation quality or geometry correctness. OCCT geometry is correct (verified: face count increases, normals point inward) but Three.js smooth shading hides shallow concave features.
- **Spur gear**: removed — tooth boxes were tangent to the cylinder surface, causing degenerate fuse results in OCCT's boolean engine.
- **Mesh quality**: reduced `angularTolerance` from 0.5 to 0.2 radians for smoother curved surfaces in the playground viewer.
- **Cleanup**: removed unused `'gaming'` category, cleaned up preview generator script.

Closes #237

## Test plan
- [x] `fn-examples.test.ts` — all remaining examples pass
- [x] Lint and typecheck clean
- [x] Remaining examples (spiral staircase, pen cup, lofted vase, compartment tray) render correctly