### PR TITLE
perf(topology): optimize sectionToFace O(n³)→O(n), healing/color test coverage

### DIFF
--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -17,7 +17,14 @@ import type { PlaneInput } from '../core/planeTypes.js';
 import { resolvePlane } from '../core/planeOps.js';
 import { vecAdd, vecScale } from '../core/vecOps.js';
 import { applyGlue } from './shapeBooleans.js';
-import { propagateOrigins, propagateOriginsByHash, getWires, getEdges } from './shapeFns.js';
+import {
+  propagateOrigins,
+  propagateOriginsByHash,
+  getWires,
+  getEdges,
+  getVertices,
+} from './shapeFns.js';
+import { HASH_CODE_MAX } from '../core/constants.js';
 import { makeFace } from './surfaceBuilders.js';
 import { propagateFaceTags } from './faceTagFns.js';
 import { propagateColors } from './colorFns.js';
@@ -483,37 +490,58 @@ export function sectionToFace(
       return err(occtError('SECTION_FAILED', 'sectionToFace: section produced no geometry'));
     }
     const oc = getKernel().oc;
-    const remaining = [...edges];
-    while (remaining.length > 0) {
-      // Collect edges for this wire by testing connectivity with a probe builder
-      const first = remaining.shift();
-      if (!first) break;
-      const wireEdges = [first];
 
-      let added = true;
-      while (added && remaining.length > 0) {
-        added = false;
-        for (let i = 0; i < remaining.length; i++) {
-          const candidate = remaining[i];
-          if (!candidate) continue;
-          // Probe: create a temporary builder to test if edge connects
-          const probe = new oc.BRepBuilderAPI_MakeWire_1();
-          for (const e of wireEdges) {
-            probe.Add_1(e.wrapped);
-          }
-          probe.Add_1(candidate.wrapped);
-          const connects = probe.Error() === oc.BRepBuilderAPI_WireError.BRepBuilderAPI_WireDone;
-          probe.delete();
-          if (connects) {
-            wireEdges.push(candidate);
-            remaining.splice(i, 1);
-            added = true;
+    // Build vertex-hash → edge adjacency map for O(n) wire assembly
+    // (replaces the previous O(n³) probe-builder approach)
+    const vertexToEdges = new Map<number, typeof edges>();
+    const edgeVertexHashes = new Map<(typeof edges)[number], [number, number]>();
+    for (const edge of edges) {
+      const verts = getVertices(edge);
+      const h0 = verts[0] ? verts[0].wrapped.HashCode(HASH_CODE_MAX) : -1;
+      const h1 = verts.length > 1 && verts[1] ? verts[1].wrapped.HashCode(HASH_CODE_MAX) : h0;
+      edgeVertexHashes.set(edge, [h0, h1]);
+      for (const h of [h0, h1]) {
+        const bucket = vertexToEdges.get(h) ?? [];
+        bucket.push(edge);
+        vertexToEdges.set(h, bucket);
+      }
+    }
+
+    // Walk connected components via adjacency map
+    const visited = new Set<(typeof edges)[number]>();
+    for (const startEdge of edges) {
+      if (visited.has(startEdge)) continue;
+      const wireEdges = [startEdge];
+      visited.add(startEdge);
+
+      // Walk from both endpoints of the growing chain
+      const hashes = edgeVertexHashes.get(startEdge);
+      if (!hashes) continue;
+      const endpoints = [hashes[1], hashes[0]]; // [forward tip, backward tip]
+      for (let dir = 0; dir < 2; dir++) {
+        let tip = endpoints[dir];
+        if (tip === undefined) continue;
+        let found = true;
+        while (found) {
+          found = false;
+          const bucket = vertexToEdges.get(tip);
+          if (!bucket) break;
+          for (const candidate of bucket) {
+            if (visited.has(candidate)) continue;
+            const ch = edgeVertexHashes.get(candidate);
+            if (!ch) continue;
+            visited.add(candidate);
+            if (dir === 0) wireEdges.push(candidate);
+            else wireEdges.unshift(candidate);
+            // Advance tip to the other endpoint of the candidate
+            tip = ch[0] === tip ? ch[1] : ch[0];
+            found = true;
             break;
           }
         }
       }
 
-      // Build the final wire from collected edges
+      // Build wire from collected edges
       const wb = new oc.BRepBuilderAPI_MakeWire_1();
       for (const e of wireEdges) {
         wb.Add_1(e.wrapped);

--- a/tests/fn-colorFns.test.ts
+++ b/tests/fn-colorFns.test.ts
@@ -28,6 +28,26 @@ describe('shape colors', () => {
     expect(c?.[3]).toBeCloseTo(1, 1);
   });
 
+  it('assigns color with 3-char hex shorthand', () => {
+    const b = box(10, 10, 10);
+    const colored = colorShape(b, '#f00');
+    const c = getShapeColor(colored);
+    expect(c).toBeDefined();
+    expect(c?.[0]).toBeCloseTo(1, 1);
+    expect(c?.[1]).toBeCloseTo(0, 1);
+    expect(c?.[2]).toBeCloseTo(0, 1);
+    expect(c?.[3]).toBeCloseTo(1, 1);
+  });
+
+  it('parses hex without # prefix', () => {
+    const b = box(10, 10, 10);
+    const colored = colorShape(b, '00ff00');
+    const c = getShapeColor(colored);
+    expect(c?.[0]).toBeCloseTo(0, 1);
+    expect(c?.[1]).toBeCloseTo(1, 1);
+    expect(c?.[2]).toBeCloseTo(0, 1);
+  });
+
   it('assigns color with RGB tuple', () => {
     const b = box(10, 10, 10);
     const colored = colorShape(b, [0.5, 0.5, 0.5]);

--- a/tests/fn-faceTagFns.test.ts
+++ b/tests/fn-faceTagFns.test.ts
@@ -93,6 +93,19 @@ describe('face tagging', () => {
     expect(getTagMetadata(b, 'nope')).toBeUndefined();
   });
 
+  it('tag metadata propagates through boolean fuse', () => {
+    const b1 = box(10, 10, 10);
+    const topFaces = faceFinder().inDirection([0, 0, 1]).findAll(b1);
+    const tagged = tagFaces(b1, topFaces, 'top');
+    setTagMetadata(tagged, 'top', { material: 'steel', thickness: 2 });
+
+    const b2 = box(5, 5, 5);
+    const fused = unwrap(fuse(tagged, b2));
+
+    const meta = getTagMetadata(fused, 'top');
+    expect(meta).toEqual({ material: 'steel', thickness: 2 });
+  });
+
   it('supports callback selector', () => {
     const b = box(10, 10, 10);
     const allFaces = getFaces(b);

--- a/tests/fn-healingFns.test.ts
+++ b/tests/fn-healingFns.test.ts
@@ -16,6 +16,7 @@ import {
   heal,
   autoHeal,
   isOk,
+  isErr,
   unwrap,
   measureVolume,
   measureArea,
@@ -23,7 +24,7 @@ import {
   isFace,
   isWire,
 } from '../src/index.js';
-import type { AutoHealOptions } from '../src/index.js';
+import type { AutoHealOptions, Solid, Face, Wire } from '../src/index.js';
 
 beforeAll(async () => {
   await initOC();
@@ -107,6 +108,35 @@ describe('healWire', () => {
     const result = healWire(wires[0], faces[0]);
     expect(isOk(result)).toBe(true);
     expect(isWire(unwrap(result))).toBe(true);
+  });
+});
+
+describe('type-guard error branches', () => {
+  it('healSolid returns NOT_A_SOLID when given a face', () => {
+    const faces = getFaces(box(10, 10, 10));
+    const result = healSolid(faces[0] as unknown as Solid);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('NOT_A_SOLID');
+    }
+  });
+
+  it('healFace returns NOT_A_FACE when given a wire', () => {
+    const wires = getWires(box(10, 10, 10));
+    const result = healFace(wires[0] as unknown as Face);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('NOT_A_FACE');
+    }
+  });
+
+  it('healWire returns NOT_A_WIRE when given a face', () => {
+    const faces = getFaces(box(10, 10, 10));
+    const result = healWire(faces[0] as unknown as Wire);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe('NOT_A_WIRE');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace O(n³) probe-builder wire assembly in `sectionToFace` with O(n) vertex adjacency hash map — eliminates per-candidate WASM `BRepBuilderAPI_MakeWire` allocations when OCCT `section()` returns loose edges
- Add type-guard error tests for `healSolid`/`healFace`/`healWire` (NOT_A_SOLID, NOT_A_FACE, NOT_A_WIRE branches)
- Add 3-char hex shorthand and no-prefix hex parsing tests for `colorFns`
- Add tag metadata propagation through boolean fuse test for `faceTagFns`

## Test plan
- [x] All 123 affected tests pass (fn-sectionToFace, fn-booleanFns, fn-healingFns, fn-colorFns, fn-faceTagFns)
- [x] Full test suite passes via pre-push hook (2000+ tests)
- [x] Typecheck clean
- [x] Layer boundary check passes
- [x] knip clean