### PR TITLE
chore(kernel): align occt-wasm mesh-format throws with OCCT default adapter

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2194,7 +2194,7 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   export3MF(_shape: KernelShape, _tolerance: number): ArrayBuffer {
-    notImplemented('export3MF');
+    throw new Error('export3MF is only available with the brepkit kernel');
   }
 
   exportGLB(shape: KernelShape, tolerance: number): ArrayBuffer {
@@ -2350,15 +2350,15 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   import3MF(_data: ArrayBuffer): KernelShape[] {
-    notImplemented('import3MF');
+    throw new Error('import3MF is only available with the brepkit kernel');
   }
 
   importOBJ(_data: ArrayBuffer): KernelShape {
-    notImplemented('importOBJ');
+    throw new Error('importOBJ is only available with the brepkit kernel');
   }
 
   importGLB(_data: ArrayBuffer): KernelShape {
-    notImplemented('importGLB');
+    throw new Error('importGLB is only available with the brepkit kernel');
   }
 
   toBREP(shape: KernelShape): string {


### PR DESCRIPTION
## Summary

Final cleanup PR for the mesh-format I/O roadmap. Changes the error messages of four remaining brepkit-exclusive stubs in `src/kernel/occtWasm/occtWasmAdapter.ts`:

| Method      | Before                                                    | After                                                         |
|-------------|-----------------------------------------------------------|---------------------------------------------------------------|
| `export3MF` | `occt-wasm: export3MF is not yet implemented`             | `export3MF is only available with the brepkit kernel`         |
| `import3MF` | `occt-wasm: import3MF is not yet implemented`             | `import3MF is only available with the brepkit kernel`         |
| `importOBJ` | `occt-wasm: importOBJ is not yet implemented`             | `importOBJ is only available with the brepkit kernel`         |
| `importGLB` | `occt-wasm: importGLB is not yet implemented`             | `importGLB is only available with the brepkit kernel`         |

## Rationale

The `not yet implemented` wording misrepresented their status — these features aren't pending work on occt-wasm; they simply don't exist on any OCCT-family kernel. `brepjs-opencascade` throws the same kernel-exclusivity message (`src/kernel/occt/defaultAdapter.ts:1897-1922`). occt-wasm now matches, so downstream code branching on error text will treat both OCCT kernels identically.

Note: `export3MF` is the only *export* in this group — it's kept as a throw because 3MF export requires the brepkit-specific tessellation pipeline (OCCT's facade doesn't expose it). The reverse-direction mesh-import methods (`import3MF/OBJ/GLB`) also remain throws because they need mesh-to-BRep reconstruction that OCCT doesn't expose.

## Roadmap completion

- [x] PR #788: cone/torus direction fix
- [x] PR #790: exportSTEP{Assembly,Configured}
- [x] PR #792: exportOBJ (beyond-OCCT parity)
- [x] PR #794: exportPLY (beyond-OCCT parity)
- [x] PR #796: exportGLB (beyond-OCCT parity)
- [x] **This PR: throw-message alignment**

The mesh-format I/O gap is closed. occt-wasm now exports OBJ/PLY/GLB natively (richer than OCCT) and communicates clearly for import paths (matching OCCT).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] CI passes on all three kernel projects

No new tests — pure message alignment, no behavior change.