### PR TITLE
ci: add manual publish workflow for brepjs main

### DIFF
--- a/.github/workflows/publish-brepjs-manual.yml
+++ b/.github/workflows/publish-brepjs-manual.yml
@@ -1,0 +1,34 @@
+name: Publish brepjs (manual)
+
+# Manual publish path for republishing brepjs from main when the
+# release-please flow has already created the release tag but the
+# auto-publish failed. Reads version from main's package.json -- the
+# tag/release machinery is bypassed.
+#
+# Usage:
+#   gh workflow run publish-brepjs-manual.yml --repo andymai/brepjs
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Publish brepjs
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The release-please.yml \`publish-brepjs\` job is gated on \`brepjs_release_created == 'true'\`, which release-please only emits once per release. When the auto-publish fails (as it did for 16.0.0 because the lockfile was stale at occt-wasm@1.5.0), there's no way to re-trigger from the same commit — \`gh run rerun\` re-checks-out the old tree.

This workflow accepts a \`workflow_dispatch\` and publishes whatever version is in main's \`package.json\`. Lets us recover from a failed release-please publish without bumping the version.

## Catch-up after merge

\`\`\`bash
gh workflow run publish-brepjs-manual.yml --repo andymai/brepjs
\`\`\`

This will publish 16.0.0 (current main version) using the now-correct lockfile.

## Test plan
- [x] YAML syntax (gh CLI parses)
- [ ] After merge: dispatch publishes 16.0.0 successfully
- [ ] \`npm view brepjs version\` returns 16.0.0