### PR TITLE
feat(playground): hovered face/edge gets a faint 3D highlight overlay

### DIFF
--- a/site/src/components/playground/SelectionHighlight.tsx
+++ b/site/src/components/playground/SelectionHighlight.tsx
@@ -6,6 +6,7 @@ import type { Selection } from '../../stores/playgroundStore';
 interface Props {
   data: MeshData;
   selections: Selection[];
+  hoverEntity: Selection | null;
 }
 
 const FACE_COLOR = '#4ACECC';
@@ -100,7 +101,7 @@ function buildEdgeHighlightGeometry(
   return geo;
 }
 
-export default function SelectionHighlight({ data, selections }: Props) {
+export default function SelectionHighlight({ data, selections, hoverEntity }: Props) {
   // Stable cache keys: ids only, so unrelated selection drift (e.g. screenPos
   // updates from re-clicking the same face) doesn't rebuild geometry.
   const { faceIds, edgeIds } = useMemo(() => partitionIds(data, selections), [data, selections]);
@@ -118,6 +119,38 @@ export default function SelectionHighlight({ data, selections }: Props) {
     [data, edgeKey]
   );
 
+  // Hover highlight uses the same geometry-builder pipeline but only when
+  // the hovered entity isn't already in `selections` (avoids z-fighting
+  // between the committed and hover overlays at the same poly-offset).
+  const hoverFaceIds = useMemo(() => {
+    if (!hoverEntity || hoverEntity.kind !== 'face') return [];
+    const id = hoverEntity.info.faceId;
+    if (faceIds.includes(id)) return [];
+    if (!data.faceGroups?.some((g) => g.faceId === id)) return [];
+    return [id];
+  }, [hoverEntity, faceIds, data.faceGroups]);
+  const hoverEdgeIds = useMemo(() => {
+    if (!hoverEntity || hoverEntity.kind !== 'edge') return [];
+    const id = hoverEntity.info.edgeId;
+    if (edgeIds.includes(id)) return [];
+    if (!data.edgeGroups?.some((g) => g.edgeId === id)) return [];
+    return [id];
+  }, [hoverEntity, edgeIds, data.edgeGroups]);
+
+  const hoverFaceKey = hoverFaceIds.join(',');
+  const hoverEdgeKey = hoverEdgeIds.join(',');
+
+  const hoverFaceGeometry = useMemo(
+    () => buildFaceHighlightGeometry(data, hoverFaceIds),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ids captured via hoverFaceKey
+    [data, hoverFaceKey]
+  );
+  const hoverEdgeGeometry = useMemo(
+    () => buildEdgeHighlightGeometry(data, hoverEdgeIds),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ids captured via hoverEdgeKey
+    [data, hoverEdgeKey]
+  );
+
   useEffect(() => {
     return () => {
       faceGeometry?.dispose();
@@ -129,6 +162,18 @@ export default function SelectionHighlight({ data, selections }: Props) {
       edgeGeometry?.dispose();
     };
   }, [edgeGeometry]);
+
+  useEffect(() => {
+    return () => {
+      hoverFaceGeometry?.dispose();
+    };
+  }, [hoverFaceGeometry]);
+
+  useEffect(() => {
+    return () => {
+      hoverEdgeGeometry?.dispose();
+    };
+  }, [hoverEdgeGeometry]);
 
   return (
     <>
@@ -156,6 +201,29 @@ export default function SelectionHighlight({ data, selections }: Props) {
               browser, so we lean on the bright color + depthTest=false (renders
               on top of the base edges) to make the highlight readable. */}
           <lineBasicMaterial color={EDGE_COLOR} depthTest={false} transparent />
+        </lineSegments>
+      )}
+      {hoverFaceGeometry && (
+        <mesh geometry={hoverFaceGeometry} raycast={skipRaycast} renderOrder={2}>
+          <meshStandardMaterial
+            color={FACE_COLOR}
+            emissive={FACE_COLOR}
+            emissiveIntensity={0.35}
+            metalness={0}
+            roughness={0.3}
+            side={THREE.DoubleSide}
+            transparent
+            opacity={0.22}
+            depthWrite={false}
+            polygonOffset
+            polygonOffsetFactor={-2}
+            polygonOffsetUnits={-2}
+          />
+        </mesh>
+      )}
+      {hoverEdgeGeometry && (
+        <lineSegments geometry={hoverEdgeGeometry} raycast={skipRaycast} renderOrder={3}>
+          <lineBasicMaterial color={EDGE_COLOR} depthTest={false} transparent opacity={0.55} />
         </lineSegments>
       )}
     </>

--- a/site/src/components/playground/SelectionHighlight.tsx
+++ b/site/src/components/playground/SelectionHighlight.tsx
@@ -119,37 +119,38 @@ export default function SelectionHighlight({ data, selections, hoverEntity }: Pr
     [data, edgeKey]
   );
 
-  // Hover highlight uses the same geometry-builder pipeline but only when
-  // the hovered entity isn't already in `selections` (avoids z-fighting
-  // between the committed and hover overlays at the same poly-offset).
-  const hoverFaceIds = useMemo(() => {
-    if (!hoverEntity || hoverEntity.kind !== 'face') return [];
+  // Hover overlay derives only from `hoverEntity` and the mesh's own group
+  // tables — NOT from `faceIds`/`edgeIds`. Including the selection-derived
+  // arrays here would re-run hover memoization on every click/deselect even
+  // when the hover target is unchanged. The `selections.includes` check
+  // moves down to the render-time gate (`shouldRenderHoverFace`) instead.
+  const hoverFaceId = useMemo(() => {
+    if (!hoverEntity || hoverEntity.kind !== 'face') return null;
     const id = hoverEntity.info.faceId;
-    if (faceIds.includes(id)) return [];
-    if (!data.faceGroups?.some((g) => g.faceId === id)) return [];
-    return [id];
-  }, [hoverEntity, faceIds, data.faceGroups]);
-  const hoverEdgeIds = useMemo(() => {
-    if (!hoverEntity || hoverEntity.kind !== 'edge') return [];
+    if (!data.faceGroups?.some((g) => g.faceId === id)) return null;
+    return id;
+  }, [hoverEntity, data.faceGroups]);
+  const hoverEdgeId = useMemo(() => {
+    if (!hoverEntity || hoverEntity.kind !== 'edge') return null;
     const id = hoverEntity.info.edgeId;
-    if (edgeIds.includes(id)) return [];
-    if (!data.edgeGroups?.some((g) => g.edgeId === id)) return [];
-    return [id];
-  }, [hoverEntity, edgeIds, data.edgeGroups]);
-
-  const hoverFaceKey = hoverFaceIds.join(',');
-  const hoverEdgeKey = hoverEdgeIds.join(',');
+    if (!data.edgeGroups?.some((g) => g.edgeId === id)) return null;
+    return id;
+  }, [hoverEntity, data.edgeGroups]);
 
   const hoverFaceGeometry = useMemo(
-    () => buildFaceHighlightGeometry(data, hoverFaceIds),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- ids captured via hoverFaceKey
-    [data, hoverFaceKey]
+    () => (hoverFaceId !== null ? buildFaceHighlightGeometry(data, [hoverFaceId]) : null),
+    [data, hoverFaceId]
   );
   const hoverEdgeGeometry = useMemo(
-    () => buildEdgeHighlightGeometry(data, hoverEdgeIds),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- ids captured via hoverEdgeKey
-    [data, hoverEdgeKey]
+    () => (hoverEdgeId !== null ? buildEdgeHighlightGeometry(data, [hoverEdgeId]) : null),
+    [data, hoverEdgeId]
   );
+
+  // Skip rendering the hover overlay when the hovered entity is already in
+  // selections — the committed overlay covers the same triangles, and two
+  // transparent quads at the same poly-offset would just produce flicker.
+  const shouldRenderHoverFace = hoverFaceId !== null && !faceIds.includes(hoverFaceId);
+  const shouldRenderHoverEdge = hoverEdgeId !== null && !edgeIds.includes(hoverEdgeId);
 
   useEffect(() => {
     return () => {
@@ -203,8 +204,12 @@ export default function SelectionHighlight({ data, selections, hoverEntity }: Pr
           <lineBasicMaterial color={EDGE_COLOR} depthTest={false} transparent />
         </lineSegments>
       )}
-      {hoverFaceGeometry && (
-        <mesh geometry={hoverFaceGeometry} raycast={skipRaycast} renderOrder={2}>
+      {hoverFaceGeometry && shouldRenderHoverFace && (
+        // renderOrder one below the committed overlay (which is `2`) so the
+        // committed face always composites on top when both happen to be
+        // visible on adjacent faces — three.js sorts transparent objects by
+        // renderOrder, so equal values would blend in unspecified order.
+        <mesh geometry={hoverFaceGeometry} raycast={skipRaycast} renderOrder={1}>
           <meshStandardMaterial
             color={FACE_COLOR}
             emissive={FACE_COLOR}
@@ -221,8 +226,10 @@ export default function SelectionHighlight({ data, selections, hoverEntity }: Pr
           />
         </mesh>
       )}
-      {hoverEdgeGeometry && (
-        <lineSegments geometry={hoverEdgeGeometry} raycast={skipRaycast} renderOrder={3}>
+      {hoverEdgeGeometry && shouldRenderHoverEdge && (
+        // renderOrder=2 keeps it below the committed edge overlay (=3) for
+        // the same blending-stability reason as the face hover above.
+        <lineSegments geometry={hoverEdgeGeometry} raycast={skipRaycast} renderOrder={2}>
           <lineBasicMaterial color={EDGE_COLOR} depthTest={false} transparent opacity={0.55} />
         </lineSegments>
       )}

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -315,7 +315,7 @@ export default function ViewerPanel() {
               {showEdges && viewMode !== 'wireframe' && m.edges.length > 0 && (
                 <EdgeRenderer edges={m.edges} edgeGroups={m.edgeGroups} edgeInfos={m.edgeInfos} />
               )}
-              <SelectionHighlight data={m} selections={selections} />
+              <SelectionHighlight data={m} selections={selections} hoverEntity={hoverEntity} />
             </group>
           ))}
         </group>


### PR DESCRIPTION
## Summary
Pairs with #865's hover preview tooltip. When you hover a face or edge, the entity now lights up directly in the 3D viewport — at lower intensity than a committed selection — so you can see exactly what the next click would pick. Same look as every CAD modeler.

Skips the hover overlay when the entity is already in the \`selections\` list (avoids z-fighting between two overlays sharing the same poly-offset).

Reuses the existing \`SelectionHighlight\` geometry-builder pipeline; the hover render path adds two extra draw calls at most (one face mesh, one line segments), each with O(1) of geometry.

## Test plan
- [ ] Hover face → faint teal tint appears on it; tooltip metadata updates
- [ ] Click → tint upgrades to the brighter "selected" tone
- [ ] Hover an already-selected face → no second overlay flicker
- [ ] Hover edge → faint orange tint, brighter on click
- [ ] Move cursor off → tint disappears immediately