### PR TITLE
chore(kernel): replace iterShapeList stub with informative throw on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -2614,7 +2614,14 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   iterShapeList(_list: KernelShape, _callback: (item: KernelShape) => void): void {
-    notImplemented('iterShapeList');
+    // occt-wasm's arena model has no TopTools_ListOfShape equivalent — the
+    // kernel only yields individual u32 shape IDs, not list handles. This
+    // method is used internally by OCCT's evolution JS fallback path, which
+    // is itself unreachable on occt-wasm (evolution data comes from the C++
+    // facade's EvolutionExtractor). No Layer 2+ code calls this directly.
+    throw new Error(
+      'iterShapeList is not applicable to occt-wasm: the arena model has no TopTools_ListOfShape handles'
+    );
   }
 
   shapeType(shape: KernelShape): ShapeType {


### PR DESCRIPTION
## Summary

Second PR in the Group A sub-roadmap. Investigation revealed that `iterShapeList` is architecturally **not applicable** to occt-wasm — not a pending implementation.

## Why not implemented

- `iterShapeList` walks a `TopTools_ListOfShape` handle. That's an Embind concept; **occt-wasm's arena model has no equivalent** — the C++ facade yields individual `u32` shape IDs, never a list handle.
- On OCCT, this method is used internally by the evolution JS fallback (`translateWithHistory` when `EvolutionExtractor` is absent in an older WASM build). On occt-wasm, that fallback doesn't exist — evolution data comes directly from the facade's `EvolutionExtractor`.
- **No Layer 2+ code calls this method** (verified by grep). It exists in `KernelIOOps` for cross-kernel interface uniformity.

## Change

Swapped the generic `notImplemented('iterShapeList')` for an informative throw with an inline comment explaining the architectural mismatch — following the spirit of the #797 cleanup (distinguishing "not applicable to this kernel" from "not yet implemented").

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] CI passes on all three kernel projects

No new tests — throw-path behavior; no reachable call site to exercise.

## Roadmap

- [x] PR #788: cone/torus direction
- [x] PR #790: exportSTEP{Assembly,Configured}
- [x] PR #792-#796: OBJ/PLY/GLB
- [x] PR #797: mesh-import throw alignment
- [x] PR #798: Group A / 2D primitives
- [x] **This PR:** Group A / iterShapeList
- [ ] Group A: `applyComposedTransformWithHistory`
- [ ] Group A: `helicalSweep` (compose from helix wire + sweep)

After Group A closes, remaining work is Group B (upstream C++ bindings) and Group C (leaky-abstraction cleanup).