### PR TITLE
feat(kernel): implement exportPLY on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2163,8 +2163,53 @@ export class OcctWasmAdapter implements KernelAdapter {
     return new TextEncoder().encode(lines.join('\n') + '\n').buffer;
   }
 
-  exportPLY(_shape: KernelShape, _tolerance: number): ArrayBuffer {
-    notImplemented('exportPLY');
+  exportPLY(shape: KernelShape, tolerance: number): ArrayBuffer {
+    const result = this.mesh(shape, {
+      tolerance,
+      angularTolerance: 0.5,
+      skipNormals: false,
+    });
+    const v = result.vertices;
+    const n = result.normals;
+    const t = result.triangles;
+    const vCount = v.length / 3;
+    const triCount = t.length / 3;
+    const hasNormals = n.length === v.length;
+
+    const lines: string[] = [
+      'ply',
+      'format ascii 1.0',
+      'comment brepjs PLY export',
+      `element vertex ${vCount}`,
+      'property float x',
+      'property float y',
+      'property float z',
+    ];
+    if (hasNormals) {
+      lines.push('property float nx', 'property float ny', 'property float nz');
+    }
+    lines.push(`element face ${triCount}`, 'property list uchar int vertex_index', 'end_header');
+    for (let i = 0; i < vCount; i++) {
+      const o = i * 3;
+      const x = v[o] ?? 0;
+      const y = v[o + 1] ?? 0;
+      const z = v[o + 2] ?? 0;
+      if (hasNormals) {
+        const nx = n[o] ?? 0;
+        const ny = n[o + 1] ?? 0;
+        const nz = n[o + 2] ?? 0;
+        lines.push(`${x} ${y} ${z} ${nx} ${ny} ${nz}`);
+      } else {
+        lines.push(`${x} ${y} ${z}`);
+      }
+    }
+    for (let i = 0; i < triCount; i++) {
+      const a = t[i * 3] ?? 0;
+      const b = t[i * 3 + 1] ?? 0;
+      const c = t[i * 3 + 2] ?? 0;
+      lines.push(`3 ${a} ${b} ${c}`);
+    }
+    return new TextEncoder().encode(lines.join('\n') + '\n').buffer;
   }
 
   import3MF(_data: ArrayBuffer): KernelShape[] {

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -199,6 +199,31 @@ describe('meshFns', () => {
     });
   });
 
+  describe('kernel.exportPLY', () => {
+    it('produces a valid PLY ArrayBuffer on kernels that support it', () => {
+      expect.hasAssertions();
+      const b = box(10, 10, 10);
+      let data: ArrayBuffer;
+      try {
+        data = getKernel().exportPLY(b.wrapped, 0.1);
+      } catch (e) {
+        // OCCT default adapter throws "only available with the brepkit kernel"
+        expect(String(e)).toContain('brepkit');
+        return;
+      }
+      expect(data.byteLength).toBeGreaterThan(0);
+      const text = new TextDecoder().decode(data);
+      // PLY header is always ASCII, even when the body is binary. Keep the
+      // assertions format-agnostic so brepkit's binary-little-endian writer
+      // and occt-wasm's ASCII writer both pass.
+      expect(text.startsWith('ply\n')).toBe(true);
+      expect(text).toMatch(/^format (ascii|binary_little_endian|binary_big_endian) 1\.0/m);
+      expect(text).toMatch(/^element vertex \d+/m);
+      expect(text).toMatch(/^element face \d+/m);
+      expect(text).toContain('end_header');
+    });
+  });
+
   describe('exportIGES', () => {
     it('exports a shape to IGES blob when IGES is available in the WASM build', () => {
       const oc = getKernel().oc;


### PR DESCRIPTION
## Summary

Second mesh-format PR (2/3 in the beyond-OCCT-parity roadmap). Implements `exportPLY(shape, tolerance): ArrayBuffer` on occt-wasm by composing `this.mesh()` tessellation with a pure-TS PLY ASCII serializer.

**Goes beyond OCCT parity:** OCCT's `defaultAdapter` throws `"exportPLY is only available with the brepkit kernel"` (`src/kernel/occt/defaultAdapter.ts:1909`). occt-wasm now implements it natively.

## Format

PLY 1.0 ASCII variant:

```
ply
format ascii 1.0
comment brepjs PLY export
element vertex N
property float x/y/z
property float nx/ny/nz
element face M
property list uchar int vertex_index
end_header
<x y z nx ny nz per vertex, 0-based>
<3 a b c per triangle>
```

Normal properties are omitted if `mesh()` returns no normals (defensive — the current call always requests them). brepkit's native writer emits `binary_little_endian` PLY; the test assertions accept either format.

## Test plan

- [x] New smoke test in `tests/meshFns.test.ts` — structural header assertions (ply magic + format regex covering ascii + both binary variants + element/end_header lines) — passes on occt, occt-wasm, and brepkit
- [x] OCCT branch correctly catches the "only available with the brepkit kernel" throw
- [x] `npm run typecheck` clean
- [ ] CI passes on all three kernel projects

## Roadmap position

- [x] PR #788: cone/torus direction fix
- [x] PR #790: exportSTEP{Assembly,Configured}
- [x] PR #792: exportOBJ
- [x] **This PR: exportPLY**
- [ ] Next: exportGLB (binary glTF — heavier, ~150 lines)
- [ ] Final: cleanup PR to match OCCT throw messages for remaining mesh-import stubs