### PR TITLE
chore: bump size-limit to 135 kB for topology optimizations

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "130 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "135 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js" },
   { "name": "brepjs/core", "path": "dist/core.js" },
   { "name": "brepjs/result", "path": "dist/result.js" },


### PR DESCRIPTION
## Summary

- Bump size-limit threshold from 130 kB to 135 kB to accommodate the topology optimizations from #309
- The hash-bucket dedup in `sharedEdges` and the iterator fallback in `iterOcList` add ~3 kB brotlied
- This is justified by the O(n*m) -> O(n+m) complexity improvement

## Test plan

- [x] `npx size-limit` passes locally (133.16 kB < 135 kB)
- [x] All 1999 tests pass