### PR TITLE
fix(docs-site): ignore /playground links in vitepress dead-link check

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -15,6 +15,9 @@ export default withMermaid(
     base: process.env.DOCS_BASE ?? '/',
     cleanUrls: true,
     lastUpdated: true,
+    // /playground is staged into the VitePress dist after this build runs
+    // (see vercel.json buildCommand), so the link checker can't see it.
+    ignoreDeadLinks: [/^\/playground(\/|$)/],
     head: [
       ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
       ['link', { rel: 'icon', href: '/favicon.ico', type: 'image/x-icon' }],


### PR DESCRIPTION
## Summary
- Vercel deploys have been failing since #884 (`68d11d85`) with `4 dead link(s) found` for `/playground` references in `migration/replicad.md`, `introduction/why-brepjs.md`, `getting-started/cheat-sheet.md`, and `reference/glossary.md`.
- The links are correct — `/playground` is the deployed URL — but VitePress's dead-link checker can't validate them because `vercel.json`'s `buildCommand` stages the playground subtree into the VitePress dist *after* VitePress finishes its own build.
- Whitelist `/playground(/...)?` in `ignoreDeadLinks` so the checker skips that one cross-build path while continuing to validate every other link.

## Test plan
- [x] `npm run build --workspace=site` succeeds (playground build unchanged)
- [x] `cd docs-site && npm run build` succeeds — previously failed with 4 dead links, now completes
- [x] Full Vercel `buildCommand` reproduced locally end-to-end; final dist contains both docs and `playground/` subtree
- [ ] Vercel preview deploy passes