### PR TITLE
fix: improve error handling across operations and queries

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-03-28T07:03:31.142Z",
+  "generated": "2026-04-13T03:34:30.182Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -150,7 +150,7 @@
     {
       "file": "src/kernel/geometry2d.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/geometry2d.ts|max-function-lines|593|"
+      "fingerprint": "src/kernel/geometry2d.ts|max-function-lines|636|"
     },
     {
       "file": "src/kernel/occt/advancedOps.ts",
@@ -193,11 +193,6 @@
       "fingerprint": "src/operations/straightSkeleton.ts|max-function-lines|330|"
     },
     {
-      "file": "src/topology/healingFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/topology/healingFns.ts|max-function-lines|185|"
-    },
-    {
       "file": "src/topology/metadata/originTrackingFns.ts",
       "rule": "max-nesting-depth",
       "fingerprint": "src/topology/metadata/originTrackingFns.ts|max-nesting-depth|209|"
@@ -205,12 +200,12 @@
     {
       "file": "src/topology/modifierFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|197|"
+      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|199|"
     },
     {
       "file": "src/topology/modifierFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|497|"
+      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|499|"
     },
     {
       "file": "src/topology/surfaceFns.ts",

--- a/src/operations/extrudeUtils.ts
+++ b/src/operations/extrudeUtils.ts
@@ -84,6 +84,9 @@ export function buildLawFromProfile(
   extrusionLength: number,
   { profile, endFactor = 1 }: ExtrusionProfile
 ): Result<KernelType> {
+  if (extrusionLength <= 0) {
+    return err(validationError('INVALID_EXTRUSION_LENGTH', 'Extrusion length must be positive'));
+  }
   if (profile !== 's-curve' && profile !== 'linear') {
     return err(
       validationError('UNSUPPORTED_PROFILE', `Unsupported extrusion profile: ${String(profile)}`)

--- a/src/operations/loftFns.ts
+++ b/src/operations/loftFns.ts
@@ -72,12 +72,12 @@ export function loft(
       return err(typeCastError('LOFT_NOT_3D', 'Loft did not produce a 3D shape'));
     }
     return ok(result);
-  } catch {
+  } catch (e) {
     return err(
       kernelError(
         'LOFT_FAILED',
         'Loft operation failed',
-        undefined,
+        e,
         undefined,
         'Common causes: wire profiles with different edge counts, self-intersecting result, or profiles too far apart. Ensure profiles are compatible and ordered.'
       )

--- a/src/operations/roofFns.ts
+++ b/src/operations/roofFns.ts
@@ -268,14 +268,16 @@ export function roof(
       const solid = kernel.sewAndSolidify(triFaces, 1e-6);
       const fixed = kernel.fixShape(solid);
       return ok(createSolid(fixed) as ValidSolid);
-    } catch {
+    } catch (solidifyErr) {
       try {
         const sewn = createSolid(kernel.sew(triFaces, 1e-6));
         // sew() doesn't guarantee a valid solid — validate before branding
         if (isValidSolid(sewn)) return ok(sewn);
-        return err(kernelError(BrepErrorCode.ROOF_FAILED, 'Sew fallback produced invalid solid'));
-      } catch {
-        return err(kernelError(BrepErrorCode.ROOF_FAILED, 'Failed to sew roof faces'));
+        return err(
+          kernelError(BrepErrorCode.ROOF_FAILED, 'Sew fallback produced invalid solid', solidifyErr)
+        );
+      } catch (sewErr) {
+        return err(kernelError(BrepErrorCode.ROOF_FAILED, 'Failed to sew roof faces', sewErr));
       }
     }
   } catch (e) {

--- a/src/operations/sweepFns.ts
+++ b/src/operations/sweepFns.ts
@@ -14,7 +14,7 @@ import type { Vec3 } from '@/core/types.js';
 import { vecAdd, vecLength } from '@/core/vecOps.js';
 import type { ClosedWire, Dimension, Wire, Shell, Solid, Shape3D } from '@/core/shapeTypes.js';
 import { castShape, isShape3D, isWire as isWireGuard } from '@/core/shapeTypes.js';
-import { type Result, ok, err, unwrap } from '@/core/result.js';
+import { type Result, ok, err, isErr } from '@/core/result.js';
 import {
   type BrepError,
   validationError,
@@ -226,7 +226,12 @@ export function complexExtrude(
   }
   const endPoint = vecAdd(center, normal);
   const spine = makeSpineWire(center, endPoint);
-  const law = profileShape ? unwrap(buildLawFromProfile(extrusionLength, profileShape)) : null;
+  let law = null;
+  if (profileShape) {
+    const lawResult = buildLawFromProfile(extrusionLength, profileShape);
+    if (isErr(lawResult)) return lawResult;
+    law = lawResult.value;
+  }
   return sweep(wire, spine, { law }, shellMode);
 }
 
@@ -269,7 +274,12 @@ export function twistExtrude(
   const pitch = (360.0 / angleDegrees) * extrusionLength;
   const auxiliarySpine = makeHelixWire(pitch, extrusionLength, 1, center, normal);
 
-  const law = profileShape ? unwrap(buildLawFromProfile(extrusionLength, profileShape)) : null;
+  let law = null;
+  if (profileShape) {
+    const lawResult = buildLawFromProfile(extrusionLength, profileShape);
+    if (isErr(lawResult)) return lawResult;
+    law = lawResult.value;
+  }
   return sweep(wire, spine, { auxiliarySpine, law }, shellMode);
 }
 

--- a/src/query/shapeFinders.ts
+++ b/src/query/shapeFinders.ts
@@ -14,7 +14,7 @@ import { DEG2RAD } from '@/core/constants.js';
 import { getCurveType, curveLength, curveIsClosed } from '@/topology/curveFns.js';
 import { normalAt as faceNormalAt, getSurfaceType, type SurfaceType } from '@/topology/faceFns.js';
 import { measureArea } from '@/measurement/measureFns.js';
-import { unwrap, isOk } from '@/core/result.js';
+import { isOk } from '@/core/result.js';
 import { getEdges } from '@/topology/topologyQueryFns.js';
 import type { CurveType } from '@/core/typeDiscriminants.js';
 import { type ShapeFinder, type Predicate, createTypedFinder } from './finderCore.js';
@@ -106,7 +106,10 @@ function buildFaceFinder(filters: ReadonlyArray<Predicate<Face>>): FaceFinderFn 
       parallelTo: (dir: DirectionInput = 'Z') => buildFaceFinder(filters).inDirection(dir, 0),
 
       ofSurfaceType: (surfaceType) =>
-        withFilter((face) => unwrap(getSurfaceType(face)) === surfaceType),
+        withFilter((face) => {
+          const r = getSurfaceType(face);
+          return isOk(r) && r.value === surfaceType;
+        }),
 
       ofArea: (area, tolerance = 1e-3) =>
         withFilter((face) => {

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -88,8 +88,10 @@ function resolveEdgeCallback(
 
   const kernelParam: KernelHashCallback<number | [number, number]> = (ocEdge) => {
     const v = hashToValue.get(getKernel().hashCode(ocEdge, HASH_CODE_MAX));
-    // Default to 1 (should not happen due to pre-filtering)
-    return v ?? 1;
+    if (v === undefined) {
+      throw new Error('fillet/chamfer: edge hash not found — possible hash collision');
+    }
+    return v;
   };
   return { edges: filteredEdges, kernelParam };
 }


### PR DESCRIPTION
## Summary

- **sweepFns**: replace `unwrap()` with proper `Result` propagation for `buildLawFromProfile` calls in `complexExtrude` and `twistExtrude` — previously threw unstructured exceptions instead of returning `Result`
- **loftFns**: pass caught error as cause in single-loft catch block (batch loft already did this)
- **roofFns**: capture error variables in nested catch blocks so root cause is preserved in diagnostics
- **shapeFinders**: replace `unwrap(getSurfaceType())` with safe `isOk()` check in `ofSurfaceType` filter — previously crashed the entire finder if any face failed
- **modifierFns**: throw on hash miss in `resolveEdgeCallback` (matching `resolveDraftCallback` behavior) instead of silently defaulting to radius 1
- **extrudeUtils**: validate `extrusionLength > 0` in `buildLawFromProfile`

## Test plan
- [x] `npm run validate` passes (typecheck + lint + boundaries + format + changed tests)
- [x] Full test suite passes (2612 tests, 0 failures)
- [x] Coverage thresholds met
- [x] `knip` clean