### PR TITLE
chore(tech-debt): relax Node.js engine constraint to >=24

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "sideEffects": false,
   "engines": {
-    "node": ">=24 <25"
+    "node": ">=24"
   },
   "packageManager": "npm@11.6.1",
   "workspaces": [


### PR DESCRIPTION
## Summary

- Relaxes `engines.node` from `">=24 <25"` to `">=24"`, allowing consumers to use newer Node versions without being blocked by the upper bound

## Test plan

- [x] `npm run typecheck` passes
- [x] No Node-version-specific code or polyfills in `src/`
- [ ] CI continues to test on Node 24

Closes #501