### PR TITLE
fix(site): allow new Function() in playground CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

Production playground still hangs after #832: the cad worker uses `new Function(code)` to evaluate user playground code, and CSP blocks it:

> Evaluating a string as JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is not an allowed source of script: script-src 'self' blob: 'wasm-unsafe-eval' ...

`'wasm-unsafe-eval'` covers WebAssembly only; string-to-JS evaluation needs the broader `'unsafe-eval'`.

## Why this is acceptable

The playground's whole purpose IS to evaluate user-authored JavaScript. The eval runs inside a sandboxed Web Worker with no DOM, cookies, or storage — the threat model already documented by the codeql comment in `cad.worker.ts`:

```ts
// Intentional: playground evaluates user-authored scripts in a sandboxed Web Worker
// with no access to DOM, cookies, or storage.
const fn = new Function(code); // codeql[js/code-injection] ...
```

Same allowance is standard for code playgrounds (CodePen, JSBin, etc.).

## Verification

Caught by the same Puppeteer diagnostic that found the prior two CSP gaps. After merge + deploy, a re-smoke should produce screenshots from at least one example.