### PR TITLE
refactor(playground): allocate edge-pick centroid locally

### DIFF
--- a/site/src/components/playground/EdgeRenderer.tsx
+++ b/site/src/components/playground/EdgeRenderer.tsx
@@ -182,7 +182,6 @@ export default function EdgeRenderer({ edges, edgeGroups, edgeInfos }: Props) {
 
 const PICK_THRESHOLD_PX = 6;
 const FALLBACK_WORLD_THRESHOLD = 0.15;
-const _center = new THREE.Vector3();
 
 function computeWorldThreshold(
   lines: THREE.LineSegments,
@@ -196,8 +195,8 @@ function computeWorldThreshold(
     if (!lines.geometry.boundingSphere) lines.geometry.computeBoundingSphere();
     const sphere = lines.geometry.boundingSphere;
     if (!sphere) return FALLBACK_WORLD_THRESHOLD;
-    _center.copy(sphere.center).applyMatrix4(lines.matrixWorld);
-    const distance = persp.position.distanceTo(_center);
+    const center = new THREE.Vector3().copy(sphere.center).applyMatrix4(lines.matrixWorld);
+    const distance = persp.position.distanceTo(center);
     const fovRad = (persp.fov * Math.PI) / 180;
     const worldPerPixel = (2 * distance * Math.tan(fovRad / 2)) / viewportHeight;
     return worldPerPixel * PICK_THRESHOLD_PX;


### PR DESCRIPTION
## Summary

Greptile flagged the module-level \`_center\` Vector3 in \`EdgeRenderer.tsx\` (introduced in #886) as shared mutable state. This PR drops it and allocates the centroid per pick instead. Cost is negligible (one Vector3 per raycast, at most 60 Hz) and the function is fully pure again, so a second \`EdgeRenderer\` mounted in the same scene can't accidentally share buffers.

Follow-up to #886, which auto-merged before Greptile's comments landed.

## Test plan

- [ ] Hover edges in the playground at a few zoom levels — pick feel should be unchanged from #886.