### PR TITLE
fix(kernel): apply direction rotation in occt-wasm makeCone/makeTorus

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -433,8 +433,8 @@ export class OcctWasmAdapter implements KernelAdapter {
     direction?: [number, number, number]
   ): KernelShape {
     let id = this.k.makeCone(radius1, radius2, height);
-    if (direction && (direction[0] !== 0 || direction[1] !== 0 || direction[2] !== 1)) {
-      // TODO: apply rotation to align Z-axis with direction
+    if (direction) {
+      id = rotateZToDirection(this.k, id, direction);
     }
     if (center && (center[0] !== 0 || center[1] !== 0 || center[2] !== 0)) {
       id = this.k.translate(id, center[0], center[1], center[2]);
@@ -449,8 +449,8 @@ export class OcctWasmAdapter implements KernelAdapter {
     direction?: [number, number, number]
   ): KernelShape {
     let id = this.k.makeTorus(majorRadius, minorRadius);
-    if (direction && (direction[0] !== 0 || direction[1] !== 0 || direction[2] !== 1)) {
-      // TODO: apply rotation to align Z-axis with direction
+    if (direction) {
+      id = rotateZToDirection(this.k, id, direction);
     }
     if (center && (center[0] !== 0 || center[1] !== 0 || center[2] !== 0)) {
       id = this.k.translate(id, center[0], center[1], center[2]);

--- a/tests/kernel-ops.test.ts
+++ b/tests/kernel-ops.test.ts
@@ -92,8 +92,21 @@ describe('constructorOps', () => {
     expect(kernel.volume(c)).toBeCloseTo(vol, 0);
   });
 
+  it('makeCone with custom center and direction', () => {
+    const c = kernel.makeCone(10, 0, 20, [1, 2, 3], [0, 1, 0]);
+    expect(kernel.isValid(c)).toBe(true);
+    expect(kernel.volume(c)).toBeCloseTo((1 / 3) * Math.PI * 100 * 20, 0);
+  });
+
   it('makeTorus', () => {
     const t = oc(torus(10, 3));
+    expect(kernel.isValid(t)).toBe(true);
+    const vol = 2 * Math.PI * Math.PI * 10 * 9;
+    expect(kernel.volume(t)).toBeCloseTo(vol, 0);
+  });
+
+  it('makeTorus with custom center and direction', () => {
+    const t = kernel.makeTorus(10, 3, [1, 2, 3], [0, 1, 0]);
     expect(kernel.isValid(t)).toBe(true);
     const vol = 2 * Math.PI * Math.PI * 10 * 9;
     expect(kernel.volume(t)).toBeCloseTo(vol, 0);


### PR DESCRIPTION
## Summary

- Fixes `makeCone` and `makeTorus` in the occt-wasm adapter: the `direction` parameter was accepted but silently ignored, leaving shapes aligned to Z regardless of input.
- Mirrors the earlier `makeCylinder` fix ([1a7e8b4](https://github.com/andymai/brepjs/commit/1a7e8b4)) — reuses the existing `rotateZToDirection` helper in `src/kernel/occtWasm/occtWasmAdapter.ts`.
- Adds regression tests in `tests/kernel-ops.test.ts` following the existing `makeCylinder with custom center and direction` pattern (isValid + volume).

This is the first item on the occt-wasm parity-gap roadmap (smallest, highest-confidence fix; pure TS).

## Test plan

- [x] New tests `makeCone with custom center and direction` and `makeTorus with custom center and direction` pass on all three kernels (occt, occt-wasm, brepkit)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Pre-push suite (`test:full` + `knip`) passes
- [ ] CI passes on all three kernel projects