### PR TITLE
chore: fix pre-existing Prettier violations in test files

### DIFF
--- a/tests/fn-applyMatrix.test.ts
+++ b/tests/fn-applyMatrix.test.ts
@@ -13,239 +13,239 @@ import {
 } from '../src/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: applyMatrix', () => {
-let hasGTransform = false;
+  let hasGTransform = false;
 
-beforeAll(async () => {
-  await initKernel();
-  // Check if BRepBuilderAPI_GTransform is available in the WASM build
+  beforeAll(async () => {
+    await initKernel();
+    // Check if BRepBuilderAPI_GTransform is available in the WASM build
 
-  hasGTransform = typeof getKernel().oc.BRepBuilderAPI_GTransform_2 === 'function';
-}, 30000);
+    hasGTransform = typeof getKernel().oc.BRepBuilderAPI_GTransform_2 === 'function';
+  }, 30000);
 
-// ── Helpers ──
+  // ── Helpers ──
 
-/** Identity 4x4 matrix */
-const IDENTITY: Matrix4x4 = [
-  [1, 0, 0, 0],
-  [0, 1, 0, 0],
-  [0, 0, 1, 0],
-  [0, 0, 0, 1],
-];
-
-/** Builds a translation-only 4x4 matrix */
-function translationMatrix(tx: number, ty: number, tz: number): Matrix4x4 {
-  return [
-    [1, 0, 0, tx],
-    [0, 1, 0, ty],
-    [0, 0, 1, tz],
+  /** Identity 4x4 matrix */
+  const IDENTITY: Matrix4x4 = [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
     [0, 0, 0, 1],
   ];
-}
 
-/** 90-degree rotation around Z axis */
-const ROTATE_Z_90: Matrix4x4 = [
-  [0, -1, 0, 0],
-  [1, 0, 0, 0],
-  [0, 0, 1, 0],
-  [0, 0, 0, 1],
-];
-
-/** Uniform scale by factor 2 */
-const UNIFORM_SCALE_2: Matrix4x4 = [
-  [2, 0, 0, 0],
-  [0, 2, 0, 0],
-  [0, 0, 2, 0],
-  [0, 0, 0, 1],
-];
-
-/** Non-uniform scale: stretch X by 2, keep Y and Z */
-const NONUNIFORM_SCALE: Matrix4x4 = [
-  [2, 0, 0, 0],
-  [0, 1, 0, 0],
-  [0, 0, 1, 0],
-  [0, 0, 0, 1],
-];
-
-/** Shear: X sheared by Y */
-const SHEAR_XY: Matrix4x4 = [
-  [1, 1, 0, 0],
-  [0, 1, 0, 0],
-  [0, 0, 1, 0],
-  [0, 0, 0, 1],
-];
-
-// ── Orthogonal fast-path tests ──
-
-describe('applyMatrix — orthogonal (fast path)', () => {
-  it('identity matrix preserves shape bounds', () => {
-    const b = box(10, 10, 10);
-    const result = applyMatrix(b, IDENTITY);
-    const bounds = getBounds(result);
-    expect(bounds.xMin).toBeCloseTo(0, 5);
-    expect(bounds.xMax).toBeCloseTo(10, 5);
-    expect(bounds.yMin).toBeCloseTo(0, 5);
-    expect(bounds.yMax).toBeCloseTo(10, 5);
-  });
-
-  it('pure translation matches translate()', () => {
-    const b = box(10, 10, 10);
-    const viaMatrix = applyMatrix(b, translationMatrix(5, 10, 15));
-    const viaTranslate = translate(b, [5, 10, 15]);
-    const mb = getBounds(viaMatrix);
-    const tb = getBounds(viaTranslate);
-    expect(mb.xMin).toBeCloseTo(tb.xMin, 5);
-    expect(mb.xMax).toBeCloseTo(tb.xMax, 5);
-    expect(mb.yMin).toBeCloseTo(tb.yMin, 5);
-    expect(mb.yMax).toBeCloseTo(tb.yMax, 5);
-    expect(mb.zMin).toBeCloseTo(tb.zMin, 5);
-    expect(mb.zMax).toBeCloseTo(tb.zMax, 5);
-  });
-
-  it('90° Z rotation moves box correctly', () => {
-    const b = box(10, 20, 5);
-    const result = applyMatrix(b, ROTATE_Z_90);
-    const bounds = getBounds(result);
-    // Box [0,10]x[0,20] rotated 90° CCW → [-20,0]x[0,10]
-    expect(bounds.xMin).toBeCloseTo(-20, 3);
-    expect(bounds.xMax).toBeCloseTo(0, 3);
-    expect(bounds.yMin).toBeCloseTo(0, 3);
-    expect(bounds.yMax).toBeCloseTo(10, 3);
-  });
-
-  it('uniform scale doubles dimensions and volume 8x', () => {
-    const b = box(10, 10, 10);
-    const result = applyMatrix(b, UNIFORM_SCALE_2);
-    const bounds = getBounds(result);
-    expect(bounds.xMax).toBeCloseTo(20, 3);
-    expect(bounds.yMax).toBeCloseTo(20, 3);
-    expect(bounds.zMax).toBeCloseTo(20, 3);
-    expect(measureVolume(result)).toBeCloseTo(8000, 0);
-  });
-
-  it('uniform scale matches scale()', () => {
-    const b = box(10, 10, 10);
-    const viaMatrix = applyMatrix(b, UNIFORM_SCALE_2);
-    const viaScale = scale(b, 2);
-    expect(measureVolume(viaMatrix)).toBeCloseTo(measureVolume(viaScale), 0);
-  });
-});
-
-// ── General affine tests (require BRepBuilderAPI_GTransform) ──
-
-describe('applyMatrix — general affine (non-orthogonal)', () => {
-  it('non-uniform scale stretches one axis', () => {
-    if (!hasGTransform) return; // requires WASM rebuild with BRepBuilderAPI_GTransform
-    const b = box(10, 10, 10);
-    const result = applyMatrix(b, NONUNIFORM_SCALE);
-    const bounds = getBounds(result);
-    expect(bounds.xMin).toBeCloseTo(0, 3);
-    expect(bounds.xMax).toBeCloseTo(20, 3);
-    expect(bounds.yMax).toBeCloseTo(10, 3);
-    expect(bounds.zMax).toBeCloseTo(10, 3);
-    // Volume doubles (2x in X, 1x in Y, 1x in Z)
-    expect(measureVolume(result)).toBeCloseTo(2000, 0);
-  });
-
-  it('shear preserves volume', () => {
-    if (!hasGTransform) return; // requires WASM rebuild with BRepBuilderAPI_GTransform
-    const b = box(10, 10, 10);
-    const result = applyMatrix(b, SHEAR_XY);
-    // Shear det = 1, so volume is preserved
-    expect(measureVolume(result)).toBeCloseTo(1000, 0);
-  });
-
-  it('combined non-uniform scale + translation', () => {
-    if (!hasGTransform) return; // requires WASM rebuild with BRepBuilderAPI_GTransform
-    const m: Matrix4x4 = [
-      [2, 0, 0, 5],
-      [0, 3, 0, 10],
-      [0, 0, 1, 0],
+  /** Builds a translation-only 4x4 matrix */
+  function translationMatrix(tx: number, ty: number, tz: number): Matrix4x4 {
+    return [
+      [1, 0, 0, tx],
+      [0, 1, 0, ty],
+      [0, 0, 1, tz],
       [0, 0, 0, 1],
     ];
-    const b = box(10, 10, 10);
-    const result = applyMatrix(b, m);
-    const bounds = getBounds(result);
-    expect(bounds.xMin).toBeCloseTo(5, 3);
-    expect(bounds.xMax).toBeCloseTo(25, 3); // 10*2 + 5
-    expect(bounds.yMin).toBeCloseTo(10, 3);
-    expect(bounds.yMax).toBeCloseTo(40, 3); // 10*3 + 10
+  }
+
+  /** 90-degree rotation around Z axis */
+  const ROTATE_Z_90: Matrix4x4 = [
+    [0, -1, 0, 0],
+    [1, 0, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+  ];
+
+  /** Uniform scale by factor 2 */
+  const UNIFORM_SCALE_2: Matrix4x4 = [
+    [2, 0, 0, 0],
+    [0, 2, 0, 0],
+    [0, 0, 2, 0],
+    [0, 0, 0, 1],
+  ];
+
+  /** Non-uniform scale: stretch X by 2, keep Y and Z */
+  const NONUNIFORM_SCALE: Matrix4x4 = [
+    [2, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+  ];
+
+  /** Shear: X sheared by Y */
+  const SHEAR_XY: Matrix4x4 = [
+    [1, 1, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+  ];
+
+  // ── Orthogonal fast-path tests ──
+
+  describe('applyMatrix — orthogonal (fast path)', () => {
+    it('identity matrix preserves shape bounds', () => {
+      const b = box(10, 10, 10);
+      const result = applyMatrix(b, IDENTITY);
+      const bounds = getBounds(result);
+      expect(bounds.xMin).toBeCloseTo(0, 5);
+      expect(bounds.xMax).toBeCloseTo(10, 5);
+      expect(bounds.yMin).toBeCloseTo(0, 5);
+      expect(bounds.yMax).toBeCloseTo(10, 5);
+    });
+
+    it('pure translation matches translate()', () => {
+      const b = box(10, 10, 10);
+      const viaMatrix = applyMatrix(b, translationMatrix(5, 10, 15));
+      const viaTranslate = translate(b, [5, 10, 15]);
+      const mb = getBounds(viaMatrix);
+      const tb = getBounds(viaTranslate);
+      expect(mb.xMin).toBeCloseTo(tb.xMin, 5);
+      expect(mb.xMax).toBeCloseTo(tb.xMax, 5);
+      expect(mb.yMin).toBeCloseTo(tb.yMin, 5);
+      expect(mb.yMax).toBeCloseTo(tb.yMax, 5);
+      expect(mb.zMin).toBeCloseTo(tb.zMin, 5);
+      expect(mb.zMax).toBeCloseTo(tb.zMax, 5);
+    });
+
+    it('90° Z rotation moves box correctly', () => {
+      const b = box(10, 20, 5);
+      const result = applyMatrix(b, ROTATE_Z_90);
+      const bounds = getBounds(result);
+      // Box [0,10]x[0,20] rotated 90° CCW → [-20,0]x[0,10]
+      expect(bounds.xMin).toBeCloseTo(-20, 3);
+      expect(bounds.xMax).toBeCloseTo(0, 3);
+      expect(bounds.yMin).toBeCloseTo(0, 3);
+      expect(bounds.yMax).toBeCloseTo(10, 3);
+    });
+
+    it('uniform scale doubles dimensions and volume 8x', () => {
+      const b = box(10, 10, 10);
+      const result = applyMatrix(b, UNIFORM_SCALE_2);
+      const bounds = getBounds(result);
+      expect(bounds.xMax).toBeCloseTo(20, 3);
+      expect(bounds.yMax).toBeCloseTo(20, 3);
+      expect(bounds.zMax).toBeCloseTo(20, 3);
+      expect(measureVolume(result)).toBeCloseTo(8000, 0);
+    });
+
+    it('uniform scale matches scale()', () => {
+      const b = box(10, 10, 10);
+      const viaMatrix = applyMatrix(b, UNIFORM_SCALE_2);
+      const viaScale = scale(b, 2);
+      expect(measureVolume(viaMatrix)).toBeCloseTo(measureVolume(viaScale), 0);
+    });
   });
-});
 
-// ── MatrixTransform input ──
+  // ── General affine tests (require BRepBuilderAPI_GTransform) ──
 
-describe('applyMatrix — MatrixTransform input', () => {
-  it('structured orthogonal input produces correct result', () => {
-    const b = box(10, 10, 10);
-    const mt: MatrixTransform = {
-      linear: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-      translation: [5, 10, 15],
-    };
-    const result = getBounds(applyMatrix(b, mt));
-    expect(result.xMin).toBeCloseTo(5, 5);
-    expect(result.xMax).toBeCloseTo(15, 5);
-    expect(result.yMin).toBeCloseTo(10, 5);
-    expect(result.yMax).toBeCloseTo(20, 5);
-    expect(result.zMin).toBeCloseTo(15, 5);
-    expect(result.zMax).toBeCloseTo(25, 5);
+  describe('applyMatrix — general affine (non-orthogonal)', () => {
+    it('non-uniform scale stretches one axis', () => {
+      if (!hasGTransform) return; // requires WASM rebuild with BRepBuilderAPI_GTransform
+      const b = box(10, 10, 10);
+      const result = applyMatrix(b, NONUNIFORM_SCALE);
+      const bounds = getBounds(result);
+      expect(bounds.xMin).toBeCloseTo(0, 3);
+      expect(bounds.xMax).toBeCloseTo(20, 3);
+      expect(bounds.yMax).toBeCloseTo(10, 3);
+      expect(bounds.zMax).toBeCloseTo(10, 3);
+      // Volume doubles (2x in X, 1x in Y, 1x in Z)
+      expect(measureVolume(result)).toBeCloseTo(2000, 0);
+    });
+
+    it('shear preserves volume', () => {
+      if (!hasGTransform) return; // requires WASM rebuild with BRepBuilderAPI_GTransform
+      const b = box(10, 10, 10);
+      const result = applyMatrix(b, SHEAR_XY);
+      // Shear det = 1, so volume is preserved
+      expect(measureVolume(result)).toBeCloseTo(1000, 0);
+    });
+
+    it('combined non-uniform scale + translation', () => {
+      if (!hasGTransform) return; // requires WASM rebuild with BRepBuilderAPI_GTransform
+      const m: Matrix4x4 = [
+        [2, 0, 0, 5],
+        [0, 3, 0, 10],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ];
+      const b = box(10, 10, 10);
+      const result = applyMatrix(b, m);
+      const bounds = getBounds(result);
+      expect(bounds.xMin).toBeCloseTo(5, 3);
+      expect(bounds.xMax).toBeCloseTo(25, 3); // 10*2 + 5
+      expect(bounds.yMin).toBeCloseTo(10, 3);
+      expect(bounds.yMax).toBeCloseTo(40, 3); // 10*3 + 10
+    });
   });
 
-  it('structured input matches equivalent Matrix4x4', () => {
-    if (!hasGTransform) return; // uses non-uniform scale, requires WASM rebuild
-    const b = box(10, 10, 10);
-    const m4: Matrix4x4 = [
-      [2, 0, 0, 5],
-      [0, 1, 0, 10],
-      [0, 0, 1, 0],
-      [0, 0, 0, 1],
-    ];
-    const mt: MatrixTransform = {
-      linear: [2, 0, 0, 0, 1, 0, 0, 0, 1],
-      translation: [5, 10, 0],
-    };
-    const r1 = getBounds(applyMatrix(b, m4));
-    const r2 = getBounds(applyMatrix(b, mt));
-    expect(r1.xMin).toBeCloseTo(r2.xMin, 5);
-    expect(r1.xMax).toBeCloseTo(r2.xMax, 5);
-    expect(r1.yMin).toBeCloseTo(r2.yMin, 5);
-    expect(r1.yMax).toBeCloseTo(r2.yMax, 5);
+  // ── MatrixTransform input ──
+
+  describe('applyMatrix — MatrixTransform input', () => {
+    it('structured orthogonal input produces correct result', () => {
+      const b = box(10, 10, 10);
+      const mt: MatrixTransform = {
+        linear: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        translation: [5, 10, 15],
+      };
+      const result = getBounds(applyMatrix(b, mt));
+      expect(result.xMin).toBeCloseTo(5, 5);
+      expect(result.xMax).toBeCloseTo(15, 5);
+      expect(result.yMin).toBeCloseTo(10, 5);
+      expect(result.yMax).toBeCloseTo(20, 5);
+      expect(result.zMin).toBeCloseTo(15, 5);
+      expect(result.zMax).toBeCloseTo(25, 5);
+    });
+
+    it('structured input matches equivalent Matrix4x4', () => {
+      if (!hasGTransform) return; // uses non-uniform scale, requires WASM rebuild
+      const b = box(10, 10, 10);
+      const m4: Matrix4x4 = [
+        [2, 0, 0, 5],
+        [0, 1, 0, 10],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ];
+      const mt: MatrixTransform = {
+        linear: [2, 0, 0, 0, 1, 0, 0, 0, 1],
+        translation: [5, 10, 0],
+      };
+      const r1 = getBounds(applyMatrix(b, m4));
+      const r2 = getBounds(applyMatrix(b, mt));
+      expect(r1.xMin).toBeCloseTo(r2.xMin, 5);
+      expect(r1.xMax).toBeCloseTo(r2.xMax, 5);
+      expect(r1.yMin).toBeCloseTo(r2.yMin, 5);
+      expect(r1.yMax).toBeCloseTo(r2.yMax, 5);
+    });
   });
-});
 
-// ── Validation ──
+  // ── Validation ──
 
-describe('applyMatrix — validation', () => {
-  it('throws on singular matrix (zero row)', () => {
-    const singular: Matrix4x4 = [
-      [1, 0, 0, 0],
-      [0, 0, 0, 0],
-      [0, 0, 1, 0],
-      [0, 0, 0, 1],
-    ];
-    expect(() => applyMatrix(box(10, 10, 10), singular)).toThrow(/singular/i);
+  describe('applyMatrix — validation', () => {
+    it('throws on singular matrix (zero row)', () => {
+      const singular: Matrix4x4 = [
+        [1, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ];
+      expect(() => applyMatrix(box(10, 10, 10), singular)).toThrow(/singular/i);
+    });
+
+    it('throws on invalid bottom row', () => {
+      const bad: Matrix4x4 = [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 1, 1],
+      ];
+      expect(() => applyMatrix(box(10, 10, 10), bad)).toThrow(/bottom row/i);
+    });
   });
 
-  it('throws on invalid bottom row', () => {
-    const bad: Matrix4x4 = [
-      [1, 0, 0, 0],
-      [0, 1, 0, 0],
-      [0, 0, 1, 0],
-      [0, 0, 1, 1],
-    ];
-    expect(() => applyMatrix(box(10, 10, 10), bad)).toThrow(/bottom row/i);
-  });
-});
+  // ── Immutability ──
 
-// ── Immutability ──
-
-describe('applyMatrix — immutability', () => {
-  it('does not mutate the original shape', () => {
-    const b = box(10, 10, 10);
-    const before = getBounds(b);
-    applyMatrix(b, translationMatrix(100, 200, 300));
-    const after = getBounds(b);
-    expect(after.xMin).toBeCloseTo(before.xMin, 5);
-    expect(after.xMax).toBeCloseTo(before.xMax, 5);
+  describe('applyMatrix — immutability', () => {
+    it('does not mutate the original shape', () => {
+      const b = box(10, 10, 10);
+      const before = getBounds(b);
+      applyMatrix(b, translationMatrix(100, 200, 300));
+      const after = getBounds(b);
+      expect(after.xMin).toBeCloseTo(before.xMin, 5);
+      expect(after.xMax).toBeCloseTo(before.xMax, 5);
+    });
   });
-});
 });

--- a/tests/fn-cast.test.ts
+++ b/tests/fn-cast.test.ts
@@ -20,138 +20,138 @@ import {
 } from '../src/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: cast', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-describe('cast()', () => {
-  it('returns Ok for a valid box shape', () => {
-    const b = box(10, 10, 10);
-    const result = cast(b.wrapped);
-    expect(isOk(result)).toBe(true);
-    expect(unwrap(result)).toBeDefined();
+  describe('cast()', () => {
+    it('returns Ok for a valid box shape', () => {
+      const b = box(10, 10, 10);
+      const result = cast(b.wrapped);
+      expect(isOk(result)).toBe(true);
+      expect(unwrap(result)).toBeDefined();
+    });
+
+    it('returns Err with NULL_SHAPE for a null KernelShape', () => {
+      const oc = getKernel().oc;
+      const nullShape = new oc.TopoDS_Solid();
+      const result = cast(nullShape);
+      expect(isErr(result)).toBe(true);
+      expect(unwrapErr(result).code).toBe('NULL_SHAPE');
+    });
   });
 
-  it('returns Err with NULL_SHAPE for a null KernelShape', () => {
-    const oc = getKernel().oc;
-    const nullShape = new oc.TopoDS_Solid();
-    const result = cast(nullShape);
-    expect(isErr(result)).toBe(true);
-    expect(unwrapErr(result).code).toBe('NULL_SHAPE');
-  });
-});
+  describe('downcast()', () => {
+    it('returns Ok for a valid box wrapped shape', () => {
+      const b = box(10, 10, 10);
+      const result = downcast(b.wrapped);
+      expect(isOk(result)).toBe(true);
+      expect(unwrap(result)).toBeDefined();
+    });
 
-describe('downcast()', () => {
-  it('returns Ok for a valid box wrapped shape', () => {
-    const b = box(10, 10, 10);
-    const result = downcast(b.wrapped);
-    expect(isOk(result)).toBe(true);
-    expect(unwrap(result)).toBeDefined();
-  });
-
-  it('returns Err for a null KernelShape', () => {
-    const oc = getKernel().oc;
-    const nullShape = new oc.TopoDS_Solid();
-    const result = downcast(nullShape);
-    expect(isErr(result)).toBe(true);
-    expect(unwrapErr(result).code).toBe('NULL_SHAPE');
-  });
-});
-
-describe('asTopo()', () => {
-  it('returns defined values for all entity types', () => {
-    const entities = [
-      'vertex',
-      'edge',
-      'wire',
-      'face',
-      'shell',
-      'solid',
-      'solidCompound',
-      'compound',
-      'shape',
-    ] as const;
-
-    for (const entity of entities) {
-      expect(asTopo(entity)).toBeDefined();
-    }
+    it('returns Err for a null KernelShape', () => {
+      const oc = getKernel().oc;
+      const nullShape = new oc.TopoDS_Solid();
+      const result = downcast(nullShape);
+      expect(isErr(result)).toBe(true);
+      expect(unwrapErr(result).code).toBe('NULL_SHAPE');
+    });
   });
 
-  it('returns distinct values for distinct topology types', () => {
-    const distinctEntities = [
-      'vertex',
-      'edge',
-      'wire',
-      'face',
-      'shell',
-      'solid',
-      'solidCompound',
-      'compound',
-    ] as const;
+  describe('asTopo()', () => {
+    it('returns defined values for all entity types', () => {
+      const entities = [
+        'vertex',
+        'edge',
+        'wire',
+        'face',
+        'shell',
+        'solid',
+        'solidCompound',
+        'compound',
+        'shape',
+      ] as const;
 
-    const values = distinctEntities.map((e) => asTopo(e));
-    // kernel enum values are WASM objects — compare with !== to verify uniqueness
-    for (let i = 0; i < values.length; i++) {
-      for (let j = i + 1; j < values.length; j++) {
-        expect(values[i]).not.toBe(values[j]);
+      for (const entity of entities) {
+        expect(asTopo(entity)).toBeDefined();
       }
-    }
-  });
-});
+    });
 
-describe('iterTopo()', () => {
-  it('yields 12 edges for a box', () => {
-    const b = box(10, 10, 10);
-    const edges = [...iterTopo(b.wrapped, 'edge')];
-    expect(edges).toHaveLength(12);
-  });
+    it('returns distinct values for distinct topology types', () => {
+      const distinctEntities = [
+        'vertex',
+        'edge',
+        'wire',
+        'face',
+        'shell',
+        'solid',
+        'solidCompound',
+        'compound',
+      ] as const;
 
-  it('yields 6 faces for a box', () => {
-    const b = box(10, 10, 10);
-    const faces = [...iterTopo(b.wrapped, 'face')];
-    expect(faces).toHaveLength(6);
-  });
-
-  it('yields 8 vertices for a box', () => {
-    const b = box(10, 10, 10);
-    const vertices = [...iterTopo(b.wrapped, 'vertex')];
-    expect(vertices).toHaveLength(8);
-  });
-});
-
-describe('fromBREP()', () => {
-  it('round-trips a box through toBREP and fromBREP', () => {
-    const b = box(10, 10, 10);
-    const brep = toBREP(b);
-    const result = fromBREP(brep);
-    expect(isOk(result)).toBe(true);
-    const shape = unwrap(result);
-    expect(isShape3D(shape)).toBe(true);
+      const values = distinctEntities.map((e) => asTopo(e));
+      // kernel enum values are WASM objects — compare with !== to verify uniqueness
+      for (let i = 0; i < values.length; i++) {
+        for (let j = i + 1; j < values.length; j++) {
+          expect(values[i]).not.toBe(values[j]);
+        }
+      }
+    });
   });
 
-  it('does not throw for garbage input', () => {
-    expect(() => {
-      const result = fromBREP('this is not valid BREP data');
-      // Result may be ok or err depending on kernel behavior, but it must not throw
-      expect(isOk(result) || isErr(result)).toBe(true);
-    }).not.toThrow();
-  });
-});
+  describe('iterTopo()', () => {
+    it('yields 12 edges for a box', () => {
+      const b = box(10, 10, 10);
+      const edges = [...iterTopo(b.wrapped, 'edge')];
+      expect(edges).toHaveLength(12);
+    });
 
-describe('type guards', () => {
-  it('isCompSolid returns false for a box', () => {
-    const b = castShape(box(10, 10, 10).wrapped);
-    expect(isCompSolid(b)).toBe(false);
+    it('yields 6 faces for a box', () => {
+      const b = box(10, 10, 10);
+      const faces = [...iterTopo(b.wrapped, 'face')];
+      expect(faces).toHaveLength(6);
+    });
+
+    it('yields 8 vertices for a box', () => {
+      const b = box(10, 10, 10);
+      const vertices = [...iterTopo(b.wrapped, 'vertex')];
+      expect(vertices).toHaveLength(8);
+    });
   });
 
-  it('isShape3D returns true for a box', () => {
-    const b = castShape(box(10, 10, 10).wrapped);
-    expect(isShape3D(b)).toBe(true);
+  describe('fromBREP()', () => {
+    it('round-trips a box through toBREP and fromBREP', () => {
+      const b = box(10, 10, 10);
+      const brep = toBREP(b);
+      const result = fromBREP(brep);
+      expect(isOk(result)).toBe(true);
+      const shape = unwrap(result);
+      expect(isShape3D(shape)).toBe(true);
+    });
+
+    it('does not throw for garbage input', () => {
+      expect(() => {
+        const result = fromBREP('this is not valid BREP data');
+        // Result may be ok or err depending on kernel behavior, but it must not throw
+        expect(isOk(result) || isErr(result)).toBe(true);
+      }).not.toThrow();
+    });
   });
 
-  it('isWire returns false for a box', () => {
-    const b = castShape(box(10, 10, 10).wrapped);
-    expect(isWire(b)).toBe(false);
+  describe('type guards', () => {
+    it('isCompSolid returns false for a box', () => {
+      const b = castShape(box(10, 10, 10).wrapped);
+      expect(isCompSolid(b)).toBe(false);
+    });
+
+    it('isShape3D returns true for a box', () => {
+      const b = castShape(box(10, 10, 10).wrapped);
+      expect(isShape3D(b)).toBe(true);
+    });
+
+    it('isWire returns false for a box', () => {
+      const b = castShape(box(10, 10, 10).wrapped);
+      expect(isWire(b)).toBe(false);
+    });
   });
-});
 });

--- a/tests/fn-disposal.test.ts
+++ b/tests/fn-disposal.test.ts
@@ -14,339 +14,339 @@ import type { Deletable } from '../src/core/disposal.js';
 import { getKernel } from '../src/kernel/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: disposal', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-/** Create a minimal kernel object for testing handle lifecycle */
-function makeOcPnt(): Deletable {
-  const oc = getKernel().oc;
-  return new oc.gp_Pnt_3(1, 2, 3);
-}
-
-/** Create a mock deletable for unit tests that don't need kernel */
-function mockDeletable(): { deleted: boolean } & Deletable {
-  const obj = {
-    deleted: false,
-    delete() {
-      obj.deleted = true;
-    },
-  };
-  return obj;
-}
-
-// ---------------------------------------------------------------------------
-// createHandle
-// ---------------------------------------------------------------------------
-
-describe('createHandle', () => {
-  it('creates a handle wrapping an kernel shape', () => {
+  /** Create a minimal kernel object for testing handle lifecycle */
+  function makeOcPnt(): Deletable {
     const oc = getKernel().oc;
-    const ocShape = new oc.BRepPrimAPI_MakeBox_2(10, 10, 10).Shape();
-    const handle = createHandle(ocShape);
-    expect(handle.wrapped).toBeDefined();
-    expect(handle.disposed).toBe(false);
-  });
+    return new oc.gp_Pnt_3(1, 2, 3);
+  }
 
-  it('allows access to wrapped shape', () => {
-    const oc = getKernel().oc;
-    const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
-    const handle = createHandle(ocShape);
-    expect(handle.wrapped).toBe(ocShape);
-  });
-
-  it('disposes via Symbol.dispose', () => {
-    const oc = getKernel().oc;
-    const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
-    const handle = createHandle(ocShape);
-    handle[Symbol.dispose]();
-    expect(handle.disposed).toBe(true);
-  });
-
-  it('throws on access after dispose', () => {
-    const oc = getKernel().oc;
-    const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
-    const handle = createHandle(ocShape);
-    handle[Symbol.dispose]();
-    expect(() => handle.wrapped).toThrow('Shape handle has been disposed');
-  });
-
-  it('double dispose is safe', () => {
-    const oc = getKernel().oc;
-    const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
-    const handle = createHandle(ocShape);
-    handle[Symbol.dispose]();
-    expect(() => {
-      handle[Symbol.dispose]();
-    }).not.toThrow();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// createKernelHandle
-// ---------------------------------------------------------------------------
-
-describe('createKernelHandle', () => {
-  it('wraps any kernel object', () => {
-    const pnt = makeOcPnt();
-    const handle = createKernelHandle(pnt);
-    expect(handle.value).toBe(pnt);
-    expect(handle.disposed).toBe(false);
-  });
-
-  it('disposes via Symbol.dispose', () => {
-    const pnt = makeOcPnt();
-    const handle = createKernelHandle(pnt);
-    handle[Symbol.dispose]();
-    expect(handle.disposed).toBe(true);
-  });
-
-  it('throws on access after dispose', () => {
-    const pnt = makeOcPnt();
-    const handle = createKernelHandle(pnt);
-    handle[Symbol.dispose]();
-    expect(() => handle.value).toThrow('kernel handle has been disposed');
-  });
-
-  it('double dispose is safe', () => {
-    const pnt = makeOcPnt();
-    const handle = createKernelHandle(pnt);
-    handle[Symbol.dispose]();
-    expect(() => {
-      handle[Symbol.dispose]();
-    }).not.toThrow();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// DisposalScope
-// ---------------------------------------------------------------------------
-
-describe('DisposalScope', () => {
-  it('registers and disposes resources', () => {
-    const scope = new DisposalScope();
-    const obj = mockDeletable();
-    scope.register(obj);
-    expect(obj.deleted).toBe(false);
-    scope[Symbol.dispose]();
-    expect(obj.deleted).toBe(true);
-  });
-
-  it('disposes in LIFO order', () => {
-    const order: number[] = [];
-    const scope = new DisposalScope();
-
-    scope.register({
+  /** Create a mock deletable for unit tests that don't need kernel */
+  function mockDeletable(): { deleted: boolean } & Deletable {
+    const obj = {
+      deleted: false,
       delete() {
-        order.push(1);
-      },
-    });
-    scope.register({
-      delete() {
-        order.push(2);
-      },
-    });
-    scope.register({
-      delete() {
-        order.push(3);
-      },
-    });
-
-    scope[Symbol.dispose]();
-    expect(order).toEqual([3, 2, 1]);
-  });
-
-  it('tracks disposable objects', () => {
-    const scope = new DisposalScope();
-    let disposed = false;
-    const disposable = {
-      [Symbol.dispose]() {
-        disposed = true;
+        obj.deleted = true;
       },
     };
-    scope.track(disposable);
-    expect(disposed).toBe(false);
-    scope[Symbol.dispose]();
-    expect(disposed).toBe(true);
-  });
+    return obj;
+  }
 
-  it('handles errors during disposal gracefully', () => {
-    const scope = new DisposalScope();
-    scope.register({
-      delete() {
-        throw new Error('already deleted');
-      },
+  // ---------------------------------------------------------------------------
+  // createHandle
+  // ---------------------------------------------------------------------------
+
+  describe('createHandle', () => {
+    it('creates a handle wrapping an kernel shape', () => {
+      const oc = getKernel().oc;
+      const ocShape = new oc.BRepPrimAPI_MakeBox_2(10, 10, 10).Shape();
+      const handle = createHandle(ocShape);
+      expect(handle.wrapped).toBeDefined();
+      expect(handle.disposed).toBe(false);
     });
-    // Should not throw
-    expect(() => {
-      scope[Symbol.dispose]();
-    }).not.toThrow();
-  });
 
-  it('can be disposed multiple times safely', () => {
-    const scope = new DisposalScope();
-    const obj = mockDeletable();
-    scope.register(obj);
-    scope[Symbol.dispose]();
-    // Second dispose should be safe (handles array cleared)
-    expect(() => {
-      scope[Symbol.dispose]();
-    }).not.toThrow();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// withScope
-// ---------------------------------------------------------------------------
-
-describe('withScope', () => {
-  it('auto-cleans up on return', () => {
-    const obj = mockDeletable();
-    const result = withScope((scope) => {
-      scope.register(obj);
-      return 42;
+    it('allows access to wrapped shape', () => {
+      const oc = getKernel().oc;
+      const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
+      const handle = createHandle(ocShape);
+      expect(handle.wrapped).toBe(ocShape);
     });
-    expect(result).toBe(42);
-    expect(obj.deleted).toBe(true);
+
+    it('disposes via Symbol.dispose', () => {
+      const oc = getKernel().oc;
+      const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
+      const handle = createHandle(ocShape);
+      handle[Symbol.dispose]();
+      expect(handle.disposed).toBe(true);
+    });
+
+    it('throws on access after dispose', () => {
+      const oc = getKernel().oc;
+      const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
+      const handle = createHandle(ocShape);
+      handle[Symbol.dispose]();
+      expect(() => handle.wrapped).toThrow('Shape handle has been disposed');
+    });
+
+    it('double dispose is safe', () => {
+      const oc = getKernel().oc;
+      const ocShape = new oc.BRepPrimAPI_MakeBox_2(5, 5, 5).Shape();
+      const handle = createHandle(ocShape);
+      handle[Symbol.dispose]();
+      expect(() => {
+        handle[Symbol.dispose]();
+      }).not.toThrow();
+    });
   });
 
-  it('auto-cleans up on throw', () => {
-    const obj = mockDeletable();
-    expect(() =>
-      withScope((scope) => {
-        scope.register(obj);
-        throw new Error('test error');
-      })
-    ).toThrow('test error');
-    expect(obj.deleted).toBe(true);
-  });
+  // ---------------------------------------------------------------------------
+  // createKernelHandle
+  // ---------------------------------------------------------------------------
 
-  it('works with kernel objects', () => {
-    const result = withScope((scope) => {
+  describe('createKernelHandle', () => {
+    it('wraps any kernel object', () => {
       const pnt = makeOcPnt();
-      scope.register(pnt);
-      return true;
+      const handle = createKernelHandle(pnt);
+      expect(handle.value).toBe(pnt);
+      expect(handle.disposed).toBe(false);
     });
-    expect(result).toBe(true);
+
+    it('disposes via Symbol.dispose', () => {
+      const pnt = makeOcPnt();
+      const handle = createKernelHandle(pnt);
+      handle[Symbol.dispose]();
+      expect(handle.disposed).toBe(true);
+    });
+
+    it('throws on access after dispose', () => {
+      const pnt = makeOcPnt();
+      const handle = createKernelHandle(pnt);
+      handle[Symbol.dispose]();
+      expect(() => handle.value).toThrow('kernel handle has been disposed');
+    });
+
+    it('double dispose is safe', () => {
+      const pnt = makeOcPnt();
+      const handle = createKernelHandle(pnt);
+      handle[Symbol.dispose]();
+      expect(() => {
+        handle[Symbol.dispose]();
+      }).not.toThrow();
+    });
   });
-});
 
-// ---------------------------------------------------------------------------
-// withScopeResult
-// ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // DisposalScope
+  // ---------------------------------------------------------------------------
 
-describe('withScopeResult', () => {
-  it('disposes scope and returns Ok', () => {
-    const obj = mockDeletable();
-    const result = withScopeResult((scope) => {
+  describe('DisposalScope', () => {
+    it('registers and disposes resources', () => {
+      const scope = new DisposalScope();
+      const obj = mockDeletable();
       scope.register(obj);
-      return ok(42);
+      expect(obj.deleted).toBe(false);
+      scope[Symbol.dispose]();
+      expect(obj.deleted).toBe(true);
     });
-    expect(result).toEqual({ ok: true, value: 42 });
-    expect(obj.deleted).toBe(true);
-  });
 
-  it('disposes scope on Err return', () => {
-    const obj = mockDeletable();
-    const result = withScopeResult((scope) => {
+    it('disposes in LIFO order', () => {
+      const order: number[] = [];
+      const scope = new DisposalScope();
+
+      scope.register({
+        delete() {
+          order.push(1);
+        },
+      });
+      scope.register({
+        delete() {
+          order.push(2);
+        },
+      });
+      scope.register({
+        delete() {
+          order.push(3);
+        },
+      });
+
+      scope[Symbol.dispose]();
+      expect(order).toEqual([3, 2, 1]);
+    });
+
+    it('tracks disposable objects', () => {
+      const scope = new DisposalScope();
+      let disposed = false;
+      const disposable = {
+        [Symbol.dispose]() {
+          disposed = true;
+        },
+      };
+      scope.track(disposable);
+      expect(disposed).toBe(false);
+      scope[Symbol.dispose]();
+      expect(disposed).toBe(true);
+    });
+
+    it('handles errors during disposal gracefully', () => {
+      const scope = new DisposalScope();
+      scope.register({
+        delete() {
+          throw new Error('already deleted');
+        },
+      });
+      // Should not throw
+      expect(() => {
+        scope[Symbol.dispose]();
+      }).not.toThrow();
+    });
+
+    it('can be disposed multiple times safely', () => {
+      const scope = new DisposalScope();
+      const obj = mockDeletable();
       scope.register(obj);
-      return err({ kind: 'VALIDATION' as const, code: 'TEST', message: 'test' });
+      scope[Symbol.dispose]();
+      // Second dispose should be safe (handles array cleared)
+      expect(() => {
+        scope[Symbol.dispose]();
+      }).not.toThrow();
     });
-    expect(result.ok).toBe(false);
-    expect(obj.deleted).toBe(true);
   });
 
-  it('disposes scope when fn throws', () => {
-    const obj = mockDeletable();
-    expect(() =>
-      withScopeResult<number>((scope) => {
+  // ---------------------------------------------------------------------------
+  // withScope
+  // ---------------------------------------------------------------------------
+
+  describe('withScope', () => {
+    it('auto-cleans up on return', () => {
+      const obj = mockDeletable();
+      const result = withScope((scope) => {
         scope.register(obj);
-        throw new Error('boom');
-      })
-    ).toThrow('boom');
-    expect(obj.deleted).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// withScopeResultAsync
-// ---------------------------------------------------------------------------
-
-describe('withScopeResultAsync', () => {
-  it('disposes scope and returns Ok', async () => {
-    const obj = mockDeletable();
-    const result = await withScopeResultAsync(async (scope) => {
-      scope.register(obj);
-      await Promise.resolve();
-      return ok(99);
+        return 42;
+      });
+      expect(result).toBe(42);
+      expect(obj.deleted).toBe(true);
     });
-    expect(result).toEqual({ ok: true, value: 99 });
-    expect(obj.deleted).toBe(true);
-  });
 
-  it('disposes scope on Err return', async () => {
-    const obj = mockDeletable();
-    const result = await withScopeResultAsync(async (scope) => {
-      scope.register(obj);
-      await Promise.resolve();
-      return err({ kind: 'VALIDATION' as const, code: 'ASYNC_TEST', message: 'async test' });
+    it('auto-cleans up on throw', () => {
+      const obj = mockDeletable();
+      expect(() =>
+        withScope((scope) => {
+          scope.register(obj);
+          throw new Error('test error');
+        })
+      ).toThrow('test error');
+      expect(obj.deleted).toBe(true);
     });
-    expect(result.ok).toBe(false);
-    expect(obj.deleted).toBe(true);
+
+    it('works with kernel objects', () => {
+      const result = withScope((scope) => {
+        const pnt = makeOcPnt();
+        scope.register(pnt);
+        return true;
+      });
+      expect(result).toBe(true);
+    });
   });
 
-  it('disposes scope when fn throws', async () => {
-    const obj = mockDeletable();
-    await expect(
-      withScopeResultAsync<number>(async (scope) => {
+  // ---------------------------------------------------------------------------
+  // withScopeResult
+  // ---------------------------------------------------------------------------
+
+  describe('withScopeResult', () => {
+    it('disposes scope and returns Ok', () => {
+      const obj = mockDeletable();
+      const result = withScopeResult((scope) => {
+        scope.register(obj);
+        return ok(42);
+      });
+      expect(result).toEqual({ ok: true, value: 42 });
+      expect(obj.deleted).toBe(true);
+    });
+
+    it('disposes scope on Err return', () => {
+      const obj = mockDeletable();
+      const result = withScopeResult((scope) => {
+        scope.register(obj);
+        return err({ kind: 'VALIDATION' as const, code: 'TEST', message: 'test' });
+      });
+      expect(result.ok).toBe(false);
+      expect(obj.deleted).toBe(true);
+    });
+
+    it('disposes scope when fn throws', () => {
+      const obj = mockDeletable();
+      expect(() =>
+        withScopeResult<number>((scope) => {
+          scope.register(obj);
+          throw new Error('boom');
+        })
+      ).toThrow('boom');
+      expect(obj.deleted).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // withScopeResultAsync
+  // ---------------------------------------------------------------------------
+
+  describe('withScopeResultAsync', () => {
+    it('disposes scope and returns Ok', async () => {
+      const obj = mockDeletable();
+      const result = await withScopeResultAsync(async (scope) => {
         scope.register(obj);
         await Promise.resolve();
-        throw new Error('async boom');
-      })
-    ).rejects.toThrow('async boom');
-    expect(obj.deleted).toBe(true);
-  });
-
-  it('resources remain live throughout async fn execution', async () => {
-    const obj = mockDeletable();
-    const result = await withScopeResultAsync(async (scope) => {
-      scope.register(obj);
-      // Simulate an async step mid-execution
-      await Promise.resolve();
-      // Resource must still be live after the await
-      expect(obj.deleted).toBe(false);
-      return ok(42);
+        return ok(99);
+      });
+      expect(result).toEqual({ ok: true, value: 99 });
+      expect(obj.deleted).toBe(true);
     });
-    expect(result).toEqual({ ok: true, value: 42 });
-    expect(obj.deleted).toBe(true); // disposed after fn resolves
-  });
-});
 
-// ---------------------------------------------------------------------------
-// isLive
-// ---------------------------------------------------------------------------
+    it('disposes scope on Err return', async () => {
+      const obj = mockDeletable();
+      const result = await withScopeResultAsync(async (scope) => {
+        scope.register(obj);
+        await Promise.resolve();
+        return err({ kind: 'VALIDATION' as const, code: 'ASYNC_TEST', message: 'async test' });
+      });
+      expect(result.ok).toBe(false);
+      expect(obj.deleted).toBe(true);
+    });
 
-describe('isLive', () => {
-  it('returns true for a live KernelHandle', () => {
-    const pnt = makeOcPnt();
-    const handle = createKernelHandle(pnt);
-    expect(isLive(handle)).toBe(true);
+    it('disposes scope when fn throws', async () => {
+      const obj = mockDeletable();
+      await expect(
+        withScopeResultAsync<number>(async (scope) => {
+          scope.register(obj);
+          await Promise.resolve();
+          throw new Error('async boom');
+        })
+      ).rejects.toThrow('async boom');
+      expect(obj.deleted).toBe(true);
+    });
+
+    it('resources remain live throughout async fn execution', async () => {
+      const obj = mockDeletable();
+      const result = await withScopeResultAsync(async (scope) => {
+        scope.register(obj);
+        // Simulate an async step mid-execution
+        await Promise.resolve();
+        // Resource must still be live after the await
+        expect(obj.deleted).toBe(false);
+        return ok(42);
+      });
+      expect(result).toEqual({ ok: true, value: 42 });
+      expect(obj.deleted).toBe(true); // disposed after fn resolves
+    });
   });
 
-  it('returns false for a disposed KernelHandle', () => {
-    const pnt = makeOcPnt();
-    const handle = createKernelHandle(pnt);
-    handle[Symbol.dispose]();
-    expect(isLive(handle)).toBe(false);
-  });
+  // ---------------------------------------------------------------------------
+  // isLive
+  // ---------------------------------------------------------------------------
 
-  it('returns true for a live ShapeHandle, false after dispose', () => {
-    const oc = getKernel().oc;
-    const ocShape = new oc.BRepPrimAPI_MakeBox_2(1, 1, 1).Shape();
-    const handle = createHandle(ocShape);
-    expect(isLive(handle)).toBe(true);
-    handle[Symbol.dispose]();
-    expect(isLive(handle)).toBe(false);
+  describe('isLive', () => {
+    it('returns true for a live KernelHandle', () => {
+      const pnt = makeOcPnt();
+      const handle = createKernelHandle(pnt);
+      expect(isLive(handle)).toBe(true);
+    });
+
+    it('returns false for a disposed KernelHandle', () => {
+      const pnt = makeOcPnt();
+      const handle = createKernelHandle(pnt);
+      handle[Symbol.dispose]();
+      expect(isLive(handle)).toBe(false);
+    });
+
+    it('returns true for a live ShapeHandle, false after dispose', () => {
+      const oc = getKernel().oc;
+      const ocShape = new oc.BRepPrimAPI_MakeBox_2(1, 1, 1).Shape();
+      const handle = createHandle(ocShape);
+      expect(isLive(handle)).toBe(true);
+      handle[Symbol.dispose]();
+      expect(isLive(handle)).toBe(false);
+    });
   });
-});
 });

--- a/tests/fn-extrudeFns.test.ts
+++ b/tests/fn-extrudeFns.test.ts
@@ -26,173 +26,173 @@ import { createFace } from '../src/core/shapeTypes.js';
 import { getKernel } from '../src/kernel/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: extrudeFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-function makeNullFace() {
-  const oc = getKernel().oc;
-  return createFace(new oc.TopoDS_Face());
-}
+  function makeNullFace() {
+    const oc = getKernel().oc;
+    return createFace(new oc.TopoDS_Face());
+  }
 
-describe('extrude', () => {
-  it('extrudes a rectangle into a box', () => {
-    const rect = sketchRectangle(10, 20);
-    const f = castShape(rect.face().wrapped);
-    const result = extrude(f, [0, 0, 30]);
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    expect(isSolid(solid)).toBe(true);
-    expect(measureVolume(solid)).toBeCloseTo(10 * 20 * 30, 0);
-  });
-
-  it('extrudes a circle into a cylinder', () => {
-    const c = sketchCircle(5);
-    const f = castShape(c.face().wrapped);
-    const result = extrude(f, [0, 0, 10]);
-    expect(isOk(result)).toBe(true);
-    expect(measureVolume(unwrap(result))).toBeCloseTo(Math.PI * 25 * 10, 0);
-  });
-});
-
-describe('extrude error paths', () => {
-  it('returns error for null face', () => {
-    const result = extrude(makeNullFace(), [0, 0, 10]);
-    expect(isErr(result)).toBe(true);
-  });
-
-  it('returns error for zero-length extrusion vector', () => {
-    const f = castShape(sketchRectangle(10, 10).face().wrapped);
-    const result = extrude(f, [0, 0, 0]);
-    expect(isErr(result)).toBe(true);
-  });
-});
-
-describe('revolve', () => {
-  it('revolves a rectangle 360 degrees into a cylinder', () => {
-    const rect = sketchRectangle(2, 5, { origin: [6, 0] });
-    const f = castShape(rect.face().wrapped);
-    const result = revolve(f, { at: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
-    expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
-  });
-
-  it('revolves a rectangle 90 degrees', () => {
-    const rect = sketchRectangle(2, 5, { origin: [6, 0] });
-    const f = castShape(rect.face().wrapped);
-    const result = revolve(f, { at: [0, 0, 0], axis: [0, 1, 0], angle: 90 });
-    expect(isOk(result)).toBe(true);
-  });
-});
-
-describe('revolve error paths', () => {
-  it('returns error for null face', () => {
-    const result = revolve(makeNullFace(), { at: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
-    expect(isErr(result)).toBe(true);
-  });
-});
-
-describe('sweep', () => {
-  it('sweeps a circle along a line', () => {
-    const c = sketchCircle(2);
-    const profile = castShape(c.wire.wrapped) as Wire;
-    const e = line([0, 0, 0], [0, 0, 20]);
-    const spine = castShape(unwrap(wire([e])).wrapped) as Wire;
-    const result = sweep(profile, spine);
-    expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
-  });
-});
-
-describe('sweep simple mode', () => {
-  it('sweeps in simple pipe mode', () => {
-    const c = sketchCircle(2);
-    const profile = castShape(c.wire.wrapped) as Wire;
-    const e = line([0, 0, 0], [0, 0, 20]);
-    const spine = castShape(unwrap(wire([e])).wrapped) as Wire;
-    const result = sweep(profile, spine, { mode: 'simple' });
-    expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
-  });
-});
-
-describe('complexExtrude', () => {
-  it('extrudes with linear profile', () => {
-    const c = sketchCircle(5);
-    const w = castShape(c.wire.wrapped) as Wire;
-    const result = complexExtrude(w, [0, 0, 0], [0, 0, 10], {
-      profile: 'linear',
-      endFactor: 0.5,
+  describe('extrude', () => {
+    it('extrudes a rectangle into a box', () => {
+      const rect = sketchRectangle(10, 20);
+      const f = castShape(rect.face().wrapped);
+      const result = extrude(f, [0, 0, 30]);
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      expect(isSolid(solid)).toBe(true);
+      expect(measureVolume(solid)).toBeCloseTo(10 * 20 * 30, 0);
     });
-    expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
-  });
 
-  it('extrudes with s-curve profile', () => {
-    const c = sketchCircle(5);
-    const w = castShape(c.wire.wrapped) as Wire;
-    const result = complexExtrude(w, [0, 0, 0], [0, 0, 10], {
-      profile: 's-curve',
-      endFactor: 0.5,
+    it('extrudes a circle into a cylinder', () => {
+      const c = sketchCircle(5);
+      const f = castShape(c.face().wrapped);
+      const result = extrude(f, [0, 0, 10]);
+      expect(isOk(result)).toBe(true);
+      expect(measureVolume(unwrap(result))).toBeCloseTo(Math.PI * 25 * 10, 0);
     });
-    expect(isOk(result)).toBe(true);
   });
 
-  it('extrudes without profile (simple)', () => {
-    const c = sketchCircle(5);
-    const w = castShape(c.wire.wrapped) as Wire;
-    const result = complexExtrude(w, [0, 0, 0], [0, 0, 10]);
-    expect(isOk(result)).toBe(true);
-  });
-});
+  describe('extrude error paths', () => {
+    it('returns error for null face', () => {
+      const result = extrude(makeNullFace(), [0, 0, 10]);
+      expect(isErr(result)).toBe(true);
+    });
 
-describe('twistExtrude', () => {
-  it('extrudes with twist', () => {
-    const rect = sketchRectangle(6, 6);
-    const w = castShape(rect.wire.wrapped) as Wire;
-    const result = twistExtrude(w, 90, [0, 0, 0], [0, 0, 20]);
-    expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
+    it('returns error for zero-length extrusion vector', () => {
+      const f = castShape(sketchRectangle(10, 10).face().wrapped);
+      const result = extrude(f, [0, 0, 0]);
+      expect(isErr(result)).toBe(true);
+    });
   });
 
-  it('returns error for zero twist angle', () => {
-    const rect = sketchRectangle(6, 6);
-    const w = castShape(rect.wire.wrapped) as Wire;
-    const result = twistExtrude(w, 0, [0, 0, 0], [0, 0, 20]);
-    expect(isErr(result)).toBe(true);
+  describe('revolve', () => {
+    it('revolves a rectangle 360 degrees into a cylinder', () => {
+      const rect = sketchRectangle(2, 5, { origin: [6, 0] });
+      const f = castShape(rect.face().wrapped);
+      const result = revolve(f, { at: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
+      expect(isOk(result)).toBe(true);
+      expect(isShape3D(unwrap(result))).toBe(true);
+    });
+
+    it('revolves a rectangle 90 degrees', () => {
+      const rect = sketchRectangle(2, 5, { origin: [6, 0] });
+      const f = castShape(rect.face().wrapped);
+      const result = revolve(f, { at: [0, 0, 0], axis: [0, 1, 0], angle: 90 });
+      expect(isOk(result)).toBe(true);
+    });
   });
 
-  it('returns error for zero-length normal', () => {
-    const rect = sketchRectangle(6, 6);
-    const w = castShape(rect.wire.wrapped) as Wire;
-    const result = twistExtrude(w, 90, [0, 0, 0], [0, 0, 0]);
-    expect(isErr(result)).toBe(true);
+  describe('revolve error paths', () => {
+    it('returns error for null face', () => {
+      const result = revolve(makeNullFace(), { at: [0, 0, 0], axis: [0, 1, 0], angle: 360 });
+      expect(isErr(result)).toBe(true);
+    });
   });
-});
 
-describe('complexExtrude error paths', () => {
-  it('returns error for zero-length extrusion normal', () => {
-    const c = sketchCircle(5);
-    const w = castShape(c.wire.wrapped) as Wire;
-    const result = complexExtrude(w, [0, 0, 0], [0, 0, 0]);
-    expect(isErr(result)).toBe(true);
+  describe('sweep', () => {
+    it('sweeps a circle along a line', () => {
+      const c = sketchCircle(2);
+      const profile = castShape(c.wire.wrapped) as Wire;
+      const e = line([0, 0, 0], [0, 0, 20]);
+      const spine = castShape(unwrap(wire([e])).wrapped) as Wire;
+      const result = sweep(profile, spine);
+      expect(isOk(result)).toBe(true);
+      expect(isShape3D(unwrap(result))).toBe(true);
+    });
   });
-});
 
-describe('supportExtrude', () => {
-  it('sweeps a profile along a support surface from a cylinder face', () => {
-    const c = sketchCircle(2);
-    const w = castShape(c.wire.wrapped) as Wire;
-    // Use the lateral face of a cylinder as the support surface
-    const cyl = cylinder(10, 20);
-    const faces = getFaces(cyl);
-    // The lateral face (largest area face) is the support surface
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test array indexing
-    const supportFace = faces[0]!;
-    const result = supportExtrude(w, [10, 0, 0], [0, 0, 10], supportFace.wrapped);
-    // supportExtrude returns a Result — it may fail for complex geometry
-    // but should not throw
-    expect(typeof result.ok).toBe('boolean');
+  describe('sweep simple mode', () => {
+    it('sweeps in simple pipe mode', () => {
+      const c = sketchCircle(2);
+      const profile = castShape(c.wire.wrapped) as Wire;
+      const e = line([0, 0, 0], [0, 0, 20]);
+      const spine = castShape(unwrap(wire([e])).wrapped) as Wire;
+      const result = sweep(profile, spine, { mode: 'simple' });
+      expect(isOk(result)).toBe(true);
+      expect(isShape3D(unwrap(result))).toBe(true);
+    });
   });
-});
+
+  describe('complexExtrude', () => {
+    it('extrudes with linear profile', () => {
+      const c = sketchCircle(5);
+      const w = castShape(c.wire.wrapped) as Wire;
+      const result = complexExtrude(w, [0, 0, 0], [0, 0, 10], {
+        profile: 'linear',
+        endFactor: 0.5,
+      });
+      expect(isOk(result)).toBe(true);
+      expect(isShape3D(unwrap(result))).toBe(true);
+    });
+
+    it('extrudes with s-curve profile', () => {
+      const c = sketchCircle(5);
+      const w = castShape(c.wire.wrapped) as Wire;
+      const result = complexExtrude(w, [0, 0, 0], [0, 0, 10], {
+        profile: 's-curve',
+        endFactor: 0.5,
+      });
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('extrudes without profile (simple)', () => {
+      const c = sketchCircle(5);
+      const w = castShape(c.wire.wrapped) as Wire;
+      const result = complexExtrude(w, [0, 0, 0], [0, 0, 10]);
+      expect(isOk(result)).toBe(true);
+    });
+  });
+
+  describe('twistExtrude', () => {
+    it('extrudes with twist', () => {
+      const rect = sketchRectangle(6, 6);
+      const w = castShape(rect.wire.wrapped) as Wire;
+      const result = twistExtrude(w, 90, [0, 0, 0], [0, 0, 20]);
+      expect(isOk(result)).toBe(true);
+      expect(isShape3D(unwrap(result))).toBe(true);
+    });
+
+    it('returns error for zero twist angle', () => {
+      const rect = sketchRectangle(6, 6);
+      const w = castShape(rect.wire.wrapped) as Wire;
+      const result = twistExtrude(w, 0, [0, 0, 0], [0, 0, 20]);
+      expect(isErr(result)).toBe(true);
+    });
+
+    it('returns error for zero-length normal', () => {
+      const rect = sketchRectangle(6, 6);
+      const w = castShape(rect.wire.wrapped) as Wire;
+      const result = twistExtrude(w, 90, [0, 0, 0], [0, 0, 0]);
+      expect(isErr(result)).toBe(true);
+    });
+  });
+
+  describe('complexExtrude error paths', () => {
+    it('returns error for zero-length extrusion normal', () => {
+      const c = sketchCircle(5);
+      const w = castShape(c.wire.wrapped) as Wire;
+      const result = complexExtrude(w, [0, 0, 0], [0, 0, 0]);
+      expect(isErr(result)).toBe(true);
+    });
+  });
+
+  describe('supportExtrude', () => {
+    it('sweeps a profile along a support surface from a cylinder face', () => {
+      const c = sketchCircle(2);
+      const w = castShape(c.wire.wrapped) as Wire;
+      // Use the lateral face of a cylinder as the support surface
+      const cyl = cylinder(10, 20);
+      const faces = getFaces(cyl);
+      // The lateral face (largest area face) is the support surface
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test array indexing
+      const supportFace = faces[0]!;
+      const result = supportExtrude(w, [10, 0, 0], [0, 0, 10], supportFace.wrapped);
+      // supportExtrude returns a Result — it may fail for complex geometry
+      // but should not throw
+      expect(typeof result.ok).toBe('boolean');
+    });
+  });
 });

--- a/tests/fn-guidedSweepFns.test.ts
+++ b/tests/fn-guidedSweepFns.test.ts
@@ -6,69 +6,69 @@ import { DisposalScope } from '../src/core/disposal.js';
 import type { Wire } from '../src/core/shapeTypes.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: guidedSweepFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-function makeCircleWire(radius: number): Wire {
-  const oc = getKernel().oc;
-  const scope = new DisposalScope();
-  const ax = scope.register(
-    new oc.gp_Ax2_3(
-      scope.register(new oc.gp_Pnt_3(0, 0, 0)),
-      scope.register(new oc.gp_Dir_4(0, 0, 1))
-    )
-  );
-  const circ = scope.register(new oc.gp_Circ_2(ax, radius));
-  const em = scope.register(new oc.BRepBuilderAPI_MakeEdge_8(circ));
-  const wm = scope.register(new oc.BRepBuilderAPI_MakeWire_2(em.Edge()));
-  return castShape(wm.Wire()) as Wire;
-}
+  function makeCircleWire(radius: number): Wire {
+    const oc = getKernel().oc;
+    const scope = new DisposalScope();
+    const ax = scope.register(
+      new oc.gp_Ax2_3(
+        scope.register(new oc.gp_Pnt_3(0, 0, 0)),
+        scope.register(new oc.gp_Dir_4(0, 0, 1))
+      )
+    );
+    const circ = scope.register(new oc.gp_Circ_2(ax, radius));
+    const em = scope.register(new oc.BRepBuilderAPI_MakeEdge_8(circ));
+    const wm = scope.register(new oc.BRepBuilderAPI_MakeWire_2(em.Edge()));
+    return castShape(wm.Wire()) as Wire;
+  }
 
-function makeLineWire(
-  x1: number,
-  y1: number,
-  z1: number,
-  x2: number,
-  y2: number,
-  z2: number
-): Wire {
-  const oc = getKernel().oc;
-  const scope = new DisposalScope();
-  const em = scope.register(
-    new oc.BRepBuilderAPI_MakeEdge_3(
-      scope.register(new oc.gp_Pnt_3(x1, y1, z1)),
-      scope.register(new oc.gp_Pnt_3(x2, y2, z2))
-    )
-  );
-  const wm = scope.register(new oc.BRepBuilderAPI_MakeWire_2(em.Edge()));
-  return castShape(wm.Wire()) as Wire;
-}
+  function makeLineWire(
+    x1: number,
+    y1: number,
+    z1: number,
+    x2: number,
+    y2: number,
+    z2: number
+  ): Wire {
+    const oc = getKernel().oc;
+    const scope = new DisposalScope();
+    const em = scope.register(
+      new oc.BRepBuilderAPI_MakeEdge_3(
+        scope.register(new oc.gp_Pnt_3(x1, y1, z1)),
+        scope.register(new oc.gp_Pnt_3(x2, y2, z2))
+      )
+    );
+    const wm = scope.register(new oc.BRepBuilderAPI_MakeWire_2(em.Edge()));
+    return castShape(wm.Wire()) as Wire;
+  }
 
-describe('guidedSweep', () => {
-  it('sweeps a circle along a line producing a solid', () => {
-    const profile = makeCircleWire(5);
-    const spine = makeLineWire(0, 0, 0, 0, 0, 20);
-    // No guides — basic sweep as fallback
-    const result = guidedSweep(profile, spine, []);
-    expect(isOk(result)).toBe(true);
-    const shape = unwrap(result);
-    expect(isSolid(shape)).toBe(true);
-    expect(measureVolume(shape)).toBeGreaterThan(1000);
+  describe('guidedSweep', () => {
+    it('sweeps a circle along a line producing a solid', () => {
+      const profile = makeCircleWire(5);
+      const spine = makeLineWire(0, 0, 0, 0, 0, 20);
+      // No guides — basic sweep as fallback
+      const result = guidedSweep(profile, spine, []);
+      expect(isOk(result)).toBe(true);
+      const shape = unwrap(result);
+      expect(isSolid(shape)).toBe(true);
+      expect(measureVolume(shape)).toBeGreaterThan(1000);
+    });
+
+    it('sweeps with an auxiliary guide wire', () => {
+      const profile = makeCircleWire(5);
+      const spine = makeLineWire(0, 0, 0, 0, 0, 20);
+      const guide = makeLineWire(5, 0, 0, 8, 0, 20);
+      const result = guidedSweep(profile, spine, [guide]);
+      // May succeed or fail depending on kernel WASM guide support
+      // At minimum, the function should not crash
+      if (isOk(result)) {
+        expect(isSolid(unwrap(result))).toBe(true);
+        expect(measureVolume(unwrap(result))).toBeGreaterThan(500);
+      }
+      // If it fails, that's acceptable — guide sweep is best-effort in WASM
+    });
   });
-
-  it('sweeps with an auxiliary guide wire', () => {
-    const profile = makeCircleWire(5);
-    const spine = makeLineWire(0, 0, 0, 0, 0, 20);
-    const guide = makeLineWire(5, 0, 0, 8, 0, 20);
-    const result = guidedSweep(profile, spine, [guide]);
-    // May succeed or fail depending on kernel WASM guide support
-    // At minimum, the function should not crash
-    if (isOk(result)) {
-      expect(isSolid(unwrap(result))).toBe(true);
-      expect(measureVolume(unwrap(result))).toBeGreaterThan(500);
-    }
-    // If it fails, that's acceptable — guide sweep is best-effort in WASM
-  });
-});
 });

--- a/tests/fn-hullFns.test.ts
+++ b/tests/fn-hullFns.test.ts
@@ -17,95 +17,95 @@ import {
 import type { Shape3D } from '../src/core/shapeTypes.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: hullFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-describe('hull', () => {
-  it('returns error for empty array', () => {
-    const result = hull([]);
-    expect(isErr(result)).toBe(true);
-    const error = unwrapErr(result);
-    expect(error.message).toContain('at least one shape');
-  });
+  describe('hull', () => {
+    it('returns error for empty array', () => {
+      const result = hull([]);
+      expect(isErr(result)).toBe(true);
+      const error = unwrapErr(result);
+      expect(error.message).toContain('at least one shape');
+    });
 
-  it('hull of a single box returns a solid with approximately same volume', () => {
-    const b = box(10, 10, 10);
-    const result = hull([b]);
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    expect(isSolid(solid)).toBe(true);
-    const vol = measureVolume(solid);
-    expect(vol).toBeCloseTo(1000, 0);
-  });
+    it('hull of a single box returns a solid with approximately same volume', () => {
+      const b = box(10, 10, 10);
+      const result = hull([b]);
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      expect(isSolid(solid)).toBe(true);
+      const vol = measureVolume(solid);
+      expect(vol).toBeCloseTo(1000, 0);
+    });
 
-  it('hull of two separated boxes has volume greater than sum', () => {
-    const b1 = box(10, 10, 10);
-    const b2 = translate(box(10, 10, 10), [20, 0, 0]) as Shape3D;
-    const result = hull([b1, b2]);
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    expect(isSolid(solid)).toBe(true);
-    const vol = measureVolume(solid);
-    expect(vol).toBeGreaterThan(2000);
-  });
+    it('hull of two separated boxes has volume greater than sum', () => {
+      const b1 = box(10, 10, 10);
+      const b2 = translate(box(10, 10, 10), [20, 0, 0]) as Shape3D;
+      const result = hull([b1, b2]);
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      expect(isSolid(solid)).toBe(true);
+      const vol = measureVolume(solid);
+      expect(vol).toBeGreaterThan(2000);
+    });
 
-  it('hull of a sphere has approximately correct volume', () => {
-    const r = 10;
-    const s = sphere(r);
-    const result = hull([s]);
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    const vol = measureVolume(solid);
-    const expected = (4 / 3) * Math.PI * r ** 3;
-    // Mesh-based hull is an approximation, allow 15% tolerance
-    expect(vol).toBeGreaterThan(expected * 0.85);
-    expect(vol).toBeLessThan(expected * 1.15);
-  });
+    it('hull of a sphere has approximately correct volume', () => {
+      const r = 10;
+      const s = sphere(r);
+      const result = hull([s]);
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      const vol = measureVolume(solid);
+      const expected = (4 / 3) * Math.PI * r ** 3;
+      // Mesh-based hull is an approximation, allow 15% tolerance
+      expect(vol).toBeGreaterThan(expected * 0.85);
+      expect(vol).toBeLessThan(expected * 1.15);
+    });
 
-  it('hull of scattered translated small boxes forms convex envelope', () => {
-    const boxes = [
-      box(1, 1, 1),
-      translate(box(1, 1, 1), [50, 0, 0]) as Shape3D,
-      translate(box(1, 1, 1), [0, 50, 0]) as Shape3D,
-      translate(box(1, 1, 1), [0, 0, 50]) as Shape3D,
-    ];
-    const result = hull(boxes);
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    expect(isSolid(solid)).toBe(true);
-    const vol = measureVolume(solid);
-    // Should form a roughly tetrahedral shape — volume well above sum of small boxes (4)
-    expect(vol).toBeGreaterThan(1000);
-  });
+    it('hull of scattered translated small boxes forms convex envelope', () => {
+      const boxes = [
+        box(1, 1, 1),
+        translate(box(1, 1, 1), [50, 0, 0]) as Shape3D,
+        translate(box(1, 1, 1), [0, 50, 0]) as Shape3D,
+        translate(box(1, 1, 1), [0, 0, 50]) as Shape3D,
+      ];
+      const result = hull(boxes);
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      expect(isSolid(solid)).toBe(true);
+      const vol = measureVolume(solid);
+      // Should form a roughly tetrahedral shape — volume well above sum of small boxes (4)
+      expect(vol).toBeGreaterThan(1000);
+    });
 
-  it('returns error when array contains a null shape', () => {
-    const oc = getKernel().oc;
-    const nullShape = createSolid(new oc.TopoDS_Solid()) as Shape3D;
-    const result = hull([nullShape]);
-    expect(isErr(result)).toBe(true);
-  });
+    it('returns error when array contains a null shape', () => {
+      const oc = getKernel().oc;
+      const nullShape = createSolid(new oc.TopoDS_Solid()) as Shape3D;
+      const result = hull([nullShape]);
+      expect(isErr(result)).toBe(true);
+    });
 
-  it('respects custom tolerance option', () => {
-    const b = box(10, 10, 10);
-    const result = hull([b], { tolerance: 0.01 });
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    expect(isSolid(solid)).toBe(true);
-    const vol = measureVolume(solid);
-    expect(vol).toBeCloseTo(1000, 0);
-  });
+    it('respects custom tolerance option', () => {
+      const b = box(10, 10, 10);
+      const result = hull([b], { tolerance: 0.01 });
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      expect(isSolid(solid)).toBe(true);
+      const vol = measureVolume(solid);
+      expect(vol).toBeCloseTo(1000, 0);
+    });
 
-  it('hull of mixed shape types (box and sphere)', () => {
-    const b = box(5, 5, 5);
-    const s = sphere(3);
-    const result = hull([b, s]);
-    expect(isOk(result)).toBe(true);
-    const solid = unwrap(result);
-    expect(isSolid(solid)).toBe(true);
-    const vol = measureVolume(solid);
-    // Hull should be at least as large as the box
-    expect(vol).toBeGreaterThanOrEqual(125);
+    it('hull of mixed shape types (box and sphere)', () => {
+      const b = box(5, 5, 5);
+      const s = sphere(3);
+      const result = hull([b, s]);
+      expect(isOk(result)).toBe(true);
+      const solid = unwrap(result);
+      expect(isSolid(solid)).toBe(true);
+      const vol = measureVolume(solid);
+      // Hull should be at least as large as the box
+      expect(vol).toBeGreaterThanOrEqual(125);
+    });
   });
-});
 });

--- a/tests/fn-igesFns.test.ts
+++ b/tests/fn-igesFns.test.ts
@@ -6,31 +6,31 @@ import { importIGES, exportIGES } from '../src/index.js';
 let oc: any;
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: igesFns', () => {
-beforeAll(async () => {
-  oc = await initOCCT();
-}, 30000);
+  beforeAll(async () => {
+    oc = await initOCCT();
+  }, 30000);
 
-describe('IGES module exports', () => {
-  it('exports importIGES function', () => {
-    expect(typeof importIGES).toBe('function');
+  describe('IGES module exports', () => {
+    it('exports importIGES function', () => {
+      expect(typeof importIGES).toBe('function');
+    });
+
+    it('exports exportIGES function', () => {
+      expect(typeof exportIGES).toBe('function');
+    });
   });
 
-  it('exports exportIGES function', () => {
-    expect(typeof exportIGES).toBe('function');
+  describe('IGES import/export (requires WASM rebuild)', () => {
+    it('IGES classes availability', () => {
+      const hasIGES = typeof oc.IGESControl_Reader_1 === 'function';
+      // This test documents that IGES support requires a WASM rebuild.
+      // Once IGESControl_Reader and IGESControl_Writer are added to
+      // defaults.yml and the WASM is rebuilt, this test will pass.
+      if (!hasIGES) {
+        console.warn('IGES classes not in WASM build — skipping IGES integration tests');
+        return;
+      }
+      expect(hasIGES).toBe(true);
+    });
   });
-});
-
-describe('IGES import/export (requires WASM rebuild)', () => {
-  it('IGES classes availability', () => {
-    const hasIGES = typeof oc.IGESControl_Reader_1 === 'function';
-    // This test documents that IGES support requires a WASM rebuild.
-    // Once IGESControl_Reader and IGESControl_Writer are added to
-    // defaults.yml and the WASM is rebuilt, this test will pass.
-    if (!hasIGES) {
-      console.warn('IGES classes not in WASM build — skipping IGES integration tests');
-      return;
-    }
-    expect(hasIGES).toBe(true);
-  });
-});
 });

--- a/tests/fn-interferenceFns.test.ts
+++ b/tests/fn-interferenceFns.test.ts
@@ -15,153 +15,153 @@ import {
 import type { Shape3D } from '../src/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: interferenceFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-describe('checkInterference', () => {
-  it('detects overlapping boxes', () => {
-    const b1 = box(10, 10, 10);
-    const b2 = translate(box(10, 10, 10), [5, 5, 5]);
+  describe('checkInterference', () => {
+    it('detects overlapping boxes', () => {
+      const b1 = box(10, 10, 10);
+      const b2 = translate(box(10, 10, 10), [5, 5, 5]);
 
-    const result = unwrap(checkInterference(b1, b2));
-    expect(result.hasInterference).toBe(true);
-    expect(result.minDistance).toBeCloseTo(0, 5);
+      const result = unwrap(checkInterference(b1, b2));
+      expect(result.hasInterference).toBe(true);
+      expect(result.minDistance).toBeCloseTo(0, 5);
+    });
+
+    it('detects touching boxes', () => {
+      const b1 = box(10, 10, 10);
+      const b2 = translate(box(10, 10, 10), [10, 0, 0]);
+
+      const result = unwrap(checkInterference(b1, b2));
+      expect(result.hasInterference).toBe(true);
+      expect(result.minDistance).toBeCloseTo(0, 5);
+    });
+
+    it('detects separated shapes', () => {
+      const b1 = box(10, 10, 10);
+      const b2 = translate(box(10, 10, 10), [20, 0, 0]);
+
+      const result = unwrap(checkInterference(b1, b2));
+      expect(result.hasInterference).toBe(false);
+      expect(result.minDistance).toBeCloseTo(10, 3);
+    });
+
+    it('returns closest points on separated shapes', () => {
+      const b1 = box(10, 10, 10);
+      const b2 = translate(box(10, 10, 10), [20, 0, 0]);
+
+      const result = unwrap(checkInterference(b1, b2));
+      // Closest point on b1 should be near x=10, on b2 near x=20
+      expect(result.pointOnShape1[0]).toBeCloseTo(10, 3);
+      expect(result.pointOnShape2[0]).toBeCloseTo(20, 3);
+    });
+
+    it('works with spheres', () => {
+      const s1 = sphere(5);
+      const s2 = translate(sphere(5), [3, 0, 0]);
+
+      const result = unwrap(checkInterference(s1, s2));
+      expect(result.hasInterference).toBe(true);
+      expect(result.minDistance).toBeCloseTo(0, 5);
+    });
+
+    it('detects separated spheres', () => {
+      const s1 = sphere(5);
+      const s2 = translate(sphere(5), [20, 0, 0]);
+
+      const result = unwrap(checkInterference(s1, s2));
+      expect(result.hasInterference).toBe(false);
+      expect(result.minDistance).toBeCloseTo(10, 2);
+    });
+
+    it('respects custom tolerance', () => {
+      const b1 = box(10, 10, 10);
+      const b2 = translate(box(10, 10, 10), [10.005, 0, 0]);
+
+      // Default tolerance (1e-6) — should not detect interference
+      const strict = unwrap(checkInterference(b1, b2));
+      expect(strict.hasInterference).toBe(false);
+
+      // Larger tolerance — should detect as interference
+      const lenient = unwrap(checkInterference(b1, b2, 0.01));
+      expect(lenient.hasInterference).toBe(true);
+    });
   });
 
-  it('detects touching boxes', () => {
-    const b1 = box(10, 10, 10);
-    const b2 = translate(box(10, 10, 10), [10, 0, 0]);
+  describe('checkAllInterferences', () => {
+    it('returns empty array for non-interfering shapes', () => {
+      const shapes = [
+        box(5, 5, 5),
+        translate(box(5, 5, 5), [10, 0, 0]),
+        translate(box(5, 5, 5), [20, 0, 0]),
+      ];
 
-    const result = unwrap(checkInterference(b1, b2));
-    expect(result.hasInterference).toBe(true);
-    expect(result.minDistance).toBeCloseTo(0, 5);
+      const pairs = checkAllInterferences(shapes);
+      expect(pairs).toHaveLength(0);
+    });
+
+    it('detects interfering pairs in a group', () => {
+      const shapes = [
+        box(10, 10, 10),
+        translate(box(10, 10, 10), [5, 0, 0]), // overlaps with [0]
+        translate(box(10, 10, 10), [30, 0, 0]), // separate
+      ];
+
+      const pairs = checkAllInterferences(shapes);
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0]!.i).toBe(0); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      expect(pairs[0]!.j).toBe(1); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      expect(pairs[0]!.result.hasInterference).toBe(true); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    });
+
+    it('returns multiple pairs when multiple shapes interfere', () => {
+      const shapes = [
+        box(10, 10, 10),
+        translate(box(10, 10, 10), [5, 0, 0]),
+        translate(box(10, 10, 10), [8, 0, 0]),
+      ];
+
+      const pairs = checkAllInterferences(shapes);
+      // [0]-[1] overlap, [0]-[2] overlap, [1]-[2] overlap
+      expect(pairs).toHaveLength(3);
+    });
+
+    it('handles single shape gracefully', () => {
+      const pairs = checkAllInterferences([box(5, 5, 5)]);
+      expect(pairs).toHaveLength(0);
+    });
+
+    it('handles empty array', () => {
+      const pairs = checkAllInterferences([]);
+      expect(pairs).toHaveLength(0);
+    });
   });
 
-  it('detects separated shapes', () => {
-    const b1 = box(10, 10, 10);
-    const b2 = translate(box(10, 10, 10), [20, 0, 0]);
+  // ---------------------------------------------------------------------------
+  // Null-shape pre-validation tests
+  // ---------------------------------------------------------------------------
 
-    const result = unwrap(checkInterference(b1, b2));
-    expect(result.hasInterference).toBe(false);
-    expect(result.minDistance).toBeCloseTo(10, 3);
+  describe('null-shape pre-validation', () => {
+    function makeNullShape(): Shape3D {
+      const oc = getKernel().oc;
+      return createSolid(new oc.TopoDS_Solid()) as Shape3D;
+    }
+
+    it('checkInterference returns err for null first shape', () => {
+      const b = box(10, 10, 10);
+      const result = checkInterference(makeNullShape(), b);
+      expect(isErr(result)).toBe(true);
+      expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
+      expect(unwrapErr(result).message).toContain('first shape');
+    });
+
+    it('checkInterference returns err for null second shape', () => {
+      const b = box(10, 10, 10);
+      const result = checkInterference(b, makeNullShape());
+      expect(isErr(result)).toBe(true);
+      expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
+      expect(unwrapErr(result).message).toContain('second shape');
+    });
   });
-
-  it('returns closest points on separated shapes', () => {
-    const b1 = box(10, 10, 10);
-    const b2 = translate(box(10, 10, 10), [20, 0, 0]);
-
-    const result = unwrap(checkInterference(b1, b2));
-    // Closest point on b1 should be near x=10, on b2 near x=20
-    expect(result.pointOnShape1[0]).toBeCloseTo(10, 3);
-    expect(result.pointOnShape2[0]).toBeCloseTo(20, 3);
-  });
-
-  it('works with spheres', () => {
-    const s1 = sphere(5);
-    const s2 = translate(sphere(5), [3, 0, 0]);
-
-    const result = unwrap(checkInterference(s1, s2));
-    expect(result.hasInterference).toBe(true);
-    expect(result.minDistance).toBeCloseTo(0, 5);
-  });
-
-  it('detects separated spheres', () => {
-    const s1 = sphere(5);
-    const s2 = translate(sphere(5), [20, 0, 0]);
-
-    const result = unwrap(checkInterference(s1, s2));
-    expect(result.hasInterference).toBe(false);
-    expect(result.minDistance).toBeCloseTo(10, 2);
-  });
-
-  it('respects custom tolerance', () => {
-    const b1 = box(10, 10, 10);
-    const b2 = translate(box(10, 10, 10), [10.005, 0, 0]);
-
-    // Default tolerance (1e-6) — should not detect interference
-    const strict = unwrap(checkInterference(b1, b2));
-    expect(strict.hasInterference).toBe(false);
-
-    // Larger tolerance — should detect as interference
-    const lenient = unwrap(checkInterference(b1, b2, 0.01));
-    expect(lenient.hasInterference).toBe(true);
-  });
-});
-
-describe('checkAllInterferences', () => {
-  it('returns empty array for non-interfering shapes', () => {
-    const shapes = [
-      box(5, 5, 5),
-      translate(box(5, 5, 5), [10, 0, 0]),
-      translate(box(5, 5, 5), [20, 0, 0]),
-    ];
-
-    const pairs = checkAllInterferences(shapes);
-    expect(pairs).toHaveLength(0);
-  });
-
-  it('detects interfering pairs in a group', () => {
-    const shapes = [
-      box(10, 10, 10),
-      translate(box(10, 10, 10), [5, 0, 0]), // overlaps with [0]
-      translate(box(10, 10, 10), [30, 0, 0]), // separate
-    ];
-
-    const pairs = checkAllInterferences(shapes);
-    expect(pairs).toHaveLength(1);
-    expect(pairs[0]!.i).toBe(0); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    expect(pairs[0]!.j).toBe(1); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    expect(pairs[0]!.result.hasInterference).toBe(true); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-  });
-
-  it('returns multiple pairs when multiple shapes interfere', () => {
-    const shapes = [
-      box(10, 10, 10),
-      translate(box(10, 10, 10), [5, 0, 0]),
-      translate(box(10, 10, 10), [8, 0, 0]),
-    ];
-
-    const pairs = checkAllInterferences(shapes);
-    // [0]-[1] overlap, [0]-[2] overlap, [1]-[2] overlap
-    expect(pairs).toHaveLength(3);
-  });
-
-  it('handles single shape gracefully', () => {
-    const pairs = checkAllInterferences([box(5, 5, 5)]);
-    expect(pairs).toHaveLength(0);
-  });
-
-  it('handles empty array', () => {
-    const pairs = checkAllInterferences([]);
-    expect(pairs).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Null-shape pre-validation tests
-// ---------------------------------------------------------------------------
-
-describe('null-shape pre-validation', () => {
-  function makeNullShape(): Shape3D {
-    const oc = getKernel().oc;
-    return createSolid(new oc.TopoDS_Solid()) as Shape3D;
-  }
-
-  it('checkInterference returns err for null first shape', () => {
-    const b = box(10, 10, 10);
-    const result = checkInterference(makeNullShape(), b);
-    expect(isErr(result)).toBe(true);
-    expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
-    expect(unwrapErr(result).message).toContain('first shape');
-  });
-
-  it('checkInterference returns err for null second shape', () => {
-    const b = box(10, 10, 10);
-    const result = checkInterference(b, makeNullShape());
-    expect(isErr(result)).toBe(true);
-    expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
-    expect(unwrapErr(result).message).toContain('second shape');
-  });
-});
 });

--- a/tests/fn-kernelExpansion.test.ts
+++ b/tests/fn-kernelExpansion.test.ts
@@ -18,72 +18,72 @@ import {
 let oc: any;
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: kernelExpansion', () => {
-beforeAll(async () => {
-  oc = await initOCCT();
-}, 30000);
+  beforeAll(async () => {
+    oc = await initOCCT();
+  }, 30000);
 
-describe('classifyPointOnFace', () => {
-  it('classifies a point inside a face as "in"', () => {
-    if (!oc.BRepClass_FaceClassifier) return; // skip if not in WASM build
-    const rect = sketchRectangle(10, 10);
-    const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    const result = classifyPointOnFace(f, [0, 0, 0]);
-    expect(result).toBe('in');
+  describe('classifyPointOnFace', () => {
+    it('classifies a point inside a face as "in"', () => {
+      if (!oc.BRepClass_FaceClassifier) return; // skip if not in WASM build
+      const rect = sketchRectangle(10, 10);
+      const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      const result = classifyPointOnFace(f, [0, 0, 0]);
+      expect(result).toBe('in');
+    });
+
+    it('classifies a point outside a face as "out"', () => {
+      if (!oc.BRepClass_FaceClassifier) return;
+      const rect = sketchRectangle(10, 10);
+      const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      const result = classifyPointOnFace(f, [100, 100, 0]);
+      expect(result).toBe('out');
+    });
+
+    it('classifies a point on the boundary as "on"', () => {
+      if (!oc.BRepClass_FaceClassifier) return;
+      const rect = sketchRectangle(10, 10);
+      const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      const result = classifyPointOnFace(f, [5, 0, 0]);
+      expect(result).toBe('on');
+    });
+
+    it('throws when BRepClass_FaceClassifier is unavailable', () => {
+      if (oc.BRepClass_FaceClassifier) return; // skip if available
+      const rect = sketchRectangle(10, 10);
+      const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      expect(() => classifyPointOnFace(f, [0, 0, 0])).toThrow(
+        'BRepClass_FaceClassifier not available'
+      );
+    });
   });
 
-  it('classifies a point outside a face as "out"', () => {
-    if (!oc.BRepClass_FaceClassifier) return;
-    const rect = sketchRectangle(10, 10);
-    const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    const result = classifyPointOnFace(f, [100, 100, 0]);
-    expect(result).toBe('out');
-  });
+  describe('split', () => {
+    it('returns the original shape when no tools provided', () => {
+      const b = box(10, 10, 10);
+      const result = split(b, []);
+      expect(isOk(result)).toBe(true);
+    });
 
-  it('classifies a point on the boundary as "on"', () => {
-    if (!oc.BRepClass_FaceClassifier) return;
-    const rect = sketchRectangle(10, 10);
-    const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    const result = classifyPointOnFace(f, [5, 0, 0]);
-    expect(result).toBe('on');
-  });
+    it('splits a box with a planar face', () => {
+      if (!oc.BRepAlgoAPI_Splitter) return; // skip if not in WASM build
+      const b = box(10, 10, 10);
+      const rect = sketchRectangle(100, 100);
+      const f = rect.face();
+      const tool = translate(f, [0, 0, 5]);
 
-  it('throws when BRepClass_FaceClassifier is unavailable', () => {
-    if (oc.BRepClass_FaceClassifier) return; // skip if available
-    const rect = sketchRectangle(10, 10);
-    const f = getFaces(castShape(rect.face().wrapped))[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    expect(() => classifyPointOnFace(f, [0, 0, 0])).toThrow(
-      'BRepClass_FaceClassifier not available'
-    );
-  });
-});
+      const result = split(b, [tool]);
+      expect(isOk(result)).toBe(true);
+      const edges = getEdges(unwrap(result));
+      expect(edges.length).toBeGreaterThan(0);
+    });
 
-describe('split', () => {
-  it('returns the original shape when no tools provided', () => {
-    const b = box(10, 10, 10);
-    const result = split(b, []);
-    expect(isOk(result)).toBe(true);
+    it('returns error when BRepAlgoAPI_Splitter is unavailable', () => {
+      if (oc.BRepAlgoAPI_Splitter) return; // skip if available
+      const b = box(10, 10, 10);
+      const rect = sketchRectangle(10, 10);
+      const tool = translate(rect.face(), [0, 0, 5]);
+      const result = split(b, [tool]);
+      expect(isErr(result)).toBe(true);
+    });
   });
-
-  it('splits a box with a planar face', () => {
-    if (!oc.BRepAlgoAPI_Splitter) return; // skip if not in WASM build
-    const b = box(10, 10, 10);
-    const rect = sketchRectangle(100, 100);
-    const f = rect.face();
-    const tool = translate(f, [0, 0, 5]);
-
-    const result = split(b, [tool]);
-    expect(isOk(result)).toBe(true);
-    const edges = getEdges(unwrap(result));
-    expect(edges.length).toBeGreaterThan(0);
-  });
-
-  it('returns error when BRepAlgoAPI_Splitter is unavailable', () => {
-    if (oc.BRepAlgoAPI_Splitter) return; // skip if available
-    const b = box(10, 10, 10);
-    const rect = sketchRectangle(10, 10);
-    const tool = translate(rect.face(), [0, 0, 5]);
-    const result = split(b, [tool]);
-    expect(isErr(result)).toBe(true);
-  });
-});
 });

--- a/tests/fn-measureFns.test.ts
+++ b/tests/fn-measureFns.test.ts
@@ -26,196 +26,196 @@ import {
 import type { Shape3D, Face } from '../src/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: measureFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-describe('measureVolume', () => {
-  it('box volume', () => {
-    const b = box(10, 20, 30);
-    expect(measureVolume(castShape(b.wrapped))).toBeCloseTo(6000, 0);
+  describe('measureVolume', () => {
+    it('box volume', () => {
+      const b = box(10, 20, 30);
+      expect(measureVolume(castShape(b.wrapped))).toBeCloseTo(6000, 0);
+    });
+
+    it('sphere volume', () => {
+      const s = sphere(5);
+      expect(measureVolume(castShape(s.wrapped))).toBeCloseTo((4 / 3) * Math.PI * 125, 0);
+    });
   });
 
-  it('sphere volume', () => {
-    const s = sphere(5);
-    expect(measureVolume(castShape(s.wrapped))).toBeCloseTo((4 / 3) * Math.PI * 125, 0);
-  });
-});
+  describe('measureArea', () => {
+    it('box surface area', () => {
+      const b = box(10, 20, 30);
+      expect(measureArea(castShape(b.wrapped))).toBeCloseTo(2200, 0);
+    });
 
-describe('measureArea', () => {
-  it('box surface area', () => {
-    const b = box(10, 20, 30);
-    expect(measureArea(castShape(b.wrapped))).toBeCloseTo(2200, 0);
-  });
-
-  it('face area', () => {
-    const rect = sketchRectangle(10, 20);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getFaces always returns at least one face for a rectangle
-    const f = getFaces(castShape(rect.face().wrapped))[0]!;
-    expect(measureArea(f)).toBeCloseTo(200, 0);
-  });
-});
-
-describe('measureLength', () => {
-  it('line length', () => {
-    const l = line([0, 0, 0], [10, 0, 0]);
-    expect(measureLength(castShape(l.wrapped))).toBeCloseTo(10, 2);
+    it('face area', () => {
+      const rect = sketchRectangle(10, 20);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getFaces always returns at least one face for a rectangle
+      const f = getFaces(castShape(rect.face().wrapped))[0]!;
+      expect(measureArea(f)).toBeCloseTo(200, 0);
+    });
   });
 
-  it('diagonal line length', () => {
-    const l = line([0, 0, 0], [3, 4, 0]);
-    expect(measureLength(castShape(l.wrapped))).toBeCloseTo(5, 2);
-  });
-});
+  describe('measureLength', () => {
+    it('line length', () => {
+      const l = line([0, 0, 0], [10, 0, 0]);
+      expect(measureLength(castShape(l.wrapped))).toBeCloseTo(10, 2);
+    });
 
-describe('measureDistance', () => {
-  it('distance between two vertices', () => {
-    const v1 = castShape(vertex([0, 0, 0]).wrapped);
-    const v2 = castShape(vertex([10, 0, 0]).wrapped);
-    expect(measureDistance(v1, v2)).toBeCloseTo(10, 2);
-  });
-
-  it('distance between boxes', () => {
-    const b1 = castShape(box(5, 5, 5).wrapped);
-    const b2 = castShape(translate(box(5, 5, 5), [10, 0, 0]).wrapped);
-    expect(measureDistance(b1, b2)).toBeCloseTo(5, 2);
-  });
-});
-
-describe('createDistanceQuery', () => {
-  it('creates reusable distance query', () => {
-    const ref = castShape(vertex([0, 0, 0]).wrapped);
-    const query = createDistanceQuery(ref);
-
-    const v1 = castShape(vertex([3, 4, 0]).wrapped);
-    const v2 = castShape(vertex([0, 0, 10]).wrapped);
-
-    expect(query.distanceTo(v1)).toBeCloseTo(5, 2);
-    expect(query.distanceTo(v2)).toBeCloseTo(10, 2);
-
-    query.dispose();
-  });
-});
-
-describe('measureVolumeProps / measureSurfaceProps / measureLinearProps', () => {
-  it('volume props include mass and centerOfMass', () => {
-    const b = box(10, 10, 10);
-    const props = measureVolumeProps(castShape(b.wrapped));
-    expect(props.mass).toBeCloseTo(1000, 0);
-    expect(props.centerOfMass[0]).toBeCloseTo(5, 0);
-    expect(props.centerOfMass[1]).toBeCloseTo(5, 0);
-    expect(props.centerOfMass[2]).toBeCloseTo(5, 0);
+    it('diagonal line length', () => {
+      const l = line([0, 0, 0], [3, 4, 0]);
+      expect(measureLength(castShape(l.wrapped))).toBeCloseTo(5, 2);
+    });
   });
 
-  it('surface props include mass and centerOfMass', () => {
-    const b = box(10, 10, 10);
-    const props = measureSurfaceProps(castShape(b.wrapped));
-    expect(props.mass).toBeCloseTo(600, 0);
-    expect(props.centerOfMass[0]).toBeCloseTo(5, 0);
+  describe('measureDistance', () => {
+    it('distance between two vertices', () => {
+      const v1 = castShape(vertex([0, 0, 0]).wrapped);
+      const v2 = castShape(vertex([10, 0, 0]).wrapped);
+      expect(measureDistance(v1, v2)).toBeCloseTo(10, 2);
+    });
+
+    it('distance between boxes', () => {
+      const b1 = castShape(box(5, 5, 5).wrapped);
+      const b2 = castShape(translate(box(5, 5, 5), [10, 0, 0]).wrapped);
+      expect(measureDistance(b1, b2)).toBeCloseTo(5, 2);
+    });
   });
 
-  it('linear props include mass', () => {
-    const l = line([0, 0, 0], [10, 0, 0]);
-    const props = measureLinearProps(castShape(l.wrapped));
-    expect(props.mass).toBeCloseTo(10, 2);
-  });
-});
+  describe('createDistanceQuery', () => {
+    it('creates reusable distance query', () => {
+      const ref = castShape(vertex([0, 0, 0]).wrapped);
+      const query = createDistanceQuery(ref);
 
-// ---------------------------------------------------------------------------
-// Null-shape pre-validation tests
-// ---------------------------------------------------------------------------
+      const v1 = castShape(vertex([3, 4, 0]).wrapped);
+      const v2 = castShape(vertex([0, 0, 10]).wrapped);
 
-describe('null-shape pre-validation', () => {
-  function makeNullSolid(): Shape3D {
-    const oc = getKernel().oc;
-    return createSolid(new oc.TopoDS_Solid()) as Shape3D;
-  }
+      expect(query.distanceTo(v1)).toBeCloseTo(5, 2);
+      expect(query.distanceTo(v2)).toBeCloseTo(10, 2);
 
-  function makeNullFace(): Face {
-    const oc = getKernel().oc;
-    return createFace(new oc.TopoDS_Face());
-  }
-
-  it('measureVolumeProps throws on null shape', () => {
-    expect(() => measureVolumeProps(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('measureVolume throws on null shape', () => {
-    expect(() => measureVolume(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('measureSurfaceProps throws on null shape', () => {
-    expect(() => measureSurfaceProps(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('measureArea throws on null shape', () => {
-    expect(() => measureArea(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('measureLinearProps throws on null shape', () => {
-    expect(() => measureLinearProps(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('measureLength throws on null shape', () => {
-    expect(() => measureLength(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('measureDistance throws on null first shape', () => {
-    const valid = castShape(vertex([0, 0, 0]).wrapped);
-    expect(() => measureDistance(makeNullSolid(), valid)).toThrow('null shape');
-  });
-
-  it('measureDistance throws on null second shape', () => {
-    const valid = castShape(vertex([0, 0, 0]).wrapped);
-    expect(() => measureDistance(valid, makeNullSolid())).toThrow('null shape');
-  });
-
-  it('createDistanceQuery throws on null reference', () => {
-    expect(() => createDistanceQuery(makeNullSolid())).toThrow('null shape');
-  });
-
-  it('createDistanceQuery.distanceTo throws on null other', () => {
-    const ref = castShape(vertex([0, 0, 0]).wrapped);
-    const query = createDistanceQuery(ref);
-    try {
-      expect(() => query.distanceTo(makeNullSolid())).toThrow('null shape');
-    } finally {
       query.dispose();
+    });
+  });
+
+  describe('measureVolumeProps / measureSurfaceProps / measureLinearProps', () => {
+    it('volume props include mass and centerOfMass', () => {
+      const b = box(10, 10, 10);
+      const props = measureVolumeProps(castShape(b.wrapped));
+      expect(props.mass).toBeCloseTo(1000, 0);
+      expect(props.centerOfMass[0]).toBeCloseTo(5, 0);
+      expect(props.centerOfMass[1]).toBeCloseTo(5, 0);
+      expect(props.centerOfMass[2]).toBeCloseTo(5, 0);
+    });
+
+    it('surface props include mass and centerOfMass', () => {
+      const b = box(10, 10, 10);
+      const props = measureSurfaceProps(castShape(b.wrapped));
+      expect(props.mass).toBeCloseTo(600, 0);
+      expect(props.centerOfMass[0]).toBeCloseTo(5, 0);
+    });
+
+    it('linear props include mass', () => {
+      const l = line([0, 0, 0], [10, 0, 0]);
+      const props = measureLinearProps(castShape(l.wrapped));
+      expect(props.mass).toBeCloseTo(10, 2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Null-shape pre-validation tests
+  // ---------------------------------------------------------------------------
+
+  describe('null-shape pre-validation', () => {
+    function makeNullSolid(): Shape3D {
+      const oc = getKernel().oc;
+      return createSolid(new oc.TopoDS_Solid()) as Shape3D;
     }
+
+    function makeNullFace(): Face {
+      const oc = getKernel().oc;
+      return createFace(new oc.TopoDS_Face());
+    }
+
+    it('measureVolumeProps throws on null shape', () => {
+      expect(() => measureVolumeProps(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('measureVolume throws on null shape', () => {
+      expect(() => measureVolume(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('measureSurfaceProps throws on null shape', () => {
+      expect(() => measureSurfaceProps(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('measureArea throws on null shape', () => {
+      expect(() => measureArea(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('measureLinearProps throws on null shape', () => {
+      expect(() => measureLinearProps(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('measureLength throws on null shape', () => {
+      expect(() => measureLength(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('measureDistance throws on null first shape', () => {
+      const valid = castShape(vertex([0, 0, 0]).wrapped);
+      expect(() => measureDistance(makeNullSolid(), valid)).toThrow('null shape');
+    });
+
+    it('measureDistance throws on null second shape', () => {
+      const valid = castShape(vertex([0, 0, 0]).wrapped);
+      expect(() => measureDistance(valid, makeNullSolid())).toThrow('null shape');
+    });
+
+    it('createDistanceQuery throws on null reference', () => {
+      expect(() => createDistanceQuery(makeNullSolid())).toThrow('null shape');
+    });
+
+    it('createDistanceQuery.distanceTo throws on null other', () => {
+      const ref = castShape(vertex([0, 0, 0]).wrapped);
+      const query = createDistanceQuery(ref);
+      try {
+        expect(() => query.distanceTo(makeNullSolid())).toThrow('null shape');
+      } finally {
+        query.dispose();
+      }
+    });
+
+    it('measureCurvatureAt throws on null face', () => {
+      expect(() => measureCurvatureAt(makeNullFace(), 0, 0)).toThrow('null shape');
+    });
+
+    it('measureCurvatureAtMid throws on null face', () => {
+      expect(() => measureCurvatureAtMid(makeNullFace())).toThrow('null shape');
+    });
   });
 
-  it('measureCurvatureAt throws on null face', () => {
-    expect(() => measureCurvatureAt(makeNullFace(), 0, 0)).toThrow('null shape');
-  });
+  describe('measurement caching', () => {
+    it('measureVolumeProps returns identical object on second call', () => {
+      const b = box(10, 20, 30);
+      const s = castShape(b.wrapped) as Shape3D;
+      const first = measureVolumeProps(s);
+      const second = measureVolumeProps(s);
+      expect(second).toBe(first); // same reference
+    });
 
-  it('measureCurvatureAtMid throws on null face', () => {
-    expect(() => measureCurvatureAtMid(makeNullFace())).toThrow('null shape');
-  });
-});
+    it('measureSurfaceProps returns identical object on second call', () => {
+      const b = box(10, 20, 30);
+      const s = castShape(b.wrapped) as Shape3D;
+      const first = measureSurfaceProps(s);
+      const second = measureSurfaceProps(s);
+      expect(second).toBe(first);
+    });
 
-describe('measurement caching', () => {
-  it('measureVolumeProps returns identical object on second call', () => {
-    const b = box(10, 20, 30);
-    const s = castShape(b.wrapped) as Shape3D;
-    const first = measureVolumeProps(s);
-    const second = measureVolumeProps(s);
-    expect(second).toBe(first); // same reference
+    it('measureLinearProps returns identical object on second call', () => {
+      const l = line([0, 0, 0], [10, 0, 0]);
+      const s = castShape(l.wrapped);
+      const first = measureLinearProps(s);
+      const second = measureLinearProps(s);
+      expect(second).toBe(first);
+    });
   });
-
-  it('measureSurfaceProps returns identical object on second call', () => {
-    const b = box(10, 20, 30);
-    const s = castShape(b.wrapped) as Shape3D;
-    const first = measureSurfaceProps(s);
-    const second = measureSurfaceProps(s);
-    expect(second).toBe(first);
-  });
-
-  it('measureLinearProps returns identical object on second call', () => {
-    const l = line([0, 0, 0], [10, 0, 0]);
-    const s = castShape(l.wrapped);
-    const first = measureLinearProps(s);
-    const second = measureLinearProps(s);
-    expect(second).toBe(first);
-  });
-});
 });

--- a/tests/fn-meshFns.test.ts
+++ b/tests/fn-meshFns.test.ts
@@ -17,204 +17,204 @@ import {
 } from '../src/index.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: meshFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-describe('mesh', () => {
-  it('meshes a box into triangles', () => {
-    const b = box(10, 10, 10);
-    const m = mesh(b);
-    expect(m.vertices.length).toBeGreaterThan(0);
-    expect(m.triangles.length).toBeGreaterThan(0);
-    expect(m.normals.length).toBeGreaterThan(0);
-    expect(m.faceGroups.length).toBe(6); // 6 faces
+  describe('mesh', () => {
+    it('meshes a box into triangles', () => {
+      const b = box(10, 10, 10);
+      const m = mesh(b);
+      expect(m.vertices.length).toBeGreaterThan(0);
+      expect(m.triangles.length).toBeGreaterThan(0);
+      expect(m.normals.length).toBeGreaterThan(0);
+      expect(m.faceGroups.length).toBe(6); // 6 faces
+    });
+
+    it('respects tolerance option', () => {
+      const b = box(10, 10, 10);
+      const coarse = mesh(b, { tolerance: 1 });
+      const fine = mesh(b, { tolerance: 0.01 });
+      // Fine mesh may have more vertices
+      expect(fine.vertices.length).toBeGreaterThanOrEqual(coarse.vertices.length);
+    });
+
+    it('returns cached result on second call with same parameters', () => {
+      clearMeshCache();
+      const b = box(10, 10, 10);
+      const mesh1 = mesh(b, { tolerance: 0.1 });
+      const mesh2 = mesh(b, { tolerance: 0.1 });
+      // Cached — same object reference
+      expect(mesh2).toBe(mesh1);
+    });
+
+    it('bypasses cache when cache option is false', () => {
+      clearMeshCache();
+      const b = box(10, 10, 10);
+      const mesh1 = mesh(b, { tolerance: 0.1 });
+      const mesh2 = mesh(b, { tolerance: 0.1, cache: false });
+      // Not cached — different object
+      expect(mesh2).not.toBe(mesh1);
+    });
   });
 
-  it('respects tolerance option', () => {
-    const b = box(10, 10, 10);
-    const coarse = mesh(b, { tolerance: 1 });
-    const fine = mesh(b, { tolerance: 0.01 });
-    // Fine mesh may have more vertices
-    expect(fine.vertices.length).toBeGreaterThanOrEqual(coarse.vertices.length);
+  describe('meshEdges', () => {
+    it('meshes edge curves of a box', () => {
+      const b = box(10, 10, 10);
+      const edgeMesh = meshEdges(b);
+      expect(edgeMesh.lines.length).toBeGreaterThan(0);
+      expect(edgeMesh.edgeGroups.length).toBe(12); // 12 edges on a box
+    });
+
+    it('returns cached result on second call with same parameters', () => {
+      clearMeshCache();
+      const b = box(10, 10, 10);
+      const mesh1 = meshEdges(b, { tolerance: 0.1 });
+      const mesh2 = meshEdges(b, { tolerance: 0.1 });
+      // Cached — same object reference
+      expect(mesh2).toBe(mesh1);
+    });
+
+    it('bypasses cache when cache option is false', () => {
+      clearMeshCache();
+      const b = box(10, 10, 10);
+      const mesh1 = meshEdges(b, { tolerance: 0.1 });
+      const mesh2 = meshEdges(b, { tolerance: 0.1, cache: false });
+      // Not cached — different object
+      expect(mesh2).not.toBe(mesh1);
+    });
   });
 
-  it('returns cached result on second call with same parameters', () => {
-    clearMeshCache();
-    const b = box(10, 10, 10);
-    const mesh1 = mesh(b, { tolerance: 0.1 });
-    const mesh2 = mesh(b, { tolerance: 0.1 });
-    // Cached — same object reference
-    expect(mesh2).toBe(mesh1);
-  });
-
-  it('bypasses cache when cache option is false', () => {
-    clearMeshCache();
-    const b = box(10, 10, 10);
-    const mesh1 = mesh(b, { tolerance: 0.1 });
-    const mesh2 = mesh(b, { tolerance: 0.1, cache: false });
-    // Not cached — different object
-    expect(mesh2).not.toBe(mesh1);
-  });
-});
-
-describe('meshEdges', () => {
-  it('meshes edge curves of a box', () => {
-    const b = box(10, 10, 10);
-    const edgeMesh = meshEdges(b);
-    expect(edgeMesh.lines.length).toBeGreaterThan(0);
-    expect(edgeMesh.edgeGroups.length).toBe(12); // 12 edges on a box
-  });
-
-  it('returns cached result on second call with same parameters', () => {
-    clearMeshCache();
-    const b = box(10, 10, 10);
-    const mesh1 = meshEdges(b, { tolerance: 0.1 });
-    const mesh2 = meshEdges(b, { tolerance: 0.1 });
-    // Cached — same object reference
-    expect(mesh2).toBe(mesh1);
-  });
-
-  it('bypasses cache when cache option is false', () => {
-    clearMeshCache();
-    const b = box(10, 10, 10);
-    const mesh1 = meshEdges(b, { tolerance: 0.1 });
-    const mesh2 = meshEdges(b, { tolerance: 0.1, cache: false });
-    // Not cached — different object
-    expect(mesh2).not.toBe(mesh1);
-  });
-});
-
-describe('exportSTEP', () => {
-  it('exports a shape to STEP blob', () => {
-    const b = box(10, 10, 10);
-    const result = exportSTEP(b);
-    expect(isOk(result)).toBe(true);
-    const blob = unwrap(result);
-    expect(blob.size).toBeGreaterThan(0);
-  });
-
-  it('returns STEP_FILE_READ_ERROR when FS.readFile throws after successful write', () => {
-    const oc = getKernel().oc;
-    const originalReadFile = oc.FS.readFile as (...args: unknown[]) => unknown;
-    // Patch readFile to throw on any .step file
-    oc.FS.readFile = (path: string) => {
-      if (path.endsWith('.step')) throw new Error('simulated FS read failure');
-      return originalReadFile.call(oc.FS, path);
-    };
-    try {
-      const b = box(5, 5, 5);
+  describe('exportSTEP', () => {
+    it('exports a shape to STEP blob', () => {
+      const b = box(10, 10, 10);
       const result = exportSTEP(b);
-      expect(isErr(result)).toBe(true);
-      expect(unwrapErr(result).code).toBe('STEP_FILE_READ_ERROR');
-    } finally {
-      oc.FS.readFile = originalReadFile;
-    }
-  });
-});
+      expect(isOk(result)).toBe(true);
+      const blob = unwrap(result);
+      expect(blob.size).toBeGreaterThan(0);
+    });
 
-describe('exportSTL', () => {
-  it('exports a shape to STL blob', () => {
-    const b = box(10, 10, 10);
-    const result = exportSTL(b);
-    expect(isOk(result)).toBe(true);
-    const blob = unwrap(result);
-    expect(blob.size).toBeGreaterThan(0);
-  });
-
-  it('exports a shape to binary STL blob', () => {
-    const b = box(10, 10, 10);
-    const result = exportSTL(b, { binary: true });
-    expect(isOk(result)).toBe(true);
-    const blob = unwrap(result);
-    expect(blob.size).toBeGreaterThan(0);
-    expect(blob.type).toBe('application/sla');
+    it('returns STEP_FILE_READ_ERROR when FS.readFile throws after successful write', () => {
+      const oc = getKernel().oc;
+      const originalReadFile = oc.FS.readFile as (...args: unknown[]) => unknown;
+      // Patch readFile to throw on any .step file
+      oc.FS.readFile = (path: string) => {
+        if (path.endsWith('.step')) throw new Error('simulated FS read failure');
+        return originalReadFile.call(oc.FS, path);
+      };
+      try {
+        const b = box(5, 5, 5);
+        const result = exportSTEP(b);
+        expect(isErr(result)).toBe(true);
+        expect(unwrapErr(result).code).toBe('STEP_FILE_READ_ERROR');
+      } finally {
+        oc.FS.readFile = originalReadFile;
+      }
+    });
   });
 
-  it('binary STL is smaller than ASCII STL for the same shape', () => {
-    const b = sphere(5);
-    const ascii = unwrap(exportSTL(b, { binary: false }));
-    const binary = unwrap(exportSTL(b, { binary: true }));
-    // Binary STL header is 84 bytes + 50 bytes per triangle; ASCII is larger in practice
-    expect(binary.size).toBeGreaterThan(0);
-    expect(ascii.size).toBeGreaterThan(0);
-  });
-
-  it('skips re-meshing when shape already has triangulation', () => {
-    // mesh() populates triangulation on the shape's underlying kernel object;
-    // exportSTL should detect that and skip the BRepMesh step.
-    const b = box(10, 10, 10);
-    mesh(b); // populate triangulation
-    const result = exportSTL(b);
-    expect(isOk(result)).toBe(true);
-    expect(unwrap(result).size).toBeGreaterThan(0);
-  });
-
-  it('returns STL_FILE_READ_ERROR when FS.readFile throws after successful write', () => {
-    const oc = getKernel().oc;
-    const originalReadFile = oc.FS.readFile as (...args: unknown[]) => unknown;
-    // Patch readFile to throw on any .stl file
-    oc.FS.readFile = (path: string) => {
-      if (path.endsWith('.stl')) throw new Error('simulated FS read failure');
-      return originalReadFile.call(oc.FS, path);
-    };
-    try {
-      const b = box(5, 5, 5);
+  describe('exportSTL', () => {
+    it('exports a shape to STL blob', () => {
+      const b = box(10, 10, 10);
       const result = exportSTL(b);
-      expect(isErr(result)).toBe(true);
-      expect(unwrapErr(result).code).toBe('STL_FILE_READ_ERROR');
-    } finally {
-      oc.FS.readFile = originalReadFile;
-    }
-  });
-});
+      expect(isOk(result)).toBe(true);
+      const blob = unwrap(result);
+      expect(blob.size).toBeGreaterThan(0);
+    });
 
-describe('exportIGES', () => {
-  it('exports a shape to IGES blob when IGES is available in the WASM build', () => {
-    const oc = getKernel().oc;
-    if (typeof oc.IGESControl_Writer_1 !== 'function') {
-      console.warn('IGESControl_Writer_1 not in WASM build — skipping IGES integration test');
-      return;
-    }
-    const b = box(10, 10, 10);
-    const result = exportIGES(b);
-    expect(isOk(result)).toBe(true);
-    const blob = unwrap(result);
-    expect(blob.size).toBeGreaterThan(0);
-    expect(blob.type).toBe('application/iges');
+    it('exports a shape to binary STL blob', () => {
+      const b = box(10, 10, 10);
+      const result = exportSTL(b, { binary: true });
+      expect(isOk(result)).toBe(true);
+      const blob = unwrap(result);
+      expect(blob.size).toBeGreaterThan(0);
+      expect(blob.type).toBe('application/sla');
+    });
+
+    it('binary STL is smaller than ASCII STL for the same shape', () => {
+      const b = sphere(5);
+      const ascii = unwrap(exportSTL(b, { binary: false }));
+      const binary = unwrap(exportSTL(b, { binary: true }));
+      // Binary STL header is 84 bytes + 50 bytes per triangle; ASCII is larger in practice
+      expect(binary.size).toBeGreaterThan(0);
+      expect(ascii.size).toBeGreaterThan(0);
+    });
+
+    it('skips re-meshing when shape already has triangulation', () => {
+      // mesh() populates triangulation on the shape's underlying kernel object;
+      // exportSTL should detect that and skip the BRepMesh step.
+      const b = box(10, 10, 10);
+      mesh(b); // populate triangulation
+      const result = exportSTL(b);
+      expect(isOk(result)).toBe(true);
+      expect(unwrap(result).size).toBeGreaterThan(0);
+    });
+
+    it('returns STL_FILE_READ_ERROR when FS.readFile throws after successful write', () => {
+      const oc = getKernel().oc;
+      const originalReadFile = oc.FS.readFile as (...args: unknown[]) => unknown;
+      // Patch readFile to throw on any .stl file
+      oc.FS.readFile = (path: string) => {
+        if (path.endsWith('.stl')) throw new Error('simulated FS read failure');
+        return originalReadFile.call(oc.FS, path);
+      };
+      try {
+        const b = box(5, 5, 5);
+        const result = exportSTL(b);
+        expect(isErr(result)).toBe(true);
+        expect(unwrapErr(result).code).toBe('STL_FILE_READ_ERROR');
+      } finally {
+        oc.FS.readFile = originalReadFile;
+      }
+    });
   });
 
-  it('exports a sphere to IGES blob when IGES is available in the WASM build', () => {
-    const oc = getKernel().oc;
-    if (typeof oc.IGESControl_Writer_1 !== 'function') {
-      console.warn('IGESControl_Writer_1 not in WASM build — skipping IGES integration test');
-      return;
-    }
-    const s = sphere(5);
-    const result = exportIGES(s);
-    expect(isOk(result)).toBe(true);
-    expect(unwrap(result).size).toBeGreaterThan(0);
-  });
-
-  it('returns IGES_EXPORT_FAILED when FS.readFile throws after successful write', () => {
-    const oc = getKernel().oc;
-    if (typeof oc.IGESControl_Writer_1 !== 'function') {
-      console.warn('IGESControl_Writer_1 not in WASM build — skipping IGES error path test');
-      return;
-    }
-    const originalReadFile = oc.FS.readFile as (...args: unknown[]) => unknown;
-    oc.FS.readFile = (path: string) => {
-      if (path.endsWith('.iges')) throw new Error('simulated FS read failure');
-      return originalReadFile.call(oc.FS, path);
-    };
-    try {
-      const b = box(5, 5, 5);
+  describe('exportIGES', () => {
+    it('exports a shape to IGES blob when IGES is available in the WASM build', () => {
+      const oc = getKernel().oc;
+      if (typeof oc.IGESControl_Writer_1 !== 'function') {
+        console.warn('IGESControl_Writer_1 not in WASM build — skipping IGES integration test');
+        return;
+      }
+      const b = box(10, 10, 10);
       const result = exportIGES(b);
-      expect(isErr(result)).toBe(true);
-      expect(unwrapErr(result).code).toBe('IGES_EXPORT_FAILED');
-    } finally {
-      oc.FS.readFile = originalReadFile;
-    }
+      expect(isOk(result)).toBe(true);
+      const blob = unwrap(result);
+      expect(blob.size).toBeGreaterThan(0);
+      expect(blob.type).toBe('application/iges');
+    });
+
+    it('exports a sphere to IGES blob when IGES is available in the WASM build', () => {
+      const oc = getKernel().oc;
+      if (typeof oc.IGESControl_Writer_1 !== 'function') {
+        console.warn('IGESControl_Writer_1 not in WASM build — skipping IGES integration test');
+        return;
+      }
+      const s = sphere(5);
+      const result = exportIGES(s);
+      expect(isOk(result)).toBe(true);
+      expect(unwrap(result).size).toBeGreaterThan(0);
+    });
+
+    it('returns IGES_EXPORT_FAILED when FS.readFile throws after successful write', () => {
+      const oc = getKernel().oc;
+      if (typeof oc.IGESControl_Writer_1 !== 'function') {
+        console.warn('IGESControl_Writer_1 not in WASM build — skipping IGES error path test');
+        return;
+      }
+      const originalReadFile = oc.FS.readFile as (...args: unknown[]) => unknown;
+      oc.FS.readFile = (path: string) => {
+        if (path.endsWith('.iges')) throw new Error('simulated FS read failure');
+        return originalReadFile.call(oc.FS, path);
+      };
+      try {
+        const b = box(5, 5, 5);
+        const result = exportIGES(b);
+        expect(isErr(result)).toBe(true);
+        expect(unwrapErr(result).code).toBe('IGES_EXPORT_FAILED');
+      } finally {
+        oc.FS.readFile = originalReadFile;
+      }
+    });
   });
-});
 });

--- a/tests/fn-minkowskiFns.test.ts
+++ b/tests/fn-minkowskiFns.test.ts
@@ -18,69 +18,69 @@ import {
 import type { Shape3D } from '../src/core/shapeTypes.js';
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: minkowskiFns', () => {
-beforeAll(async () => {
-  await initKernel();
-}, 30000);
+  beforeAll(async () => {
+    await initKernel();
+  }, 30000);
 
-function makeNullShape(): Shape3D {
-  const oc = getKernel().oc;
-  return createSolid(new oc.TopoDS_Solid()) as Shape3D;
-}
+  function makeNullShape(): Shape3D {
+    const oc = getKernel().oc;
+    return createSolid(new oc.TopoDS_Solid()) as Shape3D;
+  }
 
-describe('minkowski', () => {
-  describe('sphere fast path', () => {
-    it('produces a solid with volume > 1000 for box + sphere(1)', () => {
-      const result = minkowski(box(10, 10, 10), sphere(1));
+  describe('minkowski', () => {
+    describe('sphere fast path', () => {
+      it('produces a solid with volume > 1000 for box + sphere(1)', () => {
+        const result = minkowski(box(10, 10, 10), sphere(1));
 
-      expect(isOk(result)).toBe(true);
-      const shape = unwrap(result);
-      expect(isSolid(shape)).toBe(true);
-      expect(measureVolume(shape)).toBeGreaterThan(1000);
+        expect(isOk(result)).toBe(true);
+        const shape = unwrap(result);
+        expect(isSolid(shape)).toBe(true);
+        expect(measureVolume(shape)).toBeGreaterThan(1000);
+      });
+
+      it('volume approximately matches offset(box, 2) for sphere(2)', () => {
+        const b = box(10, 10, 10);
+        const minkResult = minkowski(b, sphere(2));
+        expect(isOk(minkResult)).toBe(true);
+        const minkShape = unwrap(minkResult);
+
+        const offsetResult = offset(b, 2);
+        expect(isOk(offsetResult)).toBe(true);
+        const offsetShape = unwrap(offsetResult);
+
+        const minkVol = measureVolume(minkShape);
+        const offsetVol = measureVolume(offsetShape);
+
+        // Within 1% tolerance
+        expect(Math.abs(minkVol - offsetVol) / offsetVol).toBeLessThan(0.01);
+      });
     });
 
-    it('volume approximately matches offset(box, 2) for sphere(2)', () => {
-      const b = box(10, 10, 10);
-      const minkResult = minkowski(b, sphere(2));
-      expect(isOk(minkResult)).toBe(true);
-      const minkShape = unwrap(minkResult);
+    describe('general path', () => {
+      it('box + translated box produces volume ~1728 (12^3)', () => {
+        const b = box(10, 10, 10);
+        const tool = translate(box(2, 2, 2), [-1, -1, -1]);
+        const result = minkowski(b, tool);
 
-      const offsetResult = offset(b, 2);
-      expect(isOk(offsetResult)).toBe(true);
-      const offsetShape = unwrap(offsetResult);
+        expect(isOk(result)).toBe(true);
+        const shape = unwrap(result);
+        expect(isSolid(shape)).toBe(true);
+        expect(measureVolume(shape)).toBeCloseTo(1728, -1);
+      });
+    });
 
-      const minkVol = measureVolume(minkShape);
-      const offsetVol = measureVolume(offsetShape);
+    describe('error handling', () => {
+      it('returns error for null shape input', () => {
+        const result = minkowski(makeNullShape(), sphere(1));
+        expect(isErr(result)).toBe(true);
+        expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
+      });
 
-      // Within 1% tolerance
-      expect(Math.abs(minkVol - offsetVol) / offsetVol).toBeLessThan(0.01);
+      it('returns error for null tool input', () => {
+        const result = minkowski(box(10, 10, 10), makeNullShape());
+        expect(isErr(result)).toBe(true);
+        expect(unwrapErr(result).code).toBe('MINKOWSKI_NULL_TOOL');
+      });
     });
   });
-
-  describe('general path', () => {
-    it('box + translated box produces volume ~1728 (12^3)', () => {
-      const b = box(10, 10, 10);
-      const tool = translate(box(2, 2, 2), [-1, -1, -1]);
-      const result = minkowski(b, tool);
-
-      expect(isOk(result)).toBe(true);
-      const shape = unwrap(result);
-      expect(isSolid(shape)).toBe(true);
-      expect(measureVolume(shape)).toBeCloseTo(1728, -1);
-    });
-  });
-
-  describe('error handling', () => {
-    it('returns error for null shape input', () => {
-      const result = minkowski(makeNullShape(), sphere(1));
-      expect(isErr(result)).toBe(true);
-      expect(unwrapErr(result).code).toBe('NULL_SHAPE_INPUT');
-    });
-
-    it('returns error for null tool input', () => {
-      const result = minkowski(box(10, 10, 10), makeNullShape());
-      expect(isErr(result)).toBe(true);
-      expect(unwrapErr(result).code).toBe('MINKOWSKI_NULL_TOOL');
-    });
-  });
-});
 });

--- a/tests/fn-multiSweepFns.test.ts
+++ b/tests/fn-multiSweepFns.test.ts
@@ -33,40 +33,40 @@ function makeLineSpine(length: number): Wire {
 }
 
 describe.skipIf(currentKernel !== 'occt')('OCCT-specific: multiSweepFns', () => {
-beforeAll(async () => {
-  await initKernel();
-});
+  beforeAll(async () => {
+    await initKernel();
+  });
 
-describe('multiSectionSweep', () => {
-  it('sweeps two circles along a straight line producing a solid with positive volume', () => {
-    const spine = makeLineSpine(50);
-    const circle1 = makeCircleWire(10);
-    const circle2 = makeCircleWire(5);
+  describe('multiSectionSweep', () => {
+    it('sweeps two circles along a straight line producing a solid with positive volume', () => {
+      const spine = makeLineSpine(50);
+      const circle1 = makeCircleWire(10);
+      const circle2 = makeCircleWire(5);
 
-    const result = multiSectionSweep([{ wire: circle1 }, { wire: circle2 }], spine, {
-      solid: true,
+      const result = multiSectionSweep([{ wire: circle1 }, { wire: circle2 }], spine, {
+        solid: true,
+      });
+
+      expect(isOk(result)).toBe(true);
+      const shape = unwrap(result);
+
+      // Compute volume via GProp_GProps
+      const oc = getKernel().oc;
+      const scope = new DisposalScope();
+      const props = scope.register(new oc.GProp_GProps_1());
+      oc.BRepGProp.VolumeProperties_1(shape.wrapped, props, false, false, false);
+      const volume = props.Mass();
+      expect(volume).toBeGreaterThan(0);
     });
 
-    expect(isOk(result)).toBe(true);
-    const shape = unwrap(result);
+    it('returns error for fewer than 2 sections', () => {
+      const spine = makeLineSpine(50);
+      const circle1 = makeCircleWire(10);
 
-    // Compute volume via GProp_GProps
-    const oc = getKernel().oc;
-    const scope = new DisposalScope();
-    const props = scope.register(new oc.GProp_GProps_1());
-    oc.BRepGProp.VolumeProperties_1(shape.wrapped, props, false, false, false);
-    const volume = props.Mass();
-    expect(volume).toBeGreaterThan(0);
+      const result = multiSectionSweep([{ wire: circle1 }], spine);
+
+      expect(isErr(result)).toBe(true);
+      expect(unwrapErr(result).code).toBe('MULTI_SWEEP_INSUFFICIENT_SECTIONS');
+    });
   });
-
-  it('returns error for fewer than 2 sections', () => {
-    const spine = makeLineSpine(50);
-    const circle1 = makeCircleWire(10);
-
-    const result = multiSectionSweep([{ wire: circle1 }], spine);
-
-    expect(isErr(result)).toBe(true);
-    expect(unwrapErr(result).code).toBe('MULTI_SWEEP_INSUFFICIENT_SECTIONS');
-  });
-});
 });


### PR DESCRIPTION
13 test files have had pre-existing Prettier formatting violations since #505 (migrate test skip logic). This is causing `format:check` to fail on CI for every PR and on main.

No logic changes — whitespace/formatting only.