### PR TITLE
fix(playground): transpile user TypeScript and stop pinning stale defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,40 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -438,40 +438,6 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -1112,7 +1078,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1134,7 +1099,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1144,14 +1108,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1920,6 +1882,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2877,7 +2840,7 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2899,8 +2862,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2935,6 +2898,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
       "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3019,6 +2983,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -3260,6 +3225,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3433,6 +3399,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3518,6 +3485,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3787,8 +3760,9 @@
       "version": "2.44.1",
       "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.44.1.tgz",
       "integrity": "sha512-YNwpk+i90kbZ/1580wJniuLvSAGhqoR2UMNFRv9/MIJzjgwFCRdMpyIBXJqE1X30OrbxavJLUHxGuYWSWGSvzg==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "devOptional": true,
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -4082,7 +4056,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
       "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
@@ -4186,6 +4160,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4261,7 +4236,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -4360,7 +4334,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -4492,6 +4467,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4578,6 +4554,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4919,7 +4896,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -5927,7 +5903,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -6375,6 +6350,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -6386,6 +6362,17 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6433,6 +6420,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6448,8 +6444,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.0.0.tgz",
       "integrity": "sha512-5/odaoPCoYMziO4pApzvkRa6uuVrTRTnJ2QUkTgh4YYcYyQqhAXsZ5psqToE3xM66shiSYa0xPZUFZer5heaTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "comlink": "^4.4.2"
       }
@@ -6760,13 +6757,21 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/pkg-types": {
@@ -7020,6 +7025,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7029,6 +7035,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7154,6 +7161,7 @@
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -7324,6 +7332,7 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -7582,6 +7591,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7673,11 +7713,33 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/three": {
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -7738,7 +7800,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -7813,6 +7874,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -7957,6 +8024,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8018,8 +8086,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
@@ -8221,6 +8288,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8325,6 +8393,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -8763,6 +8832,7 @@
         "react-dom": "19.2.5",
         "react-resizable-panels": "4.11.0",
         "shiki": "4.0.2",
+        "sucrase": "3.35.1",
         "three": "0.184.0",
         "zustand": "5.0.12"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.5",
     "react-resizable-panels": "4.11.0",
     "shiki": "4.0.2",
+    "sucrase": "3.35.1",
     "three": "0.184.0",
     "zustand": "5.0.12"
   },

--- a/site/src/hooks/useDraftPersistence.ts
+++ b/site/src/hooks/useDraftPersistence.ts
@@ -3,8 +3,41 @@ import { usePlaygroundStore } from '../stores/playgroundStore';
 import { DEFAULT_CODE } from '../lib/constants';
 import { hasShareParams } from '../lib/urlCodec';
 
-const DRAFT_KEY = 'brepjs-playground-draft';
+// v2 carries `{ code, hasUserEdit }`; v1 was a bare string. The v1 key is
+// dropped on first read so a saved old default never sticks to the user
+// after DEFAULT_CODE changes.
+const DRAFT_KEY = 'brepjs-playground-draft-v2';
+const LEGACY_DRAFT_KEY = 'brepjs-playground-draft';
 const DEBOUNCE_MS = 500;
