### PR TITLE
refactor(occt-wasm): extract helpers.ts + booleanOps.ts (PR 7 starter)

### DIFF
--- a/src/kernel/occtWasm/booleanOps.ts
+++ b/src/kernel/occtWasm/booleanOps.ts
@@ -1,0 +1,135 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Boolean operations for the occt-wasm adapter.
+ *
+ * Mirrors the decomposition pattern used by `src/kernel/occt/booleanOps.ts`:
+ * each method on the adapter is a thin delegate to a free function here.
+ *
+ * @module
+ */
+
+import type {
+  BooleanOpType,
+  BooleanOptions,
+  CheckBooleanResult,
+  KernelMeshResult,
+  KernelShape,
+} from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { makeVecU32, unwrap, wrapResult } from './helpers.js';
+
+export function fuse(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  tool: KernelShape,
+  _options?: BooleanOptions
+): KernelShape {
+  return wrapResult(k, k.fuse(unwrap(shape), unwrap(tool)));
+}
+
+export function cut(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  tool: KernelShape,
+  _options?: BooleanOptions
+): KernelShape {
+  return wrapResult(k, k.cut(unwrap(shape), unwrap(tool)));
+}
+
+export function intersect(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  tool: KernelShape,
+  _options?: BooleanOptions
+): KernelShape {
+  return wrapResult(k, k.intersect(unwrap(shape), unwrap(tool)));
+}
+
+export function section(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  plane: KernelShape,
+  _approximation?: boolean
+): KernelShape {
+  return wrapResult(k, k.section(unwrap(shape), unwrap(plane)));
+}
+
+export function fuseAll(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shapes: KernelShape[],
+  _options?: BooleanOptions
+): KernelShape {
+  const vec = makeVecU32(Module, shapes.map(unwrap));
+  try {
+    return wrapResult(k, k.fuseAll(vec));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function cutAll(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  tools: KernelShape[],
+  _options?: BooleanOptions
+): KernelShape {
+  const vec = makeVecU32(Module, tools.map(unwrap));
+  try {
+    return wrapResult(k, k.cutAll(unwrap(shape), vec));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function split(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  tools: KernelShape[]
+): KernelShape {
+  const vec = makeVecU32(Module, tools.map(unwrap));
+  try {
+    return wrapResult(k, k.split(unwrap(shape), vec));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function checkBoolean(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  tool: KernelShape,
+  _op: BooleanOpType
+): CheckBooleanResult {
+  const issues: Array<{
+    operand: 'base' | 'tool';
+    issue: 'null-shape' | 'not-valid';
+    message: string;
+  }> = [];
+  if (k.isNull(unwrap(shape))) {
+    issues.push({ operand: 'base', issue: 'null-shape', message: 'Base shape is null' });
+  }
+  if (k.isNull(unwrap(tool))) {
+    issues.push({ operand: 'tool', issue: 'null-shape', message: 'Tool shape is null' });
+  }
+  if (issues.length === 0 && !k.isValid(unwrap(shape))) {
+    issues.push({ operand: 'base', issue: 'not-valid', message: 'Base shape is not valid' });
+  }
+  if (issues.length === 0 && !k.isValid(unwrap(tool))) {
+    issues.push({ operand: 'tool', issue: 'not-valid', message: 'Tool shape is not valid' });
+  }
+  return { valid: issues.length === 0, issues };
+}
+
+export function meshBoolean(
+  _positionsA: number[],
+  _indicesA: number[],
+  _positionsB: number[],
+  _indicesB: number[],
+  _op: string,
+  _tolerance: number
+): KernelMeshResult {
+  throw new Error('occt-wasm: meshBoolean is not supported (use brepkit for mesh booleans)');
+}

--- a/src/kernel/occtWasm/helpers.ts
+++ b/src/kernel/occtWasm/helpers.ts
@@ -1,0 +1,110 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Shared helpers for the occt-wasm adapter — handle wrapping, kernel result
+ * unwrapping, and Embind vector marshalling.
+ *
+ * Extracted from occtWasmAdapter.ts to enable decomposing the adapter into
+ * per-section files (booleanOps, sweepOps, etc.). Each section imports the
+ * helpers it needs without depending on the adapter class.
+ *
+ * @module
+ */
+
+import type { KernelShape, ShapeType } from '@/kernel/types.js';
+import type {
+  OcctWasmHandle,
+  OcctWasmModule,
+  OcctKernelWasm,
+  EmVectorUint32,
+  EmVectorInt,
+  EmVectorDouble,
+} from './occtWasmTypes.js';
+
+export const noop = (): void => {};
+
+/** Build an opaque kernel handle for an arena-allocated WASM shape. */
+export function handle(type: ShapeType, id: number): OcctWasmHandle {
+  return {
+    __occtWasm: true,
+    type,
+    id,
+    delete: noop,
+    HashCode(upperBound: number) {
+      return id % upperBound;
+    },
+    IsNull() {
+      return false;
+    },
+  };
+}
+
+export function isOcctWasmHandle(shape: unknown): shape is OcctWasmHandle {
+  return typeof shape === 'object' && shape !== null && (shape as OcctWasmHandle).__occtWasm;
+}
+
+/** Extract the u32 id from a handle. */
+export function unwrap(shape: KernelShape): number {
+  if (isOcctWasmHandle(shape)) return shape.id;
+  if (typeof shape === 'number') return shape;
+  throw new Error('occt-wasm: expected an OcctWasmHandle or number, got ' + typeof shape);
+}
+
+/** Map a WASM shape type string to our ShapeType enum. */
+export function mapShapeType(wasmType: string): ShapeType {
+  const lower = wasmType.toLowerCase();
+  switch (lower) {
+    case 'vertex':
+      return 'vertex';
+    case 'edge':
+      return 'edge';
+    case 'wire':
+      return 'wire';
+    case 'face':
+      return 'face';
+    case 'shell':
+      return 'shell';
+    case 'solid':
+      return 'solid';
+    case 'compsolid':
+      return 'compsolid';
+    case 'compound':
+      return 'compound';
+    default:
+      return 'compound';
+  }
+}
+
+/** Wrap a WASM u32 result as a typed handle, querying the kernel for type. */
+export function wrapResult(kernel: OcctKernelWasm, id: number): OcctWasmHandle {
+  const type = mapShapeType(kernel.getShapeType(id));
+  return handle(type, id);
+}
+
+// ─── Embind vector helpers ───────────────────────────────────────────────────
+// Embind vectors must be created, populated, and explicitly released via
+// `.delete()`. Callers wrap the lifecycle in try/finally.
+
+export function makeVecU32(Module: OcctWasmModule, values: number[]): EmVectorUint32 {
+  const vec = new Module.VectorUint32();
+  for (const v of values) vec.push_back(v);
+  return vec;
+}
+
+export function makeVecInt(Module: OcctWasmModule, values: number[]): EmVectorInt {
+  const vec = new Module.VectorInt();
+  for (const v of values) vec.push_back(v);
+  return vec;
+}
+
+export function makeVecDouble(Module: OcctWasmModule, values: number[]): EmVectorDouble {
+  const vec = new Module.VectorDouble();
+  for (const v of values) vec.push_back(v);
+  return vec;
+}
+
+export function readVecInt(vec: EmVectorInt): number[] {
+  const result: number[] = [];
+  const n = vec.size();
+  for (let i = 0; i < n; i++) result.push(vec.get(i));
+  return result;
+}

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -57,104 +57,25 @@ import type {
   OcctWasmHandle,
   OcctWasmModule,
   OcctKernelWasm,
-  EmVectorUint32,
-  EmVectorInt,
-  EmVectorDouble,
   EmEvolutionData,
 } from './occtWasmTypes.js';
+import {
+  noop,
+  handle,
+  isOcctWasmHandle,
+  mapShapeType,
+  unwrap,
+  wrapResult,
+  makeVecU32,
+  makeVecInt,
+  makeVecDouble,
+  readVecInt,
+} from './helpers.js';
+import * as boolOps from './booleanOps.js';
 
-// ---------------------------------------------------------------------------
-// Handle helpers
-// ---------------------------------------------------------------------------
-
-const noop = () => {};
-
-function handle(type: ShapeType, id: number): OcctWasmHandle {
-  return {
-    __occtWasm: true,
-    type,
-    id,
-    delete: noop,
-    HashCode(upperBound: number) {
-      return id % upperBound;
-    },
-    IsNull() {
-      return false;
-    },
-  };
-}
-
-function isOcctWasmHandle(shape: unknown): shape is OcctWasmHandle {
-  return typeof shape === 'object' && shape !== null && (shape as OcctWasmHandle).__occtWasm;
-}
-
-/** Extract the u32 id from a handle. */
-function unwrap(shape: KernelShape): number {
-  if (isOcctWasmHandle(shape)) return shape.id;
-  if (typeof shape === 'number') return shape;
-  throw new Error('occt-wasm: expected an OcctWasmHandle or number, got ' + typeof shape);
-}
-
-/** Map a WASM shape type string to our ShapeType enum. */
-function mapShapeType(wasmType: string): ShapeType {
-  const lower = wasmType.toLowerCase();
-  // The C++ facade returns e.g. "solid", "face", "edge", etc.
-  switch (lower) {
-    case 'vertex':
-      return 'vertex';
-    case 'edge':
-      return 'edge';
-    case 'wire':
-      return 'wire';
-    case 'face':
-      return 'face';
-    case 'shell':
-      return 'shell';
-    case 'solid':
-      return 'solid';
-    case 'compsolid':
-      return 'compsolid';
-    case 'compound':
-      return 'compound';
-    default:
-      return 'compound'; // fallback
-  }
-}
-
-/** Wrap a WASM u32 result as a typed handle, querying the kernel for type. */
-function wrapResult(kernel: OcctKernelWasm, id: number): OcctWasmHandle {
-  const type = mapShapeType(kernel.getShapeType(id));
-  return handle(type, id);
-}
-
-// ---------------------------------------------------------------------------
-// Vector helpers -- Embind vectors must be created, populated, and deleted
-// ---------------------------------------------------------------------------
-
-function makeVecU32(Module: OcctWasmModule, values: number[]): EmVectorUint32 {
-  const vec = new Module.VectorUint32();
-  for (const v of values) vec.push_back(v);
-  return vec;
-}
-
-function makeVecInt(Module: OcctWasmModule, values: number[]): EmVectorInt {
-  const vec = new Module.VectorInt();
-  for (const v of values) vec.push_back(v);
-  return vec;
-}
-
-function makeVecDouble(Module: OcctWasmModule, values: number[]): EmVectorDouble {
-  const vec = new Module.VectorDouble();
-  for (const v of values) vec.push_back(v);
-  return vec;
-}
-
-function readVecInt(vec: EmVectorInt): number[] {
-  const result: number[] = [];
-  const n = vec.size();
-  for (let i = 0; i < n; i++) result.push(vec.get(i));
-  return result;
-}
+// Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
+// per-section files like ./booleanOps.ts can share them without depending
+// on the adapter class.
 
 // Currently unused but will be needed for batch operations
 // function readVecDouble(vec: EmVectorDouble): number[] {
@@ -833,80 +754,47 @@ export class OcctWasmAdapter implements KernelAdapter {
   // Booleans
   // =========================================================================
 
-  fuse(shape: KernelShape, tool: KernelShape, _options?: BooleanOptions): KernelShape {
-    return wrapResult(this.k, this.k.fuse(unwrap(shape), unwrap(tool)));
+  fuse(shape: KernelShape, tool: KernelShape, options?: BooleanOptions): KernelShape {
+    return boolOps.fuse(this.k, shape, tool, options);
   }
 
-  cut(shape: KernelShape, tool: KernelShape, _options?: BooleanOptions): KernelShape {
-    return wrapResult(this.k, this.k.cut(unwrap(shape), unwrap(tool)));
+  cut(shape: KernelShape, tool: KernelShape, options?: BooleanOptions): KernelShape {
+    return boolOps.cut(this.k, shape, tool, options);
   }
 
-  intersect(shape: KernelShape, tool: KernelShape, _options?: BooleanOptions): KernelShape {
-    return wrapResult(this.k, this.k.intersect(unwrap(shape), unwrap(tool)));
+  intersect(shape: KernelShape, tool: KernelShape, options?: BooleanOptions): KernelShape {
+    return boolOps.intersect(this.k, shape, tool, options);
   }
 
-  section(shape: KernelShape, plane: KernelShape, _approximation?: boolean): KernelShape {
-    return wrapResult(this.k, this.k.section(unwrap(shape), unwrap(plane)));
+  section(shape: KernelShape, plane: KernelShape, approximation?: boolean): KernelShape {
+    return boolOps.section(this.k, shape, plane, approximation);
   }
 
-  fuseAll(shapes: KernelShape[], _options?: BooleanOptions): KernelShape {
-    const vec = makeVecU32(this.Module, shapes.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.fuseAll(vec));
-    } finally {
-      vec.delete();
-    }
+  fuseAll(shapes: KernelShape[], options?: BooleanOptions): KernelShape {
+    return boolOps.fuseAll(this.k, this.Module, shapes, options);
   }
 
-  cutAll(shape: KernelShape, tools: KernelShape[], _options?: BooleanOptions): KernelShape {
-    const vec = makeVecU32(this.Module, tools.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.cutAll(unwrap(shape), vec));
-    } finally {
-      vec.delete();
-    }
+  cutAll(shape: KernelShape, tools: KernelShape[], options?: BooleanOptions): KernelShape {
+    return boolOps.cutAll(this.k, this.Module, shape, tools, options);
   }
 
   split(shape: KernelShape, tools: KernelShape[]): KernelShape {
-    const vec = makeVecU32(this.Module, tools.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.split(unwrap(shape), vec));
-    } finally {
-      vec.delete();
-    }
+    return boolOps.split(this.k, this.Module, shape, tools);
   }
 
-  checkBoolean(shape: KernelShape, tool: KernelShape, _op: BooleanOpType): CheckBooleanResult {
-    // Basic validation: check if shapes are null or invalid
-    const issues: Array<{
-      operand: 'base' | 'tool';
-      issue: 'null-shape' | 'not-valid';
-      message: string;
-    }> = [];
-    if (this.k.isNull(unwrap(shape))) {
-      issues.push({ operand: 'base', issue: 'null-shape', message: 'Base shape is null' });
-    }
-    if (this.k.isNull(unwrap(tool))) {
-      issues.push({ operand: 'tool', issue: 'null-shape', message: 'Tool shape is null' });
-    }
-    if (issues.length === 0 && !this.k.isValid(unwrap(shape))) {
-      issues.push({ operand: 'base', issue: 'not-valid', message: 'Base shape is not valid' });
-    }
-    if (issues.length === 0 && !this.k.isValid(unwrap(tool))) {
-      issues.push({ operand: 'tool', issue: 'not-valid', message: 'Tool shape is not valid' });
-    }
-    return { valid: issues.length === 0, issues };
+  checkBoolean(shape: KernelShape, tool: KernelShape, op: BooleanOpType): CheckBooleanResult {
+    return boolOps.checkBoolean(this.k, shape, tool, op);
   }
 
   meshBoolean(
-    _positionsA: number[],
-    _indicesA: number[],
-    _positionsB: number[],
-    _indicesB: number[],
-    _op: string,
-    _tolerance: number
+    positionsA: number[],
+    indicesA: number[],
+    positionsB: number[],
+    indicesB: number[],
+    op: string,
+    tolerance: number
   ): KernelMeshResult {
-    throw new Error('occt-wasm: meshBoolean is not supported (use brepkit for mesh booleans)');
+    return boolOps.meshBoolean(positionsA, indicesA, positionsB, indicesB, op, tolerance);
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary

First slice of decomposing the 4,341-line \`occtWasmAdapter.ts\` that the audit flagged as P2.9. Establishes the pattern; remaining sections become stacked follow-up PRs.

**New files:**
- \`src/kernel/occtWasm/helpers.ts\` (110 lines) — handle wrapping, kernel result unwrapping, Embind vector marshalling. Imported by the adapter and per-section files; no dependency on the adapter class itself.
- \`src/kernel/occtWasm/booleanOps.ts\` (135 lines) — \`fuse\`, \`cut\`, \`intersect\`, \`section\`, \`fuseAll\`, \`cutAll\`, \`split\`, \`checkBoolean\`, \`meshBoolean\` as free functions taking \`(k, Module, ...args)\`.

**Adapter shrinks** from 4,341 → 4,225 lines. Boolean methods on the class are now single-line delegates, mirroring how \`src/kernel/occt/defaultAdapter.ts\` decomposes against \`./booleanOps.ts\`, \`./measureOps.ts\`, etc.

## Why this shape

- **Free functions, not class methods on a separate class**: matches the existing \`occt/\` adapter pattern. Shared kernel-and-Module dependencies are passed explicitly, no \`this\` coupling.
- **\`helpers.ts\` is the prerequisite**: each future section file (\`sweepOps.ts\`, \`measureOps.ts\`, etc.) needs the same \`unwrap\`/\`wrapResult\`/\`makeVecU32\` helpers. Extracting them once unblocks the rest.

## Verification

- \`npm run typecheck\` ✓
- \`npm run lint\` ✓
- \`npm run check:patterns\` ✓ (clean)
- \`npm run check:boundaries\` ✓
- \`npm run format:check\` ✓
- \`npx vitest run --project occt-wasm tests/booleanFns.test.ts\` — 52 tests pass

## Follow-ups

Remaining sections to extract (rough sizes):
- Primitives (~79), Shape construction (~417)
- Sweep (~193), Modifiers (~142), Transforms (~311)
- Evolution (~359), Mesh (~100), I/O (~332)
- Measure (~166), Topology (~111), Curve (~121), Surface (~160), Repair (~45)
- 2D ops (~808 lines, mostly stubs)

Total reduction once complete: ~3,800 lines moved out of the adapter; the remaining ~500 lines is the class shell + delegates.

## Test plan

- [x] All static checks pass
- [x] Boolean tests pass against occt-wasm kernel
- [ ] Full CI green