### PR TITLE
fix(ci): remove broken threaded/exceptions WASM builds

### DIFF
--- a/.github/workflows/publish-opencascade.yml
+++ b/.github/workflows/publish-opencascade.yml
@@ -33,19 +33,10 @@ jobs:
           docker run -i --rm -v "$(pwd)":/src ghcr.io/andymai/opencascade.js:wasm-exceptions custom_build_single.yml
           mv brepjs_single* ../src/
 
-      - name: Build with exceptions
-        continue-on-error: true
-        working-directory: packages/brepjs-opencascade/build-config
-        run: |
-          docker run -i --rm -v "$(pwd)":/src ghcr.io/andymai/opencascade.js:wasm-exceptions custom_build_with_exceptions.yml
-          mv brepjs_with_exceptions* ../src/
-
-      - name: Build threaded (multi-threading)
-        continue-on-error: true
-        working-directory: packages/brepjs-opencascade/build-config
-        run: |
-          docker run -i --rm -v "$(pwd)":/src ghcr.io/andymai/opencascade.js:wasm-exceptions custom_build_threaded.yml
-          mv brepjs_threaded* ../src/
+      # Threaded and exceptions builds are disabled — the wasm-exceptions Docker
+      # image lacks the pthread toolchain needed for threaded builds, and the
+      # exceptions build has compilation issues. Gridfinity uses single only.
+      # TODO: re-enable when Docker image supports all build variants.
 
       - name: Optimize WASM binaries
         working-directory: packages/brepjs-opencascade/src


### PR DESCRIPTION
## Summary
- Remove threaded and exceptions Docker build steps from publish-opencascade.yml
- The wasm-exceptions Docker image lacks pthread toolchain for threaded builds
- Gridfinity only uses the single-threaded build
- TODO comment left for re-enabling when Docker image supports all variants