### PR TITLE
feat(playground): preview copied snippet inside selection tooltip

### DIFF
--- a/site/src/components/playground/SelectionTooltip.tsx
+++ b/site/src/components/playground/SelectionTooltip.tsx
@@ -86,16 +86,17 @@ function SingleTooltip({ selection }: { selection: Selection }) {
   );
 }
 
-// Shows the finder predicate that was just copied to the clipboard. Without
-// this, users only saw a transient toast — the tooltip is the persistent
-// confirmation of *what* landed in their clipboard, ready to paste.
+// Shows the finder predicate the click produced. We previously labeled this
+// "Copied to clipboard" but the actual clipboard write is async and can fail
+// (denied permission, insecure context); a neutral label doesn't make a
+// promise the UI can't keep — the toast still reports clipboard success/fail.
 function SnippetPreview({ snippet }: { snippet: string }) {
   return (
     <div className="mt-1 border-t border-border-subtle pt-1">
       <div className="mb-0.5 text-[10px] uppercase tracking-wider text-gray-500">
-        Copied to clipboard
+        Finder predicate
       </div>
-      <pre className="whitespace-pre-wrap break-all text-[10.5px] leading-snug text-teal-light/90">
+      <pre className="whitespace-pre-wrap break-words text-[10.5px] leading-snug text-teal-light/90">
         {snippet}
       </pre>
     </div>

--- a/site/src/components/playground/SelectionTooltip.tsx
+++ b/site/src/components/playground/SelectionTooltip.tsx
@@ -6,6 +6,7 @@ import {
   formatNormalDirection,
   formatSurfaceType,
 } from '../../lib/selectionLabels';
+import { buildEdgeFinderSnippet, buildFaceFinderSnippet } from '../../lib/finderSnippet';
 import type { Selection } from '../../stores/playgroundStore';
 
 interface Props {
@@ -71,6 +72,7 @@ function SingleTooltip({ selection }: { selection: Selection }) {
         <div className="font-semibold text-teal-light">{formatSurfaceType(f.surfaceType)}</div>
         <div className="text-gray-400">Area: {formatArea(f.area)}</div>
         <div className="text-gray-400">Facing: {formatNormalDirection(f.normal)}</div>
+        <SnippetPreview snippet={buildFaceFinderSnippet(f)} />
       </div>
     );
   }
@@ -79,6 +81,23 @@ function SingleTooltip({ selection }: { selection: Selection }) {
     <div className="flex flex-col gap-0.5">
       <div className="font-semibold text-teal-light">{formatCurveType(e.curveType)}</div>
       <div className="text-gray-400">Length: {formatLength(e.length)}</div>
+      <SnippetPreview snippet={buildEdgeFinderSnippet(e)} />
+    </div>
+  );
+}
+
+// Shows the finder predicate that was just copied to the clipboard. Without
+// this, users only saw a transient toast — the tooltip is the persistent
+// confirmation of *what* landed in their clipboard, ready to paste.
+function SnippetPreview({ snippet }: { snippet: string }) {
+  return (
+    <div className="mt-1 border-t border-border-subtle pt-1">
+      <div className="mb-0.5 text-[10px] uppercase tracking-wider text-gray-500">
+        Copied to clipboard
+      </div>
+      <pre className="whitespace-pre-wrap break-all text-[10.5px] leading-snug text-teal-light/90">
+        {snippet}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
After clicking a face or edge, users had three forms of feedback (highlight + tooltip + toast) but none of them showed *what was actually copied* to the clipboard. The toast vanishes; the tooltip shows metadata only. This PR adds a "Copied to clipboard" preview of the finder predicate inside the tooltip so users can read it at their own pace before pasting.

Pairs with the existing click-to-copy flow (#856).

## Test plan
- [ ] Click a face → tooltip shows surface type / area / facing **and** the \`faceFinder().ofSurfaceType(...).inDirection(...).withArea(...)\` snippet
- [ ] Click an edge → tooltip shows curve type / length **and** the \`edgeFinder().ofCurveType(...).withLength(...)\` snippet
- [ ] Multi-select → tooltip stays in count mode (no preview), unchanged