### PR TITLE
fix(playground): correct doc links + strict-TS-clean default snippet

### DIFF
--- a/docs-site/getting-started/cheat-sheet.md
+++ b/docs-site/getting-started/cheat-sheet.md
@@ -4,7 +4,7 @@ title: Cheat Sheet
 
 # Cheat Sheet
 
-A one-page reference for the brepjs API. Bookmark this. Every snippet here is also openable in the [playground](https://brepjs.vercel.app/).
+A one-page reference for the brepjs API. Bookmark this. Every snippet here is also openable in the [playground](/playground).
 
 ## Init
 

--- a/docs-site/introduction/why-brepjs.md
+++ b/docs-site/introduction/why-brepjs.md
@@ -4,7 +4,7 @@ title: Why brepjs
 
 # Why brepjs
 
-> **Try it live:** the [in-browser playground](https://brepjs.vercel.app/) compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds — no install, no setup.
+> **Try it live:** the [in-browser playground](/playground) compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds — no install, no setup.
 
 **brepjs** is a code-first CAD library for JavaScript. It models real solids — exact mathematical boundaries, not triangle meshes — so booleans are precise, fillets land on real edges, measurements are real numbers, and STEP export round-trips with SolidWorks, Fusion, FreeCAD, and OpenSCAD. The library is built on top of OpenCascade WASM today and a Rust-based kernel ([brepkit](https://github.com/andymai/brepkit)) tomorrow; the kernel is pluggable behind a small abstraction layer.
 

--- a/docs-site/migration/replicad.md
+++ b/docs-site/migration/replicad.md
@@ -183,7 +183,7 @@ if (isClosedWire(someWire)) {
 
 ## What you'll miss (that we'll add)
 
-- **Replicad's workbench.** brepjs has [a similar playground](https://brepjs.vercel.app/). Same idea, slightly different UI.
+- **Replicad's workbench.** brepjs has [a similar playground](/playground). Same idea, slightly different UI.
 - **Some operation names.** `revolution` → `revolve`. `loft` is the same. `pipe` → `sweep`.
 - **Replicad's higher-order helpers.** Some niche helpers (e.g. `genericSweep`) don't have direct brepjs equivalents — usually composing two operations covers the case.
 

--- a/docs-site/reference/glossary.md
+++ b/docs-site/reference/glossary.md
@@ -196,7 +196,7 @@ Terms used throughout brepjs documentation, in alphabetical order. Where a term 
 
 **`withKernel`** — `withKernel(id, fn)`. Runs `fn` synchronously with the named kernel active. Don't pass async callbacks. See [Kernels](../concepts/kernels).
 
-**Workbench** — Replicad's name for its in-browser playground. brepjs has [a similar playground](https://brepjs.vercel.app/).
+**Workbench** — Replicad's name for its in-browser playground. brepjs has [a similar playground](/playground).
 
 ## Next steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -241,7 +241,7 @@ Vite handles WASM loading automatically. For other bundlers, you may need to con
 >
 > See [Compatibility - No SSR Support](./compatibility.md#3-no-ssr-support) for patterns.
 
-Try the [interactive playground](https://brepjs.vercel.app) for live experimentation.
+Try the [interactive playground](https://docs.brepjs.dev/playground) for live experimentation.
 
 ## The 2D → 3D workflow
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -58,7 +58,7 @@ The kernel abstraction layer (`src/kernel/`) translates all brepjs calls into OC
 
 See `docs/cheat-sheet.md` for a single-page reference covering all common operations (primitives, booleans, transforms, fillets, measurement, export, memory management, error handling).
 
-Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://brepjs.vercel.app) for live experimentation.
+Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://docs.brepjs.dev/playground) for live experimentation.
 
 ## API Style
 

--- a/llms.txt
+++ b/llms.txt
@@ -58,7 +58,7 @@ The kernel abstraction layer (`src/kernel/`) translates all brepjs calls into OC
 
 See `docs/cheat-sheet.md` for a single-page reference covering all common operations (primitives, booleans, transforms, fillets, measurement, export, memory management, error handling).
 
-Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://brepjs.vercel.app) for live experimentation.
+Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://docs.brepjs.dev/playground) for live experimentation.
 
 ## API Style
 

--- a/site/src/lib/constants.ts
+++ b/site/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const DEFAULT_CODE = `import {
 //   studBrick(2, 4, 1)  → 2×4 plate (a brick is 3 plates tall)
 //   studBrick(1, 6, 3)  → 1×6 brick
 //   studBrick(8, 8, 1)  → 8×8 baseplate
-function studBrick(studsX, studsY, plateUnits) {
+function studBrick(studsX: number, studsY: number, plateUnits: number) {
   // Interlocking-brick spec (mm).
   const pitch = 8;       // stud-to-stud spacing
   const studR = 2.4;     // stud Ø4.8


### PR DESCRIPTION
## Summary

- **Doc links**: replace stale `https://brepjs.vercel.app/` references with the canonical playground URL. Inside the deployed VitePress site we use the root-relative `/playground` (the playground is bundled into the build at `/playground` per `vercel.json`); files read on GitHub (`docs/getting-started.md`, `llms*.txt`) get the absolute `https://docs.brepjs.dev/playground`.
- **Default snippet types**: annotate the `studBrick` parameters as `number`. Monaco runs the editor with `strict: true` (`site/src/lib/monacoSetup.ts:53`), so the bare-parameter signature surfaced implicit-any diagnostics on first paint after #880.

## Test plan

- [ ] Visit the deployed docs site, confirm the "Try it live" / playground links navigate to `/playground` without leaving the origin.
- [ ] Open the playground, confirm the default `studBrick(...)` snippet shows no red squiggles in the editor on first load.
- [ ] Confirm `https://docs.brepjs.dev/playground` resolves (verifies the absolute URL used in `docs/getting-started.md` and the `llms*.txt` bundles).