### PR TITLE
fix(kernel): warn on cross-kernel BREP format incompatibility (ADR-0006)

### DIFF
--- a/src/kernel/brepkitAdapter.ts
+++ b/src/kernel/brepkitAdapter.ts
@@ -2937,12 +2937,20 @@ export class BrepkitAdapter implements KernelAdapter {
   // ═══════════════════════════════════════════════════════════════════════
 
   toBREP(shape: KernelShape): string {
-    // brepkit doesn't have OCCT's BREP format — use STEP as the serialization format
+    // brepkit uses STEP as serialization format (not OCCT BREP format).
+    // Same-kernel round-trips work; cross-kernel round-trips do not.
+    warnOnce(
+      'brep-format',
+      'toBREP/fromBREP uses STEP format (not OCCT BREP). Cross-kernel BREP round-trips are not supported.'
+    );
     return this.exportSTEP([shape]);
   }
 
   fromBREP(data: string): KernelShape {
-    // Deserialize from STEP format
+    warnOnce(
+      'brep-format',
+      'toBREP/fromBREP uses STEP format (not OCCT BREP). Cross-kernel BREP round-trips are not supported.'
+    );
     const shapes = this.importSTEP(data);
     if (shapes.length === 0) throw new Error('brepkit: fromBREP produced no shapes');
     return shapes[0];

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -535,7 +535,16 @@ export interface KernelAdapter extends Kernel2DCapability {
   ): KernelShape;
 
   // --- Serialization ---
+  /**
+   * Serialize a shape to a string format for persistence.
+   *
+   * **Cross-kernel warning**: The serialization format is kernel-specific.
+   * OCCT uses its native BREP text format; brepkit proxies to STEP.
+   * Data produced by one kernel cannot be deserialized by the other.
+   * Only use for same-kernel round-trips.
+   */
   toBREP(shape: KernelShape): string;
+  /** @see {@link toBREP} for cross-kernel compatibility notes. */
   fromBREP(data: string): KernelShape;
 
   // --- Mesh preparation ---


### PR DESCRIPTION
## Summary

- Add `warnOnce()` to brepkit's `toBREP`/`fromBREP` noting that STEP format is used instead of OCCT BREP format
- Add JSDoc on `KernelAdapter.toBREP`/`fromBREP` documenting cross-kernel incompatibility
- Same-kernel round-trips continue to work; warning is informational

**Why warn instead of unsupportedError()**: brepkit's STEP-based toBREP/fromBREP works correctly for same-kernel round-trips (serialize on brepkit, deserialize on brepkit). Throwing an error would break working code. The real issue is cross-kernel round-trips (serialize on OCCT, deserialize on brepkit or vice versa), which the warning addresses.

**Discovery**: brepkit WASM has a native `toBREP()` returning JSON topology data, but no corresponding `fromBREP()`. The adapter's STEP proxy is the correct approach until brepkit adds `fromBREP()`.

This is PR 2 of 4 addressing high-impact behavioral gaps from the Phase 4 audit (#433).

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 2196 tests pass
- [x] Pre-commit/pre-push hooks pass