### PR TITLE
fix(playground): normalize face normals when classifying tangent edges

### DIFF
--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -193,8 +193,17 @@ function computeSharpEdgeHashes(bjs: any, shape: unknown): Set<number> {
         const mid = bjs.curvePointAt(edge, 0.5);
         const n1 = bjs.normalAt(faces[0], mid);
         const n2 = bjs.normalAt(faces[1], mid);
-        const dot = Math.abs(n1[0] * n2[0] + n1[1] * n2[1] + n1[2] * n2[2]);
-        if (dot > TANGENT_DOT_THRESHOLD) isTangent = true;
+        // Normalize: kernel's surfaceNormal can return un-normalized cross
+        // products (∂u×∂v) whose magnitude reflects parameterization scale —
+        // e.g. a 0.8 mm-radius fillet face yields a length-0.8 vector. Two
+        // collinear normals of different magnitudes give raw dot < 1 and
+        // would misclassify the tangent edge as sharp.
+        const m1 = Math.hypot(n1[0], n1[1], n1[2]);
+        const m2 = Math.hypot(n2[0], n2[1], n2[2]);
+        if (m1 > 0 && m2 > 0) {
+          const dot = Math.abs(n1[0] * n2[0] + n1[1] * n2[1] + n1[2] * n2[2]) / (m1 * m2);
+          if (dot > TANGENT_DOT_THRESHOLD) isTangent = true;
+        }
       }
     } catch {
       // Treat any classification failure as sharp so we never *hide* an edge


### PR DESCRIPTION
## Summary

User reported the pen-cup example *still* showed dark curve marks at every fillet boundary even after #847, #848, #849, and #850. Verified the cause via in-worker diagnostic logging:

```
[edge-filter] sharp=32 tangent=80
  mid=[0.00,-17.50,0.80] n1=[0.000,-1.000,0.000] n2=[0.000,-0.800,0.000] dot=0.8000
  mid=[0.00,-17.50,79.20] n1=[0.000,-1.000,0.000] n2=[0.000,-0.800,0.000] dot=0.8000
  ... (32 entries, all identical pattern)
```

**Root cause**: #849's filter compared face normals via raw dot product, but the kernel's `normalAt` / `surfaceNormal` returns the un-normalized cross product `∂u×∂v` whose magnitude is the parameterization's area element. For a 0.8 mm-radius fillet face that's exactly 0.8 — so a truly tangent edge between a 0.8 mm fillet and an adjacent flat wall produces normals like `[0,-1,0]` and `[0,-0.8,0]`. They're collinear (angle 0°, true cosine 1.0), but the raw dot is 0.8 — well below the 0.9962 (cos 5°) tangent threshold. Every short tangent edge bordering the small fillet face was misclassified as sharp and drawn as a dark curve mark, exactly matching what the user saw.

#849's classification *worked* between two faces with equal-magnitude normals (e.g. between two flat walls or two equal-radius cylinders) — that's why the long vertical tangent edges between the cup's outer 8 mm corners and the flat side walls *were* correctly dropped. The bug only surfaced where the two adjacent faces had different parameterization scales.

**Fix** (one expression): divide the dot product by `|n1|·|n2|` to get the true cosine.

```ts
const m1 = Math.hypot(...n1);
const m2 = Math.hypot(...n2);
if (m1 > 0 && m2 > 0) {
  const dot = Math.abs(n1·n2) / (m1 * m2);
  if (dot > TANGENT_DOT_THRESHOLD) isTangent = true;
}
```

**Verification numbers**:
- Pen-cup `fillet(0.8)` (h=80): 112 / 112 edges classified as tangent and dropped. Correct — every face boundary in this shape is G1 by construction (rounded rectangle profile + tangent fillets at top rim and bottom).
- Plain `box(40, 30, 20)`: 12 / 12 edges classified as sharp. Confirms no over-filtering on shapes with real sharp creases.

## Test plan
- [ ] Pen-cup example with **Edges** on. Inside corners and fillet boundaries should be free of dark curve marks; only silhouette and any genuine creases should darken the surface.
- [ ] Plain box / cylinder shapes still show their full edge wireframe (12 edges on a box, 3 circular edges on a cylinder).
- [ ] Compartment-tray and lofted-vase examples (also fillet-heavy) should look similarly clean.