### PR TITLE
fix(site): fix 403 on site.webmanifest

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,6 @@
     }
   ],
   "rewrites": [
-    { "source": "/((?!wasm|assets).*)", "destination": "/index.html" }
+    { "source": "/((?!wasm|assets|.*\\.webmanifest$|.*\\.ico$|.*\\.png$|.*\\.svg$).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- Exclude `.webmanifest`, `.ico`, `.png`, and `.svg` files from the SPA catch-all rewrite in `vercel.json`
- Fixes 403 error on `https://www.brepjs.dev/site.webmanifest` caused by the rewrite sending it to `index.html`

## Test plan
- [ ] Verify `https://www.brepjs.dev/site.webmanifest` returns 200 after deploy
- [ ] Verify SPA routing still works for app routes