### PR TITLE
perf: cache vertex positions and hash codes across WASM boundary

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-03-28T07:03:31.142Z",
+  "generated": "2026-03-28T13:11:53.172Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -205,12 +205,12 @@
     {
       "file": "src/topology/modifierFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|197|"
+      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|198|"
     },
     {
       "file": "src/topology/modifierFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|497|"
+      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|498|"
     },
     {
       "file": "src/topology/surfaceFns.ts",

--- a/src/core/shapePropertyCache.ts
+++ b/src/core/shapePropertyCache.ts
@@ -1,0 +1,58 @@
+/**
+ * Shape property cache — caches immutable kernel queries on KernelShape objects.
+ *
+ * Eliminates redundant WASM boundary crossings for properties that never
+ * change on an immutable shape: vertex positions, hash codes, bounding boxes.
+ *
+ * Shapes are immutable in brepjs — operations return new shapes — so
+ * cached values never go stale. Uses WeakMap to avoid memory leaks.
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { KernelAdapter } from '@/kernel/interfaces/index.js';
+import { HASH_CODE_MAX } from './constants.js';
+
+// ---------------------------------------------------------------------------
+// Vertex position cache
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelShape is typed as `any`
+const vertexPosCache = new WeakMap<any, [number, number, number]>();
+
+/**
+ * Get the vertex position from cache, or query the kernel and cache the result.
+ *
+ * Vertices are immutable — their 3D position never changes once created.
+ * This avoids WASM round-trips (~10μs each) in hot loops like vertex finders.
+ */
+export function getOrQueryVertexPosition(
+  kernel: KernelAdapter,
+  vertex: KernelShape
+): [number, number, number] {
+  const cached = vertexPosCache.get(vertex);
+  if (cached !== undefined) return cached;
+  const pos = kernel.vertexPosition(vertex);
+  vertexPosCache.set(vertex, pos);
+  return pos;
+}
+
+// ---------------------------------------------------------------------------
+// Hash code cache
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelShape is typed as `any`
+const hashCodeCache = new WeakMap<any, number>();
+
+/**
+ * Get the hash code from cache, or query the kernel and cache the result.
+ *
+ * Hash codes are deterministic on immutable shapes. This avoids WASM
+ * round-trips (~5μs each) in adjacency deduplication loops.
+ */
+export function getOrQueryHashCode(kernel: KernelAdapter, shape: KernelShape): number {
+  const cached = hashCodeCache.get(shape);
+  if (cached !== undefined) return cached;
+  const hash = kernel.hashCode(shape, HASH_CODE_MAX);
+  hashCodeCache.set(shape, hash);
+  return hash;
+}

--- a/src/topology/adjacencyFns.ts
+++ b/src/topology/adjacencyFns.ts
@@ -9,7 +9,7 @@ import { getKernel } from '@/kernel/index.js';
 import type { KernelShape, ShapeType } from '@/kernel/types.js';
 import type { AnyShape, ClosedWire, Dimension, Edge, Face, Vertex } from '@/core/shapeTypes.js';
 import { castShapeWithKnownType } from '@/core/shapeTypes.js';
-import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { getOrCreateCache } from './topologyQueryFns.js';
 
 // ---------------------------------------------------------------------------
@@ -38,7 +38,7 @@ function deduplicatedSubShapes<T extends AnyShape<Dimension>>(
   const seen = new Map<number, KernelShape[]>();
 
   for (const item of items) {
-    const hash = kernel.hashCode(item, HASH_CODE_MAX);
+    const hash = getOrQueryHashCode(kernel, item);
     const bucket = seen.get(hash);
     if (!bucket) {
       seen.set(hash, [item]);
@@ -74,7 +74,7 @@ function getEdgeToFacesMap(parent: AnyShape<Dimension>): Map<number, EdgeFaceEnt
   for (const f of allFaces) {
     const edges = kernel.iterShapes(f, 'edge');
     for (const e of edges) {
-      const hash = kernel.hashCode(e, HASH_CODE_MAX);
+      const hash = getOrQueryHashCode(kernel, e);
       let bucket = edgeToFaces.get(hash);
       if (!bucket) {
         bucket = [];
@@ -108,7 +108,7 @@ function getEdgeToFacesMap(parent: AnyShape<Dimension>): Map<number, EdgeFaceEnt
 export function facesOfEdge<D extends Dimension>(parent: AnyShape<D>, edge: Edge<D>): Face<D>[] {
   const kernel = getKernel();
   const edgeToFaces = getEdgeToFacesMap(parent);
-  const hash = kernel.hashCode(edge.wrapped, HASH_CODE_MAX);
+  const hash = getOrQueryHashCode(kernel, edge.wrapped);
   const bucket = edgeToFaces.get(hash) ?? [];
 
   // Verify via isSame on the stored edge — no need to re-extract face edges.
@@ -117,7 +117,7 @@ export function facesOfEdge<D extends Dimension>(parent: AnyShape<D>, edge: Edge
   const seen = new Map<number, KernelShape[]>();
   for (const entry of bucket) {
     if (!kernel.isSame(entry.edge, edge.wrapped)) continue;
-    const fHash = kernel.hashCode(entry.face, HASH_CODE_MAX);
+    const fHash = getOrQueryHashCode(kernel, entry.face);
     const fBucket = seen.get(fHash);
     if (!fBucket) {
       seen.set(fHash, [entry.face]);
@@ -181,11 +181,11 @@ export function adjacentFaces<D extends Dimension>(parent: AnyShape<D>, face: Fa
   const seen = new Map<number, KernelShape[]>();
 
   for (const edgeHandle of faceEdgeHandles) {
-    const hash = kernel.hashCode(edgeHandle.wrapped, HASH_CODE_MAX);
+    const hash = getOrQueryHashCode(kernel, edgeHandle.wrapped);
     const entries = edgeToFaces.get(hash) ?? [];
     for (const entry of entries) {
       if (kernel.isSame(entry.face, face.wrapped)) continue;
-      const fHash = kernel.hashCode(entry.face, HASH_CODE_MAX);
+      const fHash = getOrQueryHashCode(kernel, entry.face);
       const bucket = seen.get(fHash);
       if (!bucket) {
         seen.set(fHash, [entry.face]);
@@ -215,7 +215,7 @@ export function sharedEdges<D extends Dimension>(face1: Face<D>, face2: Face<D>)
   // Build hash-bucket index of edges2 for O(1) average lookup instead of O(nxm) isSame scans
   const edge2Map = new Map<number, KernelShape[]>();
   for (const e2 of edges2) {
-    const hash = kernel.hashCode(e2, HASH_CODE_MAX);
+    const hash = getOrQueryHashCode(kernel, e2);
     let bucket = edge2Map.get(hash);
     if (!bucket) {
       bucket = [];
@@ -226,7 +226,7 @@ export function sharedEdges<D extends Dimension>(face1: Face<D>, face2: Face<D>)
 
   const shared: KernelShape[] = [];
   for (const e1 of edges1) {
-    const bucket = edge2Map.get(kernel.hashCode(e1, HASH_CODE_MAX));
+    const bucket = edge2Map.get(getOrQueryHashCode(kernel, e1));
     if (bucket?.some((e2) => kernel.isSame(e1, e2))) {
       shared.push(e1);
     }

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -23,6 +23,7 @@ import type { PlaneInput } from '@/core/planeTypes.js';
 import { resolvePlane } from '@/core/planeOps.js';
 import { vecAdd, vecScale } from '@/core/vecOps.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { getWires, getEdges, getVertices } from './shapeFns.js';
 import { getAtOrThrow, firstOrThrow } from '@/utils/arrayAccess.js';
 import {
@@ -643,8 +644,8 @@ function buildEdgeAdjacency(edges: EdgeD[]): EdgeAdjacency {
 
   for (const edge of edges) {
     const verts: VertexD[] = getVertices(edge);
-    const h0 = verts[0] ? kernel.hashCode(verts[0].wrapped, HASH_CODE_MAX) : -1;
-    const h1 = verts.length > 1 && verts[1] ? kernel.hashCode(verts[1].wrapped, HASH_CODE_MAX) : h0;
+    const h0 = verts[0] ? getOrQueryHashCode(kernel, verts[0].wrapped) : -1;
+    const h1 = verts.length > 1 && verts[1] ? getOrQueryHashCode(kernel, verts[1].wrapped) : h0;
     edgeVertexHashes.set(edge, [h0, h1]);
     for (const h of [h0, h1]) {
       const bucket = vertexToEdges.get(h) ?? [];

--- a/src/topology/evolutionFns.ts
+++ b/src/topology/evolutionFns.ts
@@ -11,6 +11,7 @@ import type { Edge, Face, Shape3D } from '@/core/shapeTypes.js';
 import type { ValidSolid } from '@/core/validityTypes.js';
 import { castShape, isShape3D } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError, typeCastError, kernelError, BrepErrorCode } from '@/core/errors.js';
 import type { BooleanOptions, KernelShape, ShapeEvolution } from '@/kernel/types.js';
@@ -105,12 +106,12 @@ function resolveEdgeCallback(
     if (typeof val === 'number' && val <= 0) continue;
     if (Array.isArray(val) && (val[0] <= 0 || val[1] <= 0)) continue;
     filteredEdges.push(edge);
-    hashToValue.set(getKernel().hashCode(edge.wrapped, HASH_CODE_MAX), val);
+    hashToValue.set(getOrQueryHashCode(getKernel(), edge.wrapped), val);
   }
   if (filteredEdges.length === 0) return null;
 
   const kernelParam: KernelHashCallback<number | [number, number]> = (ocEdge) => {
-    const v = hashToValue.get(getKernel().hashCode(ocEdge, HASH_CODE_MAX));
+    const v = hashToValue.get(getOrQueryHashCode(getKernel(), ocEdge));
     return v ?? 1;
   };
   return { edges: filteredEdges, kernelParam };

--- a/src/topology/metadata/colorFns.ts
+++ b/src/topology/metadata/colorFns.ts
@@ -8,7 +8,7 @@
 import type { ShapeEvolution } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
 import type { AnyShape, Dimension, Face } from '@/core/shapeTypes.js';
-import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -96,7 +96,7 @@ export function colorFaces<T extends AnyShape<Dimension>>(
   const parsed = parseColor(color);
   const map = getFaceColorMap(shape);
   for (const face of faces) {
-    map.set(getKernel().hashCode(face.wrapped, HASH_CODE_MAX), parsed);
+    map.set(getOrQueryHashCode(getKernel(), face.wrapped), parsed);
   }
   return shape;
 }
@@ -114,7 +114,7 @@ export function getShapeColor(shape: AnyShape<Dimension>): Color | undefined {
 export function getFaceColor(shape: AnyShape<Dimension>, face: Face<Dimension>): Color | undefined {
   const map = faceColorStore.get(shape.wrapped);
   if (!map) return undefined;
-  return map.get(getKernel().hashCode(face.wrapped, HASH_CODE_MAX));
+  return map.get(getOrQueryHashCode(getKernel(), face.wrapped));
 }
 
 /**

--- a/src/topology/metadata/faceTagFns.ts
+++ b/src/topology/metadata/faceTagFns.ts
@@ -8,7 +8,7 @@
 import type { ShapeEvolution } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
 import type { AnyShape, Dimension, Face } from '@/core/shapeTypes.js';
-import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { getFaces } from '@/topology/shapeFns.js';
 
 // ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ export function tagFaces(
   const existing = tagMap.get(tag) ?? new Set<number>();
 
   for (const face of faces) {
-    existing.add(getKernel().hashCode(face.wrapped, HASH_CODE_MAX));
+    existing.add(getOrQueryHashCode(getKernel(), face.wrapped));
   }
 
   tagMap.set(tag, existing);
@@ -89,7 +89,7 @@ export function findFacesByTag(shape: AnyShape<Dimension>, tag: string): Face<Di
 
   const result: Face<Dimension>[] = [];
   for (const face of getFaces(shape)) {
-    const hash = getKernel().hashCode(face.wrapped, HASH_CODE_MAX);
+    const hash = getOrQueryHashCode(getKernel(), face.wrapped);
     if (hashes.has(hash)) {
       result.push(face);
     }
@@ -108,7 +108,7 @@ export function getFaceTags(shape: AnyShape<Dimension>): Map<string, Face<Dimens
   const faces = getFaces(shape);
   const faceByHash = new Map<number, Face<Dimension>>();
   for (const face of faces) {
-    faceByHash.set(getKernel().hashCode(face.wrapped, HASH_CODE_MAX), face);
+    faceByHash.set(getOrQueryHashCode(getKernel(), face.wrapped), face);
   }
 
   for (const [tag, hashes] of tagMap) {

--- a/src/topology/metadata/metadataPropagation.ts
+++ b/src/topology/metadata/metadataPropagation.ts
@@ -10,7 +10,7 @@
 import type { ShapeEvolution } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
-import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import {
   getFaceOrigins,
   propagateOriginsFromEvolution,
@@ -41,7 +41,7 @@ export function collectInputFaceHashes(inputs: readonly AnyShape<Dimension>[]): 
   for (const input of inputs) {
     const faces = kernel.iterShapes(input.wrapped, 'face');
     for (const face of faces) {
-      hashes.push(kernel.hashCode(face, HASH_CODE_MAX));
+      hashes.push(getOrQueryHashCode(kernel, face));
     }
   }
   return hashes;

--- a/src/topology/metadata/originTrackingFns.ts
+++ b/src/topology/metadata/originTrackingFns.ts
@@ -6,7 +6,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { ShapeEvolution } from '@/kernel/types.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
-import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { getOrCreateCache, getCacheEntry, getFaces } from '@/topology/topologyQueryFns.js';
 
 // ---------------------------------------------------------------------------
@@ -21,7 +21,7 @@ export function setShapeOrigin(shape: AnyShape<Dimension>, origin: number): void
   const cache = getOrCreateCache(shape);
   const map = new Map<number, number>();
   for (const f of getFaces(shape)) {
-    map.set(getKernel().hashCode(f.wrapped, HASH_CODE_MAX), origin);
+    map.set(getOrQueryHashCode(getKernel(), f.wrapped), origin);
   }
   cache.faceOrigins = map;
 }
@@ -154,7 +154,7 @@ export function propagateOriginsByHash(
 
   // Try hash-based matching first
   for (const f of resultFaces) {
-    const hash = kernel.hashCode(f.wrapped, HASH_CODE_MAX);
+    const hash = getOrQueryHashCode(kernel, f.wrapped);
     const origin = lookup.get(hash);
     if (origin !== undefined) {
       resultMap.set(hash, origin);
@@ -175,7 +175,7 @@ export function propagateOriginsByHash(
       const origins = getFaceOrigins(input);
       if (!origins) continue;
       for (const f of getFaces(input)) {
-        const hash = kernel.hashCode(f.wrapped, HASH_CODE_MAX);
+        const hash = getOrQueryHashCode(kernel, f.wrapped);
         const origin = origins.get(hash);
         if (origin === undefined) continue;
         try {
@@ -195,7 +195,7 @@ export function propagateOriginsByHash(
 
     if (inputSigs.length > 0) {
       for (const f of resultFaces) {
-        const hash = kernel.hashCode(f.wrapped, HASH_CODE_MAX);
+        const hash = getOrQueryHashCode(kernel, f.wrapped);
         try {
           const outBounds = kernel.uvBounds(f.wrapped);
           const outNormal = kernel.surfaceNormal(

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -10,6 +10,7 @@ import type { Edge, Face, Shell, Solid, Shape3D, AnyShape, Dimension } from '@/c
 import type { ValidSolid } from '@/core/validityTypes.js';
 import { castShape, isShape3D, isSolid } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { type Result, type Err, ok, err, isErr } from '@/core/result.js';
 import type { BrepError } from '@/core/errors.js';
 import { kernelError, validationError, BrepErrorCode } from '@/core/errors.js';
@@ -82,12 +83,12 @@ function resolveEdgeCallback(
     if (typeof val === 'number' && val <= 0) continue;
     if (Array.isArray(val) && (val[0] <= 0 || val[1] <= 0)) continue;
     filteredEdges.push(edge);
-    hashToValue.set(getKernel().hashCode(edge.wrapped, HASH_CODE_MAX), val);
+    hashToValue.set(getOrQueryHashCode(getKernel(), edge.wrapped), val);
   }
   if (filteredEdges.length === 0) return null;
 
   const kernelParam: KernelHashCallback<number | [number, number]> = (ocEdge) => {
-    const v = hashToValue.get(getKernel().hashCode(ocEdge, HASH_CODE_MAX));
+    const v = hashToValue.get(getOrQueryHashCode(getKernel(), ocEdge));
     // Default to 1 (should not happen due to pre-filtering)
     return v ?? 1;
   };
@@ -142,11 +143,11 @@ function resolveDraftCallback(
     const a = angle(face);
     if (a === null || a === 0 || Math.abs(a) >= 90) continue;
     filteredFaces.push(face);
-    hashToAngle.set(getKernel().hashCode(face.wrapped, HASH_CODE_MAX), a);
+    hashToAngle.set(getOrQueryHashCode(getKernel(), face.wrapped), a);
   }
 
   const kernelAngle = (ocFace: KernelShape) => {
-    const a = hashToAngle.get(getKernel().hashCode(ocFace, HASH_CODE_MAX));
+    const a = hashToAngle.get(getOrQueryHashCode(getKernel(), ocFace));
     if (a === undefined) {
       throw new Error('draft: face hash not found — possible hash collision');
     }
@@ -627,7 +628,7 @@ export function variableFillet(
   const kernel = getKernel();
   try {
     const spec = JSON.stringify({
-      edge: kernel.hashCode(edge.wrapped, HASH_CODE_MAX),
+      edge: getOrQueryHashCode(kernel, edge.wrapped),
       radii: radii.map((r) => ({ param: r.param, radius: r.radius })),
     });
     const result = kernel.filletVariable(shape.wrapped, spec);

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -9,8 +9,8 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
-import { HASH_CODE_MAX } from '@/core/constants.js';
 import type { Result } from '@/core/result.js';
+import { getOrQueryHashCode } from '@/core/shapePropertyCache.js';
 import { kernelCall, kernelCallRaw } from '@/core/kernelCall.js';
 import { BrepErrorCode } from '@/core/errors.js';
 
@@ -38,7 +38,7 @@ export function toBREP(shape: AnyShape<Dimension>): Result<string> {
 
 /** Get the topology hash code of a shape. */
 export function getHashCode(shape: AnyShape<Dimension>): number {
-  return getKernel().hashCode(shape.wrapped, HASH_CODE_MAX);
+  return getOrQueryHashCode(getKernel(), shape.wrapped);
 }
 
 /** Check if a shape is null. */

--- a/src/topology/topologyQueryFns.ts
+++ b/src/topology/topologyQueryFns.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/core/shapeTypes.js';
 import { castShapeWithKnownType } from '@/core/shapeTypes.js';
 import { getOrQueryType } from '@/core/shapeTypeCache.js';
+import { getOrQueryVertexPosition } from '@/core/shapePropertyCache.js';
 import type { Vec3 } from '@/core/types.js';
 
 // ---------------------------------------------------------------------------
@@ -248,7 +249,7 @@ export function describe(shape: AnyShape<Dimension>): ShapeDescription {
 // Vertex position
 // ---------------------------------------------------------------------------
 
-/** Get the position of a vertex as a Vec3 tuple. */
+/** Get the position of a vertex as a Vec3 tuple. Cached — no WASM call on repeat queries. */
 export function vertexPosition(vertex: Vertex): Vec3 {
-  return getKernel().vertexPosition(vertex.wrapped);
+  return getOrQueryVertexPosition(getKernel(), vertex.wrapped);
 }


### PR DESCRIPTION
## Summary

Add WeakMap caches for two frequently-queried immutable shape properties, eliminating redundant WASM round-trips (~5-10μs each) in hot loops:

- **vertexPosition**: Cached in vertex finder loops (`nearestTo`, `atPosition`, `withinBox`, `atDistance`)
- **hashCode**: Cached in adjacency deduplication, face tagging, color propagation, evolution tracking, boolean edge adjacency, and modifier edge resolution

## Design

New `src/core/shapePropertyCache.ts` follows the proven `shapeTypeCache.ts` pattern:
- `getOrQueryVertexPosition(kernel, vertex)` — WeakMap on KernelShape
- `getOrQueryHashCode(kernel, shape)` — WeakMap on KernelShape

Both properties are deterministic on immutable shapes (brepjs never mutates — operations return new shapes). WeakMap prevents memory leaks.

## Files changed (12)

- `src/core/shapePropertyCache.ts` — NEW: cache implementation
- `src/topology/topologyQueryFns.ts` — vertexPosition() now cached
- `src/topology/adjacencyFns.ts` — 8 hashCode calls cached
- `src/topology/booleanFns.ts` — 2 hashCode calls cached
- `src/topology/evolutionFns.ts` — 2 hashCode calls cached
- `src/topology/modifierFns.ts` — 5 hashCode calls cached
- `src/topology/shapeFns.ts` — 1 hashCode call cached
- `src/topology/metadata/colorFns.ts` — 2 hashCode calls cached
- `src/topology/metadata/faceTagFns.ts` — 3 hashCode calls cached
- `src/topology/metadata/metadataPropagation.ts` — 1 hashCode call cached
- `src/topology/metadata/originTrackingFns.ts` — 4 hashCode calls cached

## Test plan

- [x] `npm run validate` — all 5 checks pass (2132 passed, 66 skipped)
- [ ] CI green