+
+interface Draft {
+  code: string;
+  hasUserEdit: boolean;
+}
+
+function readDraft(): Draft | null {
+  try {
+    localStorage.removeItem(LEGACY_DRAFT_KEY);
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Draft>;
+    if (typeof parsed.code !== 'string') return null;
+    return { code: parsed.code, hasUserEdit: !!parsed.hasUserEdit };
+  } catch {
+    return null;
+  }
+}
+
+function writeDraft(code: string): void {
+  try {
+    localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ code, hasUserEdit: code !== DEFAULT_CODE })
+    );
+  } catch {
+    // best-effort: localStorage can throw under quota or privacy settings.
+  }
+}
 
 /**
  * Persists the editor code to localStorage so an accidental tab close doesn't
@@ -23,16 +56,14 @@ export function useDraftPersistence() {
     const url = new URL(window.location.href);
     if (hasShareParams(url)) return;
 
-    let draft: string | null = null;
-    try {
-      draft = localStorage.getItem(DRAFT_KEY);
-    } catch {
-      return;
-    }
-    // Skip restore when the draft matches the default — that's just noise
-    // (user never edited last time).
-    if (!draft || draft === DEFAULT_CODE) return;
-    setCode(draft);
+    const draft = readDraft();
+    if (!draft) return;
+    // `hasUserEdit:false` means the draft was the default at save time, so a
+    // newer DEFAULT_CODE shipping in this build should win — restoring would
+    // pin the user to a stale (and possibly broken) example.
+    if (!draft.hasUserEdit) return;
+    if (draft.code === DEFAULT_CODE) return;
+    setCode(draft.code);
   }, [setCode]);
 
   // Debounced save on every code change. Two guards:
@@ -53,12 +84,7 @@ export function useDraftPersistence() {
     }
     if (hasShareParams(new URL(window.location.href))) return;
     const t = setTimeout(() => {
-      try {
-        localStorage.setItem(DRAFT_KEY, code);
-      } catch {
-        // localStorage can throw under quota or privacy settings — silently
-        // give up; the draft is best-effort, not load-bearing.
-      }
+      writeDraft(code);
     }, DEBOUNCE_MS);
     return () => {
       clearTimeout(t);
@@ -69,6 +95,7 @@ export function useDraftPersistence() {
 export function clearDraft(): void {
   try {
     localStorage.removeItem(DRAFT_KEY);
+    localStorage.removeItem(LEGACY_DRAFT_KEY);
   } catch {
     // best-effort
   }

--- a/site/src/hooks/useDraftPersistence.ts
+++ b/site/src/hooks/useDraftPersistence.ts
@@ -17,12 +17,22 @@ interface Draft {
 
 function readDraft(): Draft | null {
   try {
+    // Migrate v1 user work into v2 before deleting the legacy key — otherwise
+    // anyone with a non-default v1 draft loses their code on first load.
+    const legacyRaw = localStorage.getItem(LEGACY_DRAFT_KEY);
     localStorage.removeItem(LEGACY_DRAFT_KEY);
+
     const raw = localStorage.getItem(DRAFT_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<Draft>;
-    if (typeof parsed.code !== 'string') return null;
-    return { code: parsed.code, hasUserEdit: !!parsed.hasUserEdit };
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<Draft>;
+      if (typeof parsed.code !== 'string') return null;
+      return { code: parsed.code, hasUserEdit: !!parsed.hasUserEdit };
+    }
+
+    if (typeof legacyRaw === 'string' && legacyRaw && legacyRaw !== DEFAULT_CODE) {
+      return { code: legacyRaw, hasUserEdit: true };
+    }
+    return null;
   } catch {
     return null;
   }

--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -1,3 +1,4 @@
+import { transform } from 'sucrase';
 import type { ToWorker, FromWorker, MeshTransfer, FaceGroup, EdgeGroup } from './workerProtocol';
 import { WASM_CACHE_NAME } from '../lib/wasmConfig';
 
@@ -137,6 +138,17 @@ function rewriteBrepjsImports(code: string, wrapperUrl: string): string {
   return code.replace(/(\bfrom\s+)(['"])brepjs(?:\/quick)?\2/g, `$1'${wrapperUrl}'`);
 }
 
+// Strip TypeScript syntax so the browser's `import()` of a JS blob can parse
+// the user's code. Sucrase preserves line numbers, which keeps
+// `extractUserLine` accurate for runtime error markers.
+function stripTypeScript(code: string): string {
+  return transform(code, {
+    transforms: ['typescript'],
+    disableESTransforms: true,
+    preserveDynamicImport: true,
+  }).code;
+}
+
 function extractUserLine(err: unknown, userBlobUrl: string): number | undefined {
   if (!(err instanceof Error) || !err.stack) return undefined;
   for (const line of err.stack.split('\n')) {
@@ -191,7 +203,23 @@ async function handleEval(id: string, code: string) {
     consoleOutput.push('[warn] ' + args.map(String).join(' '));
   };
 
-  const rewritten = rewriteBrepjsImports(code, brepjsBlobUrl);
+  let stripped: string;
+  try {
+    stripped = stripTypeScript(code);
+  } catch (e) {
+    // Sucrase parse errors include `(line:col)` so the existing line-number
+    // path can't recover them — pull the line out of the message instead.
+    const message = e instanceof Error ? e.message : String(e);
+    const match = message.match(/\((\d+):\d+\)/);
+    const line = match?.[1] ? parseInt(match[1], 10) : undefined;
+    post({ type: 'eval-error', id, error: message, line });
+    console.log = origLog;
+    console.warn = origWarn;
+    cancelledIds.delete(id);
+    return;
+  }
+
+  const rewritten = rewriteBrepjsImports(stripped, brepjsBlobUrl);
   const userBlob = new Blob([rewritten], { type: 'application/javascript' });
   const userBlobUrl = URL.createObjectURL(userBlob);
 

--- a/site/src/workers/cad.worker.ts
+++ b/site/src/workers/cad.worker.ts
@@ -203,27 +203,27 @@ async function handleEval(id: string, code: string) {
     consoleOutput.push('[warn] ' + args.map(String).join(' '));
   };
 
-  let stripped: string;
-  try {
-    stripped = stripTypeScript(code);
-  } catch (e) {
-    // Sucrase parse errors include `(line:col)` so the existing line-number
-    // path can't recover them — pull the line out of the message instead.
-    const message = e instanceof Error ? e.message : String(e);
-    const match = message.match(/\((\d+):\d+\)/);
-    const line = match?.[1] ? parseInt(match[1], 10) : undefined;
-    post({ type: 'eval-error', id, error: message, line });
-    console.log = origLog;
-    console.warn = origWarn;
-    cancelledIds.delete(id);
-    return;
-  }
-
-  const rewritten = rewriteBrepjsImports(stripped, brepjsBlobUrl);
-  const userBlob = new Blob([rewritten], { type: 'application/javascript' });
-  const userBlobUrl = URL.createObjectURL(userBlob);
+  // Hoisted so the single finally block can revoke if it was ever assigned.
+  let userBlobUrl: string | undefined;
 
   try {
+    let stripped: string;
+    try {
+      stripped = stripTypeScript(code);
+    } catch (e) {
+      // Sucrase parse errors include `(line:col)` so the existing line-number
+      // path can't recover them — pull the line out of the message instead.
+      const message = e instanceof Error ? e.message : String(e);
+      const match = message.match(/\((\d+):\d+\)/);
+      const line = match?.[1] ? parseInt(match[1], 10) : undefined;
+      post({ type: 'eval-error', id, error: message, line });
+      return;
+    }
+
+    const rewritten = rewriteBrepjsImports(stripped, brepjsBlobUrl);
+    const userBlob = new Blob([rewritten], { type: 'application/javascript' });
+    userBlobUrl = URL.createObjectURL(userBlob);
+
     // Playground evaluates user-authored ES modules in a sandboxed Web Worker
     // with no DOM, cookies, or storage access.
     const userModule = (await import(/* @vite-ignore */ userBlobUrl)) as { default?: unknown };
