### PR TITLE
revert(site): remove static asset exclusions from SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,6 @@
     }
   ],
   "rewrites": [
-    { "source": "/((?!wasm|assets|.*\\.webmanifest$|.*\\.ico$|.*\\.png$|.*\\.svg$).*)", "destination": "/index.html" }
+    { "source": "/((?!wasm|assets).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- Reverts the rewrite regex change from #299
- The Vercel WAF bypass rule now handles serving `.webmanifest`, `.ico`, `.png`, `.svg` through Attack Challenge Mode, making the rewrite exclusions redundant

## Test plan
- [ ] Verify `https://www.brepjs.dev/site.webmanifest` still returns 200 after deploy
- [ ] Verify SPA routing still works for app routes