### PR TITLE
fix(playground): smooth fillet shading via finer mesh tolerances

### DIFF
--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -237,8 +237,8 @@ function handleEval(id: string, code: string) {
               ? brepjs.castShape(shape.wrapped)
               : shape;
 
-        const shapeMesh = brepjs.mesh(fnShape, { tolerance: 0.1, angularTolerance: 0.2 });
-        const edgeMesh = brepjs.meshEdges(fnShape, { tolerance: 0.1, angularTolerance: 0.2 });
+        const shapeMesh = brepjs.mesh(fnShape, { tolerance: 0.05, angularTolerance: 0.1 });
+        const edgeMesh = brepjs.meshEdges(fnShape, { tolerance: 0.05, angularTolerance: 0.1 });
 
         const bufData = brepjs.toBufferGeometryData(shapeMesh);
         const lineData = brepjs.toLineGeometryData(edgeMesh);


### PR DESCRIPTION
## Summary
- Fillets in the playground 3D preview rendered with visible flat facets — most obvious on small-radius fillets like the 0.8 mm corners on the pen-cup example.
- The viewer worker was passing `{ tolerance: 0.1, angularTolerance: 0.2 }` to `brepjs.mesh` / `brepjs.meshEdges`. Angular bound dominates on small fillets (`δ ≥ r` defeats the linear bound), so each quarter-arc only got ~8 chord segments (90° / 11.5°) — exactly the count of flat segments visible in the screenshot.
- Halving linear deflection (`0.05`) and matching the brepjs library default angular tolerance (`0.1` rad ≈ 5.7°) doubles curve resolution to ~16 segments per quarter, producing smooth shading with negligible perf cost on playground-scale parts.

Before / after parameters:
| Param | Old | New |
|---|---|---|
| `tolerance` (linear, mm) | 0.1 | 0.05 |
| `angularTolerance` (rad) | 0.2 | 0.1 |

## Test plan
- [ ] Run the default pen-cup example in the playground and confirm both the 8 mm body corners and the 0.8 mm `fillet(0.8)` edges shade smoothly without visible chord segments.
- [ ] Spot-check a few other examples (boxes, cylinders, sweeps) for unchanged appearance and no perceptible eval-time regression.
- [ ] Verify the wireframe overlay (Edges toggle) still tracks fillet silhouettes cleanly at the new density.