### PR TITLE
feat(playground): toggle editor panel — full-screen the 3D viewer

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -32,6 +32,8 @@ export default function PlaygroundPage() {
   const setConsoleCollapsed = usePlaygroundStore((s) => s.setConsoleCollapsed);
   const isViewerCollapsed = usePlaygroundStore((s) => s.isViewerCollapsed);
   const setViewerCollapsed = usePlaygroundStore((s) => s.setViewerCollapsed);
+  const isEditorCollapsed = usePlaygroundStore((s) => s.isEditorCollapsed);
+  const setEditorCollapsed = usePlaygroundStore((s) => s.setEditorCollapsed);
   const isRunning = usePlaygroundStore((s) => s.isRunning);
   const error = usePlaygroundStore((s) => s.error);
   const addToast = useToastStore((s) => s.addToast);
@@ -41,6 +43,7 @@ export default function PlaygroundPage() {
 
   const consolePanelRef = usePanelRef();
   const viewerPanelRef = usePanelRef();
+  const editorAreaPanelRef = usePanelRef();
   // Mutable ref to hold the editor format function, set by EditorPanel
   const editorFormatFnRef = useMemo(() => ({ current: null as (() => void) | null }), []);
   // Mutable ref for the editor's jump-to-line bridge (used by OutputPanel).
@@ -140,6 +143,16 @@ export default function PlaygroundPage() {
     }
   }, [viewerPanelRef]);
 
+  const toggleEditor = useCallback(() => {
+    const panel = editorAreaPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) {
+      panel.expand();
+    } else {
+      panel.collapse();
+    }
+  }, [editorAreaPanelRef]);
+
   const handleFormat = useCallback(() => {
     editorFormatFnRef.current?.();
   }, [editorFormatFnRef]);
@@ -166,6 +179,13 @@ export default function PlaygroundPage() {
     [setViewerCollapsed]
   );
 
+  const handleEditorAreaResize = useCallback(
+    (size: { asPercentage: number }) => {
+      setEditorCollapsed(size.asPercentage <= 1);
+    },
+    [setEditorCollapsed]
+  );
+
   const openCommandPalette = useCallback(() => {
     setPaletteOpen(true);
   }, []);
@@ -183,6 +203,7 @@ export default function PlaygroundPage() {
       formatCode: handleFormat,
       toggleOutput: toggleConsole,
       toggleViewer: toggleViewer,
+      toggleEditor: toggleEditor,
       commandPalette: openCommandPalette,
     }),
     [
@@ -193,6 +214,7 @@ export default function PlaygroundPage() {
       handleFormat,
       toggleConsole,
       toggleViewer,
+      toggleEditor,
       openCommandPalette,
     ]
   );
