### PR TITLE
perf(kernel): use brepkit-wasm compoundCut for batch boolean operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/opentype.js": "1.3.9",
         "@vitest/coverage-v8": "4.0.18",
         "brepjs-opencascade": "*",
-        "brepkit-wasm": "0.10.1",
+        "brepkit-wasm": "1.0.2",
         "eslint": "10.0.3",
         "husky": "9.1.7",
         "knip": "5.86.0",
@@ -42,10 +42,14 @@
         "node": ">=24 <25"
       },
       "peerDependencies": {
-        "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
+        "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0",
+        "brepkit-wasm": "1.0.2"
       },
       "peerDependenciesMeta": {
         "brepjs-opencascade": {
+          "optional": true
+        },
+        "brepkit-wasm": {
           "optional": true
         }
       }
@@ -4150,9 +4154,9 @@
       "link": true
     },
     "node_modules/brepkit-wasm": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-0.10.1.tgz",
-      "integrity": "sha512-K577vEp0HFRWUDqtgmsWWXBcjmT8op8eGWLw2EoQE2zmBiBbJ7R53oEeDPlkxuX1kKWQE6pC0O48wknc8B34Bg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-1.0.2.tgz",
+      "integrity": "sha512-y2w68NhLPDp/oVr4SNhpTqgqzkBSxFp3SWrMYZh83EJTZQY1BYgvt9m7iGBQjFECg2sokzvGSb4+1RqrD7/C7A==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "@types/opentype.js": "1.3.9",
     "@vitest/coverage-v8": "4.0.18",
     "brepjs-opencascade": "*",
-    "brepkit-wasm": "0.10.1",
+    "brepkit-wasm": "1.0.2",
     "eslint": "10.0.3",
     "husky": "9.1.7",
     "knip": "5.86.0",
@@ -215,7 +215,7 @@
   },
   "peerDependencies": {
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0",
-    "brepkit-wasm": "^0.10.1"
+    "brepkit-wasm": "^0.10.1 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "brepjs-opencascade": {

--- a/src/kernel/brepkitAdapter.ts
+++ b/src/kernel/brepkitAdapter.ts
@@ -479,11 +479,25 @@ export class BrepkitAdapter implements KernelAdapter {
   }
 
   cutAll(shape: KernelShape, tools: KernelShape[], options?: BooleanOptions): KernelShape {
-    let result = shape;
+    if (tools.length === 0) return shape;
+    if (tools.length === 1) return this.cut(shape, tools[0], options);
+
+    // Extract solid IDs from all tools (exploding compounds into individual solids).
+    const baseId = unwrapSolidOrThrow(shape, 'cutAll');
+    const toolIds: number[] = [];
     for (const tool of tools) {
-      result = this.cut(result, tool, options);
+      const h = tool as BrepkitHandle;
+      if (h.type === 'compound') {
+        toolIds.push(...toArray(this.bk.getCompoundSolids(h.id)));
+      } else {
+        toolIds.push(unwrapSolidOrThrow(tool, 'cutAll'));
+      }
     }
-    return result;
+    if (toolIds.length === 0) return shape;
+
+    // Single WASM call: brepkit does AABB pre-filtering and sequential cuts in Rust.
+    const result = this.bk.compoundCut(baseId, new Uint32Array(toolIds));
+    return solidHandle(result);
   }
 
   split(shape: KernelShape, tools: KernelShape[]): KernelShape {

--- a/src/kernel/brepkitWasmTypes.ts
+++ b/src/kernel/brepkitWasmTypes.ts
@@ -132,6 +132,9 @@ export interface BrepkitKernel {
   /** Intersect two solids. Returns new solid handle. */
   intersect(a: number, b: number): number;
 
+  /** Cut target solid with multiple tool solids in a single WASM call. Returns new solid handle. */
+  compoundCut(target: number, tool_ids: Uint32Array): number;
+
   /** Fuse with evolution tracking. Returns JSON string. */
   fuseWithEvolution(a: number, b: number): string;
 


### PR DESCRIPTION
## Summary

- **`cutAll()` now makes 1 WASM call instead of N** — extracts all tool solid IDs (exploding compounds via `getCompoundSolids`), then calls `bk.compoundCut(targetId, toolIds)` which does AABB pre-filtering and sequential cuts entirely in Rust
- **Upgrade brepkit-wasm 0.10.1 → 1.0.2** — adds `compoundCut(target, tool_ids)` binding
- **Add `compoundCut` to `BrepkitKernel` interface** in `brepkitWasmTypes.ts`
- **Update peerDependencies** to accept `^0.10.1 || ^1.0.0` for backward compatibility

For a gridfinity 8×8 bin with 64 socket cylinders, this reduces 64 individual `bk.cut()` calls (64 JS↔WASM boundary crossings) to a single `bk.compoundCut()` call. The Rust side also does AABB pre-filtering to skip tools that don't overlap the base solid.

## Test plan

- [x] `npm run validate` — typecheck + lint + boundaries + format + 2196 tests all pass
- [x] `npm run knip` — no unused exports
- [x] Pre-push hook passes (full `test:coverage` + knip)
- [ ] Run `brepkit-adapter.test.ts` with brepkit-wasm 1.0.2 linked to verify `compoundCut` integration
- [ ] Benchmark gridfinity 8×8 bin with brepkit kernel to measure speedup vs N sequential cuts