### PR TITLE
fix(ci): use --registry flag in ensure-wasm.sh

### DIFF
--- a/scripts/ensure-wasm.sh
+++ b/scripts/ensure-wasm.sh
@@ -29,8 +29,9 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 echo "⬇ Downloading WASM runtime files v${EXPECTED_VERSION:-latest} (not tracked in git)..."
-npm pack "brepjs-opencascade${EXPECTED_VERSION:+@$EXPECTED_VERSION}" --pack-destination "$TMPDIR" --silent 2>/dev/null || \
-  npm pack brepjs-opencascade --pack-destination "$TMPDIR" --silent
+# Use --registry to force npm to fetch from the public registry (not the local workspace)
+npm pack "brepjs-opencascade${EXPECTED_VERSION:+@$EXPECTED_VERSION}" --pack-destination "$TMPDIR" --registry https://registry.npmjs.org --silent 2>/dev/null || \
+  npm pack brepjs-opencascade --pack-destination "$TMPDIR" --registry https://registry.npmjs.org --silent
 tar -xzf "$TMPDIR"/brepjs-opencascade-*.tgz -C "$TMPDIR"
 cp "$TMPDIR"/package/src/*.js "$TMPDIR"/package/src/*.wasm "$WASM_DIR/"
 cp "$TMPDIR"/package/src/*.d.ts "$WASM_DIR/" 2>/dev/null || true


### PR DESCRIPTION
npm pack in a monorepo resolves to the local workspace, not npm. Adding --registry flag forces fetch from registry.