@@ -270,6 +292,13 @@ export default function PlaygroundPage() {
         label: 'Toggle viewer',
         keys: formatShortcut(SHORTCUTS.toggleViewer!),
         run: toggleViewer,
+      },
+      {
+        id: 'toggleEditor',
+        group: 'Layout',
+        label: 'Toggle editor',
+        keys: formatShortcut(SHORTCUTS.toggleEditor!),
+        run: toggleEditor,
       },
       {
         id: 'view-solid',
@@ -382,6 +411,7 @@ export default function PlaygroundPage() {
       handleFormat,
       toggleConsole,
       toggleViewer,
+      toggleEditor,
       setViewMode,
       cycleViewMode,
       toggleEdges,
@@ -392,15 +422,20 @@ export default function PlaygroundPage() {
     ]
   );
 
-  // Auto-expand console when error occurs
+  // Auto-expand console when error occurs — and the editor too, so users
+  // who collapsed the editor for a screenshot don't get stuck staring at
+  // a 3D viewer with an error message they can't see or fix.
   useEffect(() => {
-    if (error && isConsoleCollapsed) {
+    if (!error) return;
+    if (isConsoleCollapsed) {
       const panel = consolePanelRef.current;
-      if (panel?.isCollapsed()) {
-        panel.expand();
-      }
+      if (panel?.isCollapsed()) panel.expand();
     }
-  }, [error, isConsoleCollapsed, consolePanelRef]);
+    if (isEditorCollapsed) {
+      const panel = editorAreaPanelRef.current;
+      if (panel?.isCollapsed()) panel.expand();
+    }
+  }, [error, isConsoleCollapsed, isEditorCollapsed, consolePanelRef, editorAreaPanelRef]);
 
   return (
     <div className="relative flex h-screen flex-col bg-gray-950">
@@ -446,36 +481,46 @@ export default function PlaygroundPage() {
         className="flex-1 overflow-hidden"
       >
         {/* Left: editor + output */}
-        <Panel id="editor-area" defaultSize="50%" minSize="20%">
-          <Group
-            orientation="vertical"
-            defaultLayout={vLayout.defaultLayout}
-            onLayoutChanged={vLayout.onLayoutChanged}
-          >
-            <Panel id="editor" defaultSize="80%" minSize="30%">
-              <EditorPanel
-                onCodeChange={handleCodeChange}
-                onFormat={editorFormatFnRef}
-                jumpToLineRef={editorJumpToLineRef}
-              />
-            </Panel>
-            <Separator className="h-px bg-border-subtle" />
-            <Panel
-              id="console"
-              panelRef={consolePanelRef}
-              collapsible
-              collapsedSize="3.5%"
-              minSize="15%"
-              defaultSize="20%"
-              onResize={handleConsoleResize}
+        <Panel
+          id="editor-area"
+          panelRef={editorAreaPanelRef}
+          collapsible
+          collapsedSize="0%"
+          minSize="20%"
+          defaultSize="50%"
+          onResize={handleEditorAreaResize}
+        >
+          {isEditorCollapsed ? null : (
+            <Group
+              orientation="vertical"
+              defaultLayout={vLayout.defaultLayout}
+              onLayoutChanged={vLayout.onLayoutChanged}
             >
-              {isConsoleCollapsed ? (
-                <CollapsedConsoleBar onExpand={toggleConsole} />
-              ) : (
-                <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
-              )}
-            </Panel>
-          </Group>
+              <Panel id="editor" defaultSize="80%" minSize="30%">
+                <EditorPanel
+                  onCodeChange={handleCodeChange}
+                  onFormat={editorFormatFnRef}
+                  jumpToLineRef={editorJumpToLineRef}
+                />
+              </Panel>
+              <Separator className="h-px bg-border-subtle" />
+              <Panel
+                id="console"
+                panelRef={consolePanelRef}
+                collapsible
+                collapsedSize="3.5%"
+                minSize="15%"
+                defaultSize="20%"
+                onResize={handleConsoleResize}
+              >
+                {isConsoleCollapsed ? (
+                  <CollapsedConsoleBar onExpand={toggleConsole} />
+                ) : (
+                  <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
+                )}
+              </Panel>
+            </Group>
+          )}
         </Panel>
 
         <Separator className="w-px bg-border-subtle" />

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from 'react-resizable-panels';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 import { useViewerStore } from '../../stores/viewerStore';
@@ -32,7 +32,6 @@ export default function PlaygroundPage() {
   const setConsoleCollapsed = usePlaygroundStore((s) => s.setConsoleCollapsed);
   const isViewerCollapsed = usePlaygroundStore((s) => s.isViewerCollapsed);
   const setViewerCollapsed = usePlaygroundStore((s) => s.setViewerCollapsed);
-  const isEditorCollapsed = usePlaygroundStore((s) => s.isEditorCollapsed);
   const setEditorCollapsed = usePlaygroundStore((s) => s.setEditorCollapsed);
   const isRunning = usePlaygroundStore((s) => s.isRunning);
   const error = usePlaygroundStore((s) => s.error);
@@ -422,20 +421,20 @@ export default function PlaygroundPage() {
     ]
   );
 
-  // Auto-expand console when error occurs — and the editor too, so users
-  // who collapsed the editor for a screenshot don't get stuck staring at
-  // a 3D viewer with an error message they can't see or fix.
+  // Auto-expand console + editor on the *transition* into an error — not on
+  // every render while an error persists. Without the wasErrorRef guard, a
+  // user who collapses the editor for a screenshot while an error is on
+  // screen would see the panel snap back open immediately, since the effect
+  // would re-fire as `isEditorCollapsed` flips.
+  const wasErrorRef = useRef(false);
   useEffect(() => {
-    if (!error) return;
-    if (isConsoleCollapsed) {
-      const panel = consolePanelRef.current;
-      if (panel?.isCollapsed()) panel.expand();
+    const isError = !!error;
+    if (isError && !wasErrorRef.current) {
+      if (consolePanelRef.current?.isCollapsed()) consolePanelRef.current.expand();
+      if (editorAreaPanelRef.current?.isCollapsed()) editorAreaPanelRef.current.expand();
     }
-    if (isEditorCollapsed) {
-      const panel = editorAreaPanelRef.current;
-      if (panel?.isCollapsed()) panel.expand();
-    }
-  }, [error, isConsoleCollapsed, isEditorCollapsed, consolePanelRef, editorAreaPanelRef]);
+    wasErrorRef.current = isError;
+  }, [error, consolePanelRef, editorAreaPanelRef]);
 
   return (
     <div className="relative flex h-screen flex-col bg-gray-950">
@@ -490,37 +489,39 @@ export default function PlaygroundPage() {
           defaultSize="50%"
           onResize={handleEditorAreaResize}
         >
-          {isEditorCollapsed ? null : (
-            <Group
-              orientation="vertical"
-              defaultLayout={vLayout.defaultLayout}
-              onLayoutChanged={vLayout.onLayoutChanged}
+          {/* Always-mounted: collapsing this Panel sends its width to 0% but
+              we keep Monaco rendered so its undo stack, cursor position, and
+              scroll state survive a toggle. The 0%-wide container hides the
+              editor visually without remounting it. */}
+          <Group
+            orientation="vertical"
+            defaultLayout={vLayout.defaultLayout}
+            onLayoutChanged={vLayout.onLayoutChanged}
+          >
+            <Panel id="editor" defaultSize="80%" minSize="30%">
+              <EditorPanel
+                onCodeChange={handleCodeChange}
+                onFormat={editorFormatFnRef}
+                jumpToLineRef={editorJumpToLineRef}
+              />
+            </Panel>
+            <Separator className="h-px bg-border-subtle" />
+            <Panel
+              id="console"
+              panelRef={consolePanelRef}
+              collapsible
+              collapsedSize="3.5%"
+              minSize="15%"
+              defaultSize="20%"
+              onResize={handleConsoleResize}
             >
-              <Panel id="editor" defaultSize="80%" minSize="30%">
-                <EditorPanel
-                  onCodeChange={handleCodeChange}
-                  onFormat={editorFormatFnRef}
-                  jumpToLineRef={editorJumpToLineRef}
-                />
-              </Panel>
-              <Separator className="h-px bg-border-subtle" />
-              <Panel
-                id="console"
-                panelRef={consolePanelRef}
-                collapsible
-                collapsedSize="3.5%"
-                minSize="15%"
-                defaultSize="20%"
-                onResize={handleConsoleResize}
-              >
-                {isConsoleCollapsed ? (
-                  <CollapsedConsoleBar onExpand={toggleConsole} />
-                ) : (
-                  <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
-                )}
-              </Panel>
-            </Group>
-          )}
+              {isConsoleCollapsed ? (
+                <CollapsedConsoleBar onExpand={toggleConsole} />
+              ) : (
+                <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
+              )}
+            </Panel>
+          </Group>
         </Panel>
 
         <Separator className="w-px bg-border-subtle" />

--- a/site/src/lib/shortcuts.ts
+++ b/site/src/lib/shortcuts.ts
@@ -36,6 +36,14 @@ export const SHORTCUTS: Record<string, ShortcutDef> = {
     label: 'Toggle Viewer',
     inEditor: false,
   },
+  toggleEditor: {
+    id: 'toggleEditor',
+    key: '\\',
+    ctrl: true,
+    shift: true,
+    label: 'Toggle Editor',
+    inEditor: false,
+  },
   commandPalette: {
     id: 'commandPalette',
     key: 'k',

--- a/site/src/stores/playgroundStore.ts
+++ b/site/src/stores/playgroundStore.ts
@@ -33,6 +33,7 @@ interface PlaygroundState {
   pendingReview: boolean;
   isConsoleCollapsed: boolean;
   isViewerCollapsed: boolean;
+  isEditorCollapsed: boolean;
   lastSuccessfulCode: string | null;
   selections: Selection[];
   hoverEntity: Selection | null;
@@ -46,6 +47,7 @@ interface PlaygroundState {
   setPendingReview: (pending: boolean) => void;
   setConsoleCollapsed: (collapsed: boolean) => void;
   setViewerCollapsed: (collapsed: boolean) => void;
+  setEditorCollapsed: (collapsed: boolean) => void;
   setLastSuccessfulCode: (code: string) => void;
   pickSelection: (selection: Selection, additive: boolean) => void;
   clearSelections: () => void;
@@ -71,6 +73,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   pendingReview: false,
   isConsoleCollapsed: false,
   isViewerCollapsed: false,
+  isEditorCollapsed: false,
   lastSuccessfulCode: null,
   selections: [],
   hoverEntity: null,
@@ -87,6 +90,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   setPendingReview: (pendingReview) => set({ pendingReview }),
   setConsoleCollapsed: (isConsoleCollapsed) => set({ isConsoleCollapsed }),
   setViewerCollapsed: (isViewerCollapsed) => set({ isViewerCollapsed }),
+  setEditorCollapsed: (isEditorCollapsed) => set({ isEditorCollapsed }),
   setLastSuccessfulCode: (lastSuccessfulCode) => set({ lastSuccessfulCode }),
   pickSelection: (selection, additive) =>
     set((s) => {


### PR DESCRIPTION
## Summary
Mirrors the existing toggle-viewer flow: users can now hide the editor + console panels to give the 3D viewer the full window. Useful for screenshots, demos, or recovering screen real estate on small displays.

- New shortcut: \`Ctrl+Shift+\\\` / \`⌘+Shift+\\\`
- New "Toggle editor" entry in the command palette
- Auto-expand-on-error covers both panels now — a collapsed editor + a thrown eval used to leave the user staring at a 3D viewer with no way to see or fix the failure

## Test plan
- [ ] Press \`Ctrl+Shift+\\\` → editor + console disappear, viewer fills the window
- [ ] Press it again → editor returns at its previous size
- [ ] Open palette → 'Toggle editor' is listed with the shortcut
- [ ] Hide editor, then trigger an error → editor auto-restores