### PR TITLE
refactor(wrapper): consolidate trust-cast double-casts into named helpers

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-05-08T21:18:11.008Z",
+  "generated": "2026-05-08T22:19:51.219Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -215,117 +215,57 @@
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|368|unwrapOrThrow(\n          fuseAllFn([val, ...tools.map(resolv"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|393|unwrapOrThrow(\n          fuseAllFn([val, ...tools.map(resolv"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|376|unwrapOrThrow(cutAllFn(val, tools, { ...opts, unsafe: true }"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|401|unwrapOrThrow(cutAllFn(val, tools, { ...opts, unsafe: true }"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|389|unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0]))"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|414|unwrapOrThrow(fillet(asValidSolid(val), args[0])) as unknown"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|389|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|424|unwrapOrThrow(chamfer(asValidSolid(val), args[0])) as unknow"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|393|unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0], "
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|431|unwrapOrThrow(shell(asValidSolid(val), faces, thickness, opt"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|393|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|434|unwrapOrThrow(offset(asValidSolid(val), distance, opts)) as "
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|402|unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0])"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|437|unwrapOrThrow(draftFn(asValidSolid(val), faces, opts)) as un"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|402|val as unknown as ValidSolid"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|460|unwrapOrThrow(linearPattern(val, dir, count, spacing)) as un"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|407|unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0],"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|462|unwrapOrThrow(circularPattern(val, axis, count, angle)) as u"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|407|val as unknown as ValidSolid"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|413|unwrapOrThrow(shell(val as unknown as ValidSolid, faces, thi"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|413|val as unknown as ValidSolid"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|417|unwrapOrThrow(offset(val as unknown as ValidSolid, distance,"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|417|val as unknown as ValidSolid"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|420|unwrapOrThrow(draftFn(val as unknown as ValidSolid, faces, o"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|420|val as unknown as ValidSolid"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|443|unwrapOrThrow(linearPattern(val, dir, count, spacing)) as un"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|445|unwrapOrThrow(circularPattern(val, axis, count, angle)) as u"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|464|val as unknown as ClosedWire"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|488|val as unknown as OrientedFace & PlanarFace"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|491|val as unknown as OrientedFace & PlanarFace"
-    },
-    {
-      "file": "src/topology/wrapperFns.ts",
-      "rule": "no-double-cast",
-      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|501|createWrappedFace(val) as unknown as Wrapped<T>"
+      "fingerprint": "src/topology/wrapperFns.ts|no-double-cast|513|createWrappedFace(val) as unknown as Wrapped<T>"
     },
     {
       "file": "src/topology/wrapperFns.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/topology/wrapperFns.ts|max-function-lines|345|"
+      "fingerprint": "src/topology/wrapperFns.ts|max-function-lines|370|"
     }
   ]
 }

--- a/src/topology/wrapperFns.ts
+++ b/src/topology/wrapperFns.ts
@@ -160,6 +160,31 @@ function unwrapOrThrow<T>(result: Result<T>): T {
 }
 
 // ---------------------------------------------------------------------------
+// Trust casts — fluent-API contract bridges
+//
+// The wrapper expresses a "trust me" contract: callers building a chain like
+// `shape(box(...)).fillet(...)` have implicitly affirmed the shape is a
+// ValidSolid by asking for an operation that requires one. Runtime validation
+// would defeat the fluent ergonomics, so these helpers consolidate the
+// unchecked `unknown` bridge in one auditable place.
+// ---------------------------------------------------------------------------
+
+function asValidSolid(s: Shape3D): ValidSolid {
+  // brepjs-patterns-disable: no-double-cast
+  return s as unknown as ValidSolid;
+}
+
+function asOrientedPlanarFace(f: Face): OrientedFace & PlanarFace {
+  // brepjs-patterns-disable: no-double-cast
+  return f as unknown as OrientedFace & PlanarFace;
+}
+
+function asClosedWire(w: Wire): ClosedWire {
+  // brepjs-patterns-disable: no-double-cast
+  return w as unknown as ClosedWire;
+}
+
+// ---------------------------------------------------------------------------
 // Wrapped interfaces (exported for type annotations)
 // ---------------------------------------------------------------------------
 
@@ -386,38 +411,30 @@ function createWrapped3D<T extends Shape3D>(val: T): Wrapped3D<T> {
     ): Wrapped3D<T> {
       // brepjs-patterns-disable: no-double-cast
       if (args.length === 1) {
-        return wrap3D(unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0])) as unknown as T);
+        return wrap3D(unwrapOrThrow(fillet(asValidSolid(val), args[0])) as unknown as T);
       }
       // brepjs-patterns-disable: no-double-cast
