### PR TITLE
chore: add npm provenance, clean up release and configs

### DIFF
--- a/.github/workflows/publish-opencascade.yml
+++ b/.github/workflows/publish-opencascade.yml
@@ -65,6 +65,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/brepjs-opencascade
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,32 +59,12 @@ jobs:
             fi
           fi
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [release-please]
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
-      - name: Ensure WASM runtime files exist
-        run: bash scripts/ensure-wasm.sh
-      - run: npm run typecheck
-      - run: npm run lint
-      - run: npm run format:check
-      - run: npm run check:boundaries
-      - run: npm run build
-      - run: npm test
-
   # brepjs-opencascade is published via the dedicated publish-opencascade.yml
   # workflow (manual dispatch) which handles the Docker WASM build.
 
   publish-brepjs:
     runs-on: ubuntu-latest
-    needs: [release-please, build]
+    needs: [release-please]
     if: ${{ needs.release-please.outputs.brepjs_release_created == 'true' }}
     permissions:
       contents: read
@@ -99,6 +79,6 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Publish brepjs
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -18,9 +18,6 @@ const config: KnipConfig = {
     site: {
       ignore: ['**'],
     },
-    'brepjs-plugin': {
-      ignore: ['**'],
-    },
   },
 };
 

--- a/packages/brepjs-opencascade/package.json
+++ b/packages/brepjs-opencascade/package.json
@@ -2,11 +2,21 @@
   "name": "brepjs-opencascade",
   "version": "0.8.3",
   "description": "OpenCascade.js custom WASM build for brepjs",
+  "keywords": [
+    "opencascade",
+    "wasm",
+    "cad",
+    "brep"
+  ],
+  "author": "Andy Mai",
   "license": "LGPL-2.1-only",
   "repository": {
     "type": "git",
     "url": "https://github.com/andymai/brepjs",
     "directory": "packages/brepjs-opencascade"
+  },
+  "engines": {
+    "node": ">=24 <25"
   },
   "sideEffects": false,
   "main": "src/brepjs_single.js",


### PR DESCRIPTION
## Summary
- Add `--provenance` flag to `npm publish` in both release workflows (permissions already configured)
- Remove redundant `build` job from release-please workflow (CI already validates on every push to main)
- Remove stale `brepjs-plugin` workspace entry from knip config
- Add `engines`, `author`, `keywords` to `brepjs-opencascade` package.json for npm consistency

## Test plan
- [ ] Verify CI passes (typecheck, lint, quality, build, test)
- [ ] Verify knip still passes without brepjs-plugin entry
- [ ] Provenance and release workflow changes are verified on next release