### PR TITLE
chore: remove dead code and simplify vestigial patterns

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -134,8 +134,6 @@ vecProjectToPlane(v, origin, normal); // Project onto plane
 vecRotate(v, axis, angleRad); // Rodrigues rotation formula
 ```
 
-**2D variants:** `vec2Add`, `vec2Sub`, `vec2Scale`, `vec2Length`, `vec2Distance`, `vec2Normalize`, `vec2Equals`
-
 ### Plane Types (`planeTypes.ts`)
 
 ```typescript
@@ -193,9 +191,7 @@ planeToLocal(plane: Plane, world: Vec3): Vec2    // 3D → 2D projection
 
 ```typescript
 translatePlane(plane, offset); // Move by vector
-translatePlaneTo(plane, newOrigin); // Move to position
 pivotPlane(plane, angleDeg, axis); // Rotate plane around axis
-rotatePlane2DAxes(plane, angleDeg); // Rotate 2D coords around normal
 ```
 
 ## OCCT Boundary Layer (`occtBoundary.ts`)
@@ -208,8 +204,6 @@ Bridges brepjs functional geometry with OCCT's mutable gp\_\* types. **Critical:
 toOcVec(v: Vec3): gp_Vec          // Caller must call .delete()
 toOcPnt(v: Vec3): gp_Pnt          // Caller must call .delete()
 toOcDir(v: Vec3): gp_Dir          // Caller must call .delete()
