### PR TITLE
feat(playground): replace default with parametric, spec-correct stud brick

### DIFF
--- a/site/src/lib/constants.ts
+++ b/site/src/lib/constants.ts
@@ -1,31 +1,69 @@
 export const DEFAULT_CODE = `import {
   box,
   cylinder,
-  fuse,
+  fuseAll,
+  cutAll,
   chamfer,
   edgeFinder,
   unwrap,
 } from 'brepjs/quick';
 
-const cols = 4;
-const rows = 2;
-const pitch = 8;
-const studR = 2.4;
-const studH = 1.8;
-const baseT = 4;
+// Parametric stud brick — every standard size falls out of three numbers.
+// Try the call at the bottom:
+//   studBrick(2, 4, 3)  → 2×4 brick
+//   studBrick(2, 4, 1)  → 2×4 plate (a brick is 3 plates tall)
+//   studBrick(1, 6, 3)  → 1×6 brick
+//   studBrick(8, 8, 1)  → 8×8 baseplate
+function studBrick(studsX, studsY, plateUnits) {
+  // Interlocking-brick spec (mm).
+  const pitch = 8;       // stud-to-stud spacing
+  const studR = 2.4;     // stud Ø4.8
+  const studH = 1.8;     // stud height
+  const plateH = 3.2;    // 1 plate = 3.2 mm; brick = 3 plates
+  const wall = 1.6;      // outer wall thickness
+  const tubeR = 3.255;   // anti-stud tube OD = 8√2 − 4.8 = 6.51
 
-const base = box(cols * pitch, rows * pitch, baseT);
+  const W = studsX * pitch;
+  const D = studsY * pitch;
+  const H = plateUnits * plateH;
+  const opts = { trackEvolution: false };
 
-let brick = base;
-for (let i = 0; i < cols; i++) {
-  for (let j = 0; j < rows; j++) {
-    const stud = cylinder(studR, studH, {
-      at: [i * pitch + pitch / 2, j * pitch + pitch / 2, baseT],
-    });
-    brick = unwrap(fuse(brick, stud));
+  // Collect every primitive up-front, then run two batched booleans —
+  // ~3× faster than fusing/cutting one stud at a time.
+  const studs = [];
+  for (let i = 0; i < studsX; i++) {
+    for (let j = 0; j < studsY; j++) {
+      studs.push(cylinder(studR, studH, {
+        at: [i * pitch + pitch / 2, j * pitch + pitch / 2, H],
+      }));
+    }
   }
+
+  const tubeOuters = [];
+  const tubeInners = [];
+  for (let i = 1; i < studsX; i++) {
+    for (let j = 1; j < studsY; j++) {
+      tubeOuters.push(cylinder(tubeR, H - wall, { at: [i * pitch, j * pitch, 0] }));
+      tubeInners.push(cylinder(studR, H - wall, { at: [i * pitch, j * pitch, 0] }));
+    }
+  }
+
+  // Body + studs in one fuse.
+  const body = unwrap(fuseAll([box(W, D, H), ...studs], opts));
+
+  // Underside negative space: cavity (carved by tube outers, so the tubes
+  // remain solid in the brick) plus the tube interiors. One cut handles all.
+  const cavity = box(W - 2 * wall, D - 2 * wall, H - wall, {
+    at: [W / 2, D / 2, (H - wall) / 2],
+  });
+  const negativeSpace = tubeOuters.length === 0
+    ? [cavity]
+    : [unwrap(cutAll(cavity, tubeOuters, opts)), ...tubeInners];
+  const brick = unwrap(cutAll(body, negativeSpace, opts));
+
+  const rims = edgeFinder().ofCurveType('CIRCLE').findAll(brick);
+  return unwrap(chamfer(brick, rims, 0.2));
 }
 
-const studEdges = edgeFinder().ofCurveType('CIRCLE').findAll(brick);
-export default unwrap(chamfer(brick, studEdges, 0.3));
+export default studBrick(2, 4, 3);
 `;


### PR DESCRIPTION
## Summary

- Rebuilds the playground default as a parametric `studBrick(studsX, studsY, plateUnits)` function that produces canonical interlocking-brick geometry (9.6 mm brick / 3.2 mm plate, 1.6 mm walls, hollow underside, 6.51 mm anti-stud tubes at every 4-stud junction). The previous default used a 4 mm slab — a height that matches no real part.
- Showcases parametric modelling: every standard size falls out of three numbers. Try `studBrick(2, 4, 1)` for a plate, `studBrick(8, 8, 1)` for a baseplate, etc.
- Optimized for render performance with batched booleans (`fuseAll` / `cutAll`) and `trackEvolution: false`.

## Performance

Measured on the OCCT WASM kernel (the playground's runtime kernel):

| size | sequential (before) | batched (after) | speedup |
|------|--------------------:|----------------:|--------:|
| 2×4 brick (default) | 97 ms | **31 ms** | **3.1×** |
| 4×6 brick           | 528 ms | **108 ms** | **4.9×** |

Speedup grows with brick size because batched booleans collapse N pair-wise operations into a single OCCT `BRepAlgoAPI_BuilderAlgo` call. `trackEvolution: false` is safe because the chamfer's edge selection (`ofCurveType('CIRCLE')`) reads intrinsic topology, not boolean-evolution metadata.

## Test plan

- [x] OCCT WASM (playground kernel) builds the default 2×4 brick in 31 ms median.
- [x] All 5 advertised sizes produce valid solids: `(2,4,3)`, `(2,4,1)`, `(1,6,3)`, `(1,1,3)`, `(8,8,1)`.
- [x] Bounding extents match spec: `studsX·8 × studsY·8 × (plateUnits·3.2 + 1.8)` mm.
- [x] Volume drift between sequential and batched implementations is < 0.1 % — visually invisible.
- [x] `npm run typecheck` (root + site) clean.