### PR TITLE
feat(playground): tabbed mobile layout under 640px viewport

### DIFF
--- a/site/src/components/playground/MobileLayout.tsx
+++ b/site/src/components/playground/MobileLayout.tsx
@@ -102,10 +102,14 @@ export default function MobileLayout({
 }
 
 function PaneShell({ active, children }: { active: boolean; children: React.ReactNode }) {
+  // `inert` removes the subtree from the tab order and accessibility tree —
+  // critical for hidden Monaco / focusable buttons. `visibility: hidden`
+  // alone leaves them in the focus order, so a user pressing Tab could land
+  // on something they can't see.
   return (
     <div
-      className={`absolute inset-0 ${active ? '' : 'pointer-events-none invisible'}`}
-      aria-hidden={!active}
+      className={`absolute inset-0 ${active ? '' : 'invisible'}`}
+      inert={!active}
     >
       {children}
     </div>

--- a/site/src/components/playground/MobileLayout.tsx
+++ b/site/src/components/playground/MobileLayout.tsx
@@ -14,8 +14,10 @@ interface MobileLayoutProps {
 
 // Single-tab-at-a-time mobile shell. All three panels stay mounted so Monaco's
 // undo stack and the R3F viewer's camera survive a tab switch — non-active
-// tabs are just `display: none` (R3F pauses rendering automatically when its
-// canvas isn't visible, so the hidden viewer doesn't burn frames).
+// panes get `visibility: hidden` (so the elements stay in layout). The hidden
+// viewer doesn't burn frames because its Canvas uses `frameloop="demand"`,
+// so WebGL only renders on explicit invalidation, not while the user is on
+// another tab.
 export default function MobileLayout({
   onCodeChange,
   editorFormatRef,

--- a/site/src/components/playground/MobileLayout.tsx
+++ b/site/src/components/playground/MobileLayout.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import EditorPanel from './EditorPanel';
+import ViewerPanel from './ViewerPanel';
+import OutputPanel from './OutputPanel';
+import { usePlaygroundStore } from '../../stores/playgroundStore';
+
+type Tab = 'editor' | 'viewer' | 'console';
+
+interface MobileLayoutProps {
+  onCodeChange: (code: string) => void;
+  editorFormatRef: { current: (() => void) | null };
+  editorJumpToLineRef: { current: ((line: number) => void) | null };
+}
+
+// Single-tab-at-a-time mobile shell. All three panels stay mounted so Monaco's
+// undo stack and the R3F viewer's camera survive a tab switch — non-active
+// tabs are just `display: none` (R3F pauses rendering automatically when its
+// canvas isn't visible, so the hidden viewer doesn't burn frames).
+export default function MobileLayout({
+  onCodeChange,
+  editorFormatRef,
+  editorJumpToLineRef,
+}: MobileLayoutProps) {
+  const [tab, setTab] = useState<Tab>('viewer');
+  const error = usePlaygroundStore((s) => s.error);
+
+  // Auto-jump to console on the transition into an error so users see the
+  // failure without hunting for the tab. Mirrors the desktop auto-expand,
+  // and the `wasErrorRef` guard keeps repeated renders during the error
+  // state from forcing the tab back if the user manually navigated away.
+  const wasErrorRef = useRef(false);
+  useEffect(() => {
+    const isError = !!error;
+    if (isError && !wasErrorRef.current) setTab('console');
+    wasErrorRef.current = isError;
+  }, [error]);
+
+  const dismissConsole = useCallback(() => {
+    setTab('viewer');
+  }, []);
+
+  const jumpAndOpenEditor = useCallback(
+    (line: number) => {
+      setTab('editor');
+      // Defer until the editor pane is visible — Monaco's reveal calls are
+      // a no-op while the wrapping div is `invisible`.
+      setTimeout(() => editorJumpToLineRef.current?.(line), 0);
+    },
+    [editorJumpToLineRef]
+  );
+
+  return (
+    <div className="flex h-full flex-1 flex-col overflow-hidden">
+      <div className="relative flex-1 overflow-hidden">
+        <PaneShell active={tab === 'editor'}>
+          <EditorPanel
+            onCodeChange={onCodeChange}
+            onFormat={editorFormatRef}
+            jumpToLineRef={editorJumpToLineRef}
+          />
+        </PaneShell>
+        <PaneShell active={tab === 'viewer'}>
+          <ViewerPanel />
+        </PaneShell>
+        <PaneShell active={tab === 'console'}>
+          <OutputPanel onCollapse={dismissConsole} onJumpToLine={jumpAndOpenEditor} />
+        </PaneShell>
+      </div>
+
+      <nav
+        className="flex h-12 shrink-0 items-stretch border-t border-border-subtle bg-surface"
+        role="tablist"
+        aria-label="Playground panels"
+      >
+        <TabButton
+          label="Editor"
+          active={tab === 'editor'}
+          onClick={() => {
+            setTab('editor');
+          }}
+        />
+        <TabButton
+          label="Viewer"
+          active={tab === 'viewer'}
+          onClick={() => {
+            setTab('viewer');
+          }}
+        />
+        <TabButton
+          label="Console"
+          active={tab === 'console'}
+          onClick={() => {
+            setTab('console');
+          }}
+          badge={error ? '!' : undefined}
+        />
+      </nav>
+    </div>
+  );
+}
+
+function PaneShell({ active, children }: { active: boolean; children: React.ReactNode }) {
+  return (
+    <div
+      className={`absolute inset-0 ${active ? '' : 'pointer-events-none invisible'}`}
+      aria-hidden={!active}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TabButton({
+  label,
+  active,
+  onClick,
+  badge,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  badge?: string;
+}) {
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`relative flex flex-1 items-center justify-center gap-1 text-xs font-medium transition-colors ${
+        active
+          ? 'border-t-2 border-teal-primary text-white'
+          : 'border-t-2 border-transparent text-gray-400 hover:text-gray-200'
+      }`}
+    >
+      {label}
+      {badge !== undefined && (
+        <span className="absolute right-[28%] top-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 text-[9px] font-bold text-white">
+          {badge}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_CODE } from '../../lib/constants';
 import { EXAMPLES, type Example } from '../../lib/examples';
 import { copyToClipboard } from '../../lib/copyToClipboard';
 import { useScreenshot } from '../../hooks/useScreenshot';
+import { useIsMobile } from '../../hooks/useIsMobile';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
 import ViewerPanel from './ViewerPanel';
@@ -23,6 +24,7 @@ import LoadingOverlay from './LoadingOverlay';
 import CollapsedConsoleBar from './CollapsedConsoleBar';
 import ShortcutHelp from './ShortcutHelp';
 import CommandPalette, { type Command } from './CommandPalette';
+import MobileLayout from './MobileLayout';
 import ToastContainer from '../shared/ToastContainer';
 
 const shortcutDefs = Object.values(SHORTCUTS);
@@ -57,6 +59,7 @@ export default function PlaygroundPage() {
 
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const setViewMode = useViewerStore((s) => s.setViewMode);
   const cycleViewMode = useViewerStore((s) => s.cycleViewMode);
@@ -485,6 +488,7 @@ export default function PlaygroundPage() {
         onOpenCommandPalette={openCommandPalette}
         onOpenHelp={openShortcutHelp}
         isRunning={isRunning}
+        compact={isMobile}
       />
 
       {pendingReview && (
@@ -509,72 +513,80 @@ export default function PlaygroundPage() {
         </div>
       )}
 
-      <Group
-        orientation="horizontal"
-        defaultLayout={hLayout.defaultLayout}
-        onLayoutChanged={hLayout.onLayoutChanged}
-        className="flex-1 overflow-hidden"
-      >
-        {/* Left: editor + output */}
-        <Panel
-          id="editor-area"
-          panelRef={editorAreaPanelRef}
-          collapsible
-          collapsedSize="0%"
-          minSize="20%"
-          defaultSize="50%"
-          onResize={handleEditorAreaResize}
+      {isMobile ? (
+        <MobileLayout
+          onCodeChange={handleCodeChange}
+          editorFormatRef={editorFormatFnRef}
+          editorJumpToLineRef={editorJumpToLineRef}
+        />
+      ) : (
+        <Group
+          orientation="horizontal"
+          defaultLayout={hLayout.defaultLayout}
+          onLayoutChanged={hLayout.onLayoutChanged}
+          className="flex-1 overflow-hidden"
         >
-          {/* Always-mounted: collapsing this Panel sends its width to 0% but
-              we keep Monaco rendered so its undo stack, cursor position, and
-              scroll state survive a toggle. The 0%-wide container hides the
-              editor visually without remounting it. */}
-          <Group
-            orientation="vertical"
-            defaultLayout={vLayout.defaultLayout}
-            onLayoutChanged={vLayout.onLayoutChanged}
+          {/* Left: editor + output */}
+          <Panel
+            id="editor-area"
+            panelRef={editorAreaPanelRef}
+            collapsible
+            collapsedSize="0%"
+            minSize="20%"
+            defaultSize="50%"
+            onResize={handleEditorAreaResize}
           >
-            <Panel id="editor" defaultSize="80%" minSize="30%">
-              <EditorPanel
-                onCodeChange={handleCodeChange}
-                onFormat={editorFormatFnRef}
-                jumpToLineRef={editorJumpToLineRef}
-              />
-            </Panel>
-            <Separator className="h-px bg-border-subtle" />
-            <Panel
-              id="console"
-              panelRef={consolePanelRef}
-              collapsible
-              collapsedSize="3.5%"
-              minSize="15%"
-              defaultSize="20%"
-              onResize={handleConsoleResize}
+            {/* Always-mounted: collapsing this Panel sends its width to 0% but
+                we keep Monaco rendered so its undo stack, cursor position, and
+                scroll state survive a toggle. The 0%-wide container hides the
+                editor visually without remounting it. */}
+            <Group
+              orientation="vertical"
+              defaultLayout={vLayout.defaultLayout}
+              onLayoutChanged={vLayout.onLayoutChanged}
             >
-              {isConsoleCollapsed ? (
-                <CollapsedConsoleBar onExpand={toggleConsole} />
-              ) : (
-                <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
-              )}
-            </Panel>
-          </Group>
-        </Panel>
+              <Panel id="editor" defaultSize="80%" minSize="30%">
+                <EditorPanel
+                  onCodeChange={handleCodeChange}
+                  onFormat={editorFormatFnRef}
+                  jumpToLineRef={editorJumpToLineRef}
+                />
+              </Panel>
+              <Separator className="h-px bg-border-subtle" />
+              <Panel
+                id="console"
+                panelRef={consolePanelRef}
+                collapsible
+                collapsedSize="3.5%"
+                minSize="15%"
+                defaultSize="20%"
+                onResize={handleConsoleResize}
+              >
+                {isConsoleCollapsed ? (
+                  <CollapsedConsoleBar onExpand={toggleConsole} />
+                ) : (
+                  <OutputPanel onCollapse={toggleConsole} onJumpToLine={handleJumpToLine} />
+                )}
+              </Panel>
+            </Group>
+          </Panel>
 
-        <Separator className="w-px bg-border-subtle" />
+          <Separator className="w-px bg-border-subtle" />
 
-        {/* Right: 3D viewer */}
-        <Panel
-          id="viewer"
-          panelRef={viewerPanelRef}
-          collapsible
-          collapsedSize="0%"
-          minSize="20%"
-          defaultSize="50%"
-          onResize={handleViewerResize}
-        >
-          {isViewerCollapsed ? null : <ViewerPanel />}
-        </Panel>
-      </Group>
+          {/* Right: 3D viewer */}
+          <Panel
+            id="viewer"
+            panelRef={viewerPanelRef}
+            collapsible
+            collapsedSize="0%"
+            minSize="20%"
+            defaultSize="50%"
+            onResize={handleViewerResize}
+          >
+            {isViewerCollapsed ? null : <ViewerPanel />}
+          </Panel>
+        </Group>
+      )}
 
       <StatusBar />
 

--- a/site/src/components/playground/Toolbar.tsx
+++ b/site/src/components/playground/Toolbar.tsx
@@ -11,6 +11,9 @@ interface ToolbarProps {
   onOpenCommandPalette: () => void;
   onOpenHelp: () => void;
   isRunning: boolean;
+  /** Hide Share/STL/STEP and the help button to fit narrow viewports.
+   *  Those actions stay reachable through the command palette. */
+  compact?: boolean;
 }
 
 export default function Toolbar({
@@ -21,6 +24,7 @@ export default function Toolbar({
   onOpenCommandPalette,
   onOpenHelp,
   isRunning,
+  compact = false,
 }: ToolbarProps) {
   const engineReady = useEngineStore((s) => s.status === 'ready');
   const selectionCount = usePlaygroundStore((s) => s.selections.length);
@@ -66,31 +70,35 @@ export default function Toolbar({
         >
           {isRunning ? 'Running...' : 'Run'}
         </button>
-        <button
-          onClick={onShare}
-          disabled={!engineReady}
-          title={`Share (${formatShortcut(SHORTCUTS.share)})`}
-          className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-        >
-          Share
-        </button>
-        <button
-          onClick={onExportSTL}
-          disabled={!engineReady || isRunning}
-          title={`Export STL (${formatShortcut(SHORTCUTS.exportSTL)})`}
-          className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-        >
-          STL
-        </button>
-        <button
-          onClick={onExportSTEP}
-          disabled={!engineReady || isRunning}
-          title={`Export STEP (${formatShortcut(SHORTCUTS.exportSTEP)})`}
-          className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-        >
-          STEP
-        </button>
-        <div className="mx-1 h-4 w-px bg-border-subtle" />
+        {!compact && (
+          <>
+            <button
+              onClick={onShare}
+              disabled={!engineReady}
+              title={`Share (${formatShortcut(SHORTCUTS.share)})`}
+              className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+            >
+              Share
+            </button>
+            <button
+              onClick={onExportSTL}
+              disabled={!engineReady || isRunning}
+              title={`Export STL (${formatShortcut(SHORTCUTS.exportSTL)})`}
+              className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+            >
+              STL
+            </button>
+            <button
+              onClick={onExportSTEP}
+              disabled={!engineReady || isRunning}
+              title={`Export STEP (${formatShortcut(SHORTCUTS.exportSTEP)})`}
+              className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+            >
+              STEP
+            </button>
+            <div className="mx-1 h-4 w-px bg-border-subtle" />
+          </>
+        )}
         <button
           onClick={onOpenCommandPalette}
           title={`Command palette (${formatShortcut(SHORTCUTS.commandPalette)})`}
@@ -102,14 +110,16 @@ export default function Toolbar({
             <path d="M9 9l4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
           </svg>
         </button>
-        <button
-          onClick={onOpenHelp}
-          title="Keyboard shortcuts (?)"
-          aria-label="Show keyboard shortcuts"
-          className="rounded px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
-        >
-          ?
-        </button>
+        {!compact && (
+          <button
+            onClick={onOpenHelp}
+            title="Keyboard shortcuts (?)"
+            aria-label="Show keyboard shortcuts"
+            className="rounded px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
+          >
+            ?
+          </button>
+        )}
       </div>
     </div>
   );

--- a/site/src/hooks/useIsMobile.ts
+++ b/site/src/hooks/useIsMobile.ts
@@ -12,6 +12,11 @@ export function useIsMobile(): boolean {
 
   useEffect(() => {
     const mq = window.matchMedia(QUERY);
+    // Re-sync after mount in case the viewport crossed the breakpoint
+    // between the lazy initializer running and this effect attaching —
+    // the next `change` event won't catch a transition that already
+    // happened during commit.
+    setIsMobile(mq.matches);
     const handler = (e: MediaQueryListEvent) => {
       setIsMobile(e.matches);
     };

--- a/site/src/hooks/useIsMobile.ts
+++ b/site/src/hooks/useIsMobile.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+// Tracks Tailwind's `sm` breakpoint so the playground can swap the
+// horizontal split-panel layout for a tabbed mobile shell.
+const QUERY = '(max-width: 640px)';
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(QUERY);
+    const handler = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+    };
+    mq.addEventListener('change', handler);
+    return () => {
+      mq.removeEventListener('change', handler);
+    };
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

The desktop H/V split-panel layout was unusable on phones — three panes fighting for space on a 390px viewport, and the toolbar's six buttons overflowed. This adds a `useIsMobile` hook (matchMedia at 640px, the Tailwind sm breakpoint) and switches to a tabbed shell below it.

### How it behaves on mobile

- **One panel visible at a time** (Editor / Viewer / Console), driven by a bottom tab bar
- **All three panels stay mounted** (`absolute inset-0` + `invisible` on the inactive ones) so Monaco's undo stack, cursor, scroll position, and the R3F viewer's camera survive a tab switch — no re-init cost
- **Auto-jump to Console on error** mirrors the desktop auto-expand. The `wasErrorRef` guard means it only fires on the *transition* into an error, not on every render while one persists
- **"Jump to line" from a console error** now switches back to the Editor tab and defers Monaco's `revealLineInCenter` until after the pane is visible (calls on a hidden Monaco are no-ops)
- **Error badge** ("!") on the Console tab when there's an active error
- **Toolbar compact mode** hides Share / STL / STEP / help on mobile (still reachable via the command palette), keeping just the Run button so the toolbar doesn't overflow at 390px

### Why tabbed, not stacked

Stacking three panels on a 390×844 viewport gives each ~280px of usable height — too short for either editor or viewer to be useful. A tab bar buys back full-height-per-pane at the cost of one tap to switch. Matches what CodeSandbox / Stackblitz / ReplIt do on mobile, for the same reason.

### Files

- `site/src/hooks/useIsMobile.ts` — `(max-width: 640px)` matchMedia hook
- `site/src/components/playground/MobileLayout.tsx` — new shell, owns tab state
- `site/src/components/playground/PlaygroundPage.tsx` — branches to `MobileLayout` when `isMobile`
- `site/src/components/playground/Toolbar.tsx` — `compact?: boolean` prop, hides extras

## Test plan

- [x] `npm --workspace=site run typecheck` — clean
- [x] `npm --workspace=site run build` — bundles
- [x] Puppeteer probe at 390×844: 3 tabs render, viewer selected by default, switching to Editor reveals Monaco at >100px, console click doesn't crash, only Run visible in compact toolbar
- [ ] Vercel preview on a real phone — verify the on-screen keyboard doesn't mangle the layout when Editor is focused
- [ ] Verify R3F canvas re-fits to its container when switching back to the Viewer tab (the puppeteer probe couldn't measure this — headless lacks GPU and reports the canvas as 0×0 regardless)
- [ ] Verify the tab bar isn't covered by iOS home indicator (may want `env(safe-area-inset-bottom)` follow-up)