### PR TITLE
feat(kernel): implement createPoint2d/Direction2d/Vector2d on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -3032,14 +3032,18 @@ export class OcctWasmAdapter implements KernelAdapter {
   // 2D operations (not implemented -- occt-wasm doesn't expose 2D API)
   // =========================================================================
 
-  createPoint2d(_x: number, _y: number): KernelType {
-    notImplemented('createPoint2d');
+  createPoint2d(x: number, y: number): KernelType {
+    return { x, y };
   }
-  createDirection2d(_x: number, _y: number): KernelType {
-    notImplemented('createDirection2d');
+  createDirection2d(x: number, y: number): KernelType {
+    const l = Math.sqrt(x * x + y * y);
+    if (l < 1e-15) {
+      throw new Error('occt-wasm: createDirection2d called with zero-length vector');
+    }
+    return { x: x / l, y: y / l };
   }
-  createVector2d(_x: number, _y: number): KernelType {
-    notImplemented('createVector2d');
+  createVector2d(x: number, y: number): KernelType {
+    return { x, y };
   }
   createAxis2d(px: number, py: number, dx: number, dy: number): KernelType {
     // Return a plain object representing the axis (used by mirrorCurve2dAcrossAxis)

--- a/tests/curve2dFns.test.ts
+++ b/tests/curve2dFns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
-import { drawRectangle, drawCircle } from '@/index.js';
+import { drawRectangle, drawCircle, getKernel } from '@/index.js';
 import {
   reverseCurve,
   curve2dBoundingBox,
@@ -123,5 +123,30 @@ describe('curve2dDistanceFrom', () => {
   it('distant point has large distance', () => {
     const curve = getLineCurve();
     expect(curve2dDistanceFrom(curve, [1000, 1000])).toBeGreaterThan(10);
+  });
+});
+
+describe('kernel 2D primitives', () => {
+  it('createPoint2d returns {x, y}', () => {
+    const p = getKernel().createPoint2d(3, 4) as { x: number; y: number };
+    expect(p.x).toBe(3);
+    expect(p.y).toBe(4);
+  });
+
+  it('createVector2d returns {x, y}', () => {
+    const v = getKernel().createVector2d(5, -2) as { x: number; y: number };
+    expect(v.x).toBe(5);
+    expect(v.y).toBe(-2);
+  });
+
+  it('createDirection2d returns a unit-length direction', () => {
+    const d = getKernel().createDirection2d(3, 4) as { x: number; y: number };
+    expect(Math.hypot(d.x, d.y)).toBeCloseTo(1, 10);
+    expect(d.x).toBeCloseTo(0.6, 10);
+    expect(d.y).toBeCloseTo(0.8, 10);
+  });
+
+  it('createDirection2d throws on zero-length vector', () => {
+    expect(() => getKernel().createDirection2d(0, 0)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

First PR in the **Group A quick wins** sub-roadmap (pure-TS gaps that close without any upstream `occt-wasm` C++ binding work).

The three 2D primitive constructors are kernel-agnostic data holders — brepkit returns plain `{x, y}` objects. occt-wasm now matches that exact pattern, following the precedent already set by the sibling `createAxis2d` method in the same file.

- `createPoint2d(x, y)` → `{x, y}`
- `createVector2d(x, y)` → `{x, y}`
- `createDirection2d(x, y)` → `{x: x/‖v‖, y: y/‖v‖}` (normalized), throws on zero-length

## Test plan

- [x] Four new tests in `tests/curve2dFns.test.ts` — structural assertions for all three constructors plus the zero-length direction guard
- [x] Passes on `occt`, `occt-wasm`, and `brepkit`
- [x] `npm run typecheck` clean
- [ ] CI passes on all three kernel projects

## Roadmap context

The preceding mesh-format roadmap is complete (#788/#790/#792/#794/#796/#797). This kicks off the next round — **7 Group A methods** remain, all pure TS:

- [x] **This PR:** `createPoint2d`, `createDirection2d`, `createVector2d`
- [ ] `iterShapeList`
- [ ] `applyComposedTransformWithHistory`
- [ ] `helicalSweep` (compose from existing helix wire + sweep)

`transformBatch` "unknown type" branch was reviewed and determined to be an exhaustiveness fallback, not a real gap — all 4 `TransformEntry` variants are already handled.