### PR TITLE
fix(playground): hover resolves the face under the cursor (not always the top)

### DIFF
--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
-import type { ThreeEvent } from '@react-three/fiber';
+import { useThree, type ThreeEvent } from '@react-three/fiber';
 import type { EdgeGroup, EdgeInfo } from '../../workers/workerProtocol';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 
@@ -30,6 +30,9 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   const setHoverEntity = usePlaygroundStore((s) => s.setHoverEntity);
   const openContextMenu = usePlaygroundStore((s) => s.openContextMenu);
   const pickable = Boolean(edgeGroups && edgeInfos);
+  const viewportHeight = useThree((s) => s.size.height);
+  const viewportHeightRef = useRef(viewportHeight);
+  viewportHeightRef.current = viewportHeight;
   // See ShapeRenderer for the rationale — pointerOut nulls hover state only
   // when *we* are still the published target. Without this guard, an edge
   // moving out of intersection while the cursor is still on a face would
@@ -142,6 +145,25 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
     };
   }, [setHoverEntity]);
 
+  const raycastLines = useCallback(
+    function (
+      this: THREE.LineSegments,
+      raycaster: THREE.Raycaster,
+      intersects: THREE.Intersection[]
+    ) {
+      const lineParams = raycaster.params.Line;
+      if (!lineParams) {
+        THREE.LineSegments.prototype.raycast.call(this, raycaster, intersects);
+        return;
+      }
+      const previousThreshold = lineParams.threshold;
+      lineParams.threshold = computeWorldThreshold(this, raycaster, viewportHeightRef.current);
+      THREE.LineSegments.prototype.raycast.call(this, raycaster, intersects);
+      lineParams.threshold = previousThreshold;
+    },
+    []
+  );
+
   return (
     <lineSegments
       geometry={geometry}
@@ -158,24 +180,32 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
   );
 }
 
