### PR TITLE
refactor(tech-debt): blueprint type safety - lib.ts (#495)

### DIFF
--- a/src/2d/blueprints/lib.ts
+++ b/src/2d/blueprints/lib.ts
@@ -1,5 +1,7 @@
 import Flatbush from 'flatbush';
 
+import { safeIndex } from '../../core/errors.js';
+
 import type { Point2D, BoundingBox2d } from '../lib/index.js';
 import type { Face, Wire } from '../../core/shapeTypes.js';
 
@@ -17,8 +19,7 @@ import CompoundBlueprint from './CompoundBlueprint.js';
  */
 const groupByBoundingBoxOverlap = (blueprints: Blueprint[]): Blueprint[][] => {
   if (blueprints.length === 0) return [];
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above
-  if (blueprints.length === 1) return [[blueprints[0]!]];
+  if (blueprints.length === 1) return [[safeIndex(blueprints, 0, 'groupByBoundingBoxOverlap')]];
 
   // Build spatial index
   const index = new Flatbush(blueprints.length);
@@ -34,8 +35,11 @@ const groupByBoundingBoxOverlap = (blueprints: Blueprint[]): Blueprint[][] => {
     const candidates = index.search(xMin, yMin, xMax, yMax);
     // Filter to indices > i (to avoid duplicates) and verify overlap
     return candidates.filter(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index from spatial query within bounds
-      (j: number) => j > i && !blueprint.boundingBox.isOut(blueprints[j]!.boundingBox)
+      (j: number) =>
+        j > i &&
+        !blueprint.boundingBox.isOut(
+          safeIndex(blueprints, j, 'groupByBoundingBoxOverlap').boundingBox
+        )
     );
   });
 
@@ -50,8 +54,7 @@ const groupByBoundingBoxOverlap = (blueprints: Blueprint[]): Blueprint[][] => {
       groups.push(myGroup);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- i is valid index from forEach
-    myGroup.push(blueprints[i]!);
+    myGroup.push(safeIndex(blueprints, i, 'groupByBoundingBoxOverlap'));
 
     if (indices.length) {
       indices.forEach((idx) => {
@@ -70,8 +73,7 @@ interface ContainedBlueprint {
 
 const addContainmentInfo = (groupedBlueprints: Blueprint[]): ContainedBlueprint[] => {
   return groupedBlueprints.map((blueprint, index) => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- blueprint always has at least one curve
-    const firstCurve = blueprint.curves[0]!;
+    const firstCurve = safeIndex(blueprint.curves, 0, 'addContainmentInfo');
     const point = firstCurve.value((firstCurve.lastParameter + firstCurve.firstParameter) / 2);
 
     const isIn = groupedBlueprints.filter((potentialOuterBlueprint, j) => {
@@ -137,8 +139,7 @@ export const organiseBlueprints = (blueprints: Blueprint[]): Blueprints => {
   const basicGrouping = groupByBoundingBoxOverlap(blueprints).map(addContainmentInfo);
   return new Blueprints(
     basicGrouping.flatMap(cleanEdgeCases).map((compounds) => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length === 1 checked
-      if (compounds.length === 1) return compounds[0]!.blueprint;
+      if (compounds.length === 1) return safeIndex(compounds, 0, 'organiseBlueprints').blueprint;
 
       compounds.sort((a, b) => a.isIn.length - b.isIn.length);
       return new CompoundBlueprint(compounds.map(({ blueprint }) => blueprint));


### PR DESCRIPTION
## Summary

Removes all 5 `no-non-null-assertion` eslint-disable comments from `src/2d/blueprints/lib.ts` using the `safeIndex<T>()` helper added in #494.

### What each assertion became

| Location | Reason given | Fix |
|----------|--------------|-----|
| `blueprints[0]` (length === 1 early-exit) | length check | `safeIndex(blueprints, 0, ctx)` |
| `blueprints[j]` (Flatbush spatial query index) | index from spatial query within bounds | `safeIndex(blueprints, j, ctx)` |
| `blueprints[i]` (forEach callback) | i is valid index from forEach | `safeIndex(blueprints, i, ctx)` |
| `blueprint.curves[0]` | blueprint always has at least one curve | `safeIndex(blueprint.curves, 0, ctx)` |
| `compounds[0]` (length === 1 early-exit) | length === 1 checked | `safeIndex(compounds, 0, ctx)` |

No behavioral changes.

**Depends on:** #508 (adds `safeIndex`)

Closes #495

## Test plan

- [x] All 200 blueprint/sketcher tests pass (both OCCT and brepkit kernels)
- [x] Typecheck, lint, format pass
- [x] Zero remaining `no-non-null-assertion` disables in `lib.ts`