### PR TITLE
fix(playground): polish toast a11y, console contrast, mesh keys

### DIFF
--- a/site/src/components/playground/OutputPanel.tsx
+++ b/site/src/components/playground/OutputPanel.tsx
@@ -11,7 +11,7 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-gray-800 px-3 py-1">
-        <span className="text-xs font-medium text-gray-400">Console</span>
+        <span className="text-xs font-medium text-gray-300">Console</span>
         <div className="flex items-center gap-1">
           <button
             onClick={() => {
@@ -19,10 +19,11 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
               store.setConsoleOutput([]);
               store.setError(null);
             }}
-            className="text-gray-500 transition-colors hover:text-gray-300"
+            className="text-gray-400 transition-colors hover:text-gray-100"
             title="Clear console"
+            aria-label="Clear console"
           >
-            <svg viewBox="0 0 16 16" className="h-3 w-3">
+            <svg viewBox="0 0 16 16" className="h-3 w-3" aria-hidden="true">
               <path d="M2 2l12 12M14 2L2 14" stroke="currentColor" strokeWidth="1.5" fill="none" />
             </svg>
           </button>
@@ -31,10 +32,11 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
               const text = [...consoleOutput, ...(error ? [error] : [])].join('\n');
               void navigator.clipboard.writeText(text);
             }}
-            className="text-gray-500 transition-colors hover:text-gray-300"
+            className="text-gray-400 transition-colors hover:text-gray-100"
             title="Copy console output"
+            aria-label="Copy console output"
           >
-            <svg viewBox="0 0 16 16" className="h-3 w-3">
+            <svg viewBox="0 0 16 16" className="h-3 w-3" aria-hidden="true">
               <rect
                 x="5"
                 y="5"
@@ -50,10 +52,11 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
           </button>
           <button
             onClick={onCollapse}
-            className="text-gray-500 transition-colors hover:text-gray-300"
+            className="text-gray-400 transition-colors hover:text-gray-100"
             title="Collapse console"
+            aria-label="Collapse console"
           >
-            <svg viewBox="0 0 16 16" className="h-3 w-3">
+            <svg viewBox="0 0 16 16" className="h-3 w-3" aria-hidden="true">
               <path d="M4.5 5.5L8 9l3.5-3.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
             </svg>
           </button>
@@ -61,7 +64,7 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
       </div>
       <div className="scrollbar-thin flex-1 overflow-auto p-2 font-mono text-xs" aria-live="polite">
         {consoleOutput.length === 0 && !error ? (
-          <div className="flex h-full items-center justify-center text-gray-600">
+          <div className="flex h-full items-center justify-center text-gray-500">
             Console output appears here
           </div>
         ) : (
@@ -74,7 +77,7 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
                     ? 'text-red-400'
                     : line.startsWith('[warn]')
                       ? 'text-amber-400'
-                      : 'text-gray-400'
+                      : 'text-gray-300'
                 }
               >
                 {line}

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -11,6 +11,21 @@ import EdgeRenderer from './EdgeRenderer';
 import ViewerToolbar from './ViewerToolbar';
 
 /**
+ * Build a content-derived React key for a mesh. The store hands us a fresh
+ * typed-array reference per eval, but using the array index as the key would
+ * make React reuse the prior ShapeRenderer when the array length is the same
+ * — and useMemo would skip if the typed-array reference were ever recycled.
+ * Sampling length + first/middle/last position values is enough to make
+ * distinct geometries hash distinct without scanning the full buffer.
+ */
+function meshKey(m: MeshData, fallback: number): string {
+  const p = m.position;
+  if (!p || p.length === 0) return `empty-${fallback}`;
+  const mid = (p.length / 6 | 0) * 3;
+  return `${p.length}-${p[0]}-${p[mid] ?? 0}-${p[p.length - 1] ?? 0}`;
+}
+
+/**
  * Compute bounding box from mesh position data in CAD coordinates,
  * then return center and radius in display coordinates (Z-up -> Y-up).
  */
@@ -221,7 +236,7 @@ export default function ViewerPanel() {
         <CameraPresetBridge meshes={meshes} />
         <group rotation={[-Math.PI / 2, 0, 0]}>
           {meshes.map((m, i) => (
-            <group key={i}>
+            <group key={meshKey(m, i)}>
               <ShapeRenderer data={m} />
               {showEdges && !showWireframe && m.edges.length > 0 && (
                 <EdgeRenderer edges={m.edges} />

--- a/site/src/components/shared/ToastContainer.tsx
+++ b/site/src/components/shared/ToastContainer.tsx
@@ -2,21 +2,43 @@ import { useToastStore } from '../../stores/toastStore';
 
 export default function ToastContainer() {
   const toasts = useToastStore((s) => s.toasts);
+  const removeToast = useToastStore((s) => s.removeToast);
 
   if (toasts.length === 0) return null;
 
   return (
     <div
       className="fixed bottom-12 right-4 z-50 flex flex-col gap-2"
-      role="status"
-      aria-live="polite"
+      // The wrapper is just a layout anchor. Each toast carries its own
+      // role=status / aria-live so screen readers announce the messages
+      // individually instead of as one running region update.
+      aria-label="Notifications"
     >
       {toasts.map((t) => (
         <div
           key={t.id}
-          className="animate-toast-in rounded-lg border border-border-subtle bg-surface-raised px-4 py-2.5 text-sm text-gray-200 shadow-lg"
+          role="status"
+          aria-live="polite"
+          className="animate-toast-in flex items-center gap-3 rounded-lg border border-border-subtle bg-surface-raised pr-2 pl-4 py-2.5 text-sm text-gray-200 shadow-lg"
         >
-          {t.message}
+          <span>{t.message}</span>
+          <button
+            type="button"
+            onClick={() => {
+              removeToast(t.id);
+            }}
+            aria-label={`Dismiss notification: ${t.message}`}
+            className="rounded p-1 text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white focus:outline-none focus:ring-1 focus:ring-teal-primary"
+          >
+            <svg viewBox="0 0 12 12" className="h-3 w-3" aria-hidden="true">
+              <path
+                d="M2 2l8 8M10 2L2 10"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                fill="none"
+              />
+            </svg>
+          </button>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

Round 2 of items deferred from #828, picked up after the smoke gate (#840) confirmed production is stable.

### ToastContainer accessibility
- Each toast now carries its own `role="status" aria-live="polite"` so screen readers announce them individually instead of as one running region update.
- Added a keyboard-reachable close button. Before this, toasts could only auto-clear after 3.5s — there was no dismiss affordance.

### OutputPanel contrast
- Lifted gray-400/500/600 text and icon colors one tier toward white so Console label, toolbar buttons, and output lines clear WCAG AA on the dark `bg-surface` (#0f0f14).
- Buttons gain explicit `aria-label`; their inner SVGs get `aria-hidden="true"`.

### ViewerPanel mesh stability
- Replaced `key={i}` on the per-mesh group with a content-derived hash (`length-first-mid-last` of the position buffer). Same-length mesh arrays with different content now correctly tear down + remount `ShapeRenderer`/`EdgeRenderer` instead of reusing cached geometry. Currently latent (the worker hands us a fresh array reference per eval), but the fix is defensive against any future change where the worker reuses buffers.

## Test plan

- [x] `npm run typecheck --workspace=site` clean
- [x] `npm run build --workspace=site` clean
- [ ] Vercel preview smoke gate green (PR #840's workflow)