### PR TITLE
fix(test): correct vitest 4 config and relocate benchmark

### DIFF
--- a/benchmarks/staircase.bench.test.ts
+++ b/benchmarks/staircase.bench.test.ts
@@ -4,7 +4,7 @@
  */
 /* eslint-disable no-console -- benchmark output */
 import { describe, it, beforeAll } from 'vitest';
-import { initOC } from './setup.js';
+import { initOC } from '../tests/setup.js';
 import {
   box,
   cylinder,

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -6,11 +6,7 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     testTimeout: 120000,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        execArgv: ['--max-old-space-size=6144'],
-      },
-    },
+    execArgv: ['--max-old-space-size=6144'],
     include: ['benchmarks/**/*.bench.test.ts'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     exclude: ['benchmarks/**', 'node_modules/**', 'site/**', '.worktrees/**'],
     pool: 'forks',
     execArgv: ['--max-old-space-size=6144'],
+    maxWorkers: 4,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary
- Remove deprecated `poolOptions.forks.execArgv` from bench config, use top-level `test.execArgv` (Vitest 4 API)
- Add `maxWorkers: 4` to cap fork concurrency (each fork loads ~100MB WASM; uncapped = OOM risk on high-core machines)
- Move `bench-staircase` from `tests/` to `benchmarks/` — it has no assertions and was slowing every CI test run

## Test plan
- [ ] All CI jobs pass
- [ ] `npm run test` no longer includes staircase benchmark
- [ ] `npx vitest --config vitest.bench.config.ts --dry-run` includes staircase benchmark