### PR TITLE
fix: use correct Bash(pattern) format in settings.json deny list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,10 @@
 {
   "permissions": {
     "deny": [
-      "rm -rf",
-      "git push --force",
-      "git reset --hard",
-      "git clean -f"
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- The deny list in `.claude/settings.json` used bare command strings (e.g. `rm -rf`) which don't match Claude Code's `Bash(pattern)` format
- Fixed to use `Bash(command*)` with glob wildcards so the rules actually take effect

## Test plan
- [x] Verified correct format per Claude Code settings docs