### PR TITLE
fix(build): bump max package files to 600 for shapeRef module

### DIFF
--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-MAX_FILES=570
+MAX_FILES=600
 
 PACK_OUTPUT=$(npm pack --dry-run --ignore-scripts 2>&1)
 TOTAL_FILES=$(echo "$PACK_OUTPUT" | grep "total files" | awk '{print $NF}')


### PR DESCRIPTION
## Summary
- Bumps `MAX_FILES` in `scripts/validate-pack.sh` from 570 to 600
- The shapeRef module added 24 new files, pushing the package from ~570 to 594 files
- This caused the Release Please publish step to fail on v14.1.1

## Test plan
- [x] `validate-pack.sh` passes locally (594 files < 600 limit)