### PR TITLE
fix(playground): camera presets in orthographic projection

### DIFF
--- a/site/src/hooks/useCameraPresets.ts
+++ b/site/src/hooks/useCameraPresets.ts
@@ -33,20 +33,30 @@ export function useCameraPresets(
     if (!activePreset || !bounds || !controlsRef.current) return;
 
     const controls = controlsRef.current;
-    const camera = controls.object as THREE.PerspectiveCamera;
+    const camera = controls.object as THREE.PerspectiveCamera | THREE.OrthographicCamera;
     const target = controls.target as THREE.Vector3;
     const { center, radius } = bounds;
 
-    // Calculate target camera distance
-    const fov = camera.fov;
+    const isOrtho = (camera as THREE.OrthographicCamera).isOrthographicCamera === true;
+
+    // Ortho has no fov; use 45° just to pick a placement distance — framing
+    // comes from zoom below, not distance.
+    const fov = isOrtho ? 45 : (camera as THREE.PerspectiveCamera).fov;
     const fovRad = (fov / 2) * (Math.PI / 180);
     const dist = (radius / Math.sin(fovRad)) * 1.2;
 
-    // Destination position
     const dir = PRESET_DIRECTIONS[activePreset];
     const destPos = new THREE.Vector3().copy(center).addScaledVector(dir, dist);
 
-    // Starting values
+    let startZoom = 1;
+    let destZoom = 1;
+    if (isOrtho) {
+      const ortho = camera as THREE.OrthographicCamera;
+      const viewSize = Math.min(ortho.right - ortho.left, ortho.top - ortho.bottom);
+      startZoom = ortho.zoom;
+      destZoom = viewSize > 0 && radius > 0 ? viewSize / (radius * 2.4) : ortho.zoom;
+    }
+
     const startPos = camera.position.clone();
     const startTarget = target.clone();
     const startTime = performance.now();
@@ -62,9 +72,13 @@ export function useCameraPresets(
       const t = Math.min(elapsed / TRANSITION_MS, 1);
       const eased = easeOutCubic(t);
 
-      // Lerp camera position and target
       camera.position.lerpVectors(startPos, destPos, eased);
       target.lerpVectors(startTarget, center, eased);
+      if (isOrtho) {
+        const ortho = camera as THREE.OrthographicCamera;
+        ortho.zoom = startZoom + (destZoom - startZoom) * eased;
+        ortho.updateProjectionMatrix();
+      }
       controls.update();
       invalidate();
 


### PR DESCRIPTION
## Summary
- In ortho mode, the front/side/top/iso preset buttons silently broke the camera. `useCameraPresets` cast `controls.object` as `PerspectiveCamera` and read `camera.fov` — undefined on `OrthographicCamera`, producing `NaN` distance and a `NaN` destination position. Even with valid placement, ortho framing comes from `camera.zoom`, which the hook never touched.
- Fix: branch on `isOrthographicCamera`. Use a 45° fallback for placement distance (parallel projection means distance only matters for staying in front of the camera), and animate `camera.zoom` from start to a sphere-fitting target alongside the position lerp — matching the rule already used by `fitCamera()` in `ViewerPanel.tsx`.

## Test plan
- [ ] In playground, toggle Ortho on, then click Front/Side/Top/Iso — camera swings to the preset and the model fills ~80% of the viewport
- [ ] Toggle back to Persp — presets still animate as before
- [ ] Switch presets while ortho zoom is far from default — animation lerps zoom smoothly, no snap at end
- [ ] OrbitControls still rotates/pans normally after a preset finishes (damping restored)