### PR TITLE
perf(playground): lazy-load ViewerPanel to defer the three subtree

### DIFF
--- a/site/src/components/playground/MobileLayout.tsx
+++ b/site/src/components/playground/MobileLayout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import EditorPanel from './EditorPanel';
-import ViewerPanel from './ViewerPanel';
+import ViewerPanel from './ViewerPanelLazy';
 import OutputPanel from './OutputPanel';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -17,7 +17,7 @@ import { useScreenshot } from '../../hooks/useScreenshot';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import Toolbar from './Toolbar';
 import EditorPanel from './EditorPanel';
-import ViewerPanel from './ViewerPanel';
+import ViewerPanel from './ViewerPanelLazy';
 import OutputPanel from './OutputPanel';
 import StatusBar from './StatusBar';
 import LoadingOverlay from './LoadingOverlay';

--- a/site/src/components/playground/ViewerPanelLazy.tsx
+++ b/site/src/components/playground/ViewerPanelLazy.tsx
@@ -1,0 +1,17 @@
+import { Suspense, lazy } from 'react';
+
+// `three` (≈900 KB) is only reachable through ViewerPanel's subtree, so
+// gating ViewerPanel behind a dynamic import moves Three.js, R3F, drei,
+// and the viewer-only render components out of the initial bundle. The
+// LoadingOverlay covers engine init, which is the same window the lazy
+// chunk has to download — so the user typically never sees the blank
+// fallback.
+const ViewerPanel = lazy(() => import('./ViewerPanel'));
+
+export default function ViewerPanelLazy() {
+  return (
+    <Suspense fallback={null}>
+      <ViewerPanel />
+    </Suspense>
+  );
+}

--- a/site/src/components/playground/ViewerPanelLazy.tsx
+++ b/site/src/components/playground/ViewerPanelLazy.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react';
+import { Component, Suspense, lazy, type ReactNode } from 'react';
 
 // `three` (≈900 KB) is only reachable through ViewerPanel's subtree, so
 // gating ViewerPanel behind a dynamic import moves Three.js, R3F, drei,
@@ -20,10 +20,45 @@ function ViewerFallback() {
   );
 }
 
+// React.lazy propagates a rejected promise as a render error. Without an
+// ErrorBoundary, a chunk-load failure (CDN hiccup, going offline mid-load)
+// would unmount the entire playground. Reload-on-retry is used because
+// `lazy()` caches its promise — clearing local state alone wouldn't re-
+// attempt the import.
+class ViewerErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    if (this.state.failed) {
+      return (
+        <div
+          className="flex h-full w-full flex-col items-center justify-center gap-2 bg-gray-950 text-sm text-gray-400"
+          role="alert"
+        >
+          <span>Viewer failed to load.</span>
+          <button
+            onClick={() => {
+              window.location.reload();
+            }}
+            className="rounded bg-surface-overlay px-3 py-1 text-xs text-white hover:bg-surface-overlay/80"
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export default function ViewerPanelLazy() {
   return (
-    <Suspense fallback={<ViewerFallback />}>
-      <ViewerPanel />
-    </Suspense>
+    <ViewerErrorBoundary>
+      <Suspense fallback={<ViewerFallback />}>
+        <ViewerPanel />
+      </Suspense>
+    </ViewerErrorBoundary>
   );
 }

--- a/site/src/components/playground/ViewerPanelLazy.tsx
+++ b/site/src/components/playground/ViewerPanelLazy.tsx
@@ -3,14 +3,26 @@ import { Suspense, lazy } from 'react';
 // `three` (≈900 KB) is only reachable through ViewerPanel's subtree, so
 // gating ViewerPanel behind a dynamic import moves Three.js, R3F, drei,
 // and the viewer-only render components out of the initial bundle. The
-// LoadingOverlay covers engine init, which is the same window the lazy
-// chunk has to download — so the user typically never sees the blank
-// fallback.
+// LoadingOverlay covers engine init, which is *usually* the same window
+// the lazy chunk needs to download — but on a slow connection the engine
+// can reach Ready before the chunk lands. The fallback below avoids a
+// blank pane in that case.
 const ViewerPanel = lazy(() => import('./ViewerPanel'));
+
+function ViewerFallback() {
+  return (
+    <div
+      className="flex h-full w-full items-center justify-center bg-gray-950"
+      aria-label="Loading viewer"
+    >
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-teal-primary border-t-transparent" />
+    </div>
+  );
+}
 
 export default function ViewerPanelLazy() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<ViewerFallback />}>
       <ViewerPanel />
     </Suspense>
   );

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -83,9 +83,14 @@ export default defineConfig({
     chunkSizeWarningLimit: 1100,
     rollupOptions: {
       output: {
+        // Keep monaco split out so it doesn't bloat the entry bundle. Three /
+        // R3F / drei are deliberately NOT named here — pinning them to a
+        // single chunk would also pull a `<link rel="modulepreload">` for
+        // the chunk into the entry HTML, defeating the lazy-import on
+        // ViewerPanel. Letting Vite default-split lets the three subtree
+        // load only when the viewer mounts.
         manualChunks(id) {
           if (id.includes('monaco-editor') || id.includes('@monaco-editor/react')) return 'monaco';
-          if (id.includes('/three/') || id.includes('@react-three/')) return 'three';
         },
       },
     },


### PR DESCRIPTION
## Summary

Three.js, R3F, drei, and the viewer-only render components were all eagerly fetched on first paint even though the viewer renders nothing meaningful until the engine reaches `Ready` (≈2s after load). Splitting `ViewerPanel` behind `React.lazy` moves the entire subtree to a deferred chunk that downloads in parallel with engine init.

## Impact

| | Before | After |
|---|---|---|
| `index` (entry) | 673 kB | 655 kB |
| `three` (eager via manualChunks) | 900 kB | — |
| `monaco` | 21 kB | 21 kB |
| **Eagerly loaded JS** | **~1594 kB** | **~676 kB** |
| `ViewerPanel.*` (lazy) | — | 920 kB |

**~57% reduction in initial JS.** The `LoadingOverlay` covers engine init, which is the same window the lazy chunk needs to download — users typically never see the blank Suspense fallback.

## Implementation

- New `ViewerPanelLazy.tsx` wraps `lazy(() => import('./ViewerPanel'))` in a Suspense boundary with a `null` fallback.
- Both `PlaygroundPage` and `MobileLayout` import the lazy variant.
- **Removed the `manualChunks` rule for `three` / `@react-three/*`.** This was the load-bearing change. Pinning them to a named chunk also pulled a `<link rel="modulepreload">` for that chunk into the entry HTML, defeating the lazy-import. Letting Vite default-split via the dynamic-import boundary keeps the three subtree out of the preload graph entirely. Confirmed by inspecting the rendered `index.html` — only `index`, `monaco`, and `rolldown-runtime` are now preloaded.

## Test plan

- [x] `npm --workspace=site run typecheck` — clean
- [x] `npm --workspace=site run build` — chunks split as expected
- [x] `npm --workspace=site run smoke` — engine reaches Ready against the production preview
- [x] Verified `<link rel="modulepreload">` no longer references the three chunk
- [ ] Verify on Vercel preview that the viewer mounts without a visible flash (the LoadingOverlay should still cover the lazy fetch in practice)
- [ ] Verify mobile: switching to the Viewer tab the *first* time may trigger the lazy fetch on phones — check on a real device