### PR TITLE
fix(playground): bundled UX pass — worker, viewer, editor, shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,29 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1140,117 +1163,6 @@
       "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
       "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@microsoft/api-extractor": {
-      "version": "7.57.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.6.tgz",
-      "integrity": "sha512-0rFv/D8Grzw1Mjs2+8NGUR+o4h9LVm5zKRtMeWnpdB5IMJF4TeHCL1zR5LMCIudkOvyvjbhMG5Wjs0B5nqsrRQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@microsoft/api-extractor-model": "7.33.4",
-        "@microsoft/tsdoc": "~0.16.0",
-        "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/rig-package": "0.7.2",
-        "@rushstack/terminal": "0.22.3",
-        "@rushstack/ts-command-line": "5.3.3",
-        "diff": "~8.0.2",
-        "lodash": "~4.17.23",
-        "minimatch": "10.2.1",
-        "resolve": "~1.22.1",
-        "semver": "~7.5.4",
-        "source-map": "~0.6.1",
-        "typescript": "5.8.2"
-      },
-      "bin": {
-        "api-extractor": "bin/api-extractor"
-      }
-    },
-    "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.33.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.4.tgz",
-      "integrity": "sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@microsoft/tsdoc": "~0.16.0",
-        "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.20.3"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
-      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@microsoft/tsdoc": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
-      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
-      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@microsoft/tsdoc": "0.16.0",
-        "ajv": "~8.18.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.22.2"
-      }
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
@@ -2008,7 +1920,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2345,154 +2256,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rushstack/node-core-library": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
-      "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ajv": "~8.18.0",
-        "ajv-draft-04": "~1.0.0",
-        "ajv-formats": "~3.0.1",
-        "fs-extra": "~11.3.0",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.22.1",
-        "semver": "~7.5.4"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/problem-matcher": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
-      "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/rig-package": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.2.tgz",
-      "integrity": "sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "resolve": "~1.22.1",
-        "strip-json-comments": "~3.1.1"
-      }
-    },
-    "node_modules/@rushstack/rig-package/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@rushstack/terminal": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.3.tgz",
-      "integrity": "sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@rushstack/node-core-library": "5.20.3",
-        "@rushstack/problem-matcher": "0.2.1",
-        "supports-color": "~8.1.1"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/terminal/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.3.tgz",
-      "integrity": "sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@rushstack/terminal": "0.22.3",
-        "@types/argparse": "1.0.38",
-        "argparse": "~1.0.9",
-        "string-argv": "~0.3.1"
-      }
-    },
-    "node_modules/@rushstack/ts-command-line/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
     },
     "node_modules/@shikijs/core": {
       "version": "4.0.2",
@@ -3034,14 +2797,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/argparse": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3122,7 +2877,7 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3144,8 +2899,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3180,7 +2935,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
       "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3265,7 +3019,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -3507,7 +3260,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3681,7 +3433,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3724,41 +3475,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -4027,9 +3743,9 @@
       }
     },
     "node_modules/brepjs": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/brepjs/-/brepjs-15.2.4.tgz",
-      "integrity": "sha512-TRmHuksfT1ju9jKhlnVVuGUl4fLUx8PMpJ7/mNtNZ3OMBKqM4XqNCFldhyyL654GheSx0NEB/trl1b5MZP2OQw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/brepjs/-/brepjs-17.0.0.tgz",
+      "integrity": "sha512-vrfQlxHIlemnsUfZjd046V0GTADWU1UJ0qkIZRYiLQad5Dy4aY8H8vwOBjCAr9ci1ntUwF00VLHTDDWvzCdoDA==",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/brepjs-opencascade",
@@ -4071,9 +3787,8 @@
       "version": "2.44.1",
       "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.44.1.tgz",
       "integrity": "sha512-YNwpk+i90kbZ/1580wJniuLvSAGhqoR2UMNFRv9/MIJzjgwFCRdMpyIBXJqE1X30OrbxavJLUHxGuYWSWGSvzg==",
-      "devOptional": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -4367,7 +4082,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
       "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
@@ -4465,26 +4180,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4560,6 +4261,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -4658,19 +4360,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
+      "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -4802,7 +4492,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4889,7 +4578,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5333,22 +5021,6 @@
         "node": ">=18.3.0"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5362,17 +5034,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -5509,20 +5170,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -5691,17 +5338,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/import-lazy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -5749,23 +5385,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -5902,14 +5521,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jju": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -5957,20 +5568,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6419,14 +6016,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -6462,20 +6051,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lunr": {
@@ -6800,7 +6375,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -6874,9 +6448,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.0.0.tgz",
       "integrity": "sha512-5/odaoPCoYMziO4pApzvkRa6uuVrTRTnJ2QUkTgh4YYcYyQqhAXsZ5psqToE3xM66shiSYa0xPZUFZer5heaTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "comlink": "^4.4.2"
       }
