### PR TITLE
fix(deps): update package-lock to occt-wasm@2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "husky": "9.1.7",
         "knip": "6.11.0",
         "lint-staged": "16.4.0",
-        "occt-wasm": "1.5.0",
+        "occt-wasm": "2.0.0",
         "prettier": "3.8.3",
         "size-limit": "12.1.0",
         "typedoc": "0.28.19",
@@ -46,7 +46,7 @@
       "peerDependencies": {
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-        "occt-wasm": "^0.1.0 || ^1.0.0"
+        "occt-wasm": "^2.0.0"
       },
       "peerDependenciesMeta": {
         "brepjs-opencascade": {
@@ -4066,7 +4066,7 @@
       "peerDependencies": {
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-        "occt-wasm": "^0.1.0 || ^1.0.0"
+        "occt-wasm": "^2.0.0"
       },
       "peerDependenciesMeta": {
         "brepjs-opencascade": {
@@ -6892,9 +6892,9 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-1.5.0.tgz",
-      "integrity": "sha512-1MqVBqTGh6MhZQSltiu4xcdpuraNe76Ysegu7lUHzI4jaO+Nzf31HX9FQ9zbZaftffYricpPlKBQdn0inJwQag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-2.0.0.tgz",
+      "integrity": "sha512-huAQFqbRYp36fU0htPJ7tXj0OoX3RzED+Ua6KvjGrc3yT99jyNnkB6mYu6jpSqvCUKK3QnQizQjK6SETCgNCTw==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peer": true,


### PR DESCRIPTION
## Summary

PR #817 bumped \`package.json\`'s \`occt-wasm\` devDep to 2.0.0 but didn't regenerate the lockfile, causing \`npm ci\` on the brepjs 16.0.0 release workflow to fail:

\`\`\`
npm error code EUSAGE
npm error Invalid: lock file's occt-wasm@1.5.0 does not satisfy occt-wasm@2.0.0
\`\`\`

Now that occt-wasm 2.0.0 is published to npm (via the OIDC publish chain in occt-wasm#95-#97), regenerating the lockfile resolves the entry cleanly and unblocks the brepjs 16.0.0 catch-up publish.

## Diff
- Only \`package-lock.json\` changes
- 5 insertions, 28 deletions (the unused tessellation-CoM dep tree shrinks)

## Catch-up after merge

\`\`\`bash
gh run rerun 25367478355 --repo andymai/brepjs --failed
\`\`\`