### PR TITLE
fix(site): unbreak Monaco type checking in playground (#761 follow-up)

### DIFF
--- a/site/src/lib/monacoSetup.ts
+++ b/site/src/lib/monacoSetup.ts
@@ -31,14 +31,19 @@ export function setupMonaco(monaco: Monaco) {
     },
   });
 
-  // Configure TypeScript compiler options
+  // Configure TypeScript compiler options.
+  // We omit `lib` so Monaco's TS worker uses the default lib for the target
+  // (`lib.es2022.full.d.ts`), which transitively pulls in lib.es5.d.ts —
+  // the file that declares `Math`, `Array<T>`, and other built-ins. Passing
+  // `lib: ['es2022']` explicitly hits a Monaco bug where the lib reference
+  // is not expanded transitively, leaving user code with `Cannot find name
+  // 'Math'` and `push does not exist on type '{}'` errors (issue #761).
   monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
     target: monaco.languages.typescript.ScriptTarget.ES2022,
     module: monaco.languages.typescript.ModuleKind.ESNext,
     strict: true,
     noEmit: true,
     allowJs: true,
-    lib: ['es2022'],
   });
 
   // Disable diagnostic errors that don't make sense for eval'd code


### PR DESCRIPTION
## Summary

Follow-up to #766. While verifying the fix in production, I confirmed the runtime errors and "endless Loading geometry" were resolved — but the Monaco editor in the playground still showed the **exact** type errors the issue reporter called out:

> Hovering the errors show "Cannot find name 'Math'" and "Property 'push' does not exist on type '{}'." on dividers.push while dividers is defined as an array a few lines above.

Root cause: `monacoSetup.ts` passed `lib: ['es2022']` explicitly to Monaco's TypeScript worker. When you set `lib` explicitly, Monaco does **not** transitively expand the reference to include `lib.es5.d.ts`, which is the file that actually declares `Math`, `Array<T>`, `Object`, and friends. So the user code saw a TypeScript environment with no standard library at all — `dividers = []` inferred as `{}`, `Math.max` was undefined, etc.

Removing the explicit `lib` lets Monaco fall back to the default for `target: ES2022`, which is `lib.es2022.full.d.ts`. That file is the "full" bundle: it transitively includes every prior `lib.esNNNN.d.ts` plus `lib.dom.d.ts`, restoring the standard library inside the editor.

## Changes

- **`site/src/lib/monacoSetup.ts`** — drop the `lib: ['es2022']` line and add a comment explaining why.

## Verification

Verified locally with puppeteer + `monaco.editor.getModelMarkers`:

| Example | Before | After |
|---|---|---|
| Default playground (`shape(box(40,30,20)).fillet(3).val`) | 7 errors | **0** |
| Compartment Tray | 7 errors | **2** |

The 2 remaining Compartment Tray errors are unrelated to lib resolution — they're real `Shape3D` → `Shapeable<ValidSolid>` narrowing errors in the example code, surfaced by brepjs v15's branded validity types (`shell()` and `cutAll()` require a proven `ValidSolid`, not the wider `Shape3D` returned by `Sketch.extrude()`). These weren't part of the original #761 report and were previously masked by the broken lib resolution making TypeScript fail upstream. They'll need either example code with `validSolid()` smart constructor calls, or wider overloads in brepjs's topology API. **Tracking as a follow-up; not blocking this fix.**

## Test plan

- [x] Local dev server (`npm run dev`) renders Compartment Tray without `Math` / `push` / `length` red squiggles
- [x] Default playground script renders filleted box with **zero** Monaco diagnostics
- [x] No regression in runtime: geometry still renders correctly
- [ ] Verify on Vercel preview deployment after merge