### PR TITLE
fix(deps): correct brepkit-wasm version to ^0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "typescript-eslint": "8.56.0",
     "vite": "7.3.1",
     "vite-plugin-dts": "4.5.4",
-    "brepkit-wasm": "^0.4.0",
+    "brepkit-wasm": "^0.1.0",
     "vitest": "4.0.18"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- Fixes `brepkit-wasm` devDependency from `^0.4.0` to `^0.1.0`
- Only `0.1.0` is published on npm — `^0.4.0` doesn't exist, causing `npm install` to fail in the `size` check on CI
- This was introduced in #373 (brepkit-wasm validation suite)