### PR TITLE
docs: clarify brepkit is an external npm package, not built-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Monorepo with two publishable packages:
 - **Layer 2+ code must never call methods on `.wrapped`** — always use `getKernel().method(shape.wrapped)`. ESLint enforces this.
 - Branded types (`Edge`, `Wire`, `Face`, `Solid`, etc.) in `src/core/shapeTypes.ts` — lightweight handles, no class hierarchy. Types carry a phantom `D extends Dimension` parameter for 2D/3D safety.
 - Validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`) in `src/core/shapeTypes.ts` — phantom types encoding topological invariants. Smart constructors (`closedWire()`, `orientedFace()`) prove validity at runtime; type guards (`isClosedWire()`, etc.) narrow in-place.
-- Two built-in kernels: OpenCascade WASM (`initFromOC`) and brepkit WASM (`BrepkitAdapter`). Tests run against both via `TEST_KERNEL` env var.
+- Two supported kernels: OpenCascade WASM (`initFromOC`, shipped via `brepjs-opencascade`) and brepkit WASM (`BrepkitAdapter`, external `brepkit-wasm` npm package). Tests run against both via `TEST_KERNEL` env var.
 - `createHandle()` / `createKernelHandle()` from `src/core/disposal.ts` — use `using` keyword for resource cleanup
 - Functional API in `*Fns.ts` files — pure functions taking/returning branded types; prefer over OO API for new code
 - **Never add new methods to class-based wrappers** (e.g. `Shape`, `Solid`, `Edge` classes in `src/topology/`). These are legacy OO wrappers. All new functionality goes in `*Fns.ts` files.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,10 +82,10 @@ graph TB
 
 No internal imports allowed.
 
-| Module    | Purpose                                                                    |
-| --------- | -------------------------------------------------------------------------- |
-| `kernel/` | Kernel adapter interface + built-in implementations (OpenCascade, brepkit) |
-| `utils/`  | Pure utilities (no dependencies)                                           |
+| Module    | Purpose                                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------------------- |
+| `kernel/` | Kernel adapter interface + adapters for OpenCascade (`brepjs-opencascade`) and brepkit (`brepkit-wasm`) |
+| `utils/`  | Pure utilities (no dependencies)                                                                        |
 
 ### Layer 1: Core
 

--- a/docs/kernel-swap.md
+++ b/docs/kernel-swap.md
@@ -1,6 +1,6 @@
 # Custom Kernel Guide
 
-brepjs is kernel-agnostic. All geometry operations go through a `KernelAdapter` interface — the library ships with two built-in implementations (OpenCascade WASM and brepkit WASM), and you can register your own kernel at runtime.
+brepjs is kernel-agnostic. All geometry operations go through a `KernelAdapter` interface. Two adapters are provided: OpenCascade WASM (shipped via the `brepjs-opencascade` companion package) and brepkit WASM (via the external `brepkit-wasm` npm package). You can also register your own kernel at runtime.
 
 ## Quick Start
 
@@ -12,10 +12,10 @@ import { initFromOC, registerKernel, withKernel, BrepkitAdapter } from 'brepjs';
 const oc = await opencascade();
 initFromOC(oc);
 
-// Register the built-in brepkit kernel as an alternative
-import brepkit from 'brepjs-opencascade/brepkit';
-const bk = await brepkit();
-registerKernel('brepkit', new BrepkitAdapter(bk));
+// Register the brepkit kernel as an alternative (external brepkit-wasm package)
+import init, { BrepKernel } from 'brepkit-wasm';
+await init();
+registerKernel('brepkit', new BrepkitAdapter(new BrepKernel()));
 
 // Run a specific kernel temporarily
 const result = withKernel('brepkit', () => {
@@ -38,7 +38,7 @@ Convenience wrapper — creates the default OpenCascade adapter from a loaded WA
 
 ### `BrepkitAdapter`
 
-Built-in alternative kernel adapter. Create with `new BrepkitAdapter(brepkitWasm)` and register via `registerKernel('brepkit', adapter)`. Coverage is growing — some advanced operations may throw "not implemented".
+Adapter for the external `brepkit-wasm` WASM package. Create with `new BrepkitAdapter(brepkitWasm)` and register via `registerKernel('brepkit', adapter)`. Coverage is growing — some advanced operations may throw "not implemented".
 
 ### `withKernel(id, fn)`
 
@@ -171,8 +171,9 @@ The test setup (`tests/setup.ts`) reads `TEST_KERNEL` and initializes the correc
 export async function initKernel() {
   const kernel = process.env.TEST_KERNEL ?? 'occt';
   if (kernel === 'brepkit') {
-    const bk = await import('brepjs-opencascade/brepkit');
-    initFromBrepkit(await bk.default());
+    const bk = await import('brepkit-wasm');
+    if (typeof bk.default === 'function') await bk.default();
+    registerKernel('brepkit', new BrepkitAdapter(new bk.BrepKernel()));
   } else {
     const oc = await import('brepjs-opencascade');
     initFromOC(await oc.default());

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # brepjs
 
-> Web CAD library with a layered architecture and pluggable kernel abstraction layer (ships with OpenCascade and brepkit WASM backends). Create 2D sketches, extrude/revolve/loft/sweep into 3D solids, apply booleans/fillets/chamfers/shells, query topology, measure geometry, heal shapes, manage assemblies, and import/export STEP, STL, IGES, glTF, DXF, 3MF, OBJ, and SVG.
+> Web CAD library with a layered architecture and pluggable kernel abstraction layer (supports OpenCascade and brepkit WASM backends). Create 2D sketches, extrude/revolve/loft/sweep into 3D solids, apply booleans/fillets/chamfers/shells, query topology, measure geometry, heal shapes, manage assemblies, and import/export STEP, STL, IGES, glTF, DXF, 3MF, OBJ, and SVG.
 
 ## API Reference & Discoverability
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # brepjs
 
-> Web CAD library with a layered architecture and pluggable kernel abstraction layer (ships with OpenCascade and brepkit WASM backends). Create 2D sketches, extrude/revolve/loft/sweep into 3D solids, apply booleans/fillets/chamfers/shells, query topology, measure geometry, heal shapes, manage assemblies, and import/export STEP, STL, IGES, glTF, DXF, 3MF, OBJ, and SVG.
+> Web CAD library with a layered architecture and pluggable kernel abstraction layer (supports OpenCascade and brepkit WASM backends). Create 2D sketches, extrude/revolve/loft/sweep into 3D solids, apply booleans/fillets/chamfers/shells, query topology, measure geometry, heal shapes, manage assemblies, and import/export STEP, STL, IGES, glTF, DXF, 3MF, OBJ, and SVG.
 
 ## API Reference & Discoverability
 

--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -1,6 +1,6 @@
 # Kernel
 
-Kernel abstraction layer — all geometry operations go through `KernelAdapter`, making the library kernel-agnostic. Ships with two built-in implementations (OpenCascade WASM and brepkit WASM); additional kernels can be registered at runtime.
+Kernel abstraction layer — all geometry operations go through `KernelAdapter`, making the library kernel-agnostic. Two adapters are provided: OpenCascade WASM (via the `brepjs-opencascade` companion package) and brepkit WASM (via the external `brepkit-wasm` npm package). Additional kernels can be registered at runtime.
 
 ```mermaid
 graph TD
