### PR TITLE
chore(deps): support brepjs-opencascade ^0.9.0 peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0"
+    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
   },
   "peerDependenciesMeta": {
     "brepjs-opencascade": {

--- a/packages/brepjs-opencascade/package.json
+++ b/packages/brepjs-opencascade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brepjs-opencascade",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "OpenCascade.js custom WASM build for brepjs",
   "keywords": [
     "opencascade",


### PR DESCRIPTION
## Summary
- Adds `^0.9.0` to the `brepjs` peerDependencies range for `brepjs-opencascade`
- The WASM package was bumped to `0.9.0` but the peer dep range only covered up to `^0.8.0`

## Test plan
- [x] Pre-commit hooks pass (typecheck, lint, boundaries, tests)
- [x] Pre-push hooks pass (full coverage, knip)