### PR TITLE
fix(site): convert manualChunks to function form for Vite 8/Rolldown

### DIFF
--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -64,9 +64,9 @@ export default defineConfig({
     chunkSizeWarningLimit: 1100,
     rollupOptions: {
       output: {
-        manualChunks: {
-          monaco: ['monaco-editor', '@monaco-editor/react'],
-          three: ['three', '@react-three/fiber', '@react-three/drei'],
+        manualChunks(id) {
+          if (id.includes('monaco-editor') || id.includes('@monaco-editor/react')) return 'monaco';
+          if (id.includes('/three/') || id.includes('@react-three/')) return 'three';
         },
       },
     },


### PR DESCRIPTION
## Summary

- Vite 8.0.0 (PR #533) switched from Rollup to Rolldown internally
- Rolldown does not support object-form `manualChunks` — requires a function
- This broke the site build and Vercel deployments since #533

## Test plan

- [x] `cd site && npm run build` — passes, produces correct chunks (monaco, three)