### PR TITLE
docs(projection): add ADR-0006 boundary citation to cameraFns

### DIFF
--- a/src/projection/cameraFns.ts
+++ b/src/projection/cameraFns.ts
@@ -1,5 +1,11 @@
 /**
  * Functional camera API — plain immutable Camera objects for 3D projection.
+ *
+ * ADR-0006 Phase 3: this module performs 3D vector math (cross products,
+ * normalization) for view setup — pure coordinate math with no topology
+ * or geometry evaluation. Stays in TypeScript: the computation is trivial,
+ * operates on plain Vec3 tuples, and would gain no benefit from WASM
+ * round-trip overhead.
  */
 
 import type { Vec3 } from '../core/types.js';


### PR DESCRIPTION
## Summary
- Adds ADR-0006 Phase 3 citation to `src/projection/cameraFns.ts` module JSDoc
- Documents why camera view-setup math (cross products, normalization) stays in TypeScript: pure coordinate operations on Vec3 tuples with no topology or geometry evaluation, no WASM benefit

## Context
ADR-0006 Phase 3 identifies `cameraFns.ts` as needing evaluation against the domain boundary heuristic. The module performs trivial 3D vector math for camera setup — no topology traversal, no geometry evaluation, no kernel data. This citation documents the decision to keep it in TS.

## Test plan
- [x] Doc-only change — no behavioral impact
- [x] Typecheck, lint, boundary check pass