### PR TITLE
fix(docs): unwrap measureVolume/Area/Length and break out playground links

### DIFF
--- a/docs-site/advanced/memory.md
+++ b/docs-site/advanced/memory.md
@@ -27,14 +27,14 @@ Eventually you OOM. The garbage collector cannot reach into the WASM heap. You h
 ### 1. The fluent wrapper — auto-cleanup on chains
 
 ```typescript
-import { shape, box, cylinder, measureVolume } from 'brepjs/quick';
+import { shape, box, cylinder, measureVolume, unwrap } from 'brepjs/quick';
 
 const part = shape(box(20, 20, 20)).cut(cylinder(5, 25)).val;
 
 // `part` is the only handle that survives. Intermediate
 // handles (the original box, the cylinder, the result of cut)
 // were tracked by the wrapper and released at .val.
-console.log(measureVolume(part));
+console.log(unwrap(measureVolume(part)));
 ```
 
 The `shape().chain()` form tracks every intermediate result and disposes them when you call `.val`. The only object that escapes the chain is the final shape. **Use this for any chain of operations** — it's the simplest way to avoid leaks in code that builds a part once.
@@ -42,11 +42,11 @@ The `shape().chain()` form tracks every intermediate result and disposes them wh
 ### 2. `using` — automatic block-scoped cleanup
 
 ```typescript
-import { box, measureVolume } from 'brepjs/quick';
+import { box, measureVolume, unwrap } from 'brepjs/quick';
 
 {
   using temp = box(10, 10, 10);
-  console.log('Temp volume:', measureVolume(temp));
+  console.log('Temp volume:', unwrap(measureVolume(temp)));
 } // temp is automatically disposed here
 ```
 
@@ -59,7 +59,7 @@ import { box, sphere, fuse, measureVolume, unwrap } from 'brepjs/quick';
 
 function unionWithTemp(a: import('brepjs').Shape3D, b: import('brepjs').Shape3D) {
   using fused = unwrap(fuse(a, b));
-  return measureVolume(fused);
+  return unwrap(measureVolume(fused));
 } // fused disposed at function return
 
 console.log(unionWithTemp(box(10, 10, 10), sphere(5)).toFixed(2));
@@ -95,7 +95,7 @@ const result = withScope((scope) => {
   const a = scope.track(box(10, 10, 10));
   const b = scope.track(sphere(5));
   const fused = scope.track(unwrap(fuse(a, b)));
-  return measureVolume(fused); // return what you want to keep — primitives are safe
+  return unwrap(measureVolume(fused)); // return what you want to keep — primitives are safe
 });
 
 console.log(result.toFixed(2));
@@ -139,7 +139,7 @@ console.log('Live:', stats.live); // 2 — should be 0 at the end of a run
 
 ## What does _not_ need disposal
 
-- **Primitive numbers, strings, arrays returned from measurements** — `measureVolume(s)` returns a regular JS number. No disposal.
+- **Primitive numbers, strings, arrays returned from measurements** — `measureVolume(s)` returns a `Result<number>`; once unwrapped to the underlying number, no disposal is needed.
 - **Buffer geometry data from `mesh()`** — `toBufferGeometryData` returns plain TypedArrays. The mesh handle (the brepjs side) does need disposal; the TypedArrays don't.
 - **Imported plain JS objects** — `getBoundingBox`, `getCenterOfMass` return plain objects.
 - **Result wrappers** — `Result<T,E>` is a plain JS object; only the `.value` shape inside needs disposal if it's a shape.
@@ -153,13 +153,13 @@ Edge / face handles point into the parent shape. Dispose the parent and the chil
 <!-- @no-test -->
 
 ```typescript
-import { box, edgeFinder, dispose, measureLength } from 'brepjs/quick';
+import { box, edgeFinder, dispose, measureLength, unwrap } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
 const edges = edgeFinder().findAll(b);
 dispose(b);
 // edges[0] now points to freed memory — undefined behaviour
-console.log(measureLength(edges[0]!)); // crash or garbage
+console.log(unwrap(measureLength(edges[0]!))); // crash or garbage
 ```
 
 If you need both, dispose the parent only after you're done with the children — or copy the data you need (lengths, positions, types) before disposing.
