### PR TITLE
chore(playground): show active kernel name in the status bar

### DIFF
--- a/site/src/components/playground/StatusBar.tsx
+++ b/site/src/components/playground/StatusBar.tsx
@@ -50,8 +50,11 @@ export default function StatusBar() {
         {timeMs !== null && !isRunning && (
           <span className="text-gray-500">{timeMs.toFixed(0)}ms</span>
         )}
-        <span className="text-gray-500" title="brepjs version (helpful when reporting bugs)">
-          brepjs v{__BREPJS_VERSION__}
+        <span
+          className="text-gray-500"
+          title="brepjs version + active kernel (helpful when reporting bugs)"
+        >
+          brepjs v{__BREPJS_VERSION__} · OCCT
         </span>
       </div>
       {lastSelection && (


### PR DESCRIPTION
Append "· OCCT" after the brepjs version so users including the status bar in a bug report capture both pieces of information automatically.

The playground only ships the OpenCascade kernel today; if/when brepkit gets wired in here we'll want to make this dynamic via \`getKernel().kernelId\`.

## Test plan
- [ ] Status bar shows \`brepjs v18.4.0 · OCCT\` (or current version)