### PR TITLE
feat(playground): right-click menu for finder copy + reliable hover

### DIFF
--- a/site/src/components/playground/ContextMenu.tsx
+++ b/site/src/components/playground/ContextMenu.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { usePlaygroundStore } from '../../stores/playgroundStore';
+import { useToastStore } from '../../stores/toastStore';
+import { buildEdgeFinderSnippet, buildFaceFinderSnippet } from '../../lib/finderSnippet';
+import { copyToClipboard } from '../../lib/copyToClipboard';
+import type { Selection } from '../../stores/playgroundStore';
+
+interface Props {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const OFFSET_X = 4;
+const OFFSET_Y = 4;
+const EDGE_PADDING = 8;
+
+export default function ContextMenu({ containerRef }: Props) {
+  const contextMenu = usePlaygroundStore((s) => s.contextMenu);
+  const closeContextMenu = usePlaygroundStore((s) => s.closeContextMenu);
+  const addToast = useToastStore((s) => s.addToast);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  // Position the menu next to the cursor, then clamp to the viewport panel
+  // so it never spills out of the canvas. useLayoutEffect avoids a flash at
+  // (0,0) before clamping resolves.
+  useLayoutEffect(() => {
+    if (!contextMenu || !containerRef.current || !menuRef.current) {
+      setPos(null);
+      return;
+    }
+    const rect = containerRef.current.getBoundingClientRect();
+    const m = menuRef.current.getBoundingClientRect();
+    let left = contextMenu.screenPos.x - rect.left + OFFSET_X;
+    let top = contextMenu.screenPos.y - rect.top + OFFSET_Y;
+    if (left + m.width > rect.width - EDGE_PADDING) {
+      left = rect.width - m.width - EDGE_PADDING;
+    }
+    if (top + m.height > rect.height - EDGE_PADDING) {
+      top = rect.height - m.height - EDGE_PADDING;
+    }
+    if (left < EDGE_PADDING) left = EDGE_PADDING;
+    if (top < EDGE_PADDING) top = EDGE_PADDING;
+    setPos({ left, top });
+  }, [contextMenu, containerRef]);
+
+  // Dismiss on outside click, Escape, scroll, or resize. The mousedown
+  // listener uses capture so a click that lands on the menu's own buttons
+  // hits the button handler first (which closes the menu itself).
+  useEffect(() => {
+    if (!contextMenu) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      closeContextMenu();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeContextMenu();
+    };
+    const handleScrollOrResize = () => closeContextMenu();
+
+    document.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('keydown', handleKey);
+    window.addEventListener('resize', handleScrollOrResize);
+    window.addEventListener('scroll', handleScrollOrResize, true);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('keydown', handleKey);
+      window.removeEventListener('resize', handleScrollOrResize);
+      window.removeEventListener('scroll', handleScrollOrResize, true);
+    };
+  }, [contextMenu, closeContextMenu]);
+
+  if (!contextMenu) return null;
+
+  const handleCopyFinder = () => {
+    const snippet = buildSnippet(contextMenu.entity);
+    void copyToClipboard(snippet).then((copied) =>
+      addToast(copied ? 'Finder copied' : 'Clipboard unavailable')
+    );
+    closeContextMenu();
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute z-30 min-w-[180px] overflow-hidden rounded-md border border-border-subtle bg-[rgba(15,15,20,0.96)] py-1 font-mono text-xs text-gray-200 shadow-xl backdrop-blur-sm"
+      style={pos ?? { left: -9999, top: -9999 }}
+      role="menu"
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={handleCopyFinder}
+        className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left transition-colors hover:bg-surface-overlay focus:bg-surface-overlay focus:outline-none"
+      >
+        <span>Copy finder predicate</span>
+        <span className="text-[10px] uppercase tracking-wider text-gray-500">
+          {contextMenu.entity.kind === 'face' ? 'face' : 'edge'}
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function buildSnippet(entity: Selection): string {
+  return entity.kind === 'face'
+    ? buildFaceFinderSnippet(entity.info)
+    : buildEdgeFinderSnippet(entity.info);
+}

--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -1,11 +1,8 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { EdgeGroup, EdgeInfo } from '../../workers/workerProtocol';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
-import { useToastStore } from '../../stores/toastStore';
-import { buildEdgeFinderSnippet } from '../../lib/finderSnippet';
-import { copyToClipboard } from '../../lib/copyToClipboard';
 
 interface Props {
   edges: Float32Array;
@@ -31,8 +28,13 @@ function findGroupAt(groups: EdgeGroup[], vertexIndex: number): EdgeGroup | null
 export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   const pickSelection = usePlaygroundStore((s) => s.pickSelection);
   const setHoverEntity = usePlaygroundStore((s) => s.setHoverEntity);
-  const addToast = useToastStore((s) => s.addToast);
+  const openContextMenu = usePlaygroundStore((s) => s.openContextMenu);
   const pickable = Boolean(edgeGroups && edgeInfos);
+  // See ShapeRenderer for the rationale — pointerOut nulls hover state only
+  // when *we* are still the published target. Without this guard, an edge
+  // moving out of intersection while the cursor is still on a face would
+  // wipe the freshly-set face hover.
+  const lastAdvertisedEdgeId = useRef<number | null>(null);
 
   const geometry = useMemo(() => {
     const geo = new THREE.BufferGeometry();
@@ -53,27 +55,43 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
     return byId;
   }, [edgeInfos]);
 
+  const resolveEdge = useCallback(
+    (event: ThreeEvent<PointerEvent | MouseEvent>): EdgeInfo | null => {
+      if (!edgeGroups || !edgeInfoById) return null;
+      const vertexIndex = event.index;
+      if (vertexIndex === undefined) return null;
+      const group = findGroupAt(edgeGroups, vertexIndex);
+      if (!group) return null;
+      return edgeInfoById.get(group.edgeId) ?? null;
+    },
+    [edgeGroups, edgeInfoById]
+  );
+
   const handleClick = useCallback(
     (event: ThreeEvent<MouseEvent>) => {
-      if (!edgeGroups || !edgeInfoById) return;
-      const vertexIndex = event.index;
-      if (vertexIndex === undefined) return;
-      const group = findGroupAt(edgeGroups, vertexIndex);
-      if (!group) return;
-      const info = edgeInfoById.get(group.edgeId);
+      const info = resolveEdge(event);
       if (!info) return;
       event.stopPropagation();
-      const additive = event.shiftKey;
       pickSelection(
         { kind: 'edge', info, screenPos: { x: event.clientX, y: event.clientY } },
-        additive
-      );
-      const snippet = buildEdgeFinderSnippet(info);
-      void copyToClipboard(snippet).then((copied) =>
-        addToast(copied ? 'Edge finder copied' : 'Edge selected (clipboard unavailable)')
+        event.shiftKey
       );
     },
-    [edgeGroups, edgeInfoById, pickSelection, addToast]
+    [resolveEdge, pickSelection]
+  );
+
+  const handleContextMenu = useCallback(
+    (event: ThreeEvent<MouseEvent>) => {
+      const info = resolveEdge(event);
+      if (!info) return;
+      event.stopPropagation();
+      event.nativeEvent.preventDefault();
+      openContextMenu(
+        { kind: 'edge', info, screenPos: { x: event.clientX, y: event.clientY } },
+        { x: event.clientX, y: event.clientY }
+      );
+    },
+    [resolveEdge, openContextMenu]
   );
 
   const handlePointerOver = useCallback(() => {
@@ -81,7 +99,11 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   }, []);
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = '';
-    setHoverEntity(null);
+    const cur = usePlaygroundStore.getState().hoverEntity;
+    if (cur?.kind === 'edge' && cur.info.edgeId === lastAdvertisedEdgeId.current) {
+      setHoverEntity(null);
+    }
+    lastAdvertisedEdgeId.current = null;
   }, [setHoverEntity]);
 
   // pointermove updates hoverEntity each frame so the tooltip tracks the
