### PR TITLE
fix: address unreviewed PR comments from past week

### DIFF
--- a/src/io/svgImportFns.ts
+++ b/src/io/svgImportFns.ts
@@ -274,7 +274,27 @@ function parseSVGPathToCurves(d: string): Curve2D[] {
             const dist = Math.sqrt(dx * dx + dy * dy);
 
             if (dist < 1e-10) {
-              // Coincident endpoints (full-circle arc) — cannot approximate; treat as no-op
+              // Coincident endpoints (full-circle arc) — split into two semi-arcs.
+              // A three-point arc cannot represent a full circle, so we create two
+              // 180° arcs via perpendicular midpoints on opposite sides of the center.
+              const r = Math.max(rx, ry);
+              const s = sweepFlag ? 1 : -1;
+              // Center is r above/below start; opposite point is r further
+              const oppositeY = cy + 2 * s * r;
+              // Semi-arc midpoints sit at 90° offsets from the circle center
+              const semi1Mid: [number, number] = [cx - s * r, cy + s * r];
+              const semi2Mid: [number, number] = [cx + s * r, cy + s * r];
+
+              try {
+                curves.push(
+                  make2dThreePointArc(flipY([cx, cy]), flipY(semi1Mid), flipY([cx, oppositeY]))
+                );
+                curves.push(
+                  make2dThreePointArc(flipY([cx, oppositeY]), flipY(semi2Mid), flipY([cx, cy]))
+                );
+              } catch {
+                // If arc construction fails, skip (degenerate circle)
+              }
               cx = x;
               cy = y;
               i += 7;

--- a/src/kernel/brepkit2d.ts
+++ b/src/kernel/brepkit2d.ts
@@ -437,7 +437,18 @@ function refineParam(c: Curve2dObj, px: number, py: number): number | null {
       bestT = t;
     }
   }
-  return bestD < 1 ? bestT : null;
+  // bestD is squared geometric distance. Derive a scale-relative threshold
+  // from the curve's geometric extent (not parameter span, which has different units).
+  const [sx, sy] = evaluateCurve2d(c, bounds.first);
+  const [ex, ey] = evaluateCurve2d(c, bounds.last);
+  const [mx, my] = evaluateCurve2d(c, (bounds.first + bounds.last) / 2);
+  const geomExtent = Math.max(
+    Math.sqrt((ex - sx) ** 2 + (ey - sy) ** 2),
+    Math.sqrt((mx - sx) ** 2 + (my - sy) ** 2),
+    1e-6
+  );
+  const maxDist = geomExtent * 0.1;
+  return bestD < maxDist * maxDist ? bestT : null;
 }
 
 function intersectLineLine(
@@ -557,8 +568,10 @@ function intersectCircleCircle(
     if (t1 === null || t2 === null) continue;
     const [x1, y1] = evaluateCurve2d(c1, t1);
     const [x2, y2] = evaluateCurve2d(c2, t2);
-    if ((x1 - px) ** 2 + (y1 - py) ** 2 > tol * 100) continue;
-    if ((x2 - px) ** 2 + (y2 - py) ** 2 > tol * 100) continue;
+    // Compare squared distances against squared tolerance to avoid sqrt
+    const tolSq = (tol * 10) ** 2;
+    if ((x1 - px) ** 2 + (y1 - py) ** 2 > tolSq) continue;
+    if ((x2 - px) ** 2 + (y2 - py) ** 2 > tolSq) continue;
     results.push([px, py]);
   }
   return results;

--- a/src/kernel/brepkitAdapter.ts
+++ b/src/kernel/brepkitAdapter.ts
@@ -2444,8 +2444,30 @@ export class BrepkitAdapter implements KernelAdapter {
     shape: KernelShape,
     param: number
   ): { point: [number, number, number]; tangent: [number, number, number] } {
-    const edgeId = this.unwrapEdgeOrFirstOfWire(shape);
-    const result: number[] = this.bk.evaluateEdgeCurveD1(edgeId, param);
+    const h = shape as BrepkitHandle;
+    let edgeId: number;
+    let evalParam = param;
+
+    if (h.type === 'wire') {
+      // Walk edges to find the right one for the composite parameter
+      const edgeIds: number[] = toArray(this.bk.getWireEdges(h.id));
+      edgeId = edgeIds[edgeIds.length - 1]!; // fallback to last edge
+      let cumulative = 0;
+      for (const eid of edgeIds) {
+        const p: number[] = this.bk.getEdgeCurveParameters(eid);
+        const span = p[1]! - p[0]!;
+        if (param <= cumulative + span || eid === edgeId) {
+          edgeId = eid;
+          evalParam = Math.min(p[0]! + (param - cumulative), p[1]!);
+          break;
+        }
+        cumulative += span;
+      }
+    } else {
+      edgeId = unwrap(shape, 'edge');
+    }
+
+    const result: number[] = this.bk.evaluateEdgeCurveD1(edgeId, evalParam);
     return {
       point: [result[0]!, result[1]!, result[2]!],
       tangent: [result[3]!, result[4]!, result[5]!],
@@ -2959,16 +2981,16 @@ export class BrepkitAdapter implements KernelAdapter {
       tolerance?: number;
     }
   ): KernelShape {
-    const buildFaceIds = (): number[] =>
-      wires.map((w) => {
-        const h = w as BrepkitHandle;
-        if (h.type === 'wire') return this.bk.makeFaceFromWire(h.id);
-        return unwrap(w, 'face');
-      });
+    // Build face IDs once and reuse across attempts to avoid leaking
+    // WASM face handles from makeFaceFromWire on each failed path.
+    const faceIds: number[] = wires.map((w) => {
+      const h = w as BrepkitHandle;
+      if (h.type === 'wire') return this.bk.makeFaceFromWire(h.id);
+      return unwrap(w, 'face');
+    });
 
     // Try the native loftWithOptions API which supports ruled, solid, tolerance
     try {
-      const faceIds = buildFaceIds();
       const opts: Record<string, unknown> = {};
       if (options?.ruled !== undefined) opts['ruled'] = options.ruled;
       if (options?.solid !== undefined) opts['solid'] = options.solid;
@@ -2983,17 +3005,16 @@ export class BrepkitAdapter implements KernelAdapter {
       }
       const id = this.bk.loftWithOptions(faceIds, JSON.stringify(opts));
       return solidHandle(id);
-    } catch {
-      // Fall back to smooth/basic loft
+    } catch (e: unknown) {
+      console.warn('brepkit: loftWithOptions failed, falling back to smooth/basic loft:', e);
     }
 
     if (!options?.ruled) {
       try {
-        const faceIds = buildFaceIds();
         const id = this.bk.loftSmooth(faceIds);
         return solidHandle(id);
-      } catch {
-        // Fall back to basic loft
+      } catch (e: unknown) {
+        console.warn('brepkit: loftSmooth failed, falling back to basic loft:', e);
       }
     }
     return this.loft(wires);
@@ -4429,23 +4450,6 @@ export class BrepkitAdapter implements KernelAdapter {
   // ═══════════════════════════════════════════════════════════════════════
   // Private helpers
   // ═══════════════════════════════════════════════════════════════════════
-
-  /**
-   * Unwrap a shape to an edge ID. If the shape is a wire, extract its first edge.
-   * This mirrors OCCT's behavior where wire-level curve queries operate on
-   * a concatenated curve starting from the first edge.
-   */
-  private unwrapEdgeOrFirstOfWire(shape: KernelShape): number {
-    const h = shape as BrepkitHandle;
-    if (h.type === 'wire') {
-      const edgeIds: number[] = toArray(this.bk.getWireEdges(h.id));
-      if (edgeIds.length === 0) {
-        throw new Error('brepkit: wire has no edges for curve query');
-      }
-      return edgeIds[0]!;
-    }
-    return unwrap(shape, 'edge');
-  }
 
   private applyMatrix(shape: KernelShape, matrix: number[]): KernelShape {
     const h = shape as BrepkitHandle;

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -71,14 +71,15 @@ export function withKernel<T extends Exclude<unknown, Promise<unknown>>>(
   fn: () => T
 ): T {
   const prev = _defaultKernelId;
-  const prevCached = _cachedDefault;
   _defaultKernelId = id;
   _cachedDefault = _kernels.get(id) ?? null;
   try {
     return fn();
   } finally {
     _defaultKernelId = prev;
-    _cachedDefault = prevCached;
+    // Re-lookup rather than restoring prevCached: a registerKernel() call
+    // inside fn may have replaced the adapter for the original default id.
+    _cachedDefault = prev ? (_kernels.get(prev) ?? null) : null;
   }
 }
 


### PR DESCRIPTION
## Summary

Audited all 48 merged PRs from the past week (Mar 1–8) for unaddressed review comments. Found 24 unaddressed + 3 deferred items across 9 PRs. Of those, 9 were already silently fixed in subsequent PRs. This PR addresses the 6 remaining issues:

- **SVG full-circle arcs** (`svgImportFns.ts`): Split into two semi-arcs instead of being silently dropped (#379)
- **Stale kernel cache** (`kernel/index.ts`): `withKernel` re-lookups cached adapter on restore instead of using a potentially stale reference (#360)
- **WASM handle leak in loft** (`brepkitAdapter.ts`): Hoisted `buildFaceIds()` to avoid creating duplicate face handles on each fallback path (#389)
- **curveTangent multi-edge wires** (`brepkitAdapter.ts`): Now walks edges with cumulative parameter offsets instead of silently using only the first edge (#382)
- **Swallowed loft exceptions** (`brepkitAdapter.ts`): Added `console.warn` to `loftWithOptions`/`loftSmooth` fallback catches (#381)
- **2D intersection tolerance bugs** (`brepkit2d.ts`): Fixed squared-vs-linear distance comparison; replaced hardcoded `refineParam` threshold with geometry-derived scale-relative cutoff (#391)

Also removed the now-unused `unwrapEdgeOrFirstOfWire` private method.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:affected` — 2114 tests pass, 0 failures
- [x] `npm run check:boundaries` — layer boundaries intact
- [x] `npm run test:coverage` — full suite passes (pre-push hook)
- [x] `npm run knip` — no unused exports (pre-push hook)
- [ ] CI passes