### PR TITLE
fix(kernel): real per-face evolution in occt-wasm applyComposedTransformWithHistory

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1994,22 +1994,31 @@ export class OcctWasmAdapter implements KernelAdapter {
     inputFaceHashes: number[],
     hashUpperBound: number
   ): OperationResult {
-    if (transformHandle.__type === 'transform_matrix') {
-      // Apply the matrix as a generalTransform, then synthesize evolution
-      const result = this.transform(shape, transformHandle);
-      const modified = new Map<number, number[]>();
-      for (const h of inputFaceHashes) {
-        const resultHash = this.hashCode(result, hashUpperBound);
-        modified.set(h, [resultHash]);
+    // transform() dispatches across all matrix-like handle shapes:
+    // { __type: 'transform_matrix', matrix }, { matrix: [] }, { elements: [] },
+    // and plain number[]. It throws on anything unrecognizable.
+    const result = this.transform(shape, transformHandle);
+
+    // Synthesize per-face evolution by pairing input and output face hashes
+    // by iteration index. Affine transforms preserve topology, and both
+    // the caller (collectInputFaceHashes) and we use iterShapes(..., 'face')
+    // which is order-stable — the correspondence holds. True C++-tracked
+    // evolution would need a facade method for generic transforms (only
+    // translateWithHistory / rotateWithHistory are exposed today).
+    const outFaces = this.iterShapes(result, 'face');
+    const modified = new Map<number, number[]>();
+    const limit = Math.min(inputFaceHashes.length, outFaces.length);
+    for (let i = 0; i < limit; i++) {
+      const outFace = outFaces[i];
+      const inHash = inputFaceHashes[i];
+      if (outFace !== undefined && inHash !== undefined) {
+        modified.set(inHash, [this.hashCode(outFace, hashUpperBound)]);
       }
-      const evolution: ShapeEvolution = {
-        modified,
-        generated: new Map(),
-        deleted: new Set(),
-      };
-      return { shape: result, evolution };
     }
-    notImplemented('applyComposedTransformWithHistory');
+    return {
+      shape: result,
+      evolution: { modified, generated: new Map(), deleted: new Set() },
+    };
   }
 
   // =========================================================================

--- a/tests/transformCopy.test.ts
+++ b/tests/transformCopy.test.ts
@@ -10,6 +10,8 @@ import {
   composeTransforms,
   transformCopy,
   unwrap,
+  getKernel,
+  HASH_CODE_MAX,
 } from '@/index.js';
 
 beforeAll(async () => {
@@ -132,5 +134,36 @@ describe('transformCopy', () => {
     expect(cb.xMax).toBeCloseTo(sb.xMax, 3);
     expect(cb.yMin).toBeCloseTo(sb.yMin, 3);
     expect(cb.yMax).toBeCloseTo(sb.yMax, 3);
+  });
+});
+
+describe('applyComposedTransformWithHistory evolution', () => {
+  it('produces per-face modified entries mapping input hashes to output face hashes', () => {
+    const kernel = getKernel();
+    const b = box(10, 10, 10);
+    const faces = kernel.iterShapes(b.wrapped, 'face');
+    const inputHashes = faces.map((f) => kernel.hashCode(f, HASH_CODE_MAX));
+
+    const trsf = composeTransforms([{ type: 'translate', v: [1, 2, 3] }]);
+    const { shape: resultShape, evolution } = kernel.applyComposedTransformWithHistory(
+      b.wrapped,
+      trsf.trsf,
+      inputHashes,
+      HASH_CODE_MAX
+    );
+    trsf.cleanup();
+
+    // Box has 6 faces — evolution should contain an entry per input face.
+    expect(evolution.modified.size).toBe(6);
+    expect(evolution.generated.size).toBe(0);
+    expect(evolution.deleted.size).toBe(0);
+
+    // Every mapped output hash should correspond to an actual face in the result.
+    const outFaces = kernel.iterShapes(resultShape, 'face');
+    const outHashSet = new Set(outFaces.map((f) => kernel.hashCode(f, HASH_CODE_MAX)));
+    for (const outHashes of evolution.modified.values()) {
+      expect(outHashes).toHaveLength(1);
+      expect(outHashSet.has(outHashes[0] ?? -1)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Third PR in the Group A sub-roadmap. The existing `applyComposedTransformWithHistory` on occt-wasm only handled `transformHandle.__type === 'transform_matrix'` and, even in that branch, synthesized a semantically broken evolution where every input face hash mapped to the output **shape** hash (not a face hash). Downstream `propagateAllMetadata` then silently failed to propagate origins/tags/colors across the transform on occt-wasm.

This PR both closes the `notImplemented` fallback and fixes the evolution quality.

## Changes

1. **Handle dispatch** — delegate to `this.transform()` which already accepts plain `number[]`, `{ matrix: [] }`, `{ elements: [] }`, and the `__type`-branded variant. Matrix-like handles all work; `notImplemented` fallback removed.

2. **Real per-face evolution** — pair input/output face hashes by iteration index. Rigid and affine transforms preserve topology, and both the caller (`collectInputFaceHashes` in `metadataPropagation.ts`) and this method iterate via `kernel.iterShapes(..., 'face')` — order-stable, so index-correspondence holds.

3. True C++-tracked per-face evolution for generic composed transforms would require a new facade method — `translateWithHistory` and `rotateWithHistory` exist, but not for composed matrix transforms. Best-effort TS synthesis is correct under the topology-preservation invariant that composed transforms satisfy.

## Why this matters

`propagateAllMetadata` reads `evolution.modified` to move face origins, tags, and colors from input to output faces. With the previous (broken) synthesis, every input face hash was mapped to a value that doesn't appear in the result's face-hash space, so metadata lookups silently found nothing. occt-wasm users relying on `transformCopy` would have had metadata silently lost. Now it works.

## Test plan

- [x] Existing `transformCopy` tests (7 across 3 kernels) still pass
- [x] New regression test in `tests/transformCopy.test.ts` — asserts evolution has one entry per input face and every mapped output hash is a real face hash in the result. Passes on occt, occt-wasm, and brepkit
- [x] `npm run typecheck` clean, `npm run lint` clean
- [ ] CI passes on all three kernel projects

## Roadmap

- [x] PR #788: cone/torus direction
- [x] PRs #790/#792/#794/#796/#797: STEP + mesh formats
- [x] PR #798: 2D primitives
- [x] PR #800: iterShapeList informative throw
- [x] **This PR:** applyComposedTransformWithHistory
- [ ] Group A final: `helicalSweep` (compose helix wire + sweep)