### PR TITLE
fix(playground): unwrap Result<number> from measureArea before exposing to UI

### DIFF
--- a/site/src/lib/selectionLabels.ts
+++ b/site/src/lib/selectionLabels.ts
@@ -56,6 +56,11 @@ export function formatNormalDirection(normal: Vec3): string {
 }
 
 function formatNumber(n: number): string {
+  // Defensive: the worker boundary erased a Result<number> bug into a
+  // crashing toFixed call once. If a non-finite value sneaks through
+  // again — null, NaN, an unwrapped Result — render `—` instead of
+  // toppling the whole tooltip.
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—';
   if (n >= 100) return Math.round(n).toLocaleString('en-US');
   return n.toFixed(2).replace(/\.?0+$/, '');
 }

--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -1,10 +1,4 @@
-import type {
-  ToWorker,
-  FromWorker,
-  MeshTransfer,
-  FaceGroup,
-  EdgeGroup,
-} from './workerProtocol';
+import type { ToWorker, FromWorker, MeshTransfer, FaceGroup, EdgeGroup } from './workerProtocol';
 import { WASM_CACHE_NAME } from '../lib/wasmConfig';
 
 declare function postMessage(message: unknown, transfer?: Transferable[]): void;
@@ -333,10 +327,15 @@ function collectFaceInfos(shape: any) {
         ? (surfaceTypeResult.value as string)
         : 'OTHER_SURFACE';
       const normal = brepjs.normalAt(face) as [number, number, number];
+      // measureArea returns Result<number>; the prior code shipped the
+      // wrapped object straight to the UI, where formatNumber crashed
+      // because the Result had no .toFixed.
+      const areaResult = brepjs.measureArea(face);
+      const area = brepjs.isOk(areaResult) ? (areaResult.value as number) : NaN;
       infos.push({
         faceId: brepjs.getHashCode(face),
         surfaceType,
-        area: brepjs.measureArea(face),
+        area,
         normal,
       });
     } catch (err) {


### PR DESCRIPTION
## Bug
Live playground crashed with \`TypeError: e.toFixed is not a function\` after clicking a face. Stack ended in React's render loop, hidden behind minified names.

## Root cause
\`brepjs.measureArea(face)\` returns \`Result<number>\`, not \`number\`. The worker shipped the wrapped \`Result\` object straight into \`face.area\`, so \`formatNumber(face.area).toFixed(2)\` saw an object with no \`.toFixed\` method and threw inside the \`SelectionTooltip\`/\`StatusBar\` render path.

## Fix
- Worker (\`cad.worker.ts\`): unwrap with \`isOk + .value\`, fall back to \`NaN\` on the rare \`measureArea\` failure (\`formatNumber\` now handles non-finite cleanly).
- \`formatNumber\`: defensive guard returns \`—\` for non-finite or non-number inputs so any future regression at this boundary degrades gracefully instead of toppling the tooltip.

## Test plan
- [ ] Open the playground, click a face → tooltip shows the area normally (no crash, no \`—\`)
- [ ] Console error \`e.toFixed is not a function\` is gone
- [ ] If \`measureArea\` ever fails, the tooltip shows \`Area: —\` instead of crashing