### PR TITLE
refactor(occt-wasm): extract topologyOps.ts + repairOps.ts

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -63,7 +63,6 @@ import {
   noop,
   handle,
   isOcctWasmHandle,
-  mapShapeType,
   unwrap,
   wrapResult,
   makeVecU32,
@@ -73,6 +72,8 @@ import {
 } from './helpers.js';
 import * as boolOps from './booleanOps.js';
 import * as primOps from './primitiveOps.js';
+import * as topoOps from './topologyOps.js';
+import * as repairOps from './repairOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -2771,110 +2772,61 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   iterShapes(shape: KernelShape, type: ShapeType): KernelShape[] {
-    const vec = this.k.getSubShapes(unwrap(shape), type);
-    const results: KernelShape[] = [];
-    const n = vec.size();
-    for (let i = 0; i < n; i++) {
-      results.push(handle(type, vec.get(i)));
-    }
-    vec.delete();
-    return results;
+    return topoOps.iterShapes(this.k, shape, type);
   }
 
   iterShapeList(_list: KernelShape, _callback: (item: KernelShape) => void): void {
     // occt-wasm's arena model has no TopTools_ListOfShape equivalent — the
-    // kernel only yields individual u32 shape IDs, not list handles. This
-    // method is used internally by OCCT's evolution JS fallback path, which
-    // is itself unreachable on occt-wasm (evolution data comes from the C++
-    // facade's EvolutionExtractor). No Layer 2+ code calls this directly.
+    // kernel only yields individual u32 shape IDs, not list handles. Layer 2+
+    // code never calls this directly (evolution data comes from the C++
+    // facade's EvolutionExtractor, not the JS fallback path).
     throw new Error(
       'iterShapeList is not applicable to occt-wasm: the arena model has no TopTools_ListOfShape handles'
     );
   }
 
   shapeType(shape: KernelShape): ShapeType {
-    if (isOcctWasmHandle(shape)) return shape.type;
-    return mapShapeType(this.k.getShapeType(unwrap(shape)));
+    return topoOps.shapeType(this.k, shape);
   }
 
   isSame(a: KernelShape, b: KernelShape): boolean {
-    return this.k.isSame(unwrap(a), unwrap(b));
+    return topoOps.isSame(this.k, a, b);
   }
 
   isEqual(a: KernelShape, b: KernelShape): boolean {
-    return this.k.isEqual(unwrap(a), unwrap(b));
+    return topoOps.isEqual(this.k, a, b);
   }
 
   downcast(shape: KernelShape, type?: ShapeType): KernelShape {
-    if (type) {
-      const id = this.k.downcast(unwrap(shape), type);
-      return handle(type, id);
-    }
-    return shape;
+    return topoOps.downcast(this.k, shape, type);
   }
 
   hashCode(shape: KernelShape, upperBound: number): number {
-    return this.k.hashCode(unwrap(shape), upperBound);
+    return topoOps.hashCode(this.k, shape, upperBound);
   }
 
   isNull(shape: KernelShape): boolean {
-    return this.k.isNull(unwrap(shape));
+    return topoOps.isNull(this.k, shape);
   }
 
   shapeOrientation(shape: KernelShape): ShapeOrientation {
-    const orient = this.k.shapeOrientation(unwrap(shape));
-    return orient.toLowerCase() as ShapeOrientation;
+    return topoOps.shapeOrientation(this.k, shape);
   }
 
   edgeToFaceMap(shape: KernelShape): string {
-    // The C++ facade returns vector<int>, we need to format as JSON
-    const HASH_UPPER = 1000000;
-    const vec = this.k.edgeToFaceMap(unwrap(shape), HASH_UPPER);
-    const data = readVecInt(vec);
-    vec.delete();
-    // Build a JSON map from edge hash -> face hash array
-    const map: Record<number, number[]> = {};
-    for (let i = 0; i + 1 < data.length; i += 2) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
-      const edgeHash = data[i]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
-      const faceHash = data[i + 1]!;
-      if (!map[edgeHash]) map[edgeHash] = [];
-
-      map[edgeHash].push(faceHash);
-    }
-    return JSON.stringify(map);
+    return topoOps.edgeToFaceMap(this.k, shape);
   }
 
   sharedEdges(faceA: KernelShape, faceB: KernelShape): KernelShape[] {
-    const vec = this.k.sharedEdges(unwrap(faceA), unwrap(faceB));
-    const results: KernelShape[] = [];
-    const n = vec.size();
-    for (let i = 0; i < n; i++) {
-      results.push(handle('edge', vec.get(i)));
-    }
-    vec.delete();
-    return results;
+    return topoOps.sharedEdges(this.k, faceA, faceB);
   }
 
   adjacentFaces(shape: KernelShape, face: KernelShape): KernelShape[] {
-    const vec = this.k.adjacentFaces(unwrap(shape), unwrap(face));
-    const results: KernelShape[] = [];
-    const n = vec.size();
-    for (let i = 0; i < n; i++) {
-      results.push(handle('face', vec.get(i)));
-    }
-    vec.delete();
-    return results;
+    return topoOps.adjacentFaces(this.k, shape, face);
   }
 
   sew(shapes: KernelShape[], tolerance?: number): KernelShape {
-    const vec = makeVecU32(this.Module, shapes.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.sew(vec, tolerance ?? 1e-6));
-    } finally {
-      vec.delete();
-    }
+    return topoOps.sew(this.k, this.Module, shapes, tolerance);
   }
 
   // =========================================================================
