### PR TITLE
fix(operations): fix geometry bugs in sweep and loft pipeline

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-04-13T03:34:30.182Z",
+  "generated": "2026-04-13T16:26:00.924Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -155,12 +155,12 @@
     {
       "file": "src/kernel/occt/advancedOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|682|"
+      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|700|"
     },
     {
       "file": "src/kernel/occt/advancedOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|1078|"
+      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|1096|"
     },
     {
       "file": "src/kernel/occt/hullOps.ts",

--- a/src/kernel/occt/advancedOps.ts
+++ b/src/kernel/occt/advancedOps.ts
@@ -190,6 +190,11 @@ export function sweepPipeShell(
   builder.Build(progress);
   progress.delete();
 
+  if (!builder.IsDone()) {
+    builder.delete();
+    throw new Error('Sweep pipe shell build failed (IsDone=false)');
+  }
+
   if (options.shellMode) {
     const shape = builder.Shape();
     const firstShape = builder.FirstShape();
@@ -351,6 +356,12 @@ export function circularPattern(
  *
  * Computes the Frenet frame (point + tangent) at the given parameter on the spine,
  * then transforms the shape from standard coordinates (origin, Z-up) to that frame.
+ *
+ * Note: gp_Ax3 with only a main direction auto-generates X/Y axes. This is
+ * deterministic for a given tangent direction but can produce discontinuous
+ * profile orientations when the tangent crosses axis-aligned thresholds on
+ * curved spines. For multi-section sweep this is acceptable because each
+ * section is independently positioned and then lofted.
  */
 export function positionOnCurve(
   oc: KernelInstance,
@@ -366,32 +377,39 @@ export function positionOnCurve(
 
   const pnt = new oc.gp_Pnt_1();
   const tangent = new oc.gp_Vec_1();
-  adaptor.D1(param, pnt, tangent);
 
-  // Build target coordinate system at the spine point
-  const tangentDir = new oc.gp_Dir_2(tangent);
-  const toAx3 = new oc.gp_Ax3_5(pnt, tangentDir);
+  try {
+    adaptor.D1(param, pnt, tangent);
 
-  // SetTransformation_2(ax3) computes transform FROM ax3 TO standard coords.
-  // We want FROM standard (origin/Z-up) TO toAx3, so invert.
-  const trsf = new oc.gp_Trsf_1();
-  trsf.SetTransformation_2(toAx3);
-  trsf.Invert();
+    // Build target coordinate system at the spine point.
+    // Use the 2-arg Ax3 constructor which is available in all WASM builds.
+    // Threaded build: gp_Ax3_4(P, V), single build: gp_Ax3_5(P, V).
+    const tangentDir = new oc.gp_Dir_2(tangent);
+    const Ax3Ctor = oc.gp_Ax3_5 ?? oc.gp_Ax3_4;
+    const toAx3 = new Ax3Ctor(pnt, tangentDir);
 
-  // Apply transform to the shape
-  const transformer = new oc.BRepBuilderAPI_Transform_2(shape, trsf, true, false);
-  const result = transformer.Shape();
+    // SetTransformation_2(ax3) computes transform FROM ax3 TO standard coords.
+    // We want FROM standard (origin/Z-up) TO toAx3, so invert.
+    const trsf = new oc.gp_Trsf_1();
+    trsf.SetTransformation_2(toAx3);
+    trsf.Invert();
 
-  // Clean up
-  transformer.delete();
-  trsf.delete();
-  toAx3.delete();
-  tangentDir.delete();
-  tangent.delete();
-  pnt.delete();
-  adaptor.delete();
+    // Apply transform to the shape
+    const transformer = new oc.BRepBuilderAPI_Transform_2(shape, trsf, true, false);
+    const result = transformer.Shape();
 
-  return result;
+    // Clean up
+    transformer.delete();
+    trsf.delete();
+    toAx3.delete();
+    tangentDir.delete();
+
+    return result;
+  } finally {
+    tangent.delete();
+    pnt.delete();
+    adaptor.delete();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/kernel/occt/sweepOps.ts
+++ b/src/kernel/occt/sweepOps.ts
@@ -102,6 +102,10 @@ export function sweep(
   const progress = new oc.Message_ProgressRange_1();
   sweepBuilder.Build(progress);
   progress.delete();
+  if (!sweepBuilder.IsDone()) {
+    sweepBuilder.delete();
+    throw new Error('Sweep build failed (IsDone=false)');
+  }
   sweepBuilder.MakeSolid();
   const result = sweepBuilder.Shape();
   sweepBuilder.delete();
@@ -125,21 +129,28 @@ export function simplePipe(
   maker.Build(progress);
   progress.delete();
 
-  // MakePipe produces a shell by default — solidify it
-  const shellShape = maker.Shape();
-  const solidMaker = new oc.BRepBuilderAPI_MakeSolid_1();
-  const shellDowncast = oc.TopoDS_Cast.Shell(shellShape);
-  solidMaker.Add(shellDowncast);
-  const solidProgress = new oc.Message_ProgressRange_1();
-  solidMaker.Build(solidProgress);
-  solidProgress.delete();
+  const pipeShape = maker.Shape();
 
-  const result = solidMaker.IsDone() ? solidMaker.Solid() : shellShape;
+  // MakePipe may produce a solid or shell depending on the profile.
+  // Only attempt solidification if the result is a shell.
+  if (pipeShape.ShapeType() === oc.TopAbs_ShapeEnum.TopAbs_SHELL) {
+    const solidMaker = new oc.BRepBuilderAPI_MakeSolid_1();
+    const shellDowncast = oc.TopoDS_Cast.Shell(pipeShape);
+    solidMaker.Add(shellDowncast);
+    const solidProgress = new oc.Message_ProgressRange_1();
+    solidMaker.Build(solidProgress);
+    solidProgress.delete();
 
-  shellDowncast.delete();
-  solidMaker.delete();
+    const result = solidMaker.IsDone() ? solidMaker.Solid() : pipeShape;
+
+    shellDowncast.delete();
+    solidMaker.delete();
+    maker.delete();
+    return result;
+  }
+
   maker.delete();
-  return result;
+  return pipeShape;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/operations/loftFns.ts
+++ b/src/operations/loftFns.ts
@@ -131,7 +131,15 @@ export function loftAll(entries: readonly LoftAllEntry[]): Result<Shape3D[]> {
   try {
     const shapes =
       kernel.loftBatch?.(kernelEntries) ??
-      kernelEntries.map((e) => kernel.loft(e.wires, e.ruled, e.startVertex, e.endVertex));
+      kernelEntries.map((e) =>
+        kernel.loftAdvanced(e.wires, {
+          solid: e.solid,
+          ruled: e.ruled,
+          tolerance: e.tolerance,
+          startVertex: e.startVertex,
+          endVertex: e.endVertex,
+        })
+      );
 
     const results: Shape3D[] = [];
     for (const shape of shapes) {

--- a/src/operations/sweepFns.ts
+++ b/src/operations/sweepFns.ts
@@ -74,10 +74,12 @@ function makeHelixWire(
   radius: number,
   center: Vec3,
   dir: Vec3,
-  _lefthand = false
+  leftHanded = false
 ): Wire {
   const kernel = getKernel();
-  return castShape(kernel.makeHelixWire(pitch, height, radius, [...center], [...dir])) as Wire;
+  return castShape(
+    kernel.makeHelixWire(pitch, height, radius, [...center], [...dir], leftHanded)
+  ) as Wire;
 }
 
 // ---------------------------------------------------------------------------
@@ -271,8 +273,9 @@ export function twistExtrude(
   const endPoint = vecAdd(center, normal);
   const spine = makeSpineWire(center, endPoint);
 
-  const pitch = (360.0 / angleDegrees) * extrusionLength;
-  const auxiliarySpine = makeHelixWire(pitch, extrusionLength, 1, center, normal);
+  const leftHanded = angleDegrees < 0;
+  const pitch = (360.0 / Math.abs(angleDegrees)) * extrusionLength;
+  const auxiliarySpine = makeHelixWire(pitch, extrusionLength, 1, center, normal, leftHanded);
 
   let law = null;
   if (profileShape) {
@@ -318,15 +321,52 @@ function computeSectionParams(
   sections: ReadonlyArray<SweepSectionConfig>,
   spine: Wire<Dimension>,
   kernel: ReturnType<typeof getKernel>
-): number[] {
+): Result<number[]> {
   const [uFirst, uLast] = kernel.curveParameters(spine.wrapped);
   const uRange = uLast - uFirst;
-  return sections.map((s, i) => {
-    if (s.location !== undefined) {
-      return uFirst + s.location * uRange;
+
+  // Build params: explicit locations override, gaps are linearly interpolated
+  // between the nearest explicit neighbors (or 0/1 at boundaries).
+  const params: number[] = new Array(sections.length);
+  // First pass: resolve explicit locations
+  for (let i = 0; i < sections.length; i++) {
+    const loc = sections[i]?.location;
+    params[i] = loc !== undefined ? uFirst + loc * uRange : Number.NaN;
+  }
+  // Second pass: interpolate gaps between explicit anchors
+  let prevIdx = -1;
+  let prevVal = uFirst; // implicit 0.0 at start
+  for (let i = 0; i <= sections.length; i++) {
+    const isEnd = i === sections.length;
+    const isExplicit = !isEnd && !Number.isNaN(params[i] ?? Number.NaN);
+    if (isExplicit || isEnd) {
+      const nextVal = isEnd ? uLast : (params[i] ?? uLast);
+      // Fill gap between prevIdx+1 and i-1
+      const gapCount = i - prevIdx - 1;
+      for (let g = 1; g <= gapCount; g++) {
+        params[prevIdx + g] = prevVal + (g / (gapCount + 1)) * (nextVal - prevVal);
+      }
+      if (!isEnd) {
+        prevIdx = i;
+        prevVal = params[i] ?? uFirst;
+      }
     }
-    return uFirst + (i / (sections.length - 1)) * uRange;
-  });
+  }
+
+  // Validate: final params must be strictly increasing
+  for (let i = 1; i < params.length; i++) {
+    if ((params[i] ?? 0) <= (params[i - 1] ?? 0)) {
+      return err(
+        validationError(
+          BrepErrorCode.MULTI_SWEEP_FAILED,
+          `Computed section parameters are not strictly increasing at index ${i} ` +
+            `(${params[i - 1]?.toFixed(4)} >= ${params[i]?.toFixed(4)})`
+        )
+      );
+    }
+  }
+
+  return ok(params);
 }
 
 // ---------------------------------------------------------------------------
@@ -367,7 +407,9 @@ export function multiSectionSweep(
 
   try {
     const kernel = getKernel();
-    const params = computeSectionParams(sections, spine, kernel);
+    const paramsResult = computeSectionParams(sections, spine, kernel);
+    if (isErr(paramsResult)) return paramsResult;
+    const params = paramsResult.value;
 
     // Position each profile wire along the spine and loft
     const positionedWires: KernelShape[] = [];


### PR DESCRIPTION
## Summary

- **twistExtrude negative angle**: negative `angleDegrees` produced a negative helix pitch, causing degenerate or backward-winding geometry. Now uses `Math.abs(pitch)` with `leftHanded` flag.
- **makeHelixWire dropped leftHanded**: the `_lefthand` parameter in `sweepFns.ts` was never forwarded to the kernel. Renamed and passed through.
- **multiSectionSweep location collisions**: mixing explicit `location` values with auto-distributed sections could place two profiles at the same spine parameter. Auto-distributed sections now interpolate between explicit anchors. Final parameters validated for strict monotonicity.
- **simplePipe unsafe shell cast**: `TopoDS_Cast.Shell()` on an already-solid pipe result is UB. Now checks `ShapeType()` before solidification.
- **loftAll fallback ignores options**: the JS fallback path called basic `kernel.loft()` which hardcodes `solid=true` and `tolerance=1e-6`. Now uses `kernel.loftAdvanced()` to respect per-entry config.
- **No IsDone() checks after sweep Build()**: `sweepPipeShell` and basic `sweep` called `MakeSolid()`/`Shape()` on potentially failed builders. Now throws on build failure.
- **positionOnCurve memory leak**: WASM objects leaked on `gp_Dir_2` exception (zero tangent at cusps). Wrapped in try/finally.
- **positionOnCurve cross-build portability**: `gp_Ax3_5` doesn't exist in the threaded WASM build. Now uses `gp_Ax3_5 ?? gp_Ax3_4` for portability.

## Test plan

- [x] All `positionFns.test.ts` tests pass across all 3 kernels (occt, occt-wasm, brepkit)
- [x] `sweepFns.test.ts`, `loftFns.test.ts` pass (same as main)
- [x] Full test suite: same pass/fail count as main (29 failed files / 101 failed tests — all pre-existing)
- [x] Typecheck, lint, boundary check, pattern check all clean
- [x] Pre-push hook passes (full coverage + knip)