### PR TITLE
refactor(tests): address review feedback on brepkit test unblocking

### DIFF
--- a/tests/fn-booleanFns.test.ts
+++ b/tests/fn-booleanFns.test.ts
@@ -34,6 +34,8 @@ beforeAll(async () => {
   await initKernel();
 }, 30000);
 
+const isBrepkit = (process.env['TEST_KERNEL'] ?? 'occt') === 'brepkit';
+
 function boxAt(x1: number, y1: number, z1: number, x2: number, y2: number, z2: number): Shape3D {
   const b = box(x2 - x1, y2 - y1, z2 - z1);
   if (x1 === 0 && y1 === 0 && z1 === 0) return b;
@@ -127,14 +129,12 @@ describe('boolean edge cases', () => {
 
     it('intersect disjoint boxes produces empty or negligible volume', (ctx) => {
       // brepkit throws on disjoint intersection instead of returning empty shape
-      if (process.env['TEST_KERNEL'] === 'brepkit') ctx.skip();
+      if (isBrepkit) ctx.skip();
       const result = intersect(boxAt(0, 0, 0, 10, 10, 10), boxAt(100, 0, 0, 110, 10, 10));
-      // kernel may return an empty shell or compound
-      expect(isOk(result) || isErr(result)).toBe(true);
-      if (isOk(result)) {
-        const vol = measureVolume(unwrap(result));
-        expect(vol).toBeLessThan(1); // Essentially zero
-      }
+      // OCCT returns Ok with an empty/near-zero-volume result for disjoint intersection
+      expect(isOk(result)).toBe(true);
+      const vol = measureVolume(unwrap(result));
+      expect(vol).toBeLessThan(1);
     });
 
     it('cut with disjoint tool preserves base volume', () => {
@@ -390,7 +390,7 @@ describe('section', () => {
 
   it('returns result for plane not intersecting shape', (ctx) => {
     // brepkit returns Err for non-intersecting section; OCCT returns Ok with empty edges
-    if (process.env['TEST_KERNEL'] === 'brepkit') ctx.skip();
+    if (isBrepkit) ctx.skip();
     // Box at z=0..10, plane at z=100 — no intersection
     const b = boxAt(0, 0, 0, 10, 10, 10);
     const result = section(b, {
@@ -423,10 +423,9 @@ describe('null-shape pre-validation', () => {
     const oc = getKernel().oc;
     return createSolid(new oc.TopoDS_Solid()) as Shape3D;
   }
-  const isBrepkit = () => process.env['TEST_KERNEL'] === 'brepkit';
 
   it('fuse rejects null first operand', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = fuse(makeNullShape(), boxAt(0, 0, 0, 10, 10, 10));
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
@@ -434,7 +433,7 @@ describe('null-shape pre-validation', () => {
   });
 
   it('fuse rejects null second operand', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = fuse(boxAt(0, 0, 0, 10, 10, 10), makeNullShape());
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
@@ -442,28 +441,28 @@ describe('null-shape pre-validation', () => {
   });
 
   it('cut rejects null base', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = cut(makeNullShape(), boxAt(0, 0, 0, 10, 10, 10));
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('cut rejects null tool', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = cut(boxAt(0, 0, 0, 10, 10, 10), makeNullShape());
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('intersect rejects null operand', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = intersect(makeNullShape(), boxAt(0, 0, 0, 10, 10, 10));
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('fuseAll rejects null shape in array', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = fuseAll([boxAt(0, 0, 0, 10, 10, 10), makeNullShape()]);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
@@ -471,21 +470,21 @@ describe('null-shape pre-validation', () => {
   });
 
   it('cutAll rejects null base', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = cutAll(makeNullShape(), [boxAt(0, 0, 0, 10, 10, 10)]);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('split rejects null shape', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = split(makeNullShape(), [boxAt(0, 0, 0, 10, 10, 10)]);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('section rejects null shape', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = section(makeNullShape(), 'XY');
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
@@ -504,7 +503,7 @@ describe('sectionToFace', () => {
 
   it('sections a sphere producing a circular face', (ctx) => {
     // brepkit sectionToFace produces degenerate face for sphere cross-sections
-    if (process.env['TEST_KERNEL'] === 'brepkit') ctx.skip();
+    if (isBrepkit) ctx.skip();
     const s = sphere(10);
     const result = sectionToFace(s, 'XY', { planeSize: 100 });
     expect(isOk(result)).toBe(true);

--- a/tests/fn-compoundOpsFns.test.ts
+++ b/tests/fn-compoundOpsFns.test.ts
@@ -27,6 +27,8 @@ beforeAll(async () => {
   await initKernel();
 }, 30000);
 
+const isBrepkit = (process.env['TEST_KERNEL'] ?? 'occt') === 'brepkit';
+
 // ---------------------------------------------------------------------------
 // drill
 // ---------------------------------------------------------------------------
@@ -93,7 +95,7 @@ describe('pocket()', () => {
 
   it('returns Err with COMPOUND_NO_FACES for shape with no faces', (ctx) => {
     // brepkit skip: uses raw OCCT API (oc.gp_Pnt_3, BRepBuilderAPI_MakeEdge_3)
-    if (process.env['TEST_KERNEL'] === 'brepkit') ctx.skip();
+    if (isBrepkit) ctx.skip();
     const oc = getKernel().oc;
     const p1 = new oc.gp_Pnt_3(0, 0, 0);
     const p2 = new oc.gp_Pnt_3(10, 0, 0);

--- a/tests/fn-modifierFns.test.ts
+++ b/tests/fn-modifierFns.test.ts
@@ -29,6 +29,8 @@ beforeAll(async () => {
   await initKernel();
 }, 30000);
 
+const isBrepkit = (process.env['TEST_KERNEL'] ?? 'occt') === 'brepkit';
+
 describe('thicken', () => {
   it('thickens a planar face into a solid', () => {
     const sketch = sketchRectangle(10, 10);
@@ -67,7 +69,7 @@ describe('thicken', () => {
 describe('fillet', () => {
   it('fillets all edges of a box with constant radius', (ctx) => {
     // brepkit over-fillets when all 12 edges are filleted (vol ~530 vs >800 expected)
-    if (process.env['TEST_KERNEL'] === 'brepkit') ctx.skip();
+    if (isBrepkit) ctx.skip();
     const b = box(10, 10, 10);
     const result = fillet(b, 1);
     expect(isOk(result)).toBe(true);
@@ -190,14 +192,15 @@ describe('offset', () => {
 });
 
 describe('fillet with array radius', () => {
-  it('fillets a specific edge with variable radius [r1, r2]', () => {
+  it('fillets a specific edge with variable radius [r1, r2]', (ctx) => {
+    // brepkit variable fillet produces vol > 1000 (physically impossible — fillet removes material)
+    if (isBrepkit) ctx.skip();
     const b = box(10, 10, 10);
     const edges = getEdges(b);
     const result = fillet(b, [edges[0]!], [1, 2]);
     expect(isOk(result)).toBe(true);
     const vol = measureVolume(unwrap(result));
-    // brepkit variable fillet may produce slightly larger volume (~1012) than OCCT
-    expect(vol).toBeLessThan(1020);
+    expect(vol).toBeLessThan(1000);
     expect(vol).toBeGreaterThan(900);
   });
 
@@ -229,14 +232,15 @@ describe('fillet with callback returning null or array', () => {
     expect(unwrapErr(result).code).toBe('FILLET_NO_EDGES');
   });
 
-  it('callback returning [r1, r2] applies variable fillet', () => {
+  it('callback returning [r1, r2] applies variable fillet', (ctx) => {
+    // brepkit variable fillet produces vol > 1000 (physically impossible — fillet removes material)
+    if (isBrepkit) ctx.skip();
     const b = box(10, 10, 10);
     const edges = getEdges(b);
     const result = fillet(b, edges.slice(0, 2), () => [1, 2]);
     expect(isOk(result)).toBe(true);
     const vol = measureVolume(unwrap(result));
-    // brepkit variable fillet may produce slightly larger volume (~1012) than OCCT
-    expect(vol).toBeLessThan(1020);
+    expect(vol).toBeLessThan(1000);
   });
 });
 
@@ -298,24 +302,23 @@ describe('null-shape pre-validation', () => {
     const oc = getKernel().oc;
     return createSolid(new oc.TopoDS_Solid()) as Shape3D;
   }
-  const isBrepkit = () => process.env['TEST_KERNEL'] === 'brepkit';
 
   it('fillet rejects null shape', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = fillet(makeNullShape(), 1);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('chamfer rejects null shape', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = chamfer(makeNullShape(), 1);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
   });
 
   it('shell rejects null shape', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const b = box(10, 10, 10);
     const faces = getFaces(b);
     const result = shell(makeNullShape(), [faces[0]!], 1);
@@ -324,7 +327,7 @@ describe('null-shape pre-validation', () => {
   });
 
   it('offset rejects null shape', (ctx) => {
-    if (isBrepkit()) ctx.skip(); // oc.TopoDS_Solid unavailable
+    if (isBrepkit) ctx.skip(); // oc.TopoDS_Solid unavailable
     const result = offset(makeNullShape(), 1);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,13 @@
 import { defineConfig } from 'vitest/config';
 
 /**
- * OCCT-only tests — use `getKernel().oc` to access raw Emscripten/OCCT objects.
- * Excluded from the brepkit project.
+ * Tests excluded from the brepkit project.
+ * Files with per-test ctx.skip() guards have been removed from this list.
  */
 const occtOnlyTests = [
   // --- Raw oc.* API usage (getKernel().oc) ---
   'tests/fn-applyMatrix.test.ts',
-  // 'tests/fn-booleanFns.test.ts', // unblocked for brepkit
   'tests/fn-cast.test.ts',
-  // 'tests/fn-compoundOpsFns.test.ts', // unblocked for brepkit
   'tests/fn-disposal.test.ts',
   'tests/fn-extrudeFns.test.ts',
   'tests/fn-guidedSweepFns.test.ts',
@@ -20,10 +18,9 @@ const occtOnlyTests = [
   'tests/fn-measureFns.test.ts',
   'tests/fn-meshFns.test.ts',
   'tests/fn-minkowskiFns.test.ts',
-  // 'tests/fn-modifierFns.test.ts', // unblocked for brepkit
   'tests/fn-multiSweepFns.test.ts',
   'tests/geometry.test.ts',
-  // --- 0% brepkit pass rate (fully unimplemented features) ---
+  // --- Unimplemented brepkit features ---
   'tests/fn-blueprintFns.test.ts',
   'tests/fn-examples.test.ts',
   'tests/fn-exporterFns.test.ts',


### PR DESCRIPTION
## Summary
- Use module-level `const isBrepkit` consistently across all three test files (removes scoped arrow function variants)
- Skip brepkit on variable fillet tests instead of widening tolerance (vol > 1000 on a 10³ box is physically impossible for fillet)
- Fix tautological assertion in disjoint intersect test (`isOk || isErr` is always true)
- Remove commented-out entries from `vitest.config.ts` `occtOnlyTests`

Follow-up to #478 — these fixes were in a second commit that was lost during squash merge.

## Test plan
- [x] All 98 tests pass on OCCT (0 skipped)
- [x] 78 tests pass on brepkit (20 skipped, all with `ctx.skip()` guards)
- [x] Pre-push coverage thresholds met