### PR TITLE
feat: upgrade occt-wasm to 1.4.0 with Worker adapter

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -11,7 +11,10 @@ const config: KnipConfig = {
   workspaces: {
     '.': {
       project: ['src/**/*.ts'],
-      entry: ['src/kernel/occtWasm/occtWasmAdapter.ts'],
+      entry: [
+        'src/kernel/occtWasm/occtWasmAdapter.ts',
+        'src/kernel/occtWasm/occtWasmWorkerAdapter.ts',
+      ],
       ignore: [],
       ignoreBinaries: ['tsx'],
       // occt-wasm is dynamically imported in tests/helpers/kernelInit.ts (outside project scope)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "husky": "9.1.7",
         "knip": "6.1.0",
         "lint-staged": "16.4.0",
-        "occt-wasm": "1.2.1",
+        "occt-wasm": "1.4.0",
         "prettier": "3.8.1",
         "size-limit": "12.0.1",
         "typedoc": "0.28.18",
@@ -4485,6 +4485,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -7131,11 +7138,14 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-1.2.1.tgz",
-      "integrity": "sha512-/37BHdn/s2U1hginbKrOaWN8ayIUcB0ERqwrd4X4yP/SeJJ5Rw3TGAWxm+4ftNDj8rObPwRDRUTlX+WuWveCEw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-1.4.0.tgz",
+      "integrity": "sha512-Un4fgQxVbByw0tdrFvbSYjSnvHw8MynmQsFD7XER6ikdMQkVuM4ea4GAWYowgoAwHPV3DGwA0k/SdWqGzv9yrw==",
       "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "comlink": "^4.4.2"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "husky": "9.1.7",
     "knip": "6.1.0",
     "lint-staged": "16.4.0",
-    "occt-wasm": "1.2.1",
+    "occt-wasm": "1.4.0",
     "prettier": "3.8.1",
     "size-limit": "12.0.1",
     "typedoc": "0.28.18",

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -144,6 +144,12 @@ export const BrepErrorCode = {
   POLYHEDRON_INVALID_INDEX: 'POLYHEDRON_INVALID_INDEX',
   POLYHEDRON_FAILED: 'POLYHEDRON_FAILED',
 
+  // Tessellation errors
+  TESSELLATION_FAILED: 'TESSELLATION_FAILED',
+
+  // General IO errors
+  IO_FAILED: 'IO_FAILED',
+
   // General validation errors
   VALIDATION_FAILED: 'VALIDATION_FAILED',
 

--- a/src/core/kernelCall.ts
+++ b/src/core/kernelCall.ts
@@ -12,7 +12,7 @@ import type { Result } from './result.js';
 import { ok, err } from './result.js';
 import type { BrepErrorKind, BrepError } from './errors.js';
 import { translateKernelError, getSuggestionForCode } from './errors.js';
-import { mapOcctError } from './occtErrorMapping.js';
+import { isOcctError, mapOcctError } from './occtErrorMapping.js';
 import { DisposalScope } from './disposal.js';
 
 type ErrorFactory = (
@@ -32,19 +32,6 @@ function buildError(
   const base: BrepError = { kind, code, message, cause };
   if (suggestion) return { ...base, suggestion };
   return base;
-}
-
-/**
- * Check if an error is an OcctError (has a string `.code` property).
- * occt-wasm ≥1.4.0 throws OcctError with structured error codes.
- */
-function isOcctError(e: unknown): boolean {
-  return (
-    typeof e === 'object' &&
-    e !== null &&
-    'code' in e &&
-    typeof (e as Record<string, unknown>)['code'] === 'string'
-  );
 }
 
 const errorFactories: Record<BrepErrorKind, ErrorFactory> = {

--- a/src/core/kernelCall.ts
+++ b/src/core/kernelCall.ts
@@ -12,6 +12,7 @@ import type { Result } from './result.js';
 import { ok, err } from './result.js';
 import type { BrepErrorKind, BrepError } from './errors.js';
 import { translateKernelError, getSuggestionForCode } from './errors.js';
+import { mapOcctError } from './occtErrorMapping.js';
 import { DisposalScope } from './disposal.js';
 
 type ErrorFactory = (
@@ -31,6 +32,19 @@ function buildError(
   const base: BrepError = { kind, code, message, cause };
   if (suggestion) return { ...base, suggestion };
   return base;
+}
+
+/**
+ * Check if an error is an OcctError (has a string `.code` property).
+ * occt-wasm ≥1.4.0 throws OcctError with structured error codes.
+ */
+function isOcctError(e: unknown): boolean {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    'code' in e &&
+    typeof (e as Record<string, unknown>)['code'] === 'string'
+  );
 }
 
 const errorFactories: Record<BrepErrorKind, ErrorFactory> = {
@@ -72,6 +86,9 @@ export function kernelCall(
   try {
     return ok(castShape(fn()));
   } catch (e) {
+    // Fast path: structured OcctError from occt-wasm ≥1.4.0
+    if (isOcctError(e)) return err(mapOcctError(e));
+
     const rawMessage = e instanceof Error ? e.message : String(e);
     const translatedMessage =
       kind === 'KERNEL_OPERATION' ? translateKernelError(rawMessage) : rawMessage;
@@ -96,6 +113,9 @@ export function kernelCallRaw<T>(
   try {
     return ok(fn());
   } catch (e) {
+    // Fast path: structured OcctError from occt-wasm ≥1.4.0
+    if (isOcctError(e)) return err(mapOcctError(e));
+
     const rawMessage = e instanceof Error ? e.message : String(e);
     const translatedMessage =
       kind === 'KERNEL_OPERATION' ? translateKernelError(rawMessage) : rawMessage;

--- a/src/core/occtErrorMapping.ts
+++ b/src/core/occtErrorMapping.ts
@@ -1,0 +1,97 @@
+/**
+ * Maps occt-wasm OcctError instances to brepjs BrepError objects.
+ *
+ * occt-wasm 1.4.0 introduced OcctErrorCode for structured error handling.
+ * This module translates those codes into brepjs's BrepError taxonomy so
+ * that downstream Result<T> consumers get consistent error kinds/codes
+ * regardless of which kernel produced them.
+ *
+ * Lives in core/ (Layer 1) because it imports BrepError types.
+ * kernel/ (Layer 0) code must NOT import this directly — wire through
+ * kernelCall or dependency injection instead.
+ *
+ * @module
+ */
+
+import type { BrepError, BrepErrorKind } from './errors.js';
+import { BrepErrorCode } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// OcctErrorCode → BrepError mapping table
+// ---------------------------------------------------------------------------
+
+interface ErrorMapping {
+  readonly kind: BrepErrorKind;
+  readonly code: string;
+}
+
+/**
+ * Static mapping from occt-wasm OcctErrorCode string values to brepjs error
+ * kind + code. Keys match the OcctErrorCode enum values from occt-wasm 1.4.0.
+ *
+ * CONSTRUCTION_FAILED uses generic VALIDATION_FAILED because it covers
+ * edges, wires, faces, and solids — not just faces.
+ */
+const OCCT_ERROR_MAP: Readonly<Record<string, ErrorMapping>> = {
+  CONSTRUCTION_FAILED: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.VALIDATION_FAILED },
+  BOOLEAN_FAILED: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.BOOLEAN_HAS_ERRORS },
+  INVALID_SHAPE_ID: { kind: 'VALIDATION', code: BrepErrorCode.NULL_SHAPE_INPUT },
+  INVALID_LABEL_ID: { kind: 'VALIDATION', code: BrepErrorCode.NULL_SHAPE_INPUT },
+  TESSELLATION_FAILED: { kind: 'COMPUTATION', code: BrepErrorCode.INTERSECTION_FAILED },
+  IMPORT_EXPORT_FAILED: { kind: 'IO', code: BrepErrorCode.STEP_IMPORT_FAILED },
+  HEALING_FAILED: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.FIX_SHAPE_FAILED },
+  DOCUMENT_CLOSED: { kind: 'VALIDATION', code: BrepErrorCode.NULL_SHAPE_INPUT },
+  KERNEL_ERROR: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.VALIDATION_FAILED },
+  UNKNOWN: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.VALIDATION_FAILED },
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether an error has an OcctErrorCode-shaped `.code` property.
+ */
+function getOcctErrorCode(error: unknown): string | undefined {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as Record<string, unknown>)['code'] === 'string'
+  ) {
+    return (error as Record<string, unknown>)['code'] as string;
+  }
+  return undefined;
+}
+
+/**
+ * Map an occt-wasm error to a {@link BrepError}.
+ *
+ * If the error is an `OcctError` (has a `.code` field), the code is mapped
+ * to the appropriate `BrepErrorKind` and `BrepErrorCode`. For unrecognised
+ * errors, falls back to a generic `KERNEL_OPERATION` error.
+ */
+export function mapOcctError(error: unknown): BrepError {
+  const code = getOcctErrorCode(error);
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (code) {
+    const mapping = OCCT_ERROR_MAP[code];
+    if (mapping) {
+      return {
+        kind: mapping.kind,
+        code: mapping.code,
+        message,
+        cause: error,
+      };
+    }
+  }
+
+  // Fallback for plain errors or unrecognised codes
+  return {
+    kind: 'KERNEL_OPERATION',
+    code: BrepErrorCode.VALIDATION_FAILED,
+    message,
+    cause: error,
+  };
+}

--- a/src/core/occtErrorMapping.ts
+++ b/src/core/occtErrorMapping.ts
@@ -37,8 +37,8 @@ const OCCT_ERROR_MAP: Readonly<Record<string, ErrorMapping>> = {
   BOOLEAN_FAILED: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.BOOLEAN_HAS_ERRORS },
   INVALID_SHAPE_ID: { kind: 'VALIDATION', code: BrepErrorCode.NULL_SHAPE_INPUT },
   INVALID_LABEL_ID: { kind: 'VALIDATION', code: BrepErrorCode.NULL_SHAPE_INPUT },
-  TESSELLATION_FAILED: { kind: 'COMPUTATION', code: BrepErrorCode.INTERSECTION_FAILED },
-  IMPORT_EXPORT_FAILED: { kind: 'IO', code: BrepErrorCode.STEP_IMPORT_FAILED },
+  TESSELLATION_FAILED: { kind: 'COMPUTATION', code: BrepErrorCode.TESSELLATION_FAILED },
+  IMPORT_EXPORT_FAILED: { kind: 'IO', code: BrepErrorCode.IO_FAILED },
   HEALING_FAILED: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.FIX_SHAPE_FAILED },
   DOCUMENT_CLOSED: { kind: 'VALIDATION', code: BrepErrorCode.NULL_SHAPE_INPUT },
   KERNEL_ERROR: { kind: 'KERNEL_OPERATION', code: BrepErrorCode.VALIDATION_FAILED },
@@ -48,6 +48,13 @@ const OCCT_ERROR_MAP: Readonly<Record<string, ErrorMapping>> = {
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the error has a string `.code` property (OcctError shape).
+ */
+export function isOcctError(error: unknown): boolean {
+  return getOcctErrorCode(error) !== undefined;
+}
 
 /**
  * Detect whether an error has an OcctErrorCode-shaped `.code` property.

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,11 @@ export type { ProjectionCapability, ConstraintSketchCapability } from './kernel/
 export { getPerformanceStats, resetPerformanceStats } from './kernel/index.js';
 export type { PerformanceStats } from './kernel/perfStats.js';
 
+// --- Async / Worker kernel ---
+export type { AsyncKernelAdapter, Asyncify } from './kernel/index.js';
+export { createWorkerAdapter } from './kernel/index.js';
+export type { WorkerAdapterResult } from './kernel/index.js';
+
 // ── Result type ──
 
 export {

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -248,3 +248,8 @@ export type { OcctWasmModule, OcctKernelWasm } from './occtWasm/occtWasmTypes.js
 
 export { getPerformanceStats, resetPerformanceStats, perfTimer } from './perfStats.js';
 export type { PerfCategory, PerformanceStats } from './perfStats.js';
+
+// --- Async kernel adapter ---
+export type { AsyncKernelAdapter, Asyncify } from './interfaces/asyncAdapter.js';
+export { createWorkerAdapter } from './occtWasm/occtWasmWorkerAdapter.js';
+export type { WorkerAdapterResult } from './occtWasm/occtWasmWorkerAdapter.js';

--- a/src/kernel/interfaces/asyncAdapter.ts
+++ b/src/kernel/interfaces/asyncAdapter.ts
@@ -1,0 +1,43 @@
+/**
+ * Async variant of KernelAdapter for off-main-thread kernel usage.
+ *
+ * Uses a mapped type (`Asyncify`) to wrap every method's return type in
+ * `Promise<T>`, keeping the interface automatically in sync with the
+ * synchronous KernelAdapter as it evolves.
+ *
+ * **Limitation:** TypeScript mapped types only capture the last overload
+ * signature for overloaded methods. If KernelAdapter gains overloads,
+ * those will lose their additional signatures in AsyncKernelAdapter.
+ *
+ * @module
+ */
+
+import type { KernelAdapter } from './index.js';
+
+// ---------------------------------------------------------------------------
+// Mapped type
+// ---------------------------------------------------------------------------
+
+/**
+ * Transform an interface so that every method returns `Promise<R>`
+ * instead of `R`. Non-function properties are preserved as-is.
+ */
+export type Asyncify<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : T[K];
+};
+
+// ---------------------------------------------------------------------------
+// AsyncKernelAdapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Async version of {@link KernelAdapter}, excluding the `oc` property
+ * (the raw WASM instance lives in the worker and cannot be proxied).
+ *
+ * Every method that returns `T` on the sync adapter returns `Promise<T>` here.
+ * The `kernelId` property is preserved as a plain string.
+ */
+export type AsyncKernelAdapter = Asyncify<Omit<KernelAdapter, 'oc'>> & {
+  /** Kernel identifier (e.g., 'occt-wasm-worker'). */
+  readonly kernelId: string;
+};

--- a/src/kernel/interfaces/index.ts
+++ b/src/kernel/interfaces/index.ts
@@ -59,3 +59,6 @@ export type { KernelSurfaceOps } from './surfaceOps.js';
 export type { KernelSweepOps } from './sweepOps.js';
 export type { KernelTopologyOps } from './topologyOps.js';
 export type { KernelTransformOps, TransformEntry } from './transformOps.js';
+
+// --- Async adapter ---
+export type { Asyncify, AsyncKernelAdapter } from './asyncAdapter.js';

--- a/src/kernel/occtWasm/occtWasmWorkerAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmWorkerAdapter.ts
@@ -128,16 +128,16 @@ const SUPPORTED: ReadonlySet<string> = new Set([
 // ---------------------------------------------------------------------------
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelShape is any
-function workerHandle(type: ShapeType, id: number): any {
+function workerHandle(type: ShapeType, id: number, releaseFn: (id: number) => void): any {
   return {
     __occtWasm: true,
     type,
     id,
     delete() {
-      console.warn(
-        'workerHandle.delete() called — shapes created via WorkerKernelAdapter ' +
-          'must be disposed through adapter.dispose(), not handle.delete().'
-      );
+      releaseFn(id);
+    },
+    [Symbol.dispose]() {
+      releaseFn(id);
     },
     HashCode(upperBound: number) {
       return id % upperBound;
@@ -202,6 +202,13 @@ export function createWorkerAdapter(
 ): WorkerAdapterResult {
   const k = kernel;
 
+  // Fire-and-forget release: Symbol.dispose is sync, but worker release is
+  // async. We kick off the remote release without awaiting to stay compatible
+  // with `using` / DisposalScope while still freeing worker-side WASM memory.
+  const fireRelease = (id: number): void => {
+    void k.release(id);
+  };
+
   const adapter = new Proxy({} as AsyncKernelAdapter, {
     get(_target, prop: string | symbol) {
       if (typeof prop === 'symbol') return undefined;
@@ -242,7 +249,7 @@ export function createWorkerAdapter(
         // Wrap returned shape handles
         if (SHAPE_RETURNING.has(remoteName) && typeof result === 'number') {
           const type = (await k.getShapeType(result)) as string as ShapeType;
-          return workerHandle(type, result);
+          return workerHandle(type, result, fireRelease);
         }
 
         return result;

--- a/src/kernel/occtWasm/occtWasmWorkerAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmWorkerAdapter.ts
@@ -1,0 +1,257 @@
+/* v8 ignore file -- worker adapter not measured in main OCCT coverage */
+/**
+ * OcctWasmWorkerAdapter — AsyncKernelAdapter backed by OcctWorker.
+ *
+ * Runs the full occt-wasm OcctKernel in a Web Worker via Comlink.
+ * All methods return Promises; shape handles (u32 numbers) pass through
+ * the Comlink boundary as-is (no serialization overhead).
+ *
+ * **Coverage:** OcctWorkerProxy exposes ~95 methods. KernelAdapter has
+ * ~200. Methods not available on OcctWorkerProxy throw an error with
+ * a descriptive message. See SUPPORTED for the full set.
+ *
+ * @module
+ */
+
+import type { AsyncKernelAdapter } from '@/kernel/interfaces/asyncAdapter.js';
+import type { ShapeType } from '@/kernel/types.js';
+
+// ---------------------------------------------------------------------------
+// Supported methods — derived from OcctWorkerProxy in occt-wasm 1.4.0
+// ---------------------------------------------------------------------------
+
+/** Methods on OcctWorkerProxy that return a ShapeHandle (u32). */
+const SHAPE_RETURNING: ReadonlySet<string> = new Set([
+  'makeBox',
+  'makeBoxFromCorners',
+  'makeCylinder',
+  'makeSphere',
+  'makeCone',
+  'makeTorus',
+  'makeEllipsoid',
+  'makeRectangle',
+  'fuse',
+  'cut',
+  'common',
+  'intersect',
+  'section',
+  'extrude',
+  'revolve',
+  'fillet',
+  'chamfer',
+  'shell',
+  'offset',
+  'draft',
+  'pipe',
+  'loft',
+  'sweep',
+  'translate',
+  'rotate',
+  'scale',
+  'mirror',
+  'copy',
+  'transform',
+  'makeVertex',
+  'makeEdge',
+  'makeLineEdge',
+  'makeCircleEdge',
+  'makeArcEdge',
+  'makeWire',
+  'makeFace',
+  'makeSolid',
+  'makeCompound',
+  'importStep',
+  'importStl',
+  'fromBREP',
+  'fixShape',
+  'unifySameDomain',
+  'draftPrism',
+  'fuseAll',
+  'cutAll',
+  'split',
+  'linearPattern',
+  'circularPattern',
+]);
+
+/** All methods available on OcctWorkerProxy (shape-returning + non-shape). */
+const SUPPORTED: ReadonlySet<string> = new Set([
+  ...SHAPE_RETURNING,
+  // Scalar/string returns
+  'getShapeType',
+  'isCompound',
+  'isSolid',
+  'isFace',
+  'isEdge',
+  'isWire',
+  'isVertex',
+  'isShell',
+  'getSubShapes',
+  'distanceBetween',
+  'isSame',
+  'isNull',
+  'shapeOrientation',
+  // Mesh/wireframe
+  'tessellate',
+  'wireframe',
+  'meshShape',
+  'meshBatch',
+  // IO
+  'exportStep',
+  'exportStl',
+  'toBREP',
+  // Measure
+  'getBoundingBox',
+  'getVolume',
+  'getSurfaceArea',
+  'getLength',
+  'getCenterOfMass',
+  // Surface/curve
+  'surfaceCurvature',
+  'surfaceType',
+  'surfaceNormal',
+  'uvBounds',
+  'classifyPointOnFace',
+  'curveType',
+  'curveLength',
+  'getNurbsCurveData',
+  // Projection
+  'projectEdges',
+  // Repair
+  'isValid',
+  // Arena
+  'release',
+  'releaseAll',
+]);
+
+// ---------------------------------------------------------------------------
+// Handle helpers
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelShape is any
+function workerHandle(type: ShapeType, id: number): any {
+  return {
+    __occtWasm: true,
+    type,
+    id,
+    delete() {
+      console.warn(
+        'workerHandle.delete() called — shapes created via WorkerKernelAdapter ' +
+          'must be disposed through adapter.dispose(), not handle.delete().'
+      );
+    },
+    HashCode(upperBound: number) {
+      return id % upperBound;
+    },
+    IsNull() {
+      return id === 0;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- opaque handle
+function handleId(shape: any): number {
+  return shape.id;
+}
+
+function unwrapArg(arg: unknown): unknown {
+  if (typeof arg === 'object' && arg !== null && '__occtWasm' in arg) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- opaque handle
+    return handleId(arg as any);
+  }
+  if (Array.isArray(arg)) {
+    return arg.map(unwrapArg);
+  }
+  return arg;
+}
+
+// ---------------------------------------------------------------------------
+// brepjs method name → OcctWorkerProxy method name aliases
+// ---------------------------------------------------------------------------
+
+const METHOD_ALIASES: Readonly<Record<string, string>> = {
+  shapeType: 'getShapeType',
+  volume: 'getVolume',
+  area: 'getSurfaceArea',
+  length: 'getLength',
+  centerOfMass: 'getCenterOfMass',
+  boundingBox: 'getBoundingBox',
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface WorkerAdapterResult {
+  adapter: AsyncKernelAdapter;
+  worker: { terminate(): void };
+}
+
+/**
+ * Create an AsyncKernelAdapter backed by an off-thread OcctKernel.
+ *
+ * The `kernel` parameter is a Comlink-proxied OcctKernel instance running
+ * in a Web Worker (or Node worker_threads via nodeEndpoint).
+ *
+ * @param kernel - Comlink proxy to the remote OcctKernel.
+ * @param terminateFn - Function to terminate the underlying worker.
+ */
+export function createWorkerAdapter(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Comlink proxy
+  kernel: any,
+  terminateFn: () => void
+): WorkerAdapterResult {
+  const k = kernel;
+
+  const adapter = new Proxy({} as AsyncKernelAdapter, {
+    get(_target, prop: string | symbol) {
+      if (typeof prop === 'symbol') return undefined;
+
+      // Non-function properties
+      if (prop === 'kernelId') return 'occt-wasm-worker';
+      if (prop === 'then') return undefined; // Prevent Promise-like detection
+
+      // dispose → release
+      if (prop === 'dispose') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelShape
+        return async (shape: any) => {
+          await k.release(handleId(shape));
+        };
+      }
+
+      const remoteName = METHOD_ALIASES[prop] ?? prop;
+
+      // Check if method is supported
+      if (!SUPPORTED.has(remoteName)) {
+        return () => {
+          return Promise.reject(
+            new Error(
+              `Method '${prop}' is not supported via the worker adapter. ` +
+                `OcctWorkerProxy exposes ~95 of KernelAdapter's ~200 methods. ` +
+                `Use the synchronous OcctWasmAdapter for full API coverage.`
+            )
+          );
+        };
+      }
+
+      // Proxy the call to the worker kernel
+      return async (...args: unknown[]) => {
+        const translatedArgs = args.map(unwrapArg);
+
+        const result = await k[remoteName](...translatedArgs);
+
+        // Wrap returned shape handles
+        if (SHAPE_RETURNING.has(remoteName) && typeof result === 'number') {
+          const type = (await k.getShapeType(result)) as string as ShapeType;
+          return workerHandle(type, result);
+        }
+
+        return result;
+      };
+    },
+  });
+
+  return {
+    adapter,
+    worker: { terminate: terminateFn },
+  };
+}

--- a/tests/asyncKernelAdapter.test.ts
+++ b/tests/asyncKernelAdapter.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration tests for OcctWasmWorkerAdapter.
+ *
+ * Spawns a real OcctKernel in a Node worker thread via Comlink and
+ * exercises the AsyncKernelAdapter interface end-to-end.
+ *
+ * Requires TEST_KERNEL=occt-wasm environment.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { AsyncKernelAdapter } from '@/kernel/interfaces/asyncAdapter.js';
+
+const KERNEL = process.env['TEST_KERNEL'] ?? 'occt';
+const skip = KERNEL !== 'occt-wasm';
+
+describe.skipIf(skip)('OcctWasmWorkerAdapter', () => {
+  let adapter: AsyncKernelAdapter;
+  let terminate: () => void;
+
+  beforeAll(async () => {
+    const { spawnNodeOcctWorker } = await import('./helpers/nodeWorkerShim.js');
+    const { createWorkerAdapter } = await import('@/kernel/occtWasm/occtWasmWorkerAdapter.js');
+    const worker = await spawnNodeOcctWorker();
+    const result = createWorkerAdapter(worker.kernel, () => {
+      worker.terminate();
+    });
+    adapter = result.adapter;
+    terminate = () => {
+      result.worker.terminate();
+    };
+  }, 60000);
+
+  afterAll(() => {
+    terminate();
+  });
+
+  it('exposes kernelId', () => {
+    expect(adapter.kernelId).toBe('occt-wasm-worker');
+  });
+
+  it('makes a box and queries its volume', async () => {
+    const box = await adapter.makeBox(10, 20, 30);
+    expect(box).toBeDefined();
+    const vol = await adapter.volume(box);
+    expect(vol).toBeCloseTo(6000, 0);
+  });
+
+  it('performs a boolean fuse', async () => {
+    const a = await adapter.makeBox(10, 10, 10);
+    const b = await adapter.makeSphere(8);
+    const fused = await adapter.fuse(a, b);
+    expect(fused).toBeDefined();
+    const vol = await adapter.volume(fused);
+    expect(vol).toBeGreaterThan(1000);
+  });
+
+  it('exports and imports BREP', async () => {
+    const box = await adapter.makeBox(5, 5, 5);
+    const brep = await adapter.toBREP(box);
+    expect(typeof brep).toBe('string');
+    expect(brep.length).toBeGreaterThan(0);
+    const reimported = await adapter.fromBREP(brep);
+    expect(reimported).toBeDefined();
+  });
+
+  it('releases shapes without error', async () => {
+    const box = await adapter.makeBox(1, 1, 1);
+    await adapter.dispose(box);
+  });
+
+  it('queries shape type', async () => {
+    const box = await adapter.makeBox(1, 1, 1);
+    const type = await adapter.shapeType(box);
+    expect(type).toBe('solid');
+  });
+
+  it('throws descriptive error for unsupported methods', async () => {
+    // KernelEvolutionOps methods are not available via OcctWorker
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing unsupported path
+      (adapter as any).fuseWithHistory({}, {}, [], 100)
+    ).rejects.toThrow(/not supported.*worker/i);
+  });
+});

--- a/tests/helpers/nodeWorkerShim.ts
+++ b/tests/helpers/nodeWorkerShim.ts
@@ -16,7 +16,7 @@
 
 import { Worker as NodeWorker } from 'node:worker_threads';
 import { resolve } from 'node:path';
-import { fileURLToPath, URL as UrlClass } from 'node:url';
+import { fileURLToPath, pathToFileURL, URL as UrlClass } from 'node:url';
 import * as Comlink from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 
@@ -56,7 +56,7 @@ export async function spawnNodeOcctWorker(): Promise<NodeOcctWorker> {
     import { parentPort } from 'node:worker_threads';
     import * as Comlink from 'comlink';
     import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
-    import { OcctKernel } from '${resolve(wasmDir, 'index.js')}';
+    import { OcctKernel } from '${pathToFileURL(resolve(wasmDir, 'index.js')).href}';
 
     let kernel = null;
     const api = {

--- a/tests/helpers/nodeWorkerShim.ts
+++ b/tests/helpers/nodeWorkerShim.ts
@@ -1,0 +1,89 @@
+/**
+ * Node.js worker shim for OcctWorker integration tests.
+ *
+ * OcctWorker.spawn() uses `Comlink.wrap(worker)` which expects a browser
+ * Worker with addEventListener/postMessage. In Node.js (Vitest's forks pool),
+ * we need `Comlink.nodeEndpoint()` to adapt `worker_threads`.
+ *
+ * This module provides `spawnNodeOcctWorker()` which replicates OcctWorker's
+ * spawn logic but uses nodeEndpoint on both sides:
+ *
+ * - Main thread: `Comlink.wrap(nodeEndpoint(worker))`
+ * - Worker thread: Custom entry script that uses `nodeEndpoint(parentPort)`
+ *
+ * @module
+ */
+
+import { Worker as NodeWorker } from 'node:worker_threads';
+import { resolve } from 'node:path';
+import { fileURLToPath, URL as UrlClass } from 'node:url';
+import * as Comlink from 'comlink';
+import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
+
+/**
+ * Resolve the directory containing occt-wasm dist files.
+ */
+function resolveOcctWasmDir(): string {
+  const occtWasmEntry = import.meta.resolve('occt-wasm');
+  return fileURLToPath(new UrlClass('.', occtWasmEntry));
+}
+
+/**
+ * Resolve the path to the occt-wasm .wasm file.
+ */
+export function resolveWasmPath(): string {
+  return resolve(resolveOcctWasmDir(), 'occt-wasm.wasm');
+}
+
+export interface NodeOcctWorker {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic proxy
+  kernel: any;
+  terminate(): void;
+}
+
+/**
+ * Spawn an OcctKernel in a Node.js worker thread using Comlink + nodeEndpoint.
+ *
+ * Equivalent to `OcctWorker.spawn()` but compatible with Node.js worker_threads.
+ */
+export async function spawnNodeOcctWorker(): Promise<NodeOcctWorker> {
+  const wasmDir = resolveOcctWasmDir();
+  const wasmPath = resolve(wasmDir, 'occt-wasm.wasm');
+
+  // Create a Node worker that loads a shim script wrapping the real worker-entry
+  // with nodeEndpoint(parentPort) for Comlink compatibility.
+  const shimCode = `
+    import { parentPort } from 'node:worker_threads';
+    import * as Comlink from 'comlink';
+    import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
+    import { OcctKernel } from '${resolve(wasmDir, 'index.js')}';
+
+    let kernel = null;
+    const api = {
+      async init(options) {
+        if (kernel) kernel.releaseAll();
+        kernel = await OcctKernel.init(options);
+      },
+      get kernel() {
+        if (!kernel) throw new Error('OcctKernel not initialized');
+        return Comlink.proxy(kernel);
+      },
+    };
+    Comlink.expose(api, nodeEndpoint(parentPort));
+  `;
+
+  const worker = new NodeWorker(shimCode, { eval: true, type: 'module' });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Comlink remote type
+  const remote = Comlink.wrap(nodeEndpoint(worker) as any) as any;
+
+  await remote.init({ wasm: wasmPath });
+  const kernel = await remote.kernel;
+
+  return {
+    kernel,
+    terminate() {
+      worker.terminate();
+    },
+  };
+}

--- a/tests/occtErrorMapping.test.ts
+++ b/tests/occtErrorMapping.test.ts
@@ -22,21 +22,23 @@ describe('mapOcctError', () => {
     expect(result.cause).toBe(error);
   });
 
-  it('maps IMPORT_EXPORT_FAILED to IO kind', () => {
+  it('maps IMPORT_EXPORT_FAILED to IO kind with generic IO_FAILED code', () => {
     const error = new Error('STEP import failed');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
     (error as any).code = 'IMPORT_EXPORT_FAILED';
     const result = mapOcctError(error);
     expect(result.kind).toBe('IO');
+    expect(result.code).toBe('IO_FAILED');
     expect(result.cause).toBe(error);
   });
 
-  it('maps TESSELLATION_FAILED to COMPUTATION kind', () => {
+  it('maps TESSELLATION_FAILED to COMPUTATION kind with TESSELLATION_FAILED code', () => {
     const error = new Error('Tessellation failed');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
     (error as any).code = 'TESSELLATION_FAILED';
     const result = mapOcctError(error);
     expect(result.kind).toBe('COMPUTATION');
+    expect(result.code).toBe('TESSELLATION_FAILED');
   });
 
   it('maps HEALING_FAILED to KERNEL_OPERATION with FIX_SHAPE_FAILED', () => {

--- a/tests/occtErrorMapping.test.ts
+++ b/tests/occtErrorMapping.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { mapOcctError } from '@/core/occtErrorMapping.js';
+
+describe('mapOcctError', () => {
+  it('maps BOOLEAN_FAILED to KERNEL_OPERATION kind', () => {
+    const error = new Error('Boolean operation failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'BOOLEAN_FAILED';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('KERNEL_OPERATION');
+    expect(result.code).toBe('BOOLEAN_HAS_ERRORS');
+    expect(result.cause).toBe(error);
+  });
+
+  it('maps CONSTRUCTION_FAILED to KERNEL_OPERATION with generic code', () => {
+    const error = new Error('Build failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'CONSTRUCTION_FAILED';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('KERNEL_OPERATION');
+    expect(result.code).toBe('VALIDATION_FAILED');
+    expect(result.cause).toBe(error);
+  });
+
+  it('maps IMPORT_EXPORT_FAILED to IO kind', () => {
+    const error = new Error('STEP import failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'IMPORT_EXPORT_FAILED';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('IO');
+    expect(result.cause).toBe(error);
+  });
+
+  it('maps TESSELLATION_FAILED to COMPUTATION kind', () => {
+    const error = new Error('Tessellation failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'TESSELLATION_FAILED';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('COMPUTATION');
+  });
+
+  it('maps HEALING_FAILED to KERNEL_OPERATION with FIX_SHAPE_FAILED', () => {
+    const error = new Error('Healing failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'HEALING_FAILED';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('KERNEL_OPERATION');
+    expect(result.code).toBe('FIX_SHAPE_FAILED');
+  });
+
+  it('maps INVALID_SHAPE_ID to VALIDATION kind', () => {
+    const error = new Error('Invalid shape');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'INVALID_SHAPE_ID';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('VALIDATION');
+    expect(result.code).toBe('NULL_SHAPE_INPUT');
+  });
+
+  it('maps unknown OcctErrorCode to KERNEL_OPERATION with original message', () => {
+    const error = new Error('Something unknown');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- simulate OcctError
+    (error as any).code = 'UNKNOWN';
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('KERNEL_OPERATION');
+    expect(result.message).toContain('Something unknown');
+  });
+
+  it('handles plain Error (no code) gracefully', () => {
+    const error = new Error('plain error');
+    const result = mapOcctError(error);
+    expect(result.kind).toBe('KERNEL_OPERATION');
+    expect(result.cause).toBe(error);
+  });
+});

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -234,6 +234,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'createTaskQueue',
   'createVertex',
   'createWire',
+  'createWorkerAdapter',
   'createWorkerClient',
   'createWorkerHandler',
   'curve2dBoundingBox',


### PR DESCRIPTION
## Summary

- Bump occt-wasm 1.2.1 → 1.4.0 (Comlink-based OcctWorker, OcctError/OcctErrorCode, TypeScript enums)
- Add `OcctError` → `BrepError` structured mapping in `kernelCall` pipeline for precise error handling
- Create `AsyncKernelAdapter` mapped type (`Asyncify<T>`) that wraps all KernelAdapter methods in `Promise<T>`
- Create `OcctWasmWorkerAdapter` — Proxy-based adapter running OcctKernel off-main-thread via Comlink
- Add Node `worker_threads` shim for Vitest integration tests
- Export `createWorkerAdapter` and `AsyncKernelAdapter` publicly from brepjs

## Architecture

- `AsyncKernelAdapter` = `Asyncify<Omit<KernelAdapter, 'oc'>>` — auto-syncs with KernelAdapter as it evolves
- Worker adapter uses JS `Proxy` for dynamic method dispatch (~95 of ~200 methods supported, rest throw descriptive errors)
- Shape handles pass as lightweight u32 IDs across Comlink boundary (no BREP serialization)
- Error mapping lives in `core/` (Layer 1) to respect Layer 0 → Layer 1 boundary
- Node worker shim wraps `worker_threads` + `Comlink.nodeEndpoint()` for Vitest compatibility

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run check:boundaries` passes  
- [ ] `npm run lint` passes
- [ ] `TEST_KERNEL=occt-wasm npx vitest run tests/asyncKernelAdapter.test.ts` — 7 worker adapter tests
- [ ] `npx vitest run tests/occtErrorMapping.test.ts` — 8 error mapping tests
- [ ] `npx vitest run --project occt` — full OCCT test suite (2625 tests)
- [ ] `npm run knip` — unused export detection (note: 3 pre-existing unused exports in curve2dGeometryFns.ts)