### PR TITLE
perf(kernel): cache default kernel lookup and skip empty evolution tracking

### DIFF
--- a/benchmarks/regression-885.bench.test.ts
+++ b/benchmarks/regression-885.bench.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression benchmark targeting changes introduced around v8.8.5–v9.x:
+ *
+ * 1. DisposalScope wrapping every transform (v8.8.7 #322)
+ * 2. Kernel registry Map lookup in getKernel() (v8.8.11 #324)
+ * 3. iterOcList native iterator vs copy-and-destroy (v8.8.5 #309)
+ * 4. Hash-bucket sharedEdges optimization (v8.8.5 #309)
+ * 5. propagateOrigins hash caching (v8.8.5 #309)
+ */
+import { describe, it, beforeAll } from 'vitest';
+import { initOC } from '../tests/setup.js';
+import {
+  box,
+  cylinder,
+  sphere,
+  translate,
+  rotate,
+  scale,
+  fuse,
+  cut,
+  getKernel,
+  unwrap,
+} from '../src/index.js';
+import { sharedEdges } from '../src/topology/adjacencyFns.js';
+import { getFaces, getEdges, getBounds } from '../src/topology/shapeFns.js';
+import { bench, printResults, type BenchResult } from './harness.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('Regression benchmarks (v8.8.5+ changes)', () => {
+  const results: BenchResult[] = [];
+
+  // --- getKernel() overhead (called on every operation) ---
+  it('getKernel() 100k calls', async () => {
+    results.push(
+      await bench(
+        'getKernel() x100k',
+        () => {
+          for (let i = 0; i < 100_000; i++) {
+            getKernel();
+          }
+        },
+        { warmup: 3, iterations: 10 }
+      )
+    );
+  });
+
+  // --- Transform overhead (DisposalScope wrapping) ---
+  it('translate 100x', async () => {
+    const b = box(10, 10, 10);
+    results.push(
+      await bench(
+        'translate x100',
+        () => {
+          for (let i = 0; i < 100; i++) {
+            translate(b, [i * 0.01, 0, 0]);
+          }
+        },
+        { warmup: 2, iterations: 5 }
+      )
+    );
+  });
+
+  it('rotate 100x', async () => {
+    const b = box(10, 10, 10);
+    results.push(
+      await bench(
+        'rotate x100',
+        () => {
+          for (let i = 0; i < 100; i++) {
+            rotate(b, i * 0.1);
+          }
+        },
+        { warmup: 2, iterations: 5 }
+      )
+    );
+  });
+
+  it('scale 100x', async () => {
+    const b = box(10, 10, 10);
+    results.push(
+      await bench(
+        'scale x100',
+        () => {
+          for (let i = 0; i < 100; i++) {
+            scale(b, 1 + i * 0.001);
+          }
+        },
+        { warmup: 2, iterations: 5 }
+      )
+    );
+  });
+
+  it('getBounds 200x', async () => {
+    const b = box(10, 10, 10);
+    results.push(
+      await bench(
+        'getBounds x200',
+        () => {
+          for (let i = 0; i < 200; i++) {
+            getBounds(b);
+          }
+        },
+        { warmup: 2, iterations: 5 }
+      )
+    );
+  });
+
+  // --- Boolean ops (tests propagateOrigins, iterOcList) ---
+  it('box + cylinder fuse', async () => {
+    results.push(
+      await bench('box+cyl fuse', () => {
+        const b = box(10, 10, 10);
+        const c = translate(cylinder(3, 10), [5, 5, 0]);
+        unwrap(fuse(b, c));
+      })
+    );
+  });
+
+  it('box - sphere cut', async () => {
+    results.push(
+      await bench('box-sphere cut', () => {
+        const b = box(10, 10, 10);
+        const s = translate(sphere(4), [5, 5, 5]);
+        unwrap(cut(b, s));
+      })
+    );
+  });
+
+  // --- sharedEdges (hash-bucket optimization) ---
+  it('sharedEdges on fused result', async () => {
+    const b = box(10, 10, 10);
+    const c = translate(cylinder(3, 10), [5, 5, 0]);
+    const fused = unwrap(fuse(b, c));
+    const faces = getFaces(fused);
+
+    results.push(
+      await bench(
+        'sharedEdges (all face pairs)',
+        () => {
+          for (let i = 0; i < faces.length; i++) {
+            for (let j = i + 1; j < faces.length; j++) {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              sharedEdges(faces[i]!, faces[j]!);
+            }
+          }
+        },
+        { warmup: 1, iterations: 3 }
+      )
+    );
+  });
+
+  // --- Topology iteration (getEdges, getFaces on complex shape) ---
+  it('getFaces + getEdges on complex shape', async () => {
+    results.push(
+      await bench(
+        'getFaces+getEdges x50',
+        () => {
+          for (let i = 0; i < 50; i++) {
+            // Force uncached by creating new cut each time
+            const b = box(10 + i * 0.001, 10, 10);
+            const s = translate(sphere(4), [5, 5, 5]);
+            const r = unwrap(cut(b, s));
+            getFaces(r);
+            getEdges(r);
+          }
+        },
+        { warmup: 1, iterations: 3 }
+      )
+    );
+  });
+
+  it('prints results', () => {
+    printResults(results);
+  });
+});

--- a/src/kernel/evolutionOps.ts
+++ b/src/kernel/evolutionOps.ts
@@ -56,6 +56,10 @@ export function buildEvolution(
   const generated = new Map<number, number[]>();
   const deleted = new Set<number>();
 
+  if (inputFaceHashes.length === 0) {
+    return { modified, generated, deleted };
+  }
+
   // Build a map from hash → face for the input faces across all input shapes
   const inputHashSet = new Set(inputFaceHashes);
   const facesById = new Map<number, KernelShape>();
@@ -112,7 +116,14 @@ export function transformWithEvolution(
 ): OperationResult {
   const transformer = new oc.BRepBuilderAPI_Transform_2(shape, trsf, true);
   const resultShape = transformer.Shape();
-  const evolution = buildEvolution(oc, transformer, shape, inputFaceHashes, hashUpperBound);
+  const evolution =
+    inputFaceHashes.length === 0
+      ? {
+          modified: new Map<number, number[]>(),
+          generated: new Map<number, number[]>(),
+          deleted: new Set<number>(),
+        }
+      : buildEvolution(oc, transformer, shape, inputFaceHashes, hashUpperBound);
   transformer.delete();
   return { shape: resultShape, evolution };
 }

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -9,6 +9,7 @@ import { DefaultAdapter } from './defaultAdapter.js';
 
 const _kernels = new Map<string, KernelAdapter>();
 let _defaultKernelId: string | null = null;
+let _cachedDefault: KernelAdapter | null = null;
 
 /**
  * Register a kernel adapter under a unique identifier.
@@ -17,6 +18,7 @@ let _defaultKernelId: string | null = null;
 export function registerKernel(id: string, adapter: KernelAdapter): void {
   _kernels.set(id, adapter);
   if (!_defaultKernelId) _defaultKernelId = id;
+  if (id === _defaultKernelId) _cachedDefault = adapter;
 }
 
 /**
@@ -25,6 +27,8 @@ export function registerKernel(id: string, adapter: KernelAdapter): void {
  * @throws If no kernel has been registered via {@link registerKernel} or {@link initFromOC}.
  */
 export function getKernel(id?: string): KernelAdapter {
+  if (!id && _cachedDefault) return _cachedDefault;
+
   const targetId = id ?? _defaultKernelId;
   if (!targetId) {
     throw new Error(
@@ -64,11 +68,14 @@ export function withKernel<T extends Exclude<unknown, Promise<unknown>>>(
   fn: () => T
 ): T {
   const prev = _defaultKernelId;
+  const prevCached = _cachedDefault;
   _defaultKernelId = id;
+  _cachedDefault = _kernels.get(id) ?? null;
   try {
     return fn();
   } finally {
     _defaultKernelId = prev;
+    _cachedDefault = prevCached;
   }
 }
 
@@ -77,6 +84,7 @@ export function initFromOC(oc: KernelInstance): void {
   const adapter = new DefaultAdapter(oc);
   registerKernel('occt', adapter);
   _defaultKernelId = 'occt';
+  _cachedDefault = adapter;
 }
 
 export type {


### PR DESCRIPTION
## Summary
- Cache the default kernel adapter in `getKernel()` to avoid a `Map` lookup on every call
- Early-return in `buildEvolution()` when `inputFaceHashes` is empty — skips WASM `TopExp_Explorer` creation and face iteration entirely
- Short-circuit `transformWithEvolution()` to skip `buildEvolution()` call for the common empty-hashes case

Fixes ~10% transform regression (translate/rotate/scale) introduced in v9.x by the kernel registry change (PR #324).

## Test plan
- [x] `npm run typecheck` passes
- [x] All 2135 tests pass
- [x] Regression benchmark medians back near v8.8.4 baselines (translate 11.0ms vs 10.8ms, rotate 9.9ms vs 9.3ms, scale 9.0ms vs 8.6ms)