-      return wrap3D(
-        unwrapOrThrow(fillet(val as unknown as ValidSolid, args[0], args[1])) as unknown as T
-      );
+      return wrap3D(unwrapOrThrow(fillet(asValidSolid(val), args[0], args[1])) as unknown as T);
     },
     chamfer(
       ...args: [ChamferDistance] | [Edge[] | FinderFn<Edge> | ShapeFinder<Edge>, ChamferDistance]
     ): Wrapped3D<T> {
       // brepjs-patterns-disable: no-double-cast
       if (args.length === 1) {
-        return wrap3D(
-          unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0])) as unknown as T
-        );
+        return wrap3D(unwrapOrThrow(chamfer(asValidSolid(val), args[0])) as unknown as T);
       }
       // brepjs-patterns-disable: no-double-cast
-      return wrap3D(
-        unwrapOrThrow(chamfer(val as unknown as ValidSolid, args[0], args[1])) as unknown as T
-      );
+      return wrap3D(unwrapOrThrow(chamfer(asValidSolid(val), args[0], args[1])) as unknown as T);
     },
     // brepjs-patterns-disable: no-double-cast
     shell: (faces, thickness, opts) =>
-      wrap3D(
-        unwrapOrThrow(shell(val as unknown as ValidSolid, faces, thickness, opts)) as unknown as T
-      ),
+      wrap3D(unwrapOrThrow(shell(asValidSolid(val), faces, thickness, opts)) as unknown as T),
     // brepjs-patterns-disable: no-double-cast
     offset: (distance, opts) =>
-      wrap3D(unwrapOrThrow(offset(val as unknown as ValidSolid, distance, opts)) as unknown as T),
+      wrap3D(unwrapOrThrow(offset(asValidSolid(val), distance, opts)) as unknown as T),
     // brepjs-patterns-disable: no-double-cast
     draft: (faces, opts) =>
-      wrap3D(unwrapOrThrow(draftFn(val as unknown as ValidSolid, faces, opts)) as unknown as T),
+      wrap3D(unwrapOrThrow(draftFn(asValidSolid(val), faces, opts)) as unknown as T),
 
     // Compound operations
     drill: (opts) => wrap3D(unwrapOrThrow(drillFn(val, opts))),
@@ -461,8 +478,7 @@ function createWrappedCurve<T extends Edge | Wire>(val: T): WrappedCurve<T> {
 
     sweep(spine: Shapeable<Wire>, opts?: SweepOptions): Wrapped3D<Shape3D> {
       if (!isWire(val)) throw new Error('sweep requires a Wire');
-      const w = val as unknown as ClosedWire;
-      const result = unwrapOrThrow(_sweep(w, resolve(spine), opts));
+      const result = unwrapOrThrow(_sweep(asClosedWire(val), resolve(spine), opts));
       // _sweep may return [Shape3D, Wire, Wire] in shell mode; extract the shape
       const shape3D: Shape3D = Array.isArray(result) ? result[0] : result;
       return wrap3D(shape3D);
@@ -483,12 +499,8 @@ function createWrappedFace(val: Face): WrappedFace {
     innerWires: () => innerWires(val),
 
     // Wrapped faces from the fluent API are always oriented and planar
-    // brepjs-patterns-disable: no-double-cast
-    extrude: (height) =>
-      wrap3D(unwrapOrThrow(extrude(val as unknown as OrientedFace & PlanarFace, height))),
-    // brepjs-patterns-disable: no-double-cast
-    revolve: (opts) =>
-      wrap3D(unwrapOrThrow(revolve(val as unknown as OrientedFace & PlanarFace, opts))),
+    extrude: (height) => wrap3D(unwrapOrThrow(extrude(asOrientedPlanarFace(val), height))),
+    revolve: (opts) => wrap3D(unwrapOrThrow(revolve(asOrientedPlanarFace(val), opts))),
   };
 }
 


### PR DESCRIPTION
## Summary

Centralizes the wrapper's \`as unknown as\` trust casts into 3 named helpers. The fluent API contract is the same — \`shape(box(...)).fillet(...)\` trusts the user's implicit affirmation that the shape is a \`ValidSolid\` — but now that contract is documented once at the helper definition rather than spread across 12+ call sites each with its own \`brepjs-patterns-disable\` directive.

**New helpers:**
- \`asValidSolid(s: Shape3D): ValidSolid\` — for fillet/chamfer/shell/offset/draft
- \`asOrientedPlanarFace(f: Face): OrientedFace & PlanarFace\` — for extrude/revolve
- \`asClosedWire(w: Wire): ClosedWire\` — for sweep

**Pattern baseline:** 65 → 53 entries (−12 \`no-double-cast\` violations in wrapperFns.ts).

## Out of scope

The result-narrowing \`as unknown as T\` casts (where the wrapper's parametric \`T\` is structurally guaranteed by the 3D context) are unchanged. Abstracting those needs a generic helper, but the simplest signature \`narrowResult<T>(value: AnyShape): T\` trips lint's \`@typescript-eslint/no-unnecessary-type-parameters\` rule. Worth its own PR.

## Test plan

- [x] \`npm run typecheck\` — passes
- [x] \`npm run lint\` — passes
- [x] \`npm run check:patterns\` — 0 new violations
- [x] \`npm run check:boundaries\` — passes
- [x] \`npm run format:check\` — passes
- [ ] CI green