### PR TITLE
fix(ci): add WASM download step to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,6 +70,14 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - name: Download WASM runtime files (not tracked in git)
+        run: |
+          if [ ! -f packages/brepjs-opencascade/src/brepjs_single.js ]; then
+            npm pack brepjs-opencascade --pack-destination /tmp
+            tar -xzf /tmp/brepjs-opencascade-*.tgz -C /tmp
+            cp /tmp/package/src/*.js /tmp/package/src/*.wasm packages/brepjs-opencascade/src/
+            rm -rf /tmp/package /tmp/brepjs-opencascade-*.tgz
+          fi
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run format:check


### PR DESCRIPTION
## Summary
- Add the missing "Download WASM runtime files" step to the `release-please.yml` build job
- This step was added to `ci.yml` in d0a0348 but not propagated to `release-please.yml`

## Root cause
Commit d0a0348 removed WASM binaries from git tracking. It correctly added a fallback download step to `ci.yml` that fetches the published npm package when files are missing. However, `release-please.yml` has its own `build` job that also runs `npm test`, and it was not updated.

The failure only surfaced now because the release-please build job runs conditionally (`releases_created == 'true'`), and the v8.7.0 release was the first release after WASM removal.

Fixes the failing check: https://github.com/andymai/brepjs/actions/runs/22115829235/job/63923592912

## Test plan
- [x] Verified the added step matches `ci.yml` exactly
- [ ] CI passes on this PR (validates the workflow syntax)