### PR TITLE
fix(occt-wasm): lift arcs via 3-point makeArcEdge to share endpoints

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -4059,30 +4059,26 @@ export class OcctWasmAdapter implements KernelAdapter {
         return handle('edge', this.k.makeLineEdge(p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]));
       }
       if (trimmed.basis && trimmed.basis.__bk2d === 'circle') {
-        // Use makeCircleArc with center/normal/radius/angles for robust arc creation
-        const basis = trimmed.basis;
-        const [pcx, pcy, pcz] = lift(basis.cx, basis.cy);
-        const startAngle = basis.sense ? trimmed.tStart : -trimmed.tStart;
-        const endAngle = basis.sense ? trimmed.tEnd : -trimmed.tEnd;
-        try {
-          return handle(
-            'edge',
-            this.k.makeCircleArc(pcx, pcy, pcz, zx, zy, zz, basis.radius, startAngle, endAngle)
-          );
-        } catch {
-          // Fall back to 3-point arc if circle arc fails
-          const bounds = ow2d.curveBounds(cu);
-          const [u1, v1] = ow2d.evaluateCurve2d(cu, bounds.first);
-          const [um, vm] = ow2d.evaluateCurve2d(cu, (bounds.first + bounds.last) / 2);
-          const [u2, v2] = ow2d.evaluateCurve2d(cu, bounds.last);
-          const p1 = lift(u1, v1);
-          const pm = lift(um, vm);
-          const p2 = lift(u2, v2);
-          return handle(
-            'edge',
-            this.k.makeArcEdge(p1[0], p1[1], p1[2], pm[0], pm[1], pm[2], p2[0], p2[1], p2[2])
-          );
-        }
+        // 3-point arc through three lifted points. Building via
+        // makeCircleArc(center, normal, radius, startAngle, endAngle) routes
+        // angles through OCCT's plane-local X-axis, which can disagree with
+        // the Y-axis brepjs computes here (Y = Z × X) on non-XY planes — that
+        // produced arcs at positions displaced by 2r and FP-divergent
+        // endpoints that didn't merge with adjacent line endpoints in
+        // makeWire (rounded-rectangle cutouts on XZ failing as 10F/32E/32V
+        // invalid). Sharing the lift() with the line branches makes endpoint
+        // coordinates bit-identical so MakeWire merges with default tolerance.
+        const bounds = ow2d.curveBounds(cu);
+        const [u1, v1] = ow2d.evaluateCurve2d(cu, bounds.first);
+        const [um, vm] = ow2d.evaluateCurve2d(cu, (bounds.first + bounds.last) / 2);
+        const [u2, v2] = ow2d.evaluateCurve2d(cu, bounds.last);
+        const p1 = lift(u1, v1);
+        const pm = lift(um, vm);
+        const p2 = lift(u2, v2);
+        return handle(
+          'edge',
+          this.k.makeArcEdge(p1[0], p1[1], p1[2], pm[0], pm[1], pm[2], p2[0], p2[1], p2[2])
+        );
       }
       // Fall through to interpolation for other trimmed basis types
     }

