### PR TITLE
feat(playground): encode selection state in share URL

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -6,6 +6,7 @@ import { useToastStore } from '../../stores/toastStore';
 import { useCodeExecution } from '../../hooks/useCodeExecution';
 import { useUrlState } from '../../hooks/useUrlState';
 import { useDraftPersistence, clearDraft } from '../../hooks/useDraftPersistence';
+import { useApplyPendingSelections } from '../../hooks/useApplyPendingSelections';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
@@ -40,6 +41,7 @@ export default function PlaygroundPage() {
   const { runCode, exportSTL, exportSTEP, debouncedRun } = useCodeExecution();
   const { updateUrl, copyShareUrl } = useUrlState();
   useDraftPersistence();
+  useApplyPendingSelections();
 
   const consolePanelRef = usePanelRef();
   const viewerPanelRef = usePanelRef();

--- a/site/src/hooks/useApplyPendingSelections.ts
+++ b/site/src/hooks/useApplyPendingSelections.ts
@@ -26,7 +26,7 @@ export function useApplyPendingSelections() {
       return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
     })();
 
-    let firstAdditive = false;
+    let hasMatched = false;
     for (const want of pending) {
       let matched = false;
       for (const mesh of meshes) {
@@ -35,16 +35,16 @@ export function useApplyPendingSelections() {
           if (info) {
             // Replace on first match, additive after, so the final selection
             // list is exactly the requested set in URL order.
-            pickSelection({ kind: 'face', info, screenPos }, firstAdditive);
-            firstAdditive = true;
+            pickSelection({ kind: 'face', info, screenPos }, hasMatched);
+            hasMatched = true;
             matched = true;
             break;
           }
         } else {
           const info = mesh.edgeInfos?.find((e) => e.edgeId === want.id);
           if (info) {
-            pickSelection({ kind: 'edge', info, screenPos }, firstAdditive);
-            firstAdditive = true;
+            pickSelection({ kind: 'edge', info, screenPos }, hasMatched);
+            hasMatched = true;
             matched = true;
             break;
           }

--- a/site/src/hooks/useApplyPendingSelections.ts
+++ b/site/src/hooks/useApplyPendingSelections.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+import { usePlaygroundStore } from '../stores/playgroundStore';
+
+/**
+ * Drains `pendingSharedSelections` (decoded from a `&sel=` URL param) by
+ * matching each id against the meshes' faceInfos / edgeInfos and calling
+ * `pickSelection` for the hits. Runs once per mesh update — if the user's
+ * code edits change face ids, mismatched entries silently drop.
+ *
+ * Selections from a share URL have no associated cursor position, so we
+ * stamp the screenPos at the viewport center; the floating tooltip will
+ * still render in a sane place if the user keeps the cursor off the model.
+ */
+export function useApplyPendingSelections() {
+  const meshes = usePlaygroundStore((s) => s.meshes);
+  const pending = usePlaygroundStore((s) => s.pendingSharedSelections);
+
+  useEffect(() => {
+    if (pending.length === 0 || meshes.length === 0) return;
+
+    const setPending = usePlaygroundStore.getState().setPendingSharedSelections;
+    const pickSelection = usePlaygroundStore.getState().pickSelection;
+
+    const screenPos = (() => {
+      if (typeof window === 'undefined') return { x: 0, y: 0 };
+      return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+    })();
+
+    let firstAdditive = false;
+    for (const want of pending) {
+      let matched = false;
+      for (const mesh of meshes) {
+        if (want.kind === 'face') {
+          const info = mesh.faceInfos?.find((f) => f.faceId === want.id);
+          if (info) {
+            // Replace on first match, additive after, so the final selection
+            // list is exactly the requested set in URL order.
+            pickSelection({ kind: 'face', info, screenPos }, firstAdditive);
+            firstAdditive = true;
+            matched = true;
+            break;
+          }
+        } else {
+          const info = mesh.edgeInfos?.find((e) => e.edgeId === want.id);
+          if (info) {
+            pickSelection({ kind: 'edge', info, screenPos }, firstAdditive);
+            firstAdditive = true;
+            matched = true;
+            break;
+          }
+        }
+      }
+      // Silent: a stale id (recipient ran modified code) just doesn't restore.
+      if (!matched) continue;
+    }
+
+    setPending([]);
+  }, [meshes, pending]);
+}

--- a/site/src/hooks/useUrlState.ts
+++ b/site/src/hooks/useUrlState.ts
@@ -1,11 +1,27 @@
 import { useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../stores/playgroundStore';
 import { useToastStore } from '../stores/toastStore';
-import { decodeShare, encodeCodeQuery, hasShareParams } from '../lib/urlCodec';
+import {
+  decodeShare,
+  encodeCodeQuery,
+  hasShareParams,
+  type SharedSelection,
+} from '../lib/urlCodec';
+
+function selectionsForUrl(): SharedSelection[] {
+  return usePlaygroundStore
+    .getState()
+    .selections.map((s) =>
+      s.kind === 'face'
+        ? { kind: 'face' as const, id: s.info.faceId }
+        : { kind: 'edge' as const, id: s.info.edgeId }
+    );
+}
 
 export function useUrlState() {
   const setCode = usePlaygroundStore((s) => s.setCode);
   const setPendingReview = usePlaygroundStore((s) => s.setPendingReview);
+  const setPendingSharedSelections = usePlaygroundStore((s) => s.setPendingSharedSelections);
   const initialized = useRef(false);
 
   useEffect(() => {
@@ -27,20 +43,23 @@ export function useUrlState() {
 
     setCode(result.code);
     setPendingReview(true);
+    if (result.selections.length > 0) {
+      setPendingSharedSelections(result.selections);
+    }
 
     if (result.legacy) {
       const next = `${url.pathname}${encodeCodeQuery(result.code)}`;
       history.replaceState(null, '', next);
     }
-  }, [setCode, setPendingReview]);
+  }, [setCode, setPendingReview, setPendingSharedSelections]);
 
   const updateUrl = (code: string) => {
-    const query = encodeCodeQuery(code);
+    const query = encodeCodeQuery(code, selectionsForUrl());
     history.replaceState(null, '', `${window.location.pathname}${query}`);
   };
 
   const copyShareUrl = async (code: string) => {
-    const query = encodeCodeQuery(code);
+    const query = encodeCodeQuery(code, selectionsForUrl());
     const url = `${window.location.origin}${window.location.pathname}${query}`;
     history.replaceState(null, '', `${window.location.pathname}${query}`);
     try {

--- a/site/src/lib/urlCodec.ts
+++ b/site/src/lib/urlCodec.ts
@@ -1,9 +1,29 @@
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
 
-type DecodedShare = { code: string; legacy: boolean };
+export type SharedSelection = { kind: 'face' | 'edge'; id: number };
+type DecodedShare = { code: string; legacy: boolean; selections: SharedSelection[] };
 
-export function encodeCodeQuery(code: string): string {
-  return `?code=${compressToEncodedURIComponent(code)}`;
+export function encodeCodeQuery(code: string, selections: SharedSelection[] = []): string {
+  const base = `?code=${compressToEncodedURIComponent(code)}`;
+  if (selections.length === 0) return base;
+  // `f12,e5,f23` — small, human-debuggable, no compression overhead.
+  const sel = selections.map((s) => (s.kind === 'face' ? `f${s.id}` : `e${s.id}`)).join(',');
+  return `${base}&sel=${encodeURIComponent(sel)}`;
+}
+
+function parseSelectionsParam(raw: string | null): SharedSelection[] {
+  if (!raw) return [];
+  const out: SharedSelection[] = [];
+  for (const token of raw.split(',')) {
+    if (token.length < 2) continue;
+    const prefix = token[0];
+    const idStr = token.slice(1);
+    const id = Number(idStr);
+    if (!Number.isFinite(id) || !Number.isInteger(id)) continue;
+    if (prefix === 'f') out.push({ kind: 'face', id });
+    else if (prefix === 'e') out.push({ kind: 'edge', id });
+  }
+  return out;
 }
 
 // Whether the URL carries an explicit share payload (`?code=` or legacy
@@ -14,12 +34,15 @@ export function hasShareParams(url: URL): boolean {
 }
 
 // Reads `?code=` first; falls back to the legacy `#code/` hash format so links
-// shared before the format change still resolve.
+// shared before the format change still resolve. The optional `&sel=` carries
+// face/edge ids to pre-select after the first eval lands.
 export function decodeShare(url: URL): DecodedShare | null {
+  const selections = parseSelectionsParam(url.searchParams.get('sel'));
+
   const code = url.searchParams.get('code');
   if (code) {
     const text = decompressFromEncodedURIComponent(code);
-    if (text) return { code: text, legacy: false };
+    if (text) return { code: text, legacy: false, selections };
     console.warn('Could not decode `?code=` share param — link is corrupted or truncated.');
     return null;
   }
@@ -30,7 +53,7 @@ export function decodeShare(url: URL): DecodedShare | null {
 
   if (stripped.startsWith('code/')) {
     const text = decompressFromEncodedURIComponent(stripped.slice(5));
-    if (text) return { code: text, legacy: true };
+    if (text) return { code: text, legacy: true, selections };
     console.warn('Could not decode `#code/` share hash — legacy link is corrupted or truncated.');
     return null;
   }

--- a/site/src/stores/playgroundStore.ts
+++ b/site/src/stores/playgroundStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { DEFAULT_CODE } from '../lib/constants';
 import type { FaceGroup, EdgeGroup, FaceInfo, EdgeInfo } from '../workers/workerProtocol';
+import type { SharedSelection } from '../lib/urlCodec';
 
 export interface MeshData {
   position: Float32Array;
@@ -37,6 +38,10 @@ interface PlaygroundState {
   lastSuccessfulCode: string | null;
   selections: Selection[];
   hoverEntity: Selection | null;
+  // Selections decoded from a share URL but not yet applied — they need a
+  // mesh with valid faceInfos/edgeInfos before they can become real
+  // Selection objects. Drained by an effect that runs after each eval.
+  pendingSharedSelections: SharedSelection[];
 
   setCode: (code: string) => void;
   setMeshes: (meshes: MeshData[]) => void;
@@ -52,6 +57,7 @@ interface PlaygroundState {
   pickSelection: (selection: Selection, additive: boolean) => void;
   clearSelections: () => void;
   setHoverEntity: (entity: Selection | null) => void;
+  setPendingSharedSelections: (sel: SharedSelection[]) => void;
   clearResults: () => void;
 }
 
@@ -77,6 +83,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   lastSuccessfulCode: null,
   selections: [],
   hoverEntity: null,
+  pendingSharedSelections: [],
 
   setCode: (code) => set({ code }),
   // Drop selections on every new render — they're bound to the mesh by
@@ -104,6 +111,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
     }),
   clearSelections: () => set({ selections: [] }),
   setHoverEntity: (hoverEntity) => set({ hoverEntity }),
+  setPendingSharedSelections: (pendingSharedSelections) => set({ pendingSharedSelections }),
   clearResults: () =>
     set({
       meshes: [],


### PR DESCRIPTION
## Summary
Share links can now carry a \`&sel=f12,e5,f23\` param that pre-selects the listed faces and edges on the recipient's side after the first eval lands. Useful for tutorials and bug reports that hinge on a specific piece of geometry — "look at *this* face" links now actually land on the face.

## Implementation
- \`urlCodec\` gains \`SharedSelection\` + sel encoding/parsing. Format is \`f<id>\` / \`e<id>\` joined by commas — small, human-debuggable, no compression overhead
- \`decodeShare\` returns selections alongside code; \`useUrlState\` writes them to a new \`pendingSharedSelections\` store field on first load
- \`useApplyPendingSelections\` drains the pending list once meshes arrive, matching ids against \`faceInfos\`/\`edgeInfos\`. Stale ids silently drop
- \`updateUrl\` + \`copyShareUrl\` now include the current selections so the URL stays in sync after each Run / Share

## Test plan
- [ ] Click a face, click Share → shared URL ends in \`&sel=fNN\`
- [ ] Open the shared URL in a new tab → that face is highlighted after first eval
- [ ] Shift-click multiple faces, Share → URL has \`&sel=fA,fB,fC\`, recipient sees all three highlighted
- [ ] Edit recipient code so face ids change → no error, no highlight (silent skip)