### PR TITLE
fix(ci): increase spiral-staircase example timeout

### DIFF
--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -76,7 +76,7 @@ describe('playground examples', () => {
   const SLOW_IDS = new Set(['spiral-staircase']);
 
   for (const example of examples) {
-    const timeout = SLOW_IDS.has(example.id) ? 60000 : 15000;
+    const timeout = SLOW_IDS.has(example.id) ? 120000 : 15000;
 
     it(
       `${example.id}: runs without error and returns geometry`,


### PR DESCRIPTION
## Summary
- Bumps `spiral-staircase` example test timeout from 60s to 120s
- The test took 71s on GitHub Actions due to 16 boolean fuse operations on the WASM kernel

## Test plan
- [x] CI passes with the new timeout