### PR TITLE
ci: skip CI checks for release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,19 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Release-please PRs only touch CHANGELOG.md, package.json versions,
+      # and .release-please-manifest.json — no code changes to validate.
+      - name: Skip release-please PRs
+        id: release-please
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" == release-please--* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
+        if: steps.release-please.outputs.skip != 'true'
         with:
           filters: |
             code:


### PR DESCRIPTION
## Summary
- Release-please PRs only touch `CHANGELOG.md`, `package.json` versions, and `.release-please-manifest.json` — no code to validate
- Detects the `release-please--` branch name pattern and skips the paths-filter, so all downstream jobs (typecheck, lint, build, test, size) are skipped
- `ci-pass` still succeeds (skipped ≠ failed)

## Test plan
- [ ] Verify this PR's CI runs normally (it touches `.github/workflows/ci.yml`, which is in the paths-filter)
- [ ] Next release-please PR should skip all CI jobs