### PR TITLE
feat(occtWasm): wire importSTL adapter method

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2067,8 +2067,28 @@ export class OcctWasmAdapter implements KernelAdapter {
     return [wrapResult(this.k, id)];
   }
 
-  importSTL(_data: string | ArrayBuffer): KernelShape {
-    notImplemented('importSTL');
+  importSTL(data: string | ArrayBuffer): KernelShape {
+    // Binary STL contains null bytes that corrupt Embind's std::string.
+    // Write raw bytes to the Emscripten virtual FS, then call importStl with
+    // the file path (passed as an empty string sentinel to read from /tmp).
+    const bytes = typeof data === 'string' ? new TextEncoder().encode(data) : new Uint8Array(data);
+
+    // Write to Emscripten FS directly via HEAPU8
+    const mod = this.Module as OcctWasmModule & {
+      FS?: { writeFile(path: string, data: Uint8Array): void };
+    };
+    if (mod.FS) {
+      mod.FS.writeFile('/tmp/import.stl', bytes);
+    } else {
+      // Fallback: pass as Latin-1 string (works for ASCII STL only)
+      const str = Array.from(bytes, (b) => String.fromCharCode(b)).join('');
+      const id = this.k.importStl(str);
+      return wrapResult(this.k, id);
+    }
+
+    // Call importStl with empty string — the C++ side reads from /tmp/import.stl
+    const id = this.k.importStl('');
+    return wrapResult(this.k, id);
   }
 
   exportIGES(shapes: KernelShape[]): string {

--- a/src/kernel/occtWasm/occtWasmTypes.ts
+++ b/src/kernel/occtWasm/occtWasmTypes.ts
@@ -401,6 +401,7 @@ export interface OcctKernelWasm {
   // --- I/O ---
   importStep(data: string): number;
   exportStep(id: number): string;
+  importStl(data: string): number;
   importIges(data: string): number;
   exportIges(id: number): string;
   exportStl(id: number, linearDeflection: number, ascii: boolean): string;


### PR DESCRIPTION
## Summary
- Wire occt-wasm adapter's `importSTL` to call the new `importStl` facade method
- Use Emscripten `FS.writeFile` for binary STL data to avoid null-byte corruption through Embind string marshaling
- Add `importStl` to `OcctKernelWasm` TypeScript interface

Companion to andymai/occt-wasm#41.

## Test plan
- [x] Full brepjs suite with `TEST_KERNEL=occt-wasm`: 2556/2556 passing, 0 failures
- [x] Pre-commit hooks pass (typecheck, lint, boundaries, changed-file tests)