### PR TITLE
fix: update brepkit-wasm peer dep range to include v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
   },
   "peerDependencies": {
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0",
-    "brepkit-wasm": "^0.10.1"
+    "brepkit-wasm": "^0.10.1 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "brepjs-opencascade": {


### PR DESCRIPTION
## Summary

- Update `peerDependencies.brepkit-wasm` from `^0.10.1` to `^0.10.1 || ^1.0.0` to support the newly released brepkit-wasm v1.0.0

## Test plan

- [x] No code changes — peer dep range only