### PR TITLE
fix(sketching): remove redundant Math.abs() on positive radii

### DIFF
--- a/src/sketching/sketcherlib.ts
+++ b/src/sketching/sketcherlib.ts
@@ -500,7 +500,7 @@ export function convertSvgEllipseParams(
   if (ry < 0) {
     ry = -ry;
   }
-  if (Math.abs(rx) < 1e-10 || Math.abs(ry) < 1e-10) {
+  if (rx < 1e-10 || ry < 1e-10) {
     // invalid arguments
     bug('convertSvgEllipseParams', 'rx and ry cannot be 0');
   }


### PR DESCRIPTION
## Summary

- Remove unnecessary `Math.abs()` calls on `rx`/`ry` in `convertSvgEllipseParams` — both values are already guaranteed non-negative by preceding `if (rx < 0) { rx = -rx; }` guards

Follow-up from Greptile review on #773.

## Test plan
- [x] All tests pass (2612 passed)
- [x] Pre-push checks pass