### PR TITLE
revert(playground): restore 3D preview to pre-#847 state

### DIFF
--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -16,7 +16,7 @@ export default function EdgeRenderer({ edges }: { edges: Float32Array }) {
 
   return (
     <lineSegments geometry={geometry} renderOrder={1}>
-      <lineBasicMaterial color="#3a4046" transparent opacity={0.55} depthTest={true} />
+      <lineBasicMaterial color="#000000" depthTest={true} />
     </lineSegments>
   );
 }

--- a/site/src/components/shared/SceneLighting.tsx
+++ b/site/src/components/shared/SceneLighting.tsx
@@ -1,10 +1,9 @@
 export default function SceneLighting() {
   return (
     <>
-      <hemisphereLight args={['#ffffff', '#5a5d6e', 0.85]} />
-      <ambientLight intensity={0.25} color="#c8ccd6" />
-      <directionalLight position={[-50, 60, 80]} intensity={0.75} color="#fff8f0" />
-      <directionalLight position={[40, -40, 30]} intensity={0.2} color="#e0e8ff" />
+      <hemisphereLight args={['#ffffff', '#1a1a2e', 0.65]} />
+      <directionalLight position={[-50, 60, 80]} intensity={0.85} color="#fff8f0" />
+      <directionalLight position={[40, -40, 30]} intensity={0.15} color="#e0e8ff" />
     </>
   );
 }

--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -136,84 +136,6 @@ async function handleInit() {
   }
 }
 
-// ── Edge classification ──
-
-const TANGENT_DOT_THRESHOLD = 0.9962; // |cos(5°)| — edges whose adjacent face
-// normals are this parallel are treated as tangent (G1+) and dropped from
-// the wireframe overlay so they don't paint dark stripes on smooth regions.
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- brepjs runtime
-function filterTangentEdges(
-  bjs: any,
-  shape: unknown,
-  edgeMesh: {
-    lines: Float32Array;
-    edgeGroups: { start: number; count: number; edgeId: number }[];
-  }
-): Float32Array {
-  let sharpHashes: Set<number>;
-  try {
-    sharpHashes = computeSharpEdgeHashes(bjs, shape);
-  } catch {
-    // If classification fails for any reason, fall back to drawing every edge.
-    return edgeMesh.lines;
-  }
-
-  let outFloats = 0;
-  for (const g of edgeMesh.edgeGroups) {
-    if (sharpHashes.has(g.edgeId)) outFloats += g.count * 3;
-  }
-  if (outFloats === edgeMesh.lines.length) return edgeMesh.lines;
-
-  const out = new Float32Array(outFloats);
-  let off = 0;
-  for (const g of edgeMesh.edgeGroups) {
-    if (!sharpHashes.has(g.edgeId)) continue;
-    const startFloat = g.start * 3;
-    const numFloats = g.count * 3;
-    out.set(edgeMesh.lines.subarray(startFloat, startFloat + numFloats), off);
-    off += numFloats;
-  }
-  return out;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- brepjs runtime
-function computeSharpEdgeHashes(bjs: any, shape: unknown): Set<number> {
-  const kernel = bjs.getKernel();
-  const HASH_MAX: number = bjs.HASH_CODE_MAX;
-  const sharp = new Set<number>();
-  const edges = bjs.getEdges(shape);
-
-  for (const edge of edges) {
-    const hash = kernel.hashCode(edge.wrapped, HASH_MAX);
-    let isTangent = false;
-    try {
-      const faces = bjs.facesOfEdge(shape, edge);
-      if (faces.length === 2) {
-        const mid = bjs.curvePointAt(edge, 0.5);
-        const n1 = bjs.normalAt(faces[0], mid);
-        const n2 = bjs.normalAt(faces[1], mid);
-        // Normalize: kernel's surfaceNormal can return un-normalized cross
-        // products (∂u×∂v) whose magnitude reflects parameterization scale —
-        // e.g. a 0.8 mm-radius fillet face yields a length-0.8 vector. Two
-        // collinear normals of different magnitudes give raw dot < 1 and
-        // would misclassify the tangent edge as sharp.
-        const m1 = Math.hypot(n1[0], n1[1], n1[2]);
-        const m2 = Math.hypot(n2[0], n2[1], n2[2]);
-        if (m1 > 0 && m2 > 0) {
-          const dot = Math.abs(n1[0] * n2[0] + n1[1] * n2[1] + n1[2] * n2[2]) / (m1 * m2);
-          if (dot > TANGENT_DOT_THRESHOLD) isTangent = true;
-        }
-      }
-    } catch {
-      // Treat any classification failure as sharp so we never *hide* an edge
-      // we couldn't analyze — far better than over-filtering.
-    }
-    if (!isTangent) sharp.add(hash);
-  }
-  return sharp;
-}
-
 // ── Eval ──
 
 function handleEval(id: string, code: string) {
@@ -315,17 +237,17 @@ function handleEval(id: string, code: string) {
               ? brepjs.castShape(shape.wrapped)
               : shape;
 
-        const shapeMesh = brepjs.mesh(fnShape, { tolerance: 0.05, angularTolerance: 0.1 });
-        const edgeMesh = brepjs.meshEdges(fnShape, { tolerance: 0.05, angularTolerance: 0.1 });
+        const shapeMesh = brepjs.mesh(fnShape, { tolerance: 0.1, angularTolerance: 0.2 });
+        const edgeMesh = brepjs.meshEdges(fnShape, { tolerance: 0.1, angularTolerance: 0.2 });
 
         const bufData = brepjs.toBufferGeometryData(shapeMesh);
-        const filteredEdges = filterTangentEdges(brepjs, fnShape, edgeMesh);
+        const lineData = brepjs.toLineGeometryData(edgeMesh);
 
         const mesh: MeshTransfer = {
           position: bufData.position,
           normal: bufData.normal,
           index: bufData.index,
-          edges: filteredEdges,
+          edges: lineData.position,
         };
 
         meshes.push(mesh);


### PR DESCRIPTION
## Summary

The cumulative effect of #847, #848, #849, #850, and #851 produced a 3D preview the user feels looks worse than the original. Reverting all five at once rather than trying to back them out individually.

Touches the same three files those PRs collectively modified, restoring each to its state at \`f1aeb9ee\` (the commit immediately before #847):

- **\`site/src/workers/cad.worker.ts\`** — \`brepjs.mesh\` / \`brepjs.meshEdges\` back to \`tolerance: 0.1, angularTolerance: 0.2\`. Tangent-edge classifier (\`computeSharpEdgeHashes\`, \`filterTangentEdges\`, \`TANGENT_DOT_THRESHOLD\`) removed entirely.
- **\`site/src/components/playground/EdgeRenderer.tsx\`** — solid black, fully opaque edge overlay (\`color="#000000"\`).
- **\`site/src/components/shared/SceneLighting.tsx\`** — original two directional lights + dim hemisphere ground (\`#1a1a2e\` @ 0.65 intensity, no \`ambientLight\`).

No other files are affected; the revert is scoped strictly to the three rendering touchpoints those PRs modified.

## Test plan
- [ ] Pen-cup, lofted-vase, compartment-tray, and spiral-staircase examples render exactly as they did before #847 was merged.
- [ ] No type / lint regressions (verified locally).