### PR TITLE
feat!: remove JS mesh fallback, require C++ MeshExtractor

### DIFF
--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -51,7 +51,7 @@ All raw kernel API calls are isolated in these files. A new kernel replaces `def
 | `transformOps.ts`           | `translate`, `rotate`, `mirror`, `scale`, `generalTransform`, `simplify`                                                                                        |
 | `measureOps.ts`             | `volume`, `area`, `length`, `centerOfMass`, `boundingBox`, `distance`, `classifyPointOnFace`                                                                    |
 | `geometryQueryOps.ts`       | `hashCode`, `isNull`, `shapeType`, `surfaceType`, `vertexPosition`, `curvePointAtParam`, `curveIsClosed`, `curveType`, `reverseShape`, `getSurfaceCylinderData` |
-| `meshOps.ts`                | `mesh`, `meshEdges` (dual path: C++ bulk extractor or JS fallback)                                                                                              |
+| `meshOps.ts`                | `mesh`, `meshEdges` (C++ bulk extraction via MeshExtractor/EdgeMeshExtractor)                                                                                   |
 | `topologyOps.ts`            | `iterShapes`, `iterShapeList`, `isSame`, `isEqual`, `isValid`, `sew`                                                                                            |
 | `ioOps.ts`                  | `exportSTEP`, `exportSTL`, `importSTEP`, `importSTL`, `exportIGES`, `importIGES`                                                                                |
 | `exportOps.ts`              | `wrapString`, `wrapColorRGBA`, `configureStepUnits`, `configureStepWriter`                                                                                      |
@@ -91,7 +91,7 @@ See [Custom Kernel Guide](../../docs/kernel-swap.md) for writing your own kernel
 1. **Must initialize first** — `getKernel()` throws if no kernel has been registered
 2. **Manual memory management** — All intermediate kernel objects need `.delete()` inside ops modules; only final shapes are returned
 3. **WASM enum values** — Emscripten returns enum objects with `.value` property, not raw numbers. Use `typeof val === 'number' ? val : Number(val?.value ?? val)` pattern
-4. **Dual mesh path** — `meshOps.ts` has bulk C++ `MeshExtractor` if available, JS `TopExp_Explorer` fallback
+4. **C++ mesh extraction** — `meshOps.ts` uses `MeshExtractor`/`EdgeMeshExtractor` for all mesh operations (normals, UVs, face groups computed in C++)
 5. **Virtual filesystem** — File I/O uses Emscripten virtual filesystem, not real disk paths
 6. **Degree conversion** — `rotate()` takes degrees, converts internally to radians
 7. **withKernel is sync-only** — The kernel override is restored in `finally`, so async functions would observe the wrong kernel after `await`

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -2,7 +2,6 @@ import type { KernelAdapter, KernelInstance } from './types.js';
 import type { Kernel2DCapability } from './kernel2dTypes.js';
 import { supportsKernel2D } from './kernel2dTypes.js';
 import { DefaultAdapter } from './defaultAdapter.js';
-import { resetMeshDetectionCache } from './meshOps.js';
 import { resetMeasureDetectionCache } from './measureOps.js';
 import { resetTransformDetectionCache } from './transformOps.js';
 
@@ -85,7 +84,6 @@ export function withKernel<T extends Exclude<unknown, Promise<unknown>>>(
 
 /** Initialise the brepjs kernel from a loaded WASM instance. */
 export function initFromOC(oc: KernelInstance): void {
-  resetMeshDetectionCache();
   resetMeasureDetectionCache();
   resetTransformDetectionCache();
   const adapter = new DefaultAdapter(oc);

--- a/src/kernel/meshOps.ts
+++ b/src/kernel/meshOps.ts
@@ -1,9 +1,13 @@
 /**
  * Meshing operations for OCCT shapes.
  *
- * Provides face mesh and edge mesh extraction with dual implementations:
- * - C++ bulk extraction (MeshExtractor/EdgeMeshExtractor) when available
- * - JS fallback using TopExp_Explorer
+ * Uses C++ bulk extraction (MeshExtractor/EdgeMeshExtractor) for all
+ * mesh operations. These are compiled into the brepjs-opencascade WASM
+ * build and handle vertex, normal, UV, and triangle extraction in a
+ * single WASM call per shape.
+ *
+ * ADR-0006 Phase 2: no TS code iterates triangulation data to compute
+ * normals — all normal computation happens in C++.
  *
  * Used by DefaultAdapter.
  */
@@ -15,7 +19,6 @@ import type {
   KernelMeshResult,
   KernelEdgeMeshResult,
 } from './types.js';
-import { HASH_CODE_MAX } from './measureOps.js';
 
 /** Slice a Float32Array from the WASM heap, or return empty if size is 0. */
 function sliceF32(heap: Float32Array, ptr: number, size: number): Float32Array {
@@ -25,86 +28,29 @@ function sliceF32(heap: Float32Array, ptr: number, size: number): Float32Array {
 }
 
 /**
- * Check if a shape already has face triangulation (from a prior mesh call).
- * Avoids redundant BRepMesh_IncrementalMesh creation.
- */
-function hasTriangulation(oc: KernelInstance, shape: KernelShape): boolean {
-  const explorer = new oc.TopExp_Explorer_2(
-    shape,
-    oc.TopAbs_ShapeEnum.TopAbs_FACE,
-    oc.TopAbs_ShapeEnum.TopAbs_SHAPE
-  );
-  let hasTri = false;
-  if (explorer.More()) {
-    const face = oc.TopoDS.Face_1(explorer.Current());
-    const loc = new oc.TopLoc_Location_1();
-    const tri = oc.BRep_Tool.Triangulation(face, loc, 0);
-    hasTri = !tri.IsNull();
-    loc.delete();
-    tri.delete();
-  }
-  explorer.delete();
-  return hasTri;
-}
-
-/** Cached flag: does the WASM MeshExtractor support the 5-arg includeUVs signature? */
-let meshExtractorHasUVs: boolean | undefined;
-
-/** Reset detection cache (called when kernel is re-initialized). */
-export function resetMeshDetectionCache(): void {
-  meshExtractorHasUVs = undefined;
-}
-
-function detectMeshExtractorUVs(oc: KernelInstance): void {
-  try {
-    // Use a minimal empty shape to detect signature support without meshing the user's shape
-    const emptyShape = new oc.TopoDS_Shape();
-    try {
-      const probe = oc.MeshExtractor.extract(emptyShape, 0.1, 0.5, true, false);
-      meshExtractorHasUVs = typeof probe.getUvsSize === 'function';
-      probe.delete();
-    } finally {
-      emptyShape.delete();
-    }
-  } catch {
-    meshExtractorHasUVs = false;
-  }
-}
-
-/**
  * Meshes a shape using C++ bulk extraction.
+ *
+ * Single WASM call handles meshing, vertex/normal/UV extraction, face
+ * grouping, and triangle winding correction.
  */
-export function meshBulk(
+export function mesh(
   oc: KernelInstance,
   shape: KernelShape,
   options: MeshOptions
 ): KernelMeshResult {
-  // Detect 5-arg signature support once, then cache
-  if (meshExtractorHasUVs === undefined) {
-    detectMeshExtractorUVs(oc);
-  }
-
-  // Single WASM call: mesh + extract all data in C++
-  const raw = meshExtractorHasUVs
-    ? oc.MeshExtractor.extract(
-        shape,
-        options.tolerance,
-        options.angularTolerance,
-        !!options.skipNormals,
-        !!options.includeUVs
-      )
-    : oc.MeshExtractor.extract(
-        shape,
-        options.tolerance,
-        options.angularTolerance,
-        !!options.skipNormals
-      );
+  const raw = oc.MeshExtractor.extract(
+    shape,
+    options.tolerance,
+    options.angularTolerance,
+    !!options.skipNormals,
+    !!options.includeUVs
+  );
 
   const verticesSize = raw.getVerticesSize() as number;
   const normalsSize = raw.getNormalsSize() as number;
   const trianglesSize = raw.getTrianglesSize() as number;
   const faceGroupsSize = raw.getFaceGroupsSize() as number;
-  const uvsSize = meshExtractorHasUVs ? (raw.getUvsSize() as number) : 0;
+  const uvsSize = raw.getUvsSize() as number;
 
   // Copy from WASM heap into owned TypedArrays.
   // Must .slice() before any other WASM call could grow/relocate the heap.
@@ -141,226 +87,9 @@ export function meshBulk(
 }
 
 /**
- * Mutable write positions for pre-allocated mesh arrays.
- *
- * Passed into `_meshFace` so each face writes at the correct offset
- * within the shared pre-allocated buffers.
- */
-interface MeshWriteState {
-  vIdx: number;
-  nIdx: number;
-  uvIdx: number;
-  tIdx: number;
-}
-
-/**
- * Extract mesh data for a single OCCT face into pre-allocated arrays.
- *
- * Encapsulates per-face vertex, normal, UV, and triangle extraction
- * — including the normal computation via Poly_Connect +
- * StdPrs_ToolTriangulatedShape.Normal().
- *
- * ADR-0006 Phase 2: isolates the OCCT normal-computation orchestration
- * into a single function, mirroring brepkit's meshSingleFace() pattern.
- * When the C++ MeshExtractor is available, this function is not called
- * (meshBulk handles everything in a single WASM call).
- */
-function _meshFace(
-  oc: KernelInstance,
-  face: KernelShape,
-  triangulation: { IsNull(): boolean; get(): KernelShape },
-  location: KernelShape,
-  options: MeshOptions,
-  vertices: Float32Array,
-  normals: Float32Array,
-  uvs: Float32Array,
-  triangles: Uint32Array,
-  state: MeshWriteState,
-  faceGroups: KernelMeshResult['faceGroups']
-): void {
-  const tri = triangulation.get();
-  const transformation = location.Transformation();
-  const nbNodes = tri.NbNodes();
-  const vertexOffset = state.vIdx / 3;
-  const triStart = state.tIdx;
-
-  // Vertices
-  for (let i = 1; i <= nbNodes; i++) {
-    const p = tri.Node(i).Transformed(transformation);
-    vertices[state.vIdx++] = p.X();
-    vertices[state.vIdx++] = p.Y();
-    vertices[state.vIdx++] = p.Z();
-    p.delete();
-  }
-
-  // Normals — computed from triangulation connectivity via OCCT
-  if (!options.skipNormals) {
-    const normalsArray = new oc.TColgp_Array1OfDir_2(1, nbNodes);
-    const pc = new oc.Poly_Connect_2(triangulation);
-    oc.StdPrs_ToolTriangulatedShape.Normal(face, pc, normalsArray);
-    for (let i = normalsArray.Lower(); i <= normalsArray.Upper(); i++) {
-      const d = normalsArray.Value(i).Transformed(transformation);
-      normals[state.nIdx++] = d.X();
-      normals[state.nIdx++] = d.Y();
-      normals[state.nIdx++] = d.Z();
-      d.delete();
-    }
-    normalsArray.delete();
-    pc.delete();
-  }
-
-  // UVs
-  if (options.includeUVs && tri.HasUVNodes()) {
-    for (let i = 1; i <= nbNodes; i++) {
-      const uv = tri.UVNode(i);
-      uvs[state.uvIdx++] = uv.X();
-      uvs[state.uvIdx++] = uv.Y();
-      uv.delete();
-    }
-  } else if (options.includeUVs) {
-    // No UV data for this face — fill with zeros
-    for (let i = 0; i < nbNodes; i++) {
-      uvs[state.uvIdx++] = 0;
-      uvs[state.uvIdx++] = 0;
-    }
-  }
-
-  // Triangles — reverse winding for non-forward faces
-  const orient = face.Orientation_1();
-  const isForward = orient === oc.TopAbs_Orientation.TopAbs_FORWARD;
-  const nbTriangles = tri.NbTriangles();
-
-  for (let nt = 1; nt <= nbTriangles; nt++) {
-    const t = tri.Triangle(nt);
-    let n1 = t.Value(1);
-    let n2 = t.Value(2);
-    const n3 = t.Value(3);
-    if (!isForward) {
-      const tmp = n1;
-      n1 = n2;
-      n2 = tmp;
-    }
-    triangles[state.tIdx++] = n1 - 1 + vertexOffset;
-    triangles[state.tIdx++] = n2 - 1 + vertexOffset;
-    triangles[state.tIdx++] = n3 - 1 + vertexOffset;
-    t.delete();
-  }
-
-  faceGroups.push({
-    start: triStart,
-    count: state.tIdx - triStart,
-    faceHash: face.HashCode(HASH_CODE_MAX),
-  });
-  transformation.delete();
-}
-
-/**
- * Meshes a shape using JS-side TopExp_Explorer extraction.
- */
-export function meshJS(
-  oc: KernelInstance,
-  shape: KernelShape,
-  options: MeshOptions
-): KernelMeshResult {
-  const mesher = new oc.BRepMesh_IncrementalMesh_2(
-    shape,
-    options.tolerance,
-    false,
-    options.angularTolerance,
-    false
-  );
-  mesher.delete();
-
-  // Pass 1: count totals so we can pre-allocate
-  let totalNodes = 0;
-  let totalTris = 0;
-
-  const explorer = new oc.TopExp_Explorer_2(
-    shape,
-    oc.TopAbs_ShapeEnum.TopAbs_FACE,
-    oc.TopAbs_ShapeEnum.TopAbs_SHAPE
-  );
-  while (explorer.More()) {
-    const face = oc.TopoDS.Face_1(explorer.Current());
-    const loc = new oc.TopLoc_Location_1();
-    const tri = oc.BRep_Tool.Triangulation(face, loc, 0);
-    if (!tri.IsNull()) {
-      const t = tri.get();
-      totalNodes += t.NbNodes() as number;
-      totalTris += t.NbTriangles() as number;
-    }
-    loc.delete();
-    tri.delete();
-    explorer.Next();
-  }
-
-  // Pass 2: fill pre-allocated arrays via _meshFace
-  const vertices = new Float32Array(totalNodes * 3);
-  const normals = options.skipNormals ? new Float32Array(0) : new Float32Array(totalNodes * 3);
-  const uvs = options.includeUVs ? new Float32Array(totalNodes * 2) : new Float32Array(0);
-  const triangles = new Uint32Array(totalTris * 3);
-  const faceGroups: KernelMeshResult['faceGroups'] = [];
-  const state: MeshWriteState = { vIdx: 0, nIdx: 0, uvIdx: 0, tIdx: 0 };
-
-  explorer.Init(shape, oc.TopAbs_ShapeEnum.TopAbs_FACE, oc.TopAbs_ShapeEnum.TopAbs_SHAPE);
-
-  while (explorer.More()) {
-    options.signal?.throwIfAborted();
-    const face = oc.TopoDS.Face_1(explorer.Current());
-    const location = new oc.TopLoc_Location_1();
-    const triangulation = oc.BRep_Tool.Triangulation(face, location, 0);
-
-    if (!triangulation.IsNull()) {
-      _meshFace(
-        oc,
-        face,
-        triangulation,
-        location,
-        options,
-        vertices,
-        normals,
-        uvs,
-        triangles,
-        state,
-        faceGroups
-      );
-    }
-
-    location.delete();
-    triangulation.delete();
-    explorer.Next();
-  }
-  explorer.delete();
-
-  return { vertices, normals, triangles, uvs, faceGroups };
-}
-
-/**
- * Meshes a shape, using C++ bulk extraction when available.
- */
-export function mesh(
-  oc: KernelInstance,
-  shape: KernelShape,
-  options: MeshOptions
-): KernelMeshResult {
-  if (oc.MeshExtractor) {
-    // Ensure UV capability is detected before routing
-    if (meshExtractorHasUVs === undefined) {
-      detectMeshExtractorUVs(oc);
-    }
-    // If UVs are requested but C++ doesn't support them, fall back to JS
-    if (options.includeUVs && !meshExtractorHasUVs) {
-      return meshJS(oc, shape, options);
-    }
-    return meshBulk(oc, shape, options);
-  }
-  return meshJS(oc, shape, options);
-}
-
-/**
  * Extracts edge meshes using C++ bulk extraction.
  */
-export function meshEdgesBulk(
+export function meshEdges(
   oc: KernelInstance,
   shape: KernelShape,
   tolerance: number,
@@ -388,171 +117,4 @@ export function meshEdgesBulk(
 
   raw.delete();
   return { lines, edgeGroups };
-}
-
-/**
- * Extracts edge meshes using JS-side extraction.
- */
-export function meshEdgesJS(
-  oc: KernelInstance,
-  shape: KernelShape,
-  tolerance: number,
-  angularTolerance: number
-): KernelEdgeMeshResult {
-  // Only mesh if triangulation doesn't already exist (e.g. from a prior mesh() call)
-  if (!hasTriangulation(oc, shape)) {
-    const mesher = new oc.BRepMesh_IncrementalMesh_2(
-      shape,
-      tolerance,
-      false,
-      angularTolerance,
-      false
-    );
-    mesher.delete();
-  }
-
-  const lines: number[] = [];
-  const edgeGroups: KernelEdgeMeshResult['edgeGroups'] = [];
-  const seenHashes = new Set<number>();
-
-  // Pass 1: edges from face triangulations
-  const faceExplorer = new oc.TopExp_Explorer_2(
-    shape,
-    oc.TopAbs_ShapeEnum.TopAbs_FACE,
-    oc.TopAbs_ShapeEnum.TopAbs_SHAPE
-  );
-  while (faceExplorer.More()) {
-    const face = oc.TopoDS.Face_1(faceExplorer.Current());
-    const faceLoc = new oc.TopLoc_Location_1();
-    const tri = oc.BRep_Tool.Triangulation(face, faceLoc, 0);
-
-    if (!tri.IsNull()) {
-      const triObj = tri.get();
-      const edgeExplorer = new oc.TopExp_Explorer_2(
-        face,
-        oc.TopAbs_ShapeEnum.TopAbs_EDGE,
-        oc.TopAbs_ShapeEnum.TopAbs_SHAPE
-      );
-      while (edgeExplorer.More()) {
-        const edgeShape = edgeExplorer.Current();
-        const edge = oc.TopoDS.Edge_1(edgeShape);
-        const edgeHash = edge.HashCode(HASH_CODE_MAX);
-        if (!seenHashes.has(edgeHash)) {
-          seenHashes.add(edgeHash);
-          const edgeLoc = new oc.TopLoc_Location_1();
-          const polygon = oc.BRep_Tool.PolygonOnTriangulation_1(edge, tri, edgeLoc);
-          // Check both existence and IsNull() - Handle can exist but be null
-          const edgeNodes = polygon && !polygon.IsNull() ? polygon.get().Nodes() : null;
-          if (edgeNodes) {
-            const lineStart = lines.length / 3;
-            let prevX = 0,
-              prevY = 0,
-              prevZ = 0;
-            let hasPrev = false;
-            // Hoist Transformation() outside the loop — same for all nodes of this edge
-            const trsf = edgeLoc.Transformation();
-            for (let i = edgeNodes.Lower(); i <= edgeNodes.Upper(); i++) {
-              const p = triObj.Node(edgeNodes.Value(i)).Transformed(trsf);
-              const x = p.X(),
-                y = p.Y(),
-                z = p.Z();
-              if (hasPrev) {
-                lines.push(prevX, prevY, prevZ, x, y, z);
-              }
-              prevX = x;
-              prevY = y;
-              prevZ = z;
-              hasPrev = true;
-              p.delete();
-            }
-            trsf.delete();
-            edgeGroups.push({
-              start: lineStart,
-              count: lines.length / 3 - lineStart,
-              edgeHash,
-            });
-            edgeNodes.delete();
-          }
-          if (polygon && !polygon.IsNull()) polygon.delete();
-          edgeLoc.delete();
-        }
-        edgeExplorer.Next();
-      }
-      edgeExplorer.delete();
-    }
-
-    tri.delete();
-    faceLoc.delete();
-    faceExplorer.Next();
-  }
-  faceExplorer.delete();
-
-  // Pass 2: remaining edges via curve tessellation
-  const edgeExplorer = new oc.TopExp_Explorer_2(
-    shape,
-    oc.TopAbs_ShapeEnum.TopAbs_EDGE,
-    oc.TopAbs_ShapeEnum.TopAbs_SHAPE
-  );
-  while (edgeExplorer.More()) {
-    const edgeShape = edgeExplorer.Current();
-    const edge = oc.TopoDS.Edge_1(edgeShape);
-    const edgeHash = edge.HashCode(HASH_CODE_MAX);
-    if (!seenHashes.has(edgeHash)) {
-      seenHashes.add(edgeHash);
-      const adaptor = new oc.BRepAdaptor_Curve_2(edge);
-      const tangDef = new oc.GCPnts_TangentialDeflection_2(
-        adaptor,
-        tolerance,
-        angularTolerance,
-        2,
-        1e-9,
-        1e-7
-      );
-      const lineStart = lines.length / 3;
-      let prevX = 0,
-        prevY = 0,
-        prevZ = 0;
-      let hasPrev = false;
-      for (let j = 1; j <= tangDef.NbPoints(); j++) {
-        const p = tangDef.Value(j);
-        const x = p.X(),
-          y = p.Y(),
-          z = p.Z();
-        if (hasPrev) {
-          lines.push(prevX, prevY, prevZ, x, y, z);
-        }
-        prevX = x;
-        prevY = y;
-        prevZ = z;
-        hasPrev = true;
-        p.delete();
-      }
-      edgeGroups.push({
-        start: lineStart,
-        count: lines.length / 3 - lineStart,
-        edgeHash,
-      });
-      tangDef.delete();
-      adaptor.delete();
-    }
-    edgeExplorer.Next();
-  }
-  edgeExplorer.delete();
-
-  return { lines: new Float32Array(lines), edgeGroups };
-}
-
-/**
- * Extracts edge meshes, using C++ bulk extraction when available.
- */
-export function meshEdges(
-  oc: KernelInstance,
-  shape: KernelShape,
-  tolerance: number,
-  angularTolerance: number
-): KernelEdgeMeshResult {
-  if (oc.EdgeMeshExtractor) {
-    return meshEdgesBulk(oc, shape, tolerance, angularTolerance);
-  }
-  return meshEdgesJS(oc, shape, tolerance, angularTolerance);
 }


### PR DESCRIPTION
## Summary
- **BREAKING**: Removes JS mesh fallback paths (`meshJS`, `_meshFace`, `meshEdgesJS`), requiring C++ `MeshExtractor`/`EdgeMeshExtractor` (present in all current brepjs-opencascade builds)
- Removes UV signature detection cache (`meshExtractorHasUVs`, `detectMeshExtractorUVs`, `resetMeshDetectionCache`) — always calls 5-arg `extract()`
- Renames `meshBulk` → `mesh`, `meshEdgesBulk` → `meshEdges` (sole implementations)
- **Net: -440 lines** from `meshOps.ts`

## Context
ADR-0006 Phase 2 acceptance criteria: "No TS code iterates triangulation data to compute normals." The C++ `MeshExtractor` already handles all normal/UV computation in a single WASM call. The JS fallback (`meshJS`/`_meshFace`) was dead code on all current builds — it only ran when `MeshExtractor` was unavailable (older WASM builds) or when UVs were requested without C++ support (no longer the case).

This is a **breaking change** (requires C++ extractors) and should trigger a major version bump.

## Test plan
- [x] `tests/fn-meshFns.test.ts` — all 17 tests pass
- [x] `tests/fn-uvMesh.test.ts` — all 6 UV mesh tests pass
- [x] Typecheck, lint, boundary check, knip all pass
- [x] Full test coverage passes (pre-push hook)