@@ -3163,40 +3115,35 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   isValid(shape: KernelShape): boolean {
-    return this.k.isValid(unwrap(shape));
+    return repairOps.isValid(this.k, shape);
   }
 
   healSolid(shape: KernelShape): KernelShape | null {
-    const id = this.k.healSolid(unwrap(shape), 1e-6);
-    if (id === 0) return null;
-    return wrapResult(this.k, id);
+    return repairOps.healSolid(this.k, shape);
   }
 
   healFace(shape: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.healFace(unwrap(shape), 1e-6));
+    return repairOps.healFace(this.k, shape);
   }
 
-  healWire(wire: KernelShape, _face?: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.healWire(unwrap(wire), 1e-6));
+  healWire(wire: KernelShape, face?: KernelShape): KernelShape {
+    return repairOps.healWire(this.k, wire, face);
   }
 
-  mergeCoincidentVertices(_shape: KernelShape, _tolerance: number): number {
-    // Not directly in the C++ facade
-    return 0;
+  mergeCoincidentVertices(shape: KernelShape, tolerance: number): number {
+    return repairOps.mergeCoincidentVertices(this.k, shape, tolerance);
   }
 
-  removeDegenerateEdges(shape: KernelShape, _tolerance: number): number {
-    this.k.removeDegenerateEdges(unwrap(shape));
-    return 0; // count not returned by facade
+  removeDegenerateEdges(shape: KernelShape, tolerance: number): number {
+    return repairOps.removeDegenerateEdges(this.k, shape, tolerance);
   }
 
   fixFaceOrientations(shape: KernelShape): number {
-    this.k.fixFaceOrientations(unwrap(shape));
-    return 0; // count not returned by facade
+    return repairOps.fixFaceOrientations(this.k, shape);
   }
 
   fixShape(shape: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.fixShape(unwrap(shape)));
+    return repairOps.fixShape(this.k, shape);
   }
 
   fixSelfIntersection(_wire: KernelShape): KernelShape {

--- a/src/kernel/occtWasm/repairOps.ts
+++ b/src/kernel/occtWasm/repairOps.ts
@@ -1,0 +1,57 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Shape repair / healing operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { OcctKernelWasm } from './occtWasmTypes.js';
+import { unwrap, wrapResult } from './helpers.js';
+
+const HEAL_TOLERANCE = 1e-6;
+
+export function isValid(k: OcctKernelWasm, shape: KernelShape): boolean {
+  return k.isValid(unwrap(shape));
+}
+
+export function healSolid(k: OcctKernelWasm, shape: KernelShape): KernelShape | null {
+  const id = k.healSolid(unwrap(shape), HEAL_TOLERANCE);
+  if (id === 0) return null;
+  return wrapResult(k, id);
+}
+
+export function healFace(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  return wrapResult(k, k.healFace(unwrap(shape), HEAL_TOLERANCE));
+}
+
+export function healWire(k: OcctKernelWasm, wire: KernelShape, _face?: KernelShape): KernelShape {
+  return wrapResult(k, k.healWire(unwrap(wire), HEAL_TOLERANCE));
+}
+
+export function mergeCoincidentVertices(
+  _k: OcctKernelWasm,
+  _shape: KernelShape,
+  _tolerance: number
+): number {
+  // Not directly in the C++ facade.
+  return 0;
+}
+
+export function removeDegenerateEdges(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  _tolerance: number
+): number {
+  k.removeDegenerateEdges(unwrap(shape));
+  return 0; // count not returned by facade
+}
+
+export function fixFaceOrientations(k: OcctKernelWasm, shape: KernelShape): number {
+  k.fixFaceOrientations(unwrap(shape));
+  return 0; // count not returned by facade
+}
+
+export function fixShape(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  return wrapResult(k, k.fixShape(unwrap(shape)));
+}

--- a/src/kernel/occtWasm/topologyOps.ts
+++ b/src/kernel/occtWasm/topologyOps.ts
@@ -1,0 +1,124 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Topology query and assembly operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape, ShapeOrientation, ShapeType } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import {
+  handle,
+  isOcctWasmHandle,
+  makeVecU32,
+  mapShapeType,
+  readVecInt,
+  unwrap,
+  wrapResult,
+} from './helpers.js';
+
+export function iterShapes(k: OcctKernelWasm, shape: KernelShape, type: ShapeType): KernelShape[] {
+  const vec = k.getSubShapes(unwrap(shape), type);
+  const results: KernelShape[] = [];
+  const n = vec.size();
+  for (let i = 0; i < n; i++) {
+    results.push(handle(type, vec.get(i)));
+  }
+  vec.delete();
+  return results;
+}
+
+export function shapeType(k: OcctKernelWasm, shape: KernelShape): ShapeType {
+  if (isOcctWasmHandle(shape)) return shape.type;
+  return mapShapeType(k.getShapeType(unwrap(shape)));
+}
+
+export function isSame(k: OcctKernelWasm, a: KernelShape, b: KernelShape): boolean {
+  return k.isSame(unwrap(a), unwrap(b));
+}
+
+export function isEqual(k: OcctKernelWasm, a: KernelShape, b: KernelShape): boolean {
+  return k.isEqual(unwrap(a), unwrap(b));
+}
+
+export function downcast(k: OcctKernelWasm, shape: KernelShape, type?: ShapeType): KernelShape {
+  if (type) {
+    const id = k.downcast(unwrap(shape), type);
+    return handle(type, id);
+  }
+  return shape;
+}
+
+export function hashCode(k: OcctKernelWasm, shape: KernelShape, upperBound: number): number {
+  return k.hashCode(unwrap(shape), upperBound);
+}
+
+export function isNull(k: OcctKernelWasm, shape: KernelShape): boolean {
+  return k.isNull(unwrap(shape));
+}
+
+export function shapeOrientation(k: OcctKernelWasm, shape: KernelShape): ShapeOrientation {
+  const orient = k.shapeOrientation(unwrap(shape));
+  return orient.toLowerCase() as ShapeOrientation;
+}
+
+export function edgeToFaceMap(k: OcctKernelWasm, shape: KernelShape): string {
+  const HASH_UPPER = 1000000;
+  const vec = k.edgeToFaceMap(unwrap(shape), HASH_UPPER);
+  const data = readVecInt(vec);
+  vec.delete();
+  const map: Record<number, number[]> = {};
+  for (let i = 0; i + 1 < data.length; i += 2) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
+    const edgeHash = data[i]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
+    const faceHash = data[i + 1]!;
+    if (!map[edgeHash]) map[edgeHash] = [];
+    map[edgeHash].push(faceHash);
+  }
+  return JSON.stringify(map);
+}
+
+export function sharedEdges(
+  k: OcctKernelWasm,
+  faceA: KernelShape,
+  faceB: KernelShape
+): KernelShape[] {
+  const vec = k.sharedEdges(unwrap(faceA), unwrap(faceB));
+  const results: KernelShape[] = [];
+  const n = vec.size();
+  for (let i = 0; i < n; i++) {
+    results.push(handle('edge', vec.get(i)));
+  }
+  vec.delete();
+  return results;
+}
+
+export function adjacentFaces(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  face: KernelShape
+): KernelShape[] {
+  const vec = k.adjacentFaces(unwrap(shape), unwrap(face));
+  const results: KernelShape[] = [];
+  const n = vec.size();
+  for (let i = 0; i < n; i++) {
+    results.push(handle('face', vec.get(i)));
+  }
+  vec.delete();
+  return results;
+}
+
+export function sew(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shapes: KernelShape[],
+  tolerance?: number
+): KernelShape {
+  const vec = makeVecU32(Module, shapes.map(unwrap));
+  try {
+    return wrapResult(k, k.sew(vec, tolerance ?? 1e-6));
+  } finally {
+    vec.delete();
+  }
+}

