### PR TITLE
fix(ci): add postinstall script to ensure WASM runtime files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,8 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Download WASM runtime files (not tracked in git)
-        run: |
-          if [ ! -f packages/brepjs-opencascade/src/brepjs_single.js ]; then
-            npm pack brepjs-opencascade --pack-destination /tmp
-            tar -xzf /tmp/brepjs-opencascade-*.tgz -C /tmp
-            cp /tmp/package/src/*.js /tmp/package/src/*.wasm packages/brepjs-opencascade/src/
-            rm -rf /tmp/package /tmp/brepjs-opencascade-*.tgz
-          fi
+      - name: Ensure WASM runtime files exist
+        run: bash scripts/ensure-wasm.sh
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run format:check

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,14 +70,8 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Download WASM runtime files (not tracked in git)
-        run: |
-          if [ ! -f packages/brepjs-opencascade/src/brepjs_single.js ]; then
-            npm pack brepjs-opencascade --pack-destination /tmp
-            tar -xzf /tmp/brepjs-opencascade-*.tgz -C /tmp
-            cp /tmp/package/src/*.js /tmp/package/src/*.wasm packages/brepjs-opencascade/src/
-            rm -rf /tmp/package /tmp/brepjs-opencascade-*.tgz
-          fi
+      - name: Ensure WASM runtime files exist
+        run: bash scripts/ensure-wasm.sh
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run format:check

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
     "docs:api": "typedoc",
     "docs:generate-lookup": "npx tsx scripts/generate-function-lookup.ts",
     "docs:generate-previews": "npx tsx scripts/generate-example-previews.ts",
+    "postinstall": "bash scripts/ensure-wasm.sh",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/ensure-wasm.sh
+++ b/scripts/ensure-wasm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Ensures WASM runtime files exist in the brepjs-opencascade workspace package.
+# These files are not tracked in git (gitignored) and are distributed via npm only.
+# This script downloads them from the published npm package if they are missing.
+
+set -e
+
+WASM_DIR="packages/brepjs-opencascade/src"
+MARKER="$WASM_DIR/brepjs_single.js"
+
+if [ -f "$MARKER" ]; then
+  exit 0
+fi
+
+echo "⬇ Downloading WASM runtime files (not tracked in git)..."
+npm pack brepjs-opencascade --pack-destination /tmp --silent
+tar -xzf /tmp/brepjs-opencascade-*.tgz -C /tmp
+cp /tmp/package/src/*.js /tmp/package/src/*.wasm "$WASM_DIR/"
+rm -rf /tmp/package /tmp/brepjs-opencascade-*.tgz
+echo "✅ WASM runtime files restored to $WASM_DIR"


### PR DESCRIPTION
## Summary
- Extract WASM download logic into `scripts/ensure-wasm.sh` (idempotent, exits immediately if files exist)
- Add `postinstall` hook in root `package.json` so fresh clones get WASM files automatically after `npm install`
- Update `ci.yml` and `release-please.yml` to use the shared script instead of inline commands

Follows up on #264 which fixed the release-please workflow. This ensures the problem doesn't recur for local development either.

## Test plan
- [x] Verified script downloads files when missing
- [x] Verified script is a no-op when files exist
- [x] All 1707 tests pass locally after restore
- [ ] CI passes on this PR