### PR TITLE
feat(occtWasm)!: consume occt-wasm 3.0 — close issue #90 parity gap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "husky": "9.1.7",
         "knip": "6.11.0",
         "lint-staged": "16.4.0",
-        "occt-wasm": "2.0.0",
+        "occt-wasm": "3.0.0",
         "prettier": "3.8.3",
         "size-limit": "12.1.0",
         "typedoc": "0.28.19",
@@ -46,7 +46,7 @@
       "peerDependencies": {
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-        "occt-wasm": "^2.0.0"
+        "occt-wasm": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "brepjs-opencascade": {
@@ -4066,7 +4066,7 @@
       "peerDependencies": {
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-        "occt-wasm": "^2.0.0"
+        "occt-wasm": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "brepjs-opencascade": {
@@ -6892,9 +6892,9 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-2.0.0.tgz",
-      "integrity": "sha512-huAQFqbRYp36fU0htPJ7tXj0OoX3RzED+Ua6KvjGrc3yT99jyNnkB6mYu6jpSqvCUKK3QnQizQjK6SETCgNCTw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.0.0.tgz",
+      "integrity": "sha512-5/odaoPCoYMziO4pApzvkRa6uuVrTRTnJ2QUkTgh4YYcYyQqhAXsZ5psqToE3xM66shiSYa0xPZUFZer5heaTQ==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "husky": "9.1.7",
     "knip": "6.11.0",
     "lint-staged": "16.4.0",
-    "occt-wasm": "2.0.0",
+    "occt-wasm": "3.0.0",
     "prettier": "3.8.3",
     "size-limit": "12.1.0",
     "typedoc": "0.28.19",
@@ -238,7 +238,7 @@
   "peerDependencies": {
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0",
     "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-    "occt-wasm": "^2.0.0"
+    "occt-wasm": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "brepjs-opencascade": {

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -400,7 +400,10 @@ function collectDistanceSamples(
   // Tessellation samples — coarse linear deflection (≈1% of bbox diagonal)
   // is enough to seed a witness-point search; refinement comes from picking
   // the closest pair, not from sample density per se.
-  const bb = k.getBoundingBox(shapeId);
+  // useTriangulation=true matches brepjs-occt's BRepBndLib.Add(shape, box, true)
+  // semantics — refines the bound via surface analysis when triangulation is
+  // present, falls back to surface-precise AddOptimal otherwise.
+  const bb = k.getBoundingBox(shapeId, true);
   const diag = Math.sqrt(
     (bb.xmax - bb.xmin) ** 2 + (bb.ymax - bb.ymin) ** 2 + (bb.zmax - bb.zmin) ** 2
   );
@@ -1566,18 +1569,21 @@ export class OcctWasmAdapter implements KernelAdapter {
     shape: KernelShape,
     faces: KernelShape[],
     thickness: number,
-    _tolerance?: number
+    tolerance?: number
   ): KernelShape {
     const vec = makeVecU32(this.Module, faces.map(unwrap));
     try {
-      return wrapResult(this.k, this.k.shell(unwrap(shape), vec, thickness));
+      return wrapResult(this.k, this.k.shell(unwrap(shape), vec, thickness, tolerance ?? 1e-3));
     } finally {
       vec.delete();
     }
   }
 
   thicken(shape: KernelShape, thickness: number): KernelShape {
-    return wrapResult(this.k, this.k.thicken(unwrap(shape), thickness));
+    // 1e-3 matches OCCT's pre-3.0 hardcoded default; brepjs's KernelInstance
+    // interface doesn't expose tolerance for thicken, so we keep the prior
+    // behavior. Bump to 1e-6 if/when the interface widens to accept it.
+    return wrapResult(this.k, this.k.thicken(unwrap(shape), thickness, 1e-3));
   }
 
   offset(shape: KernelShape, distance: number, tolerance?: number): KernelShape {
@@ -1628,7 +1634,8 @@ export class OcctWasmAdapter implements KernelAdapter {
   defeature(shape: KernelShape, faces: KernelShape[]): KernelShape {
     const vec = makeVecU32(this.Module, faces.map(unwrap));
     try {
-      return wrapResult(this.k, this.k.defeature(unwrap(shape), vec));
+      // 1e-3 matches OCCT's pre-3.0 hardcoded default; see `thicken`.
+      return wrapResult(this.k, this.k.defeature(unwrap(shape), vec, 1e-3));
     } finally {
       vec.delete();
     }
@@ -2202,7 +2209,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     thickness: number,
     inputFaceHashes: number[],
     hashUpperBound: number,
-    _tolerance?: number
+    tolerance?: number
   ): OperationResult {
     const faceVec = makeVecU32(this.Module, faces.map(unwrap));
     const hashVec = makeVecInt(this.Module, inputFaceHashes);
@@ -2211,6 +2218,7 @@ export class OcctWasmAdapter implements KernelAdapter {
         unwrap(shape),
         faceVec,
         thickness,
+        tolerance ?? 1e-3,
         hashVec,
         hashUpperBound
       );
@@ -2230,7 +2238,13 @@ export class OcctWasmAdapter implements KernelAdapter {
   ): OperationResult {
     const hashVec = makeVecInt(this.Module, inputFaceHashes);
     try {
-      const evo = this.k.thickenWithHistory(unwrap(shape), thickness, hashVec, hashUpperBound);
+      const evo = this.k.thickenWithHistory(
+        unwrap(shape),
+        thickness,
+        1e-3,
+        hashVec,
+        hashUpperBound
+      );
       const { id, evolution } = parseEvolution(evo);
       return { shape: wrapResult(this.k, id), evolution };
     } finally {
@@ -2243,11 +2257,17 @@ export class OcctWasmAdapter implements KernelAdapter {
     distance: number,
     inputFaceHashes: number[],
     hashUpperBound: number,
-    _tolerance?: number
+    tolerance?: number
   ): OperationResult {
     const hashVec = makeVecInt(this.Module, inputFaceHashes);
     try {
-      const evo = this.k.offsetWithHistory(unwrap(shape), distance, hashVec, hashUpperBound);
+      const evo = this.k.offsetWithHistory(
+        unwrap(shape),
+        distance,
+        tolerance ?? 1e-6,
+        hashVec,
+        hashUpperBound
+      );
       const { id, evolution } = parseEvolution(evo);
       return { shape: wrapResult(this.k, id), evolution };
     } finally {
@@ -2777,7 +2797,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     min: [number, number, number];
     max: [number, number, number];
   } {
-    const bb = this.k.getBoundingBox(unwrap(shape));
+    const bb = this.k.getBoundingBox(unwrap(shape), true);
     return {
       min: [bb.xmin, bb.ymin, bb.zmin],
       max: [bb.xmax, bb.ymax, bb.zmax],

--- a/src/kernel/occtWasm/occtWasmTypes.ts
+++ b/src/kernel/occtWasm/occtWasmTypes.ts
@@ -193,7 +193,7 @@ export interface OcctKernelWasm {
     distance: number,
     angleDeg: number
   ): number;
-  shell(solidId: number, faceIds: EmVectorUint32, thickness: number): number;
+  shell(solidId: number, faceIds: EmVectorUint32, thickness: number, tolerance: number): number;
   offset(solidId: number, distance: number, tolerance: number): number;
   draft(
     shapeId: number,
@@ -410,7 +410,7 @@ export interface OcctKernelWasm {
   fromBREP(data: string): number;
 
   // --- Query / Measure ---
-  getBoundingBox(id: number): EmBBoxData;
+  getBoundingBox(id: number, useTriangulation: boolean): EmBBoxData;
   getVolume(id: number): number;
   getSurfaceArea(id: number): number;
   getLength(id: number): number;
@@ -489,8 +489,8 @@ export interface OcctKernelWasm {
   makeNullShape(): number;
 
   // --- Modifier ---
-  thicken(shapeId: number, thickness: number): number;
-  defeature(shapeId: number, faceIds: EmVectorUint32): number;
+  thicken(shapeId: number, thickness: number, tolerance: number): number;
+  defeature(shapeId: number, faceIds: EmVectorUint32, tolerance: number): number;
   reverseShape(id: number): number;
   simplify(id: number): number;
   filletVariable(solidId: number, edgeId: number, startRadius: number, endRadius: number): number;
@@ -573,18 +573,21 @@ export interface OcctKernelWasm {
     solidId: number,
     faceIds: EmVectorUint32,
     thickness: number,
+    tolerance: number,
     inputFaceHashes: EmVectorInt,
     hashUpperBound: number
   ): EmEvolutionData;
   offsetWithHistory(
     solidId: number,
     distance: number,
+    tolerance: number,
     inputFaceHashes: EmVectorInt,
     hashUpperBound: number
   ): EmEvolutionData;
   thickenWithHistory(
     shapeId: number,
     thickness: number,
+    tolerance: number,
     inputFaceHashes: EmVectorInt,
     hashUpperBound: number
   ): EmEvolutionData;


### PR DESCRIPTION
Consumes the upstream parity fix landed in [andymai/occt-wasm#98](https://github.com/andymai/occt-wasm/pull/98) (released as 3.0.0) and plumbs the new args through `OcctWasmAdapter`.

## What occt-wasm 3.0 fixed

Three classes of silent-substitution bug versus brepjs-occt:

1. **Tolerance plumbing** — `shell`, `thicken`, `defeature`, `shellWithHistory`, `offsetWithHistory`, and `thickenWithHistory` had hardcoded `1e-3` in the C++ facade and silently dropped the caller's tolerance. Now required positional args.
2. **`getBoundingBox` precision** — used `BRepBndLib::Add` (BSpline pole-hull fallback overshoots curved geometry by ~0.27·r). Switched to `AddOptimal` with new `useTriangulation: boolean` parameter matching brepjs-occt's `BRepBndLib.Add(shape, box, true)` call surface.
3. **Shell sign convention** — `shell`/`shellWithHistory` were passing positive thickness to `MakeThickSolidByJoin`, which thickens *outward* (bounds inflate by `thickness` in every direction with a removed face). brepjs-occt's path negates: `builder.MakeThickSolidByJoin(shape, faces, -thickness, tolerance, ...)`. The facade now negates internally so positive `thickness` hollows inward, matching the OCCT tutorial and conventional CAD usage.

For the gridfinity parity test, the 1×1 flat-no-lip case had +10.4% volume divergence (occt-wasm thickening outward instead of hollowing inward) and a uniform ~1.2mm xMin shift across every bin variant — both root-caused to the sign + bounds bugs.

## Adapter changes (this PR)

- **`occtWasmAdapter.ts`**: dropped the `_tolerance?: number` underscore-ignored params on `shell`, `shellWithHistory`, `offsetWithHistory` and now plumbs them through to the raw kernel (defaulting to `1e-3` / `1e-6` to preserve prior behavior). Hardcoded `1e-3` for `thicken`, `thickenWithHistory`, `defeature` since the `KernelInstance` interface doesn't expose tolerance for those (matches OCCT pre-3.0 default). Added `true` for `useTriangulation` at both `getBoundingBox` call sites.
- **`occtWasmTypes.ts`**: raw kernel interface mirrors the upstream signature changes so TypeScript catches stale callers.
- **`package.json`**: bumped `occt-wasm` devDep to `3.0.0` and peerDep to `^3.0.0`. The peerDep narrows to a single major because the adapter's correctness now relies on the new sign + signatures — running it against 2.x would hit the old buggy paths.

## API

No changes to brepjs's public API. `kernel.shell(s, f, t)` still hollows inward as the name and docs imply.

Closes [andymai/occt-wasm#90](https://github.com/andymai/occt-wasm/issues/90) at the brepjs layer.