### PR TITLE
feat(playground): viewport selection highlight + persist viewer settings

### DIFF
--- a/site/src/components/playground/SelectionHighlight.tsx
+++ b/site/src/components/playground/SelectionHighlight.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import type { MeshData } from '../../stores/playgroundStore';
+import type { Selection } from '../../stores/playgroundStore';
+
+interface Props {
+  data: MeshData;
+  selections: Selection[];
+}
+
+const FACE_COLOR = '#4ACECC';
+const EDGE_COLOR = '#fbbf24';
+
+/**
+ * Walk the selections list and pull out the ids that match this mesh's
+ * face/edge groups. With multi-shape evals the worker doesn't emit picking
+ * metadata at all (see workerProtocol.MeshTransfer comment), so each id
+ * matches at most one mesh in practice.
+ */
+function partitionIds(
+  data: MeshData,
+  selections: Selection[]
+): { faceIds: number[]; edgeIds: number[] } {
+  const faceById = new Map<number, true>();
+  if (data.faceGroups) for (const g of data.faceGroups) faceById.set(g.faceId, true);
+  const edgeById = new Map<number, true>();
+  if (data.edgeGroups) for (const g of data.edgeGroups) edgeById.set(g.edgeId, true);
+
+  const faceIds: number[] = [];
+  const edgeIds: number[] = [];
+  for (const sel of selections) {
+    if (sel.kind === 'face' && faceById.has(sel.info.faceId)) {
+      faceIds.push(sel.info.faceId);
+    } else if (sel.kind === 'edge' && edgeById.has(sel.info.edgeId)) {
+      edgeIds.push(sel.info.edgeId);
+    }
+  }
+  return { faceIds, edgeIds };
+}
+
+function buildFaceHighlightGeometry(
+  data: MeshData,
+  faceIds: number[]
+): THREE.BufferGeometry | null {
+  if (faceIds.length === 0 || !data.faceGroups || !data.index) return null;
+  const groupById = new Map(data.faceGroups.map((g) => [g.faceId, g]));
+
+  let total = 0;
+  const ranges: { start: number; count: number }[] = [];
+  for (const id of faceIds) {
+    const g = groupById.get(id);
+    if (g) {
+      ranges.push({ start: g.start, count: g.count });
+      total += g.count;
+    }
+  }
+  if (total === 0) return null;
+
+  const newIndex = new Uint32Array(total);
+  let off = 0;
+  for (const r of ranges) {
+    newIndex.set(data.index.subarray(r.start, r.start + r.count), off);
+    off += r.count;
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(data.position, 3));
+  geo.setAttribute('normal', new THREE.BufferAttribute(data.normal, 3));
+  geo.setIndex(new THREE.BufferAttribute(newIndex, 1));
+  return geo;
+}
+
+function buildEdgeHighlightGeometry(
+  data: MeshData,
+  edgeIds: number[]
+): THREE.BufferGeometry | null {
+  if (edgeIds.length === 0 || !data.edgeGroups) return null;
+  const groupById = new Map(data.edgeGroups.map((g) => [g.edgeId, g]));
+
+  let totalVerts = 0;
+  const ranges: { start: number; count: number }[] = [];
+  for (const id of edgeIds) {
+    const g = groupById.get(id);
+    if (g) {
+      ranges.push({ start: g.start, count: g.count });
+      totalVerts += g.count;
+    }
+  }
+  if (totalVerts === 0) return null;
+
+  const newPos = new Float32Array(totalVerts * 3);
+  let off = 0;
+  for (const r of ranges) {
+    newPos.set(data.edges.subarray(r.start * 3, (r.start + r.count) * 3), off);
+    off += r.count * 3;
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(newPos, 3));
+  return geo;
+}
+
+export default function SelectionHighlight({ data, selections }: Props) {
+  // Stable cache keys: ids only, so unrelated selection drift (e.g. screenPos
+  // updates from re-clicking the same face) doesn't rebuild geometry.
+  const { faceIds, edgeIds } = useMemo(() => partitionIds(data, selections), [data, selections]);
+  const faceKey = faceIds.join(',');
+  const edgeKey = edgeIds.join(',');
+
+  const faceGeometry = useMemo(
+    () => buildFaceHighlightGeometry(data, faceIds),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- faceIds is captured via faceKey
+    [data, faceKey]
+  );
+  const edgeGeometry = useMemo(
+    () => buildEdgeHighlightGeometry(data, edgeIds),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- edgeIds is captured via edgeKey
+    [data, edgeKey]
+  );
+
+  useEffect(() => {
+    return () => {
+      faceGeometry?.dispose();
+    };
+  }, [faceGeometry]);
+
+  useEffect(() => {
+    return () => {
+      edgeGeometry?.dispose();
+    };
+  }, [edgeGeometry]);
+
+  return (
+    <>
+      {faceGeometry && (
+        <mesh geometry={faceGeometry} raycast={skipRaycast} renderOrder={2}>
+          <meshStandardMaterial
+            color={FACE_COLOR}
+            emissive={FACE_COLOR}
+            emissiveIntensity={0.6}
+            metalness={0}
+            roughness={0.3}
+            side={THREE.DoubleSide}
+            transparent
+            opacity={0.55}
+            depthWrite={false}
+            polygonOffset
+            polygonOffsetFactor={-2}
+            polygonOffsetUnits={-2}
+          />
+        </mesh>
+      )}
+      {edgeGeometry && (
+        <lineSegments geometry={edgeGeometry} raycast={skipRaycast} renderOrder={3}>
+          <lineBasicMaterial color={EDGE_COLOR} linewidth={3} depthTest={false} transparent />
+        </lineSegments>
+      )}
+    </>
+  );
+}
+
+// The highlight overlay must never absorb pointer events — it sits on top of
+// the pickable mesh/edges and would otherwise block re-clicking the same
+// entity (or shift-click toggle-off).
+function skipRaycast() {
+  // intentionally empty
+}

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -11,6 +11,7 @@ import ShapeRenderer from './ShapeRenderer';
 import EdgeRenderer from './EdgeRenderer';
 import ViewerToolbar from './ViewerToolbar';
 import SelectionTooltip from './SelectionTooltip';
