### PR TITLE
fix(sketching): handle CompoundSketch in sweepSketch callback (#744)

### DIFF
--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -222,17 +222,24 @@ export default class Sketch implements SketchInterface {
       ...startPoint,
     ]);
 
-    // The callback may return a Sketches (plural) when the Drawing used a
-    // 2D boolean that split the profile into multiple pieces. Extract the
-    // first sketch's wire and dispose the rest to prevent WASM leaks.
-    // Duck-type check avoids circular import (sketches.ts imports Sketch).
+    // The callback may return Sketches (plural) or CompoundSketch when the
+    // Drawing used 2D booleans. Extract a single Sketch with a .wire for sweep.
+    // Duck-type checks avoid circular imports (sketches.ts/compoundSketch.ts import Sketch).
     let sketch: Sketch;
     if ('sketches' in result && Array.isArray((result as { sketches: unknown[] }).sketches)) {
-      const pieces = (result as { sketches: Sketch[] }).sketches;
-      sketch = pieces[0] as Sketch;
+      const pieces = (
+        result as { sketches: Array<Sketch | { outerSketch: Sketch; delete(): void }> }
+      ).sketches;
+      const first = pieces[0];
+      // CompoundSketch has .outerSketch (a Sketch with .wire); plain Sketch has .wire directly
+      sketch = 'outerSketch' in first ? first.outerSketch : (first as Sketch);
+      // Dispose unused pieces (skip the one we extracted from)
       for (let i = 1; i < pieces.length; i++) {
         pieces[i]?.delete();
       }
+    } else if ('outerSketch' in result) {
+      // Direct CompoundSketch return (from CompoundBlueprint.sketchOnPlane)
+      sketch = (result as { outerSketch: Sketch }).outerSketch;
     } else {
       sketch = result as Sketch;
     }

--- a/tests/sweepDrawingBoolean.test.ts
+++ b/tests/sweepDrawingBoolean.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Reproduction test for #744 — Drawing with 2D booleans → sweepSketch crash.
+ * Mimics the gridfinity stacking lip builder pattern.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import {
+  draw,
+  drawRoundedRectangle,
+  drawRectangle,
+} from '../src/index.js';
+import type { Sketch, Plane, Vec3 } from '../src/index.js';
+
+beforeAll(() => initKernel());
+
+describe('sweepSketch with Drawing booleans (#744)', () => {
+  it('sweeps a profile that uses Drawing.intersect() + Drawing.cut()', () => {
+    const LIP_TAPER_WIDTH = 0.7;
+    const LIP_SMALL_TAPER = 0.7;
+    const LIP_VERTICAL_PART = 1.8;
+    const LIP_BIG_TAPER = 1.9;
+    const LIP_EXTENSION = 1.2;
+
+    const topProfile = (plane: Plane, _origin: Vec3): Sketch => {
+      const basicShape = draw([-LIP_TAPER_WIDTH, 0])
+        .line(LIP_SMALL_TAPER, LIP_SMALL_TAPER)
+        .vLine(LIP_VERTICAL_PART)
+        .line(LIP_BIG_TAPER, LIP_BIG_TAPER)
+        .vLineTo(-(LIP_TAPER_WIDTH + LIP_EXTENSION))
+        .lineTo([-LIP_TAPER_WIDTH, -LIP_EXTENSION])
+        .close();
+
+      let topProfileShape = basicShape.intersect(
+        drawRoundedRectangle(10, 10).translate(-5, 0)
+      );
+
+      topProfileShape = topProfileShape.cut(
+        drawRectangle(LIP_EXTENSION, 10).translate(-LIP_EXTENSION / 2, -5)
+      );
+
+      const result = topProfileShape.sketchOnPlane(plane);
+      console.log('sketchOnPlane result type:', result.constructor.name);
+      console.log('has wire?', 'wire' in result);
+      console.log('has sketches?', 'sketches' in result);
+      if ('sketches' in result) {
+        const sketches = (result as { sketches: unknown[] }).sketches;
+        console.log('sketches count:', sketches.length);
+        console.log('sketches[0] type:', sketches[0]?.constructor.name);
+        console.log('sketches[0] has wire?', sketches[0] && 'wire' in (sketches[0] as object));
+      }
+      return result as Sketch;
+    };
+
+    const outerW = 2 * 42 - 0.5;
+    const outerD = 2 * 42 - 0.5;
+    const BOX_CORNER_RADIUS = 3.75;
+
+    const boxSketch = drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS)
+      .sketchOnPlane() as Sketch;
+
+    expect(() => {
+      boxSketch.sweepSketch(topProfile as (plane: Plane, origin: Vec3) => typeof boxSketch, { withContact: true });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `sweepSketch` crash when the profile callback returns `Sketches` containing `CompoundSketch` entries (from Drawing 2D booleans like `.intersect()` + `.cut()`).

**Root cause:** After the #700 revert (PR #742), 2D booleans produce `Blueprints` (plural) where v15.1.11 produced `Blueprint` (singular). When sketched onto a plane, this becomes `Sketches` containing `CompoundSketch` entries. The fix in #746 (v15.1.13) extracts `pieces[0]` but casts it `as Sketch` — when it's actually a `CompoundSketch` (no `.wire` property), causing `sweep()` to crash on `undefined.wrapped`.

**Fix:** Extract `.outerSketch` from `CompoundSketch` entries to get a real `Sketch` with `.wire`. Also handle direct `CompoundSketch` returns.

## Remaining issue

This fixes the crash, but the lip profile geometry differs from v15.1.11 because the 2D boolean layer now produces multi-piece results. The `outerSketch` wire is the correct outer boundary but doesn't include inner profile details. 25 tests still fail in gridfinity-layout-tool due to dimension mismatches on split+lip geometry. A deeper fix in the 2D boolean layer is needed to restore the single-piece result consistency.

## Test plan

- [x] All 2612 OCCT tests pass
- [x] New `sweepDrawingBoolean.test.ts` reproducing the exact gridfinity pattern
- [x] gridfinity `boxBuilder.test.ts` passes (9/9)
- [x] gridfinity failures reduced from 68 → 25 (remaining are geometry dimension issues, not crashes)

Fixes #744