@@ -93,21 +115,17 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   // never win.
   const handlePointerMove = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
-      if (!edgeGroups || !edgeInfoById) return;
-      const vertexIndex = event.index;
-      if (vertexIndex === undefined) return;
-      const group = findGroupAt(edgeGroups, vertexIndex);
-      if (!group) return;
-      const info = edgeInfoById.get(group.edgeId);
+      const info = resolveEdge(event);
       if (!info) return;
       event.stopPropagation();
+      lastAdvertisedEdgeId.current = info.edgeId;
       setHoverEntity({
         kind: 'edge',
         info,
         screenPos: { x: event.clientX, y: event.clientY },
       });
     },
-    [edgeGroups, edgeInfoById, setHoverEntity]
+    [resolveEdge, setHoverEntity]
   );
 
   // R3F doesn't synthesize `pointerout` for an object that gets unmounted
@@ -117,7 +135,10 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   useEffect(() => {
     return () => {
       document.body.style.cursor = '';
-      setHoverEntity(null);
+      const cur = usePlaygroundStore.getState().hoverEntity;
+      if (cur?.kind === 'edge' && cur.info.edgeId === lastAdvertisedEdgeId.current) {
+        setHoverEntity(null);
+      }
     };
   }, [setHoverEntity]);
 
@@ -126,6 +147,7 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
       geometry={geometry}
       renderOrder={1}
       onClick={pickable ? handleClick : undefined}