@@ -7161,14 +6734,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -7455,7 +7020,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7465,7 +7029,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7481,44 +7044,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.14.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-use-measure": {
@@ -7579,28 +7104,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7651,7 +7154,6 @@
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -7705,12 +7207,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7828,7 +7324,6 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -7952,14 +7447,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -8108,20 +7595,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/suspend-react": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
@@ -8204,8 +7677,7 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8485,7 +7957,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8547,7 +8018,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
@@ -8615,17 +8087,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/unplugin": {
@@ -8760,7 +8221,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8865,7 +8325,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -9116,14 +8575,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -9304,14 +8755,13 @@
         "@monaco-editor/react": "4.7.0",
         "@react-three/drei": "10.7.7",
         "@react-three/fiber": "9.6.1",
-        "brepjs": "^15.0.0",
+        "brepjs": "*",
         "brepjs-opencascade": "*",
         "lz-string": "1.5.0",
         "monaco-editor": "0.55.1",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-resizable-panels": "4.11.0",
-        "react-router-dom": "7.14.2",
         "shiki": "4.0.2",
         "three": "0.184.0",
         "zustand": "5.0.12"
@@ -9327,29 +8777,6 @@
         "tailwindcss": "4.2.4",
         "tsx": "4.21.0",
         "typescript": "6.0.3"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     }
   }

--- a/site/package.json
+++ b/site/package.json
@@ -15,7 +15,7 @@
     "@monaco-editor/react": "4.7.0",
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.6.1",
-    "brepjs": "^15.0.0",
+    "brepjs": "*",
     "brepjs-opencascade": "*",
     "lz-string": "1.5.0",
     "monaco-editor": "0.55.1",

