### PR TITLE
fix(kernel): consolidate BrepkitHandle type export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,13 @@ export {
   withKernel,
   BrepkitAdapter,
 } from './kernel/index.js';
-export type { KernelAdapter, SurfaceType, ShapeOrientation, ShapeType } from './kernel/index.js';
-export type { BrepkitHandle } from './kernel/index.js';
+export type {
+  KernelAdapter,
+  BrepkitHandle,
+  SurfaceType,
+  ShapeOrientation,
+  ShapeType,
+} from './kernel/index.js';
 export { supportsProjection } from './kernel/index.js';
 export type { ProjectionCapability } from './kernel/index.js';
 


### PR DESCRIPTION
## Summary

- Merge the separate `BrepkitHandle` type-only re-export into the main kernel type export block in `src/index.ts`
- No functional change — cosmetic cleanup that also ensures release-please properly tracks the BrepkitAdapter export change from #447

## Test plan
- [x] `npm run typecheck` passes
- [x] Full OCCT coverage passes thresholds