+      onContextMenu={pickable ? handleContextMenu : undefined}
       onPointerOver={pickable ? handlePointerOver : undefined}
       onPointerOut={pickable ? handlePointerOut : undefined}
       onPointerMove={pickable ? handlePointerMove : undefined}
@@ -136,9 +158,12 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   );
 }
 
-// Bumps the line-pick threshold so users don't need to hit the 1-pixel-wide
-// line dead-on; the default threshold is too tight on hi-DPI displays.
-const PICK_THRESHOLD_WORLD = 0.5;
+// Pick threshold for line raycasting. Earlier we used 0.5mm world-units to
+// be forgiving on hi-DPI displays, but on a 9.6mm-tall stud brick that
+// makes every side face partially "inside" the line pick volume — edges
+// then win the closest-hit race for hovers that visually land on a face.
+// 0.15 keeps lines easy to grab without swallowing face area.
+const PICK_THRESHOLD_WORLD = 0.15;
 function raycastLines(
   this: THREE.LineSegments,
   raycaster: THREE.Raycaster,

--- a/site/src/components/playground/OnboardingHint.tsx
+++ b/site/src/components/playground/OnboardingHint.tsx
@@ -21,8 +21,8 @@ function writeDismissed(): void {
 
 /**
  * Small pill at the bottom-center of the viewport that teaches first-time
- * visitors about the click-to-copy flow. Auto-dismisses on the first
- * selection (the user found it on their own) or on click.
+ * visitors that right-click reveals copy-finder actions. Auto-dismisses on
+ * the first selection (the user is interacting with the model) or on click.
  */
 export default function OnboardingHint() {
   const [visible, setVisible] = useState(false);
@@ -60,7 +60,7 @@ export default function OnboardingHint() {
     >
       <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-teal-primary/30 bg-[rgba(15,15,20,0.92)] px-3 py-1.5 text-xs text-gray-300 shadow-lg backdrop-blur-sm">
         <span aria-hidden="true">💡</span>
-        <span>Click a face or edge to copy a finder predicate</span>
+        <span>Right-click a face or edge to copy a finder predicate</span>
         <button
           onClick={() => {
             writeDismissed();

--- a/site/src/components/playground/SelectionTooltip.tsx
+++ b/site/src/components/playground/SelectionTooltip.tsx
@@ -71,8 +71,9 @@ export default function SelectionTooltip({ selections, hoverEntity, containerRef
 }
 
 function SingleTooltip({ selection, isHover }: { selection: Selection; isHover: boolean }) {
-  // Hover state shows metadata only — the snippet preview is committed UI
-  // that pairs with a clipboard write, and we haven't written anything yet.
+  // Selection state previews the finder predicate as a hint that right-click
+  // → "Copy finder predicate" will copy it. Hover state hides the preview
+  // because the user hasn't committed to anything yet.
   if (selection.kind === 'face') {
     const f = selection.info;
     return (
@@ -94,15 +95,12 @@ function SingleTooltip({ selection, isHover }: { selection: Selection; isHover: 
   );
 }
 
-// Shows the finder predicate the click produced. We previously labeled this
-// "Copied to clipboard" but the actual clipboard write is async and can fail
-// (denied permission, insecure context); a neutral label doesn't make a
-// promise the UI can't keep — the toast still reports clipboard success/fail.
 function SnippetPreview({ snippet }: { snippet: string }) {
   return (
     <div className="mt-1 border-t border-border-subtle pt-1">
-      <div className="mb-0.5 text-[10px] uppercase tracking-wider text-gray-500">
-        Finder predicate
+      <div className="mb-0.5 flex items-center justify-between text-[10px] uppercase tracking-wider text-gray-500">
+        <span>Finder predicate</span>
+        <span className="normal-case tracking-normal">right-click to copy</span>
       </div>
       <pre className="whitespace-pre-wrap break-words text-[10.5px] leading-snug text-teal-light/90">
         {snippet}
@@ -128,7 +126,7 @@ function MultiTooltip({ selections }: { selections: Selection[] }) {
         </div>
       )}
       <div className="mt-1 border-t border-border-subtle pt-1 text-[10px] text-gray-500">
-        Last picked copies to clipboard
+        Right-click any face or edge to copy its finder
       </div>
     </div>
   );

--- a/site/src/components/playground/ShapeRenderer.tsx
+++ b/site/src/components/playground/ShapeRenderer.tsx
@@ -1,20 +1,22 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { MeshData } from '../../stores/playgroundStore';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 import type { FaceInfo } from '../../workers/workerProtocol';
 import { useViewerStore } from '../../stores/viewerStore';
-import { buildFaceFinderSnippet } from '../../lib/finderSnippet';
-import { copyToClipboard } from '../../lib/copyToClipboard';
-import { useToastStore } from '../../stores/toastStore';
 
 export default function ShapeRenderer({ data }: { data: MeshData }) {
   const viewMode = useViewerStore((s) => s.viewMode);
   const pickSelection = usePlaygroundStore((s) => s.pickSelection);
   const setHoverEntity = usePlaygroundStore((s) => s.setHoverEntity);
-  const addToast = useToastStore((s) => s.addToast);
+  const openContextMenu = usePlaygroundStore((s) => s.openContextMenu);
   const pickable = Boolean(data.faceGroups && data.faceInfos);
+  // Tracks the faceId we last advertised to the global hover store so
+  // pointerOut only nulls hover when *we* are the current target. R3F can
+  // fire a sibling's pointerMove before our pointerOut in the same tick;
+  // unconditionally nulling here would clobber a freshly-set hover.
+  const lastAdvertisedFaceId = useRef<number | null>(null);
 
   const geometry = useMemo(() => {
     const geo = new THREE.BufferGeometry();
@@ -45,27 +47,43 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
     return byId;
   }, [data.faceInfos]);
 
+  const resolveFace = useCallback(
+    (event: ThreeEvent<PointerEvent | MouseEvent>): FaceInfo | null => {
+      if (!data.faceGroups || !faceInfoById) return null;
+      const materialIndex = event.face?.materialIndex;
+      if (materialIndex === undefined) return null;
+      const group = data.faceGroups[materialIndex];
+      if (!group) return null;
+      return faceInfoById.get(group.faceId) ?? null;
+    },
+    [data.faceGroups, faceInfoById]
+  );
+
   const handleClick = useCallback(
     (event: ThreeEvent<MouseEvent>) => {
-      if (!data.faceGroups || !faceInfoById) return;
-      const materialIndex = event.face?.materialIndex;
-      if (materialIndex === undefined) return;
-      const group = data.faceGroups[materialIndex];
-      if (!group) return;
-      const info = faceInfoById.get(group.faceId);
+      const info = resolveFace(event);
       if (!info) return;
       event.stopPropagation();
-      const additive = event.shiftKey;
       pickSelection(
         { kind: 'face', info, screenPos: { x: event.clientX, y: event.clientY } },
-        additive
-      );
-      const snippet = buildFaceFinderSnippet(info);
-      void copyToClipboard(snippet).then((copied) =>
-        addToast(copied ? 'Face finder copied' : 'Face selected (clipboard unavailable)')
+        event.shiftKey
       );
     },
-    [data.faceGroups, faceInfoById, pickSelection, addToast]
+    [resolveFace, pickSelection]
+  );
+
+  const handleContextMenu = useCallback(
+    (event: ThreeEvent<MouseEvent>) => {
+      const info = resolveFace(event);
+      if (!info) return;
+      event.stopPropagation();
+      event.nativeEvent.preventDefault();
+      openContextMenu(
+        { kind: 'face', info, screenPos: { x: event.clientX, y: event.clientY } },
+        { x: event.clientX, y: event.clientY }
+      );
+    },
+    [resolveFace, openContextMenu]
   );
 
   const handlePointerOver = useCallback(() => {
@@ -73,7 +91,16 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
   }, []);
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = '';
-    setHoverEntity(null);
+    // Only null hover if WE are the current target. A sibling pointerMove
+    // (e.g. an edge in the same canvas) may have already overwritten the
+    // store with its own entity in the same tick — clobbering it here
+    // produced the "+Z tops only" symptom by nulling face hovers seconds
+    // after they were set.
+    const cur = usePlaygroundStore.getState().hoverEntity;
+    if (cur?.kind === 'face' && cur.info.faceId === lastAdvertisedFaceId.current) {
+      setHoverEntity(null);
+    }
+    lastAdvertisedFaceId.current = null;
   }, [setHoverEntity]);
 
   // pointermove fires per-frame while hovering. We update on every tick so
@@ -81,20 +108,16 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
   // move and re-renders only the tooltip via zustand selectors.
   const handlePointerMove = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
-      if (!data.faceGroups || !faceInfoById) return;
-      const materialIndex = event.face?.materialIndex;
-      if (materialIndex === undefined) return;
-      const group = data.faceGroups[materialIndex];
-      if (!group) return;
-      const info = faceInfoById.get(group.faceId);
+      const info = resolveFace(event);
       if (!info) return;
+      lastAdvertisedFaceId.current = info.faceId;
       setHoverEntity({
         kind: 'face',
         info,
         screenPos: { x: event.clientX, y: event.clientY },
       });
     },
-    [data.faceGroups, faceInfoById, setHoverEntity]
+    [resolveFace, setHoverEntity]
   );
 
   // R3F doesn't synthesize `pointerout` for an object that gets unmounted
@@ -104,7 +127,10 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
   useEffect(() => {
     return () => {
       document.body.style.cursor = '';
-      setHoverEntity(null);
+      const cur = usePlaygroundStore.getState().hoverEntity;
+      if (cur?.kind === 'face' && cur.info.faceId === lastAdvertisedFaceId.current) {
+        setHoverEntity(null);
+      }
     };
   }, [setHoverEntity]);
 
@@ -112,6 +138,7 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
     <mesh
       geometry={geometry}
       onClick={pickable ? handleClick : undefined}
+      onContextMenu={pickable ? handleContextMenu : undefined}
       onPointerOver={pickable ? handlePointerOver : undefined}
       onPointerOut={pickable ? handlePointerOut : undefined}
       onPointerMove={pickable ? handlePointerMove : undefined}

--- a/site/src/components/playground/ShortcutHelp.tsx
+++ b/site/src/components/playground/ShortcutHelp.tsx
@@ -15,6 +15,7 @@ const VIEWPORT_ROWS: Row[] = [
   { label: 'Pick face/edge', keys: 'Click' },
   { label: 'Add to selection', keys: 'Shift+Click' },
   { label: 'Clear selection', keys: 'Click empty space' },
+  { label: 'Copy finder predicate', keys: 'Right-click' },
 ];
 
 export default function ShortcutHelp({ open, onClose }: Props) {

--- a/site/src/components/playground/ViewerPanel.tsx
+++ b/site/src/components/playground/ViewerPanel.tsx
@@ -13,6 +13,7 @@ import ViewerToolbar from './ViewerToolbar';
 import SelectionTooltip from './SelectionTooltip';
 import SelectionHighlight from './SelectionHighlight';
 import OnboardingHint from './OnboardingHint';
+import ContextMenu from './ContextMenu';
 
 /**
  * Build a content-derived React key for a mesh. The store hands us a fresh
@@ -254,16 +255,30 @@ export default function ViewerPanel() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const selections = usePlaygroundStore((s) => s.selections);
   const hoverEntity = usePlaygroundStore((s) => s.hoverEntity);
+  const closeContextMenu = usePlaygroundStore((s) => s.closeContextMenu);
 
   const handleControlsStart = useCallback(() => {
     clearPreset();
-  }, [clearPreset]);
+    closeContextMenu();
+  }, [clearPreset, closeContextMenu]);
 
   // R3F fires onPointerMissed when a click hits the canvas but no mesh in
-  // the scene — empty-space click clears the selection.
-  const handlePointerMissed = useCallback(() => {
-    clearSelections();
-  }, [clearSelections]);
+  // the scene — empty-space click clears the selection. Right-click in
+  // empty space gets the same handler (R3F fires onPointerMissed for any
+  // missed pointer event), which we treat as menu-dismiss only — selection
+  // stays intact when the user is just dismissing the menu.
+  const handlePointerMissed = useCallback(
+    (event: MouseEvent) => {
+      if (event.button === 2) {
+        event.preventDefault();
+        closeContextMenu();
+        return;
+      }
+      closeContextMenu();
+      clearSelections();
+    },
+    [clearSelections, closeContextMenu]
+  );
 
   // Snapshot the initial pointer-class via matchMedia so the props object we
   // hand drei stays stable across renders. Runtime device-class flips (a user
@@ -292,7 +307,16 @@ export default function ViewerPanel() {
   }, [isTouch]);
 
   return (
-    <div ref={containerRef} className="relative h-full w-full">
+    <div
+      ref={containerRef}
+      className="relative h-full w-full"
+      onContextMenu={(e) => {
+        // Suppress the browser's native menu on the canvas itself — R3F's
+        // onContextMenu on individual meshes calls preventDefault, but a
+        // right-click on empty canvas would otherwise pop Chrome's menu.
+        e.preventDefault();
+      }}
+    >
       <Canvas
         camera={{ position: [40, 30, 40], fov: 45, near: 0.1, far: 2000 }}
         frameloop="demand"
@@ -327,6 +351,7 @@ export default function ViewerPanel() {
         hoverEntity={hoverEntity}
         containerRef={containerRef}
       />
+      <ContextMenu containerRef={containerRef} />
       <OnboardingHint />
     </div>
   );

--- a/site/src/stores/playgroundStore.ts
+++ b/site/src/stores/playgroundStore.ts
@@ -23,6 +23,13 @@ export type Selection =
   | { kind: 'face'; info: FaceInfo; screenPos: ScreenPos }
   | { kind: 'edge'; info: EdgeInfo; screenPos: ScreenPos };
 
+export interface ContextMenuState {
+  // The entity the user right-clicked. Right-click does NOT mutate selections,
+  // so we carry the target separately rather than reading from `selections`.
+  entity: Selection;
+  screenPos: ScreenPos;
+}
+
 interface PlaygroundState {
   code: string;
   meshes: MeshData[];
@@ -38,6 +45,7 @@ interface PlaygroundState {
   lastSuccessfulCode: string | null;
   selections: Selection[];
   hoverEntity: Selection | null;
+  contextMenu: ContextMenuState | null;
   // Selections decoded from a share URL but not yet applied — they need a
   // mesh with valid faceInfos/edgeInfos before they can become real
   // Selection objects. Drained by an effect that runs after each eval.
@@ -57,6 +65,8 @@ interface PlaygroundState {
   pickSelection: (selection: Selection, additive: boolean) => void;
   clearSelections: () => void;
   setHoverEntity: (entity: Selection | null) => void;
+  openContextMenu: (entity: Selection, screenPos: ScreenPos) => void;
+  closeContextMenu: () => void;
   setPendingSharedSelections: (sel: SharedSelection[]) => void;
   clearResults: () => void;
 }
@@ -83,13 +93,21 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   lastSuccessfulCode: null,
   selections: [],
   hoverEntity: null,
+  contextMenu: null,
   pendingSharedSelections: [],
 
   setCode: (code) => set({ code }),
   // Drop selections on every new render — they're bound to the mesh by
   // faceId/edgeId and the new mesh likely won't have the same ids.
   setMeshes: (meshes) =>
-    set({ meshes, error: null, errorLine: null, selections: [], hoverEntity: null }),
+    set({
+      meshes,
+      error: null,
+      errorLine: null,
+      selections: [],
+      hoverEntity: null,
+      contextMenu: null,
+    }),
   setError: (error, line) => set({ error, errorLine: line ?? null }),
   setConsoleOutput: (consoleOutput) => set({ consoleOutput }),
   setTimeMs: (timeMs) => set({ timeMs }),
@@ -111,6 +129,8 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
     }),
   clearSelections: () => set({ selections: [] }),
   setHoverEntity: (hoverEntity) => set({ hoverEntity }),
+  openContextMenu: (entity, screenPos) => set({ contextMenu: { entity, screenPos } }),
+  closeContextMenu: () => set({ contextMenu: null }),
   setPendingSharedSelections: (pendingSharedSelections) => set({ pendingSharedSelections }),
   clearResults: () =>
     set({
@@ -121,5 +141,6 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
       timeMs: null,
       selections: [],
       hoverEntity: null,
+      contextMenu: null,
     }),
 }));


### PR DESCRIPTION
## Summary

- **Right-click menu**: replaces left-click-to-copy with a context menu that surfaces a "Copy finder predicate" action; left-click now only selects.
- **Hover fix**: every face/edge of a shape is now hoverable. Earlier, large +Z top faces of a stud brick were the only reliable hover targets.

## Hover root cause

Two compounding bugs in `ShapeRenderer.tsx` / `EdgeRenderer.tsx`:

1. `pointerOut` unconditionally nulled global `hoverEntity`. R3F can fire one renderer's `pointerOut` after a sibling's `pointerMove` already set hover state in the same tick, blanking valid hovers. The renderer now compares its own last-published id (`useRef`) against `getState().hoverEntity` and only nulls if it is still the active target.
2. `PICK_THRESHOLD_WORLD = 0.5` for line raycasting was huge relative to a 9.6mm stud-brick body; every side face partially fell inside line pick volumes, so edges always won the closest-hit race via `stopPropagation`. Tightened to `0.15`.

## Right-click menu

- New `ContextMenu.tsx`, viewport-clamped, modeled after `SelectionTooltip.tsx`.
- Dismisses on outside click, Escape, scroll, resize, camera drag, and new eval.
- `onContextMenu` on face mesh and edge `lineSegments` resolves the target, calls `event.nativeEvent.preventDefault()`, and opens the menu without mutating `selections`.
- Wrapper `<div>` on `ViewerPanel` suppresses the browser context menu on empty canvas. `onPointerMissed` distinguishes button=2 (close menu only) from left-click (close + clear selection).
- Toast still confirms clipboard write/fail; click handlers and copy logic are now decoupled.

## Messaging

- `OnboardingHint`, `SelectionTooltip` snippet preview, and `ShortcutHelp` updated to point users at right-click for the copy action.

## Test plan

- [ ] Hover every face of `studBrick(2, 4, 3)` (default code) — top, sides, stud sides, stud tops, bottom, cavity walls. Tooltip should follow the cursor on each.
- [ ] Hover every visible edge — should switch to edge tooltip, not get blocked by face hover.
- [ ] Left-click a face: selection commits, no clipboard write, no toast.
- [ ] Right-click a face: menu opens at cursor, "Copy finder predicate" copies the snippet, toast confirms.
- [ ] Right-click while menu is open elsewhere: replaces the menu at the new location.
- [ ] Escape, scroll, camera-drag, click-outside all dismiss the menu.
- [ ] Right-click empty canvas: no menu, no native browser menu.
- [ ] Right-click does not change `selections` even when right-clicking an unselected face.