--- a/src/kernel/occtWasm/topologyOps.ts
+++ b/src/kernel/occtWasm/topologyOps.ts
@@ -20,11 +20,14 @@ import {
 export function iterShapes(k: OcctKernelWasm, shape: KernelShape, type: ShapeType): KernelShape[] {
   const vec = k.getSubShapes(unwrap(shape), type);
   const results: KernelShape[] = [];
-  const n = vec.size();
-  for (let i = 0; i < n; i++) {
-    results.push(handle(type, vec.get(i)));
+  try {
+    const n = vec.size();
+    for (let i = 0; i < n; i++) {
+      results.push(handle(type, vec.get(i)));
+    }
+  } finally {
+    vec.delete();
   }
-  vec.delete();
   return results;
 }
 
@@ -65,8 +68,12 @@ export function shapeOrientation(k: OcctKernelWasm, shape: KernelShape): ShapeOr
 export function edgeToFaceMap(k: OcctKernelWasm, shape: KernelShape): string {
   const HASH_UPPER = 1000000;
   const vec = k.edgeToFaceMap(unwrap(shape), HASH_UPPER);
-  const data = readVecInt(vec);
-  vec.delete();
+  let data: number[];
+  try {
+    data = readVecInt(vec);
+  } finally {
+    vec.delete();
+  }
   const map: Record<number, number[]> = {};
   for (let i = 0; i + 1 < data.length; i += 2) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
@@ -86,11 +93,14 @@ export function sharedEdges(
 ): KernelShape[] {
   const vec = k.sharedEdges(unwrap(faceA), unwrap(faceB));
   const results: KernelShape[] = [];
-  const n = vec.size();
-  for (let i = 0; i < n; i++) {
-    results.push(handle('edge', vec.get(i)));
+  try {
+    const n = vec.size();
+    for (let i = 0; i < n; i++) {
+      results.push(handle('edge', vec.get(i)));
+    }
+  } finally {
+    vec.delete();
   }
-  vec.delete();
   return results;
 }
 
@@ -101,11 +111,14 @@ export function adjacentFaces(
 ): KernelShape[] {
   const vec = k.adjacentFaces(unwrap(shape), unwrap(face));
   const results: KernelShape[] = [];
-  const n = vec.size();
-  for (let i = 0; i < n; i++) {
-    results.push(handle('face', vec.get(i)));
+  try {
+    const n = vec.size();
+    for (let i = 0; i < n; i++) {
+      results.push(handle('face', vec.get(i)));
+    }
+  } finally {
+    vec.delete();
   }
-  vec.delete();
   return results;
 }
 


### PR DESCRIPTION
## Summary

Continuation of PRs #919 (booleans) + #920 (primitives). Two more sections decomposed from \`occtWasmAdapter.ts\`:

- **\`topologyOps.ts\` (124 lines)** — \`iterShapes\`, \`shapeType\`, \`isSame\`, \`isEqual\`, \`downcast\`, \`hashCode\`, \`isNull\`, \`shapeOrientation\`, \`edgeToFaceMap\`, \`sharedEdges\`, \`adjacentFaces\`, \`sew\`. \`iterShapeList\` stays in the adapter — it's a no-op error-throwing stub specific to the JS evolution fallback path that occt-wasm doesn't take.
- **\`repairOps.ts\` (57 lines)** — \`isValid\`, \`healSolid\`, \`healFace\`, \`healWire\`, \`mergeCoincidentVertices\`, \`removeDegenerateEdges\`, \`fixFaceOrientations\`, \`fixShape\`. \`fixSelfIntersection\` stays as a \`notImplemented\` stub.

**Adapter:** 4174 → 4121 lines (−53). With booleans (#919) + primitives (#920) + this PR, total adapter reduction is **220 lines** (4341 → 4121, ~5% of the file).

## Verification

- \`npm run typecheck\` ✓
- \`npm run lint\` ✓
- \`npm run check:patterns\` ✓
- \`npm run check:boundaries\` ✓
- \`npm run format:check\` ✓
- \`npx vitest run --project occt-wasm tests/{booleanFns,api}.test.ts\` — 111 tests pass

## Test plan

- [x] All static checks pass
- [x] Combined boolean + API test suites pass
- [ ] Full CI green (note: the gridfinity benchmark is noisy on this branch — 30+% variance run-to-run; if it fails, expect to retry)