-// Pick threshold for line raycasting. Earlier we used 0.5mm world-units to
-// be forgiving on hi-DPI displays, but on a 9.6mm-tall stud brick that
-// makes every side face partially "inside" the line pick volume — edges
-// then win the closest-hit race for hovers that visually land on a face.
-// 0.15 keeps lines easy to grab without swallowing face area.
-const PICK_THRESHOLD_WORLD = 0.15;
-function raycastLines(
-  this: THREE.LineSegments,
+const PICK_THRESHOLD_PX = 6;
+const FALLBACK_WORLD_THRESHOLD = 0.15;
+const _center = new THREE.Vector3();
+
+function computeWorldThreshold(
+  lines: THREE.LineSegments,
   raycaster: THREE.Raycaster,
-  intersects: THREE.Intersection[]
-) {
-  const lineParams = raycaster.params.Line;
-  if (!lineParams) {
-    THREE.LineSegments.prototype.raycast.call(this, raycaster, intersects);
-    return;
+  viewportHeight: number
+): number {
+  const camera = raycaster.camera as THREE.Camera | null;
+  if (!camera || viewportHeight <= 0) return FALLBACK_WORLD_THRESHOLD;
+  if ((camera as THREE.PerspectiveCamera).isPerspectiveCamera) {
+    const persp = camera as THREE.PerspectiveCamera;
+    if (!lines.geometry.boundingSphere) lines.geometry.computeBoundingSphere();
+    const sphere = lines.geometry.boundingSphere;
+    if (!sphere) return FALLBACK_WORLD_THRESHOLD;
+    _center.copy(sphere.center).applyMatrix4(lines.matrixWorld);
+    const distance = persp.position.distanceTo(_center);
+    const fovRad = (persp.fov * Math.PI) / 180;
+    const worldPerPixel = (2 * distance * Math.tan(fovRad / 2)) / viewportHeight;
+    return worldPerPixel * PICK_THRESHOLD_PX;
   }
-  const previousThreshold = lineParams.threshold;
-  lineParams.threshold = PICK_THRESHOLD_WORLD;
-  THREE.LineSegments.prototype.raycast.call(this, raycaster, intersects);
-  lineParams.threshold = previousThreshold;
+  if ((camera as THREE.OrthographicCamera).isOrthographicCamera) {
+    const ortho = camera as THREE.OrthographicCamera;
+    const worldPerPixel = (ortho.top - ortho.bottom) / ortho.zoom / viewportHeight;
+    return worldPerPixel * PICK_THRESHOLD_PX;
+  }
+  return FALLBACK_WORLD_THRESHOLD;
 }

--- a/site/src/components/playground/ShapeRenderer.tsx
+++ b/site/src/components/playground/ShapeRenderer.tsx
@@ -3,8 +3,22 @@ import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { MeshData } from '../../stores/playgroundStore';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
-import type { FaceInfo } from '../../workers/workerProtocol';
+import type { FaceGroup, FaceInfo } from '../../workers/workerProtocol';
 import { useViewerStore } from '../../stores/viewerStore';
+
+function findFaceGroupAt(groups: FaceGroup[], triangleIndex: number): FaceGroup | null {
+  const indexBufferOffset = triangleIndex * 3;
+  let lo = 0;
+  let hi = groups.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const group = groups[mid]!;
+    if (indexBufferOffset < group.start) hi = mid - 1;
+    else if (indexBufferOffset >= group.start + group.count) lo = mid + 1;
+    else return group;
+  }
+  return null;
+}
 
 export default function ShapeRenderer({ data }: { data: MeshData }) {
   const viewMode = useViewerStore((s) => s.viewMode);
@@ -23,16 +37,8 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
     geo.setAttribute('position', new THREE.BufferAttribute(data.position, 3));
     geo.setAttribute('normal', new THREE.BufferAttribute(data.normal, 3));
     geo.setIndex(new THREE.BufferAttribute(data.index, 1));
-    // Add per-face groups so raycaster intersections expose `materialIndex`,
-    // which we map back to faceId via `data.faceGroups`.
-    if (data.faceGroups) {
-      for (let i = 0; i < data.faceGroups.length; i++) {
-        const group = data.faceGroups[i]!;
-        geo.addGroup(group.start, group.count, i);
-      }
-    }
     return geo;
-  }, [data.position, data.normal, data.index, data.faceGroups]);
+  }, [data.position, data.normal, data.index]);
 
   useEffect(() => {
     return () => {
@@ -47,12 +53,14 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
     return byId;
   }, [data.faceInfos]);
 
+  // three.js only sets face.materialIndex when the mesh has a materials array;
+  // with a single material it defaults to 0. Look up by faceIndex instead.
   const resolveFace = useCallback(
     (event: ThreeEvent<PointerEvent | MouseEvent>): FaceInfo | null => {
       if (!data.faceGroups || !faceInfoById) return null;
-      const materialIndex = event.face?.materialIndex;
-      if (materialIndex === undefined) return null;
-      const group = data.faceGroups[materialIndex];
+      const triangleIndex = event.faceIndex;
+      if (triangleIndex === undefined || triangleIndex === null) return null;
+      const group = findFaceGroupAt(data.faceGroups, triangleIndex);
       if (!group) return null;
       return faceInfoById.get(group.faceId) ?? null;
     },
@@ -149,7 +157,7 @@ export default function ShapeRenderer({ data }: { data: MeshData }) {
         roughness={0.45}
         emissive="#d4d8dc"
         emissiveIntensity={0.08}
-        side={THREE.DoubleSide}
+        side={viewMode === 'solid' ? THREE.FrontSide : THREE.DoubleSide}
         polygonOffset
         polygonOffsetFactor={1}
         polygonOffsetUnits={1}


### PR DESCRIPTION
## Summary

Three bugs surfaced in the playground 3D viewer's hover behavior.

**Root cause — every hover returned the top face.** Three.js writes `intersection.face.materialIndex` only when a mesh has a *materials array*; with our single `MeshStandardMaterial` it defaults to `0`, so the materialIndex-based lookup always resolved to `faceGroups[0]` (the top face) regardless of which triangle the ray hit. The geometry's groups were effectively invisible to the raycaster. Switched the resolver to use `event.faceIndex` (the triangle index, always populated) with a binary search over `faceGroups[start, start+count)`, mirroring the existing edge resolver.

**Edge picking is now zoom-independent.** Replaced the fixed `0.15mm` world-space pick threshold with a ~6px screen-space threshold computed per-pick from the camera distance and viewport height (perspective + orthographic both supported). Edges now feel the same to grab whether you're zoomed in or out.

**Solid view no longer picks back-facing geometry.** Switched from `THREE.DoubleSide` to `THREE.FrontSide` in solid mode so rotating around the model never resolves to a face on the far side. Wireframe and xray keep `DoubleSide` since both let you see and pick through the solid.

## Test plan

- [ ] Open the playground with the default stud-brick. Hover the side faces, the cavity walls, the anti-stud tubes, and the underside of the top — tooltip should match the cursor target on each.
- [ ] Zoom in close on an edge and zoom way out. Edges should feel similarly easy to grab at both extremes.
- [ ] Rotate the brick so the bottom face is angled toward the camera — hovering near the silhouette should not resolve to a back-facing face on the opposite side.
- [ ] Switch to wireframe and xray, confirm hover still works through-the-model in both.