### PR TITLE
fix(kernel): declare brepkit-wasm as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,10 +214,14 @@
     "vitest": "4.0.18"
   },
   "peerDependencies": {
-    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
+    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0",
+    "brepkit-wasm": "^0.10.1"
   },
   "peerDependenciesMeta": {
     "brepjs-opencascade": {
+      "optional": true
+    },
+    "brepkit-wasm": {
       "optional": true
     }
   },


### PR DESCRIPTION
## Summary

- Add `brepkit-wasm` as an optional peer dependency (`^0.10.1`), symmetric with the existing `brepjs-opencascade` treatment
- Previously only in `devDependencies`, so published brepjs gave consumers no install guidance or version compatibility signal when using `BrepkitAdapter`

## Test plan
- [x] Pre-commit and pre-push hooks pass
- [x] No code changes — metadata only