### PR TITLE
fix(playground): force HTML revalidation so deploys aren't shadowed by browser cache

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,24 @@
       ]
     },
     {
+      "source": "/playground",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/playground/index.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/playground/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
       "source": "/playground/wasm/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary

Users were seeing stale playground UI after every deploy and had to manually clear browser cache to pick up changes. Root cause is `vercel.json`: the `/playground(/.*)?` rule sets COEP/COOP/CSP headers but no `Cache-Control`, and Vercel's per-framework defaults under `framework: vitepress` don't reliably set `must-revalidate` on nested static directories.

The HTML at `/playground` and `/playground/index.html` is the only mutable artifact in the bundle — JS/CSS already get content hashes from Vite, so when a user holds onto stale HTML their browser keeps loading the old hashed bundles via the immutable cache for those assets.

## Change

Add explicit `Cache-Control` header rules in `vercel.json`:
- `/playground` and `/playground/index.html` → `public, max-age=0, must-revalidate` (browser must check with origin before serving from cache)
- `/playground/assets/(.*)` → `public, max-age=31536000, immutable` (was relying on Vercel auto-detection that may not fire when an explicit COEP/COOP rule already matches the path)
- `/playground/wasm/(.*)` → unchanged (already explicit)

Vercel applies all matching header rules; for repeated headers the last rule wins, so the order is HTML rules first, asset/wasm rules last.

## Test plan

- [ ] Deploy preview → first load of `/playground` returns `Cache-Control: public, max-age=0, must-revalidate` on the HTML
- [ ] Subsequent loads send `If-None-Match` and accept `304`
- [ ] Hashed assets in `/playground/assets/` return `Cache-Control: public, max-age=31536000, immutable`
- [ ] WASM still returns immutable
- [ ] Deploy a tiny visible change → load on a previously-cached browser (no manual cache clear) shows the new code on first reload