### PR TITLE
chore: add tech-debt slash command for incremental debt reduction

### DIFF
--- a/.claude/commands/tech-debt.md
+++ b/.claude/commands/tech-debt.md
@@ -136,13 +136,13 @@ describe.skipIf(currentKernel !== 'occt')('OCCT-specific: <module>', () => {
 
 **Keep**:
 
-- `test` — changed files only, no coverage (current `test:affected` behavior)
+- `test` — changed files only, no coverage (**new behavior** — currently `test:affected`; the old full-suite `test` script will be replaced)
 - `test:full` — all tests + coverage thresholds (current `test:coverage`)
 - `test:brepkit` — brepkit kernel tests (current `test:brepkit`)
 
 **Remove**:
 
-- `test:coverage:changed` — redundant with `test:full`
+- `test:coverage:changed` — redundant with the new `test` (both run changed files without coverage thresholds)
 - `test:all` — can be done with `test:full` + `TEST_KERNEL=brepkit npm run test`
 
 **Steps**:


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/tech-debt.md` — a reusable `/tech-debt` slash command that provides a prioritized, actionable playbook for systematically reducing tech debt one PR at a time
- Covers 11 items across 3 priority tiers: adapter splitting, blueprint type safety, test config cleanup, API surface audit, script consolidation, and bundle optimization
- Companion GitHub issues created (#493–#503) with `tech-debt` label for tracking

## Test plan

- [ ] No code changes — documentation/tooling only
- [ ] Verify `/tech-debt` command loads correctly in Claude Code