### PR TITLE
feat(playground): hover preview shows face/edge metadata before commit

### DIFF
--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -86,7 +86,11 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
 
   // pointermove updates hoverEntity each frame so the tooltip tracks the
   // cursor across the same edge. Cost is one shallow store merge per move
-  // and re-renders only the tooltip via zustand selectors.
+  // and re-renders only the tooltip via zustand selectors. Stop propagation
+  // so the underlying face mesh's onPointerMove doesn't fire after this and
+  // overwrite the hoverEntity with a face — R3F dispatches to every
+  // intersected object in the same frame, so without this the edge would
+  // never win.
   const handlePointerMove = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
       if (!edgeGroups || !edgeInfoById) return;
@@ -96,6 +100,7 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
       if (!group) return;
       const info = edgeInfoById.get(group.edgeId);
       if (!info) return;
+      event.stopPropagation();
       setHoverEntity({
         kind: 'edge',
         info,

--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -30,6 +30,7 @@ function findGroupAt(groups: EdgeGroup[], vertexIndex: number): EdgeGroup | null
 
 export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   const pickSelection = usePlaygroundStore((s) => s.pickSelection);
+  const setHoverEntity = usePlaygroundStore((s) => s.setHoverEntity);
   const addToast = useToastStore((s) => s.addToast);
   const pickable = Boolean(edgeGroups && edgeInfos);
 
@@ -80,16 +81,40 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   }, []);
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = '';
-  }, []);
+    setHoverEntity(null);
+  }, [setHoverEntity]);
+
+  // pointermove updates hoverEntity each frame so the tooltip tracks the
+  // cursor across the same edge. Cost is one shallow store merge per move
+  // and re-renders only the tooltip via zustand selectors.
+  const handlePointerMove = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (!edgeGroups || !edgeInfoById) return;
+      const vertexIndex = event.index;
+      if (vertexIndex === undefined) return;
+      const group = findGroupAt(edgeGroups, vertexIndex);
+      if (!group) return;
+      const info = edgeInfoById.get(group.edgeId);
+      if (!info) return;
+      setHoverEntity({
+        kind: 'edge',
+        info,
+        screenPos: { x: event.clientX, y: event.clientY },
+      });
+    },
+    [edgeGroups, edgeInfoById, setHoverEntity]
+  );
 
   // R3F doesn't synthesize `pointerout` for an object that gets unmounted
   // mid-hover (e.g. a new eval drops the previous mesh). Without this
