### PR TITLE
feat(playground): console auto-scroll + error count badge

### DIFF
--- a/site/src/components/playground/CollapsedConsoleBar.tsx
+++ b/site/src/components/playground/CollapsedConsoleBar.tsx
@@ -1,8 +1,16 @@
+import { usePlaygroundStore } from '../../stores/playgroundStore';
+
 interface CollapsedConsoleBarProps {
   onExpand: () => void;
 }
 
 export default function CollapsedConsoleBar({ onExpand }: CollapsedConsoleBarProps) {
+  const consoleOutput = usePlaygroundStore((s) => s.consoleOutput);
+  const error = usePlaygroundStore((s) => s.error);
+
+  let errorCount = error ? 1 : 0;
+  for (const l of consoleOutput) if (l.startsWith('[error]')) errorCount++;
+
   return (
     <button
       onClick={onExpand}
@@ -12,6 +20,14 @@ export default function CollapsedConsoleBar({ onExpand }: CollapsedConsoleBarPro
         <path d="M4.5 10.5L8 7l3.5 3.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
       </svg>
       Console
+      {errorCount > 0 && (
+        <span
+          className="rounded-full bg-red-500/25 px-1.5 py-0.5 text-[10px] font-semibold text-red-300"
+          title={`${errorCount} error${errorCount === 1 ? '' : 's'}`}
+        >
+          {errorCount}
+        </span>
+      )}
     </button>
   );
 }

--- a/site/src/components/playground/CollapsedConsoleBar.tsx
+++ b/site/src/components/playground/CollapsedConsoleBar.tsx
@@ -1,4 +1,5 @@
 import { usePlaygroundStore } from '../../stores/playgroundStore';
+import { countErrors } from '../../lib/consoleStats';
 
 interface CollapsedConsoleBarProps {
   onExpand: () => void;
@@ -7,9 +8,7 @@ interface CollapsedConsoleBarProps {
 export default function CollapsedConsoleBar({ onExpand }: CollapsedConsoleBarProps) {
   const consoleOutput = usePlaygroundStore((s) => s.consoleOutput);
   const error = usePlaygroundStore((s) => s.error);
-
-  let errorCount = error ? 1 : 0;
-  for (const l of consoleOutput) if (l.startsWith('[error]')) errorCount++;
+  const errorCount = countErrors(consoleOutput, error);
 
   return (
     <button
@@ -22,7 +21,7 @@ export default function CollapsedConsoleBar({ onExpand }: CollapsedConsoleBarPro
       Console
       {errorCount > 0 && (
         <span
-          className="rounded-full bg-red-500/25 px-1.5 py-0.5 text-[10px] font-semibold text-red-300"
+          className="rounded-full bg-red-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-red-300"
           title={`${errorCount} error${errorCount === 1 ? '' : 's'}`}
         >
           {errorCount}

--- a/site/src/components/playground/OutputPanel.tsx
+++ b/site/src/components/playground/OutputPanel.tsx
@@ -1,14 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
+import { countErrors } from '../../lib/consoleStats';
 
 interface OutputPanelProps {
   onCollapse: () => void;
-}
-
-function countErrors(lines: string[], error: string | null): number {
-  let n = error ? 1 : 0;
-  for (const l of lines) if (l.startsWith('[error]')) n++;
-  return n;
 }
 
 export default function OutputPanel({ onCollapse }: OutputPanelProps) {
@@ -16,14 +11,14 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
   const error = usePlaygroundStore((s) => s.error);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  // Auto-scroll on new lines so the latest output is always visible. Triggers
-  // on length+error change rather than the consoleOutput reference itself
-  // because identity-equal arrays could otherwise short-circuit the effect.
-  const tick = consoleOutput.length + (error ? 1 : 0);
+  // Auto-scroll on new content. zustand replaces the array on every
+  // `setConsoleOutput`, so identity is a reliable change signal — counter
+  // arithmetic could collide across evals (eval A 4 lines → eval B error
+  // adds 1 → eval C 4 lines clears error: net same number, missed scroll).
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [tick]);
+  }, [consoleOutput, error]);
 
   const errorCount = countErrors(consoleOutput, error);
 

--- a/site/src/components/playground/OutputPanel.tsx
+++ b/site/src/components/playground/OutputPanel.tsx
@@ -1,17 +1,46 @@
+import { useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 
 interface OutputPanelProps {
   onCollapse: () => void;
 }
 
+function countErrors(lines: string[], error: string | null): number {
+  let n = error ? 1 : 0;
+  for (const l of lines) if (l.startsWith('[error]')) n++;
+  return n;
+}
+
 export default function OutputPanel({ onCollapse }: OutputPanelProps) {
   const consoleOutput = usePlaygroundStore((s) => s.consoleOutput);
   const error = usePlaygroundStore((s) => s.error);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll on new lines so the latest output is always visible. Triggers
+  // on length+error change rather than the consoleOutput reference itself
+  // because identity-equal arrays could otherwise short-circuit the effect.
+  const tick = consoleOutput.length + (error ? 1 : 0);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [tick]);
+
+  const errorCount = countErrors(consoleOutput, error);
 
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-gray-800 px-3 py-1">
-        <span className="text-xs font-medium text-gray-300">Console</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-gray-300">Console</span>
+          {errorCount > 0 && (
+            <span
+              className="rounded-full bg-red-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-red-300"
+              title={`${errorCount} error${errorCount === 1 ? '' : 's'}`}
+            >
+              {errorCount}
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-1">
           <button
             onClick={() => {
@@ -62,7 +91,11 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
           </button>
         </div>
       </div>
-      <div className="scrollbar-thin flex-1 overflow-auto p-2 font-mono text-xs" aria-live="polite">
+      <div
+        ref={scrollRef}
+        className="scrollbar-thin flex-1 overflow-auto p-2 font-mono text-xs"
+        aria-live="polite"
+      >
         {consoleOutput.length === 0 && !error ? (
           <div className="flex h-full items-center justify-center text-gray-500">
             Console output appears here

--- a/site/src/lib/consoleStats.ts
+++ b/site/src/lib/consoleStats.ts
@@ -1,0 +1,9 @@
+// Counts errors visible in the console: every line tagged `[error]` from
+// `console.error` plus the eval-level `error` field set when a run throws.
+// Shared between OutputPanel (expanded header badge) and CollapsedConsoleBar
+// so the two badges always agree.
+export function countErrors(lines: readonly string[], error: string | null): number {
+  let n = error ? 1 : 0;
+  for (const l of lines) if (l.startsWith('[error]')) n++;
+  return n;
+}


### PR DESCRIPTION
## Summary
Two small studio-style polishes to the console panel.

- **Auto-scroll** to the bottom on new lines so the latest output is always visible. Previously a long prior eval would leave the console scrolled mid-buffer when the next eval ran, hiding what the user actually wanted to see.
- **Error count badge** in the expanded console header **and** on the collapsed bar, so a hidden console can't silently swallow errors. Counts both `[error]` lines from `console.error` and the eval-level `error` field.

## Test plan
- [ ] Run code that prints many lines → console scrolls to the bottom automatically
- [ ] Run code that throws → red badge with "1" appears in the header
- [ ] Collapse the console panel → red badge appears next to "Console" in the bar
- [ ] Click clear → badge disappears