--- a/site/src/components/playground/EditorPanel.tsx
+++ b/site/src/components/playground/EditorPanel.tsx
@@ -1,4 +1,4 @@
-import Editor, { type OnMount } from '@monaco-editor/react';
+import Editor, { type BeforeMount, type OnMount } from '@monaco-editor/react';
 import { useCallback, useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 import { setupMonaco } from '../../lib/monacoSetup';
@@ -18,12 +18,16 @@ export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps
   // Track last code from user typing to distinguish from external updates
   const lastUserCodeRef = useRef(code);
 
+  // beforeMount fires before the Editor instance is created, so the theme is
+  // registered ahead of first paint and we no longer flash from `vs-dark`.
+  const handleBeforeMount: BeforeMount = useCallback((monaco) => {
+    setupMonaco(monaco);
+  }, []);
+
   const handleMount: OnMount = useCallback(
     (editor, monaco) => {
       editorRef.current = editor;
       monacoRef.current = monaco;
-      setupMonaco(monaco);
-      monaco.editor.setTheme('brepjs-dark');
 
       // Register format function for external access
       if (onFormat) {
@@ -45,13 +49,25 @@ export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps
     [setCode, onCodeChange]
   );
 
-  // Sync external code changes (example picker, URL state) to editor
+  // Sync external code changes (example picker, URL state) to editor.
+  // We replace the model contents through pushEditOperations so the user's
+  // undo stack survives loading an example.
   useEffect(() => {
-    if (!editorRef.current) return;
-    if (code !== lastUserCodeRef.current) {
-      lastUserCodeRef.current = code;
-      editorRef.current.setValue(code);
+    const editor = editorRef.current;
+    if (!editor) return;
+    if (code === lastUserCodeRef.current) return;
+
+    lastUserCodeRef.current = code;
+    const model = editor.getModel();
+    if (!model) {
+      editor.setValue(code);
+      return;
     }
+    model.pushEditOperations(
+      [],
+      [{ range: model.getFullModelRange(), text: code }],
+      () => null
+    );
   }, [code]);
 
   // Update error markers
@@ -65,14 +81,18 @@ export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps
       if (!model) return;
 
       if (error && errorLine) {
+        // Clamp to the current line count — a stale error line from a previous
+        // run can exceed the buffer after the user shortens the file.
+        const lineCount = model.getLineCount();
+        const line = Math.min(Math.max(errorLine, 1), lineCount);
         monaco.editor.setModelMarkers(model, 'brepjs', [
           {
             severity: monaco.MarkerSeverity.Error,
             message: error,
-            startLineNumber: errorLine,
+            startLineNumber: line,
             startColumn: 1,
-            endLineNumber: errorLine,
-            endColumn: model.getLineMaxColumn(errorLine),
+            endLineNumber: line,
+            endColumn: model.getLineMaxColumn(line),
           },
         ]);
       } else {
@@ -91,6 +111,7 @@ export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps
       defaultValue={code}
       keepCurrentModel
       onChange={handleChange}
+      beforeMount={handleBeforeMount}
       onMount={handleMount}
       theme="brepjs-dark"
       options={{

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo, useEffect, useRef } from 'react';
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from 'react-resizable-panels';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
+import { useEngineStore } from '../../stores/engineStore';
 import { useToastStore } from '../../stores/toastStore';
 import { useCodeExecution } from '../../hooks/useCodeExecution';
 import { useUrlState } from '../../hooks/useUrlState';
@@ -31,10 +32,14 @@ export default function PlaygroundPage() {
   const setViewerCollapsed = usePlaygroundStore((s) => s.setViewerCollapsed);
   const isRunning = usePlaygroundStore((s) => s.isRunning);
   const error = usePlaygroundStore((s) => s.error);
+  const engineStatus = useEngineStore((s) => s.status);
   const addToast = useToastStore((s) => s.addToast);
   const { runCode, exportSTL, exportSTEP, debouncedRun } = useCodeExecution();
   const { updateUrl, copyShareUrl } = useUrlState();
   const heroMesh = useHeroMesh();
+  // Latches once the engine is ready so we don't re-seed the hero mesh after
+  // a failed run clears the viewer.
+  const heroSeededRef = useRef(false);
 
   const consolePanelRef = usePanelRef();
   const viewerPanelRef = usePanelRef();
@@ -51,12 +56,20 @@ export default function PlaygroundPage() {
     startWASMPreload();
   }, []);
 
-  // Seed viewer with pre-computed mesh while WASM engine loads
+  // Seed viewer with pre-computed mesh while WASM engine loads. Once the
+  // engine becomes ready we stop seeding — otherwise an error path that
+  // clears the viewer would silently re-render the staircase under the
+  // user's failing code.
   useEffect(() => {
+    if (engineStatus === 'ready') {
+      heroSeededRef.current = true;
+      return;
+    }
+    if (heroSeededRef.current) return;
     if (heroMesh && meshes.length === 0) {
       setMeshes([heroMesh]);
     }
-  }, [heroMesh, meshes.length, setMeshes]);
+  }, [heroMesh, meshes.length, setMeshes, engineStatus]);
 
   const handleCodeChange = useCallback(
     (newCode: string) => {

--- a/site/src/components/playground/Toolbar.tsx
+++ b/site/src/components/playground/Toolbar.tsx
@@ -32,9 +32,14 @@ export default function Toolbar({
         setShowExamples(false);
       }
     };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowExamples(false);
+    };
     document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
     return () => {
       document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
     };
   }, [showExamples]);
 
@@ -53,6 +58,8 @@ export default function Toolbar({
             onClick={() => {
               setShowExamples((v) => !v);
             }}
+            aria-haspopup="menu"
+            aria-expanded={showExamples}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
           >
             Examples
@@ -96,7 +103,7 @@ export default function Toolbar({
         </button>
         <button
           onClick={onExportSTL}
-          disabled={!engineReady}
+          disabled={!engineReady || isRunning}
           title={`Export STL (${formatShortcut(SHORTCUTS.exportSTL)})`}
           className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
         >
@@ -104,7 +111,7 @@ export default function Toolbar({
         </button>
         <button
           onClick={onExportSTEP}
-          disabled={!engineReady}
+          disabled={!engineReady || isRunning}
           title={`Export STEP (${formatShortcut(SHORTCUTS.exportSTEP)})`}
           className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
         >

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -120,14 +120,30 @@ function AutoFit({ meshes }: { meshes: MeshData[] }) {
   return null;
 }
 
-/** Keeps the render loop alive while OrbitControls damping is settling. */
+/**
+ * Keeps the render loop alive while OrbitControls damping is still settling
+ * AFTER user interaction. We invalidate only when the camera moved since the
+ * previous frame — checking `enableDamping` alone (always true) caused an
+ * unbounded render loop in `frameloop="demand"` mode and pegged the GPU.
+ */
 function Invalidator() {
-  const { controls } = useThree();
+  const { controls, camera } = useThree();
+  const lastPos = useRef(new THREE.Vector3());
+  const lastTarget = useRef(new THREE.Vector3());
 
   useFrame(({ invalidate }) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- drei OrbitControls
     const ctrl = controls as any;
-    if (ctrl?.enableDamping) {
+    if (!ctrl?.enableDamping) return;
+
+    const target = ctrl.target as THREE.Vector3 | undefined;
+    const moved =
+      !camera.position.equals(lastPos.current) ||
+      (target ? !target.equals(lastTarget.current) : false);
+
+    if (moved) {
+      lastPos.current.copy(camera.position);
+      if (target) lastTarget.current.copy(target);
       invalidate();
     }
   });
@@ -135,18 +151,22 @@ function Invalidator() {
   return null;
 }
 
-/** Wires up the camera preset hook to store + controls. */
+/**
+ * Wires up the camera preset hook to the live OrbitControls instance.
+ * The synthetic ref is memoized so `useCameraPresets`'s effect doesn't
+ * re-fire on every render (which would restart any in-flight preset
+ * animation when meshes update).
+ */
 function CameraPresetBridge({ meshes }: { meshes: MeshData[] }) {
-  const { invalidate } = useThree();
+  const { invalidate, controls } = useThree();
   const bounds = useBoundsComputation(meshes);
-  const { controls } = useThree();
-
-  useCameraPresets(
+  const controlsRef = useMemo(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- drei OrbitControls
-    { current: controls } as React.RefObject<any>,
-    invalidate,
-    bounds
+    () => ({ current: controls }) as React.RefObject<any>,
+    [controls]
   );
+
+  useCameraPresets(controlsRef, invalidate, bounds);
 
   return null;
 }

--- a/site/src/hooks/useCameraPresets.ts
+++ b/site/src/hooks/useCameraPresets.ts
@@ -51,6 +51,12 @@ export function useCameraPresets(
     const startTarget = target.clone();
     const startTime = performance.now();
 
+    // Suspend damping for the duration: damping interpolates camera.position
+    // toward an internal `_lastPosition`, which fights our explicit lerp and
+    // makes the camera "snap back" or oscillate at the end of the animation.
+    const dampingWasOn = controls.enableDamping;
+    controls.enableDamping = false;
+
     function animate() {
       const elapsed = performance.now() - startTime;
       const t = Math.min(elapsed / TRANSITION_MS, 1);
@@ -64,6 +70,8 @@ export function useCameraPresets(
 
       if (t < 1) {
         animFrameRef.current = requestAnimationFrame(animate);
+      } else {
+        controls.enableDamping = dampingWasOn;
       }
     }
 
@@ -73,6 +81,7 @@ export function useCameraPresets(
 
     return () => {
       cancelAnimationFrame(animFrameRef.current);
+      controls.enableDamping = dampingWasOn;
     };
   }, [activePreset, bounds, controlsRef, invalidate]);
 }

--- a/site/src/hooks/useCodeExecution.ts
+++ b/site/src/hooks/useCodeExecution.ts
@@ -12,78 +12,106 @@ export function useCodeExecution() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestIdRef = useRef<string>('');
   const isRecoveringRef = useRef(false);
+  // Snapshot the code submitted under each eval id so eval-result records
+  // what actually ran, not whatever the user has typed since.
+  const codeByIdRef = useRef<Map<string, string>>(new Map());
 
   // Ref so onMessage can post directly without depending on React state
   const postMessageRef = useRef<(msg: ToWorker) => void>(() => {});
   const restartRef = useRef<(() => Promise<void>) | null>(null);
 
-  const onMessage = useCallback((msg: FromWorker) => {
+  const submitEval = useCallback((code: string) => {
+    const id = `eval-${++evalCounter}`;
+    latestIdRef.current = id;
+    codeByIdRef.current.set(id, code);
     const store = usePlaygroundStore.getState();
-    const engineStore = useEngineStore.getState();
-    switch (msg.type) {
-      case 'init-done': {
-        // Auto-run current code the moment engine is ready —
-        // reads directly from store, posts directly to worker,
-        // no dependency on React render cycle.
-        // Skip auto-run for shared links (pendingReview) — user must review first.
-        if (store.code.trim() && !store.pendingReview) {
-          const id = `eval-${++evalCounter}`;
-          latestIdRef.current = id;
-          store.setIsRunning(true);
-          postMessageRef.current({ type: 'eval', id, code: store.code });
-        }
-        break;
-      }
-      case 'eval-result':
-        if (msg.id !== latestIdRef.current) return;
-        store.setMeshes(msg.meshes);
-        store.setConsoleOutput(msg.console);
-        store.setTimeMs(msg.timeMs);
-        store.setIsRunning(false);
-        // Track last successful code execution
-        store.setLastSuccessfulCode(store.code);
-        // Reset recovery attempts on successful execution
-        engineStore.resetRecoveryAttempts();
-        // Show recovery success message if we just recovered
-        if (isRecoveringRef.current) {
-          isRecoveringRef.current = false;
-          useToastStore.getState().addToast('Worker restarted successfully.');
-        }
-        break;
-      case 'eval-error':
-        if (msg.id !== latestIdRef.current) return;
-        store.setError(msg.error, msg.line);
-        store.setIsRunning(false);
-        break;
-      case 'eval-cancelled':
-        if (msg.id !== latestIdRef.current) return;
-        store.setIsRunning(false);
-        break;
-      case 'export-result': {
-        const stlBlob = new Blob([msg.stl], { type: 'model/stl' });
-        const stlUrl = URL.createObjectURL(stlBlob);
-        const stlLink = document.createElement('a');
-        stlLink.href = stlUrl;
-        stlLink.download = 'model.stl';
-        stlLink.click();
-        URL.revokeObjectURL(stlUrl);
-        break;
-      }
-      case 'export-step-result': {
-        const stepBlob = new Blob([msg.step], { type: 'application/step' });
-        const stepUrl = URL.createObjectURL(stepBlob);
-        const stepLink = document.createElement('a');
-        stepLink.href = stepUrl;
-        stepLink.download = 'model.step';
-        stepLink.click();
-        URL.revokeObjectURL(stepUrl);
-        break;
-      }
-      case 'export-error':
-        store.setError(msg.error);
-        break;
-    }
+    store.setIsRunning(true);
+    store.setError(null);
+    // Clear meshes the moment a new run starts so a failed eval can't render
+    // stale geometry under the error banner (and the seeded hero mesh is
+    // dropped on the user's first real run).
+    store.setMeshes([]);
+    postMessageRef.current({ type: 'eval', id, code });
+    return id;
   }, []);
+
+  const onMessage = useCallback(
+    (msg: FromWorker) => {
+      const store = usePlaygroundStore.getState();
+      const engineStore = useEngineStore.getState();
+      switch (msg.type) {
+        case 'init-done': {
+          // Auto-run current code the moment engine is ready.
+          // Skip auto-run for shared links (pendingReview) — user must review first.
+          if (store.code.trim() && !store.pendingReview) {
+            submitEval(store.code);
+          }
+          break;
+        }
+        case 'eval-result': {
+          if (msg.id !== latestIdRef.current) {
+            codeByIdRef.current.delete(msg.id);
+            return;
+          }
+          const ranCode = codeByIdRef.current.get(msg.id) ?? store.code;
+          codeByIdRef.current.delete(msg.id);
+          store.setMeshes(msg.meshes);
+          store.setConsoleOutput(msg.console);
+          store.setTimeMs(msg.timeMs);
+          store.setIsRunning(false);
+          store.setLastSuccessfulCode(ranCode);
+          engineStore.resetRecoveryAttempts();
+          if (isRecoveringRef.current) {
+            isRecoveringRef.current = false;
+            useToastStore.getState().addToast('Worker restarted successfully.');
+          }
+          break;
+        }
+        case 'eval-error':
+          if (msg.id !== latestIdRef.current) {
+            codeByIdRef.current.delete(msg.id);
+            return;
+          }
+          codeByIdRef.current.delete(msg.id);
+          store.setError(msg.error, msg.line);
+          store.setIsRunning(false);
+          // Drop the recovery flag so the next successful run doesn't show a
+          // stale "Worker restarted successfully" toast minutes later.
+          isRecoveringRef.current = false;
+          break;
+        case 'eval-cancelled':
+          codeByIdRef.current.delete(msg.id);
+          if (msg.id !== latestIdRef.current) return;
+          store.setIsRunning(false);
+          isRecoveringRef.current = false;
+          break;
+        case 'export-result': {
+          const stlBlob = new Blob([msg.stl], { type: 'model/stl' });
+          const stlUrl = URL.createObjectURL(stlBlob);
+          const stlLink = document.createElement('a');
+          stlLink.href = stlUrl;
+          stlLink.download = 'model.stl';
+          stlLink.click();
+          URL.revokeObjectURL(stlUrl);
+          break;
+        }
+        case 'export-step-result': {
+          const stepBlob = new Blob([msg.step], { type: 'application/step' });
+          const stepUrl = URL.createObjectURL(stepBlob);
+          const stepLink = document.createElement('a');
+          stepLink.href = stepUrl;
+          stepLink.download = 'model.step';
+          stepLink.click();
+          URL.revokeObjectURL(stepUrl);
+          break;
+        }
+        case 'export-error':
+          store.setError(msg.error);
+          break;
+      }
+    },
+    [submitEval]
+  );
 
   const recoverFromCrash = useCallback(async () => {
     const playgroundStore = usePlaygroundStore.getState();
@@ -115,14 +143,10 @@ export function useCodeExecution() {
     toastStore.addToast('Worker crashed. Restarting and restoring last successful code...');
     if (restartRef.current) {
       await restartRef.current();
-      // After restart, restore code and re-execute
       playgroundStore.setCode(lastSuccessfulCode);
-      const id = `eval-${++evalCounter}`;
-      latestIdRef.current = id;
-      playgroundStore.setIsRunning(true);
-      postMessageRef.current({ type: 'eval', id, code: lastSuccessfulCode });
+      submitEval(lastSuccessfulCode);
     }
-  }, []);
+  }, [submitEval]);
 
   const { postMessage, restart } = useWorker(onMessage, recoverFromCrash);
 
@@ -140,13 +164,9 @@ export function useCodeExecution() {
         postMessage({ type: 'cancel', id: latestIdRef.current });
       }
 
-      const id = `eval-${++evalCounter}`;
-      latestIdRef.current = id;
-      store.setIsRunning(true);
-      store.setError(null);
-      postMessage({ type: 'eval', id, code });
+      submitEval(code);
     },
-    [engineStatus, postMessage]
+    [engineStatus, postMessage, submitEval]
   );
 
   const exportSTL = useCallback(

--- a/site/src/hooks/useKeyboardShortcuts.ts
+++ b/site/src/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,16 @@ import type { ShortcutDef } from '../lib/shortcuts';
 
 type ShortcutActions = Record<string, () => void>;
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+  // Monaco renders a textarea inside `.monaco-editor`, but the focused element
+  // can be an inner div with role="textbox" — cover both.
+  return target.closest('.monaco-editor') !== null;
+}
+
 export function useKeyboardShortcuts(actions: ShortcutActions, shortcuts: ShortcutDef[]) {
   const actionsRef = useRef(actions);
   actionsRef.current = actions;
@@ -13,12 +23,16 @@ export function useKeyboardShortcuts(actions: ShortcutActions, shortcuts: Shortc
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const ctrl = e.ctrlKey || e.metaKey;
+      const inEditable = isEditableTarget(e.target);
       for (const def of shortcutsRef.current) {
         if (
           ctrl === def.ctrl &&
           e.shiftKey === def.shift &&
           e.key.toLowerCase() === def.key.toLowerCase()
         ) {
+          // Skip layout toggles (Ctrl+B / Ctrl+\\) when the user is typing —
+          // those overlap with Monaco's own keybindings.
+          if (inEditable && def.inEditor === false) return;
           e.preventDefault();
           const action = actionsRef.current[def.id] as (() => void) | undefined;
           if (action) action();
@@ -26,9 +40,11 @@ export function useKeyboardShortcuts(actions: ShortcutActions, shortcuts: Shortc
         }
       }
     };
-    document.addEventListener('keydown', handler, { capture: true });
+    // Bubble phase, not capture: lets Monaco handle text-editing keys first
+    // (e.g. Backspace, arrow keys) without our handler ever seeing them.
+    document.addEventListener('keydown', handler);
     return () => {
-      document.removeEventListener('keydown', handler, { capture: true });
+      document.removeEventListener('keydown', handler);
     };
   }, []);
 }

--- a/site/src/hooks/useUrlState.ts
+++ b/site/src/hooks/useUrlState.ts
@@ -1,7 +1,17 @@
 import { useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../stores/playgroundStore';
+import { useToastStore } from '../stores/toastStore';
 import { decodeShare, encodeCodeQuery } from '../lib/urlCodec';
 import { findExample } from '../lib/examples';
+
+function hasShareParams(url: URL): boolean {
+  return (
+    url.searchParams.has('code') ||
+    url.searchParams.has('example') ||
+    url.hash.startsWith('#code/') ||
+    url.hash.startsWith('#example/')
+  );
+}
 
 export function useUrlState() {
   const setCode = usePlaygroundStore((s) => s.setCode);
@@ -13,15 +23,28 @@ export function useUrlState() {
     initialized.current = true;
 
     const url = new URL(window.location.href);
+    const addToast = useToastStore.getState().addToast;
     const result = decodeShare(url);
-    if (!result) return;
+    if (!result) {
+      // The URL had a share param but it failed to decode — tell the user
+      // instead of silently dropping it. Default-loaded sessions (no params)
+      // pass through without a toast.
+      if (hasShareParams(url)) {
+        addToast("Couldn't read the shared link — loaded the default code instead.");
+      }
+      return;
+    }
 
     if (result.type === 'code') {
       setCode(result.code);
       setPendingReview(true); // shared links require review before run
     } else {
       const ex = findExample(result.id);
-      if (ex) setCode(ex.code);
+      if (ex) {
+        setCode(ex.code);
+      } else {
+        addToast(`Example "${result.id}" not found — loaded the default code instead.`);
+      }
     }
 
     // Migrate legacy hash URLs to the new query format so further updates

--- a/site/src/lib/shortcuts.ts
+++ b/site/src/lib/shortcuts.ts
@@ -4,6 +4,14 @@ export interface ShortcutDef {
   ctrl: boolean;
   shift: boolean;
   label: string;
+  /**
+   * Whether the shortcut should fire while the user is typing in an editable
+   * surface (Monaco editor, input, contenteditable). Defaults to true for
+   * action shortcuts that the user expects to invoke from anywhere; layout
+   * toggles set this false so they don't fight Monaco's own bindings
+   * (e.g. Ctrl+B, Ctrl+\\).
+   */
+  inEditor?: boolean;
 }
 
 export const SHORTCUTS: Record<string, ShortcutDef> = {
@@ -12,8 +20,22 @@ export const SHORTCUTS: Record<string, ShortcutDef> = {
   exportSTL: { id: 'exportSTL', key: 'e', ctrl: true, shift: false, label: 'Export STL' },
   exportSTEP: { id: 'exportSTEP', key: 'e', ctrl: true, shift: true, label: 'Export STEP' },
   formatCode: { id: 'formatCode', key: 'f', ctrl: true, shift: true, label: 'Format Code' },
-  toggleOutput: { id: 'toggleOutput', key: 'b', ctrl: true, shift: false, label: 'Toggle Console' },
-  toggleViewer: { id: 'toggleViewer', key: '\\', ctrl: true, shift: false, label: 'Toggle Viewer' },
+  toggleOutput: {
+    id: 'toggleOutput',
+    key: 'b',
+    ctrl: true,
+    shift: false,
+    label: 'Toggle Console',
+    inEditor: false,
+  },
+  toggleViewer: {
+    id: 'toggleViewer',
+    key: '\\',
+    ctrl: true,
+    shift: false,
+    label: 'Toggle Viewer',
+    inEditor: false,
+  },
 };
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);

--- a/site/src/stores/toastStore.ts
+++ b/site/src/stores/toastStore.ts
@@ -12,15 +12,26 @@ interface ToastState {
 }
 
 let toastCounter = 0;
+const MAX_TOASTS = 4;
+const TOAST_TTL_MS = 3500;
 
 export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
   addToast: (message) => {
     const id = `toast-${++toastCounter}`;
-    set((s) => ({ toasts: [...s.toasts, { id, message }] }));
+    set((s) => {
+      // Collapse repeated identical messages — spamming Share shouldn't pile
+      // up vertical "Link copied" toasts. Re-issuing the most recent toast
+      // also resets its TTL implicitly via the new setTimeout below.
+      let next = s.toasts.filter((t) => t.message !== message);
+      if (next.length >= MAX_TOASTS) {
+        next = next.slice(-(MAX_TOASTS - 1));
+      }
+      return { toasts: [...next, { id, message }] };
+    });
     setTimeout(() => {
       set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
-    }, 3500);
+    }, TOAST_TTL_MS);
   },
   removeToast: (id) => {
     set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));

--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -101,6 +101,13 @@ async function loadWasmBuild() {
 }
 
 async function handleInit() {
+  // React StrictMode and crash-recovery paths can dispatch `init` twice; the
+  // OCCT module rejects re-initialization, so short-circuit when we already
+  // have a live kernel.
+  if (brepjs) {
+    post({ type: 'init-done' });
+    return;
+  }
   try {
     post({ type: 'init-progress', stage: 'Downloading kernel...', progress: 0.1 });
 
@@ -159,12 +166,15 @@ function handleEval(id: string, code: string) {
       },
       transferables
     );
+    activeEvalId = null;
     return;
   }
 
   const consoleOutput: string[] = [];
 
-  // Capture console.log
+  // Capture console.log/warn for the duration of user code so output appears in
+  // the playground console panel. Restoration happens in `finally` so cancel
+  // paths and unexpected throws don't leak the patched console.
   const origLog = console.log;
   const origWarn = console.warn;
   console.log = (...args: unknown[]) => {
@@ -183,14 +193,9 @@ function handleEval(id: string, code: string) {
     const fn = new Function(code); // codeql[js/code-injection] Playground evaluates user-authored scripts in sandboxed Web Worker
     let result = fn();
 
-    // Restore console
-    console.log = origLog;
-    console.warn = origWarn;
-
     // Check if cancelled before proceeding with expensive meshing
     if (cancelRequested && activeEvalId === id) {
       post({ type: 'eval-cancelled', id });
-      activeEvalId = null;
       return;
     }
 
@@ -202,7 +207,6 @@ function handleEval(id: string, code: string) {
         console: consoleOutput,
         timeMs: performance.now() - t0,
       });
-      activeEvalId = null;
       return;
     }
 
@@ -221,7 +225,6 @@ function handleEval(id: string, code: string) {
       // Check for cancellation before each shape (expensive operation)
       if (cancelRequested && activeEvalId === id) {
         post({ type: 'eval-cancelled', id });
-        activeEvalId = null;
         return;
       }
 
@@ -255,8 +258,9 @@ function handleEval(id: string, code: string) {
           mesh.edges.buffer
         );
       } catch (meshErr) {
+        // `[error]` prefix matches the red styling in OutputPanel.
         consoleOutput.push(
-          `[mesh error] ${meshErr instanceof Error ? meshErr.message : String(meshErr)}`
+          `[error] ${meshErr instanceof Error ? meshErr.message : String(meshErr)}`
         );
       }
     }
@@ -266,7 +270,6 @@ function handleEval(id: string, code: string) {
     // Final cancellation check before sending result
     if (cancelRequested && activeEvalId === id) {
       post({ type: 'eval-cancelled', id });
-      activeEvalId = null;
       return;
     }
 
@@ -283,11 +286,7 @@ function handleEval(id: string, code: string) {
     });
 
     post({ type: 'eval-result', id, meshes, console: consoleOutput, timeMs }, transferables);
-    activeEvalId = null;
   } catch (e) {
-    console.log = origLog;
-    console.warn = origWarn;
-
     const errorMsg = e instanceof Error ? e.message : String(e);
     // Try to extract line number from stack trace
     let line: number | undefined;
@@ -300,8 +299,13 @@ function handleEval(id: string, code: string) {
     }
 
     post({ type: 'eval-error', id, error: errorMsg, line });
-    activeEvalId = null;
   } finally {
+    // Always restore console and clear active id, regardless of which return
+    // path we took (cancelled / errored / cached / completed).
+    console.log = origLog;
+    console.warn = origWarn;
+    activeEvalId = null;
+
     // Clean up user-added globalThis keys
     const globalAny = globalThis as Record<string, unknown>;
     for (const key of Object.keys(globalAny)) {


### PR DESCRIPTION
Stacked on top of #827 (the docs-site-as-root swap). Once #827 merges this PR's base will auto-rebase to main.

## Summary

A static review across the playground surfaced ~20 high-confidence UX bugs. This PR fixes the ones with visible impact, grouped by area:

### Worker (`cad.worker.ts`)
- **Console restoration moved into `finally`** — the cancel paths returned without restoring `console.log/warn`, leaking the patched console for the worker's lifetime. Any later kernel warning got swallowed.
- **Cache-hit path resets `activeEvalId`** — a stray `cancel` for that id was poisoning the next eval's `cancelRequested` flag.
- **`handleInit` guards against re-entry** — React StrictMode and crash recovery were dispatching `init` twice; OCCT rejects re-init.
- **`[error]` prefix on mesh errors** — matches the red styling already in `OutputPanel` (the `[mesh error]` prefix never matched, so dead branch).

### Run lifecycle (`useCodeExecution.ts` + `PlaygroundPage.tsx`)
- **Code is snapshotted per eval id** — `lastSuccessfulCode` now records what actually ran, not whatever the user typed since.
- **Meshes cleared on every new run** — a failed eval no longer renders stale geometry under the error banner.
- **Hero-mesh seed latches once** — without this the new "clear meshes on submit" path would re-seed the staircase under the user's failing code on every error.
- **`isRecoveringRef` cleared on error/cancel** — prevents a misplaced "Worker restarted successfully" toast minutes later on the next successful run.

### Editor (`EditorPanel.tsx`)
- **Theme registered in `beforeMount`** — prior code registered it inside `onMount`, after Editor instantiated; first paint flashed `vs-dark`.
- **`setValue` → `pushEditOperations`** — loading an example/share link no longer wipes the user's undo stack.
- **`errorLine` clamped to model line count** — stale errors after deleting lines no longer throw on `getLineMaxColumn`.

### Keyboard shortcuts (`useKeyboardShortcuts.ts` + `lib/shortcuts.ts`)
- **Bubble phase, not capture** — Monaco handles text-editing keys first.
- **`inEditor: false` on layout toggles** (Ctrl+B, Ctrl+\\) so they don't fight Monaco's own bindings while typing. Run/Format/Share/Export still fire from inside the editor.

### Viewer (`ViewerPanel.tsx` + `useCameraPresets.ts`)
- **Infinite render loop fixed.** `Invalidator` was calling `invalidate()` every frame because it checked the `enableDamping` config flag (always true), not actual damping state. With `frameloop="demand"` this self-perpetuated, pegging the GPU. Now invalidates only when the camera moved between frames.
- **Camera preset bridge ref memoized** — synthetic `{ current: controls }` was rebuilt every render and re-fired `useCameraPresets`'s effect, cancelling in-flight preset animations on every meshes update.
- **Damping suspended during preset transitions** — damping was fighting `lerpVectors` and made the camera oscillate / snap back at the end of the transition.

### Toolbar / toast / share UX
- Export STL/STEP buttons disabled while a run is in flight (concurrent eval was racing `lastEvalResult`).
- Examples menu: `aria-haspopup`, `aria-expanded`, Esc-to-close.
- Toasts collapse repeated identical messages and cap at 4. Spamming Share no longer piles up "Link copied" toasts.
- URL decode failures and missing example IDs now toast instead of silently loading the default code.

### Version drift (`site/package.json`)
- **Bump `brepjs` from `^15.0.0` to `^17.0.0`.** With the 15.x range, npm fetched `15.7.1` from the registry while the shipped WASM at `/playground/wasm/*` came from the workspace at v17. The v17 OCCT facade (#817, #823) has different signatures from v15's bindings, so the playground was running mismatched JS-against-WASM. After the bump, npm workspaces resolve `brepjs` to the local v17 package and JS + WASM are in sync.

## Test plan

- [x] `npm run typecheck --workspace=site` (clean)
- [x] `npm run build --workspace=site` (clean; bundle grew ~7KB on v17 bump)
- [x] `npm run lint` (root passes)
- [ ] Vercel preview: manual smoke test
  - [ ] Cold load: hero mesh seeds, then auto-run replaces it; no `vs-dark` theme flash
  - [ ] Edit code → wait → debounced auto-run produces fresh shape (no stale meshes lingering on syntax errors)
  - [ ] Cmd-Z after picking an example restores prior typed code
  - [ ] Type Ctrl+B inside the editor → Monaco does its thing; outside the editor → console toggles
  - [ ] Click Front/Side/Top preset → camera animates smoothly, doesn't oscillate at end
  - [ ] Sit idle → CPU/GPU drops to ~0% (no infinite render loop)
  - [ ] Spam Share button → only one "Link copied" toast at a time
  - [ ] Visit `/playground?example=does-not-exist` → toast says example not found
  - [ ] Visit a stale `/playground/#code/xyz` legacy share URL → loads code, URL silently rewritten to `?code=`

## Notes

This is a deliberately bundled PR (one swap-pass commit) per the agreed plan in the kickoff conversation. Each change is independently revertable by file in git.

Items deferred from the review for follow-up PRs: WCAG contrast tweaks on the console panel, ToastContainer close-button affordance, useTouchDevice rebuild causing momentary OrbitControls prop loss, ShapeRenderer keyed by index (low impact when `meshes` array reference always changes), grid z-fighting on bottom faces.