-  // cleanup the body cursor stays `pointer` for the rest of the session.
+  // cleanup the body cursor stays `pointer` for the rest of the session
+  // and the hover tooltip would linger pointing at a destroyed mesh.
   useEffect(() => {
     return () => {
       document.body.style.cursor = '';
+      setHoverEntity(null);
     };
-  }, []);
+  }, [setHoverEntity]);
 
   return (
     <lineSegments
@@ -98,6 +123,7 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
       onClick={pickable ? handleClick : undefined}
       onPointerOver={pickable ? handlePointerOver : undefined}
       onPointerOut={pickable ? handlePointerOut : undefined}
+      onPointerMove={pickable ? handlePointerMove : undefined}
       raycast={raycastLines}
     >
       <lineBasicMaterial color="#000000" depthTest={true} linewidth={2} />

--- a/site/src/components/playground/SelectionTooltip.tsx
+++ b/site/src/components/playground/SelectionTooltip.tsx
@@ -11,6 +11,7 @@ import type { Selection } from '../../stores/playgroundStore';
 
 interface Props {
   selections: Selection[];
+  hoverEntity: Selection | null;
   containerRef: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -18,10 +19,15 @@ const OFFSET_X = 12;
 const OFFSET_Y = 12;
 const EDGE_PADDING = 8;
 
-export default function SelectionTooltip({ selections, containerRef }: Props) {
+export default function SelectionTooltip({ selections, hoverEntity, containerRef }: Props) {
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
-  const last = selections[selections.length - 1] ?? null;
+  // Hover wins over selection while present — the user is actively pointing at
+  // something new, so the tooltip should follow their attention. When the
+  // pointer leaves the mesh, hoverEntity nulls and we fall back to the most
+  // recent selection (the persistent confirmation of what they last picked).
+  const last = hoverEntity ?? selections[selections.length - 1] ?? null;
+  const isHover = hoverEntity !== null;
 
   // Keep the tooltip pinned next to the click position while clamping to the
   // viewport panel so it never escapes the canvas. useLayoutEffect avoids a
@@ -55,16 +61,18 @@ export default function SelectionTooltip({ selections, containerRef }: Props) {
       style={pos ?? { left: -9999, top: -9999 }}
       role="tooltip"
     >
-      {selections.length > 1 ? (
+      {!isHover && selections.length > 1 ? (
         <MultiTooltip selections={selections} />
       ) : (
-        <SingleTooltip selection={last} />
+        <SingleTooltip selection={last} isHover={isHover} />
       )}
     </div>
   );
 }
 
-function SingleTooltip({ selection }: { selection: Selection }) {
+function SingleTooltip({ selection, isHover }: { selection: Selection; isHover: boolean }) {
+  // Hover state shows metadata only — the snippet preview is committed UI
+  // that pairs with a clipboard write, and we haven't written anything yet.
   if (selection.kind === 'face') {
     const f = selection.info;
     return (
@@ -72,7 +80,7 @@ function SingleTooltip({ selection }: { selection: Selection }) {
         <div className="font-semibold text-teal-light">{formatSurfaceType(f.surfaceType)}</div>
         <div className="text-gray-400">Area: {formatArea(f.area)}</div>
         <div className="text-gray-400">Facing: {formatNormalDirection(f.normal)}</div>
-        <SnippetPreview snippet={buildFaceFinderSnippet(f)} />
+        {!isHover && <SnippetPreview snippet={buildFaceFinderSnippet(f)} />}
       </div>
     );
   }
@@ -81,7 +89,7 @@ function SingleTooltip({ selection }: { selection: Selection }) {
     <div className="flex flex-col gap-0.5">
       <div className="font-semibold text-teal-light">{formatCurveType(e.curveType)}</div>
       <div className="text-gray-400">Length: {formatLength(e.length)}</div>
-      <SnippetPreview snippet={buildEdgeFinderSnippet(e)} />
+      {!isHover && <SnippetPreview snippet={buildEdgeFinderSnippet(e)} />}
     </div>
   );
 }

--- a/site/src/components/playground/ShapeRenderer.tsx
+++ b/site/src/components/playground/ShapeRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { MeshData } from '../../stores/playgroundStore';
@@ -12,6 +12,7 @@ import { useToastStore } from '../../stores/toastStore';
 export default function ShapeRenderer({ data }: { data: MeshData }) {
   const viewMode = useViewerStore((s) => s.viewMode);
   const pickSelection = usePlaygroundStore((s) => s.pickSelection);
+  const setHoverEntity = usePlaygroundStore((s) => s.setHoverEntity);
   const addToast = useToastStore((s) => s.addToast);
   const pickable = Boolean(data.faceGroups && data.faceInfos);
 
@@ -72,16 +73,45 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
   }, []);
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = '';
-  }, []);
+    lastHoverIdRef.current = null;
+    setHoverEntity(null);
+  }, [setHoverEntity]);
+
+  // pointermove fires per-frame while hovering. We update on every tick so
+  // the tooltip follows the cursor (cheap: one shallow-merge re-renders just
+  // the tooltip via zustand selectors). lastHoverIdRef holds the active face
+  // id so handlePointerOut can avoid clearing a stale hover after we've
+  // already moved off this mesh into another.
+  const lastHoverIdRef = useRef<number | null>(null);
+  const handlePointerMove = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (!data.faceGroups || !faceInfoById) return;
+      const materialIndex = event.face?.materialIndex;
+      if (materialIndex === undefined) return;
+      const group = data.faceGroups[materialIndex];
+      if (!group) return;
+      const info = faceInfoById.get(group.faceId);
+      if (!info) return;
+      lastHoverIdRef.current = group.faceId;
+      setHoverEntity({
+        kind: 'face',
+        info,
+        screenPos: { x: event.clientX, y: event.clientY },
+      });
+    },
+    [data.faceGroups, faceInfoById, setHoverEntity]
+  );
 
   // R3F doesn't synthesize `pointerout` for an object that gets unmounted
   // mid-hover (e.g. a new eval drops the previous mesh). Without this
-  // cleanup the body cursor stays `pointer` for the rest of the session.
+  // cleanup the body cursor stays `pointer` for the rest of the session
+  // and the hover tooltip would linger pointing at a destroyed mesh.
   useEffect(() => {
     return () => {
       document.body.style.cursor = '';
+      setHoverEntity(null);
     };
-  }, []);
+  }, [setHoverEntity]);
 
   return (
     <mesh
@@ -89,6 +119,7 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
       onClick={pickable ? handleClick : undefined}
       onPointerOver={pickable ? handlePointerOver : undefined}
       onPointerOut={pickable ? handlePointerOut : undefined}
+      onPointerMove={pickable ? handlePointerMove : undefined}
     >
       <meshStandardMaterial
         color="#d4d8dc"

--- a/site/src/components/playground/ShapeRenderer.tsx
+++ b/site/src/components/playground/ShapeRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { MeshData } from '../../stores/playgroundStore';
@@ -73,16 +73,12 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
   }, []);
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = '';
-    lastHoverIdRef.current = null;
     setHoverEntity(null);
   }, [setHoverEntity]);
 
   // pointermove fires per-frame while hovering. We update on every tick so
