### PR TITLE
feat(playground): "Go to line N" button jumps editor to error line

### DIFF
--- a/site/src/components/playground/EditorPanel.tsx
+++ b/site/src/components/playground/EditorPanel.tsx
@@ -6,9 +6,10 @@ import { setupMonaco } from '../../lib/monacoSetup';
 interface EditorPanelProps {
   onCodeChange: (code: string) => void;
   onFormat?: { current: (() => void) | null };
+  jumpToLineRef?: { current: ((line: number) => void) | null };
 }
 
-export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps) {
+export default function EditorPanel({ onCodeChange, onFormat, jumpToLineRef }: EditorPanelProps) {
   const code = usePlaygroundStore((s) => s.code);
   const setCode = usePlaygroundStore((s) => s.setCode);
   const error = usePlaygroundStore((s) => s.error);
@@ -35,8 +36,21 @@ export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps
           void editor.getAction('editor.action.formatDocument')?.run();
         };
       }
+      // Expose a jump-to-line bridge so the console panel's "Go to line"
+      // button can scroll the editor to the offending line and focus it.
+      if (jumpToLineRef) {
+        jumpToLineRef.current = (line: number) => {
+          const model = editor.getModel();
+          if (!model) return;
+          const lineCount = model.getLineCount();
+          const target = Math.min(Math.max(line, 1), lineCount);
+          editor.revealLineInCenter(target);
+          editor.setPosition({ lineNumber: target, column: 1 });
+          editor.focus();
+        };
+      }
     },
-    [onFormat]
+    [onFormat, jumpToLineRef]
   );
 
   const handleChange = useCallback(
@@ -63,11 +77,7 @@ export default function EditorPanel({ onCodeChange, onFormat }: EditorPanelProps
       editor.setValue(code);
       return;
     }
-    model.pushEditOperations(
-      [],
-      [{ range: model.getFullModelRange(), text: code }],
-      () => null
-    );
+    model.pushEditOperations([], [{ range: model.getFullModelRange(), text: code }], () => null);
   }, [code]);
 
   // Update error markers

--- a/site/src/components/playground/OutputPanel.tsx
+++ b/site/src/components/playground/OutputPanel.tsx
@@ -4,11 +4,13 @@ import { countErrors } from '../../lib/consoleStats';
 
 interface OutputPanelProps {
   onCollapse: () => void;
+  onJumpToLine?: (line: number) => void;
 }
 
-export default function OutputPanel({ onCollapse }: OutputPanelProps) {
+export default function OutputPanel({ onCollapse, onJumpToLine }: OutputPanelProps) {
   const consoleOutput = usePlaygroundStore((s) => s.consoleOutput);
   const error = usePlaygroundStore((s) => s.error);
+  const errorLine = usePlaygroundStore((s) => s.errorLine);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   // Auto-scroll on new content. zustand replaces the array on every
@@ -111,7 +113,22 @@ export default function OutputPanel({ onCollapse }: OutputPanelProps) {
                 {line}
               </div>
             ))}
-            {error && <div className="text-red-400">{error}</div>}
+            {error && (
+              <div className="flex flex-wrap items-baseline gap-2 text-red-400">
+                <span>{error}</span>
+                {errorLine !== null && onJumpToLine && (
+                  <button
+                    onClick={() => {
+                      onJumpToLine(errorLine);
+                    }}
+                    className="rounded border border-red-500/40 bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-200 transition-colors hover:bg-red-500/20"
+                    title="Jump to error line in editor"
+                  >
+                    Go to line {errorLine}
+                  </button>
+                )}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -43,6 +43,11 @@ export default function PlaygroundPage() {
   const viewerPanelRef = usePanelRef();
   // Mutable ref to hold the editor format function, set by EditorPanel
   const editorFormatFnRef = useMemo(() => ({ current: null as (() => void) | null }), []);
+  // Mutable ref for the editor's jump-to-line bridge (used by OutputPanel).
+  const editorJumpToLineRef = useMemo(
+    () => ({ current: null as ((line: number) => void) | null }),
+    []
+  );
 
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -138,6 +143,13 @@ export default function PlaygroundPage() {
   const handleFormat = useCallback(() => {
     editorFormatFnRef.current?.();
   }, [editorFormatFnRef]);
+
+  const handleJumpToLine = useCallback(
+    (line: number) => {
+      editorJumpToLineRef.current?.(line);
+    },
+    [editorJumpToLineRef]
+  );
 
   const handleConsoleResize = useCallback(
     (size: { asPercentage: number }) => {
@@ -441,7 +453,11 @@ export default function PlaygroundPage() {
             onLayoutChanged={vLayout.onLayoutChanged}
           >
             <Panel id="editor" defaultSize="80%" minSize="30%">
-              <EditorPanel onCodeChange={handleCodeChange} onFormat={editorFormatFnRef} />
+              <EditorPanel
+                onCodeChange={handleCodeChange}
+                onFormat={editorFormatFnRef}
+                jumpToLineRef={editorJumpToLineRef}
+              />
             </Panel>
             <Separator className="h-px bg-border-subtle" />
             <Panel
@@ -456,7 +472,7 @@ export default function PlaygroundPage() {
               {isConsoleCollapsed ? (
                 <CollapsedConsoleBar onExpand={toggleConsole} />
               ) : (
-                <OutputPanel onCollapse={toggleConsole} />
+                <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
               )}
             </Panel>
           </Group>


### PR DESCRIPTION
## Summary
When an eval throws and the worker reports a line number, the editor already paints a marker — but users still have to scroll manually if their cursor is elsewhere. This PR puts the jump one click away: a small "Go to line N" pill next to the error message scrolls the editor, parks the cursor on the offending line, and focuses the editor so the next keystroke goes there.

Implementation pattern mirrors the existing \`editorFormatFnRef\` bridge between \`PlaygroundPage\` and \`EditorPanel\`, kept consistent so future editor-action handoffs follow the same shape.

## Test plan
- [ ] Trigger an error (e.g. typo in default code) → red error line appears in console with a "Go to line N" button
- [ ] Click the button → editor scrolls to and focuses that line
- [ ] Edit the line → next eval clears the error marker
- [ ] Long file, error on a far-down line → button still scrolls correctly (clamped to line count)