### PR TITLE
feat(kernel): implement exportOBJ on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2144,12 +2144,21 @@ export class OcctWasmAdapter implements KernelAdapter {
       const o = i * 3;
       lines.push(`vn ${n[o] ?? 0} ${n[o + 1] ?? 0} ${n[o + 2] ?? 0}`);
     }
-    const triCount = t.length / 3;
-    for (let i = 0; i < triCount; i++) {
-      const a = (t[i * 3] ?? 0) + 1;
-      const b = (t[i * 3 + 1] ?? 0) + 1;
-      const c = (t[i * 3 + 2] ?? 0) + 1;
+    const pushTri = (offset: number) => {
+      const a = (t[offset] ?? 0) + 1;
+      const b = (t[offset + 1] ?? 0) + 1;
+      const c = (t[offset + 2] ?? 0) + 1;
       lines.push(`f ${a}//${a} ${b}//${b} ${c}//${c}`);
+    };
+    if (result.faceGroups.length > 0) {
+      for (const group of result.faceGroups) {
+        lines.push(`g face_${group.faceHash}`);
+        const count = group.count / 3;
+        for (let i = 0; i < count; i++) pushTri(group.start + i * 3);
+      }
+    } else {
+      const triCount = t.length / 3;
+      for (let i = 0; i < triCount; i++) pushTri(i * 3);
     }
     return new TextEncoder().encode(lines.join('\n') + '\n').buffer;
   }

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2123,8 +2123,35 @@ export class OcctWasmAdapter implements KernelAdapter {
     notImplemented('exportGLB');
   }
 
-  exportOBJ(_shape: KernelShape, _tolerance: number): ArrayBuffer {
-    notImplemented('exportOBJ');
+  exportOBJ(shape: KernelShape, tolerance: number): ArrayBuffer {
+    const result = this.mesh(shape, {
+      tolerance,
+      angularTolerance: 0.5,
+      skipNormals: false,
+    });
+    const v = result.vertices;
+    const n = result.normals;
+    const t = result.triangles;
+
+    const lines: string[] = ['# brepjs OBJ export'];
+    const vCount = v.length / 3;
+    for (let i = 0; i < vCount; i++) {
+      const o = i * 3;
+      lines.push(`v ${v[o] ?? 0} ${v[o + 1] ?? 0} ${v[o + 2] ?? 0}`);
+    }
+    const nCount = n.length / 3;
+    for (let i = 0; i < nCount; i++) {
+      const o = i * 3;
+      lines.push(`vn ${n[o] ?? 0} ${n[o + 1] ?? 0} ${n[o + 2] ?? 0}`);
+    }
+    const triCount = t.length / 3;
+    for (let i = 0; i < triCount; i++) {
+      const a = (t[i * 3] ?? 0) + 1;
+      const b = (t[i * 3 + 1] ?? 0) + 1;
+      const c = (t[i * 3 + 2] ?? 0) + 1;
+      lines.push(`f ${a}//${a} ${b}//${b} ${c}//${c}`);
+    }
+    return new TextEncoder().encode(lines.join('\n') + '\n').buffer;
   }
 
   exportPLY(_shape: KernelShape, _tolerance: number): ArrayBuffer {

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -178,6 +178,26 @@ describe('meshFns', () => {
     );
   });
 
+  describe('kernel.exportOBJ', () => {
+    it('produces a valid OBJ ArrayBuffer on kernels that support it', () => {
+      const b = box(10, 10, 10);
+      let data: ArrayBuffer;
+      try {
+        data = getKernel().exportOBJ(b.wrapped, 0.1);
+      } catch (e) {
+        // OCCT default adapter throws "only available with the brepkit kernel"
+        expect(String(e)).toContain('brepkit');
+        return;
+      }
+      expect(data.byteLength).toBeGreaterThan(0);
+      const text = new TextDecoder().decode(data);
+      // Structural assertions are kernel-agnostic — brepkit's C++ writer
+      // and occt-wasm's TS writer both emit standard OBJ.
+      expect(text).toMatch(/^v /m);
+      expect(text).toMatch(/^f /m);
+    });
+  });
+
   describe('exportIGES', () => {
     it('exports a shape to IGES blob when IGES is available in the WASM build', () => {
       const oc = getKernel().oc;

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -180,6 +180,7 @@ describe('meshFns', () => {
 
   describe('kernel.exportOBJ', () => {
     it('produces a valid OBJ ArrayBuffer on kernels that support it', () => {
+      expect.hasAssertions();
       const b = box(10, 10, 10);
       let data: ArrayBuffer;
       try {


### PR DESCRIPTION
## Summary

Third roadmap PR for occt-wasm parity. Implements `exportOBJ(shape, tolerance): ArrayBuffer` by composing the existing `mesh()` tessellation primitive with a pure-TS Wavefront OBJ serializer.

**Goes beyond OCCT parity:** the OCCT default adapter throws `"exportOBJ is only available with the brepkit kernel"` (`src/kernel/occt/defaultAdapter.ts:1905`). occt-wasm now implements it natively, matching brepkit's functionality via the existing C++ tessellation facade — no upstream work needed.

## Format

Standard Wavefront OBJ:
- Vertices: `v x y z`
- Normals: `vn x y z`
- Faces: `f a//na b//nb c//nc` (1-based, triangle-only)

Angular deflection defaults to 0.5 rad (OCCT standard). Linear deflection comes from the `tolerance` parameter.

## Test plan

- [x] New smoke test in `tests/meshFns.test.ts` — asserts non-empty output + structural OBJ lines (`/^v /`, `/^f /`) — passes on occt, occt-wasm, and brepkit
- [x] OCCT branch correctly catches the pre-existing "only available with the brepkit kernel" throw
- [x] `npm run typecheck` clean
- [ ] CI passes on all three kernel projects

## Next in roadmap

- PR 2/3: `exportPLY` (same pattern, different format)
- PR 3/3: `exportGLB` (binary glTF — heavier)
- Cleanup PR: match OCCT throw messages for `import3MF`/`importGLB`/`importOBJ`/`export3MF` (features that remain brepkit-exclusive)