### PR TITLE
fix(playground): stabilize OrbitControls props + grid z-fighting

### DIFF
--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -208,15 +208,31 @@ export default function ViewerPanel() {
     clearPreset();
   }, [clearPreset]);
 
-  const controlsProps = useMemo(
-    () => ({
+  // Snapshot the initial pointer-class via matchMedia so the props object we
+  // hand drei stays stable across renders. Runtime device-class flips (a user
+  // plugging in a touchscreen, a tablet rotating) are rare but real, and
+  // recreating controlsProps on each flip would jolt drei's OrbitControls
+  // mid-pointer-down and lose interaction state. Apply runtime updates via
+  // direct mutation in the effect below instead.
+  const controlsProps = useMemo(() => {
+    const initialIsTouch =
+      typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+    return {
       ...BASE_CONTROLS_PROPS,
-      rotateSpeed: isTouch ? 1.0 : 0.8,
-      zoomSpeed: isTouch ? 1.2 : 1.0,
-      enablePan: !isTouch,
-    }),
-    [isTouch]
-  );
+      rotateSpeed: initialIsTouch ? 1.0 : 0.8,
+      zoomSpeed: initialIsTouch ? 1.2 : 1.0,
+      enablePan: !initialIsTouch,
+    };
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- drei OrbitControls
+    const c = controlsRef.current as any;
+    if (!c) return;
+    c.rotateSpeed = isTouch ? 1.0 : 0.8;
+    c.zoomSpeed = isTouch ? 1.2 : 1.0;
+    c.enablePan = !isTouch;
+  }, [isTouch]);
 
   return (
     <div className="relative h-full w-full">

--- a/site/src/components/shared/InfiniteGrid.tsx
+++ b/site/src/components/shared/InfiniteGrid.tsx
@@ -77,6 +77,14 @@ export default function InfiniteGrid({
         transparent
         depthWrite={false}
         side={THREE.DoubleSide}
+        // Bias grid fragments slightly deeper than coplanar geometry so
+        // shapes resting on z=0 always win the depth test, even at
+        // oblique camera angles where float precision degrades. Combined
+        // with the y=-0.01 position above, this is a belt-and-suspenders
+        // fix for shapes whose bottom face touches the grid plane.
+        polygonOffset
+        polygonOffsetFactor={1}
+        polygonOffsetUnits={1}
       />
     </mesh>
   );


### PR DESCRIPTION
## Summary

The last two deferred items from the bundled UX review (#828).

### ViewerPanel: stable controls props
Recreating `controlsProps` on every `isTouch` flip would push a fresh prop object to drei's `<OrbitControls>` mid-pointer-down — under a touchscreen plug-in or tablet rotation, an in-flight interaction could lose its `rotateSpeed` / `zoomSpeed` / `enablePan` state. Two changes:
- Snapshot the initial pointer-class via `window.matchMedia` in a `useMemo` with empty deps. The props object handed to drei is now stable across renders.
- Apply runtime device-class changes via direct mutation of the live OrbitControls in an effect.

Net effect: same UX for the common case (no device flip), no jolt for the rare flip case.

### InfiniteGrid: polygonOffset
Shapes resting on `z=0` (their bottom face exactly on the build plate) z-fight with the grid plane at oblique camera angles where float precision degrades. The grid is already at `y=-0.01` with `depthWrite={false}`, but that's not enough in all cases. Adding `polygonOffset / polygonOffsetFactor=1 / polygonOffsetUnits=1` biases grid fragments slightly deeper at the GPU level, so coplanar shapes always win the depth test regardless of angle.

## Test plan

- [x] `npm run typecheck --workspace=site` clean
- [x] `npm run build --workspace=site` clean
- [ ] Vercel preview smoke gate green