@@ -323,10 +323,10 @@ async function handleEval(id: string, code: string) {
     );
   } catch (e) {
     const errorMsg = e instanceof Error ? e.message : String(e);
-    const line = extractUserLine(e, userBlobUrl);
+    const line = userBlobUrl ? extractUserLine(e, userBlobUrl) : undefined;
     post({ type: 'eval-error', id, error: errorMsg, line });
   } finally {
-    URL.revokeObjectURL(userBlobUrl);
+    if (userBlobUrl) URL.revokeObjectURL(userBlobUrl);
     console.log = origLog;
     console.warn = origWarn;
     cancelledIds.delete(id);


### PR DESCRIPTION
## Summary

Two bugs that compounded — fresh users typing valid TS hit a parser error, and existing users with a saved draft from a since-changed default got stuck on the stale code until they cleared localStorage.

**Worker (`Unexpected token ':'`).** The worker wrapped user code in `Blob<application/javascript>` and `import()`ed it directly. Anything TS-only — type annotations, `as`, generics in expressions — died on parse. The shipped `DEFAULT_CODE` already has `(studsX: number, ...)`, so even an untouched playground was broken in any browser without TC39 type-stripping. Adds `sucrase` in strip-only mode (preserves line numbers so `extractUserLine` still works) before the import-rewriter, and reports parse failures as `eval-error` with the line pulled from sucrase's `(line:col)` suffix.

**Draft persistence (stale defaults).** `useDraftPersistence` skipped restore only when the draft equalled the *current* `DEFAULT_CODE`. A draft that matched a *previous* default was restored verbatim, so `DEFAULT_CODE` updates never reached users who'd loaded the playground before the change. New shape is `{ code, hasUserEdit }` under a v2 key — `hasUserEdit` is recomputed at save time as `code !== DEFAULT_CODE`, and the restore branch only fires when it's true. The legacy v1 key is dropped on first read so old stale-default strings don't leak forward.

## Bundle impact

`cad.worker.js` grew **5.7 kB → 207 kB** (sucrase parser). It's its own chunk so the main thread is unaffected. Worth it: the worker has been silently broken for any TS-syntax in user code since #880 introduced typed defaults.

## Test plan

- [x] `npm --workspace=site run typecheck` — clean
- [x] `npm --workspace=site run build` — bundles, sucrase ends up in the worker chunk
- [x] `npm --workspace=site run smoke` — engine reaches Ready against the preview build
- [x] Headless puppeteer probe — playground loads, no error banner shown for the default code
- [ ] Verify on Vercel preview that the default `studBrick` actually meshes
- [ ] Verify the v1→v2 migration: load preview with `localStorage.setItem('brepjs-playground-draft', '<old default>')`, reload, expect new default (not old)