### PR TITLE
feat(playground): studio-style polish for selection, viewport, and shortcuts

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"ea8a302d-503e-4694-befb-82313a43bc7f","pid":119036,"procStart":"565940","acquiredAt":1778028264667}
+{"sessionId":"2e9444c7-757f-4210-9b84-4379ddb9ee72","pid":34654,"procStart":"24602","acquiredAt":1778167093868}

--- a/site/src/components/playground/CommandPalette.tsx
+++ b/site/src/components/playground/CommandPalette.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export interface Command {
+  id: string;
+  label: string;
+  group?: string;
+  keys?: string;
+  run: () => void;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  commands: Command[];
+}
+
+// Subsequence match scorer: every char of `q` must appear in `text` in order.
+// Lower = closer match. Returns null when no match. Used for fuzzy filtering
+// without pulling in a heavier library like fuse.js — palette has <30 entries.
+function fuzzyScore(text: string, q: string): number | null {
+  if (!q) return 0;
+  const lower = text.toLowerCase();
+  let ti = 0;
+  let lastMatch = -1;
+  let runs = 0;
+  for (let qi = 0; qi < q.length; qi++) {
+    const target = q[qi];
+    if (target === undefined) continue;
+    const found = lower.indexOf(target, ti);
+    if (found === -1) return null;
+    if (found !== lastMatch + 1) runs++;
+    lastMatch = found;
+    ti = found + 1;
+  }
+  return runs * 10 + lastMatch;
+}
+
+export default function CommandPalette({ open, onClose, commands }: Props) {
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset transient palette state every time it opens so the user always
+  // starts at the first match with an empty query.
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setActive(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    if (!open) return [];
+    const q = query.trim().toLowerCase();
+    const scored = commands
+      .map((c) => ({ c, score: fuzzyScore(`${c.group ?? ''} ${c.label}`, q) }))
+      .filter((x): x is { c: Command; score: number } => x.score !== null);
+    scored.sort((a, b) => a.score - b.score);
+    return scored.map((x) => x.c);
+  }, [open, query, commands]);
+
+  // Clamp the active index when the filtered list shrinks below it.
+  useEffect(() => {
+    if (active >= filtered.length) setActive(0);
+  }, [filtered.length, active]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive((a) => Math.min(filtered.length - 1, a + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive((a) => Math.max(0, a - 1));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const cmd = filtered[active];
+        if (cmd) {
+          cmd.run();
+          onClose();
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  }, [open, filtered, active, onClose]);
+
+  // Keep the active row scrolled into view as the user navigates.
+  useEffect(() => {
+    if (!listRef.current) return;
+    const el = listRef.current.querySelector<HTMLElement>(`[data-index="${active}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [active]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 pt-[15vh] backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden rounded-lg border border-border-subtle bg-surface shadow-xl"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+          placeholder="Search actions..."
+          className="w-full border-b border-border-subtle bg-transparent px-3 py-2.5 text-sm text-gray-200 placeholder:text-gray-500 focus:outline-none"
+        />
+        <div ref={listRef} className="max-h-[50vh] overflow-y-auto py-1">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2 text-sm text-gray-500">No matching action</div>
+          ) : (
+            filtered.map((cmd, i) => (
+              <button
+                key={cmd.id}
+                data-index={i}
+                onClick={() => {
+                  cmd.run();
+                  onClose();
+                }}
+                onMouseEnter={() => {
+                  setActive(i);
+                }}
+                className={`flex w-full items-center justify-between px-3 py-1.5 text-left text-sm ${
+                  i === active ? 'bg-teal-primary/15 text-teal-light' : 'text-gray-300'
+                }`}
+              >
+                <span className="truncate">
+                  {cmd.group && (
+                    <span className="mr-1.5 text-[10px] uppercase tracking-wider text-gray-500">
+                      {cmd.group}
+                    </span>
+                  )}
+                  {cmd.label}
+                </span>
+                {cmd.keys && (
+                  <kbd className="ml-2 shrink-0 rounded border border-border-subtle bg-surface-overlay px-1.5 py-0.5 font-mono text-[10px] text-gray-400">
+                    {cmd.keys}
+                  </kbd>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -29,7 +29,7 @@ function findGroupAt(groups: EdgeGroup[], vertexIndex: number): EdgeGroup | null
 }
 
 export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
-  const setSelection = usePlaygroundStore((s) => s.setSelection);
+  const pickSelection = usePlaygroundStore((s) => s.pickSelection);
   const addToast = useToastStore((s) => s.addToast);
   const pickable = Boolean(edgeGroups && edgeInfos);
 
@@ -62,13 +62,17 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
       const info = edgeInfoById.get(group.edgeId);
       if (!info) return;
       event.stopPropagation();
-      setSelection({ kind: 'edge', info });
+      const additive = event.shiftKey;
+      pickSelection(
+        { kind: 'edge', info, screenPos: { x: event.clientX, y: event.clientY } },
+        additive
+      );
       const snippet = buildEdgeFinderSnippet(info);
       void copyToClipboard(snippet).then((copied) =>
         addToast(copied ? 'Edge finder copied' : 'Edge selected (clipboard unavailable)')
       );
     },
-    [edgeGroups, edgeInfoById, setSelection, addToast]
+    [edgeGroups, edgeInfoById, pickSelection, addToast]
   );
 
   const handlePointerOver = useCallback(() => {

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo, useEffect, useState } from 'react';
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from 'react-resizable-panels';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
+import { useViewerStore } from '../../stores/viewerStore';
 import { useToastStore } from '../../stores/toastStore';
 import { useCodeExecution } from '../../hooks/useCodeExecution';
 import { useUrlState } from '../../hooks/useUrlState';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
-import { SHORTCUTS } from '../../lib/shortcuts';
+import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
@@ -14,6 +15,8 @@ import OutputPanel from './OutputPanel';
 import StatusBar from './StatusBar';
 import LoadingOverlay from './LoadingOverlay';
 import CollapsedConsoleBar from './CollapsedConsoleBar';
+import ShortcutHelp from './ShortcutHelp';
+import CommandPalette, { type Command } from './CommandPalette';
 import ToastContainer from '../shared/ToastContainer';
 
 const shortcutDefs = Object.values(SHORTCUTS);
@@ -36,6 +39,17 @@ export default function PlaygroundPage() {
   const viewerPanelRef = usePanelRef();
   // Mutable ref to hold the editor format function, set by EditorPanel
   const editorFormatFnRef = useMemo(() => ({ current: null as (() => void) | null }), []);
+
+  const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const setViewMode = useViewerStore((s) => s.setViewMode);
+  const cycleViewMode = useViewerStore((s) => s.cycleViewMode);
+  const toggleEdges = useViewerStore((s) => s.toggleEdges);
+  const toggleGrid = useViewerStore((s) => s.toggleGrid);
+  const toggleProjection = useViewerStore((s) => s.toggleProjection);
+  const requestFit = useViewerStore((s) => s.requestFit);
+  const setCameraPreset = useViewerStore((s) => s.setCameraPreset);
 
   // Layout persistence
   const storage = typeof window !== 'undefined' ? localStorage : undefined;
@@ -114,6 +128,10 @@ export default function PlaygroundPage() {
     [setViewerCollapsed]
   );
 
+  const openCommandPalette = useCallback(() => {
+    setPaletteOpen(true);
+  }, []);
+
   const shortcutActions = useMemo(
     () => ({
       run: handleRun,
@@ -123,6 +141,7 @@ export default function PlaygroundPage() {
       formatCode: handleFormat,
       toggleOutput: toggleConsole,
       toggleViewer: toggleViewer,
+      commandPalette: openCommandPalette,
     }),
     [
       handleRun,
@@ -132,10 +151,177 @@ export default function PlaygroundPage() {
       handleFormat,
       toggleConsole,
       toggleViewer,
+      openCommandPalette,
     ]
   );
 
   useKeyboardShortcuts(shortcutActions, shortcutDefs);
+
+  // `?` opens the shortcut help. Lives outside useKeyboardShortcuts because it
+  // has no modifier, so it would clobber typed `?` characters in the editor.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== '?') return;
+      const target = e.target;
+      if (target instanceof HTMLElement) {
+        if (target.isContentEditable) return;
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        if (target.closest('.monaco-editor')) return;
+      }
+      e.preventDefault();
+      setShortcutHelpOpen((o) => !o);
+    };
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  }, []);
+
+  const commands: Command[] = useMemo(
+    () => [
+      {
+        id: 'run',
+        group: 'Run',
+        label: 'Run code',
+        keys: formatShortcut(SHORTCUTS.run!),
+        run: handleRun,
+      },
+      {
+        id: 'share',
+        group: 'Run',
+        label: 'Share link',
+        keys: formatShortcut(SHORTCUTS.share!),
+        run: handleShare,
+      },
+      {
+        id: 'exportSTL',
+        group: 'Export',
+        label: 'Export STL',
+        keys: formatShortcut(SHORTCUTS.exportSTL!),
+        run: handleExportSTL,
+      },
+      {
+        id: 'exportSTEP',
+        group: 'Export',
+        label: 'Export STEP',
+        keys: formatShortcut(SHORTCUTS.exportSTEP!),
+        run: handleExportSTEP,
+      },
+      {
+        id: 'format',
+        group: 'Editor',
+        label: 'Format code',
+        keys: formatShortcut(SHORTCUTS.formatCode!),
+        run: handleFormat,
+      },
+      {
+        id: 'toggleConsole',
+        group: 'Layout',
+        label: 'Toggle console',
+        keys: formatShortcut(SHORTCUTS.toggleOutput!),
+        run: toggleConsole,
+      },
+      {
+        id: 'toggleViewer',
+        group: 'Layout',
+        label: 'Toggle viewer',
+        keys: formatShortcut(SHORTCUTS.toggleViewer!),
+        run: toggleViewer,
+      },
+      {
+        id: 'view-solid',
+        group: 'View',
+        label: 'View: Solid',
+        run: () => {
+          setViewMode('solid');
+        },
+      },
+      {
+        id: 'view-wire',
+        group: 'View',
+        label: 'View: Wireframe',
+        run: () => {
+          setViewMode('wireframe');
+        },
+      },
+      {
+        id: 'view-xray',
+        group: 'View',
+        label: 'View: X-ray',
+        run: () => {
+          setViewMode('xray');
+        },
+      },
+      { id: 'cycle-view', group: 'View', label: 'Cycle view mode', run: cycleViewMode },
+      { id: 'toggle-edges', group: 'View', label: 'Toggle edges', run: toggleEdges },
+      { id: 'toggle-grid', group: 'View', label: 'Toggle grid', run: toggleGrid },
+      {
+        id: 'toggle-proj',
+        group: 'View',
+        label: 'Toggle projection (perspective/ortho)',
+        run: toggleProjection,
+      },
+      { id: 'fit', group: 'Camera', label: 'Fit to view', run: requestFit },
+      {
+        id: 'cam-front',
+        group: 'Camera',
+        label: 'Front view',
+        run: () => {
+          setCameraPreset('front');
+        },
+      },
+      {
+        id: 'cam-side',
+        group: 'Camera',
+        label: 'Side view',
+        run: () => {
+          setCameraPreset('side');
+        },
+      },
+      {
+        id: 'cam-top',
+        group: 'Camera',
+        label: 'Top view',
+        run: () => {
+          setCameraPreset('top');
+        },
+      },
+      {
+        id: 'cam-iso',
+        group: 'Camera',
+        label: 'Isometric view',
+        run: () => {
+          setCameraPreset('isometric');
+        },
+      },
+      {
+        id: 'help',
+        group: 'Help',
+        label: 'Show keyboard shortcuts',
+        keys: '?',
+        run: () => {
+          setShortcutHelpOpen(true);
+        },
+      },
+    ],
+    [
+      handleRun,
+      handleShare,
+      handleExportSTL,
+      handleExportSTEP,
+      handleFormat,
+      toggleConsole,
+      toggleViewer,
+      setViewMode,
+      cycleViewMode,
+      toggleEdges,
+      toggleGrid,
+      toggleProjection,
+      requestFit,
+      setCameraPreset,
+    ]
+  );
 
   // Auto-expand console when error occurs
   useEffect(() => {
@@ -234,6 +420,20 @@ export default function PlaygroundPage() {
       </Group>
 
       <StatusBar />
+
+      <ShortcutHelp
+        open={shortcutHelpOpen}
+        onClose={() => {
+          setShortcutHelpOpen(false);
+        }}
+      />
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => {
+          setPaletteOpen(false);
+        }}
+        commands={commands}
+      />
     </div>
   );
 }

--- a/site/src/components/playground/SelectionTooltip.tsx
+++ b/site/src/components/playground/SelectionTooltip.tsx
@@ -1,0 +1,107 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import {
+  formatArea,
+  formatCurveType,
+  formatLength,
+  formatNormalDirection,
+  formatSurfaceType,
+} from '../../lib/selectionLabels';
+import type { Selection } from '../../stores/playgroundStore';
+
+interface Props {
+  selections: Selection[];
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const OFFSET_X = 12;
+const OFFSET_Y = 12;
+const EDGE_PADDING = 8;
+
+export default function SelectionTooltip({ selections, containerRef }: Props) {
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const last = selections[selections.length - 1] ?? null;
+
+  // Keep the tooltip pinned next to the click position while clamping to the
+  // viewport panel so it never escapes the canvas. useLayoutEffect avoids a
+  // visible flash where the tooltip shows at (0,0) before being clamped.
+  useLayoutEffect(() => {
+    if (!last || !containerRef.current || !tooltipRef.current) {
+      setPos(null);
+      return;
+    }
+    const rect = containerRef.current.getBoundingClientRect();
+    const t = tooltipRef.current.getBoundingClientRect();
+    let left = last.screenPos.x - rect.left + OFFSET_X;
+    let top = last.screenPos.y - rect.top + OFFSET_Y;
+    if (left + t.width > rect.width - EDGE_PADDING) {
+      left = rect.width - t.width - EDGE_PADDING;
+    }
+    if (top + t.height > rect.height - EDGE_PADDING) {
+      top = rect.height - t.height - EDGE_PADDING;
+    }
+    if (left < EDGE_PADDING) left = EDGE_PADDING;
+    if (top < EDGE_PADDING) top = EDGE_PADDING;
+    setPos({ left, top });
+  }, [last, containerRef]);
+
+  if (!last) return null;
+
+  return (
+    <div
+      ref={tooltipRef}
+      className="pointer-events-none absolute z-20 min-w-[160px] max-w-[260px] rounded-md border border-border-subtle bg-[rgba(15,15,20,0.94)] px-2.5 py-1.5 font-mono text-xs text-gray-200 shadow-lg backdrop-blur-sm"
+      style={pos ?? { left: -9999, top: -9999 }}
+      role="tooltip"
+    >
+      {selections.length > 1 ? (
+        <MultiTooltip selections={selections} />
+      ) : (
+        <SingleTooltip selection={last} />
+      )}
+    </div>
+  );
+}
+
+function SingleTooltip({ selection }: { selection: Selection }) {
+  if (selection.kind === 'face') {
+    const f = selection.info;
+    return (
+      <div className="flex flex-col gap-0.5">
+        <div className="font-semibold text-teal-light">{formatSurfaceType(f.surfaceType)}</div>
+        <div className="text-gray-400">Area: {formatArea(f.area)}</div>
+        <div className="text-gray-400">Facing: {formatNormalDirection(f.normal)}</div>
+      </div>
+    );
+  }
+  const e = selection.info;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="font-semibold text-teal-light">{formatCurveType(e.curveType)}</div>
+      <div className="text-gray-400">Length: {formatLength(e.length)}</div>
+    </div>
+  );
+}
+
+function MultiTooltip({ selections }: { selections: Selection[] }) {
+  const faceCount = selections.filter((s) => s.kind === 'face').length;
+  const edgeCount = selections.length - faceCount;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="font-semibold text-teal-light">{selections.length} selected</div>
+      {faceCount > 0 && (
+        <div className="text-gray-400">
+          {faceCount} face{faceCount === 1 ? '' : 's'}
+        </div>
+      )}
+      {edgeCount > 0 && (
+        <div className="text-gray-400">
+          {edgeCount} edge{edgeCount === 1 ? '' : 's'}
+        </div>
+      )}
+      <div className="mt-1 border-t border-border-subtle pt-1 text-[10px] text-gray-500">
+        Last picked copies to clipboard
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/playground/ShapeRenderer.tsx
+++ b/site/src/components/playground/ShapeRenderer.tsx
@@ -10,8 +10,8 @@ import { copyToClipboard } from '../../lib/copyToClipboard';
 import { useToastStore } from '../../stores/toastStore';
 
 export default function ShapeRenderer({ data }: { data: MeshData }) {
-  const showWireframe = useViewerStore((s) => s.showWireframe);
-  const setSelection = usePlaygroundStore((s) => s.setSelection);
+  const viewMode = useViewerStore((s) => s.viewMode);
+  const pickSelection = usePlaygroundStore((s) => s.pickSelection);
   const addToast = useToastStore((s) => s.addToast);
   const pickable = Boolean(data.faceGroups && data.faceInfos);
 
@@ -54,13 +54,17 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
       const info = faceInfoById.get(group.faceId);
       if (!info) return;
       event.stopPropagation();
-      setSelection({ kind: 'face', info });
+      const additive = event.shiftKey;
+      pickSelection(
+        { kind: 'face', info, screenPos: { x: event.clientX, y: event.clientY } },
+        additive
+      );
       const snippet = buildFaceFinderSnippet(info);
       void copyToClipboard(snippet).then((copied) =>
         addToast(copied ? 'Face finder copied' : 'Face selected (clipboard unavailable)')
       );
     },
-    [data.faceGroups, faceInfoById, setSelection, addToast]
+    [data.faceGroups, faceInfoById, pickSelection, addToast]
   );
 
   const handlePointerOver = useCallback(() => {
@@ -96,7 +100,10 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
         polygonOffset
         polygonOffsetFactor={1}
         polygonOffsetUnits={1}
-        wireframe={showWireframe}
+        wireframe={viewMode === 'wireframe'}
+        transparent={viewMode === 'xray'}
+        opacity={viewMode === 'xray' ? 0.35 : 1}
+        depthWrite={viewMode !== 'xray'}
       />
     </mesh>
   );

--- a/site/src/components/playground/ShortcutHelp.tsx
+++ b/site/src/components/playground/ShortcutHelp.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
+import { SHORTCUTS, formatShortcut, isMac } from '../../lib/shortcuts';
 
 interface Props {
   open: boolean;
@@ -10,8 +10,6 @@ interface Row {
   label: string;
   keys: string;
 }
-
-const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
 const VIEWPORT_ROWS: Row[] = [
   { label: 'Pick face/edge', keys: 'Click' },

--- a/site/src/components/playground/ShortcutHelp.tsx
+++ b/site/src/components/playground/ShortcutHelp.tsx
@@ -1,0 +1,101 @@
+import { useEffect } from 'react';
+import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface Row {
+  label: string;
+  keys: string;
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
+
+const VIEWPORT_ROWS: Row[] = [
+  { label: 'Pick face/edge', keys: 'Click' },
+  { label: 'Add to selection', keys: 'Shift+Click' },
+  { label: 'Clear selection', keys: 'Click empty space' },
+];
+
+export default function ShortcutHelp({ open, onClose }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const editorRows: Row[] = Object.values(SHORTCUTS).map((def) => ({
+    label: def.label,
+    keys: formatShortcut(def),
+  }));
+  const helpRow: Row = {
+    label: 'Show this help',
+    keys: '?',
+  };
+  const paletteRow: Row = {
+    label: 'Command palette',
+    keys: isMac ? '⌘+K' : 'Ctrl+K',
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div
+        className="w-full max-w-md rounded-lg border border-border-subtle bg-surface p-5 shadow-xl"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-200">Keyboard shortcuts</h2>
+          <button
+            onClick={onClose}
+            className="text-xs text-gray-500 hover:text-gray-300"
+            aria-label="Close shortcut help"
+          >
+            Esc
+          </button>
+        </div>
+        <Section title="Actions" rows={[...editorRows, paletteRow, helpRow]} />
+        <Section title="Viewport" rows={VIEWPORT_ROWS} />
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, rows }: { title: string; rows: Row[] }) {
+  return (
+    <div className="mb-3 last:mb-0">
+      <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+        {title}
+      </div>
+      <div className="flex flex-col gap-1">
+        {rows.map((r) => (
+          <div key={r.label} className="flex items-center justify-between text-xs">
+            <span className="text-gray-300">{r.label}</span>
+            <kbd className="rounded border border-border-subtle bg-surface-overlay px-1.5 py-0.5 font-mono text-[10px] text-gray-300">
+              {r.keys}
+            </kbd>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/playground/StatusBar.tsx
+++ b/site/src/components/playground/StatusBar.tsx
@@ -14,7 +14,8 @@ export default function StatusBar() {
   const error = usePlaygroundStore((s) => s.error);
   const timeMs = usePlaygroundStore((s) => s.timeMs);
   const isRunning = usePlaygroundStore((s) => s.isRunning);
-  const selection = usePlaygroundStore((s) => s.selection);
+  const selections = usePlaygroundStore((s) => s.selections);
+  const lastSelection = selections[selections.length - 1] ?? null;
 
   let statusText: string;
   let statusColor: string;
@@ -50,9 +51,14 @@ export default function StatusBar() {
           <span className="text-gray-500">{timeMs.toFixed(0)}ms</span>
         )}
       </div>
-      {selection && (
+      {lastSelection && (
         <div className="flex min-w-0 items-center gap-2 truncate whitespace-nowrap text-gray-300">
-          <SelectionLine selection={selection} />
+          {selections.length > 1 && (
+            <span className="rounded bg-teal-primary/20 px-1.5 py-0.5 text-teal-light">
+              {selections.length} selected
+            </span>
+          )}
+          <SelectionLine selection={lastSelection} />
         </div>
       )}
     </div>

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -1,14 +1,16 @@
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrthographicCamera } from '@react-three/drei';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { usePlaygroundStore, type MeshData } from '../../stores/playgroundStore';
-import { useViewerStore } from '../../stores/viewerStore';
+import { useViewerStore, type Projection } from '../../stores/viewerStore';
 import { useCameraPresets } from '../../hooks/useCameraPresets';
 import { useTouchDevice } from '../../hooks/useTouchDevice';
 import SceneSetup from '../shared/SceneSetup';
 import ShapeRenderer from './ShapeRenderer';
 import EdgeRenderer from './EdgeRenderer';
 import ViewerToolbar from './ViewerToolbar';
+import SelectionTooltip from './SelectionTooltip';
 
 /**
  * Build a content-derived React key for a mesh. The store hands us a fresh
@@ -21,7 +23,7 @@ import ViewerToolbar from './ViewerToolbar';
 function meshKey(m: MeshData, fallback: number): string {
   const p = m.position;
   if (!p || p.length === 0) return `empty-${fallback}`;
-  const mid = (p.length / 6 | 0) * 3;
+  const mid = ((p.length / 6) | 0) * 3;
   return `${p.length}-${p[0]}-${p[mid] ?? 0}-${p[p.length - 1] ?? 0}`;
 }
 
@@ -87,7 +89,8 @@ function fitCamera(
   controls: any
 ) {
   const { center, radius } = bounds;
-  const fov = (camera as THREE.PerspectiveCamera).fov;
+  const isOrtho = (camera as THREE.OrthographicCamera).isOrthographicCamera === true;
+  const fov = isOrtho ? 45 : (camera as THREE.PerspectiveCamera).fov;
   const fovRad = (fov / 2) * (Math.PI / 180);
   const dist = (radius / Math.sin(fovRad)) * 1.2;
 
@@ -98,18 +101,28 @@ function fitCamera(
     center.z + dist * Math.cos(angle) * Math.sin(angle)
   );
 
+  if (isOrtho) {
+    // For ortho, fov-based distance is meaningless — set zoom so the
+    // bounding sphere fills ~80% of the smaller viewport dimension.
+    const ortho = camera as THREE.OrthographicCamera;
+    const viewSize = Math.min(ortho.right - ortho.left, ortho.top - ortho.bottom);
+    if (viewSize > 0 && radius > 0) {
+      ortho.zoom = viewSize / (radius * 2.4);
+    }
+  }
+
   if (controls?.target) {
     controls.target.copy(center);
     controls.update();
   }
-  (camera as THREE.PerspectiveCamera).updateProjectionMatrix();
+  (camera as THREE.PerspectiveCamera | THREE.OrthographicCamera).updateProjectionMatrix();
 }
 
 /**
  * Inner component that adjusts the camera to fit the model whenever meshes change
  * or a manual fit is requested via the viewer store.
  */
-function AutoFit({ meshes }: { meshes: MeshData[] }) {
+function AutoFit({ meshes, projection }: { meshes: MeshData[]; projection: Projection }) {
   const { camera, controls } = useThree();
   const bounds = useBoundsComputation(meshes);
   const prevBoundsKey = useRef('');
@@ -131,6 +144,14 @@ function AutoFit({ meshes }: { meshes: MeshData[] }) {
     if (fitRequest === 0 || !bounds || !controls) return;
     fitCamera(bounds, camera, controls);
   }, [fitRequest, bounds, camera, controls]);
+
+  // Re-fit on projection change so ortho zoom matches the model size.
+  useEffect(() => {
+    if (!bounds || !controls) return;
+    fitCamera(bounds, camera, controls);
+    // Only fire when projection actually flips, not on every bounds tick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bounds intentionally omitted
+  }, [projection, camera, controls]);
 
   return null;
 }
@@ -186,6 +207,29 @@ function CameraPresetBridge({ meshes }: { meshes: MeshData[] }) {
   return null;
 }
 
+/**
+ * Mounts an OrthographicCamera with `makeDefault` only when ortho is active,
+ * starting it at the current PerspectiveCamera's position so the swap is
+ * visually continuous. On unmount drei restores the canvas's PerspectiveCamera.
+ */
+function OrthoCameraSwitch() {
+  const { camera } = useThree();
+  // Snapshot the perspective camera's position at swap-in time (ref keeps the
+  // capture stable; React would otherwise re-read it on rerenders).
+  const initialPosition = useRef<[number, number, number]>(
+    camera.position.toArray() as [number, number, number]
+  );
+  return (
+    <OrthographicCamera
+      makeDefault
+      position={initialPosition.current}
+      zoom={20}
+      near={0.1}
+      far={2000}
+    />
+  );
+}
+
 const BASE_CONTROLS_PROPS = {
   enableDamping: true,
   dampingFactor: 0.12,
@@ -197,13 +241,16 @@ const BASE_CONTROLS_PROPS = {
 
 export default function ViewerPanel() {
   const meshes = usePlaygroundStore((s) => s.meshes);
-  const setSelection = usePlaygroundStore((s) => s.setSelection);
+  const clearSelections = usePlaygroundStore((s) => s.clearSelections);
   const showEdges = useViewerStore((s) => s.showEdges);
   const showGrid = useViewerStore((s) => s.showGrid);
-  const showWireframe = useViewerStore((s) => s.showWireframe);
+  const viewMode = useViewerStore((s) => s.viewMode);
+  const projection = useViewerStore((s) => s.projection);
   const clearPreset = useViewerStore((s) => s.clearPreset);
   const isTouch = useTouchDevice();
   const controlsRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const selections = usePlaygroundStore((s) => s.selections);
 
   const handleControlsStart = useCallback(() => {
     clearPreset();
@@ -212,8 +259,8 @@ export default function ViewerPanel() {
   // R3F fires onPointerMissed when a click hits the canvas but no mesh in
   // the scene — empty-space click clears the selection.
   const handlePointerMissed = useCallback(() => {
-    setSelection(null);
-  }, [setSelection]);
+    clearSelections();
+  }, [clearSelections]);
 
   // Snapshot the initial pointer-class via matchMedia so the props object we
   // hand drei stays stable across renders. Runtime device-class flips (a user
@@ -242,13 +289,14 @@ export default function ViewerPanel() {
   }, [isTouch]);
 
   return (
-    <div className="relative h-full w-full">
+    <div ref={containerRef} className="relative h-full w-full">
       <Canvas
         camera={{ position: [40, 30, 40], fov: 45, near: 0.1, far: 2000 }}
         frameloop="demand"
         gl={{ antialias: true, preserveDrawingBuffer: true }}
         onPointerMissed={handlePointerMissed}
       >
+        {projection === 'orthographic' && <OrthoCameraSwitch />}
         <SceneSetup
           gridVisible={showGrid}
           controlsProps={controlsProps}
@@ -256,24 +304,21 @@ export default function ViewerPanel() {
           onControlsStart={handleControlsStart}
         />
         <Invalidator />
-        <AutoFit meshes={meshes} />
+        <AutoFit meshes={meshes} projection={projection} />
         <CameraPresetBridge meshes={meshes} />
         <group rotation={[-Math.PI / 2, 0, 0]}>
           {meshes.map((m, i) => (
             <group key={meshKey(m, i)}>
               <ShapeRenderer data={m} />
-              {showEdges && !showWireframe && m.edges.length > 0 && (
-                <EdgeRenderer
-                  edges={m.edges}
-                  edgeGroups={m.edgeGroups}
-                  edgeInfos={m.edgeInfos}
-                />
+              {showEdges && viewMode !== 'wireframe' && m.edges.length > 0 && (
+                <EdgeRenderer edges={m.edges} edgeGroups={m.edgeGroups} edgeInfos={m.edgeInfos} />
               )}
             </group>
           ))}
         </group>
       </Canvas>
       <ViewerToolbar />
+      <SelectionTooltip selections={selections} containerRef={containerRef} />
     </div>
   );
 }

--- a/site/src/components/playground/ViewerToolbar.tsx
+++ b/site/src/components/playground/ViewerToolbar.tsx
@@ -1,22 +1,33 @@
-import { useViewerStore, type CameraPreset } from '../../stores/viewerStore';
+import { useViewerStore, type CameraPreset, type ViewMode } from '../../stores/viewerStore';
 
 export default function ViewerToolbar() {
-  const showWireframe = useViewerStore((s) => s.showWireframe);
+  const viewMode = useViewerStore((s) => s.viewMode);
   const showEdges = useViewerStore((s) => s.showEdges);
   const showGrid = useViewerStore((s) => s.showGrid);
+  const projection = useViewerStore((s) => s.projection);
   const activePreset = useViewerStore((s) => s.activePreset);
-  const toggleWireframe = useViewerStore((s) => s.toggleWireframe);
+  const setViewMode = useViewerStore((s) => s.setViewMode);
   const toggleEdges = useViewerStore((s) => s.toggleEdges);
   const toggleGrid = useViewerStore((s) => s.toggleGrid);
+  const toggleProjection = useViewerStore((s) => s.toggleProjection);
   const requestFit = useViewerStore((s) => s.requestFit);
   const setCameraPreset = useViewerStore((s) => s.setCameraPreset);
 
   return (
     <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-1">
       <ToolbarButton onClick={requestFit} label="Fit" active={false} />
-      <ToolbarButton onClick={toggleWireframe} label="Wire" active={showWireframe} />
+      <div className="my-1 border-t border-border-subtle" />
+      <ModeButton mode="solid" label="Solid" active={viewMode} onClick={setViewMode} />
+      <ModeButton mode="wireframe" label="Wire" active={viewMode} onClick={setViewMode} />
+      <ModeButton mode="xray" label="X-ray" active={viewMode} onClick={setViewMode} />
+      <div className="my-1 border-t border-border-subtle" />
       <ToolbarButton onClick={toggleEdges} label="Edges" active={showEdges} />
       <ToolbarButton onClick={toggleGrid} label="Grid" active={showGrid} />
+      <ToolbarButton
+        onClick={toggleProjection}
+        label={projection === 'orthographic' ? 'Ortho' : 'Persp'}
+        active={projection === 'orthographic'}
+      />
       <div className="my-1 border-t border-border-subtle" />
       <PresetButton preset="front" label="Front" active={activePreset} onClick={setCameraPreset} />
       <PresetButton preset="side" label="Side" active={activePreset} onClick={setCameraPreset} />
@@ -28,6 +39,34 @@ export default function ViewerToolbar() {
         onClick={setCameraPreset}
       />
     </div>
+  );
+}
+
+function ModeButton({
+  mode,
+  label,
+  active,
+  onClick,
+}: {
+  mode: ViewMode;
+  label: string;
+  active: ViewMode;
+  onClick: (mode: ViewMode) => void;
+}) {
+  return (
+    <button
+      onClick={() => {
+        onClick(mode);
+      }}
+      aria-pressed={active === mode}
+      className={`pointer-events-auto rounded px-2 py-1 text-xs font-medium transition-colors ${
+        active === mode
+          ? 'bg-teal-primary/20 text-teal-light'
+          : 'bg-surface/70 text-gray-500 hover:text-gray-300'
+      } border border-border-subtle backdrop-blur-sm`}
+    >
+      {label}
+    </button>
   );
 }
 

--- a/site/src/lib/shortcuts.ts
+++ b/site/src/lib/shortcuts.ts
@@ -45,7 +45,8 @@ export const SHORTCUTS: Record<string, ShortcutDef> = {
   },
 };
 
-const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
+export const isMac =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
 export function formatShortcut(def: ShortcutDef): string {
   const mod = isMac ? '\u2318' : 'Ctrl';

--- a/site/src/lib/shortcuts.ts
+++ b/site/src/lib/shortcuts.ts
@@ -36,6 +36,13 @@ export const SHORTCUTS: Record<string, ShortcutDef> = {
     label: 'Toggle Viewer',
     inEditor: false,
   },
+  commandPalette: {
+    id: 'commandPalette',
+    key: 'k',
+    ctrl: true,
+    shift: false,
+    label: 'Command Palette',
+  },
 };
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);

--- a/site/src/stores/playgroundStore.ts
+++ b/site/src/stores/playgroundStore.ts
@@ -13,9 +13,14 @@ export interface MeshData {
   edgeInfos?: EdgeInfo[];
 }
 
+export interface ScreenPos {
+  x: number;
+  y: number;
+}
+
 export type Selection =
-  | { kind: 'face'; info: FaceInfo }
-  | { kind: 'edge'; info: EdgeInfo };
+  | { kind: 'face'; info: FaceInfo; screenPos: ScreenPos }
+  | { kind: 'edge'; info: EdgeInfo; screenPos: ScreenPos };
 
 interface PlaygroundState {
   code: string;
@@ -29,7 +34,7 @@ interface PlaygroundState {
   isConsoleCollapsed: boolean;
   isViewerCollapsed: boolean;
   lastSuccessfulCode: string | null;
-  selection: Selection | null;
+  selections: Selection[];
 
   setCode: (code: string) => void;
   setMeshes: (meshes: MeshData[]) => void;
@@ -41,8 +46,16 @@ interface PlaygroundState {
   setConsoleCollapsed: (collapsed: boolean) => void;
   setViewerCollapsed: (collapsed: boolean) => void;
   setLastSuccessfulCode: (code: string) => void;
-  setSelection: (selection: Selection | null) => void;
+  pickSelection: (selection: Selection, additive: boolean) => void;
+  clearSelections: () => void;
   clearResults: () => void;
+}
+
+function sameEntity(a: Selection, b: Selection): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'face' && b.kind === 'face') return a.info.faceId === b.info.faceId;
+  if (a.kind === 'edge' && b.kind === 'edge') return a.info.edgeId === b.info.edgeId;
+  return false;
 }
 
 export const usePlaygroundStore = create<PlaygroundState>((set) => ({
@@ -57,12 +70,12 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   isConsoleCollapsed: false,
   isViewerCollapsed: false,
   lastSuccessfulCode: null,
-  selection: null,
+  selections: [],
 
   setCode: (code) => set({ code }),
-  // Drop the prior selection on every new render — selection is bound to the
-  // mesh by faceId/edgeId and the new mesh likely won't have the same ids.
-  setMeshes: (meshes) => set({ meshes, error: null, errorLine: null, selection: null }),
+  // Drop selections on every new render — they're bound to the mesh by
+  // faceId/edgeId and the new mesh likely won't have the same ids.
+  setMeshes: (meshes) => set({ meshes, error: null, errorLine: null, selections: [] }),
   setError: (error, line) => set({ error, errorLine: line ?? null }),
   setConsoleOutput: (consoleOutput) => set({ consoleOutput }),
   setTimeMs: (timeMs) => set({ timeMs }),
@@ -71,7 +84,17 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   setConsoleCollapsed: (isConsoleCollapsed) => set({ isConsoleCollapsed }),
   setViewerCollapsed: (isViewerCollapsed) => set({ isViewerCollapsed }),
   setLastSuccessfulCode: (lastSuccessfulCode) => set({ lastSuccessfulCode }),
-  setSelection: (selection) => set({ selection }),
+  pickSelection: (selection, additive) =>
+    set((s) => {
+      if (!additive) return { selections: [selection] };
+      const existing = s.selections.findIndex((sel) => sameEntity(sel, selection));
+      if (existing >= 0) {
+        // Toggle: shift-clicking an already-selected entity removes it.
+        return { selections: s.selections.filter((_, i) => i !== existing) };
+      }
+      return { selections: [...s.selections, selection] };
+    }),
+  clearSelections: () => set({ selections: [] }),
   clearResults: () =>
     set({
       meshes: [],
@@ -79,6 +102,6 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
       errorLine: null,
       consoleOutput: [],
       timeMs: null,
-      selection: null,
+      selections: [],
     }),
 }));

--- a/site/src/stores/viewerStore.ts
+++ b/site/src/stores/viewerStore.ts
@@ -1,37 +1,57 @@
 import { create } from 'zustand';
 
 export type CameraPreset = 'front' | 'side' | 'top' | 'isometric';
+export type ViewMode = 'solid' | 'wireframe' | 'xray';
+export type Projection = 'perspective' | 'orthographic';
 
 interface ViewerState {
-  showWireframe: boolean;
+  viewMode: ViewMode;
   showEdges: boolean;
   showGrid: boolean;
+  projection: Projection;
   fitRequest: number;
   activePreset: CameraPreset | null;
 
-  toggleWireframe: () => void;
+  setViewMode: (mode: ViewMode) => void;
+  cycleViewMode: () => void;
   toggleEdges: () => void;
   toggleGrid: () => void;
+  toggleProjection: () => void;
   requestFit: () => void;
   setCameraPreset: (preset: CameraPreset) => void;
   clearPreset: () => void;
 }
 
+const VIEW_MODE_CYCLE: ViewMode[] = ['solid', 'wireframe', 'xray'];
+
 export const useViewerStore = create<ViewerState>((set) => ({
-  showWireframe: false,
+  viewMode: 'solid',
   showEdges: true,
   showGrid: true,
+  projection: 'perspective',
   fitRequest: 0,
   activePreset: null,
 
-  toggleWireframe: () => {
-    set((s) => ({ showWireframe: !s.showWireframe }));
+  setViewMode: (viewMode) => {
+    set({ viewMode });
+  },
+  cycleViewMode: () => {
+    set((s) => {
+      const next =
+        VIEW_MODE_CYCLE[(VIEW_MODE_CYCLE.indexOf(s.viewMode) + 1) % VIEW_MODE_CYCLE.length];
+      return { viewMode: next ?? 'solid' };
+    });
   },
   toggleEdges: () => {
     set((s) => ({ showEdges: !s.showEdges }));
   },
   toggleGrid: () => {
     set((s) => ({ showGrid: !s.showGrid }));
+  },
+  toggleProjection: () => {
+    set((s) => ({
+      projection: s.projection === 'perspective' ? 'orthographic' : 'perspective',
+    }));
   },
   requestFit: () => {
     set((s) => ({ fitRequest: s.fitRequest + 1 }));


### PR DESCRIPTION
## Summary
Cherry-picks high-value UX from `brepjs-studio` while keeping the playground lightweight.

**Selection**
- Floating tooltip near the click, anchored to the viewport panel
- Shift-click extends selection (toggles existing entity off)
- Status bar shows count + last-picked summary

**Viewport**
- View mode picker: Solid / Wireframe / X-ray (replaces the single Wire toggle)
- Projection toggle: Persp / Ortho via drei `OrthographicCamera makeDefault`
- AutoFit re-runs on projection swap so ortho zoom matches model size

**Discoverability**
- Shortcut help overlay (`?`) listing all bindings
- Command palette (`Ctrl+K`) with fuzzy filter and arrow-key navigation, plus dedicated entries for view modes, edges/grid/projection toggles, and camera presets

## Test plan
- [ ] Click face → tooltip appears near cursor with surface type / area / facing
- [ ] Click edge → tooltip shows curve type / length
- [ ] Shift+click adds; shift+clicking same entity toggles it off
- [ ] Status bar shows "N selected" badge when multi-selected
- [ ] Ctrl+K opens palette; type "toggle gri" → Enter toggles grid; Esc closes
- [ ] Arrow keys move active row in palette; mouse hover follows
- [ ] `?` opens shortcut help; Esc closes; clicking backdrop closes
- [ ] Wire / X-ray buttons swap material; Persp ↔ Ortho toggle re-fits
- [ ] No regressions in existing flow: Run / STL / STEP / Share / shape clicks