### PR TITLE
feat(playground): screenshot button captures viewer as PNG

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -11,7 +11,7 @@ import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
 import { DEFAULT_CODE } from '../../lib/constants';
 import { copyToClipboard } from '../../lib/copyToClipboard';
-import { downloadViewerScreenshot } from '../../lib/screenshot';
+import { useScreenshot } from '../../hooks/useScreenshot';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
 import ViewerPanel from './ViewerPanel';
@@ -123,10 +123,7 @@ export default function PlaygroundPage() {
     addToast('Viewer settings reset');
   }, [resetViewerDefaults, addToast]);
 
-  const handleScreenshot = useCallback(() => {
-    const ok = downloadViewerScreenshot();
-    addToast(ok ? 'Screenshot saved' : 'Screenshot failed');
-  }, [addToast]);
+  const handleScreenshot = useScreenshot();
 
   const toggleConsole = useCallback(() => {
     const panel = consolePanelRef.current;

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -11,6 +11,7 @@ import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
 import { DEFAULT_CODE } from '../../lib/constants';
 import { copyToClipboard } from '../../lib/copyToClipboard';
+import { downloadViewerScreenshot } from '../../lib/screenshot';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
 import ViewerPanel from './ViewerPanel';
@@ -121,6 +122,11 @@ export default function PlaygroundPage() {
     resetViewerDefaults();
     addToast('Viewer settings reset');
   }, [resetViewerDefaults, addToast]);
+
+  const handleScreenshot = useCallback(() => {
+    const ok = downloadViewerScreenshot();
+    addToast(ok ? 'Screenshot saved' : 'Screenshot failed');
+  }, [addToast]);
 
   const toggleConsole = useCallback(() => {
     const panel = consolePanelRef.current;
@@ -339,6 +345,7 @@ export default function PlaygroundPage() {
         run: handleResetViewer,
       },
       { id: 'fit', group: 'Camera', label: 'Fit to view', run: requestFit },
+      { id: 'screenshot', group: 'Camera', label: 'Save screenshot (PNG)', run: handleScreenshot },
       {
         id: 'cam-front',
         group: 'Camera',
@@ -403,6 +410,7 @@ export default function PlaygroundPage() {
       openShortcutHelp,
       handleResetToDefault,
       handleResetViewer,
+      handleScreenshot,
       handleCopyCode,
       clearSelections,
       handleExportSTL,

--- a/site/src/components/playground/ViewerToolbar.tsx
+++ b/site/src/components/playground/ViewerToolbar.tsx
@@ -1,7 +1,5 @@
-import { useCallback } from 'react';
 import { useViewerStore, type CameraPreset, type ViewMode } from '../../stores/viewerStore';
-import { useToastStore } from '../../stores/toastStore';
-import { downloadViewerScreenshot } from '../../lib/screenshot';
+import { useScreenshot } from '../../hooks/useScreenshot';
 
 export default function ViewerToolbar() {
   const viewMode = useViewerStore((s) => s.viewMode);
@@ -15,12 +13,7 @@ export default function ViewerToolbar() {
   const toggleProjection = useViewerStore((s) => s.toggleProjection);
   const requestFit = useViewerStore((s) => s.requestFit);
   const setCameraPreset = useViewerStore((s) => s.setCameraPreset);
-  const addToast = useToastStore((s) => s.addToast);
-
-  const handleScreenshot = useCallback(() => {
-    const ok = downloadViewerScreenshot();
-    addToast(ok ? 'Screenshot saved' : 'Screenshot failed');
-  }, [addToast]);
+  const handleScreenshot = useScreenshot();
 
   return (
     <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-1">

--- a/site/src/components/playground/ViewerToolbar.tsx
+++ b/site/src/components/playground/ViewerToolbar.tsx
@@ -1,4 +1,7 @@
+import { useCallback } from 'react';
 import { useViewerStore, type CameraPreset, type ViewMode } from '../../stores/viewerStore';
+import { useToastStore } from '../../stores/toastStore';
+import { downloadViewerScreenshot } from '../../lib/screenshot';
 
 export default function ViewerToolbar() {
   const viewMode = useViewerStore((s) => s.viewMode);
@@ -12,10 +15,17 @@ export default function ViewerToolbar() {
   const toggleProjection = useViewerStore((s) => s.toggleProjection);
   const requestFit = useViewerStore((s) => s.requestFit);
   const setCameraPreset = useViewerStore((s) => s.setCameraPreset);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handleScreenshot = useCallback(() => {
+    const ok = downloadViewerScreenshot();
+    addToast(ok ? 'Screenshot saved' : 'Screenshot failed');
+  }, [addToast]);
 
   return (
     <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-1">
       <ToolbarButton onClick={requestFit} label="Fit" active={false} />
+      <ToolbarButton onClick={handleScreenshot} label="Snap" active={false} />
       <div className="my-1 border-t border-border-subtle" />
       <ModeButton mode="solid" label="Solid" active={viewMode} onClick={setViewMode} />
       <ModeButton mode="wireframe" label="Wire" active={viewMode} onClick={setViewMode} />

--- a/site/src/hooks/useScreenshot.ts
+++ b/site/src/hooks/useScreenshot.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { useToastStore } from '../stores/toastStore';
+import { downloadViewerScreenshot } from '../lib/screenshot';
+
+// Shared hook so the viewer toolbar button and the command palette entry
+// stay in sync — toast text used to live in two places, which would have
+// drifted on the next copy edit.
+export function useScreenshot(): () => void {
+  const addToast = useToastStore((s) => s.addToast);
+  return useCallback(() => {
+    void downloadViewerScreenshot().then((ok) => {
+      addToast(ok ? 'Screenshot saved' : 'Screenshot failed');
+    });
+  }, [addToast]);
+}

--- a/site/src/lib/screenshot.ts
+++ b/site/src/lib/screenshot.ts
@@ -1,29 +1,45 @@
 // Captures the playground viewer's canvas as a PNG and triggers a download.
-// Returns true if the capture started, false if no canvas was found.
+// Resolves to true if the file was offered to the user, false otherwise.
 //
 // The R3F Canvas is created with `preserveDrawingBuffer: true` so the GPU
-// buffer survives between frames — `toDataURL` would otherwise return a
-// blank image on browsers that auto-clear after present.
-export function downloadViewerScreenshot(filename = `brepjs-${Date.now()}.png`): boolean {
-  if (typeof document === 'undefined') return false;
+// buffer survives between frames — `toBlob` would otherwise return null on
+// browsers that auto-clear after present.
+//
+// Uses `canvas.toBlob` instead of `toDataURL` so PNG compression hands off
+// to the browser thread instead of stalling the JS event loop. On a 2x
+// retina viewport (~5 MP, ~20 MB raw), the sync path can freeze the UI for
+// hundreds of milliseconds.
+export function downloadViewerScreenshot(
+  filename = `brepjs-${Date.now()}.png`
+): Promise<boolean> {
+  if (typeof document === 'undefined') return Promise.resolve(false);
   // The viewer is the only canvas the playground mounts, so a single
   // querySelector is sufficient. If we ever add a second canvas (e.g. a
   // sketch overlay), the lookup needs scoping to the viewer container.
   const canvas = document.querySelector('canvas');
-  if (!canvas) return false;
-  let dataUrl: string;
-  try {
-    dataUrl = canvas.toDataURL('image/png');
-  } catch {
-    // Cross-origin tainted canvas would throw here; brepjs draws no foreign
-    // textures so this is unexpected, but we'd rather no-op than crash.
-    return false;
-  }
-  const link = document.createElement('a');
-  link.download = filename;
-  link.href = dataUrl;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  return true;
+  if (!canvas) return Promise.resolve(false);
+
+  return new Promise<boolean>((resolve) => {
+    try {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          resolve(false);
+          return;
+        }
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.download = filename;
+        link.href = url;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        resolve(true);
+      }, 'image/png');
+    } catch {
+      // Cross-origin tainted canvas would throw here; brepjs draws no foreign
+      // textures so this is unexpected, but we'd rather no-op than crash.
+      resolve(false);
+    }
+  });
 }

--- a/site/src/lib/screenshot.ts
+++ b/site/src/lib/screenshot.ts
@@ -1,0 +1,29 @@
+// Captures the playground viewer's canvas as a PNG and triggers a download.
+// Returns true if the capture started, false if no canvas was found.
+//
+// The R3F Canvas is created with `preserveDrawingBuffer: true` so the GPU
+// buffer survives between frames — `toDataURL` would otherwise return a
+// blank image on browsers that auto-clear after present.
+export function downloadViewerScreenshot(filename = `brepjs-${Date.now()}.png`): boolean {
+  if (typeof document === 'undefined') return false;
+  // The viewer is the only canvas the playground mounts, so a single
+  // querySelector is sufficient. If we ever add a second canvas (e.g. a
+  // sketch overlay), the lookup needs scoping to the viewer container.
+  const canvas = document.querySelector('canvas');
+  if (!canvas) return false;
+  let dataUrl: string;
+  try {
+    dataUrl = canvas.toDataURL('image/png');
+  } catch {
+    // Cross-origin tainted canvas would throw here; brepjs draws no foreign
+    // textures so this is unexpected, but we'd rather no-op than crash.
+    return false;
+  }
+  const link = document.createElement('a');
+  link.download = filename;
+  link.href = dataUrl;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  return true;
+}


### PR DESCRIPTION
## Summary
A "Snap" button next to "Fit" in the viewer toolbar (and a "Save screenshot (PNG)" entry in the command palette) downloads the current 3D view as a timestamped PNG file. Useful for sharing renders, bug reports, or saving design iterations.

## Implementation
- New \`lib/screenshot.ts\` finds the canvas, calls \`toDataURL('image/png')\`, triggers an anchor click for download
- Reuses the R3F canvas's existing \`preserveDrawingBuffer: true\` so \`toDataURL\` returns the rendered pixels rather than a blank frame
- try/catch around \`toDataURL\` in case a future change introduces a cross-origin texture
- Returns a boolean so callers can toast success/failure

## Test plan
- [ ] Click "Snap" in viewer toolbar → file downloads, toast shows "Screenshot saved"
- [ ] Open the PNG → matches the viewer's last rendered frame
- [ ] Try same via command palette ("Save screenshot (PNG)") → same outcome