### PR TITLE
feat(check-patterns): content-based fingerprints stable under line shifts

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated": "2026-05-08T21:52:22.179Z",
+  "generated": "2026-05-08T22:19:18.117Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -15,7 +15,7 @@
     {
       "file": "src/core/disposal.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/core/disposal.ts|no-double-cast|class NoOpFinalizationRegistry { register(_target: object, _heldValue: un...|#0"
+      "fingerprint": "src/core/disposal.ts|no-double-cast|class NoOpFinalizationRegistry { register(_target: object, _heldValue: unknow...|#0"
     },
     {
       "file": "src/io/gltfExportFns.ts",
@@ -215,7 +215,7 @@
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow( fuseAllFn([val, ...tools.map(resolve)], { ...|#0"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow( fuseAllFn([val, ...tools.map(resolve)], { ...opts, unsafe: tru...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",

--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,331 +1,331 @@
 {
-  "version": 1,
-  "generated": "2026-05-08T21:18:11.008Z",
+  "version": 2,
+  "generated": "2026-05-08T21:52:22.179Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/core/dimensionTypes.ts|no-double-cast|36|s as unknown as Record<string, unknown>"
+      "fingerprint": "src/core/dimensionTypes.ts|no-double-cast|s as unknown as Record<string, unknown>|#0"
     },
     {
       "file": "src/core/dimensionTypes.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/core/dimensionTypes.ts|no-double-cast|46|s as unknown as Record<string, unknown>"
+      "fingerprint": "src/core/dimensionTypes.ts|no-double-cast|s as unknown as Record<string, unknown>|#1"
     },
     {
       "file": "src/core/disposal.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/core/disposal.ts|no-double-cast|48|class NoOpFinalizationRegistry {\n    register(_target: objec"
+      "fingerprint": "src/core/disposal.ts|no-double-cast|class NoOpFinalizationRegistry { register(_target: object, _heldValue: un...|#0"
     },
     {
       "file": "src/io/gltfExportFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/io/gltfExportFns.ts|max-function-lines|228|"
+      "fingerprint": "src/io/gltfExportFns.ts|max-function-lines|buildGltfDocument|#0"
     },
     {
       "file": "src/io/gltfExportFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/io/gltfExportFns.ts|max-function-lines|431|"
+      "fingerprint": "src/io/gltfExportFns.ts|max-function-lines|buildGltfDocFromLayout|#0"
     },
     {
       "file": "src/io/threemfExportFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/io/threemfExportFns.ts|max-function-lines|66|"
+      "fingerprint": "src/io/threemfExportFns.ts|max-function-lines|buildZip|#0"
     },
     {
       "file": "src/io/threemfExportFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/io/threemfExportFns.ts|max-function-lines|205|"
+      "fingerprint": "src/io/threemfExportFns.ts|max-function-lines|build3MFModel|#0"
     },
     {
       "file": "src/kernel/brepkit/constructionOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|682|"
+      "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|makeCircleNurbs|#0"
     },
     {
       "file": "src/kernel/brepkit/constructionOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|794|"
+      "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|makeEllipseNurbs|#0"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-function-lines|121|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-function-lines|matchFacesGeometrically|#0"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|289|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|buildEvolution/if@5|#0"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|299|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|buildEvolution/if@5|#1"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|317|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|buildEvolution/for@5|#0"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|321|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|buildEvolution/if@5|#2"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|426|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#0"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|432|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#1"
     },
     {
       "file": "src/kernel/brepkit/evolutionOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|438|"
+      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#2"
     },
     {
       "file": "src/kernel/brepkit/modifierOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-function-lines|125|"
+      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-function-lines|shell|#0"
     },
     {
       "file": "src/kernel/brepkit/modifierOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-function-lines|142|"
+      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-function-lines|<anonymous>|#0"
     },
     {
       "file": "src/kernel/brepkit/modifierOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|196|"
+      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|<anonymous>/if@5|#0"
     },
     {
       "file": "src/kernel/brepkit/modifierOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|200|"
+      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|<anonymous>/for-of@5|#0"
     },
     {
       "file": "src/kernel/brepkit/modifierOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|214|"
+      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|<anonymous>/if@5|#1"
     },
     {
       "file": "src/kernel/brepkit/sweepOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-function-lines|252|"
+      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-function-lines|sweepPipeShell|#0"
     },
     {
       "file": "src/kernel/brepkit/sweepOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-nesting-depth|288|"
+      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-nesting-depth|sweepPipeShell/try@5|#0"
     },
     {
       "file": "src/kernel/brepkit/sweepOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-nesting-depth|293|"
+      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-nesting-depth|sweepPipeShell/if@6|#0"
     },
     {
       "file": "src/kernel/brepkit/topologyOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-function-lines|21|"
+      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-function-lines|iterShapes|#0"
     },
     {
       "file": "src/kernel/brepkit/topologyOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|77|"
+      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|iterShapes/if@5|#0"
     },
     {
       "file": "src/kernel/brepkit/topologyOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|113|"
+      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|iterShapes/if@5|#1"
     },
     {
       "file": "src/kernel/brepkit/topologyOps.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|220|"
+      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|sew/for-of@5|#0"
     },
     {
       "file": "src/kernel/geometry2d.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/geometry2d.ts|max-function-lines|636|"
+      "fingerprint": "src/kernel/geometry2d.ts|max-function-lines|numericalIntersect|#0"
     },
     {
       "file": "src/kernel/occt/advancedOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|700|"
+      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|surfaceCurvature|#0"
     },
     {
       "file": "src/kernel/occt/advancedOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|1096|"
+      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|exportSTEPConfigured|#0"
     },
     {
       "file": "src/kernel/occt/hullOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/hullOps.ts|max-function-lines|208|"
+      "fingerprint": "src/kernel/occt/hullOps.ts|max-function-lines|quickHull|#0"
     },
     {
       "file": "src/operations/mateFns.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|133|"
+      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@5|#0"
     },
     {
       "file": "src/operations/mateFns.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|135|"
+      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@5|#1"
     },
     {
       "file": "src/operations/mateFns.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|137|"
+      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@6|#0"
     },
     {
       "file": "src/operations/mateFns.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|142|"
+      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@6|#1"
     },
     {
       "file": "src/operations/straightSkeleton.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/operations/straightSkeleton.ts|max-function-lines|330|"
+      "fingerprint": "src/operations/straightSkeleton.ts|max-function-lines|computeStraightSkeletonImpl|#0"
     },
     {
       "file": "src/topology/metadata/originTrackingFns.ts",
       "rule": "max-nesting-depth",
-      "fingerprint": "src/topology/metadata/originTrackingFns.ts|max-nesting-depth|209|"
+      "fingerprint": "src/topology/metadata/originTrackingFns.ts|max-nesting-depth|propagateOriginsByHash/if@5|#0"
     },
     {
       "file": "src/topology/modifierFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|199|"
+      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|fillet|#0"
     },
     {
       "file": "src/topology/modifierFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|499|"
+      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|draft|#0"
     },
     {
       "file": "src/topology/surfaceFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/surfaceFns.ts|max-function-lines|176|"
+      "fingerprint": "src/topology/surfaceFns.ts|max-function-lines|surfaceFromImage|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|368|unwrapOrThrow(\n          fuseAllFn([val, ...tools.map(resolv"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow( fuseAllFn([val, ...tools.map(resolve)], { ...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|376|unwrapOrThrow(cutAllFn(val, tools, { ...opts, unsafe: true }"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(cutAllFn(val, tools, { ...opts, unsafe: true })) as unknown as T|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|389|unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0]))"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0])) as unknown as T|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|389|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|393|unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0], "
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0], args[1])) as unkn...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|393|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#1"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|402|unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0])"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0])) as unknown as T|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|402|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#2"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|407|unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0],"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0], args[1])) as unk...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|407|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#3"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|413|unwrapOrThrow(shell(val as unknown as ValidSolid, faces, thi"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(shell(val as unknown as ValidSolid, faces, thickness, opts)) as...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|413|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#4"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|417|unwrapOrThrow(offset(val as unknown as ValidSolid, distance,"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(offset(val as unknown as ValidSolid, distance, opts)) as unknow...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|417|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#5"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|420|unwrapOrThrow(draftFn(val as unknown as ValidSolid, faces, o"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(draftFn(val as unknown as ValidSolid, faces, opts)) as unknown ...|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|420|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ValidSolid|#6"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|443|unwrapOrThrow(linearPattern(val, dir, count, spacing)) as un"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(linearPattern(val, dir, count, spacing)) as unknown as T|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|445|unwrapOrThrow(circularPattern(val, axis, count, angle)) as u"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|unwrapOrThrow(circularPattern(val, axis, count, angle)) as unknown as T|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|464|val as unknown as ClosedWire"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as ClosedWire|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|488|val as unknown as OrientedFace & PlanarFace"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as OrientedFace & PlanarFace|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|491|val as unknown as OrientedFace & PlanarFace"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|val as unknown as OrientedFace & PlanarFace|#1"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|501|createWrappedFace(val) as unknown as Wrapped<T>"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|createWrappedFace(val) as unknown as Wrapped<T>|#0"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/wrapperFns.ts|max-function-lines|345|"
+      "fingerprint": "src/topology/wrapperFns.ts|max-function-lines|createWrapped3D|#0"
     }
   ]
 }