--- a/tests/sketchOnPlaneArcs.test.ts
+++ b/tests/sketchOnPlaneArcs.test.ts
@@ -55,9 +55,9 @@ describe('sketchOnPlane is plane-invariant for arc-containing drawings', () => {
     expect(new Set(tops.map((t) => t.edges)).size).toBe(1);
     expect(new Set(tops.map((t) => t.verts)).size).toBe(1);
     // Sanity: edges == 1.5x verts for a closed prism (2 rims + 1 vertical per rim vert).
-    const ref = tops[0];
-    expect(ref).toBeDefined();
-    if (ref) expect(ref.edges).toBe(ref.verts * 1.5);
+    const [ref] = tops;
+    if (!ref) throw new Error('PLANES must yield at least one topology');
+    expect(ref.edges).toBe(ref.verts * 1.5);
   });
 
   it('drawCircle produces identical topology on XY/XZ/YZ', () => {

--- a/tests/sketchOnPlaneArcs.test.ts
+++ b/tests/sketchOnPlaneArcs.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import {
+  draw,
+  drawCircle,
+  drawRectangle,
+  drawRoundedRectangle,
+  describe as describeSolid,
+  isValid,
+} from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+interface Topology {
+  faces: number;
+  edges: number;
+  verts: number;
+  valid: boolean;
+}
+
+function topology(shape: unknown): Topology {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- brepjs returns Shape3D-shaped object
+  const s = shape as any;
+  const d = describeSolid(s);
+  return {
+    faces: d.faceCount,
+    edges: d.edgeCount,
+    verts: d.vertexCount,
+    valid: isValid(s),
+  };
+}
+
+const PLANES = ['XY', 'XZ', 'YZ'] as const;
+
+// Regression: extrudes of arc-containing 2D drawings on non-XY planes used to
+// emit doubled edge/vertex topology and invalid solids under occt-wasm because
+// `liftCurve2dToPlane`'s trimmed-circle branch routed through `makeCircleArc`
+// (center+normal+angles), which interpreted angles in OCCT's plane-local frame
+// rather than the brepjs lift frame. Endpoints diverged from adjacent line
+// endpoints, defeating MakeWire's vertex merging. The fix is to always build
+// arcs via `makeArcEdge` with three explicitly lifted points so endpoints are
+// bit-identical to the adjacent line endpoints. The plane-invariance assertion
+// below is what catches a regression.
+
+describe('sketchOnPlane is plane-invariant for arc-containing drawings', () => {
+  it('drawRoundedRectangle produces identical topology on XY/XZ/YZ', () => {
+    const tops = PLANES.map((p) =>
+      topology(drawRoundedRectangle(30, 12.4, 1.2).sketchOnPlane(p).extrude(3.4))
+    );
+    for (const t of tops) expect(t.valid).toBe(true);
+    // Plane-invariance: every plane should produce the same topology counts.
+    expect(new Set(tops.map((t) => t.faces)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.edges)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.verts)).size).toBe(1);
+    // Sanity: edges == 1.5x verts for a closed prism (2 rims + 1 vertical per rim vert).
+    const ref = tops[0];
+    expect(ref).toBeDefined();
+    if (ref) expect(ref.edges).toBe(ref.verts * 1.5);
+  });
+
+  it('drawCircle produces identical topology on XY/XZ/YZ', () => {
+    const tops = PLANES.map((p) => topology(drawCircle(5).sketchOnPlane(p).extrude(10)));
+    for (const t of tops) expect(t.valid).toBe(true);
+    expect(new Set(tops.map((t) => t.faces)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.edges)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.verts)).size).toBe(1);
+  });
+
+  it('drawRectangle (no arcs) produces identical topology on XY/XZ/YZ', () => {
+    const tops = PLANES.map((p) => topology(drawRectangle(10, 10).sketchOnPlane(p).extrude(5)));
+    for (const t of tops) {
+      expect(t.valid).toBe(true);
+      expect(t.faces).toBe(6);
+      expect(t.edges).toBe(12);
+      expect(t.verts).toBe(8);
+    }
+  });
+
+  it('scoop profile (sagittaArc + lines) is plane-invariant', () => {
+    const cutWidth = 30,
+      userCutHeight = 8,
+      overshoot = 4.4;
+    const totalHeight = userCutHeight + overshoot;
+    const hw = cutWidth / 2;
+    const sagitta = Math.min(hw, userCutHeight);
+    const topY = totalHeight / 2;
+    const arcCenterY = topY - overshoot;
+    const buildScoop = () =>
+      draw([-hw, topY])
+        .lineTo([hw, topY])
+        .lineTo([hw, arcCenterY])
+        .sagittaArc(-cutWidth, 0, sagitta)
+        .close();
+    const tops = PLANES.map((p) => topology(buildScoop().sketchOnPlane(p).extrude(3.4)));
+    for (const t of tops) expect(t.valid).toBe(true);
+    expect(new Set(tops.map((t) => t.faces)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.edges)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.verts)).size).toBe(1);
+  });
+
+  it('funnel profile (lines + customCorner arcs) is plane-invariant', () => {
+    const cutWidth = 30,
+      userCutHeight = 8,
+      overshoot = 4.4;
+    const totalHeight = userCutHeight + overshoot;
+    const cornerR = 1.2;
+    const topHW = cutWidth / 2;
+    const bottomHW = (cutWidth * 0.6) / 2;
+    const topY = totalHeight / 2;
+    const bottomY = -totalHeight / 2;
+    const buildFunnel = () =>
+      draw([-topHW, topY])
+        .lineTo([topHW, topY])
+        .lineTo([bottomHW, bottomY])
+        .customCorner(cornerR)
+        .lineTo([-bottomHW, bottomY])
+        .customCorner(cornerR)
+        .close();
+    const tops = PLANES.map((p) => topology(buildFunnel().sketchOnPlane(p).extrude(3.4)));
+    for (const t of tops) expect(t.valid).toBe(true);
+    expect(new Set(tops.map((t) => t.faces)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.edges)).size).toBe(1);
+    expect(new Set(tops.map((t) => t.verts)).size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Trimmed-circle edges in `liftCurve2dToPlane` previously routed through `makeCircleArc(center, normal, radius, startAngle, endAngle)`, which interprets angles in OCCT's plane-local X-axis. On non-XY sketch planes (e.g. `'XZ'`) that frame disagrees with brepjs's lift frame (`Y = Z × X`) — arc endpoints diverged from line endpoints meeting at the same vertex, `MakeWire` failed to share vertices, and the resulting solid was malformed (e.g. rounded-rectangle on XZ → 10F/32E/32V invalid). Downstream, `cut(bin, cutouts)` produced empty geometry.
- Fix: build the arc via `makeArcEdge` from three points produced by the same `lift()` used for adjacent line endpoints, so coordinates are bit-identical and `MakeWire` merges them under default tolerance. No kernel change required — the adapter sidesteps OCCT's plane-local angle interpretation entirely.

## Impact (downstream)

Caught by the gridfinity-layout-tool wall-cutout occt-wasm parity suite (4 failures → 0 after this fix). Wall cutouts in that codebase sketch on `'XZ'` and use `drawRoundedRectangle`/`sagittaArc` profiles — exactly the trigger pattern.

## Test plan

- [x] `tests/sketchOnPlaneArcs.test.ts` (new, 5 cases): plane-invariance assertions across XY/XZ/YZ for `drawRoundedRectangle`, `drawCircle`, `drawRectangle`, `sagittaArc` (scoop), `customCorner` (funnel). All 5 pass under occt-wasm.
- [x] Full brepjs suite: 2310/2310 pass.
- [x] Downstream: gridfinity occtWasmParity 53/57 → 57/57.