### PR TITLE
feat(occt-wasm)!: consume occt-wasm 2.0 facade for parity with occt kernel

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "husky": "9.1.7",
     "knip": "6.11.0",
     "lint-staged": "16.4.0",
-    "occt-wasm": "1.5.0",
+    "occt-wasm": "2.0.0",
     "prettier": "3.8.3",
     "size-limit": "12.1.0",
     "typedoc": "0.28.19",
@@ -238,7 +238,7 @@
   "peerDependencies": {
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0",
     "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-    "occt-wasm": "^0.1.0 || ^1.0.0"
+    "occt-wasm": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "brepjs-opencascade": {

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1343,13 +1343,13 @@ export class OcctWasmAdapter implements KernelAdapter {
 
   loft(
     wires: KernelShape[],
-    _ruled?: boolean,
+    ruled?: boolean,
     _startShape?: KernelShape,
     _endShape?: KernelShape
   ): KernelShape {
     const vec = makeVecU32(this.Module, wires.map(unwrap));
     try {
-      return wrapResult(this.k, this.k.loft(vec, true));
+      return wrapResult(this.k, this.k.loft(vec, true, ruled ?? false));
     } finally {
       vec.delete();
     }
@@ -1449,14 +1449,15 @@ export class OcctWasmAdapter implements KernelAdapter {
     }
   ): KernelShape {
     const isSolid = options?.solid ?? true;
+    const ruled = options?.ruled ?? false;
     const startV = options?.startVertex ? unwrap(options.startVertex) : 0;
     const endV = options?.endVertex ? unwrap(options.endVertex) : 0;
     const vec = makeVecU32(this.Module, wires.map(unwrap));
     try {
       if (startV || endV) {
-        return wrapResult(this.k, this.k.loftWithVertices(vec, isSolid, startV, endV));
+        return wrapResult(this.k, this.k.loftWithVertices(vec, isSolid, ruled, startV, endV));
       }
-      return wrapResult(this.k, this.k.loft(vec, isSolid));
+      return wrapResult(this.k, this.k.loft(vec, isSolid, ruled));
     } finally {
       vec.delete();
     }
@@ -1579,8 +1580,8 @@ export class OcctWasmAdapter implements KernelAdapter {
     return wrapResult(this.k, this.k.thicken(unwrap(shape), thickness));
   }
 
-  offset(shape: KernelShape, distance: number, _tolerance?: number): KernelShape {
-    return wrapResult(this.k, this.k.offset(unwrap(shape), distance));
+  offset(shape: KernelShape, distance: number, tolerance?: number): KernelShape {
+    return wrapResult(this.k, this.k.offset(unwrap(shape), distance, tolerance ?? 1e-6));
   }
 
   filletVariable(shape: KernelShape, spec: string): KernelShape {
@@ -2857,71 +2858,20 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   surfaceCenterOfMass(face: KernelShape): [number, number, number] {
-    // Area-weighted triangle centroid via tessellation. Mathematically exact
-    // for the triangulated face; converges to the true surface center of mass
-    // as deflection → 0. Tessellation deflection is scaled to the face's
-    // bounding-box diagonal so small and large faces both get adequate fidelity.
-    const faceId = unwrap(face);
-    const bb = this.k.getBoundingBox(faceId);
-    const dx = bb.xmax - bb.xmin;
-    const dy = bb.ymax - bb.ymin;
-    const dz = bb.zmax - bb.zmin;
-    const diag = Math.sqrt(dx * dx + dy * dy + dz * dz);
-    const linDef = Math.max(diag * 1e-3, 1e-5);
-    const angDef = 0.1;
-
-    let meshData: ReturnType<OcctKernelWasm['tessellate']>;
+    // Delegates to occt-wasm's exact `BRepGProp::SurfaceProperties.CentreOfMass()`
+    // (added in occt-wasm 2.0). The previous tessellation-triangle centroid
+    // diverged from brepjs-occt for non-planar faces — for cylindrical faces
+    // it landed `+radius` off-axis (on the surface), and for holed planar
+    // faces it biased toward the holes' weighted x-position. See occt-wasm#90.
     try {
-      meshData = this.k.tessellate(faceId, linDef, angDef);
+      const v = this.k.getSurfaceCenterOfMass(unwrap(face));
+      const result: [number, number, number] = [v.get(0), v.get(1), v.get(2)];
+      v.delete();
+      return result;
     } catch {
-      // Degenerate or unmeshable face — fall back to no centroid rather than
-      // propagating the WASM exception. Matches collectDistanceSamples.
+      // Degenerate or unmeshable face — preserve previous behavior of
+      // returning origin rather than propagating the WASM exception.
       return [0, 0, 0];
-    }
-    try {
-      const idxCount = meshData.indexCount;
-      if (idxCount < 3) return [0, 0, 0];
-      const posPtr = meshData.getPositionsPtr() >> 2;
-      const idxPtr = meshData.getIndicesPtr() >> 2;
-      const heapF32 = this.Module.HEAPF32;
-      const heapU32 = this.Module.HEAPU32;
-      let cx = 0,
-        cy = 0,
-        cz = 0,
-        totalArea = 0;
-      for (let t = 0; t < idxCount; t += 3) {
-        const i0 = (heapU32[idxPtr + t] ?? 0) * 3;
-        const i1 = (heapU32[idxPtr + t + 1] ?? 0) * 3;
-        const i2 = (heapU32[idxPtr + t + 2] ?? 0) * 3;
-        const p0x = heapF32[posPtr + i0] ?? 0;
-        const p0y = heapF32[posPtr + i0 + 1] ?? 0;
-        const p0z = heapF32[posPtr + i0 + 2] ?? 0;
-        const p1x = heapF32[posPtr + i1] ?? 0;
-        const p1y = heapF32[posPtr + i1 + 1] ?? 0;
-        const p1z = heapF32[posPtr + i1 + 2] ?? 0;
-        const p2x = heapF32[posPtr + i2] ?? 0;
-        const p2y = heapF32[posPtr + i2 + 1] ?? 0;
-        const p2z = heapF32[posPtr + i2 + 2] ?? 0;
-        const ux = p1x - p0x,
-          uy = p1y - p0y,
-          uz = p1z - p0z;
-        const vx = p2x - p0x,
-          vy = p2y - p0y,
-          vz = p2z - p0z;
-        const nx = uy * vz - uz * vy;
-        const ny = uz * vx - ux * vz;
-        const nz = ux * vy - uy * vx;
-        const area = 0.5 * Math.sqrt(nx * nx + ny * ny + nz * nz);
-        if (area === 0) continue;
-        cx += ((p0x + p1x + p2x) / 3) * area;
-        cy += ((p0y + p1y + p2y) / 3) * area;
-        cz += ((p0z + p1z + p2z) / 3) * area;
-        totalArea += area;
-      }
-      if (totalArea < 1e-30) return [0, 0, 0];
-      return [cx / totalArea, cy / totalArea, cz / totalArea];
-    } finally {
-      meshData.delete();
     }
   }
 

--- a/src/kernel/occtWasm/occtWasmTypes.ts
+++ b/src/kernel/occtWasm/occtWasmTypes.ts
@@ -194,7 +194,7 @@ export interface OcctKernelWasm {
     angleDeg: number
   ): number;
   shell(solidId: number, faceIds: EmVectorUint32, thickness: number): number;
-  offset(solidId: number, distance: number): number;
+  offset(solidId: number, distance: number, tolerance: number): number;
   draft(
     shapeId: number,
     faceId: number,
@@ -207,10 +207,11 @@ export interface OcctKernelWasm {
   // --- Sweep operations ---
   pipe(profileId: number, spineId: number): number;
   simplePipe(profileId: number, spineId: number): number;
-  loft(wireIds: EmVectorUint32, isSolid: boolean): number;
+  loft(wireIds: EmVectorUint32, isSolid: boolean, ruled: boolean): number;
   loftWithVertices(
     wireIds: EmVectorUint32,
     isSolid: boolean,
+    ruled: boolean,
     startVertexId: number,
     endVertexId: number
   ): number;
@@ -414,6 +415,7 @@ export interface OcctKernelWasm {
   getSurfaceArea(id: number): number;
   getLength(id: number): number;
   getCenterOfMass(id: number): EmVectorDouble;
+  getSurfaceCenterOfMass(faceId: number): EmVectorDouble;
   getLinearCenterOfMass(id: number): EmVectorDouble;
   surfaceCurvature(faceId: number, u: number, v: number): EmVectorDouble;
 


### PR DESCRIPTION
## Summary

Updates the `OcctWasmAdapter` to use occt-wasm 2.0's expanded facade, fixing three silent-correctness bugs identified in [occt-wasm#90](https://github.com/andymai/occt-wasm/issues/90):

1. **`surfaceCenterOfMass`** now calls occt-wasm's new `getSurfaceCenterOfMass(faceId)` (added in occt-wasm#94) which uses `BRepGProp::SurfaceProperties.CentreOfMass()` directly. The previous tessellation-triangle centroid diverged from the occt kernel for cylindrical faces (off-axis by `+radius`) and biased toward holes for holed planar faces. **Root cause** of the ~1.2 mm bounds shift in the parity test.
2. **`loft`** now passes the `ruled` flag through (default `false`). Previously dropped, so callers requesting linear interpolation got smooth/B-spline lofts.
3. **`offset`** now passes the `tolerance` argument through (default `1e-6` to match brepjs-occt). Previously dropped, occt-wasm hardcoded `1e-3` internally.

## Drafted because

⏳ **Blocked on:** [occt-wasm#94](https://github.com/andymai/occt-wasm/pull/94) merging + occt-wasm 2.0.0 publishing to npm. Once that's live, `npm install` will succeed and CI will pass.

## Diff size

```
 package.json                           |  4 +-
 src/kernel/occtWasm/occtWasmAdapter.ts | 86 +++++-------------------
 src/kernel/occtWasm/occtWasmTypes.ts   |  6 +-
 3 files changed, 24 insertions(+), 72 deletions(-)
```

The bulk of the deletions are the now-unused tessellation-triangle centroid implementation (~70 lines) replaced with a 13-line call to the exact OCCT method.

## Breaking change

Peer range narrows from `^0.1.0 || ^1.0.0` to `^2.0.0`. The adapter's `loft` and `offset` paths require the new positional args; calling them against occt-wasm 1.x at runtime would silently drop the new args (Embind ignores extra arguments).

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] `npm install` (blocked on occt-wasm 2.0.0 publish)
- [ ] `npm test` (blocked on install)
- [ ] Verify the parity test in [gridfinity-layout-tool](https://github.com/andymai/gridfinity-layout-tool/blob/0d567041f/src/features/generation/worker/generators/__dual-kernel__/occtWasmParity.test.ts) closes the gap once occt-wasm 2.0.0 is available