### PR TITLE
fix(operations): use consistent 1e-10 threshold in buildLawFromProfile

### DIFF
--- a/src/operations/extrudeUtils.ts
+++ b/src/operations/extrudeUtils.ts
@@ -85,7 +85,7 @@ export function buildLawFromProfile(
   { profile, endFactor = 1 }: ExtrusionProfile
 ): Result<KernelType> {
   if (extrusionLength < 1e-10) {
-    return err(validationError('INVALID_EXTRUSION_LENGTH', 'Extrusion length must be positive'));
+    return err(validationError('INVALID_EXTRUSION_LENGTH', 'Extrusion length too small (< 1e-10)'));
   }
   if (profile !== 's-curve' && profile !== 'linear') {
     return err(

--- a/src/operations/extrudeUtils.ts
+++ b/src/operations/extrudeUtils.ts
@@ -84,7 +84,7 @@ export function buildLawFromProfile(
   extrusionLength: number,
   { profile, endFactor = 1 }: ExtrusionProfile
 ): Result<KernelType> {
-  if (extrusionLength <= 0) {
+  if (extrusionLength < 1e-10) {
     return err(validationError('INVALID_EXTRUSION_LENGTH', 'Extrusion length must be positive'));
   }
   if (profile !== 's-curve' && profile !== 'linear') {


### PR DESCRIPTION
## Summary

- Use `< 1e-10` instead of `<= 0` in `buildLawFromProfile` to match the threshold used by callers (`complexExtrude`, `twistExtrude`)
- Prevents very small positive values (e.g. `1e-20`) from reaching `law.Trim(0, 1e-20, 1e-6)` where the tolerance exceeds the trim interval

Follow-up from Greptile review on #777.

## Test plan
- [x] All tests pass (2612 passed)
- [x] Pre-push checks pass