--- a/scripts/check-patterns.ts
+++ b/scripts/check-patterns.ts
@@ -86,7 +86,9 @@ function getLineAndCol(sourceFile: ts.SourceFile, pos: number): { line: number; 
 }
 
 function getSnippet(sourceFile: ts.SourceFile, node: ts.Node): string {
-  const text = node.getText(sourceFile);
+  // Normalize whitespace BEFORE truncating so multi-line and single-line
+  // formattings of the same expression produce identical fingerprints.
+  const text = node.getText(sourceFile).trim().replace(/\s+/g, ' ');
   return text.length > 80 ? text.slice(0, 77) + '...' : text;
 }
 
@@ -508,7 +510,12 @@ function loadBaseline(): Baseline | null {
       return null;
     }
     return raw as Baseline;
-  } catch {
+  } catch (err) {
+    console.error(
+      `\x1b[33m⚠ Failed to parse .pattern-baseline.json: ${
+        err instanceof Error ? err.message : String(err)
+      }\x1b[0m\n  Treating as missing; all violations will report as new.`
+    );
     return null;
   }
 }

--- a/scripts/check-patterns.ts
+++ b/scripts/check-patterns.ts
@@ -23,10 +23,13 @@
  * Note: Only src/**\/*.ts files are scanned. This script (in scripts/) is
  * exempt from its own rules by design.
  *
- * Baseline: Fingerprints include the violation's line number. Insertions or
- * deletions above a baselined violation will shift its line, causing it to
- * appear as "new". Run `--update-baseline` after non-trivial edits near
- * baselined code.
+ * Baseline (v2): fingerprints are content-based — `file|rule|snippet|#index`.
+ * Edits *above* a violation no longer reshuffle fingerprints. Editing the
+ * violation itself (rename, signature change, cast text) DOES change the
+ * fingerprint and the line will appear as "new" — which is desired.
+ * Duplicate (file, rule, snippet) triples are disambiguated by source-order
+ * occurrence index, so adding/removing one entry only shifts indices for the
+ * later occurrences in the same group.
  */
 
 import * as ts from 'typescript';
