### PR TITLE
fix(deps): pin opentype.js to 1.3.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # 1.3.5 throws on GSUB lookup type 6 substFormat 2 used by DejaVu Sans / Noto Sans
+      # for ccmp glyph composition — breaks textBlueprints/textMetrics with system fonts.
+      # Re-allow once opentype.js supports this lookup format.
+      - dependency-name: opentype.js
+        versions: ['1.3.5']
     groups:
       minor-and-patch:
         update-types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "flatbush": "4.5.1",
-        "opentype.js": "1.3.5"
+        "opentype.js": "1.3.4"
       },
       "devDependencies": {
         "@commitlint/cli": "20.5.3",
@@ -435,29 +435,6 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -4088,22 +4065,6 @@
       "resolved": "site",
       "link": true
     },
-    "node_modules/brepjs/node_modules/opentype.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
-      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
-      "license": "MIT",
-      "dependencies": {
-        "string.prototype.codepointat": "^0.2.1",
-        "tiny-inflate": "^1.0.3"
-      },
-      "bin": {
-        "ot": "bin/ot"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/brepkit-wasm": {
       "version": "2.44.1",
       "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.44.1.tgz",
@@ -6962,12 +6923,19 @@
       }
     },
     "node_modules/opentype.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.5.tgz",
-      "integrity": "sha512-thKDiELidAApOvXlncrpwDZKJCa9fXLEKM4+FoEWI+qTLDeNb+h7EkN+8a7KQODsB1GZ+Exz9KknkoPrEdXZDw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
       "license": "MIT",
+      "dependencies": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
+      },
       "bin": {
         "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/optionator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -436,6 +436,29 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
   },
   "dependencies": {
     "flatbush": "4.5.1",
-    "opentype.js": "1.3.5"
+    "opentype.js": "1.3.4"
   },
   "overrides": {
     "minimatch@>=10.0.0 <10.2.3": "10.2.3"


### PR DESCRIPTION
## Summary
- `opentype.js` 1.3.5 (introduced in #813) throws `substitutionType : 62 lookupType: 6 - substFormat: 2 is not yet supported` for the `ccmp` GSUB feature, which DejaVu Sans and Noto Sans both use.
- Tests `tests/textMetrics.test.ts` and `tests/textBlueprints.test.ts` fail on Linux runners because they load system fonts that hit this lookup.
- `ccmp` is applied unconditionally in opentype.js's `Bidi.applyFeaturesToContexts`, so the `{ features: {} }` workaround can't bypass it.

Pinned to 1.3.4 and added a Dependabot ignore for 1.3.5 so it doesn't immediately re-bump. Once opentype.js supports this lookup format, remove the ignore.

CI failure: https://github.com/andymai/brepjs/actions/runs/25303304311

## Test plan
- [x] `npx vitest run tests/textBlueprints.test.ts tests/textMetrics.test.ts` — 54/54 pass locally
- [ ] CI green on PR