### PR TITLE
fix(kernel): replace bare catch blocks with diagnostic logging

### DIFF
--- a/src/kernel/brepkitAdapter.ts
+++ b/src/kernel/brepkitAdapter.ts
@@ -1869,7 +1869,7 @@ export class BrepkitAdapter implements KernelAdapter {
       this.bk.healSolid(unwrap(shape));
       return shape; // Healing modifies in-place; return same handle
     } catch (e: unknown) {
-      console.warn('brepkit: healShape failed:', e);
+      console.warn('brepkit: healSolid failed:', e);
       return null;
     }
   }
@@ -3441,7 +3441,7 @@ export class BrepkitAdapter implements KernelAdapter {
 
         vertexOffset += vertCount;
       } catch (e: unknown) {
-        console.warn('brepkit: face tessellation failed:', e);
+        console.warn(`brepkit: face tessellation failed (faceId=${faceId}):`, e);
       }
     }
 


### PR DESCRIPTION
## Summary
Replace 7 bare `catch {}` blocks with `catch (e: unknown)` + `console.warn` diagnostics:
- uvFromPoint, simplify (healing), isValid, healShape, makeNonPlanarFace, fillSurface (Coons patch), mesh loop (tessellation)

Depends on: PR-K (types)

## Test plan
- [x] `npx tsc --noEmit` zero errors
- [x] `npx eslint` zero errors
- [ ] Full test suite