@@ -43,6 +46,8 @@ interface Diagnostic {
   line: number;
   column: number;
   source?: string;
+  /** 0-based index among same (file, ruleId, source) — assigned post-collection. */
+  occurrenceIdx?: number;
 }
 
 interface Rule {
@@ -59,7 +64,7 @@ interface BaselineEntry {
 }
 
 interface Baseline {
-  version: 1;
+  version: 2;
   generated: string;
   entries: BaselineEntry[];
 }
@@ -95,8 +100,42 @@ function isDisabledAt(lines: string[], line: number, ruleId: string): boolean {
   return false;
 }
 
-function makeFingerprint(file: string, ruleId: string, line: number, source: string): string {
-  return `${file}|${ruleId}|${line}|${source.trim().slice(0, 60)}`;
+/**
+ * Stable fingerprint that ignores line numbers — invariant under edits above
+ * the violation. Duplicate `(file, rule, snippet)` triples are disambiguated
+ * by occurrence index (0-based, source-order).
+ *
+ * Snippet is whitespace-normalized to absorb formatter changes.
+ */
+function makeFingerprint(file: string, ruleId: string, snippet: string, occurrenceIdx: number): string {
+  const normalized = snippet.trim().replace(/\s+/g, ' ').slice(0, 80);
+  return `${file}|${ruleId}|${normalized}|#${occurrenceIdx}`;
+}
+
+function fingerprintFor(d: Diagnostic): string {
+  return makeFingerprint(d.file, d.ruleId, d.source ?? '', d.occurrenceIdx ?? 0);
+}
+
+/**
+ * Assign each diagnostic an occurrence index among others sharing the same
+ * (file, rule, snippet). Source-ordered so adding/removing a violation only
+ * shifts indices for the violations after it within the same group.
+ */
+function annotateOccurrences(diagnostics: Diagnostic[]): void {
+  const sorted = [...diagnostics].sort((a, b) => {
+    if (a.file !== b.file) return a.file.localeCompare(b.file);
+    if (a.ruleId !== b.ruleId) return a.ruleId.localeCompare(b.ruleId);
+    if (a.line !== b.line) return a.line - b.line;
+    return a.column - b.column;
+  });
+  const counters = new Map<string, number>();
+  for (const d of sorted) {
+    const snippetKey = (d.source ?? '').trim().replace(/\s+/g, ' ').slice(0, 80);
+    const groupKey = `${d.file}|${d.ruleId}|${snippetKey}`;
+    const idx = counters.get(groupKey) ?? 0;
+    d.occurrenceIdx = idx;
+    counters.set(groupKey, idx + 1);
+  }
 }
 
 function isUsingDeclaration(declList: ts.VariableDeclarationList): boolean {
@@ -333,6 +372,7 @@ const maxFunctionLines: Rule = {
               file: filePath,
               line,
               column: col,
+              source: name,
             });
           }
         }
