### PR TITLE
feat(kernel): add BrepkitKernel type interface for WASM exports

### DIFF
--- a/src/kernel/brepkitAdapter.ts
+++ b/src/kernel/brepkitAdapter.ts
@@ -45,6 +45,7 @@ import type {
   MeshOptions,
   StepAssemblyPart,
 } from './types.js';
+import type { BrepkitKernel } from './brepkitWasmTypes.js';
 import type { Curve2dHandle, BBox2dHandle } from './kernel2dTypes.js';
 import * as bk2d from './brepkit2d.js';
 import type { Curve2dObj, BBox2d as BkBBox2d } from './brepkit2d.js';
@@ -237,11 +238,11 @@ export class BrepkitAdapter implements KernelAdapter {
   readonly oc: KernelInstance;
   readonly kernelId = 'brepkit';
 
-  /** The underlying brepkit WASM kernel instance. */
-  private readonly bk: KernelInstance;
+  /** The underlying brepkit WASM kernel instance (typed). */
+  private readonly bk: BrepkitKernel;
 
   constructor(brepkitKernel: KernelInstance) {
-    this.bk = brepkitKernel;
+    this.bk = brepkitKernel as BrepkitKernel;
     // `oc` is the escape hatch — expose the raw kernel for advanced usage
     this.oc = brepkitKernel;
   }
@@ -561,7 +562,9 @@ export class BrepkitAdapter implements KernelAdapter {
 
     // Project p1, p2, p3 into the local 2D frame (relative to p1 as origin)
     const proj = (p: [number, number, number]): [number, number] => {
-      const dx = p[0] - p1[0], dy = p[1] - p1[1], dz = p[2] - p1[2];
+      const dx = p[0] - p1[0],
+        dy = p[1] - p1[1],
+        dz = p[2] - p1[2];
       return [dx * ux[0] + dy * ux[1] + dz * ux[2], dx * uy[0] + dy * uy[1] + dz * uy[2]];
     };
     const [ax2, ay2] = proj(p1); // (0, 0)
@@ -576,11 +579,13 @@ export class BrepkitAdapter implements KernelAdapter {
     const ccx =
       ((ax2 ** 2 + ay2 ** 2) * (by2 - cy2) +
         (bx2 ** 2 + by2 ** 2) * (cy2 - ay2) +
-        (cx2 ** 2 + cy2 ** 2) * (ay2 - by2)) / d;
+        (cx2 ** 2 + cy2 ** 2) * (ay2 - by2)) /
+      d;
     const ccy =
       ((ax2 ** 2 + ay2 ** 2) * (cx2 - bx2) +
         (bx2 ** 2 + by2 ** 2) * (ax2 - cx2) +
-        (cx2 ** 2 + cy2 ** 2) * (bx2 - ax2)) / d;
+        (cx2 ** 2 + cy2 ** 2) * (bx2 - ax2)) /
+      d;
 
     // Lift 2D center back to 3D
     const center: [number, number, number] = [
@@ -588,7 +593,9 @@ export class BrepkitAdapter implements KernelAdapter {
       p1[1] + ccx * ux[1] + ccy * uy[1],
       p1[2] + ccx * ux[2] + ccy * uy[2],
     ];
-    const radius = Math.sqrt((p1[0] - center[0]) ** 2 + (p1[1] - center[1]) ** 2 + (p1[2] - center[2]) ** 2);
+    const radius = Math.sqrt(
+      (p1[0] - center[0]) ** 2 + (p1[1] - center[1]) ** 2 + (p1[2] - center[2]) ** 2
+    );
 
     // Build local frame for angle computation: x-axis from center→p1
     const lx: [number, number, number] = [p1[0] - center[0], p1[1] - center[1], p1[2] - center[2]];
@@ -1737,10 +1744,10 @@ export class BrepkitAdapter implements KernelAdapter {
     // Point to solid
     if (h1.type === 'vertex' && h2.type === 'solid') {
       const pos = this.bk.getVertexPosition(h1.id);
-      const result: number[] = this.bk.pointToSolidDistance(pos[0], pos[1], pos[2], h2.id);
+      const result: number[] = this.bk.pointToSolidDistance(pos[0]!, pos[1]!, pos[2]!, h2.id);
       return {
         value: result[0]!,
-        point1: [pos[0], pos[1], pos[2]],
+        point1: [pos[0]!, pos[1]!, pos[2]!],
         point2: [result[1]!, result[2]!, result[3]!],
       };
     }
@@ -1749,7 +1756,7 @@ export class BrepkitAdapter implements KernelAdapter {
     const getPos = (s: BrepkitHandle): [number, number, number] => {
       if (s.type === 'vertex') {
         const p = this.bk.getVertexPosition(s.id);
-        return [p[0], p[1], p[2]];
+        return [p[0]!, p[1]!, p[2]!];
       }
       // Use bounding box center as approximation
       if (s.type === 'solid') {
@@ -2500,11 +2507,13 @@ export class BrepkitAdapter implements KernelAdapter {
     const cx =
       ((x1 * x1 + y1 * y1) * (ym - y2) +
         (xm * xm + ym * ym) * (y2 - y1) +
-        (x2 * x2 + y2 * y2) * (y1 - ym)) / d;
+        (x2 * x2 + y2 * y2) * (y1 - ym)) /
+      d;
     const cy =
       ((x1 * x1 + y1 * y1) * (x2 - xm) +
         (xm * xm + ym * ym) * (x1 - x2) +
-        (x2 * x2 + y2 * y2) * (xm - x1)) / d;
+        (x2 * x2 + y2 * y2) * (xm - x1)) /
+      d;
     const radius = Math.sqrt((x1 - cx) ** 2 + (y1 - cy) ** 2);
 
     // Compute angles for start (p1), mid (pm), and end (p2)
@@ -2542,10 +2551,12 @@ export class BrepkitAdapter implements KernelAdapter {
     const chord = Math.sqrt((ex - sx) ** 2 + (ey - sy) ** 2);
     const offset = chord * 0.25;
     return this.makeArc2dThreePoints(
-      sx, sy,
+      sx,
+      sy,
       (sx + ex) / 2 + nty * offset,
       (sy + ey) / 2 - ntx * offset,
-      ex, ey
+      ex,
+      ey
     );
   }
   makeEllipse2d(
@@ -2732,14 +2743,12 @@ export class BrepkitAdapter implements KernelAdapter {
     if (mode === 'axis' && dx !== undefined && dy !== undefined) {
       // Mirror across axis through (ox ?? cx, oy ?? cy) with direction (dx, dy)
       const len = Math.sqrt(dx * dx + dy * dy);
-      const nx = dx / len, ny = dy / len;
+      const nx = dx / len,
+        ny = dy / len;
       // Reflection matrix: R = 2*n*nT - I
-      const m = [
-        2 * nx * nx - 1, 2 * nx * ny, 0,
-        2 * nx * ny, 2 * ny * ny - 1, 0,
-        0, 0, 1,
-      ];
-      const px = ox ?? cx, py = oy ?? cy;
+      const m = [2 * nx * nx - 1, 2 * nx * ny, 0, 2 * nx * ny, 2 * ny * ny - 1, 0, 0, 0, 1];
+      const px = ox ?? cx,
+        py = oy ?? cy;
       // Translation: p - R*p
       const txv = px - m[0]! * px - m[1]! * py;
       const tyv = py - m[3]! * px - m[4]! * py;
@@ -3110,16 +3119,31 @@ export class BrepkitAdapter implements KernelAdapter {
         return solidHandle(copy);
       }
       case 'face': {
+        if (typeof this.bk.copyFace !== 'function' || typeof this.bk.transformFace !== 'function') {
+          throw new Error(
+            'brepkit: applyMatrix for faces requires copyFace/transformFace WASM exports'
+          );
+        }
         const copy = this.bk.copyFace(h.id);
         this.bk.transformFace(copy, matrix);
         return faceHandle(copy);
       }
       case 'wire': {
+        if (typeof this.bk.copyWire !== 'function' || typeof this.bk.transformWire !== 'function') {
+          throw new Error(
+            'brepkit: applyMatrix for wires requires copyWire/transformWire WASM exports'
+          );
+        }
         const copy = this.bk.copyWire(h.id);
         this.bk.transformWire(copy, matrix);
         return wireHandle(copy);
       }
       case 'edge': {
+        if (typeof this.bk.copyEdge !== 'function' || typeof this.bk.transformEdge !== 'function') {
+          throw new Error(
+            'brepkit: applyMatrix for edges requires copyEdge/transformEdge WASM exports'
+          );
+        }
         const copy = this.bk.copyEdge(h.id);
         this.bk.transformEdge(copy, matrix);
         return edgeHandle(copy);
@@ -3341,12 +3365,12 @@ export class BrepkitAdapter implements KernelAdapter {
     const endPt = controlPoints.slice(-3);
 
     const id = this.bk.makeNurbsEdge(
-      startPt[0],
-      startPt[1],
-      startPt[2],
-      endPt[0],
-      endPt[1],
-      endPt[2],
+      startPt[0]!,
+      startPt[1]!,
+      startPt[2]!,
+      endPt[0]!,
+      endPt[1]!,
+      endPt[2]!,
       degree,
       knots,
       controlPoints,
@@ -3368,7 +3392,7 @@ export class BrepkitAdapter implements KernelAdapter {
 
     // Try to get NURBS data from the edge
     const nurbsJson = this.bk.getEdgeNurbsData(h.id);
-    if (nurbsJson && nurbsJson !== null && typeof nurbsJson === 'string') {
+    if (nurbsJson) {
       const data = JSON.parse(nurbsJson);
       return {
         degree: data.degree,
@@ -3452,12 +3476,12 @@ export class BrepkitAdapter implements KernelAdapter {
     const endPt = controlPoints.slice(-3);
 
     const id = this.bk.makeNurbsEdge(
-      startPt[0],
-      startPt[1],
-      startPt[2],
-      endPt[0],
-      endPt[1],
-      endPt[2],
+      startPt[0]!,
+      startPt[1]!,
+      startPt[2]!,
+      endPt[0]!,
+      endPt[1]!,
+      endPt[2]!,
       degree,
       knots,
       controlPoints,

--- a/src/kernel/brepkitWasmTypes.ts
+++ b/src/kernel/brepkitWasmTypes.ts
@@ -1,0 +1,753 @@
+/**
+ * Type-safe interface for the brepkit WASM kernel (`BrepKernel`).
+ *
+ * This mirrors the Rust `BrepKernel` struct's `#[wasm_bindgen]` exports.
+ * Every `this.bk.*` call in `brepkitAdapter.ts` is typed here so TypeScript
+ * catches mismatches at compile time.
+ *
+ * Methods not yet exposed by the WASM build are marked **optional** (`?`).
+ * Callers must guard with `typeof this.bk.method === 'function'` before use.
+ *
+ * @module
+ */
+
+// ── Mesh result from tessellation ────────────────────────────────
+
+/** Triangle mesh returned by `tessellateFace` / `tessellateSolid`. */
+export interface BrepkitMesh {
+  /** Flattened vertex positions `[x, y, z, ...]`. */
+  readonly positions: number[];
+  /** Flattened per-vertex normals `[nx, ny, nz, ...]`. */
+  readonly normals: number[];
+  /** Triangle indices (groups of 3). */
+  readonly indices: number[];
+  /** Number of vertices. */
+  readonly vertexCount: number;
+  /** Number of triangles. */
+  readonly triangleCount: number;
+  /** All mesh data in a single packed buffer for efficient FFI transfer. */
+  packedBuffer(): Uint8Array;
+}
+
+// ── Main kernel interface ────────────────────────────────────────
+
+/**
+ * Type-safe view of brepkit's WASM `BrepKernel` class.
+ *
+ * All handle parameters and return values are `number` (u32 arena indices).
+ * Coordinate arrays are flat `number[]` (`[x,y,z, ...]`).
+ * Matrices are 16-element row-major `number[]`.
+ */
+export interface BrepkitKernel {
+  // ── Primitives ──────────────────────────────────────────────────
+
+  /** Create a box solid centered at origin. Returns solid handle. */
+  makeBox(dx: number, dy: number, dz: number): number;
+
+  /** Create a cylinder solid, axis along +Z. Returns solid handle. */
+  makeCylinder(radius: number, height: number): number;
+
+  /** Create a sphere solid centered at origin. Returns solid handle. */
+  makeSphere(radius: number, segments: number): number;
+
+  /** Create a cone/frustum solid, axis along +Z. Returns solid handle. */
+  makeCone(bottomRadius: number, topRadius: number, height: number): number;
+
+  /** Create a torus solid in XY plane. Returns solid handle. */
+  makeTorus(majorRadius: number, minorRadius: number, segments: number): number;
+
+  /** Create a rectangular face centered at origin in XY. Returns face handle. */
+  makeRectangle(width: number, height: number): number;
+
+  /** Create a polygonal face from flat coords `[x,y,z,...]`. Returns face handle. */
+  makePolygon(coords: number[]): number;
+
+  /** Create a circular polygon face in XY. Returns face handle. */
+  makeCircle(radius: number, segments: number): number;
+
+  // ── Shape construction (low-level) ─────────────────────────────
+
+  /** Create a vertex at (x,y,z). Returns vertex handle. */
+  makeVertex(x: number, y: number, z: number): number;
+
+  /** Create a line edge between two points. Returns edge handle. */
+  makeLineEdge(x1: number, y1: number, z1: number, x2: number, y2: number, z2: number): number;
+
+  /** Create a NURBS curve edge. Returns edge handle. */
+  makeNurbsEdge(
+    startX: number,
+    startY: number,
+    startZ: number,
+    endX: number,
+    endY: number,
+    endZ: number,
+    degree: number,
+    knots: number[],
+    controlPoints: number[],
+    weights: number[]
+  ): number;
+
+  /** Create a wire from ordered edge handles. Returns wire handle. */
+  makeWire(edgeHandles: number[], closed: boolean): number;
+
+  /** Create a planar face from a wire. Returns face handle. */
+  makeFaceFromWire(wire: number): number;
+
+  /** Create a solid from a shell. Returns solid handle. */
+  solidFromShell(shell: number): number;
+
+  /** Create a compound from solid handles. Returns compound handle. */
+  makeCompound(solidHandles: number[]): number;
+
+  /** Create a closed polygon wire from flat coords. Returns wire handle. */
+  makePolygonWire(coords: number[]): number;
+
+  /** Create a regular polygon wire in XY. Returns wire handle. */
+  makeRegularPolygonWire(radius: number, nSides: number): number;
+
+  /** Create a circle face using NURBS arcs. Returns face handle. */
+  makeCircleFace(radius: number, segments: number): number;
+
+  /** Add holes (inner wires) to a face. Returns new face handle. */
+  addHolesToFace(face: number, wireIds: number[]): number;
+
+  // ── Boolean operations ─────────────────────────────────────────
+
+  /** Fuse (union) two solids. Returns new solid handle. */
+  fuse(a: number, b: number): number;
+
+  /** Cut (subtract) solid b from a. Returns new solid handle. */
+  cut(a: number, b: number): number;
+
+  /** Intersect two solids. Returns new solid handle. */
+  intersect(a: number, b: number): number;
+
+  // ── Sweep / Loft / Extrude ─────────────────────────────────────
+
+  /** Extrude a face along direction. Returns solid handle. */
+  extrude(face: number, dirX: number, dirY: number, dirZ: number, distance: number): number;
+
+  /**
+   * Revolve a face around an axis. Angle in degrees.
+   * Returns solid handle.
+   */
+  revolve(
+    face: number,
+    ox: number,
+    oy: number,
+    oz: number,
+    dx: number,
+    dy: number,
+    dz: number,
+    angleDegrees: number
+  ): number;
+
+  /** Sweep a face along a NURBS path. Returns solid handle. */
+  sweep(
+    face: number,
+    pathDegree: number,
+    pathKnots: number[],
+    pathControlPoints: number[],
+    pathWeights: number[]
+  ): number;
+
+  /** Loft through an array of face profiles. Returns solid handle. */
+  loft(faceIds: number[]): number;
+
+  /** Pipe sweep along a NURBS path. Returns solid handle. */
+  pipe(
+    face: number,
+    pathDegree: number,
+    pathKnots: number[],
+    pathControlPoints: number[],
+    pathWeights: number[]
+  ): number;
+
+  /** Sweep a face along edge handles. Returns solid handle. */
+  sweepAlongEdges(profile: number, edgeIds: number[]): number;
+
+  /** Helical sweep of a profile. Returns solid handle. */
+  helicalSweep(
+    profile: number,
+    axisOriginX: number,
+    axisOriginY: number,
+    axisOriginZ: number,
+    axisDirX: number,
+    axisDirY: number,
+    axisDirZ: number,
+    radius: number,
+    pitch: number,
+    turns: number
+  ): number;
+
+  /** Sweep with advanced options (contact mode, scale law). Returns solid handle. */
+  sweepWithOptions(
+    profile: number,
+    pathEdge: number,
+    contactMode: string,
+    scaleValues: number[],
+    segments: number
+  ): number;
+
+  // ── Modifiers ──────────────────────────────────────────────────
+
+  /** Fillet edges of a solid with constant radius. Returns solid handle. */
+  fillet(solid: number, edgeIds: number[], radius: number): number;
+
+  /** Fillet edges with variable radius (JSON spec). Returns solid handle. */
+  filletVariable(solid: number, json: string): number;
+
+  /** Chamfer edges of a solid. Returns solid handle. */
+  chamfer(solid: number, edgeIds: number[], distance: number): number;
+
+  /** Shell a solid by removing faces. Returns solid handle. */
+  shell(solid: number, thickness: number, faceIds: number[]): number;
+
+  /** Offset a solid by distance. Returns solid handle. */
+  offsetSolid(solid: number, distance: number): number;
+
+  /** Offset a face. Returns solid handle. */
+  offsetFace(face: number, distance: number, tolerance: number): number;
+
+  /** Offset a wire on a planar face. Returns wire handle. */
+  offsetWire(face: number, distance: number): number;
+
+  /** Draft (taper) faces of a solid. Returns solid handle. */
+  draft(
+    solid: number,
+    faceHandles: number[],
+    pullX: number,
+    pullY: number,
+    pullZ: number,
+    neutralX: number,
+    neutralY: number,
+    neutralZ: number,
+    angleDegrees: number
+  ): number;
+
+  // ── Section / Split ────────────────────────────────────────────
+
+  /** Section a solid with a plane. Returns face handle array. */
+  section(
+    solid: number,
+    px: number,
+    py: number,
+    pz: number,
+    nx: number,
+    ny: number,
+    nz: number
+  ): number[];
+
+  /** Split a solid along a plane. Returns `[positive, negative]` solid handles. */
+  split(
+    solid: number,
+    px: number,
+    py: number,
+    pz: number,
+    nx: number,
+    ny: number,
+    nz: number
+  ): number[];
+
+  // ── Transform / Copy / Mirror / Pattern ────────────────────────
+
+  /** Transform a solid in-place with 4×4 row-major matrix. */
+  transformSolid(solid: number, matrix: number[]): void;
+
+  /** Deep copy a solid. Returns new solid handle. */
+  copySolid(solid: number): number;
+
+  /** Copy and transform in one pass. Returns new solid handle. */
+  copyAndTransformSolid(solid: number, matrix: number[]): number;
+
+  /** Mirror a solid across a plane. Returns new solid handle. */
+  mirror(
+    solid: number,
+    px: number,
+    py: number,
+    pz: number,
+    nx: number,
+    ny: number,
+    nz: number
+  ): number;
+
+  /** Linear pattern (array). Returns compound handle. */
+  linearPattern(
+    solid: number,
+    dx: number,
+    dy: number,
+    dz: number,
+    spacing: number,
+    count: number
+  ): number;
+
+  /** Circular pattern around axis. Returns compound handle. */
+  circularPattern(solid: number, ax: number, ay: number, az: number, count: number): number;
+
+  // ── Sewing / Fill ──────────────────────────────────────────────
+
+  /** Sew faces into a solid. Returns solid handle. */
+  sewFaces(faceHandles: number[], tolerance: number): number;
+
+  /** Fill a 4-sided boundary with Coons patch. Returns face handle. */
+  fillCoonsPatch(boundaryCoords: number[], curveLengths: number[]): number;
+
+  /** Untrim a NURBS face. Returns new face handle. */
+  untrimFace(face: number, samplesPerCurve: number, interiorSamples: number): number;
+
+  // ── Topology queries ───────────────────────────────────────────
+
+  /** Get face handles of a solid. */
+  getSolidFaces(solid: number): number[];
+
+  /** Get edge handles of a solid. */
+  getSolidEdges(solid: number): number[];
+
+  /** Get vertex handles of a solid. */
+  getSolidVertices(solid: number): number[];
+
+  /** Get edge handles of a face. */
+  getFaceEdges(face: number): number[];
+
+  /** Get vertex handles of a face. */
+  getFaceVertices(face: number): number[];
+
+  /** Get the outer wire of a face. */
+  getFaceOuterWire(face: number): number;
+
+  /** Get all wires (outer + inner) of a face. */
+  faceWires(face: number): number[];
+
+  /**
+   * Get vertex positions of an edge.
+   * Returns `[startX, startY, startZ, endX, endY, endZ]`.
+   */
+  getEdgeVertices(edge: number): number[];
+
+  /** Get vertex position `[x, y, z]`. */
+  getVertexPosition(vertex: number): number[];
+
+  /** Get face normal `[nx, ny, nz]` (planar faces only). */
+  getFaceNormal(face: number): number[];
+
+  /** Get entity counts `[faces, edges, vertices]` of a solid. */
+  getEntityCounts(solid: number): number[];
+
+  /** Get edge-to-face adjacency map as JSON string. */
+  edgeToFaceMap(solid: number): string;
+
+  /** Get shared edges between two faces. */
+  sharedEdges(faceA: number, faceB: number): number[];
+
+  /** Get faces adjacent to a face within a solid. */
+  adjacentFaces(solid: number, face: number): number[];
+
+  /** Check if an edge is forward in its parent wire. */
+  isEdgeForwardInWire(edge: number, wire: number): boolean;
+
+  // ── Geometry queries ───────────────────────────────────────────
+
+  /** Get the surface type of a face (e.g. "plane", "cylinder", "nurbs"). */
+  getSurfaceType(face: number): string;
+
+  /** Get the curve type of an edge (e.g. "line", "nurbs"). */
+  getEdgeCurveType(edge: number): string;
+
+  /** Get edge curve parameter range `[tMin, tMax]`. */
+  getEdgeCurveParameters(edge: number): number[];
+
+  /** Evaluate edge curve at parameter. Returns `[x, y, z]`. */
+  evaluateEdgeCurve(edge: number, param: number): number[];
+
+  /** Evaluate edge curve + tangent at parameter. Returns `[px,py,pz, tx,ty,tz]`. */
+  evaluateEdgeCurveD1(edge: number, param: number): number[];
+
+  /** Evaluate surface at (u,v). Returns `[x, y, z]`. */
+  evaluateSurface(face: number, u: number, v: number): number[];
+
+  /** Evaluate surface normal at (u,v). Returns `[nx, ny, nz]`. */
+  evaluateSurfaceNormal(face: number, u: number, v: number): number[];
+
+  /** Get UV domain `[uMin, uMax, vMin, vMax]`. */
+  getSurfaceDomain(face: number): number[];
+
+  /** Project a 3D point onto a face surface. Returns `[x, y, z]`. */
+  projectPointOnSurface(face: number, x: number, y: number, z: number): number[];
+
+  /** Get analytic surface parameters as JSON. */
+  getAnalyticSurfaceParams(face: number): string;
+
+  /** Get NURBS curve data for an edge as JSON. */
+  getEdgeNurbsData(edge: number): string;
+
+  // ── Measurement ────────────────────────────────────────────────
+
+  /** Bounding box `[minX, minY, minZ, maxX, maxY, maxZ]`. */
+  boundingBox(solid: number): number[];
+
+  /** Volume of a solid (tessellation-based). */
+  volume(solid: number, deflection: number): number;
+
+  /** Total surface area of a solid. */
+  surfaceArea(solid: number, deflection: number): number;
+
+  /** Area of a single face. */
+  faceArea(face: number, deflection: number): number;
+
+  /** Center of mass `[x, y, z]`. */
+  centerOfMass(solid: number, deflection: number): number[];
+
+  /** Edge length. */
+  edgeLength(edge: number): number;
+
+  /** Face perimeter. */
+  facePerimeter(face: number): number;
+
+  // ── Distance / Classification ──────────────────────────────────
+
+  /** Classify a point relative to a solid. Returns "inside"|"outside"|"boundary". */
+  classifyPoint(solid: number, x: number, y: number, z: number): string;
+
+  /** Classify using generalized winding numbers. */
+  classifyPointWinding(solid: number, x: number, y: number, z: number, tolerance: number): string;
+
+  /** Classify using robust dual-method. */
+  classifyPointRobust(solid: number, x: number, y: number, z: number, tolerance: number): string;
+
+  /**
+   * Distance from a point to a solid.
+   * Returns `[distance, closestX, closestY, closestZ]`.
+   */
+  pointToSolidDistance(px: number, py: number, pz: number, solid: number): number[];
+
+  /** Minimum distance between two solids. */
+  solidToSolidDistance(a: number, b: number): number;
+
+  // ── Validation / Repair ────────────────────────────────────────
+
+  /** Validate solid topology. Returns error count. */
+  validateSolid(solid: number): number;
+
+  /** Heal a solid (fix orientations, merge vertices, etc.). */
+  healSolid(solid: number): void;
+
+  /** Merge coincident vertices. Returns merge count. */
+  mergeCoincidentVertices(solid: number, tolerance: number): number;
+
+  /** Remove zero-length edges. Returns removal count. */
+  removeDegenerateEdges(solid: number, tolerance: number): number;
+
+  /** Fix face orientations for consistent normals. Returns fix count. */
+  fixFaceOrientations(solid: number): number;
+
+  // ── Tessellation ───────────────────────────────────────────────
+
+  /** Tessellate a face into a triangle mesh. */
+  tessellateFace(face: number, deflection: number): BrepkitMesh;
+
+  /** Tessellate all faces of a solid into a merged mesh. */
+  tessellateSolid(solid: number, deflection: number): BrepkitMesh;
+
+  /** Tessellate an edge into polyline points. Returns flat `[x,y,z,...]`. */
+  tessellateEdge(edge: number, numPoints: number): number[];
+
+  /** Convex hull from flat coords. Returns solid handle. */
+  convexHull(coords: number[]): number;
+
+  // ── Export ─────────────────────────────────────────────────────
+
+  /** Export to STEP format. Returns bytes. */
+  exportStep(solid: number): Uint8Array;
+
+  /** Export to binary STL. Returns bytes. */
+  exportStl(solid: number, deflection: number): Uint8Array;
+
+  /** Export to IGES format. Returns bytes. */
+  exportIges(solid: number): Uint8Array;
+
+  /** Export to 3MF format. Returns bytes. */
+  export3mf(solid: number, deflection: number): Uint8Array;
+
+  /** Export to OBJ format. Returns bytes. */
+  exportObj(solid: number, deflection: number): Uint8Array;
+
+  /** Export to GLB format. Returns bytes. */
+  exportGlb(solid: number, deflection: number): Uint8Array;
+
+  /** Export to PLY format. Returns bytes. */
+  exportPly(solid: number, deflection: number, binary: boolean): Uint8Array;
+
+  // ── Import ─────────────────────────────────────────────────────
+
+  /** Import from STEP. Returns solid handle array. */
+  importStep(data: Uint8Array): number[];
+
+  /** Import from STL. Returns solid handle. */
+  importStl(data: Uint8Array): number;
+
+  /** Import from IGES. Returns solid handle array. */
+  importIges(data: Uint8Array): number[];
+
+  /** Import from 3MF. Returns solid handle array. */
+  import3mf(data: Uint8Array): number[];
+
+  /** Import from OBJ. Returns solid handle. */
+  importObj(data: Uint8Array): number;
+
+  /** Import from GLB. Returns solid handle. */
+  importGlb(data: Uint8Array): number;
+
+  // ── NURBS curve operations ─────────────────────────────────────
+
+  /** Approximate a curve through points (least-squares). Returns edge handle. */
+  approximateCurve(coords: number[], degree: number, numControlPoints: number): number;
+
+  /** Approximate via LSPIA. Returns edge handle. */
+  approximateCurveLspia(
+    coords: number[],
+    degree: number,
+    numControlPoints: number,
+    tolerance: number,
+    maxIterations: number
+  ): number;
+
+  /** Interpolate points into a smooth NURBS edge. Returns edge handle. */
+  interpolatePoints(coords: number[], degree: number): number;
+
+  /** Insert a knot into an edge's NURBS curve. Returns new edge handle. */
+  curveKnotInsert(edge: number, knot: number, times: number): number;
+
+  /** Remove a knot from a NURBS curve. Returns new edge handle. */
+  curveKnotRemove(edge: number, knot: number, tolerance: number): number;
+
+  /** Split a NURBS curve at parameter. Returns `[edge1, edge2]`. */
+  curveSplit(edge: number, u: number): number[];
+
+  /** Elevate degree of a NURBS curve. Returns new edge handle. */
+  curveDegreeElevate(edge: number, elevateBy: number): number;
+
+  // ── NURBS surface operations ───────────────────────────────────
+
+  /** Interpolate a grid of points into a NURBS surface. Returns face handle. */
+  interpolateSurface(
+    coords: number[],
+    rows: number,
+    cols: number,
+    degreeU: number,
+    degreeV: number
+  ): number;
+
+  /** Approximate a point grid via LSPIA. Returns face handle. */
+  approximateSurfaceLspia(
+    coords: number[],
+    rows: number,
+    cols: number,
+    degreeU: number,
+    degreeV: number,
+    numCpsU: number,
+    numCpsV: number,
+    tolerance: number,
+    maxIterations: number
+  ): number;
+
+  // ── Feature detection ──────────────────────────────────────────
+
+  /** Detect small features (faces below area threshold). Returns face handles. */
+  detectSmallFeatures(solid: number, areaThreshold: number, deflection: number): number[];
+
+  /** Recognize geometric features. Returns JSON string. */
+  recognizeFeatures(solid: number, deflection: number): string;
+
+  /** Remove faces from a solid (defeaturing). Returns new solid handle. */
+  defeature(solid: number, faceHandles: number[]): number;
+
+  // ── Mesh boolean ───────────────────────────────────────────────
+
+  /** Boolean on raw triangle data. Returns BrepkitMesh. */
+  meshBoolean(
+    positionsA: number[],
+    indicesA: number[],
+    positionsB: number[],
+    indicesB: number[],
+    op: string,
+    tolerance: number
+  ): BrepkitMesh;
+
+  // ── Copy sub-shapes ────────────────────────────────────────────
+
+  /** Deep copy an edge. Returns new edge handle. */
+  copyEdge?(edge: number): number;
+
+  /** Deep copy a face. Returns new face handle. */
+  copyFace?(face: number): number;
+
+  /** Deep copy a wire. Returns new wire handle. */
+  copyWire?(wire: number): number;
+
+  /** Transform an edge in-place. */
+  transformEdge?(edge: number, matrix: number[]): void;
+
+  /** Transform a face in-place. */
+  transformFace?(face: number, matrix: number[]): void;
+
+  /** Transform a wire in-place. */
+  transformWire?(wire: number, matrix: number[]): void;
+
+  // ── Sketch ─────────────────────────────────────────────────────
+
+  /** Create a new sketch. Returns sketch index. */
+  sketchNew(): number;
+
+  /** Add a point to a sketch. Returns point index. */
+  sketchAddPoint(sketch: number, x: number, y: number, fixed: boolean): number;
+
+  /** Add a constraint to a sketch (JSON string). */
+  sketchAddConstraint(sketch: number, json: string): void;
+
+  /** Solve sketch constraints. Returns JSON result. */
+  sketchSolve(sketch: number, maxIterations: number, tolerance: number): string;
+
+  // ── Assembly ───────────────────────────────────────────────────
+
+  /** Create a new assembly. Returns assembly index. */
+  assemblyNew(name: string): number;
+
+  /** Add a root component. Returns component ID. */
+  assemblyAddRoot(assembly: number, name: string, solid: number, matrix: number[]): number;
+
+  /** Add a child component. Returns component ID. */
+  assemblyAddChild(
+    assembly: number,
+    parent: number,
+    name: string,
+    solid: number,
+    matrix: number[]
+  ): number;
+
+  /** Flatten assembly to JSON `[{solid, matrix}, ...]`. */
+  assemblyFlatten(assembly: number): string;
+
+  /** Bill of materials as JSON. */
+  assemblyBom(assembly: number): string;
+
+  // ── 2D polygon ─────────────────────────────────────────────────
+
+  /** Offset a 2D polygon. Coords are flat `[x,y, ...]`. Returns flat coords. */
+  offsetPolygon2d(coords: number[], distance: number, tolerance: number): number[];
+
+  // ── Batch execution ────────────────────────────────────────────
+
+  /** Execute a batch of operations from JSON. Returns JSON result. */
+  executeBatch(json: string): string;
+
+  // ── Not yet exposed (future PRs) ──────────────────────────────
+  // These are planned for Themes A, C, G, F
+
+  /** Get solids within a compound. (Theme A) */
+  getCompoundSolids?(compound: number): number[];
+
+  /** Get faces of a shell. (Theme A) */
+  getShellFaces?(shell: number): number[];
+
+  /** Get edges of a wire. (Theme A) */
+  getWireEdges?(wire: number): number[];
+
+  /** Classify a point on a face (trim-aware). (Theme G) */
+  classifyPointOnFace?(face: number, u: number, v: number, tolerance: number): number;
+
+  /** Get shape orientation flag. (Theme G) */
+  getShapeOrientation?(id: number): string;
+
+  /** Reverse shape orientation. (Theme G) */
+  reverseShape?(id: number): number;
+
+  /** Distance between two arbitrary shapes. (Theme G) */
+  shapeToShapeDistance?(id1: number, id2: number): number[];
+
+  /** 2D curve intersection. (Theme F) */
+  intersectCurves2d?(...args: number[]): number[];
+
+  /** Project point onto 2D curve. (Theme F) */
+  projectPointOnCurve2d?(...args: number[]): number[];
+
+  /** Reverse a 2D curve. (Theme F) */
+  reverseCurve2d?(...args: number[]): number[];
+
+  // ── Evolution tracking (Theme C — 15 methods) ──────────────────
+
+  /** Fuse with evolution tracking. Returns `{ solid, evolution_json }`. */
+  fuseWithEvolution?(a: number, b: number): BrepkitEvolutionResult;
+  /** Cut with evolution tracking. */
+  cutWithEvolution?(a: number, b: number): BrepkitEvolutionResult;
+  /** Intersect with evolution tracking. */
+  intersectWithEvolution?(a: number, b: number): BrepkitEvolutionResult;
+  /** Fillet with evolution tracking. */
+  filletWithEvolution?(solid: number, edgeIds: number[], radius: number): BrepkitEvolutionResult;
+  /** Chamfer with evolution tracking. */
+  chamferWithEvolution?(solid: number, edgeIds: number[], distance: number): BrepkitEvolutionResult;
+  /** Shell with evolution tracking. */
+  shellWithEvolution?(solid: number, thickness: number, faceIds: number[]): BrepkitEvolutionResult;
+  /** Offset with evolution tracking. */
+  offsetSolidWithEvolution?(solid: number, distance: number): BrepkitEvolutionResult;
+  /** Thicken with evolution tracking. */
+  thickenWithEvolution?(face: number, distance: number): BrepkitEvolutionResult;
+  /** Draft with evolution tracking. */
+  draftWithEvolution?(
+    solid: number,
+    faceHandles: number[],
+    pullX: number,
+    pullY: number,
+    pullZ: number,
+    neutralX: number,
+    neutralY: number,
+    neutralZ: number,
+    angleDegrees: number
+  ): BrepkitEvolutionResult;
+  /** Translate with evolution tracking. */
+  translateWithEvolution?(
+    solid: number,
+    dx: number,
+    dy: number,
+    dz: number
+  ): BrepkitEvolutionResult;
+  /** Rotate with evolution tracking. */
+  rotateWithEvolution?(
+    solid: number,
+    ox: number,
+    oy: number,
+    oz: number,
+    dx: number,
+    dy: number,
+    dz: number,
+    angleDegrees: number
+  ): BrepkitEvolutionResult;
+  /** Mirror with evolution tracking. */
+  mirrorWithEvolution?(
+    solid: number,
+    px: number,
+    py: number,
+    pz: number,
+    nx: number,
+    ny: number,
+    nz: number
+  ): BrepkitEvolutionResult;
+  /** Scale with evolution tracking. */
+  scaleWithEvolution?(solid: number, factor: number): BrepkitEvolutionResult;
+  /** General transform with evolution tracking. */
+  generalTransformWithEvolution?(solid: number, matrix: number[]): BrepkitEvolutionResult;
+  /** Copy with evolution tracking. */
+  copyWithEvolution?(solid: number): BrepkitEvolutionResult;
+
+  // ── wasm-bindgen destructor ────────────────────────────────────
+
+  /** Release the entire arena. */
+  free(): void;
+}
+
+/** Result from `*WithEvolution` WASM methods (Theme C). */
+export interface BrepkitEvolutionResult {
+  /** The resulting solid handle. */
+  readonly solid: number;
+  /** JSON-encoded evolution map. */
+  readonly evolution_json: string;
+}


### PR DESCRIPTION
## Summary
- New `src/kernel/brepkitWasmTypes.ts` with full `BrepkitKernel` interface for ~140 WASM methods
- Change `bk` property from `KernelInstance` (any) to typed `BrepkitKernel`
- Mark not-yet-exposed WASM methods as optional (`?`) with runtime typeof guards
- Fix array access non-null assertions and redundant type guards caught by new types

Foundation PR — all other brepkit adapter PRs depend on this.

## Test plan
- [x] `npx tsc --noEmit` zero errors
- [x] `npx eslint` zero errors
- [ ] Full test suite