-pointToOcPnt(p: PointInput): gp_Pnt
-pointToOcDir(p: PointInput): gp_Dir
 ```
 
 ### Extraction (No Cleanup Needed)

--- a/src/core/occtBoundary.ts
+++ b/src/core/occtBoundary.ts
@@ -4,8 +4,7 @@
  * Use withOcVec/withOcPnt/withOcDir for scoped conversions.
  */
 
-import type { Vec3, PointInput } from './types.js';
-import { toVec3 } from './types.js';
+import type { Vec3 } from './types.js';
 import { getKernel } from '../kernel/index.js';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- OCCT types are dynamic
 type OcType = any;
@@ -30,16 +29,6 @@ export function toOcPnt(v: Vec3): OcType {
 export function toOcDir(v: Vec3): OcType {
   const oc = getKernel().oc;
   return new oc.gp_Dir_4(v[0], v[1], v[2]);
-}
-
-/** Convert PointInput to OCCT gp_Pnt. Caller must call .delete() when done. */
-export function pointToOcPnt(p: PointInput): OcType {
-  return toOcPnt(toVec3(p));
-}
-
-/** Convert PointInput to OCCT gp_Dir. Caller must call .delete() when done. */
-export function pointToOcDir(p: PointInput): OcType {
-  return toOcDir(toVec3(p));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/planeOps.ts
+++ b/src/core/planeOps.ts
@@ -134,21 +134,6 @@ export function planeToLocal(plane: Plane, world: Vec3): Vec2 {
   return [vecDot(relative, plane.xDir), vecDot(relative, plane.yDir)];
 }
 
-/** Convert 3D local coordinates to 3D world coordinates on the plane. */
-export function planeToWorldVec3(plane: Plane, local: Vec3): Vec3 {
-  const [u, v, w] = local;
-  return vecAdd(
-    vecAdd(vecAdd(plane.origin, vecScale(plane.xDir, u)), vecScale(plane.yDir, v)),
-    vecScale(plane.zDir, w)
-  );
-}
-
-/** Convert 3D world coordinates to 3D local coordinates on the plane. */
-export function planeToLocalVec3(plane: Plane, world: Vec3): Vec3 {
-  const relative = vecSub(world, plane.origin);
-  return [vecDot(relative, plane.xDir), vecDot(relative, plane.yDir), vecDot(relative, plane.zDir)];
-}
-
 // ---------------------------------------------------------------------------
 // Plane transformations (all return new Plane)
 // ---------------------------------------------------------------------------
@@ -156,11 +141,6 @@ export function planeToLocalVec3(plane: Plane, world: Vec3): Vec3 {
 /** Translate a plane by a vector. */
 export function translatePlane(plane: Plane, offset: Vec3): Plane {
   return { ...plane, origin: vecAdd(plane.origin, offset) };
-}
-
-/** Translate a plane to a new origin. */
-export function translatePlaneTo(plane: Plane, newOrigin: Vec3): Plane {
-  return { ...plane, origin: newOrigin };
 }
 
 /**
@@ -175,16 +155,4 @@ export function pivotPlane(plane: Plane, angleDeg: number, axis: Vec3 = [1, 0, 0
   const newXDir = vecRotate(plane.xDir, axis, angleRad);
   const newYDir = vecNormalize(vecCross(newZDir, newXDir));
   return { origin: plane.origin, xDir: newXDir, yDir: newYDir, zDir: newZDir };
-}
-
-/**
- * Rotate the X/Y axes of a plane around its normal (Z direction).
- *
- * @param angleDeg - Rotation angle in **degrees**.
- */
-export function rotatePlane2DAxes(plane: Plane, angleDeg: number): Plane {
-  const angleRad = angleDeg * DEG2RAD;
-  const newXDir = vecRotate(plane.xDir, plane.zDir, angleRad);
-  const newYDir = vecNormalize(vecCross(plane.zDir, newXDir));
-  return { ...plane, xDir: newXDir, yDir: newYDir };
 }

--- a/src/core/vecOps.ts
+++ b/src/core/vecOps.ts
@@ -4,7 +4,7 @@
  * Zero dependencies — pure math functions.
  */
 
-import type { Vec3, Vec2 } from './types.js';
+import type { Vec3 } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Arithmetic
@@ -153,50 +153,4 @@ const round3 = (v: number): number => Math.round(v * 1000) / 1000;
 /** Format a Vec3 as a human-readable string rounded to 3 decimal places. */
 export function vecRepr(v: Vec3): string {
   return `x: ${round3(v[0])}, y: ${round3(v[1])}, z: ${round3(v[2])}`;
-}
-
-// ---------------------------------------------------------------------------
-// 2D operations
-// ---------------------------------------------------------------------------
-
-/** Add two 2D vectors component-wise. */
-export function vec2Add(a: Vec2, b: Vec2): Vec2 {
-  return [a[0] + b[0], a[1] + b[1]];
-}
-
-/** Subtract vector `b` from vector `a` in 2D. */
-export function vec2Sub(a: Vec2, b: Vec2): Vec2 {
-  return [a[0] - b[0], a[1] - b[1]];
-}
-
-/** Multiply each component of a 2D vector by a scalar. */
-export function vec2Scale(v: Vec2, s: number): Vec2 {
-  return [v[0] * s, v[1] * s];
-}
-
-/** Compute the Euclidean length of a 2D vector. */
-export function vec2Length(v: Vec2): number {
-  return Math.sqrt(v[0] * v[0] + v[1] * v[1]);
-}
-
-/** Compute the Euclidean distance between two 2D points. */
-export function vec2Distance(a: Vec2, b: Vec2): number {
-  return vec2Length(vec2Sub(a, b));
-}
-
-/** Return a unit-length 2D vector in the same direction, or `[0,0]` for zero input. */
-export function vec2Normalize(v: Vec2): Vec2 {
-  const len = vec2Length(v);
-  if (len === 0) return [0, 0];
-  return [v[0] / len, v[1] / len];
-}
-
-/**
- * Test whether two 2D vectors are approximately equal.
- *
- * @param tolerance - Per-component absolute tolerance.
- * @default tolerance `1e-5`
- */
-export function vec2Equals(a: Vec2, b: Vec2, tolerance = 1e-5): boolean {
-  return Math.abs(a[0] - b[0]) < tolerance && Math.abs(a[1] - b[1]) < tolerance;
 }

--- a/src/operations/extrude.ts
+++ b/src/operations/extrude.ts
@@ -249,7 +249,7 @@ function complexExtrude(
 
   const result = shellMode
     ? genericSweep(wire, spine, { law }, shellMode)
-    : genericSweep(wire, spine, { law }, shellMode);
+    : genericSweep(wire, spine, { law });
 
   gc();
   return result;
@@ -308,7 +308,7 @@ function twistExtrude(
 
   const result = shellMode
     ? genericSweep(wire, spine, { auxiliarySpine, law }, shellMode)
-    : genericSweep(wire, spine, { auxiliarySpine, law }, shellMode);
+    : genericSweep(wire, spine, { auxiliarySpine, law });
 
   gc();
   return result;

--- a/src/topology/api.ts
+++ b/src/topology/api.ts
@@ -211,15 +211,6 @@ function resolveFaces(
 }
 
 /**
- * Normalize a FilletRadius to the format the kernel expects.
- */
-function normalizeFilletRadius(
-  radius: FilletRadius
-): number | [number, number] | ((edge: Edge) => number | [number, number] | null) {
-  return radius;
-}
-
-/**
  * Normalize a ChamferDistance, handling the {distance, angle} case.
  * Returns either a kernel-compatible distance or signals distance-angle mode.
  */
@@ -282,7 +273,7 @@ export function fillet<T extends Shape3D>(
     radius = edgesOrRadius as FilletRadius;
   }
 
-  return modifiers.fillet(s, edges, normalizeFilletRadius(radius)) as Result<T>;
+  return modifiers.fillet(s, edges, radius) as Result<T>;
 }
 
 /** Apply a chamfer to all edges of a 3D shape. */

--- a/tests/fn-occtBoundary.test.ts
+++ b/tests/fn-occtBoundary.test.ts
@@ -4,8 +4,6 @@ import {
   toOcVec,
   toOcPnt,
   toOcDir,
-  pointToOcPnt,
-  pointToOcDir,
   fromOcVec,
   fromOcPnt,
   fromOcDir,
@@ -86,29 +84,6 @@ describe('toOcDir / fromOcDir', () => {
     const back = fromOcDir(ocDir);
     ocDir.delete();
     expect(vecEquals(back, d)).toBe(true);
-  });
-});
-
-describe('pointToOcPnt / pointToOcDir', () => {
-  it('converts Vec2 to gp_Pnt with z=0', () => {
-    const ocPnt = pointToOcPnt([5, 10]);
-    const back = fromOcPnt(ocPnt);
-    ocPnt.delete();
-    expect(vecEquals(back, [5, 10, 0])).toBe(true);
-  });
-
-  it('converts Vec3 to gp_Pnt', () => {
-    const ocPnt = pointToOcPnt([1, 2, 3]);
-    const back = fromOcPnt(ocPnt);
-    ocPnt.delete();
-    expect(vecEquals(back, [1, 2, 3])).toBe(true);
-  });
-
-  it('converts PointInput to gp_Dir', () => {
-    const ocDir = pointToOcDir([0, 0, 1]);
-    const back = fromOcDir(ocDir);
-    ocDir.delete();
-    expect(vecEquals(back, [0, 0, 1])).toBe(true);
   });
 });
 

--- a/tests/fn-planeOps.test.ts
+++ b/tests/fn-planeOps.test.ts
@@ -6,12 +6,8 @@ import {
   resolvePlane,
   planeToWorld,
   planeToLocal,
-  planeToWorldVec3,
-  planeToLocalVec3,
   translatePlane,
-  translatePlaneTo,
   pivotPlane,
-  rotatePlane2DAxes,
 } from '../src/core/planeOps.js';
 import { vecEquals, vecLength, vecDot } from '../src/core/vecOps.js';
 
@@ -161,51 +157,6 @@ describe('planeToWorld / planeToLocal', () => {
   });
 });
 
-describe('planeToWorldVec3 / planeToLocalVec3', () => {
-  it('converts 3D local to world on XY plane', () => {
-    const plane = resolvePlane('XY');
-    const world = planeToWorldVec3(plane, [3, 4, 5]);
-    expect(world[0]).toBeCloseTo(3);
-    expect(world[1]).toBeCloseTo(4);
-    expect(world[2]).toBeCloseTo(5);
-  });
-
-  it('converts 3D world to local on XY plane', () => {
-    const plane = resolvePlane('XY');
-    const local = planeToLocalVec3(plane, [3, 4, 5]);
-    expect(local[0]).toBeCloseTo(3);
-    expect(local[1]).toBeCloseTo(4);
-    expect(local[2]).toBeCloseTo(5);
-  });
-
-  it('round-trips correctly with 3D coordinates', () => {
-    const plane = resolvePlane('XY');
-    const local = [7, 11, 13] as const;
-    const world = planeToWorldVec3(plane, local);
-    const backToLocal = planeToLocalVec3(plane, world);
-    expect(backToLocal[0]).toBeCloseTo(local[0]);
-    expect(backToLocal[1]).toBeCloseTo(local[1]);
-    expect(backToLocal[2]).toBeCloseTo(local[2]);
-  });
-
-  it('works with rotated plane', () => {
-    const plane = resolvePlane('YZ'); // Normal along X
-    const world = planeToWorldVec3(plane, [1, 2, 3]);
-    // YZ plane: x maps to Y, y maps to Z, z maps to X
-    expect(world[0]).toBeCloseTo(3); // z component along X
-    expect(world[1]).toBeCloseTo(1); // x component along Y
-    expect(world[2]).toBeCloseTo(2); // y component along Z
-  });
-
-  it('works with offset plane', () => {
-    const plane = resolvePlane('XY', 10);
-    const world = planeToWorldVec3(plane, [1, 2, 3]);
-    expect(world[0]).toBeCloseTo(1);
-    expect(world[1]).toBeCloseTo(2);
-    expect(world[2]).toBeCloseTo(13); // 10 + 3
-  });
-});
-
 describe('translatePlane', () => {
   it('translates origin by vector', () => {
     const plane = resolvePlane('XY');
@@ -215,15 +166,6 @@ describe('translatePlane', () => {
     expect(vecEquals(translated.xDir, plane.xDir)).toBe(true);
     expect(vecEquals(translated.yDir, plane.yDir)).toBe(true);
     expect(vecEquals(translated.zDir, plane.zDir)).toBe(true);
-  });
-});
-
-describe('translatePlaneTo', () => {
-  it('moves plane to new origin', () => {
-    const plane = resolvePlane('XY');
-    const moved = translatePlaneTo(plane, [100, 200, 300]);
-    expect(vecEquals(moved.origin, [100, 200, 300])).toBe(true);
-    expect(vecEquals(moved.zDir, plane.zDir)).toBe(true);
   });
 });
 
@@ -237,7 +179,7 @@ describe('pivotPlane', () => {
   });
 
   it('preserves origin', () => {
-    const plane = translatePlaneTo(resolvePlane('XY'), [5, 5, 5]);
+    const plane = createPlane([5, 5, 5], null, [0, 0, 1]);
     const pivoted = pivotPlane(plane, 45);
     expect(vecEquals(pivoted.origin, [5, 5, 5])).toBe(true);
   });
@@ -247,27 +189,5 @@ describe('pivotPlane', () => {
     expect(vecLength(pivoted.xDir)).toBeCloseTo(1);
     expect(vecLength(pivoted.yDir)).toBeCloseTo(1);
     expect(vecLength(pivoted.zDir)).toBeCloseTo(1);
-  });
-});
-
-describe('rotatePlane2DAxes', () => {
-  it('rotates x/y around normal', () => {
-    const plane = resolvePlane('XY');
-    const rotated = rotatePlane2DAxes(plane, 90);
-    // After 90deg rotation on XY plane: xDir should become Y direction
-    expect(rotated.xDir[0]).toBeCloseTo(0, 3);
-    expect(rotated.xDir[1]).toBeCloseTo(1, 3);
-  });
-
-  it('preserves normal direction', () => {
-    const plane = resolvePlane('XY');
-    const rotated = rotatePlane2DAxes(plane, 45);
-    expect(vecEquals(rotated.zDir, plane.zDir)).toBe(true);
-  });
-
-  it('preserves origin', () => {
-    const plane = translatePlaneTo(resolvePlane('XY'), [5, 5, 5]);
-    const rotated = rotatePlane2DAxes(plane, 30);
-    expect(vecEquals(rotated.origin, [5, 5, 5])).toBe(true);
   });
 });

--- a/tests/fn-vecOps.test.ts
+++ b/tests/fn-vecOps.test.ts
@@ -16,15 +16,8 @@ import {
   vecProjectToPlane,
   vecRotate,
   vecRepr,
-  vec2Add,
-  vec2Sub,
-  vec2Scale,
-  vec2Length,
-  vec2Distance,
-  vec2Normalize,
-  vec2Equals,
 } from '../src/core/vecOps.js';
-import type { Vec3, Vec2 } from '../src/core/types.js';
+import type { Vec3 } from '../src/core/types.js';
 
 // ---------------------------------------------------------------------------
 // 3D Arithmetic
@@ -305,71 +298,5 @@ describe('vecRepr', () => {
 
   it('rounds to 3 decimal places', () => {
     expect(vecRepr([1.23456, 0, 0])).toBe('x: 1.235, y: 0, z: 0');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 2D Operations
-// ---------------------------------------------------------------------------
-
-describe('vec2Add', () => {
-  it('adds two 2D vectors', () => {
-    expect(vec2Add([1, 2], [3, 4])).toEqual([4, 6]);
-  });
-});
-
-describe('vec2Sub', () => {
-  it('subtracts two 2D vectors', () => {
-    expect(vec2Sub([5, 7], [3, 4])).toEqual([2, 3]);
-  });
-});
-
-describe('vec2Scale', () => {
-  it('scales a 2D vector', () => {
-    expect(vec2Scale([3, 4], 2)).toEqual([6, 8]);
-  });
-});
-
-describe('vec2Length', () => {
-  it('computes 2D length', () => {
-    expect(vec2Length([3, 4])).toBe(5);
-  });
-
-  it('zero vector has zero length', () => {
-    expect(vec2Length([0, 0])).toBe(0);
-  });
-});
-
-describe('vec2Distance', () => {
-  it('computes 2D distance', () => {
-    expect(vec2Distance([0, 0], [3, 4])).toBe(5);
-  });
-});
-
-describe('vec2Normalize', () => {
-  it('normalizes to unit length', () => {
-    const n = vec2Normalize([3, 4]);
-    expect(vec2Length(n)).toBeCloseTo(1);
-    expect(n[0]).toBeCloseTo(0.6);
-    expect(n[1]).toBeCloseTo(0.8);
-  });
-
-  it('zero vector returns zero', () => {
-    expect(vec2Normalize([0, 0])).toEqual([0, 0]);
-  });
-});
-
-describe('vec2Equals', () => {
-  it('equal vectors return true', () => {
-    expect(vec2Equals([1, 2], [1, 2])).toBe(true);
-  });
-
-  it('different vectors return false', () => {
-    expect(vec2Equals([1, 2], [1, 3])).toBe(false);
-  });
-
-  it('respects tolerance', () => {
-    expect(vec2Equals([1, 2], [1.0001, 2], 0.001)).toBe(true);
-    expect(vec2Equals([1, 2], [1.01, 2], 0.001)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Remove identical ternary branches in `complexExtrude`/`twistExtrude` that masked TypeScript overload narrowing; fix by omitting `shellMode` in falsy branch
- Remove no-op `normalizeFilletRadius` identity function in `topology/api`
- Remove unused `pointToOcPnt`/`pointToOcDir` exports from `occtBoundary`
- Remove unused `vec2*` functions from `vecOps` (duplicated by `2d/lib/vectorOperations`)
- Remove unused plane utilities (`planeToWorldVec3`, `planeToLocalVec3`, `translatePlaneTo`, `rotatePlane2DAxes`) with zero production callers
- Update tests and `core/README.md` to match

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run check:boundaries` passes
- [x] `npm run knip` passes
- [x] All affected test files pass (fn-vecOps, fn-occtBoundary, fn-planeOps)
- [x] Pre-commit hooks pass (lint-staged + typecheck + boundary check + coverage)
- [x] Pre-push hooks pass (full test:coverage + knip)