@@ -365,17 +405,39 @@ const maxNestingDepth: Rule = {
       );
     }
 
-    function visit(node: ts.Node, depth: number) {
-      let newDepth = depth;
+    function nestingNodeKind(node: ts.Node): string {
+      if (ts.isIfStatement(node)) return 'if';
+      if (ts.isForStatement(node)) return 'for';
+      if (ts.isForInStatement(node)) return 'for-in';
+      if (ts.isForOfStatement(node)) return 'for-of';
+      if (ts.isWhileStatement(node)) return 'while';
+      if (ts.isDoStatement(node)) return 'do';
+      if (ts.isSwitchStatement(node)) return 'switch';
+      if (ts.isTryStatement(node)) return 'try';
+      return '?';
+    }
 
-      // Reset depth inside function bodies
-      if (
-        ts.isFunctionDeclaration(node) ||
-        ts.isMethodDeclaration(node) ||
-        ts.isArrowFunction(node) ||
-        ts.isFunctionExpression(node)
+    function visit(node: ts.Node, depth: number, fnName: string) {
+      let newDepth = depth;
+      let nextFnName = fnName;
+
+      // Reset depth inside function bodies; capture name for snippet
+      if (ts.isFunctionDeclaration(node) && node.name) {
+        newDepth = 0;
+        nextFnName = node.name.text;
+      } else if (ts.isMethodDeclaration(node)) {
+        newDepth = 0;
+        nextFnName = node.name.getText(sourceFile);
+      } else if (
+        ts.isArrowFunction(node) &&
+        ts.isVariableDeclaration(node.parent) &&
+        ts.isIdentifier(node.parent.name)
       ) {
         newDepth = 0;
+        nextFnName = node.parent.name.text;
+      } else if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+        newDepth = 0;
+        nextFnName = '<anonymous>';
       }
 
       if (isNestingNode(node)) {
@@ -391,14 +453,15 @@ const maxNestingDepth: Rule = {
               file: filePath,
               line,
               column: col,
+              source: `${fnName}/${nestingNodeKind(node)}@${newDepth}`,
             });
           }
         }
       }
 
