### PR TITLE
fix(build): use static import for BrepkitAdapter

### DIFF
--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -2,6 +2,7 @@ import type { KernelAdapter, KernelInstance } from './types.js';
 import type { Kernel2DCapability } from './kernel2dTypes.js';
 import { supportsKernel2D } from './kernel2dTypes.js';
 import { DefaultAdapter } from './occt/defaultAdapter.js';
+import { BrepkitAdapter } from './brepkit/brepkitAdapter.js';
 import { resetMeasureDetectionCache } from './occt/measureOps.js';
 import { resetTransformDetectionCache } from './occt/transformOps.js';
 
@@ -163,7 +164,6 @@ export async function init(): Promise<string> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import
     const bk = (await import(/* @vite-ignore */ 'brepkit-wasm')) as any;
     if (typeof bk.default === 'function') await bk.default();
-    const { BrepkitAdapter } = await import(/* @vite-ignore */ './brepkit/brepkitAdapter.js');
     registerKernel('brepkit', new BrepkitAdapter(new bk.BrepKernel()));
     return 'brepkit';
   } catch {


### PR DESCRIPTION
## Summary

- Replace dynamic `import('./brepkit/brepkitAdapter.js')` with a static import in `src/kernel/index.ts`

The dynamic relative import caused consumer build failures — Rollup resolves relative dynamic imports at build time even with `@vite-ignore`, and the adapter module was inlined into a shared chunk instead of being emitted at the expected path. Since `BrepkitAdapter` is part of brepjs itself (not an external package), a static import is correct. The `brepkit-wasm` npm package import remains dynamic for optional dependency resolution.

## Test plan

- [x] 2514 tests pass, coverage thresholds met
- [x] `npm run build` succeeds, no `brepkitAdapter` dynamic import in dist output
- [x] knip passes (no unused exports)