### PR TITLE
chore: exclude site/ and docs-site/ from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "exclude-paths": ["site", "docs-site"]
     },
     "packages/brepjs-opencascade": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Add `exclude-paths: [\"site\", \"docs-site\"]` to the root release-please package config so commits whose entire file set is under those directories don't trigger a brepjs library version bump.

## Why

PR #827 (`feat(site)!: serve docs-site at root, playground at /playground`) auto-cut **brepjs v18.0.0** even though no library code under `src/` or `packages/` changed — release-please treats every `!` commit anywhere in the repo as a major bump for the root package. Going forward, `site/` and `docs-site/` reorganizations should be invisible to the release-please version-bump parser.

This is a backstop. The preferred convention is still to drop `!` from site/docs commit subjects entirely (the breaking semantic for users belongs in the PR description, not the version tag).

## Test plan

- [x] release-please schema confirms `exclude-paths` is a valid per-package option ("Path of commits to be excluded from parsing. If all files from commit belong to one of the paths it will be skipped").
- [ ] After merge, the next site-only PR should not trigger a release-please PR. (Will manifest as the absence of an automated `chore(main): release brepjs ...` PR.)

## Related

- v18 was already cut and is left in place — no library code changed, so the bump is harmless.
- See feedback memory: don't use `!` on site/docs-only commits.