### PR TITLE
perf(kernel): batch tessellation via tessellateSolidGrouped

### DIFF
--- a/src/kernel/brepkitAdapter.ts
+++ b/src/kernel/brepkitAdapter.ts
@@ -4660,7 +4660,11 @@ export class BrepkitAdapter implements KernelAdapter {
   private meshSolid(solidId: number, deflection: number): KernelMeshResult {
     try {
       return this.meshSolidGrouped(solidId, deflection);
-    } catch {
+    } catch (e: unknown) {
+      console.warn(
+        `brepkit: tessellateSolidGrouped failed (solidId=${solidId}), falling back to per-face:`,
+        e
+      );
       return this.meshSolidPerFace(solidId, deflection);
     }
   }
@@ -4679,6 +4683,12 @@ export class BrepkitAdapter implements KernelAdapter {
     } = JSON.parse(json);
 
     const faceIds = toArray(this.bk.getSolidFaces(solidId));
+    const groupCount = data.faceOffsets.length - 1;
+    if (groupCount !== faceIds.length) {
+      throw new Error(
+        `faceOffsets/faceIds length mismatch: ${groupCount} groups vs ${faceIds.length} faces`
+      );
+    }
     const vertexCount = data.positions.length / 3;
 
     const faceGroups: Array<{ start: number; count: number; faceHash: number }> = [];

--- a/tests/brepkitAdapter.test.ts
+++ b/tests/brepkitAdapter.test.ts
@@ -467,6 +467,27 @@ describe('BrepkitAdapter', () => {
       expect(result.faceGroups.length).toBe(3);
     });
 
+    it('falls back when faceOffsets/faceIds counts diverge', () => {
+      const mock = createMockBrepKernel();
+      // Return 4 face groups but getSolidFaces returns 3 → mismatch
+      mock.tessellateSolidGrouped.mockReturnValue(
+        JSON.stringify({
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+          indices: [0, 1, 2],
+          faceOffsets: [0, 3, 3, 3, 3],
+        })
+      );
+      const adapter = new BrepkitAdapter(mock);
+      const box = adapter.makeBox(1, 1, 1);
+
+      const result = adapter.mesh(box, { tolerance: 0.1, angularTolerance: 0.5 });
+
+      // Should have fallen back to per-face
+      expect(mock.tessellateFace).toHaveBeenCalled();
+      expect(result.faceGroups.length).toBe(3);
+    });
+
     it('skips degenerate faces with zero-count groups', () => {
       const mock = createMockBrepKernel();
       mock.tessellateSolidGrouped.mockReturnValue(


### PR DESCRIPTION
## Summary

- Replace per-face tessellation loop (N WASM boundary crossings) with single `bk.tessellateSolidGrouped()` call in `BrepkitAdapter.meshSolid()`
- Add graceful fallback to per-face path (`meshSolidPerFace`) when grouped call fails (older brepkit-wasm or pathological geometry)
- Convert `faceOffsets` sentinel array to `faceGroups` format, skip degenerate faces with zero-count groups

## Test plan

- [x] `npx vitest run tests/brepkitAdapter.test.ts` — 4 new tests: grouped primary path, faceHash mapping, fallback on error, degenerate face skipping
- [x] `npm run typecheck` — passes
- [x] `npm run test:affected` — 111 files, 1899 tests, 0 failures
- [ ] Manual: run Gridfinity benchmark before/after to measure improvement