### PR TITLE
fix: remove accidentally committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ examples/output/
 # Git worktrees
 .worktrees/
 
-node_modules/
+node_modules
 dist/
 docs-api/
 coverage/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/andy/Git/brepjs/node_modules


### PR DESCRIPTION
## Summary

- Remove circular `node_modules` symlink that was accidentally committed in 7f954ea
- Fix `.gitignore` to use `node_modules` (no trailing slash) so it matches both symlinks and directories

The symlink pointed to `/home/andy/Git/brepjs/node_modules` which on Fedora immutable OS (`/home` → `/var/home`) resolves back to itself, causing "Too many levels of symbolic links" errors on all `node_modules/.bin/*` executables after any git operation that restores the tracked symlink.

## Test plan

- [x] Pre-push checks pass (tests, coverage, knip)