### PR TITLE
feat(site): add vercel web analytics to docs and playground

### DIFF
--- a/docs-site/.vitepress/theme/index.ts
+++ b/docs-site/.vitepress/theme/index.ts
@@ -7,6 +7,14 @@ import './custom.css';
 const theme: Theme = {
   extends: DefaultTheme,
   Layout: () => h(Layout),
+  enhanceApp() {
+    // VitePress prerenders pages, so guard against SSR. inject() wraps
+    // history.pushState — VitePress's own router uses it, so route changes
+    // emit pageviews automatically once mounted.
+    if (typeof window !== 'undefined') {
+      void import('@vercel/analytics').then(({ inject }) => inject());
+    }
+  },
 };
 
 export default theme;

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "brepjs-docs-site",
       "version": "0.0.0",
+      "dependencies": {
+        "@vercel/analytics": "2.0.1"
+      },
       "devDependencies": {
         "lz-string": "1.5.0",
         "mermaid": "11.14.0",
@@ -1717,6 +1720,48 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-vue": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -14,5 +14,8 @@
     "vitepress": "1.6.3",
     "vitepress-plugin-mermaid": "2.0.17",
     "vue": "3.5.13"
+  },
+  "dependencies": {
+    "@vercel/analytics": "2.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1916,7 +1916,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2874,7 +2873,7 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2896,8 +2895,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2932,7 +2931,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
       "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3017,7 +3015,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -3227,6 +3224,48 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -3259,7 +3298,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3433,7 +3471,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3794,9 +3831,8 @@
       "version": "2.44.1",
       "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.44.1.tgz",
       "integrity": "sha512-YNwpk+i90kbZ/1580wJniuLvSAGhqoR2UMNFRv9/MIJzjgwFCRdMpyIBXJqE1X30OrbxavJLUHxGuYWSWGSvzg==",
-      "devOptional": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -4090,7 +4126,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
       "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/comma-separated-tokens": {
@@ -4194,7 +4230,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4270,6 +4305,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -4368,8 +4404,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -4501,7 +4536,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4588,7 +4622,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6384,7 +6417,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -6478,9 +6510,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.0.0.tgz",
       "integrity": "sha512-5/odaoPCoYMziO4pApzvkRa6uuVrTRTnJ2QUkTgh4YYcYyQqhAXsZ5psqToE3xM66shiSYa0xPZUFZer5heaTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "comlink": "^4.4.2"
       }
@@ -7059,7 +7090,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7069,7 +7099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7195,7 +7224,6 @@
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
         "@rolldown/pluginutils": "1.0.0-rc.17"
@@ -7366,7 +7394,6 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -7772,8 +7799,7 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -8058,7 +8084,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8120,7 +8145,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
@@ -8322,7 +8348,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8427,7 +8452,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -8858,6 +8882,7 @@
         "@monaco-editor/react": "4.7.0",
         "@react-three/drei": "10.7.7",
         "@react-three/fiber": "9.6.1",
+        "@vercel/analytics": "2.0.1",
         "brepjs": "*",
         "brepjs-opencascade": "*",
         "lz-string": "1.5.0",

--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,7 @@
     "@monaco-editor/react": "4.7.0",
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.6.1",
+    "@vercel/analytics": "2.0.1",
     "brepjs": "*",
     "brepjs-opencascade": "*",
     "lz-string": "1.5.0",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,5 +1,11 @@
+import { Analytics } from '@vercel/analytics/react';
 import PlaygroundPage from './components/playground/PlaygroundPage';
 
 export default function App() {
-  return <PlaygroundPage />;
+  return (
+    <>
+      <PlaygroundPage />
+      <Analytics />
+    </>
+  );
 }

--- a/site/src/components/playground/PlaygroundPage.tsx
+++ b/site/src/components/playground/PlaygroundPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { track } from '@vercel/analytics';
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from 'react-resizable-panels';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
 import { useViewerStore } from '../../stores/viewerStore';
@@ -89,21 +90,25 @@ export default function PlaygroundPage() {
   const handleRun = useCallback(() => {
     runCode(code);
     updateUrl(code);
+    track('playground_run');
   }, [runCode, code, updateUrl]);
 
   const handleExportSTL = useCallback(() => {
     exportSTL(code);
     addToast('Exporting STL...');
+    track('playground_export', { format: 'stl' });
   }, [exportSTL, code, addToast]);
 
   const handleExportSTEP = useCallback(() => {
     exportSTEP(code);
     addToast('Exporting STEP...');
+    track('playground_export', { format: 'step' });
   }, [exportSTEP, code, addToast]);
 
   const handleShare = useCallback(() => {
     void copyShareUrl(code);
     addToast('Link copied to clipboard');
+    track('playground_share');
   }, [copyShareUrl, code, addToast]);
 
   const handleResetToDefault = useCallback(() => {

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://va.vercel-scripts.com; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Wires `@vercel/analytics` into both apps in the Vercel deploy:
  - **VitePress docs** — `inject()` in `theme/index.ts` `enhanceApp`, lazy-imported so the SSR build pass stays clean. Pageviews flow through VitePress's `pushState` routing automatically.
  - **React playground** — `<Analytics />` mounted next to `<PlaygroundPage />` in `site/src/App.tsx`.
- Adds custom events for the actions that signal real engagement (no-op outside production by default): `playground_run`, `playground_share`, and `playground_export` with a `format: 'stl' | 'step'` property.
- Relaxes the playground CSP `script-src` to allow `https://va.vercel-scripts.com`; beacons remain same-origin via Vercel's `/_vercel/insights/*` rewrite, so `connect-src 'self'` is unchanged.

## Notes

- Web Analytics only — Speed Insights was deliberately not included.
- After this lands, enable Web Analytics in the Vercel dashboard (Settings → Analytics) so the tab populates.
- Beacons and the script will be blocked by ad blockers like uBlock Origin in many users' browsers; counts undercount but trend signal is intact.

## Test plan

- [x] `npm run typecheck --workspace=site` passes
- [x] `vitepress build` produces both client + server bundles cleanly (no SSR error from analytics import)
- [x] `npm run build --workspace=site` produces playground bundle
- [x] Pre-commit suite (typecheck, lint-staged, layer boundaries, changed tests, knip) passes
- [ ] Verify on Preview deploy: docs pageview event fires on `/`, navigation event fires on route change, playground pageview event fires on `/playground`, no CSP violation in console
- [ ] Verify custom events: click Run/Share/Export STL/Export STEP and confirm events appear in Vercel dashboard