### PR TITLE
chore(deps): update typedoc and add brepjs-opencascade 0.8.x support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "brepjs",
       "version": "8.7.2",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -28,7 +29,7 @@
         "knip": "5.83.1",
         "lint-staged": "16.2.7",
         "prettier": "3.8.1",
-        "typedoc": "0.28.16",
+        "typedoc": "0.28.17",
         "typescript": "5.9.3",
         "typescript-eslint": "8.56.0",
         "vite": "7.3.1",
@@ -39,7 +40,7 @@
         "node": ">=24 <25"
       },
       "peerDependencies": {
-        "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0"
+        "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8729,9 +8730,9 @@
       "license": "MIT"
     },
     "node_modules/typedoc": {
-      "version": "0.28.16",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.16.tgz",
-      "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+      "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9531,8 +9532,8 @@
       }
     },
     "packages/brepjs-opencascade": {
-      "version": "0.7.2",
-      "license": "MIT"
+      "version": "0.8.1",
+      "license": "LGPL-2.1-only"
     },
     "site": {
       "name": "brepjs-site",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "knip": "5.83.1",
     "lint-staged": "16.2.7",
     "prettier": "3.8.1",
-    "typedoc": "0.28.16",
+    "typedoc": "0.28.17",
     "typescript": "5.9.3",
     "typescript-eslint": "8.56.0",
     "vite": "7.3.1",
@@ -207,7 +207,7 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0"
+    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0"
   },
   "dependencies": {
     "flatbush": "4.5.0",


### PR DESCRIPTION
## Summary
- Update `typedoc` from 0.28.16 to 0.28.17
- Extend `brepjs-opencascade` peer dependency range to include `^0.8.0`

## Test plan
- [x] Typecheck passes
- [x] All tests pass
- [x] Pre-commit hooks pass