@@ -71,11 +71,11 @@ import opencascade from 'brepjs-opencascade';
 const oc = await opencascade();
 initFromOC(oc);
 
-// Built-in alternative (brepkit WASM)
+// brepkit kernel (external brepkit-wasm package)
 import { BrepkitAdapter } from 'brepjs';
-import brepkit from 'brepjs-opencascade/brepkit';
-const bk = await brepkit();
-registerKernel('brepkit', new BrepkitAdapter(bk));
+import init, { BrepKernel } from 'brepkit-wasm';
+await init();
+registerKernel('brepkit', new BrepkitAdapter(new BrepKernel()));
 
 // Custom kernel
 registerKernel('rust', new RustAdapter(wasm));


### PR DESCRIPTION
## Summary

- Corrected documentation that described brepkit as a "built-in" kernel — it is actually an external npm dependency (`brepkit-wasm`)
- Fixed incorrect import paths (`brepjs-opencascade/brepkit` → `brepkit-wasm`) in code examples across `docs/kernel-swap.md` and `src/kernel/README.md`
- Clarified package provenance: OpenCascade via companion `brepjs-opencascade`, brepkit via external `brepkit-wasm`

## Test plan

- [x] All pre-commit hooks pass (lint, typecheck, boundary check, coverage)
- [x] All pre-push hooks pass (full test coverage, knip)
- [ ] Verify code examples match actual `tests/setup-kernel.ts` initialization pattern