### PR TITLE
fix(topology): double-free in surfaceFns, resource leak in curveFns, extrude coverage

### DIFF
--- a/src/topology/curveFns.ts
+++ b/src/topology/curveFns.ts
@@ -121,10 +121,9 @@ export function curveIsPeriodic(shape: Edge | Wire): boolean {
 
 /** Get the period of a periodic curve. */
 export function curvePeriod(shape: Edge | Wire): number {
-  const adaptor = getAdaptor(shape);
-  const result = adaptor.Period();
-  adaptor.delete();
-  return result;
+  using scope = new DisposalScope();
+  const adaptor = scope.register(getAdaptor(shape));
+  return adaptor.Period();
 }
 
 /** Get the topological orientation of an edge or wire. */

--- a/src/topology/surfaceFns.ts
+++ b/src/topology/surfaceFns.ts
@@ -191,7 +191,6 @@ function buildTriangulatedSurface(
     }
 
     if (faceCount === 0) {
-      sewing.delete();
       return err(
         occtError(BrepErrorCode.SURFACE_FAILED, 'surfaceFromGrid: no valid triangular faces built')
       );

--- a/tests/fn-extrudeFns.test.ts
+++ b/tests/fn-extrudeFns.test.ts
@@ -13,15 +13,23 @@ import {
   twistExtrude,
   measureVolume,
   isOk,
+  isErr,
   unwrap,
   isSolid,
   isShape3D,
 } from '../src/index.js';
 import type { Wire } from '../src/core/shapeTypes.js';
+import { createFace } from '../src/core/shapeTypes.js';
+import { getKernel } from '../src/kernel/index.js';
 
 beforeAll(async () => {
   await initOC();
 }, 30000);
+
+function makeNullFace() {
+  const oc = getKernel().oc;
+  return createFace(new oc.TopoDS_Face());
+}
 
 describe('extrude', () => {
   it('extrudes a rectangle into a box', () => {
@@ -43,11 +51,24 @@ describe('extrude', () => {
   });
 });
 
+describe('extrude error paths', () => {
+  it('returns error for null face', () => {
+    const result = extrude(makeNullFace(), [0, 0, 10]);
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('returns error for zero-length extrusion vector', () => {
+    const f = castShape(sketchRectangle(10, 10).face().wrapped);
+    const result = extrude(f, [0, 0, 0]);
+    expect(isErr(result)).toBe(true);
+  });
+});
+
 describe('revolve', () => {
   it('revolves a rectangle 360 degrees into a cylinder', () => {
     const rect = sketchRectangle(2, 5, { origin: [6, 0] });
     const f = castShape(rect.face().wrapped);
-    const result = revolve(f, { around: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
+    const result = revolve(f, { at: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
     expect(isOk(result)).toBe(true);
     expect(isShape3D(unwrap(result))).toBe(true);
   });
@@ -55,8 +76,15 @@ describe('revolve', () => {
   it('revolves a rectangle 90 degrees', () => {
     const rect = sketchRectangle(2, 5, { origin: [6, 0] });
     const f = castShape(rect.face().wrapped);
-    const result = revolve(f, { around: [0, 0, 0], axis: [0, 1, 0], angle: 90 });
+    const result = revolve(f, { at: [0, 0, 0], axis: [0, 1, 0], angle: 90 });
     expect(isOk(result)).toBe(true);
+  });
+});
+
+describe('revolve error paths', () => {
+  it('returns error for null face', () => {
+    const result = revolve(makeNullFace(), { at: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
+    expect(isErr(result)).toBe(true);
   });
 });
 
@@ -67,6 +95,18 @@ describe('sweep', () => {
     const e = line([0, 0, 0], [0, 0, 20]);
     const spine = castShape(unwrap(wire([e])).wrapped) as Wire;
     const result = sweep(profile, spine);
+    expect(isOk(result)).toBe(true);
+    expect(isShape3D(unwrap(result))).toBe(true);
+  });
+});
+
+describe('sweep simple mode', () => {
+  it('sweeps in simple pipe mode', () => {
+    const c = sketchCircle(2);
+    const profile = castShape(c.wire.wrapped) as Wire;
+    const e = line([0, 0, 0], [0, 0, 20]);
+    const spine = castShape(unwrap(wire([e])).wrapped) as Wire;
+    const result = sweep(profile, spine, { mode: 'simple' });
     expect(isOk(result)).toBe(true);
     expect(isShape3D(unwrap(result))).toBe(true);
   });
@@ -109,5 +149,28 @@ describe('twistExtrude', () => {
     const result = twistExtrude(w, 90, [0, 0, 0], [0, 0, 20]);
     expect(isOk(result)).toBe(true);
     expect(isShape3D(unwrap(result))).toBe(true);
+  });
+
+  it('returns error for zero twist angle', () => {
+    const rect = sketchRectangle(6, 6);
+    const w = castShape(rect.wire.wrapped) as Wire;
+    const result = twistExtrude(w, 0, [0, 0, 0], [0, 0, 20]);
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('returns error for zero-length normal', () => {
+    const rect = sketchRectangle(6, 6);
+    const w = castShape(rect.wire.wrapped) as Wire;
+    const result = twistExtrude(w, 90, [0, 0, 0], [0, 0, 0]);
+    expect(isErr(result)).toBe(true);
+  });
+});
+
+describe('complexExtrude error paths', () => {
+  it('returns error for zero-length extrusion normal', () => {
+    const c = sketchCircle(5);
+    const w = castShape(c.wire.wrapped) as Wire;
+    const result = complexExtrude(w, [0, 0, 0], [0, 0, 0]);
+    expect(isErr(result)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- **Bug fix**: Remove duplicate `sewing.delete()` in `buildTriangulatedSurface` that caused double-free when `faceCount === 0` — the `finally` block already handles cleanup
- **Bug fix**: Use `DisposalScope` in `curvePeriod()` to match sibling functions, preventing adaptor leak if `Period()` throws
- **Test fix**: Correct `revolve()` test using wrong option key (`around` → `at`) — tests passed by coincidence since `at` defaults to `[0,0,0]`
- Add error-path tests: null face for extrude/revolve, zero-vector extrude, zero-angle twistExtrude, zero-length complexExtrude
- Add sweep `mode: 'simple'` test exercising the fast `BRepOffsetAPI_MakePipe` path

## Test plan
- [x] All 57 affected tests pass (fn-extrudeFns, fn-curveFns, fn-surfaceFns)
- [x] Full test suite passes via pre-push hook (2000+ tests)
- [x] Typecheck clean
- [x] Layer boundary check passes
- [x] knip clean