### PR TITLE
ci: parallelize CI into 5 independent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
             node-24-${{ runner.os }}-
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+      - run: bash scripts/ensure-wasm.sh
       - run: npm run check:boundaries
       - run: npm run knip
 


### PR DESCRIPTION
## Summary
- Split serial CI job into 5 parallel jobs (typecheck, lint, quality, build, test)
- Added `ci-pass` gate job — single required check for branch protection
- Added `dorny/paths-filter` changes job so docs-only PRs skip CI but `ci-pass` still reports status
- Added concurrency cancellation for PR runs (main pushes queue instead)
- Switched to `actions/cache@v4` on `node_modules` with Node version in key and `restore-keys` fallback

## Architecture

```
                    ┌──────────┐
                    │ changes  │  (dorny/paths-filter)
                    └────┬─────┘
                         │ code == 'true'
        ┌────────┬───────┼────────┬──────────┐
        ▼        ▼       ▼        ▼          ▼
  typecheck    lint   quality   build      test
        │        │       │        │          │
        └────────┴───────┴────────┴──────────┘
                         │
                    ┌────▼─────┐
                    │ ci-pass  │  (gate)
                    └──────────┘
```

## After merge
Update branch protection: change required status check from `build` to `ci-pass`.

## Test plan
- [ ] All 7 jobs appear in PR checks (changes, typecheck, lint, quality, build, test, ci-pass)
- [ ] All jobs pass
- [ ] Verify concurrency cancellation by pushing a follow-up commit while CI runs
- [ ] Verify docs-only changes would skip the 5 main jobs (ci-pass still reports)