### PR TITLE
fix(ci): install Chrome explicitly for smoke

### DIFF
--- a/.github/workflows/playground-smoke.yml
+++ b/.github/workflows/playground-smoke.yml
@@ -43,7 +43,15 @@ jobs:
 
       - name: Install site dependencies
         working-directory: site
+        # --ignore-scripts skips the root `prepare` (husky + ensure-wasm)
+        # which we don't need in a smoke runner. We then run puppeteer's
+        # browser install explicitly below since --ignore-scripts also
+        # suppressed it.
         run: npm install --legacy-peer-deps --no-audit --no-fund --ignore-scripts
+
+      - name: Install Chrome for Puppeteer
+        working-directory: site
+        run: npx puppeteer browsers install chrome
 
       - name: Run smoke against deployment
         working-directory: site


### PR DESCRIPTION
## Summary

#838 added `--ignore-scripts` to skip the root husky prepare hook, but that also suppressed puppeteer's postinstall which downloads Chrome:

```
Error: Could not find Chrome (ver. 147.0.7727.57). This can occur
if either you did not perform an installation before running the
script (e.g. `npx puppeteer browsers install chrome`) ...
```

Adding an explicit install step. Idempotent — the puppeteer cache hit (path `~/.cache/puppeteer`) makes subsequent runs no-ops.

## Test plan

- [ ] After merge, this PR's own preview-deploy smoke succeeds — proves the workflow end-to-end
- [ ] The triggered production deploy smoke also succeeds