### PR TITLE
feat(playground): more command palette entries + viewer reset

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -51,8 +51,10 @@ export default function PlaygroundPage() {
   const toggleEdges = useViewerStore((s) => s.toggleEdges);
   const toggleGrid = useViewerStore((s) => s.toggleGrid);
   const toggleProjection = useViewerStore((s) => s.toggleProjection);
+  const resetViewerDefaults = useViewerStore((s) => s.resetViewerDefaults);
   const requestFit = useViewerStore((s) => s.requestFit);
   const setCameraPreset = useViewerStore((s) => s.setCameraPreset);
+  const clearSelections = usePlaygroundStore((s) => s.clearSelections);
 
   // Layout persistence
   const storage = typeof window !== 'undefined' ? localStorage : undefined;
@@ -97,6 +99,26 @@ export default function PlaygroundPage() {
     clearDraft();
     addToast('Reset to default code');
   }, [addToast]);
+
+  const handleCopyCode = useCallback(() => {
+    void navigator.clipboard?.writeText(code).then(
+      () => {
+        addToast('Code copied to clipboard');
+      },
+      () => {
+        addToast('Clipboard unavailable');
+      }
+    );
+  }, [code, addToast]);
+
+  const handleResetViewer = useCallback(() => {
+    resetViewerDefaults();
+    addToast('Viewer settings reset');
+  }, [resetViewerDefaults, addToast]);
+
+  const handleClearSelection = useCallback(() => {
+    clearSelections();
+  }, [clearSelections]);
 
   const toggleConsole = useCallback(() => {
     const panel = consolePanelRef.current;
@@ -271,6 +293,12 @@ export default function PlaygroundPage() {
         label: 'Toggle projection (perspective/ortho)',
         run: toggleProjection,
       },
+      {
+        id: 'reset-viewer',
+        group: 'View',
+        label: 'Reset viewer to defaults',
+        run: handleResetViewer,
+      },
       { id: 'fit', group: 'Camera', label: 'Fit to view', run: requestFit },
       {
         id: 'cam-front',
@@ -311,6 +339,18 @@ export default function PlaygroundPage() {
         run: handleResetToDefault,
       },
       {
+        id: 'copy-code',
+        group: 'Editor',
+        label: 'Copy code to clipboard',
+        run: handleCopyCode,
+      },
+      {
+        id: 'clear-selection',
+        group: 'Selection',
+        label: 'Clear selection',
+        run: handleClearSelection,
+      },
+      {
         id: 'help',
         group: 'Help',
         label: 'Show keyboard shortcuts',
@@ -324,6 +364,9 @@ export default function PlaygroundPage() {
       handleRun,
       handleShare,
       handleResetToDefault,
+      handleResetViewer,
+      handleCopyCode,
+      handleClearSelection,
       handleExportSTL,
       handleExportSTEP,
       handleFormat,

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -10,6 +10,7 @@ import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
 import { DEFAULT_CODE } from '../../lib/constants';
+import { copyToClipboard } from '../../lib/copyToClipboard';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
 import ViewerPanel from './ViewerPanel';
@@ -100,25 +101,19 @@ export default function PlaygroundPage() {
     addToast('Reset to default code');
   }, [addToast]);
 
+  // copyToClipboard handles both undefined `navigator.clipboard` (HTTP /
+  // sandboxed iframe / older browsers) and a sync throw — neither of which
+  // a bare `navigator.clipboard?.writeText(...).then(...)` chain catches.
   const handleCopyCode = useCallback(() => {
-    void navigator.clipboard?.writeText(code).then(
-      () => {
-        addToast('Code copied to clipboard');
-      },
-      () => {
-        addToast('Clipboard unavailable');
-      }
-    );
+    void copyToClipboard(code).then((copied) => {
+      addToast(copied ? 'Code copied to clipboard' : 'Clipboard unavailable');
+    });
   }, [code, addToast]);
 
   const handleResetViewer = useCallback(() => {
     resetViewerDefaults();
     addToast('Viewer settings reset');
   }, [resetViewerDefaults, addToast]);
-
-  const handleClearSelection = useCallback(() => {
-    clearSelections();
-  }, [clearSelections]);
 
   const toggleConsole = useCallback(() => {
     const panel = consolePanelRef.current;
@@ -348,7 +343,7 @@ export default function PlaygroundPage() {
         id: 'clear-selection',
         group: 'Selection',
         label: 'Clear selection',
-        run: handleClearSelection,
+        run: clearSelections,
       },
       {
         id: 'help',
@@ -366,7 +361,7 @@ export default function PlaygroundPage() {
       handleResetToDefault,
       handleResetViewer,
       handleCopyCode,
-      handleClearSelection,
+      clearSelections,
       handleExportSTL,
       handleExportSTEP,
       handleFormat,

--- a/site/src/stores/viewerStore.ts
+++ b/site/src/stores/viewerStore.ts
@@ -18,20 +18,25 @@ interface ViewerState {
   toggleEdges: () => void;
   toggleGrid: () => void;
   toggleProjection: () => void;
+  resetViewerDefaults: () => void;
   requestFit: () => void;
   setCameraPreset: (preset: CameraPreset) => void;
   clearPreset: () => void;
 }
+
+const VIEWER_DEFAULTS = {
+  viewMode: 'solid' as ViewMode,
+  showEdges: true,
+  showGrid: true,
+  projection: 'perspective' as Projection,
+};
 
 const VIEW_MODE_CYCLE: ViewMode[] = ['solid', 'wireframe', 'xray'];
 
 export const useViewerStore = create<ViewerState>()(
   persist(
     (set) => ({
-      viewMode: 'solid',
-      showEdges: true,
-      showGrid: true,
-      projection: 'perspective',
+      ...VIEWER_DEFAULTS,
       fitRequest: 0,
       activePreset: null,
 
@@ -55,6 +60,9 @@ export const useViewerStore = create<ViewerState>()(
         set((s) => ({
           projection: s.projection === 'perspective' ? 'orthographic' : 'perspective',
         }));
+      },
+      resetViewerDefaults: () => {
+        set({ ...VIEWER_DEFAULTS });
       },
       requestFit: () => {
         set((s) => ({ fitRequest: s.fitRequest + 1 }));


### PR DESCRIPTION
## Summary
Three new command palette entries plus a \`resetViewerDefaults\` action so users can escape an awkward configuration without manually toggling each setting back.

- **Copy code to clipboard** — useful when pasting into a different editor or sharing without going through the URL-encoded share link
- **Clear selection** — pairs with click-empty-space, but discoverable via \`Ctrl+K\`
- **Reset viewer to defaults** — restores view mode / edges / grid / projection to their initial values

Pulls the viewer defaults out into a single \`VIEWER_DEFAULTS\` const so the initial-state and reset paths can't drift.

## Test plan
- [ ] Ctrl+K → "Copy code" → editor contents on clipboard, toast appears
- [ ] Ctrl+K → "Clear selection" → highlights / tooltip clear
- [ ] Toggle xray + ortho + grid off → "Reset viewer to defaults" → solid + persp + grid back
- [ ] Reload after reset → viewer settings persisted at defaults