### PR TITLE
feat(playground): auto-run shared links; fix mobile console-jump on first error

### DIFF
--- a/site/src/components/playground/MobileLayout.tsx
+++ b/site/src/components/playground/MobileLayout.tsx
@@ -25,17 +25,20 @@ export default function MobileLayout({
 }: MobileLayoutProps) {
   const [tab, setTab] = useState<Tab>('viewer');
   const error = usePlaygroundStore((s) => s.error);
+  const hasHadSuccess = usePlaygroundStore((s) => s.lastSuccessfulCode !== null);
 
   // Auto-jump to console on the transition into an error so users see the
-  // failure without hunting for the tab. Mirrors the desktop auto-expand,
-  // and the `wasErrorRef` guard keeps repeated renders during the error
-  // state from forcing the tab back if the user manually navigated away.
+  // failure without hunting for the tab. Gated on `hasHadSuccess` so the very
+  // first eval's error (e.g. a shared link, a stale draft, the seeded default
+  // failing to compile) leaves the user on Viewer — the Console tab's red
+  // badge handles discoverability. Without this gate, mobile silently
+  // teleports docs-link visitors away from the viewport they came to see.
   const wasErrorRef = useRef(false);
   useEffect(() => {
     const isError = !!error;
-    if (isError && !wasErrorRef.current) setTab('console');
+    if (isError && !wasErrorRef.current && hasHadSuccess) setTab('console');
     wasErrorRef.current = isError;
-  }, [error]);
+  }, [error, hasHadSuccess]);
 
   const dismissConsole = useCallback(() => {
     setTab('viewer');

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -31,8 +31,6 @@ const shortcutDefs = Object.values(SHORTCUTS);
 
 export default function PlaygroundPage() {
   const code = usePlaygroundStore((s) => s.code);
-  const pendingReview = usePlaygroundStore((s) => s.pendingReview);
-  const setPendingReview = usePlaygroundStore((s) => s.setPendingReview);
   const isConsoleCollapsed = usePlaygroundStore((s) => s.isConsoleCollapsed);
   const setConsoleCollapsed = usePlaygroundStore((s) => s.setConsoleCollapsed);
   const isViewerCollapsed = usePlaygroundStore((s) => s.isViewerCollapsed);
@@ -89,10 +87,9 @@ export default function PlaygroundPage() {
   );
 
   const handleRun = useCallback(() => {
-    if (pendingReview) setPendingReview(false);
     runCode(code);
     updateUrl(code);
-  }, [runCode, code, updateUrl, pendingReview, setPendingReview]);
+  }, [runCode, code, updateUrl]);
 
   const handleExportSTL = useCallback(() => {
     exportSTL(code);
@@ -490,28 +487,6 @@ export default function PlaygroundPage() {
         isRunning={isRunning}
         compact={isMobile}
       />
-
-      {pendingReview && (
-        <div className="flex items-center gap-3 border-b border-amber-700/50 bg-amber-950/40 px-4 py-2">
-          <span className="text-sm text-amber-200">
-            Code loaded from a shared link. Review before running.
-          </span>
-          <button
-            onClick={handleRun}
-            className="rounded bg-amber-600 px-3 py-0.5 text-xs font-semibold text-white hover:bg-amber-500"
-          >
-            Run
-          </button>
-          <button
-            onClick={() => {
-              setPendingReview(false);
-            }}
-            className="text-xs text-amber-400 hover:text-amber-200"
-          >
-            Dismiss
-          </button>
-        </div>
-      )}
 
       {isMobile ? (
         <MobileLayout

--- a/site/src/hooks/useCodeExecution.ts
+++ b/site/src/hooks/useCodeExecution.ts
@@ -41,11 +41,7 @@ export function useCodeExecution() {
       const engineStore = useEngineStore.getState();
       switch (msg.type) {
         case 'init-done': {
-          // Auto-run current code the moment engine is ready.
-          // Skip auto-run for shared links (pendingReview) — user must review first.
-          if (store.code.trim() && !store.pendingReview) {
-            submitEval(store.code);
-          }
+          if (store.code.trim()) submitEval(store.code);
           break;
         }
         case 'eval-result': {

--- a/site/src/hooks/useUrlState.ts
+++ b/site/src/hooks/useUrlState.ts
@@ -20,7 +20,6 @@ function selectionsForUrl(): SharedSelection[] {
 
 export function useUrlState() {
   const setCode = usePlaygroundStore((s) => s.setCode);
-  const setPendingReview = usePlaygroundStore((s) => s.setPendingReview);
   const setPendingSharedSelections = usePlaygroundStore((s) => s.setPendingSharedSelections);
   const initialized = useRef(false);
 
@@ -42,7 +41,6 @@ export function useUrlState() {
     }
 
     setCode(result.code);
-    setPendingReview(true);
     if (result.selections.length > 0) {
       setPendingSharedSelections(result.selections);
     }
@@ -51,7 +49,7 @@ export function useUrlState() {
       const next = `${url.pathname}${encodeCodeQuery(result.code)}`;
       history.replaceState(null, '', next);
     }
-  }, [setCode, setPendingReview, setPendingSharedSelections]);
+  }, [setCode, setPendingSharedSelections]);
 
   const updateUrl = (code: string) => {
     const query = encodeCodeQuery(code, selectionsForUrl());

--- a/site/src/stores/playgroundStore.ts
+++ b/site/src/stores/playgroundStore.ts
@@ -38,7 +38,6 @@ interface PlaygroundState {
   consoleOutput: string[];
   timeMs: number | null;
   isRunning: boolean;
-  pendingReview: boolean;
   isConsoleCollapsed: boolean;
   isViewerCollapsed: boolean;
   isEditorCollapsed: boolean;
@@ -57,7 +56,6 @@ interface PlaygroundState {
   setConsoleOutput: (output: string[]) => void;
   setTimeMs: (ms: number) => void;
   setIsRunning: (running: boolean) => void;
-  setPendingReview: (pending: boolean) => void;
   setConsoleCollapsed: (collapsed: boolean) => void;
   setViewerCollapsed: (collapsed: boolean) => void;
   setEditorCollapsed: (collapsed: boolean) => void;
@@ -86,7 +84,6 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   consoleOutput: [],
   timeMs: null,
   isRunning: false,
-  pendingReview: false,
   isConsoleCollapsed: false,
   isViewerCollapsed: false,
   isEditorCollapsed: false,
@@ -112,7 +109,6 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   setConsoleOutput: (consoleOutput) => set({ consoleOutput }),
   setTimeMs: (timeMs) => set({ timeMs }),
   setIsRunning: (isRunning) => set({ isRunning }),
-  setPendingReview: (pendingReview) => set({ pendingReview }),
   setConsoleCollapsed: (isConsoleCollapsed) => set({ isConsoleCollapsed }),
   setViewerCollapsed: (isViewerCollapsed) => set({ isViewerCollapsed }),
   setEditorCollapsed: (isEditorCollapsed) => set({ isEditorCollapsed }),


### PR DESCRIPTION
## Summary
- **Auto-run incoming `?code=` links.** Drop the `pendingReview` review-before-running gate. Every other major code playground (CodeSandbox, StackBlitz, CodePen, Vue SFC, Svelte REPL, TS Playground) auto-runs incoming code and relies on the worker/iframe sandbox for safety; the manual-run banner was an unusual friction point that slowed every docs-link click into the playground.
- **Fix mobile silently teleporting to Console on first-load errors.** `MobileLayout`'s auto-jump-to-console now gates on `lastSuccessfulCode !== null`, so first-eval errors (stale draft, broken example, etc.) leave the user on Viewer. The Console tab's red `!` badge handles discoverability. Mid-session error transitions still auto-jump as before.

## Why
- Users clicking "Open in Playground" from the docs site previously saw an empty viewer with an amber "Review before running. [Run]" banner — extra tap, unfamiliar pattern. Auto-run matches every other code playground users have likely encountered.
- On mobile, `wasErrorRef` would fire on the very first error transition during the initial auto-run, forcing the user to the Console tab before they ever saw the viewport they came to see. Gating on a successful prior render keeps mid-session error UX intact while fixing the cold-start case.

## Files changed
- `site/src/hooks/useCodeExecution.ts` — drop `!store.pendingReview` from the `init-done` auto-run condition
- `site/src/hooks/useUrlState.ts` — drop `setPendingReview(true)` after decoding share params
- `site/src/stores/playgroundStore.ts` — remove `pendingReview` field and setter
- `site/src/components/playground/PlaygroundPage.tsx` — remove the amber review banner JSX and the `pendingReview` selectors / `handleRun` dismissal
- `site/src/components/playground/MobileLayout.tsx` — gate console auto-jump on `lastSuccessfulCode !== null`

## Test plan
- [ ] Open a docs `?code=` link in the deployed playground — code should run automatically; no amber banner
- [ ] Visit playground with a deliberately-broken localStorage draft on mobile (<640px viewport) — should land on Viewer, not Console; Console tab shows red `!` badge
- [ ] After a successful run, edit code to introduce an error on mobile — Console tab should auto-activate (existing mid-session behavior preserved)
- [ ] Desktop: docs link auto-runs; no banner; Run button still works for re-runs after edits