### PR TITLE
fix: reconcile release-please manifest for brepjs-opencascade to 0.9.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   ".": "9.3.10",
-  "packages/brepjs-opencascade": "0.8.4"
+  "packages/brepjs-opencascade": "0.9.0"
 }


### PR DESCRIPTION
## Summary

- Fixes `.release-please-manifest.json` which was tracking `brepjs-opencascade` at `0.8.4` while `package.json` had already been bumped to `0.9.0`
- Closes #374 — the release-please PR was generating a `0.8.5` release, which would have downgraded the package on npm and broken peer dependency resolution for packages declaring `^0.9.0` compatibility
- After this merges, release-please will correctly generate the next release as `0.9.1`

Closes #374