### PR TITLE
fix(test): resolve brepkit-wasm to Node CJS entry in vitest

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,7 +8,10 @@ const config: KnipConfig = {
     // brepjs-opencascade is an intentional optional peerDependency
     optionalPeerDependencies: 'off',
   },
-  ignoreDependencies: [],
+  ignoreDependencies: [
+    // Resolved via vitest alias to its Node CJS entry (path-based, not bare specifier)
+    'brepkit-wasm',
+  ],
   workspaces: {
     '.': {
       project: ['src/**/*.ts'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 
 /**
@@ -18,6 +19,14 @@ const alwaysExclude = [
 ];
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Vite resolves the "import" exports condition by default, hitting the ESM
+      // bundler entry that uses the unsupported WASM ESM integration proposal.
+      // Alias to the Node CJS entry so brepkit tests run under vitest.
+      'brepkit-wasm': resolve(__dirname, 'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'),
+    },
+  },
   test: {
     globals: true,
     setupFiles: ['./tests/setup.ts'],


### PR DESCRIPTION
## Summary
- Vitest/Vite resolves the `"import"` exports condition by default, hitting brepkit-wasm's ESM bundler entry that does `import * from '*.wasm'` (unsupported WASM ESM integration proposal)
- Added `resolve.alias` to point `brepkit-wasm` to its Node CJS entry (`brepkit_wasm_node.cjs`)
- Added `brepkit-wasm` to knip's `ignoreDependencies` since the alias uses a path instead of bare specifier

Fixes 87 brepkit test files that were failing with 'ESM integration proposal for Wasm is not supported'.

## Test plan
- [x] `npx vitest run` — 243 passed, 0 failed, 4403 tests green
- [x] `npx knip` — clean