### PR TITLE
feat(playground): examples gallery via command palette

### DIFF
--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -11,6 +11,7 @@ import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { SHORTCUTS, formatShortcut } from '../../lib/shortcuts';
 import { startWASMPreload } from '../../lib/wasmPreloader.js';
 import { DEFAULT_CODE } from '../../lib/constants';
+import { EXAMPLES, type Example } from '../../lib/examples';
 import { copyToClipboard } from '../../lib/copyToClipboard';
 import { useScreenshot } from '../../hooks/useScreenshot';
 import Toolbar from './Toolbar';
@@ -110,6 +111,18 @@ export default function PlaygroundPage() {
     clearDraft();
     addToast('Reset to default code');
   }, [addToast]);
+
+  // Loading swaps the editor buffer through the store; EditorPanel's sync
+  // effect picks it up and replaces content via Monaco's pushEditOperations,
+  // which preserves the undo stack — Cmd+Z restores prior work if the user
+  // overwrites edits by accident.
+  const handleLoadExample = useCallback(
+    (example: Example) => {
+      usePlaygroundStore.getState().setCode(example.code);
+      addToast(`Loaded: ${example.label}`);
+    },
+    [addToast]
+  );
 
   // copyToClipboard handles both undefined `navigator.clipboard` (HTTP /
   // sandboxed iframe / older browsers) and a sync throw — neither of which
@@ -409,6 +422,14 @@ export default function PlaygroundPage() {
         keys: '?',
         run: openShortcutHelp,
       },
