### PR TITLE
feat(kernel): implement exportSTEP{Assembly,Configured} on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2108,7 +2108,11 @@ export class OcctWasmAdapter implements KernelAdapter {
   exportSTEPAssembly(parts: StepAssemblyPart[], _options?: { unit?: string }): string {
     if (parts.length === 0) return '';
     const doc = this.createXCAFDocument(parts);
-    return this.writeXCAFToSTEP(doc);
+    try {
+      return this.writeXCAFToSTEP(doc);
+    } finally {
+      doc.delete();
+    }
   }
 
   export3MF(_shape: KernelShape, _tolerance: number): ArrayBuffer {
@@ -2215,7 +2219,11 @@ export class OcctWasmAdapter implements KernelAdapter {
       color: s.color,
     }));
     const doc = this.createXCAFDocument(named);
-    return this.writeXCAFToSTEP(doc);
+    try {
+      return this.writeXCAFToSTEP(doc);
+    } finally {
+      doc.delete();
+    }
   }
 
   wrapString(_str: string): KernelType {

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2105,8 +2105,10 @@ export class OcctWasmAdapter implements KernelAdapter {
     return [wrapResult(this.k, id)];
   }
 
-  exportSTEPAssembly(_parts: StepAssemblyPart[], _options?: { unit?: string }): string {
-    notImplemented('exportSTEPAssembly');
+  exportSTEPAssembly(parts: StepAssemblyPart[], _options?: { unit?: string }): string {
+    if (parts.length === 0) return '';
+    const doc = this.createXCAFDocument(parts);
+    return this.writeXCAFToSTEP(doc);
   }
 
   export3MF(_shape: KernelShape, _tolerance: number): ArrayBuffer {
@@ -2195,7 +2197,7 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   exportSTEPConfigured(
-    _shapes: Array<{
+    shapes: Array<{
       shape: KernelShape;
       name?: string | undefined;
       color?: [number, number, number, number] | undefined;
@@ -2206,7 +2208,14 @@ export class OcctWasmAdapter implements KernelAdapter {
       schema?: number | undefined;
     }
   ): string {
-    notImplemented('exportSTEPConfigured');
+    if (shapes.length === 0) return '';
+    const named = shapes.map((s) => ({
+      shape: s.shape,
+      name: s.name ?? '',
+      color: s.color,
+    }));
+    const doc = this.createXCAFDocument(named);
+    return this.writeXCAFToSTEP(doc);
   }
 
   wrapString(_str: string): KernelType {


### PR DESCRIPTION
## Summary

Second item on the occt-wasm parity-gap roadmap. Implements `exportSTEPAssembly` and `exportSTEPConfigured` by composing the existing `createXCAFDocument` + `writeXCAFToSTEP` primitives that were already implemented on occt-wasm. Removes two `notImplemented` stubs.

Previously, `tests/stepConfigFns.test.ts` had a lenient `isOk(result) ? ... : expect(error.code === 'STEP_EXPORT_CONFIGURED_FAILED')` branch to accept occt-wasm's stub failure. Those tests now take the happy path on occt-wasm.

## Known limitation

`options.unit`, `options.modelUnit`, and `options.schema` are currently ignored on occt-wasm — the underlying C++ facade (`occt-wasm@1.5.0`) exposes `writeXCAFToSTEP(docId)` without configuration parameters, and does not expose `Interface_Static` access. Output defaults to OCCT's `MM` + schema 5.

Full configurability requires an upstream binding change (e.g. `writeXCAFToSTEPConfigured(docId, unit, modelUnit, schema)`). Tracking as a follow-up.

## What's left in the "STEP assembly + config helpers" gap

The four adapter stubs `wrapString`, `wrapColor`, `configureStepUnits`, `configureStepWriter` remain as `notImplemented`. They are **OCCT-adapter-internal** helpers exposed by the `KernelIOOps` interface — they leak OCCT Embind types (`TCollection_ExtendedString_2`, `Interface_Static`, `STEPCAFControl_Writer`) into the kernel abstraction. Since occt-wasm now implements `exportSTEPConfigured` directly via composition, these helpers are never called on the occt-wasm path.

Cleaning them up is a broader kernel-interface refactor (remove from `KernelIOOps`) and out of scope for this PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `tests/stepConfigFns.test.ts` — all 9 tests pass on occt, occt-wasm, brepkit
- [ ] CI passes on all three kernel projects