### PR TITLE
fix(site): unbreak production playground CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

Production playground at https://www.brepjs.dev/playground is **broken** as of #827 — the LoadingOverlay sticks forever and the kernel never initializes. Root cause: the CSP set in #827 was missing two allowances the playground actually needs.

### Two CSP gaps

1. **`script-src` lacks `'wasm-unsafe-eval'`.** Chromium refuses to compile/instantiate the OCCT WASM module:

   ```
   wasm streaming compile failed: CompileError: WebAssembly.instantiate(): Compiling or
   instantiating WebAssembly module violates ... script-src 'self' blob: https://cdn.jsdelivr.net
   ```

   With WASM blocked, `init-done` never fires and the playground hangs on the loading overlay.

2. **`style-src` lacks `https://cdn.jsdelivr.net`.** Monaco loads `editor.main.css` from jsDelivr; without the allowance the editor renders unstyled. Same origin added to `font-src` for Monaco's icon fonts.

## Verification

Reproduced via Puppeteer smoke against production:

```
[console.error] wasm streaming compile failed: CompileError: WebAssembly.instantiateStreaming(): Compiling or instantiating WebAssembly module violates the following Content Security policy directive because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' blob: https://cdn.jsdelivr.net".
[console.error] Loading the stylesheet 'https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs/editor/editor.main.css' violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline'".
```

`'wasm-unsafe-eval'` is the modern, narrow allowance for WebAssembly compilation (more granular than `'unsafe-eval'`, supported in Chrome 102+ / Safari 15.4+ / Firefox 102+).

## Test plan

- [x] `npm run build --workspace=site` (no code change, sanity)
- [ ] After Vercel preview deploys, re-run Puppeteer smoke against the preview URL — engine should reach `ready` and at least one example screenshot should save.