### PR TITLE
fix(playground): brighten cavity ambient so curved fillets stop reading as dark stripes

### DIFF
--- a/site/src/components/shared/SceneLighting.tsx
+++ b/site/src/components/shared/SceneLighting.tsx
@@ -1,9 +1,10 @@
 export default function SceneLighting() {
   return (
     <>
-      <hemisphereLight args={['#ffffff', '#1a1a2e', 0.65]} />
-      <directionalLight position={[-50, 60, 80]} intensity={0.85} color="#fff8f0" />
-      <directionalLight position={[40, -40, 30]} intensity={0.15} color="#e0e8ff" />
+      <hemisphereLight args={['#ffffff', '#5a5d6e', 0.85]} />
+      <ambientLight intensity={0.25} color="#c8ccd6" />
+      <directionalLight position={[-50, 60, 80]} intensity={0.75} color="#fff8f0" />
+      <directionalLight position={[40, -40, 30]} intensity={0.2} color="#e0e8ff" />
     </>
   );
 }


### PR DESCRIPTION
## Summary

User reported the pen-cup example *still* showed dark stripes inside the cup after #847 (smoother tessellation), #848 (softened edges), and #849 (filtered tangent edges). Verified the actual cause via Playwright pixel-level A/B testing: edges-on and edges-off screenshots at the same camera angle were **visually identical**, meaning the dark stripes weren't wireframe at all — they were lighting.

**Root cause**: the hemisphere light's ground color was `#1a1a2e` (~7% luminance). Surfaces facing inward/down get the ground color. On the pen-cup's inner walls and especially the curved 6 mm-radius fillet faces at inner corners (whose normals sweep through orientations pointing into the cup's self-shadow), there's almost no fill light reaching the geometry — the directional key light is blocked by the cup walls, and the hemisphere ground was effectively black. Result: the fillet faces rendered near-zero luminance and read as visible dark bands on otherwise smooth geometry.

**Fix** (1 file, 4 lines):
- Hemisphere ground `#1a1a2e` → `#5a5d6e` (~30% luminance), intensity bumped 0.65 → 0.85
- Add small ambient `<ambientLight intensity={0.25} color="#c8ccd6" />` for a flat fill floor
- Trim directional key intensity 0.85 → 0.75 so total scene exposure stays roughly constant
- Nudge fill directional 0.15 → 0.2 to keep bottom-side surfaces from going too dark relative to the now-brighter top

The fillet faces now show a gentle gradient as they curve, rather than near-black bands. Sharp shading (silhouettes, real creases) is preserved because the directional key is still doing most of the form-defining work.

## Test plan
- [ ] Open the pen-cup example with **Edges** on. Inside corners should show smooth gradient shading rather than dark vertical stripes.
- [ ] Sharp-edged shapes like `box(40, 30, 20)` should still read as clearly faceted; the directional shading is what makes them legible.
- [ ] Default filleted-box example should look ~unchanged from before (visible-from-outside surfaces shade similarly).
- [ ] Compartment-tray and lofted-vase examples (also hollow) should look similarly improved.