+      ...EXAMPLES.map((ex) => ({
+        id: `example-${ex.id}`,
+        group: 'Examples',
+        label: `Load: ${ex.label}`,
+        run: () => {
+          handleLoadExample(ex);
+        },
+      })),
     ],
     [
       handleRun,
@@ -418,6 +439,7 @@ export default function PlaygroundPage() {
       handleResetViewer,
       handleScreenshot,
       handleCopyCode,
+      handleLoadExample,
       clearSelections,
       handleExportSTL,
       handleExportSTEP,

--- a/site/src/lib/examples.ts
+++ b/site/src/lib/examples.ts
@@ -89,20 +89,39 @@ export default pegboard(6, 4);
 
 const mortiseAndTenon = `import { box, cut, fuse, translate, unwrap } from 'brepjs/quick';
 
-// Two boards joined with a mortise-and-tenon. The tenon (boss on board A)
-// fits into the mortise (slot in board B) cut by the same dimensions.
-const tenonW = 12;
-const tenonH = 10;
-const tenonD = 16;
+// Two boards joined with a mortise-and-tenon. The tenon (boss on partA)
+// plugs into the mortise (slot in partB) when assembled. Rendered with a
+// 20 mm visual gap between them so both halves are clearly visible.
+const len = 60;          // board length (X)
+const width = 30;        // board width  (Y)
+const thickness = 16;    // board thickness (Z)
 
-const boardA = box(60, 30, 16);
-const tenon = translate(box(tenonW, tenonH, tenonD), [60, (30 - tenonH) / 2, (16 - tenonW) / 2 + 2]);
+const tenonD = 16;       // depth of the tenon along X
+const tenonH = 14;       // tenon height in Y
+const tenonW = 10;       // tenon thickness in Z
+const clearance = 0.2;   // mortise oversize for a sliding fit
+const visualGap = 20;    // air between the parts in the render
+
+// Tenon protrudes from boardA's right face along +X.
+const boardA = box(len, width, thickness);
+const tenon = translate(
+  box(tenonD, tenonH, tenonW),
+  [len, (width - tenonH) / 2, (thickness - tenonW) / 2]
+);
 const partA = unwrap(fuse(boardA, tenon));
 
-const boardB = translate(box(60, 30, 16), [60 + tenonD, 0, 0]);
+// boardB sits visualGap mm beyond where the tenon tip would land. The
+// mortise is cut into its left face, sized to accept the tenon plus
+// clearance.
+const boardBX = len + tenonD + visualGap;
+const boardB = translate(box(len, width, thickness), [boardBX, 0, 0]);
 const mortise = translate(
-  box(tenonW + 0.4, tenonH + 0.4, tenonD + 0.2),
-  [60 - 0.1, (30 - tenonH) / 2 - 0.2, (16 - tenonW) / 2 + 1.9]
+  box(tenonD + clearance, tenonH + clearance, tenonW + clearance),
+  [
+    boardBX - clearance / 2,
+    (width - tenonH) / 2 - clearance / 2,
+    (thickness - tenonW) / 2 - clearance / 2,
+  ]
 );
 const partB = unwrap(cut(boardB, mortise));
 

--- a/site/src/lib/examples.ts
+++ b/site/src/lib/examples.ts
@@ -1,0 +1,144 @@
+/**
+ * Curated playground examples surfaced through the command palette.
+ *
+ * Each entry must be self-contained — no shared helpers, no TS-only constructs
+ * the worker's sucrase strip can't handle. The `code` field becomes the editor
+ * buffer verbatim when the user picks the example.
+ */
+export interface Example {
+  id: string;
+  label: string;
+  description: string;
+  code: string;
+}
+
+const drilledBracket = `import { box, cut, cylinder, fillet, edgeFinder, unwrap } from 'brepjs/quick';
+
+// The canonical 5-line code-CAD loop:
+// drill a hole, fillet the vertical edges, hand back a Solid.
+const drilled = unwrap(cut(box(30, 20, 10), cylinder(5, 15, { at: [15, 10, -2] })));
+const part = unwrap(fillet(drilled, edgeFinder().inDirection('Z').findAll(drilled), 1.5));
+
+export default part;
+`;
+
+const primitivesShowcase = `import { box, cone, cylinder, sphere, torus, translate } from 'brepjs/quick';
+
+// Multi-shape return: export an array of solids and the playground renders
+// each one. Useful for spec sheets, side-by-side comparisons, and tests.
+const s = sphere(8);
+const b = translate(box(14, 14, 14), [22, 0, -7]);
+const c = translate(cylinder(6, 14), [-22, 0, -7]);
+const co = translate(cone(7, 0, 14), [0, 22, -7]);
+const t = translate(torus(7, 2), [0, -22, 0]);
+
+export default [s, b, c, co, t];
+`;
+
+const vase = `import { Sketcher, revolve, fillet, edgeFinder, unwrap } from 'brepjs/quick';
+
+// Sketch a 2D profile, revolve it 360° around Z to make a solid of revolution.
+// The closing \`hLineTo(0)\` snaps the profile back to the axis so the revolve
+// produces a watertight body.
+const profile = new Sketcher('XZ')
+  .hLine(18)
+  .vLine(2)
+  .smoothSplineTo([8, 30])
+  .smoothSplineTo([14, 60])
+  .vLine(8)
+  .hLineTo(0)
+  .close();
+
+const body = unwrap(revolve(profile));
+
+// Fillet the rim and base for that thrown-on-a-wheel feel.
+const lipEdges = edgeFinder().atZ(70, { tol: 0.5 }).findAll(body);
+const filleted = unwrap(fillet(body, lipEdges, 0.6));
+
+export default filleted;
+`;
+
+const pegboard = `import { box, cutAll, cylinder } from 'brepjs/quick';
+import { unwrap } from 'brepjs/quick';
+
+// Parametric pegboard: any width × height, fixed 25 mm grid, 6 mm pegs.
+function pegboard(cols: number, rows: number) {
+  const pitch = 25;
+  const padding = 12.5;
+  const thickness = 6;
+  const pegRadius = 3;
+
+  const W = cols * pitch + padding * 2;
+  const H = rows * pitch + padding * 2;
+
+  const plate = box(W, H, thickness, { at: [-W / 2, -H / 2, 0] });
+
+  const pegs = [];
+  for (let i = 0; i < cols; i++) {
+    for (let j = 0; j < rows; j++) {
+      const x = -W / 2 + padding + i * pitch + pitch / 2;
+      const y = -H / 2 + padding + j * pitch + pitch / 2;
+      pegs.push(cylinder(pegRadius, thickness + 2, { at: [x, y, -1] }));
+    }
+  }
+
+  return unwrap(cutAll(plate, pegs));
+}
+
+export default pegboard(6, 4);
+`;
+
+const mortiseAndTenon = `import { box, cut, fuse, translate, unwrap } from 'brepjs/quick';
+
+// Two boards joined with a mortise-and-tenon. The tenon (boss on board A)
+// fits into the mortise (slot in board B) cut by the same dimensions.
+const tenonW = 12;
+const tenonH = 10;
+const tenonD = 16;
+
+const boardA = box(60, 30, 16);
+const tenon = translate(box(tenonW, tenonH, tenonD), [60, (30 - tenonH) / 2, (16 - tenonW) / 2 + 2]);
+const partA = unwrap(fuse(boardA, tenon));
+
+const boardB = translate(box(60, 30, 16), [60 + tenonD, 0, 0]);
+const mortise = translate(
+  box(tenonW + 0.4, tenonH + 0.4, tenonD + 0.2),
+  [60 - 0.1, (30 - tenonH) / 2 - 0.2, (16 - tenonW) / 2 + 1.9]
+);
+const partB = unwrap(cut(boardB, mortise));
+
+export default [partA, partB];
+`;
+
+export const EXAMPLES: readonly Example[] = [
+  {
+    id: 'drilled-bracket',
+    label: 'Drilled bracket (5 lines)',
+    description: 'box → cut a cylinder → fillet vertical edges. The canonical workflow.',
+    code: drilledBracket,
+  },
+  {
+    id: 'primitives',
+    label: 'Primitives showcase',
+    description: 'sphere · box · cylinder · cone · torus arranged in a plus.',
+    code: primitivesShowcase,
+  },
+  {
+    id: 'vase',
+    label: 'Vase (sketch + revolve)',
+    description: '2D profile with smooth splines revolved 360° around Z.',
+    code: vase,
+  },
+  {
+    id: 'pegboard',
+    label: 'Parametric pegboard',
+    description: 'cols × rows grid of pegs cut from a plate. Tweak the call at the bottom.',
+    code: pegboard,
+  },
+  {
+    id: 'mortise-tenon',
+    label: 'Mortise & tenon',
+    description: 'Two boards joined by boolean fuse + cut, exported side by side.',
+    code: mortiseAndTenon,
+  },
+];

--- a/site/src/lib/examples.ts
+++ b/site/src/lib/examples.ts
@@ -51,15 +51,14 @@ const profile = new Sketcher('XZ')
 
 const body = unwrap(revolve(profile));
 
-// Fillet the rim and base for that thrown-on-a-wheel feel.
-const lipEdges = edgeFinder().atZ(70, { tol: 0.5 }).findAll(body);
+// Fillet the rim — the top of the profile sits at Z=68.
+const lipEdges = edgeFinder().atZ(68, { tol: 0.5 }).findAll(body);
 const filleted = unwrap(fillet(body, lipEdges, 0.6));
 
 export default filleted;
 `;
 
-const pegboard = `import { box, cutAll, cylinder } from 'brepjs/quick';
-import { unwrap } from 'brepjs/quick';
+const pegboard = `import { box, cutAll, cylinder, unwrap } from 'brepjs/quick';
 
 // Parametric pegboard: any width × height, fixed 25 mm grid, 6 mm pegs.
 function pegboard(cols: number, rows: number) {


### PR DESCRIPTION
## Summary

Curated set of 5 runnable examples surfaced through `Cmd+K` (or whatever the palette shortcut is on your platform). Closes the gap from the original audit: the docs cookbook had 8 categories of recipes, but none were one-click runnable in the playground.

Each entry calls `setCode(example.code)`, which routes through `EditorPanel`'s existing `pushEditOperations` sync — Monaco's undo stack survives the swap, so `Cmd+Z` restores prior work if the user picks an example over their own draft by accident. Auto-eval fires through the existing `debouncedRun` chain; no new run path needed.

## What's in the gallery

- **Drilled bracket (5 lines)** — the canonical box → cut a cylinder → fillet vertical edges
- **Primitives showcase** — sphere, box, cylinder, cone, torus arranged in a plus, demos multi-shape array return
- **Vase (sketch + revolve)** — `Sketcher` building a 2D profile with smooth splines, revolved 360° around Z, lip filleted via `edgeFinder`
- **Parametric pegboard** — `cols × rows` grid of pegs cut from a plate; tweak the call at the bottom for custom sizes
- **Mortise & tenon** — two boards joined by `fuse` + `cut`, exported side by side

Examples live in `site/src/lib/examples.ts` so adding more is just appending an entry.

## Why command palette only (no toolbar dropdown)

Toolbar real estate is already tight (Run / Share / STL / STEP / Palette / Help). The palette is the existing discoverability surface — Cmd+K is industry-standard, and grouping under "Examples" makes them findable without crowding the chrome. A toolbar dropdown can be a follow-up if the palette path turns out to bury them.

## Test plan

- [x] `npm --workspace=site run typecheck` — clean
- [x] `npm --workspace=site run build` — bundles
- [x] Headless puppeteer probe: open palette → type "Load: \<name\>" → Enter → wait for eval → assert no error banner. All 5 examples pass.
- [ ] Verify on Vercel preview that each example renders the expected geometry (no eval error ≠ correct geometry)
- [ ] Verify Cmd+Z restores prior code after loading an example