### PR TITLE
fix(opencascade): enable -Os + LTO in Docker image

### DIFF
--- a/packages/brepjs-opencascade/package.json
+++ b/packages/brepjs-opencascade/package.json
@@ -37,6 +37,6 @@
     "buildWasm": "pnpm run buildSingle && pnpm run optimizeWasm",
     "updateDocker": "docker pull ghcr.io/andymai/opencascade.js:v8",
     "buildSingle": "cd build-config && docker run -it --rm -v $(pwd):/src -u $(id -u):$(id -g) ghcr.io/andymai/opencascade.js:v8 brepjs.yml && mv brepjs_single* ../src && cd -",
-    "optimizeWasm": "npx wasm-opt -O4 --strip-debug --strip-producers src/brepjs_single.wasm -o src/brepjs_single.wasm"
+    "optimizeWasm": "npx wasm-opt -O4 --strip-debug --strip-producers --enable-exception-handling src/brepjs_single.wasm -o src/brepjs_single.wasm"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `--enable-exception-handling` to wasm-opt in local build script
- Docker image `ghcr.io/andymai/opencascade.js:v8` already rebuilt and pushed with `-Os + LTO`
- This triggers release-please to bump `brepjs-opencascade` for the next publish

## Context
The V8 Docker image was compiling OCCT sources at `-O0` with no LTO because
`OCJS_OPT`/`OCJS_LTO` env vars were never set. The image has been fixed and pushed.
Next publish will produce a **52-72% faster, 12% smaller** WASM binary.

## Test plan
- [x] 2,519 tests pass
- [x] Docker image verified with correct env vars