### PR TITLE
fix(kernel): export BrepkitAdapter from main entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,15 @@
 
 // ── Layer 0: kernel / utils ──
 
-export { initFromOC, getKernel, registerKernel, withKernel } from './kernel/index.js';
+export {
+  initFromOC,
+  getKernel,
+  registerKernel,
+  withKernel,
+  BrepkitAdapter,
+} from './kernel/index.js';
 export type { KernelAdapter, SurfaceType, ShapeOrientation, ShapeType } from './kernel/index.js';
+export type { BrepkitHandle } from './kernel/index.js';
 export { supportsProjection } from './kernel/index.js';
 export type { ProjectionCapability } from './kernel/index.js';
 

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -146,6 +146,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'BrepBugError',
   'BrepErrorCode',
   'BrepWrapperError',
+  'BrepkitAdapter',
   'CompoundBlueprint',
   'CompoundSketch',
   'Curve2D',


### PR DESCRIPTION
## Summary

- Re-export `BrepkitAdapter` and `BrepkitHandle` from `src/index.ts` so consumers can import them from the published package
- Previously only exported from `src/kernel/index.ts` — unreachable since no Vite entry point or package.json export path included the kernel module
- Update public API types test with `BrepkitAdapter` in the runtime export snapshot

Consumer usage:
```ts
import init, { BrepKernel } from 'brepkit-wasm';
import { BrepkitAdapter, registerKernel } from 'brepjs';

await init();
registerKernel('brepkit', new BrepkitAdapter(new BrepKernel()));
```

## Test plan
- [x] `npm run typecheck` passes
- [x] `public-api-types.test.ts` passes (61/61)
- [x] Full OCCT coverage passes thresholds
- [x] Full brepkit test suite passes