### PR TITLE
feat(playground): show brepjs version in the status bar

### DIFF
--- a/site/src/components/playground/StatusBar.tsx
+++ b/site/src/components/playground/StatusBar.tsx
@@ -50,6 +50,9 @@ export default function StatusBar() {
         {timeMs !== null && !isRunning && (
           <span className="text-gray-500">{timeMs.toFixed(0)}ms</span>
         )}
+        <span className="text-gray-500" title="brepjs version (helpful when reporting bugs)">
+          brepjs v{__BREPJS_VERSION__}
+        </span>
       </div>
       {lastSelection && (
         <div className="flex min-w-0 items-center gap-2 truncate whitespace-nowrap text-gray-300">

--- a/site/src/vite-env.d.ts
+++ b/site/src/vite-env.d.ts
@@ -4,3 +4,7 @@ declare module '*.d.ts?raw' {
   const content: string;
   export default content;
 }
+
+// Build-time constant injected via Vite's `define`. Sourced from the brepjs
+// monorepo's root package.json at build time.
+declare const __BREPJS_VERSION__: string;

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -2,12 +2,16 @@ import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { createReadStream, existsSync, mkdirSync, copyFileSync, readFileSync } from 'fs';
 
 interface PackageJson {
   version?: string;
 }
-const brepjsPkg = JSON.parse(readFileSync(resolve('../package.json'), 'utf8')) as PackageJson;
+// Resolve relative to this config file, not cwd, so the build works regardless
+// of where vite is invoked from (e.g. monorepo root vs `site/`).
+const brepjsPkgPath = fileURLToPath(new URL('../package.json', import.meta.url));
+const brepjsPkg = JSON.parse(readFileSync(brepjsPkgPath, 'utf8')) as PackageJson;
 const BREPJS_VERSION = brepjsPkg.version ?? '0.0.0-dev';
 
 const WASM_FILES = ['brepjs_single.js', 'brepjs_single.wasm'];

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -2,7 +2,13 @@ import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
-import { createReadStream, existsSync, mkdirSync, copyFileSync } from 'fs';
+import { createReadStream, existsSync, mkdirSync, copyFileSync, readFileSync } from 'fs';
+
+interface PackageJson {
+  version?: string;
+}
+const brepjsPkg = JSON.parse(readFileSync(resolve('../package.json'), 'utf8')) as PackageJson;
+const BREPJS_VERSION = brepjsPkg.version ?? '0.0.0-dev';
 
 const WASM_FILES = ['brepjs_single.js', 'brepjs_single.wasm'];
 
@@ -54,6 +60,11 @@ function opencascadeWasm(): Plugin {
 
 export default defineConfig({
   base: BASE,
+  define: {
+    // Surfaced in the playground status bar so users can include the running
+    // brepjs version in bug reports without needing devtools.
+    __BREPJS_VERSION__: JSON.stringify(BREPJS_VERSION),
+  },
   plugins: [react(), tailwindcss(), opencascadeWasm()],
   server: {
     headers: {


### PR DESCRIPTION
## Summary
Pulls the brepjs version from the monorepo's root \`package.json\` at build time via Vite's \`define\`, surfaces it next to the run-time indicator. Lets users include the running version in bug reports without opening devtools or guessing.

## Implementation
- \`site/vite.config.ts\` reads \`../package.json\` once and exposes the version as a \`__BREPJS_VERSION__\` global via Vite's \`define\` (string-replaced at build time, no runtime cost)
- \`site/src/vite-env.d.ts\` declares the global so TypeScript is happy
- \`StatusBar\` renders \`brepjs vX.Y.Z\` in the left cluster

## Test plan
- [ ] Status bar shows \`brepjs v18.3.0\` (or the current version)
- [ ] Hover the version → tooltip explains it's helpful for bug reports
- [ ] Bumping the root version (release-please) updates the displayed string after a rebuild