### PR TITLE
feat(playground): persist editor draft to localStorage

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -5,9 +5,11 @@ import { useViewerStore } from '../../stores/viewerStore';
 import { useToastStore } from '../../stores/toastStore';
 import { useCodeExecution } from '../../hooks/useCodeExecution';
 import { useUrlState } from '../../hooks/useUrlState';
+import { useDraftPersistence, clearDraft } from '../../hooks/useDraftPersistence';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
+import { DEFAULT_CODE } from '../../lib/constants';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
 import ViewerPanel from './ViewerPanel';
@@ -34,6 +36,7 @@ export default function PlaygroundPage() {
   const addToast = useToastStore((s) => s.addToast);
   const { runCode, exportSTL, exportSTEP, debouncedRun } = useCodeExecution();
   const { updateUrl, copyShareUrl } = useUrlState();
+  useDraftPersistence();
 
   const consolePanelRef = usePanelRef();
   const viewerPanelRef = usePanelRef();
@@ -88,6 +91,12 @@ export default function PlaygroundPage() {
     void copyShareUrl(code);
     addToast('Link copied to clipboard');
   }, [copyShareUrl, code, addToast]);
+
+  const handleResetToDefault = useCallback(() => {
+    usePlaygroundStore.getState().setCode(DEFAULT_CODE);
+    clearDraft();
+    addToast('Reset to default code');
+  }, [addToast]);
 
   const toggleConsole = useCallback(() => {
     const panel = consolePanelRef.current;
@@ -296,6 +305,12 @@ export default function PlaygroundPage() {
         },
       },
       {
+        id: 'reset-default',
+        group: 'Editor',
+        label: 'Reset to default code',
+        run: handleResetToDefault,
+      },
+      {
         id: 'help',
         group: 'Help',
         label: 'Show keyboard shortcuts',
@@ -308,6 +323,7 @@ export default function PlaygroundPage() {
     [
       handleRun,
       handleShare,
+      handleResetToDefault,
       handleExportSTL,
       handleExportSTEP,
       handleFormat,

--- a/site/src/hooks/useDraftPersistence.ts
+++ b/site/src/hooks/useDraftPersistence.ts
@@ -1,13 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../stores/playgroundStore';
 import { DEFAULT_CODE } from '../lib/constants';
+import { hasShareParams } from '../lib/urlCodec';
 
 const DRAFT_KEY = 'brepjs-playground-draft';
 const DEBOUNCE_MS = 500;
-
-function hasShareParams(url: URL): boolean {
-  return url.searchParams.has('code') || url.hash.startsWith('#code/');
-}
 
 /**
  * Persists the editor code to localStorage so an accidental tab close doesn't
@@ -20,13 +17,9 @@ function hasShareParams(url: URL): boolean {
 export function useDraftPersistence() {
   const code = usePlaygroundStore((s) => s.code);
   const setCode = usePlaygroundStore((s) => s.setCode);
-  const initialized = useRef(false);
 
   // One-shot: restore from draft on mount if appropriate.
   useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
-
     const url = new URL(window.location.href);
     if (hasShareParams(url)) return;
 
@@ -42,10 +35,23 @@ export function useDraftPersistence() {
     setCode(draft);
   }, [setCode]);
 
-  // Debounced save on every code change. Skip the very first synchronous
-  // tick so we don't write the default before any user input.
+  // Debounced save on every code change. Two guards:
+  //   1. savedOnce: skip the very first call so we don't write the default
+  //      (or a freshly-restored draft) right back. The previous version used
+  //      the restore effect's `initialized` ref, but React fires effects in
+  //      declaration order so that ref was always `true` by the time this
+  //      effect ran — making the guard dead.
+  //   2. hasShareParams: when the URL carries `?code=` or `#code/`, the
+  //      pending `code` is the shared payload, not the user's own work.
+  //      Writing it would silently clobber whatever draft they had on a
+  //      future fresh visit.
+  const savedOnce = useRef(false);
   useEffect(() => {
-    if (!initialized.current) return;
+    if (!savedOnce.current) {
+      savedOnce.current = true;
+      return;
+    }
+    if (hasShareParams(new URL(window.location.href))) return;
     const t = setTimeout(() => {
       try {
         localStorage.setItem(DRAFT_KEY, code);

--- a/site/src/hooks/useDraftPersistence.ts
+++ b/site/src/hooks/useDraftPersistence.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+import { usePlaygroundStore } from '../stores/playgroundStore';
+import { DEFAULT_CODE } from '../lib/constants';
+
+const DRAFT_KEY = 'brepjs-playground-draft';
+const DEBOUNCE_MS = 500;
+
+function hasShareParams(url: URL): boolean {
+  return url.searchParams.has('code') || url.hash.startsWith('#code/');
+}
+
+/**
+ * Persists the editor code to localStorage so an accidental tab close doesn't
+ * lose unrun work. On mount, restores the draft only when the URL has no
+ * share params — share links always win because they were chosen explicitly.
+ *
+ * Pair with useUrlState: that hook runs first and has already settled any
+ * URL-decoded code by the time this effect's restore branch checks the URL.
+ */
+export function useDraftPersistence() {
+  const code = usePlaygroundStore((s) => s.code);
+  const setCode = usePlaygroundStore((s) => s.setCode);
+  const initialized = useRef(false);
+
+  // One-shot: restore from draft on mount if appropriate.
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    const url = new URL(window.location.href);
+    if (hasShareParams(url)) return;
+
+    let draft: string | null = null;
+    try {
+      draft = localStorage.getItem(DRAFT_KEY);
+    } catch {
+      return;
+    }
+    // Skip restore when the draft matches the default — that's just noise
+    // (user never edited last time).
+    if (!draft || draft === DEFAULT_CODE) return;
+    setCode(draft);
+  }, [setCode]);
+
+  // Debounced save on every code change. Skip the very first synchronous
+  // tick so we don't write the default before any user input.
+  useEffect(() => {
+    if (!initialized.current) return;
+    const t = setTimeout(() => {
+      try {
+        localStorage.setItem(DRAFT_KEY, code);
+      } catch {
+        // localStorage can throw under quota or privacy settings — silently
+        // give up; the draft is best-effort, not load-bearing.
+      }
+    }, DEBOUNCE_MS);
+    return () => {
+      clearTimeout(t);
+    };
+  }, [code]);
+}
+
+export function clearDraft(): void {
+  try {
+    localStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/site/src/hooks/useUrlState.ts
+++ b/site/src/hooks/useUrlState.ts
@@ -1,11 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../stores/playgroundStore';
 import { useToastStore } from '../stores/toastStore';
-import { decodeShare, encodeCodeQuery } from '../lib/urlCodec';
-
-function hasShareParams(url: URL): boolean {
-  return url.searchParams.has('code') || url.hash.startsWith('#code/');
-}
+import { decodeShare, encodeCodeQuery, hasShareParams } from '../lib/urlCodec';
 
 export function useUrlState() {
   const setCode = usePlaygroundStore((s) => s.setCode);

--- a/site/src/lib/urlCodec.ts
+++ b/site/src/lib/urlCodec.ts
@@ -6,6 +6,13 @@ export function encodeCodeQuery(code: string): string {
   return `?code=${compressToEncodedURIComponent(code)}`;
 }
 
+// Whether the URL carries an explicit share payload (`?code=` or legacy
+// `#code/`). Shared link URLs always take precedence over local drafts —
+// the user picked them on purpose.
+export function hasShareParams(url: URL): boolean {
+  return url.searchParams.has('code') || url.hash.startsWith('#code/');
+}
+
 // Reads `?code=` first; falls back to the legacy `#code/` hash format so links
 // shared before the format change still resolve.
 export function decodeShare(url: URL): DecodedShare | null {


### PR DESCRIPTION
## Summary
Auto-saves the editor code (debounced 500ms) so an accidental tab close doesn't lose unrun work. On reload, restores the draft **only when the URL has no share params** — share links always win because they were chosen explicitly.

Also adds a "Reset to default code" command in the palette so users can escape a bad draft without manually clearing storage.

Pairs with #860's persisted viewer settings: now both code and viewport state survive a refresh.

## Implementation notes
- New hook \`useDraftPersistence\` mounts a one-shot restore effect plus a debounced-write effect.
- Restore checks the live URL — not the current \`code\` value — so it can't race with \`useUrlState\`.
- localStorage writes are wrapped in try/catch (quota / privacy mode tolerant); the draft is best-effort, not load-bearing.
- \`clearDraft\` is exported for the "Reset to default" path.

## Test plan
- [ ] Type code, refresh tab → typed code restored
- [ ] Type code, click Share, refresh URL → URL code wins, draft replaced
- [ ] Open \`/playground/?code=...\` link → URL wins, draft ignored on first load
- [ ] Run "Reset to default code" from palette → editor jumps to default, draft cleared
- [ ] Refresh after Reset → default code stays (no draft to restore)