### PR TITLE
chore(husky): only print pre-commit help on real failures

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 set -e
 
 # Show helpful error message on failure
-trap 'bash scripts/pre-commit-help.sh 2>/dev/null || true' EXIT
+trap 'rc=$?; [ "$rc" -ne 0 ] && bash scripts/pre-commit-help.sh 2>/dev/null; exit "$rc"' EXIT
 
 # Tier 1: Fast, independent checks (parallel)
 npx lint-staged &


### PR DESCRIPTION
## Summary
- The pre-commit hook's `trap … EXIT` ran `scripts/pre-commit-help.sh` unconditionally, so every successful commit was followed by a misleading `❌ Pre-commit hook failed` banner. The actual exit status was always correct, just the chrome lied.
- Capture `$?` at the top of the trap, gate the help script on a non-zero status, and re-exit with the original code so a help-script failure can never mask the real one.

## Test plan
- [x] `bash -c 'set -e; trap "rc=$?; …" EXIT; exit 0'` → no banner, exit 0
- [x] `bash -c 'set -e; trap "rc=$?; …" EXIT; exit 7'` → banner printed, exit 7
- [x] The commit that introduces this fix went through pre-commit cleanly with no banner — proof on this very branch