### PR TITLE
fix(playground): soften edge overlay so tangent edges fade into the mesh

### DIFF
--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -16,7 +16,7 @@ export default function EdgeRenderer({ edges }: { edges: Float32Array }) {
 
   return (
     <lineSegments geometry={geometry} renderOrder={1}>
-      <lineBasicMaterial color="#000000" depthTest={true} />
+      <lineBasicMaterial color="#3a4046" transparent opacity={0.55} depthTest={true} />
     </lineSegments>
   );
 }


### PR DESCRIPTION
## Summary
- After #847 fixed fillet shading, the remaining \"weird shading\" on screenshots like the pen-cup is the **wireframe edge overlay** drawn at every topological face boundary — including the *tangent* edges where a fillet face meets its adjacent flat walls. Those produce visible dark stripes on regions where the underlying surface already shades smoothly.
- The fix is cosmetic: drop the line color from pure \`#000000\` to a cool dark gray \`#3a4046\` and add 55% opacity. On smooth (G1+) regions, the line picks up the underlying shading gradient and visually disappears; at sharp creases the geometric shading discontinuity beneath the line preserves contrast so silhouette edges still read.
- This is the small-blast-radius fix. The architecturally-correct alternative is **edge classification** — call OCCT's \`BRepLib::ContinuityOfFaces(edge, face1, face2, angTol)\`, drop tangent edges from the line buffer entirely, and keep sharp edges fully opaque black. That's a 5-file change (kernel interface + OCCT impl + brepkit stub + adapter wiring + worker filter). I'd rather propose that as its own PR if/when needed.

## Test plan
- [ ] Run the default pen-cup example with **Edges** toggled on. Confirm the dark vertical stripes along the inside fillet boundaries visibly fade — they should read as soft surface seams, not high-contrast black lines.
- [ ] Confirm sharp silhouette edges (top rim, vertical wall corners on the *outside* before the fillet) remain readable as crisp boundaries.
- [ ] Spot-check a sharp-edged shape like \`box(40, 30, 20)\` to ensure all 12 edges still render distinctly with the new opacity.
- [ ] Toggle **Wireframe** on/off — wireframe overrides edges, so the change should be inert in that mode.