### PR TITLE
chore(playground): drop ignored linewidth on edge highlight

### DIFF
--- a/site/src/components/playground/SelectionHighlight.tsx
+++ b/site/src/components/playground/SelectionHighlight.tsx
@@ -152,7 +152,10 @@ export default function SelectionHighlight({ data, selections }: Props) {
       )}
       {edgeGeometry && (
         <lineSegments geometry={edgeGeometry} raycast={skipRaycast} renderOrder={3}>
-          <lineBasicMaterial color={EDGE_COLOR} linewidth={3} depthTest={false} transparent />
+          {/* `linewidth` is silently clamped to 1 in WebGL2 across every major
+              browser, so we lean on the bright color + depthTest=false (renders
+              on top of the base edges) to make the highlight readable. */}
+          <lineBasicMaterial color={EDGE_COLOR} depthTest={false} transparent />
         </lineSegments>
       )}
     </>


### PR DESCRIPTION
## Summary
Follow-up to #860. Greptile flagged that `lineBasicMaterial.linewidth` is silently clamped to 1 in WebGL2 across every major browser, so `linewidth={3}` never took effect. The edge highlight already stands out via color + `depthTest=false` rendering on top of the base edges. Comment captures the WebGL constraint so the next reader doesn't try to revive it.

The fix landed locally before #860 merged, but a race condition (PR auto-merged via the existing rule before my push hit GitHub) meant only the original commit shipped. This PR brings the fix to main.

## Test plan
- [ ] Click edge → visible orange highlight (color contrast handles readability)
- [ ] No regression in face highlight or selection state