### PR TITLE
chore(kernel): replace helicalSweep stub with informative throw on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1094,8 +1094,19 @@ export class OcctWasmAdapter implements KernelAdapter {
     _pitch: number,
     _turns: number
   ): KernelShape {
-    // TODO: compose from helix wire + sweep
-    notImplemented('helicalSweep');
+    // Primitive composition via makeHelixWire + sweep/sweepPipeShell runs
+    // into OCCT's BRepOffsetAPI_MakePipe{Shell} requirement that the profile
+    // be positioned at the spine's first vertex and oriented perpendicular
+    // to the spine tangent there. Replicating that positioning+orientation
+    // step in TS is real geometric work (extract helix start point and
+    // tangent, transform the profile into that frame) — not a trivial
+    // composition. brepkit exposes a dedicated C++ helicalSweep that
+    // handles this internally; OCCT's defaultAdapter declines with
+    // "only available with the brepkit kernel". Matching that posture
+    // until the composition is fleshed out or a C++ facade method lands.
+    throw new Error(
+      'helicalSweep on occt-wasm requires profile positioning+orientation logic not yet implemented; brepkit has a native implementation'
+    );
   }
 
   sweepWithOptions(

--- a/tests/sweepFns.test.ts
+++ b/tests/sweepFns.test.ts
@@ -7,11 +7,13 @@ import {
   castShape,
   sweep,
   isOk,
-  isErr,
   unwrap,
   isSolid,
   isShape3D,
   measureVolume,
+  box,
+  getFaces,
+  getKernel,
 } from '@/index.js';
 import type { Wire } from '@/core/shapeTypes.js';
 
@@ -74,5 +76,38 @@ describe('sweepFns', () => {
     const actual = unwrap(measureVolume(shape));
     expect(actual).toBeGreaterThan(expected * 0.99);
     expect(actual).toBeLessThan(expected * 1.01);
+  });
+
+  describe('kernel.helicalSweep', () => {
+    it('produces a solid on kernels that support it', () => {
+      expect.hasAssertions();
+      // Use a box face as the profile, sweep along a helix around Z axis.
+      const b = box(2, 2, 1);
+      const faces = getFaces(b);
+      const profileFace = faces[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      let result: unknown;
+      try {
+        result = getKernel().helicalSweep(
+          profileFace.wrapped,
+          [0, 0, 0],
+          [0, 0, 1],
+          10, // radius
+          5, // pitch
+          2 // turns
+        );
+      } catch (e) {
+        // OCCT and occt-wasm both decline: OCCT says "only available with
+        // the brepkit kernel"; occt-wasm says brepkit has a native impl
+        // while its own composition isn't fleshed out yet. Either way,
+        // the message mentions brepkit — brepkit is the only kernel that
+        // currently implements helicalSweep.
+        expect(String(e)).toContain('brepkit');
+        return;
+      }
+      expect(result).toBeDefined();
+      // Result should be a valid solid with positive volume.
+      expect(getKernel().isValid(result)).toBe(true);
+      expect(getKernel().volume(result)).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Final PR in the Group A sub-roadmap. The adapter's `TODO: compose from helix wire + sweep` comment turned out to be harder than a naive composition admits.

## Investigation

Both `this.sweep(wireProfile, helix)` (MakePipe) and `this.sweepPipeShell(wireProfile, helix)` reject the composition:

- `sweepPipeShell`: `"BRepFill_Section: bad shape type of section"` (requires wire/vertex, not a face; after extracting the face's outer wire the error becomes empty-detail)
- `sweep`: silent failure with empty detail

Root cause: OCCT's `BRepOffsetAPI_MakePipe{Shell}` requires the profile to be positioned at the spine's first vertex and oriented perpendicular to the spine tangent there. A helix starts at e.g. `(radius, 0, 0)` on the helix axis circle — the profile is typically at origin, orthogonal to Z. The positioning + orientation delta between them is what must be applied before the sweep call.

Replicating that in TS is real geometric work: extract helix start vertex and tangent, build a local frame, compose rotate+translate transforms to bring the profile into that frame, then sweep. Not a "Group A quick win."

## Change

- Replaced `notImplemented('helicalSweep')` with a specific throw explaining what's needed for the composition to work. Mentions brepkit (which has a native C++ helicalSweep) so the test below catches it the same way it catches OCCT's `"only available with the brepkit kernel"` throw.
- Smoke test in `tests/sweepFns.test.ts` exercises the method on all three kernels; brepkit passes via its native C++ impl, occt and occt-wasm both decline and the test accepts the `brepkit`-mentioning error.
- Also removes a pre-existing unused `isErr` import in `sweepFns.test.ts` that lint-staged surfaced.

## Roadmap — Group A closed

- [x] PR #788: cone/torus direction
- [x] PRs #790/#792/#794/#796/#797: STEP + mesh formats
- [x] PR #798: 2D primitives
- [x] PR #800: iterShapeList informative throw
- [x] PR #801: applyComposedTransformWithHistory (closed stub + fixed latent metadata bug)
- [x] **This PR:** helicalSweep informative throw

Group A → complete. Next options:
- **Group C cleanup** — remove leaky `wrapString`/`wrapColor`/`configureStep*` from `KernelIOOps`
- **Group B upstream C++** — `hull`, `filletVariable`, `sweepWithOptions`, NURBS curve editing (requires two-repo PRs)
- **TODO polish** — witness points (line 2509) and curvature maxDirection (line 2538)

## Test plan

- [x] Smoke test passes on occt, occt-wasm, brepkit
- [x] `npm run typecheck` clean, `npm run lint` clean
- [ ] CI passes on all three kernel projects