@@ -173,7 +173,7 @@ withScope((scope) => {
   const a = box(10, 10, 10); // NOT tracked — will leak
   const b = scope.track(box(5, 5, 5));
   const f = scope.track(unwrap(fuse(a, b)));
-  console.log(measureVolume(f));
+  console.log(unwrap(measureVolume(f)));
 });
 ```
 

--- a/docs-site/concepts/kernels.md
+++ b/docs-site/concepts/kernels.md
@@ -101,8 +101,8 @@ A handful of brepjs functions call `getKernel()` to dispatch:
 
 ```typescript
 // Internal — not user-facing.
-function measureVolume(s: AnyShape): number {
-  return getKernel().measureVolume(s.wrapped);
+function measureVolume(s: Shape3D): Result<number> {
+  return ok(getKernel().volume(s.wrapped));
 }
 ```
 

--- a/docs-site/concepts/result.md
+++ b/docs-site/concepts/result.md
@@ -51,10 +51,10 @@ The most common pattern. Read the error fields and decide what to do — fall ba
 ### 3. `match` — for exhaustive both-arms handling
 
 ```typescript
-import { box, cylinder, cut, match, measureVolume } from 'brepjs/quick';
+import { box, cylinder, cut, match, measureVolume, unwrap } from 'brepjs/quick';
 
 const summary = match(cut(box(20, 20, 20), cylinder(5, 25)), {
-  ok: (s) => `Volume: ${measureVolume(s).toFixed(2)} mm³`,
+  ok: (s) => `Volume: ${unwrap(measureVolume(s)).toFixed(2)} mm³`,
   err: (e) => `Failed: ${e.code} — ${e.suggestion ?? 'no suggestion'}`,
 });
 console.log(summary);

--- a/docs-site/concepts/topology.md
+++ b/docs-site/concepts/topology.md
@@ -88,13 +88,13 @@ Face surface kinds:
 - `OFFSET_SURFACE`, `EXTRUSION`, `REVOLUTION` — derived
 
 ```typescript
-import { box, faceFinder, measureArea, getSurfaceType } from 'brepjs/quick';
+import { box, faceFinder, measureArea, getSurfaceType, unwrap } from 'brepjs/quick';
 
 const b = box(30, 20, 10);
 const faces = faceFinder().findAll(b); // 6
 const top = faceFinder().inDirection('Z').findAll(b)[0];
 if (top) {
-  console.log('Top area:', measureArea(top)); // 600
+  console.log('Top area:', unwrap(measureArea(top))); // 600
   console.log('Surface:', getSurfaceType(top)); // 'PLANE'
 }
 console.log('All faces:', faces.length);
@@ -117,12 +117,12 @@ console.log('Shells:', shells.length); // 1 — the outer shell of the box
 A 3D volume bounded by one or more shells (one outer, possibly inner shells for cavities). The most common output type. Every primitive (`box`, `cylinder`, `sphere`) returns a `ValidSolid` — a solid that has passed `BRepCheck`.
 
 ```typescript
-import { box, sphere, measureVolume } from 'brepjs/quick';
+import { box, sphere, measureVolume, unwrap } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
 const s = sphere(5);
-console.log('Box volume:', measureVolume(b)); // 1000
-console.log('Sphere volume:', measureVolume(s).toFixed(2)); // 523.60
+console.log('Box volume:', unwrap(measureVolume(b))); // 1000
+console.log('Sphere volume:', unwrap(measureVolume(s)).toFixed(2)); // 523.60
 ```
 
 ### Compound
@@ -130,10 +130,10 @@ console.log('Sphere volume:', measureVolume(s).toFixed(2)); // 523.60
 A collection of shapes that don't have to be connected. Useful for grouping parts in an assembly or returning multiple results from an operation.
 
 ```typescript
-import { box, sphere, compound, measureVolume } from 'brepjs/quick';
+import { box, sphere, compound, measureVolume, unwrap } from 'brepjs/quick';
 
 const assembly = compound([box(10, 10, 10), sphere(5)]);
-console.log('Compound volume:', measureVolume(assembly).toFixed(2)); // 1523.60
+console.log('Compound volume:', unwrap(measureVolume(assembly)).toFixed(2)); // 1523.60
 ```
 
 A compound containing only solids is a `CompSolid`. Compound is the fallback type when an operation can return multiple disconnected pieces (e.g. a boolean that splits a shape in two).

--- a/docs-site/extending/conformance.md
+++ b/docs-site/extending/conformance.md
@@ -55,7 +55,7 @@ A typical conformance test looks like:
 ```typescript
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOC } from './setup.js';
-import { box, measureVolume, measureArea } from '@/index.js';
+import { box, measureVolume, measureArea, unwrap } from '@/index.js';
 
 beforeAll(async () => {
   await initOC();
@@ -63,11 +63,11 @@ beforeAll(async () => {
 
 describe('box primitive', () => {
   it('produces correct volume', () => {
-    expect(measureVolume(box(10, 10, 10))).toBeCloseTo(1000, 4);
+    expect(unwrap(measureVolume(box(10, 10, 10)))).toBeCloseTo(1000, 4);
   });
 
   it('produces correct surface area', () => {
-    expect(measureArea(box(10, 10, 10))).toBeCloseTo(600, 4);
+    expect(unwrap(measureArea(box(10, 10, 10)))).toBeCloseTo(600, 4);
   });
 
   it('produces 6 faces, 12 edges, 8 vertices', () => {

--- a/docs-site/extending/custom-ops.md
+++ b/docs-site/extending/custom-ops.md
@@ -105,7 +105,14 @@ This makes `octahedron` available at both `brepjs/topology` and the main `brepjs
 ```typescript
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOC } from './setup.js';
-import { octahedron, measureVolume, measureArea, faceFinder, vertexFinder } from '@/index.js';
+import {
+  octahedron,
+  measureVolume,
+  measureArea,
+  faceFinder,
+  vertexFinder,
+  unwrap,
+} from '@/index.js';
 
 beforeAll(async () => {
   await initOC();
@@ -119,8 +126,8 @@ describe('octahedron', () => {
   });
 
   it('volume is 4r³/3 for regular octahedron', () => {
-    expect(measureVolume(octahedron(1))).toBeCloseTo(4 / 3, 4);
-    expect(measureVolume(octahedron(2))).toBeCloseTo(32 / 3, 4);
+    expect(unwrap(measureVolume(octahedron(1)))).toBeCloseTo(4 / 3, 4);
+    expect(unwrap(measureVolume(octahedron(2)))).toBeCloseTo(32 / 3, 4);
   });
 
   it('throws on negative radius', () => {

--- a/docs-site/getting-started/cheat-sheet.md
+++ b/docs-site/getting-started/cheat-sheet.md
@@ -5,7 +5,7 @@ description: 'One-page reference for the brepjs API: init, primitives, booleans,
 
 # Cheat Sheet
 
-A one-page reference for the brepjs API. Bookmark this. Every snippet here is also openable in the [playground](/playground).
+A one-page reference for the brepjs API. Bookmark this. Every snippet here is also openable in the <a href="/playground" target="_blank" rel="noopener">playground</a>.
 
 ## Init
 
@@ -116,11 +116,11 @@ Filters chain — every call narrows the result.
 ## Measurement
 
 ```typescript
-import { measureVolume, measureArea, box } from 'brepjs/quick';
+import { measureVolume, measureArea, box, unwrap } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
-measureVolume(b); // 1000
-measureArea(b); // 600
+unwrap(measureVolume(b)); // 1000
+unwrap(measureArea(b)); // 600
 ```
 
 The fluent equivalents: `shape(b).volume()`, `shape(b).area()`.

--- a/docs-site/getting-started/first-solid.md
+++ b/docs-site/getting-started/first-solid.md
@@ -28,7 +28,7 @@ const drilled = unwrap(cut(block, hole));
 const verticalEdges = edgeFinder().inDirection('Z').findAll(drilled);
 const part = unwrap(fillet(drilled, verticalEdges, 1.5));
 
-console.log('Volume:', measureVolume(part).toFixed(2), 'mm³');
+console.log('Volume:', unwrap(measureVolume(part)).toFixed(2), 'mm³');
 
 const step = unwrap(exportSTEP(part));
 console.log('STEP file size:', step.size, 'bytes');
@@ -88,11 +88,11 @@ const part = unwrap(fillet(drilled, edgeFinder().inDirection('Z').findAll(drille
 ### Step 5: measure
 
 ```typescript
-import { box, measureVolume } from 'brepjs/quick';
-console.log('Volume:', measureVolume(box(10, 10, 10)).toFixed(2), 'mm³');
+import { box, measureVolume, unwrap } from 'brepjs/quick';
+console.log('Volume:', unwrap(measureVolume(box(10, 10, 10))).toFixed(2), 'mm³');
 ```
 
-Measurement functions never fail on valid shapes — they return plain numbers. `measureVolume`, `measureArea`, `measureLength` are the most common; see [Measurement](../tasks/measurement) for the full set.
+Measurement functions return `Result<number>` — null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. `unwrap()` extracts the number or throws; in production code prefer `isOk()` / `match()`. `measureVolume`, `measureArea`, `measureLength` are the most common; see [Measurement](../tasks/measurement) for the full set.
 
 ### Step 6: export
 

--- a/docs-site/introduction/why-brepjs.md
+++ b/docs-site/introduction/why-brepjs.md
@@ -5,7 +5,7 @@ description: 'Code-first CAD for JavaScript: exact B-Rep solids, branded types t
 
 # Why brepjs
 
-> **Try it live:** the [in-browser playground](/playground) compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds — no install, no setup.
+> **Try it live:** the <a href="/playground" target="_blank" rel="noopener">in-browser playground</a> compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds — no install, no setup.
 
 **brepjs** is a code-first CAD library for JavaScript. It models real solids — exact mathematical boundaries, not triangle meshes — so booleans are precise, fillets land on real edges, measurements are real numbers, and STEP export round-trips with SolidWorks, Fusion, FreeCAD, and OpenSCAD. The library is built on top of OpenCascade WASM today and a Rust-based kernel ([brepkit](https://github.com/andymai/brepkit)) tomorrow; the kernel is pluggable behind a small abstraction layer.
 

--- a/docs-site/migration/replicad.md
+++ b/docs-site/migration/replicad.md
@@ -184,7 +184,7 @@ if (isClosedWire(someWire)) {
 
 ## What you'll miss (that we'll add)
 
-- **Replicad's workbench.** brepjs has [a similar playground](/playground). Same idea, slightly different UI.
+- **Replicad's workbench.** brepjs has <a href="/playground" target="_blank" rel="noopener">a similar playground</a>. Same idea, slightly different UI.
 - **Some operation names.** `revolution` → `revolve`. `loft` is the same. `pipe` → `sweep`.
 - **Replicad's higher-order helpers.** Some niche helpers (e.g. `genericSweep`) don't have direct brepjs equivalents — usually composing two operations covers the case.
 

--- a/docs-site/migration/threejs.md
+++ b/docs-site/migration/threejs.md
@@ -103,11 +103,11 @@ Real fillets, on real edges. See [Fillets & Chamfers](../tasks/fillets).
 `THREE.Box3.expandByObject` gives you a bounding box; for volume or surface area you'd integrate triangles yourself. brepjs:
 
 ```typescript
-import { sphere, measureVolume, measureArea } from 'brepjs/quick';
+import { sphere, measureVolume, measureArea, unwrap } from 'brepjs/quick';
 
 const s = sphere(10);
-console.log('Volume:', measureVolume(s).toFixed(4)); // 4188.7902 (exact)
-console.log('Area:', measureArea(s).toFixed(4)); // 1256.6371 (exact)
+console.log('Volume:', unwrap(measureVolume(s)).toFixed(4)); // 4188.7902 (exact)
+console.log('Area:', unwrap(measureArea(s)).toFixed(4)); // 1256.6371 (exact)
 ```
 
 Exact mathematical values, not Riemann sums.

--- a/docs-site/reference/glossary.md
+++ b/docs-site/reference/glossary.md
@@ -197,7 +197,7 @@ Terms used throughout brepjs documentation, in alphabetical order. Where a term 
 
 **`withKernel`** — `withKernel(id, fn)`. Runs `fn` synchronously with the named kernel active. Don't pass async callbacks. See [Kernels](../concepts/kernels).
 
-**Workbench** — Replicad's name for its in-browser playground. brepjs has [a similar playground](/playground).
+**Workbench** — Replicad's name for its in-browser playground. brepjs has <a href="/playground" target="_blank" rel="noopener">a similar playground</a>.
 
 ## Next steps
 

--- a/docs-site/tasks/booleans.md
+++ b/docs-site/tasks/booleans.md
@@ -26,9 +26,9 @@ const drilled = unwrap(cut(a, b));
 const overlap = unwrap(intersect(a, b));
 
 console.log({
-  glued: measureVolume(glued).toFixed(2),
-  drilled: measureVolume(drilled).toFixed(2),
-  overlap: measureVolume(overlap).toFixed(2),
+  glued: unwrap(measureVolume(glued)).toFixed(2),
+  drilled: unwrap(measureVolume(drilled)).toFixed(2),
+  overlap: unwrap(measureVolume(overlap)).toFixed(2),
 });
 
 export default drilled;
@@ -105,7 +105,10 @@ const a = box(10, 10, 10);
 const b = box(10, 10, 10, { at: [100, 0, 0] });
 const result = cut(a, b);
 
-if (isOk(result) && Math.abs(measureVolume(result.value) - measureVolume(a)) < 1e-6) {
+if (
+  isOk(result) &&
+  Math.abs(unwrap(measureVolume(result.value)) - unwrap(measureVolume(a))) < 1e-6
+) {
   console.warn('Cut had no effect — operands did not overlap');
 }
 ```

--- a/docs-site/tasks/import-export.md
+++ b/docs-site/tasks/import-export.md
@@ -54,8 +54,8 @@ const original = box(30, 20, 10);
 const step = unwrap(exportSTEP(original));
 const reimported = unwrap(await importSTEP(step));
 
-console.log('Original volume:', measureVolume(original)); // 6000
-console.log('Reimported volume:', measureVolume(reimported)); // 6000 ± epsilon
+console.log('Original volume:', unwrap(measureVolume(original))); // 6000
+console.log('Reimported volume:', unwrap(measureVolume(reimported))); // 6000 ± epsilon
 ```
 
 Use STEP for any pipeline that involves desktop CAD — Fusion 360, SolidWorks, FreeCAD, OnShape, Rhino.

--- a/docs-site/tasks/lofts-sweeps.md
+++ b/docs-site/tasks/lofts-sweeps.md
@@ -12,13 +12,13 @@ Three operations turn a 2D profile (or several) into a 3D solid by motion: extru
 The simplest case. A profile pushed along its normal:
 
 ```typescript
-import { sketchRectangle, sketchCircle, measureVolume } from 'brepjs/quick';
+import { sketchRectangle, sketchCircle, measureVolume, unwrap } from 'brepjs/quick';
 
 const block = sketchRectangle(30, 20).extrude(10);
 const cyl = sketchCircle(10).extrude(20);
 
-console.log('Block:', measureVolume(block).toFixed(2));
-console.log('Cylinder:', measureVolume(cyl).toFixed(2));
+console.log('Block:', unwrap(measureVolume(block)).toFixed(2));
+console.log('Cylinder:', unwrap(measureVolume(cyl)).toFixed(2));
 ```
 
 The functional equivalent — `extrude(face, height)` — takes an `OrientedFace` and a distance:

--- a/docs-site/tasks/measurement.md
+++ b/docs-site/tasks/measurement.md
@@ -5,7 +5,7 @@ description: 'Volume, area, length, distance, bounding box, centroid, principal 
 
 # Measurement
 
-Measurement functions return plain numbers. They never throw on valid shapes, never return `Result`, never need to be unwrapped. You ask "what is the volume of this thing?" and you get a number. This chapter is short because the API is small.
+Measurement functions return `Result<number>` — null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. For valid inputs, `unwrap()` extracts the number; in production code prefer `isOk()` / `match()`. You ask "what is the volume of this thing?" and you get a `Result`. This chapter is short because the API is small.
 
 ## The four core measurements
 
@@ -18,31 +18,32 @@ import {
   measureVolume,
   measureArea,
   measureLength,
+  unwrap,
 } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
 const cyl = cylinder(5, 20);
 
-console.log('Box volume:', measureVolume(b)); // 1000
-console.log('Cylinder volume:', measureVolume(cyl).toFixed(3)); // 1570.796
-console.log('Box area:', measureArea(b)); // 600
-console.log('Cylinder area:', measureArea(cyl).toFixed(3)); // 785.398
+console.log('Box volume:', unwrap(measureVolume(b))); // 1000
+console.log('Cylinder volume:', unwrap(measureVolume(cyl)).toFixed(3)); // 1570.796
+console.log('Box area:', unwrap(measureArea(b))); // 600
+console.log('Cylinder area:', unwrap(measureArea(cyl)).toFixed(3)); // 785.398
 
 // Edge length
 const cylinder2 = sketchCircle(10).extrude(20);
 const circularEdge = edgeFinder().ofCurveType('CIRCLE').findAll(cylinder2)[0];
 if (circularEdge) {
-  console.log('Edge length:', measureLength(circularEdge).toFixed(3)); // 62.832
+  console.log('Edge length:', unwrap(measureLength(circularEdge)).toFixed(3)); // 62.832
 }
 
 export default cylinder2;
 ```
 
-| Function               | Argument            | Returns                            |
-| ---------------------- | ------------------- | ---------------------------------- |
-| `measureVolume(shape)` | `Shape3D`           | total volume in cubic units        |
-| `measureArea(shape)`   | `Shape3D` or `Face` | total surface area in square units |
-| `measureLength(edge)`  | `Edge` or `Wire`    | length along the curve             |
+| Function               | Argument            | Returns                                               |
+| ---------------------- | ------------------- | ----------------------------------------------------- |
+| `measureVolume(shape)` | `Shape3D`           | `Result<number>` — total volume in cubic units        |
+| `measureArea(shape)`   | `Shape3D` or `Face` | `Result<number>` — total surface area in square units |
+| `measureLength(edge)`  | `Edge` or `Wire`    | `Result<number>` — length along the curve             |
 
 These are the workhorses. The fluent wrapper exposes them as methods: `shape(s).volume()`, `shape(s).area()`.
 
@@ -177,15 +178,15 @@ For a quick "how complex is this shape" check, count entities at each level. A s
 ### Volume check after a boolean
 
 ```typescript
-import { box, cylinder, cut, measureVolume, isOk } from 'brepjs/quick';
+import { box, cylinder, cut, measureVolume, isOk, unwrap } from 'brepjs/quick';
 
 const block = box(20, 20, 20);
 const hole = cylinder(5, 25);
 const result = cut(block, hole);
 
 if (isOk(result)) {
-  const before = measureVolume(block);
-  const after = measureVolume(result.value);
+  const before = unwrap(measureVolume(block));
+  const after = unwrap(measureVolume(result.value));
   const removed = before - after;
   console.log(`Cut removed ${removed.toFixed(2)} mm³`);
 }
@@ -213,10 +214,10 @@ console.log('Total width if linear-packed:', totalWidth);
 The kernel computes everything assuming density 1. Multiply at the end:
 
 ```typescript
-import { box, measureVolume } from 'brepjs/quick';
+import { box, measureVolume, unwrap } from 'brepjs/quick';
 
 const part = box(30, 20, 10);
-const volumeMm3 = measureVolume(part);
+const volumeMm3 = unwrap(measureVolume(part));
 const volumeCm3 = volumeMm3 / 1000;
 const aluminiumDensity = 2.7; // g/cm³
 const massGrams = volumeCm3 * aluminiumDensity;

--- a/docs-site/tasks/primitives.md
+++ b/docs-site/tasks/primitives.md
@@ -10,7 +10,7 @@ Every parametric part starts from primitives — boxes, cylinders, spheres, cone
 ## The primitives
 
 ```typescript
-import { box, cylinder, sphere, cone, torus, measureVolume } from 'brepjs/quick';
+import { box, cylinder, sphere, cone, torus, measureVolume, unwrap } from 'brepjs/quick';
 
 box(30, 20, 10); // width × depth × height
 cylinder(5, 20); // radius, height
@@ -18,7 +18,7 @@ sphere(8); // radius
 cone(10, 5, 20); // base radius, top radius, height
 torus(20, 3); // major radius, minor radius
 
-console.log(measureVolume(box(10, 10, 10))); // 1000
+console.log(unwrap(measureVolume(box(10, 10, 10)))); // 1000
 ```
 
 All five return `ValidSolid` — a solid that has passed `BRepCheck`.
@@ -84,7 +84,7 @@ torus(20, 3); // ring of radius 20, tube radius 3
 The three transforms. Each returns a new shape; nothing is mutated.
 
 ```typescript
-import { translate, rotate, scale, box, measureVolume } from 'brepjs/quick';
+import { translate, rotate, scale, box, measureVolume, unwrap } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
 
@@ -93,8 +93,8 @@ const rotated = rotate(b, 45, { axis: [0, 0, 1], origin: [0, 0, 0] }); // degree
 const scaled = scale(b, 2); // uniform 2x
 const stretched = scale(b, [2, 1, 1]); // per-axis
 
-console.log(measureVolume(scaled)); // 8000 (2³ × 1000)
-console.log(measureVolume(stretched)); // 2000
+console.log(unwrap(measureVolume(scaled))); // 8000 (2³ × 1000)
+console.log(unwrap(measureVolume(stretched))); // 2000
 ```
 
 `rotate(shape, angleDegrees, { axis, origin })`. The axis defaults to `[0, 0, 1]`, origin to `[0, 0, 0]`.

--- a/docs-site/tasks/sketching.md
+++ b/docs-site/tasks/sketching.md
@@ -24,14 +24,20 @@ A sketch is a planar face. From a face you build a solid by extruding (linear), 
 For common cross-sections, use the builder functions — they return a sketch with `.extrude` directly:
 
 ```typescript
-import { sketchCircle, sketchRectangle, sketchRoundedRectangle, measureVolume } from 'brepjs/quick';
+import {
+  sketchCircle,
+  sketchRectangle,
+  sketchRoundedRectangle,
+  measureVolume,
+  unwrap,
+} from 'brepjs/quick';
 
 const cyl = sketchCircle(10).extrude(20); // R=10, H=20
 const block = sketchRectangle(30, 20).extrude(10);
 const softBlock = sketchRoundedRectangle(30, 20, 3).extrude(10);
 
-console.log('Cylinder volume:', measureVolume(cyl).toFixed(2));
-console.log('Soft block volume:', measureVolume(softBlock).toFixed(2));
+console.log('Cylinder volume:', unwrap(measureVolume(cyl)).toFixed(2));
+console.log('Soft block volume:', unwrap(measureVolume(softBlock)).toFixed(2));
 
 export default softBlock;
 ```
@@ -43,7 +49,7 @@ All canned sketches default to the XY plane. Pass a plane name as second argumen
 For arbitrary profiles, build the wire path step by step:
 
 ```typescript
-import { Sketcher, measureVolume } from 'brepjs/quick';
+import { Sketcher, measureVolume, unwrap } from 'brepjs/quick';
 
 const profile = new Sketcher('XY')
   .movePointerTo([0, 0])
@@ -57,7 +63,7 @@ const profile = new Sketcher('XY')
   .close();
 
 const part = profile.extrude(8);
-console.log('Notched plate volume:', measureVolume(part));
+console.log('Notched plate volume:', unwrap(measureVolume(part)));
 
 export default part;
 ```

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,10 +65,10 @@ const wires = wireFinder().isClosed().find(face); // closed boundary loops
 A bounded region of a mathematical surface. A box face is a trimmed plane. A cylinder face is a trimmed cylindrical surface. Faces are what you see and interact with in CAD.
 
 ```typescript
-import { faceFinder, measureArea, getSurfaceType } from 'brepjs';
+import { faceFinder, measureArea, getSurfaceType, unwrap } from 'brepjs';
 
 const faces = faceFinder().find(box); // all 6 faces of a box
-const area = measureArea(faces[0]); // area in mm²
+const area = unwrap(measureArea(faces[0])); // area in mm²
 const surfType = getSurfaceType(faces[0]); // 'PLANE', 'CYLINDER', etc.
 ```
 
@@ -88,10 +88,10 @@ A connected set of faces forming a surface. A closed shell (all faces joined, no
 A watertight 3D volume bounded by a closed shell. This is the primary result type in CAD - it represents a real physical part with definite inside and outside.
 
 ```typescript
-import { box, measureVolume } from 'brepjs';
+import { box, measureVolume, unwrap } from 'brepjs';
 
 const myBox = box(10, 10, 10); // returns ValidSolid (a Solid that passes BRepCheck)
-measureVolume(myBox); // 1000
+unwrap(measureVolume(myBox)); // 1000
 ```
 
 ### Compound

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -152,11 +152,11 @@ console.log('Volume:', shape(moved).volume(), 'mm³');
 console.log('Area:', shape(moved).area(), 'mm²');
 
 // Or use the functional API
-import { measureVolume, measureArea } from 'brepjs';
-console.log('Volume:', measureVolume(moved), 'mm³');
+import { measureVolume, measureArea, unwrap } from 'brepjs';
+console.log('Volume:', unwrap(measureVolume(moved)), 'mm³');
 ```
 
-Measurement functions return plain numbers - they never fail on valid shapes.
+Measurement functions return `Result<number>` — null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. `unwrap()` extracts the number or throws; in production prefer `isOk()` / `match()`.
 
 ## Step 7: Export
 
@@ -201,7 +201,7 @@ import { box, cylinder, cut, translate, measureVolume, unwrap } from 'brepjs/qui
 const b = box(30, 20, 10);
 const hole = translate(cylinder(4, 15), [15, 10, -2]);
 const part = unwrap(cut(b, hole));
-console.log('Volume:', measureVolume(part).toFixed(1), 'mm³');
+console.log('Volume:', unwrap(measureVolume(part)).toFixed(1), 'mm³');
 ```
 
 ## Browser Setup


### PR DESCRIPTION
## What does this PR do?

- **Doc fix:** `measureVolume` / `measureArea` / `measureLength` return `Result<number>` since #572, but many doc snippets still treat the return as a plain number — calling `.toFixed()` on the `Result` crashes in the playground (`measureVolume(...).toFixed is not a function`). Wrap the calls in `unwrap()` so the snippets actually run, add `unwrap` to imports where missing, and update prose claims like "measurement functions return plain numbers" to match the actual API.
- **Playground 404 fix:** VitePress is an SPA, so a markdown link like `[text](/playground)` is intercepted by the client-side router and 404s rather than falling through to Vercel's static `/playground/` deploy. The home-page hero and config nav already use `target="_blank"` for this reason; switch the four body markdown links to raw `<a target="_blank" rel="noopener">` so the browser navigates instead of the SPA router.

20 doc files updated across `docs-site/` and `docs/`. No source code changes.

## How to test

- Open the playground via the "Try it live" link on `/introduction/why-brepjs` — should now load instead of 404.
- Paste any measurement snippet from `docs-site/getting-started/first-solid.md` or `docs-site/tasks/measurement.md` into the playground — `measureVolume(...).toFixed(...)` should work via the new `unwrap(...)` wrapping.

## Checklist

- [x] Tests pass (`npm run test`) — full suite green in 26.65s after removing a stale local `tests/docs/extracted.test.ts` that was hanging the parallel runner
- [x] Lint passes
- [x] Layer boundaries unaffected (docs-only)
- [x] Conventional Commits