### PR TITLE
refactor(test): derive coverage excludes from kernel registry

### DIFF
--- a/tests/helpers/kernelRegistry.ts
+++ b/tests/helpers/kernelRegistry.ts
@@ -18,6 +18,14 @@ export interface KernelConfig {
   readonly envOverrides?: Record<string, string> | undefined;
   readonly excludeTests?: readonly string[] | undefined;
   readonly coverageThresholds?: CoverageThresholds | 'informational' | undefined;
+  /**
+   * Adapter directory under `src/kernel/` exercised by this kernel's tests.
+   * Used to derive coverage exclude patterns: every kernel excludes the
+   * adapter dirs it doesn't load.
+   */
+  readonly adapterDir: string;
+  /** Extra coverage exclude patterns specific to this kernel (e.g. files the kernel doesn't load). */
+  readonly extraCoverageExcludes?: readonly string[] | undefined;
   readonly capabilities: {
     readonly projection: boolean;
     readonly constraintSketch: boolean;
@@ -33,6 +41,9 @@ export const kernelConfigs: readonly KernelConfig[] = [
     id: 'occt',
     displayName: 'OpenCascade',
     coverageThresholds: { statements: 84, branches: 74, functions: 90, lines: 84 },
+    adapterDir: 'src/kernel/occt',
+    // OCCT.js adapter doesn't load the pure-TS 2D module (occt's own 2D ops cover it).
+    extraCoverageExcludes: ['src/kernel/geometry2d.ts'],
     capabilities: {
       projection: true,
       constraintSketch: true,
@@ -46,6 +57,7 @@ export const kernelConfigs: readonly KernelConfig[] = [
     id: 'brepkit',
     displayName: 'brepkit',
     coverageThresholds: 'informational',
+    adapterDir: 'src/kernel/brepkit',
     capabilities: {
       projection: false,
       constraintSketch: true,
@@ -59,6 +71,7 @@ export const kernelConfigs: readonly KernelConfig[] = [
     id: 'occt-wasm',
     displayName: 'occt-wasm',
     coverageThresholds: 'informational',
+    adapterDir: 'src/kernel/occtWasm',
     excludeTests: [
       'tests/brepkitExtended.test.ts',
       'tests/brepkitAdapter.test.ts',
@@ -76,6 +89,18 @@ export const kernelConfigs: readonly KernelConfig[] = [
     },
   },
 ] as const;
+
+/**
+ * Coverage exclude patterns for a given kernel: every other kernel's adapter
+ * directory (those files aren't loaded so coverage there is meaningless),
+ * plus any kernel-specific extras.
+ */
+export function coverageExcludesFor(id: string): readonly string[] {
+  return [
+    ...kernelConfigs.filter((k) => k.id !== id).map((k) => `${k.adapterDir}/**`),
+    ...(getKernelConfig(id)?.extraCoverageExcludes ?? []),
+  ];
+}
 
 export function getKernelConfig(id: string): KernelConfig | undefined {
   return kernelConfigs.find((k) => k.id === id);

--- a/tests/helpers/kernelRegistry.ts
+++ b/tests/helpers/kernelRegistry.ts
@@ -19,7 +19,7 @@ export interface KernelConfig {
   readonly excludeTests?: readonly string[] | undefined;
   readonly coverageThresholds?: CoverageThresholds | 'informational' | undefined;
   /**
-   * Adapter directory under `src/kernel/` exercised by this kernel's tests.
+   * Repo-root-relative path to this kernel's adapter directory (e.g. `"src/kernel/occt"`).
    * Used to derive coverage exclude patterns: every kernel excludes the
    * adapter dirs it doesn't load.
    */
@@ -94,11 +94,16 @@ export const kernelConfigs: readonly KernelConfig[] = [
  * Coverage exclude patterns for a given kernel: every other kernel's adapter
  * directory (those files aren't loaded so coverage there is meaningless),
  * plus any kernel-specific extras.
+ *
+ * Throws on unknown id so a typo fails at config-load time rather than
+ * silently producing a wrong exclude list.
  */
 export function coverageExcludesFor(id: string): readonly string[] {
+  const config = getKernelConfig(id);
+  if (!config) throw new Error(`Unknown kernel: "${id}"`);
   return [
     ...kernelConfigs.filter((k) => k.id !== id).map((k) => `${k.adapterDir}/**`),
-    ...(getKernelConfig(id)?.extraCoverageExcludes ?? []),
+    ...(config.extraCoverageExcludes ?? []),
   ];
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,15 +42,11 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       reporter: ['text', 'text-summary', 'lcov'],
       reportsDirectory: './coverage',
-      // Per-kernel exclude lists: each project measures its own adapter dir
-      // and excludes the others' (which it doesn't load). Source of truth in
-      // kernelRegistry.ts so adding a kernel doesn't require a vitest edit.
-      exclude: [
-        'src/**/*.d.ts',
-        'src/**/index.ts',
-        // Default to OCCT excludes for the root config; per-project blocks below override.
-        ...coverageExcludesFor('occt'),
-      ],
+      // OCCT-flavored excludes are applied at the root because vitest's
+      // project-level coverage.exclude does not override the root list (yet);
+      // see PR description. Source of truth lives in kernelRegistry.ts so
+      // adding a kernel doesn't require a vitest edit.
+      exclude: ['src/**/*.d.ts', 'src/**/index.ts', ...coverageExcludesFor('occt')],
       thresholds: {
         statements: 84,
         // 74 reflects intentional skips for V8 RC4 regressions (PRs #605, #639, #641, commit 8c857d65).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
-import { kernelConfigs } from './tests/helpers/kernelRegistry.js';
+import { kernelConfigs, coverageExcludesFor } from './tests/helpers/kernelRegistry.js';
 
 /**
  * Tests excluded from all kernel projects:
@@ -40,18 +40,17 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],
+      reporter: ['text', 'text-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      // Per-kernel exclude lists: each project measures its own adapter dir
+      // and excludes the others' (which it doesn't load). Source of truth in
+      // kernelRegistry.ts so adding a kernel doesn't require a vitest edit.
       exclude: [
         'src/**/*.d.ts',
         'src/**/index.ts',
-        'src/kernel/brepkit/**',
-        'src/kernel/occtWasm/**',
-        // geometry2d.ts is pure-TS 2D used by brepkit/occt-wasm, not by OCCT.
-        // Excluded from OCCT coverage (the only enforced project). Covered
-        // informally by brepkit/occt-wasm test runs.
-        'src/kernel/geometry2d.ts',
+        // Default to OCCT excludes for the root config; per-project blocks below override.
+        ...coverageExcludesFor('occt'),
       ],
-      reporter: ['text', 'text-summary', 'lcov'],
-      reportsDirectory: './coverage',
       thresholds: {
         statements: 84,
         // 74 reflects intentional skips for V8 RC4 regressions (PRs #605, #639, #641, commit 8c857d65).


### PR DESCRIPTION
## Summary

Smaller-than-planned scope after investigation. The audit's recommendation to give brepkit/occt-wasm projects coverage signal on their adapter directories needs deeper work into vitest's project-level coverage inheritance — empirically, project `coverage.exclude` doesn't override the root for files inside `include`, which means simply removing the global excludes also drops them from the OCCT project (which doesn't load brepkit/occtWasm code) and tanks thresholds.

This PR is the **structural prerequisite** for that follow-up: extract per-kernel adapter directories and derive vitest's exclude list from the registry, single source of truth.

- New: `KernelConfig.adapterDir` (which dir under `src/kernel/` each kernel implements)
- New: `KernelConfig.extraCoverageExcludes` (per-kernel extras like OCCT's `geometry2d.ts`)
- New: `coverageExcludesFor(id)` helper — returns "every other kernel's adapter dir + this kernel's extras"
- `vitest.config.ts` now uses `coverageExcludesFor('occt')` to build its exclude list instead of hardcoding the three kernel paths

Behavior is identical: OCCT thresholds 84/74/90/88 still pass on `test:full`. Adding a new kernel now only touches `kernelRegistry.ts`.

## Follow-up (deferred)

The audit's actual ask — coverage reports for the brepkit and occt-wasm adapter directories — needs separate investigation:

- `vitest run --project occt --coverage` is the canonical command (`test:full`)
- With per-project `coverage.exclude` overrides, the OCCT project still measures other kernels' code (16K statements vs 11K), failing thresholds
- Likely needs three separate vitest configs or a different split. Will file as `feat(test): per-kernel coverage reports` once we know the right shape.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run check:patterns` — clean
- [x] `npm run check:boundaries` — passes
- [x] `npm run test:full` — same coverage numbers as main (86.7/74.43/93.46/88.1)
- [ ] CI green