-  // the tooltip follows the cursor (cheap: one shallow-merge re-renders just
-  // the tooltip via zustand selectors). lastHoverIdRef holds the active face
-  // id so handlePointerOut can avoid clearing a stale hover after we've
-  // already moved off this mesh into another.
-  const lastHoverIdRef = useRef<number | null>(null);
+  // the tooltip follows the cursor — cost is one shallow store merge per
+  // move and re-renders only the tooltip via zustand selectors.
   const handlePointerMove = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
       if (!data.faceGroups || !faceInfoById) return;
@@ -92,7 +88,6 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
       if (!group) return;
       const info = faceInfoById.get(group.faceId);
       if (!info) return;
-      lastHoverIdRef.current = group.faceId;
       setHoverEntity({
         kind: 'face',
         info,

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -252,6 +252,7 @@ export default function ViewerPanel() {
   const controlsRef = useRef(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const selections = usePlaygroundStore((s) => s.selections);
+  const hoverEntity = usePlaygroundStore((s) => s.hoverEntity);
 
   const handleControlsStart = useCallback(() => {
     clearPreset();
@@ -320,7 +321,11 @@ export default function ViewerPanel() {
         </group>
       </Canvas>
       <ViewerToolbar />
-      <SelectionTooltip selections={selections} containerRef={containerRef} />
+      <SelectionTooltip
+        selections={selections}
+        hoverEntity={hoverEntity}
+        containerRef={containerRef}
+      />
     </div>
   );
 }

--- a/site/src/stores/playgroundStore.ts
+++ b/site/src/stores/playgroundStore.ts
@@ -35,6 +35,7 @@ interface PlaygroundState {
   isViewerCollapsed: boolean;
   lastSuccessfulCode: string | null;
   selections: Selection[];
+  hoverEntity: Selection | null;
 
   setCode: (code: string) => void;
   setMeshes: (meshes: MeshData[]) => void;
@@ -48,6 +49,7 @@ interface PlaygroundState {
   setLastSuccessfulCode: (code: string) => void;
   pickSelection: (selection: Selection, additive: boolean) => void;
   clearSelections: () => void;
+  setHoverEntity: (entity: Selection | null) => void;
   clearResults: () => void;
 }
 
@@ -71,11 +73,13 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   isViewerCollapsed: false,
   lastSuccessfulCode: null,
   selections: [],
+  hoverEntity: null,
 
   setCode: (code) => set({ code }),
   // Drop selections on every new render — they're bound to the mesh by
   // faceId/edgeId and the new mesh likely won't have the same ids.
-  setMeshes: (meshes) => set({ meshes, error: null, errorLine: null, selections: [] }),
+  setMeshes: (meshes) =>
+    set({ meshes, error: null, errorLine: null, selections: [], hoverEntity: null }),
   setError: (error, line) => set({ error, errorLine: line ?? null }),
   setConsoleOutput: (consoleOutput) => set({ consoleOutput }),
   setTimeMs: (timeMs) => set({ timeMs }),
@@ -95,6 +99,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
       return { selections: [...s.selections, selection] };
     }),
   clearSelections: () => set({ selections: [] }),
+  setHoverEntity: (hoverEntity) => set({ hoverEntity }),
   clearResults: () =>
     set({
       meshes: [],
@@ -103,5 +108,6 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
       consoleOutput: [],
       timeMs: null,
       selections: [],
+      hoverEntity: null,
     }),
 }));


### PR DESCRIPTION
## Summary
Hovering a face or edge now shows its metadata in the floating tooltip without requiring a click — the way every CAD tool works. Click still commits the selection (highlight + clipboard + persistent tooltip); hover is purely informational and omits the snippet preview because no clipboard write happens until the user actually picks.

## Implementation
- New \`hoverEntity\` field in \`playgroundStore\` (separate from \`selections\`).
- \`ShapeRenderer\` + \`EdgeRenderer\` push the current face/edge under the cursor on every \`pointermove\`. Cost is one shallow store merge per frame; re-renders are scoped to the tooltip thanks to zustand selectors.
- \`pointerout\` and unmount clear \`hoverEntity\` so a destroyed mesh can't leave a stale tooltip.
- \`SelectionTooltip\` prefers \`hoverEntity\` over the most recent selection while present, falling back to selection on \`pointerout\`.

## Test plan
- [ ] Hover a face → tooltip shows surface type / area / facing without clicking
- [ ] Move cursor across faces → tooltip updates
- [ ] Click → tooltip commits with snippet preview, clipboard toast fires
- [ ] Move cursor off mesh → tooltip falls back to last selection
- [ ] Hover edge → tooltip shows curve type / length
- [ ] Run new code while hovering → tooltip clears (no stale ref to old mesh)