### PR TITLE
chore(topology): luminance constants, loft tolerance, bspline tests

### DIFF
--- a/src/operations/loftFns.ts
+++ b/src/operations/loftFns.ts
@@ -20,6 +20,8 @@ export interface LoftOptions {
   startPoint?: PointInput;
   /** Optional end vertex after the last wire profile. */
   endPoint?: PointInput;
+  /** Sewing tolerance for ThruSections builder. Defaults to `1e-6`. */
+  tolerance?: number;
 }
 
 /**
@@ -43,7 +45,7 @@ export interface LoftOptions {
  */
 export function loft(
   wires: Wire[],
-  { ruled = true, startPoint, endPoint }: LoftOptions = {},
+  { ruled = true, startPoint, endPoint, tolerance = 1e-6 }: LoftOptions = {},
   returnShell = false
 ): Result<Shape3D> {
   if (wires.length === 0 && !startPoint && !endPoint) {
@@ -53,7 +55,7 @@ export function loft(
   const oc = getKernel().oc;
   using scope = new DisposalScope();
 
-  const builder = scope.register(new oc.BRepOffsetAPI_ThruSections(!returnShell, ruled, 1e-6));
+  const builder = scope.register(new oc.BRepOffsetAPI_ThruSections(!returnShell, ruled, tolerance));
 
   if (startPoint) {
     const pnt = scope.register(toOcPnt(toVec3(startPoint)));

--- a/src/topology/surfaceFns.ts
+++ b/src/topology/surfaceFns.ts
@@ -10,6 +10,11 @@ import { type Result, ok, err } from '../core/result.js';
 import { validationError, occtError, ioError, BrepErrorCode } from '../core/errors.js';
 import { DisposalScope } from '../core/disposal.js';
 
+/** Rec. 601 luma coefficients for luminance calculation. */
+const REC601_R = 0.299;
+const REC601_G = 0.587;
+const REC601_B = 0.114;
+
 export interface SurfaceFromGridOptions {
   /** Physical width in X direction. Default: number of columns - 1. */
   width?: number;
@@ -314,7 +319,7 @@ export async function surfaceFromImage(
           value = b / 255;
           break;
         default:
-          value = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+          value = (REC601_R * r + REC601_G * g + REC601_B * b) / 255;
           break;
       }
       row.push(value);

--- a/tests/fn-bsplineFns.test.ts
+++ b/tests/fn-bsplineFns.test.ts
@@ -56,6 +56,15 @@ describe('approximateCurve', () => {
     });
     expect(isOk(result)).toBe(true);
   });
+
+  it('accepts smoothing weights', () => {
+    const result = approximateCurve(samplePoints, {
+      smoothing: [1, 1, 1],
+    });
+    expect(isOk(result)).toBe(true);
+    const edge = unwrap(result);
+    expect(curveLength(edge)).toBeGreaterThan(15);
+  });
 });
 
 describe('interpolateCurve', () => {
@@ -82,5 +91,17 @@ describe('interpolateCurve', () => {
   it('returns error for fewer than 2 points', () => {
     const result = interpolateCurve([[0, 0, 0]]);
     expect(isErr(result)).toBe(true);
+  });
+
+  it('creates a curve with periodic option', () => {
+    const closedPoints: Vec3[] = [
+      [10, 0, 0],
+      [0, 10, 0],
+      [-10, 0, 0],
+      [0, -10, 0],
+    ];
+    const result = interpolateCurve(closedPoints, { periodic: true });
+    expect(isOk(result)).toBe(true);
+    expect(curveLength(unwrap(result))).toBeGreaterThan(0);
   });
 });

--- a/tests/fn-loftFns.test.ts
+++ b/tests/fn-loftFns.test.ts
@@ -75,4 +75,12 @@ describe('loft', () => {
     expect(isOk(result)).toBe(true);
     expect(isShape3D(unwrap(result))).toBe(true);
   });
+
+  it('lofts with custom tolerance', () => {
+    const w1 = castShape(sketchCircle(5).wire.wrapped);
+    const w2 = translate(castShape(sketchCircle(5).wire.wrapped), [0, 0, 10]);
+    const result = loft([w1, w2], { tolerance: 1e-4 });
+    expect(isOk(result)).toBe(true);
+    expect(isShape3D(unwrap(result))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Extract hardcoded Rec. 601 luminance coefficients (0.299/0.587/0.114) to named constants in `surfaceFns.ts`
- Expose `tolerance` option in `LoftOptions` (default `1e-6`, previously hardcoded in `loftFns.ts`)
- Add test for `interpolateCurve` with `periodic: true` option
- Add test for `approximateCurve` with `smoothing` weights
- Add test for `loft` with custom `tolerance`

## Test plan
- [x] All 46 affected tests pass (bspline, loft, surface)
- [x] Full test suite passes (pre-push hook)
- [x] Typecheck clean