### PR TITLE
chore(deps): support brepjs-opencascade ^0.11.0 peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "vitest": "4.1.0"
   },
   "peerDependencies": {
-    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+    "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0",
     "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary
- Add `^0.11.0` to brepjs-opencascade peer dependency range

Required for the upcoming brepjs-opencascade 0.11.0 release with batch C++ extractors.