### PR TITLE
chore: bump package file limit 600→650 for occtWasm adapter

### DIFF
--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-MAX_FILES=600
+MAX_FILES=650
 
 PACK_OUTPUT=$(npm pack --dry-run --ignore-scripts 2>&1)
 TOTAL_FILES=$(echo "$PACK_OUTPUT" | grep "total files" | awk '{print $NF}')


### PR DESCRIPTION
The occtWasm adapter added 4 new files, pushing the npm pack count from ~598 to 604. Bumps the validate-pack limit to 650.