### PR TITLE
chore: retire docs.brepjs.dev references after domain merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ When you add or modify a code block in a chapter, the doc-test harness picks it 
 
 ### Docs deployment
 
-The chapter site (`docs-site/`) is deployed to Vercel at `https://docs.brepjs.dev` via a Vercel project rooted at `docs-site/` (config: `docs-site/vercel.json`). Pushing to `main` produces a production deploy; PRs get preview deploys.
+The chapter site (`docs-site/`) is deployed to Vercel at `https://brepjs.dev` via a Vercel project rooted at `docs-site/` (config: `docs-site/vercel.json`). Pushing to `main` produces a production deploy; PRs get preview deploys.
 
 The TypeDoc API reference is a separate deploy on GitHub Pages (`https://andymai.github.io/brepjs/`) via `.github/workflows/docs.yml`. Keeping them split lets the chapter site iterate without re-running TypeDoc.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CAD modeling for JavaScript.
 [![CI](https://github.com/andymai/brepjs/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/brepjs/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
-**[Getting Started](./docs/getting-started.md)** · **[Cheat Sheet](./docs/cheat-sheet.md)** · **[Docs](https://docs.brepjs.dev/)**
+**[Getting Started](./docs/getting-started.md)** · **[Cheat Sheet](./docs/cheat-sheet.md)** · **[Docs](https://brepjs.dev/)**
 
 Shapes are exact mathematical boundaries - not triangle meshes - so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
 
@@ -69,16 +69,16 @@ Imports flow downward only. Boundaries are enforced in CI.
 
 The chapter-based guide is the recommended starting point:
 
-- **[Why brepjs](https://docs.brepjs.dev/introduction/why-brepjs)** — what makes it different, who it's for
-- **[Install & Initialize](https://docs.brepjs.dev/getting-started/install)** — three init styles, bundler notes
-- **[Your First Solid](https://docs.brepjs.dev/getting-started/first-solid)** — the canonical drill-fillet-export workflow
-- **[Cheat Sheet](https://docs.brepjs.dev/getting-started/cheat-sheet)** — single-page reference
-- **[Core Concepts](https://docs.brepjs.dev/concepts/brep-vs-mesh)** — B-Rep, topology, types, kernels, tolerance
-- **[Common Tasks](https://docs.brepjs.dev/tasks/booleans)** — booleans, fillets, sketching, lofts, sweeps, finders, measurement, IO
-- **[Three.js Integration](https://docs.brepjs.dev/integration/threejs)** — meshing and rendering
-- **[Migration](https://docs.brepjs.dev/migration/replicad)** — coming from Replicad, OpenSCAD, or Three.js
-- **[Extending brepjs](https://docs.brepjs.dev/extending/architecture)** — custom kernels, custom operations, architecture
-- **[Reference](https://docs.brepjs.dev/reference/glossary)** — glossary, function lookup, error codes, ADRs
+- **[Why brepjs](https://brepjs.dev/introduction/why-brepjs)** — what makes it different, who it's for
+- **[Install & Initialize](https://brepjs.dev/getting-started/install)** — three init styles, bundler notes
+- **[Your First Solid](https://brepjs.dev/getting-started/first-solid)** — the canonical drill-fillet-export workflow
+- **[Cheat Sheet](https://brepjs.dev/getting-started/cheat-sheet)** — single-page reference
+- **[Core Concepts](https://brepjs.dev/concepts/brep-vs-mesh)** — B-Rep, topology, types, kernels, tolerance
+- **[Common Tasks](https://brepjs.dev/tasks/booleans)** — booleans, fillets, sketching, lofts, sweeps, finders, measurement, IO
+- **[Three.js Integration](https://brepjs.dev/integration/threejs)** — meshing and rendering
+- **[Migration](https://brepjs.dev/migration/replicad)** — coming from Replicad, OpenSCAD, or Three.js
+- **[Extending brepjs](https://brepjs.dev/extending/architecture)** — custom kernels, custom operations, architecture
+- **[Reference](https://brepjs.dev/reference/glossary)** — glossary, function lookup, error codes, ADRs
 - **[API Reference (TypeDoc)](https://andymai.github.io/brepjs/)** — searchable type-level reference
 
 Legacy single-page docs in [./docs/](./docs/) remain available; the chapter site is the canonical location going forward.

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -156,7 +156,7 @@ export default withMermaid(
       theme: 'default',
     },
     sitemap: {
-      hostname: 'https://docs.brepjs.dev',
+      hostname: 'https://brepjs.dev',
     },
   })
 );

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -241,7 +241,7 @@ Vite handles WASM loading automatically. For other bundlers, you may need to con
 >
 > See [Compatibility - No SSR Support](./compatibility.md#3-no-ssr-support) for patterns.
 
-Try the [interactive playground](https://docs.brepjs.dev/playground) for live experimentation.
+Try the [interactive playground](https://brepjs.dev/playground) for live experimentation.
 
 ## The 2D → 3D workflow
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -58,7 +58,7 @@ The kernel abstraction layer (`src/kernel/`) translates all brepjs calls into OC
 
 See `docs/cheat-sheet.md` for a single-page reference covering all common operations (primitives, booleans, transforms, fillets, measurement, export, memory management, error handling).
 
-Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://docs.brepjs.dev/playground) for live experimentation.
+Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://brepjs.dev/playground) for live experimentation.
 
 ## API Style
 

--- a/llms.txt
+++ b/llms.txt
@@ -58,7 +58,7 @@ The kernel abstraction layer (`src/kernel/`) translates all brepjs calls into OC
 
 See `docs/cheat-sheet.md` for a single-page reference covering all common operations (primitives, booleans, transforms, fillets, measurement, export, memory management, error handling).
 
-Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://docs.brepjs.dev/playground) for live experimentation.
+Works in both Node.js and browsers. For browser setup with Vite, see `docs/getting-started.md` (Browser Setup section). Try the [interactive playground](https://brepjs.dev/playground) for live experimentation.
 
 ## API Style
 


### PR DESCRIPTION
## Summary
- The `docs.brepjs.dev` subdomain was pointing at an older Vercel deployment that hadn't been redeployed since before the docs-site and root projects were merged. Result: the old subdomain serves a 45-hour-old build with no `/playground` route.
- Replace `https://docs.brepjs.dev` with `https://brepjs.dev` (apex; transparently 307s to `www.brepjs.dev` where the merged project deploys) across user-facing docs, the llms.txt feeds, CONTRIBUTING, and the VitePress sitemap hostname.

## Files changed
- `README.md` — 11 hyperlinks
- `llms.txt`, `llms-full.txt` — playground link in each
- `CONTRIBUTING.md` — docs-deployment description
- `docs/getting-started.md` — playground link
- `docs-site/.vitepress/config.ts` — sitemap hostname

## Possible follow-ups (not in this PR)
- `docs-site/vercel.json` and the "Vercel project rooted at `docs-site/`" wording in CONTRIBUTING look like leftovers from the pre-merge two-project setup. If the merged project is the only active deploy, both can be removed/updated. Happy to do a follow-up PR if you confirm.

## Test plan
- [x] `rg 'docs\.brepjs\.dev'` returns no hits in tracked files after the change
- [x] `https://brepjs.dev/playground` resolves to HTTP 200 (verified live, post-#888/#889 merge)
- [ ] Vercel preview build passes