+import SelectionHighlight from './SelectionHighlight';
 
 /**
  * Build a content-derived React key for a mesh. The store hands us a fresh
@@ -313,6 +314,7 @@ export default function ViewerPanel() {
               {showEdges && viewMode !== 'wireframe' && m.edges.length > 0 && (
                 <EdgeRenderer edges={m.edges} edgeGroups={m.edgeGroups} edgeInfos={m.edgeInfos} />
               )}
+              <SelectionHighlight data={m} selections={selections} />
             </group>
           ))}
         </group>

--- a/site/src/stores/viewerStore.ts
+++ b/site/src/stores/viewerStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export type CameraPreset = 'front' | 'side' | 'top' | 'isometric';
 export type ViewMode = 'solid' | 'wireframe' | 'xray';
@@ -24,42 +25,59 @@ interface ViewerState {
 
 const VIEW_MODE_CYCLE: ViewMode[] = ['solid', 'wireframe', 'xray'];
 
-export const useViewerStore = create<ViewerState>((set) => ({
-  viewMode: 'solid',
-  showEdges: true,
-  showGrid: true,
-  projection: 'perspective',
-  fitRequest: 0,
-  activePreset: null,
+export const useViewerStore = create<ViewerState>()(
+  persist(
+    (set) => ({
+      viewMode: 'solid',
+      showEdges: true,
+      showGrid: true,
+      projection: 'perspective',
+      fitRequest: 0,
+      activePreset: null,
 
-  setViewMode: (viewMode) => {
-    set({ viewMode });
-  },
-  cycleViewMode: () => {
-    set((s) => {
-      const next =
-        VIEW_MODE_CYCLE[(VIEW_MODE_CYCLE.indexOf(s.viewMode) + 1) % VIEW_MODE_CYCLE.length];
-      return { viewMode: next ?? 'solid' };
-    });
-  },
-  toggleEdges: () => {
-    set((s) => ({ showEdges: !s.showEdges }));
-  },
-  toggleGrid: () => {
-    set((s) => ({ showGrid: !s.showGrid }));
-  },
-  toggleProjection: () => {
-    set((s) => ({
-      projection: s.projection === 'perspective' ? 'orthographic' : 'perspective',
-    }));
-  },
-  requestFit: () => {
-    set((s) => ({ fitRequest: s.fitRequest + 1 }));
-  },
-  setCameraPreset: (preset) => {
-    set({ activePreset: preset });
-  },
-  clearPreset: () => {
-    set({ activePreset: null });
-  },
-}));
+      setViewMode: (viewMode) => {
+        set({ viewMode });
+      },
+      cycleViewMode: () => {
+        set((s) => {
+          const next =
+            VIEW_MODE_CYCLE[(VIEW_MODE_CYCLE.indexOf(s.viewMode) + 1) % VIEW_MODE_CYCLE.length];
+          return { viewMode: next ?? 'solid' };
+        });
+      },
+      toggleEdges: () => {
+        set((s) => ({ showEdges: !s.showEdges }));
+      },
+      toggleGrid: () => {
+        set((s) => ({ showGrid: !s.showGrid }));
+      },
+      toggleProjection: () => {
+        set((s) => ({
+          projection: s.projection === 'perspective' ? 'orthographic' : 'perspective',
+        }));
+      },
+      requestFit: () => {
+        set((s) => ({ fitRequest: s.fitRequest + 1 }));
+      },
+      setCameraPreset: (preset) => {
+        set({ activePreset: preset });
+      },
+      clearPreset: () => {
+        set({ activePreset: null });
+      },
+    }),
+    {
+      name: 'brepjs-viewer-settings',
+      storage: createJSONStorage(() => localStorage),
+      // Persist only display preferences. fitRequest is a counter for one-shot
+      // signals and activePreset is a transient highlight state — neither
+      // belongs in storage.
+      partialize: (s) => ({
+        viewMode: s.viewMode,
+        showEdges: s.showEdges,
+        showGrid: s.showGrid,
+        projection: s.projection,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
Two follow-ups to PR #858 that close visible gaps in the click-to-inspect flow.

**Selection highlight** — picked face/edge now lights up directly in the 3D viewport (teal emissive overlay for faces, bright orange line for edges). Until now, selection was only visible in the status bar and floating tooltip, so users had to mentally map the chip back to geometry. Multi-select highlights everything in the list. The overlay opts out of raycasting so it never absorbs the next click.

**Persisted viewer settings** — view mode, edges/grid toggles, and projection survive a page reload via `zustand` `persist` middleware (`brepjs-viewer-settings`). Transient state (`fitRequest`, `activePreset`) is intentionally excluded via `partialize`.

## Test plan
- [ ] Click a face → it tints teal in the scene
- [ ] Click an edge → it draws thicker / brighter
- [ ] Shift+click a second face → both stay highlighted
- [ ] Shift+click already-selected → toggles off, highlight removed
- [ ] Click empty space → all highlights clear
- [ ] Toggle X-ray, then Ortho, then reload → both still active
- [ ] Toggle grid off, reload → grid stays off
- [ ] No regression: tooltip + status bar + clipboard copy still work