-      ts.forEachChild(node, (child) => visit(child, newDepth));
+      ts.forEachChild(node, (child) => visit(child, newDepth, nextFnName));
     }
-    visit(sourceFile, 0);
+    visit(sourceFile, 0, '<top>');
   },
 };
 
@@ -436,20 +499,29 @@ function collectSrcFiles(dir: string): string[] {
 function loadBaseline(): Baseline | null {
   if (!existsSync(BASELINE_PATH)) return null;
   try {
-    return JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as Baseline;
+    const raw = JSON.parse(readFileSync(BASELINE_PATH, 'utf-8')) as { version: number };
+    if (raw.version !== 2) {
+      console.error(
+        `\x1b[33m⚠ .pattern-baseline.json is version ${raw.version}; expected version 2.\x1b[0m\n` +
+          `  Run \`npm run check:patterns:baseline\` to regenerate with the content-hash format.`
+      );
+      return null;
+    }
+    return raw as Baseline;
   } catch {
     return null;
   }
 }
 
 function saveBaseline(diagnostics: Diagnostic[]): void {
+  annotateOccurrences(diagnostics);
   const entries: BaselineEntry[] = diagnostics.map((d) => ({
     file: d.file,
     rule: d.ruleId,
-    fingerprint: makeFingerprint(d.file, d.ruleId, d.line, d.source ?? ''),
+    fingerprint: fingerprintFor(d),
   }));
   const baseline: Baseline = {
-    version: 1,
+    version: 2,
     generated: new Date().toISOString(),
     entries,
   };
@@ -457,11 +529,9 @@ function saveBaseline(diagnostics: Diagnostic[]): void {
 }
 
 function filterNewViolations(diagnostics: Diagnostic[], baseline: Baseline): Diagnostic[] {
+  annotateOccurrences(diagnostics);
   const baselineSet = new Set(baseline.entries.map((e) => e.fingerprint));
-  return diagnostics.filter((d) => {
-    const fp = makeFingerprint(d.file, d.ruleId, d.line, d.source ?? '');
-    return !baselineSet.has(fp);
-  });
+  return diagnostics.filter((d) => !baselineSet.has(fingerprintFor(d)));
 }
 
 // ─── Output formatters ──────────────────────────────────


### PR DESCRIPTION
## Summary

The v1 baseline format embedded each violation's line number, so any edit *above* a baselined entry shifted its fingerprint and the next pre-commit erroneously flagged it as new. PR #911 had to regenerate the baseline for this exact reason — that ritual goes away.

**v2 fingerprint:** \`file|rule|snippet|#index\`

- \`snippet\` is the violation's identifying text:
  - **no-double-cast**: cast expression text (e.g. \`s as unknown as Wrapped<T>\`)
  - **max-function-lines**: function name (e.g. \`buildGltfDocument\`)
  - **max-nesting-depth**: enclosing fn + control-flow kind + depth (e.g. \`processSegment/if@5\`)
- \`#index\` is a 0-based occurrence counter, source-ordered, that disambiguates duplicate snippets within a file

## Stability properties

- Whitespace, comment, and unrelated-line edits anywhere in the file → fingerprint unchanged
- Renaming a violating function or changing the cast text → fingerprint changes (correctly appears as new)
- Adding/removing one violation only shifts indices for later occurrences in the *same* (file, rule, snippet) group

## Migration

\`loadBaseline\` rejects v1 files with a clear message pointing to \`npm run check:patterns:baseline\`. The baseline file is regenerated to v2 format in this PR.

## Verification

I tested by inserting two blank lines at the top of \`src/topology/wrapperFns.ts\`:

- **v1**: would produce 23 false-positive "new violation" reports (every cast in the file shifts down)
- **v2**: 0 new violations reported ✓

## Test plan

- [x] \`npm run typecheck\` — passes
- [x] \`npm run check:patterns\` against v2 baseline — clean
- [x] \`npm run check:patterns:baseline\` regenerates v2 — same 65 violations
- [x] Manual stability test (insert 2 blank lines in wrapperFns.ts) — clean
- [ ] CI green