### PR TITLE
feat(kernel): implement exportGLB on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -251,6 +251,7 @@ function computePositionBounds(positions: Float32Array, vCount: number): Vec3Bou
 
 function buildGltfManifest(
   vCount: number,
+  nCount: number,
   iCount: number,
   posBytes: number,
   nrmBytes: number,
@@ -288,7 +289,7 @@ function buildGltfManifest(
         min: bounds.min,
         max: bounds.max,
       },
-      { bufferView: 1, componentType: 5126, count: vCount, type: 'VEC3' },
+      { bufferView: 1, componentType: 5126, count: nCount, type: 'VEC3' },
       { bufferView: 2, componentType: 5125, count: iCount, type: 'SCALAR' },
     ],
   };
@@ -2206,6 +2207,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     const normals = result.normals;
     const indices = result.triangles;
     const vCount = positions.length / 3;
+    const nCount = normals.length / 3;
     const iCount = indices.length;
 
     // Binary buffer: positions | normals | indices. All components are
@@ -2218,6 +2220,7 @@ export class OcctWasmAdapter implements KernelAdapter {
 
     const manifest = buildGltfManifest(
       vCount,
+      nCount,
       iCount,
       posBytes,
       nrmBytes,

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -217,6 +217,83 @@ function notImplemented(method: string): never {
   throw new Error(`occt-wasm: ${method} is not yet implemented`);
 }
 
+// ---------------------------------------------------------------------------
+// GLB (binary glTF 2.0) helpers — used by exportGLB
+// ---------------------------------------------------------------------------
+
+interface Vec3Bounds {
+  readonly min: [number, number, number];
+  readonly max: [number, number, number];
+}
+
+function computePositionBounds(positions: Float32Array, vCount: number): Vec3Bounds {
+  if (vCount === 0) return { min: [0, 0, 0], max: [0, 0, 0] };
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+  for (let i = 0; i < vCount; i++) {
+    const o = i * 3;
+    const x = positions[o] ?? 0;
+    const y = positions[o + 1] ?? 0;
+    const z = positions[o + 2] ?? 0;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+function buildGltfManifest(
+  vCount: number,
+  iCount: number,
+  posBytes: number,
+  nrmBytes: number,
+  idxBytes: number,
+  bufferLength: number,
+  bounds: Vec3Bounds
+): object {
+  return {
+    asset: { version: '2.0', generator: 'brepjs occt-wasm' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0 }],
+    meshes: [
+      {
+        primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2, mode: 4 }],
+      },
+    ],
+    buffers: [{ byteLength: bufferLength }],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes, target: 34962 },
+      { buffer: 0, byteOffset: posBytes, byteLength: nrmBytes, target: 34962 },
+      {
+        buffer: 0,
+        byteOffset: posBytes + nrmBytes,
+        byteLength: idxBytes,
+        target: 34963,
+      },
+    ],
+    accessors: [
+      {
+        bufferView: 0,
+        componentType: 5126,
+        count: vCount,
+        type: 'VEC3',
+        min: bounds.min,
+        max: bounds.max,
+      },
+      { bufferView: 1, componentType: 5126, count: vCount, type: 'VEC3' },
+      { bufferView: 2, componentType: 5125, count: iCount, type: 'SCALAR' },
+    ],
+  };
+}
+
 /**
  * Wrap an OcctKernelWasm instance so that every method call converts
  * C++ exceptions (WebAssembly.Exception) into readable JS Errors.
@@ -2119,8 +2196,65 @@ export class OcctWasmAdapter implements KernelAdapter {
     notImplemented('export3MF');
   }
 
-  exportGLB(_shape: KernelShape, _tolerance: number): ArrayBuffer {
-    notImplemented('exportGLB');
+  exportGLB(shape: KernelShape, tolerance: number): ArrayBuffer {
+    const result = this.mesh(shape, {
+      tolerance,
+      angularTolerance: 0.5,
+      skipNormals: false,
+    });
+    const positions = result.vertices;
+    const normals = result.normals;
+    const indices = result.triangles;
+    const vCount = positions.length / 3;
+    const iCount = indices.length;
+
+    // Binary buffer: positions | normals | indices. All components are
+    // 4 bytes, so segment offsets are naturally aligned.
+    const posBytes = positions.byteLength;
+    const nrmBytes = normals.byteLength;
+    const idxBytes = indices.byteLength;
+    const binLength = posBytes + nrmBytes + idxBytes;
+    const paddedBinLength = binLength + ((4 - (binLength % 4)) % 4);
+
+    const manifest = buildGltfManifest(
+      vCount,
+      iCount,
+      posBytes,
+      nrmBytes,
+      idxBytes,
+      paddedBinLength,
+      computePositionBounds(positions, vCount)
+    );
+    const jsonBytes = new TextEncoder().encode(JSON.stringify(manifest));
+    const paddedJsonLength = jsonBytes.byteLength + ((4 - (jsonBytes.byteLength % 4)) % 4);
+
+    const totalLength = 12 + 8 + paddedJsonLength + 8 + paddedBinLength;
+    const glb = new ArrayBuffer(totalLength);
+    const view = new DataView(glb);
+
+    view.setUint32(0, 0x46546c67, true);
+    view.setUint32(4, 2, true);
+    view.setUint32(8, totalLength, true);
+    view.setUint32(12, paddedJsonLength, true);
+    view.setUint32(16, 0x4e4f534a, true);
+    const jsonDst = new Uint8Array(glb, 20, paddedJsonLength);
+    jsonDst.set(jsonBytes);
+    for (let i = jsonBytes.byteLength; i < paddedJsonLength; i++) jsonDst[i] = 0x20;
+
+    const binHeaderOffset = 20 + paddedJsonLength;
+    view.setUint32(binHeaderOffset, paddedBinLength, true);
+    view.setUint32(binHeaderOffset + 4, 0x004e4942, true);
+    const binDataOffset = binHeaderOffset + 8;
+    new Uint8Array(glb, binDataOffset, posBytes).set(
+      new Uint8Array(positions.buffer, positions.byteOffset, posBytes)
+    );
+    new Uint8Array(glb, binDataOffset + posBytes, nrmBytes).set(
+      new Uint8Array(normals.buffer, normals.byteOffset, nrmBytes)
+    );
+    new Uint8Array(glb, binDataOffset + posBytes + nrmBytes, idxBytes).set(
+      new Uint8Array(indices.buffer, indices.byteOffset, idxBytes)
+    );
+    return glb;
   }
 
   exportOBJ(shape: KernelShape, tolerance: number): ArrayBuffer {

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -224,6 +224,27 @@ describe('meshFns', () => {
     });
   });
 
+  describe('kernel.exportGLB', () => {
+    it('produces a valid GLB ArrayBuffer on kernels that support it', () => {
+      expect.hasAssertions();
+      const b = box(10, 10, 10);
+      let data: ArrayBuffer;
+      try {
+        data = getKernel().exportGLB(b.wrapped, 0.1);
+      } catch (e) {
+        // OCCT default adapter throws "only available with the brepkit kernel"
+        expect(String(e)).toContain('brepkit');
+        return;
+      }
+      expect(data.byteLength).toBeGreaterThan(0);
+      // GLB spec: 12-byte header = magic 'glTF' (0x46546C67) | version 2 | total length
+      const view = new DataView(data);
+      expect(view.getUint32(0, true)).toBe(0x46546c67);
+      expect(view.getUint32(4, true)).toBe(2);
+      expect(view.getUint32(8, true)).toBe(data.byteLength);
+    });
+  });
+
   describe('exportIGES', () => {
     it('exports a shape to IGES blob when IGES is available in the WASM build', () => {
       const oc = getKernel().oc;


### PR DESCRIPTION
## Summary

Final mesh-format PR (3/3 in the beyond-OCCT-parity roadmap). Implements `exportGLB(shape, tolerance): ArrayBuffer` on occt-wasm by composing `this.mesh()` tessellation with a pure-TS binary glTF 2.0 writer.

**Goes beyond OCCT parity:** OCCT's `defaultAdapter` throws `"exportGLB is only available with the brepkit kernel"` (`src/kernel/occt/defaultAdapter.ts:1901`). occt-wasm now emits a valid GLB 2.0 container natively.

## Format

GLB 2.0 container:

```
Header (12 bytes):
  magic     : u32 LE = 0x46546C67 ('glTF')
  version   : u32 LE = 2
  length    : u32 LE = total bytes

Chunk 0 (JSON):
  chunkLength : u32 LE (padded to 4-byte boundary)
  chunkType   : u32 LE = 0x4E4F534A ('JSON')
  chunkData   : UTF-8 manifest, padded with ASCII space 0x20

Chunk 1 (BIN):
  chunkLength : u32 LE (padded to 4-byte boundary)
  chunkType   : u32 LE = 0x004E4942 ('BIN\0')
  chunkData   : positions (VEC3 float) | normals (VEC3 float) | indices (UINT32)
```

Manifest references three accessors (POSITION, NORMAL, indices) via three bufferViews over a single interleaved binary buffer. POSITION accessor includes required min/max bounds. Indices use `UNSIGNED_INT` (componentType 5125) to avoid overflow on large meshes.

## Endianness

`DataView` is used for all multi-byte header writes to guarantee little-endian order per GLB spec. Typed-array bodies (Float32 positions/normals, Uint32 indices) are copied via `Uint8Array` views — valid on all JS runtimes in practice (all little-endian).

## Test plan

- [x] New smoke test in `tests/meshFns.test.ts` — asserts GLB magic bytes (`0x46546C67`), version 2, and `length` field matches `ArrayBuffer.byteLength`
- [x] OCCT branch correctly catches the "only available with the brepkit kernel" throw
- [x] `npm run typecheck` clean
- [x] `npx tsx scripts/check-patterns.ts` — bounds + manifest construction extracted to module-level helpers to satisfy max-function-lines
- [ ] CI passes on all three kernel projects

## Roadmap position

- [x] PR #788: cone/torus direction fix
- [x] PR #790: exportSTEP{Assembly,Configured}
- [x] PR #792: exportOBJ
- [x] PR #794: exportPLY
- [x] **This PR: exportGLB**
- [ ] Final: cleanup PR to match OCCT throw messages for remaining import stubs (`import3MF`/`importGLB`/`importOBJ`/`export3MF`) — features that remain brepkit-exclusive