### PR TITLE
feat(playground): bind v to cycle view modes

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -207,6 +207,7 @@ export default function PlaygroundPage() {
       toggleViewer: toggleViewer,
       toggleEditor: toggleEditor,
       commandPalette: openCommandPalette,
+      cycleViewMode: cycleViewMode,
     }),
     [
       handleRun,
@@ -326,7 +327,13 @@ export default function PlaygroundPage() {
           setViewMode('xray');
         },
       },
-      { id: 'cycle-view', group: 'View', label: 'Cycle view mode', run: cycleViewMode },
+      {
+        id: 'cycle-view',
+        group: 'View',
+        label: 'Cycle view mode',
+        keys: formatShortcut(SHORTCUTS.cycleViewMode!),
+        run: cycleViewMode,
+      },
       { id: 'toggle-edges', group: 'View', label: 'Toggle edges', run: toggleEdges },
       { id: 'toggle-grid', group: 'View', label: 'Toggle grid', run: toggleGrid },
       {

--- a/site/src/lib/shortcuts.ts
+++ b/site/src/lib/shortcuts.ts
@@ -51,14 +51,24 @@ export const SHORTCUTS: Record<string, ShortcutDef> = {
     shift: false,
     label: 'Command Palette',
   },
+  cycleViewMode: {
+    id: 'cycleViewMode',
+    key: 'v',
+    ctrl: false,
+    shift: false,
+    label: 'Cycle View Mode',
+    // Plain `v` would clobber the user typing the letter inside the editor;
+    // restrict to the viewport / outside Monaco.
+    inEditor: false,
+  },
 };
 
 export const isMac =
   typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
 export function formatShortcut(def: ShortcutDef): string {
-  const mod = isMac ? '\u2318' : 'Ctrl';
+  const mod = def.ctrl ? (isMac ? '\u2318+' : 'Ctrl+') : '';
   const shift = def.shift ? (isMac ? '\u21E7+' : 'Shift+') : '';
   const key = def.key === 'Enter' ? '\u21B5' : def.key === '\\' ? '\\' : def.key.toUpperCase();
-  return `${mod}+${shift}${key}`;
+  return `${mod}${shift}${key}`;
 }


### PR DESCRIPTION
## Summary
Single-key binding for the existing view-mode cycle action — \`solid\` → \`wireframe\` → \`x-ray\` → \`solid\`. \`inEditor: false\` keeps it from clobbering the literal letter when the user is typing in Monaco; the binding only fires when focus is in the viewport / outside the editor.

\`formatShortcut\` also gains conditional Ctrl/⌘ prefixing — every existing shortcut had \`ctrl: true\` so the prefix was always unconditionally rendered. Modifierless bindings now display as the bare key in the palette and shortcut help.

## Test plan
- [ ] Click on viewport → press \`V\` → view cycles solid → wireframe
- [ ] Press \`V\` again → wireframe → x-ray
- [ ] Press \`V\` again → x-ray → solid
- [ ] Click into editor → press \`V\` → letter \`v\` appears in code, no cycling
- [ ] Open palette → "Cycle view mode" shows the bare \`V\` shortcut hint (not \`Ctrl+V\`)