### PR TITLE
fix(build): bump package file limit to 550

### DIFF
--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-MAX_FILES=450
+MAX_FILES=550
 
 PACK_OUTPUT=$(npm pack --dry-run --ignore-scripts 2>&1)
 TOTAL_FILES=$(echo "$PACK_OUTPUT" | grep "total files" | awk '{print $NF}')


### PR DESCRIPTION
## Summary
- Bumps `MAX_FILES` in `scripts/validate-pack.sh` from 450 to 550
- Kernel decomposition (ADR-0007) and Layer 1/2 restructuring added 39 new source files, pushing the package from ~440 to 518 files
- Unblocks the v12.9.0 release

## Test plan
- [x] `npm pack --dry-run` passes locally (518 < 550)