### PR TITLE
fix(ci): skip lifecycle scripts in smoke install

### DIFF
--- a/.github/workflows/playground-smoke.yml
+++ b/.github/workflows/playground-smoke.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install site dependencies
         working-directory: site
-        run: npm install --legacy-peer-deps --no-audit --no-fund
+        run: npm install --legacy-peer-deps --no-audit --no-fund --ignore-scripts
 
       - name: Run smoke against deployment
         working-directory: site


### PR DESCRIPTION
## Summary

The Playground Smoke workflow added in #836 fails on its first run with:

```
> husky && bash scripts/ensure-wasm.sh
sh: 1: husky: not found
npm error code 127
```

Root cause: `npm install` from `site/` climbs to the workspace root and runs the root `prepare` lifecycle, but husky's bin isn't on PATH yet at that moment. The smoke only needs `puppeteer + tsx`; neither depends on the husky setup or the WASM artifacts that `ensure-wasm` downloads (the smoke hits a deployed URL, not local code).

Adding `--ignore-scripts` skips the root prepare entirely.

## Test plan

- [ ] After merge, the production smoke triggered by #836's deploy succeeds
- [ ] This PR's own preview-deploy smoke also succeeds (proves the fix end-to-end)