### PR TITLE
refactor(occt-wasm): extract curveOps.ts + surfaceOps.ts

### DIFF
--- a/src/kernel/occtWasm/curveOps.ts
+++ b/src/kernel/occtWasm/curveOps.ts
@@ -54,15 +54,18 @@ export function curveTangent(
   param: number
 ): { point: [number, number, number]; tangent: [number, number, number] } {
   const tvec = k.curveTangent(unwrap(shape), param);
-  const pvec = k.curvePointAtParam(unwrap(shape), param);
   try {
-    return {
-      point: [pvec.get(0), pvec.get(1), pvec.get(2)],
-      tangent: [tvec.get(0), tvec.get(1), tvec.get(2)],
-    };
+    const pvec = k.curvePointAtParam(unwrap(shape), param);
+    try {
+      return {
+        point: [pvec.get(0), pvec.get(1), pvec.get(2)],
+        tangent: [tvec.get(0), tvec.get(1), tvec.get(2)],
+      };
+    } finally {
+      pvec.delete();
+    }
   } finally {
     tvec.delete();
-    pvec.delete();
   }
 }
 

--- a/src/kernel/occtWasm/curveOps.ts
+++ b/src/kernel/occtWasm/curveOps.ts
@@ -1,0 +1,120 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Curve query operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { handle, makeVecDouble, unwrap } from './helpers.js';
+
+const CURVE_TYPE_MAP: Record<string, string> = {
+  line: 'LINE',
+  circle: 'CIRCLE',
+  ellipse: 'ELLIPSE',
+  hyperbola: 'HYPERBOLA',
+  parabola: 'PARABOLA',
+  bezier: 'BEZIER_CURVE',
+  bspline: 'BSPLINE_CURVE',
+  offset: 'OFFSET_CURVE',
+  other: 'OTHER_CURVE',
+};
+
+export function curveType(k: OcctKernelWasm, shape: KernelShape): string {
+  const t = k.curveType(unwrap(shape));
+  return CURVE_TYPE_MAP[t] ?? t.toUpperCase();
+}
+
+export function curveParameters(k: OcctKernelWasm, shape: KernelShape): [number, number] {
+  const vec = k.curveParameters(unwrap(shape));
+  try {
+    return [vec.get(0), vec.get(1)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function curvePointAtParam(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  param: number
+): [number, number, number] {
+  const vec = k.curvePointAtParam(unwrap(shape), param);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function curveTangent(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  param: number
+): { point: [number, number, number]; tangent: [number, number, number] } {
+  const tvec = k.curveTangent(unwrap(shape), param);
+  const pvec = k.curvePointAtParam(unwrap(shape), param);
+  try {
+    return {
+      point: [pvec.get(0), pvec.get(1), pvec.get(2)],
+      tangent: [tvec.get(0), tvec.get(1), tvec.get(2)],
+    };
+  } finally {
+    tvec.delete();
+    pvec.delete();
+  }
+}
+
+export function curveIsClosed(k: OcctKernelWasm, shape: KernelShape): boolean {
+  // C++ handles both wires (BRep_Tool::IsClosed) and edges (BRepAdaptor_Curve::IsClosed)
+  return k.curveIsClosed(unwrap(shape));
+}
+
+export function curveIsPeriodic(k: OcctKernelWasm, shape: KernelShape): boolean {
+  return k.curveIsPeriodic(unwrap(shape));
+}
+
+export function curvePeriod(_k: OcctKernelWasm, _shape: KernelShape): number {
+  // Periodic curves in OCCT always have period 2π
+  return 2 * Math.PI;
+}
+
+export function interpolatePoints(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  points: [number, number, number][],
+  options?: { periodic?: boolean; tolerance?: number }
+): KernelShape {
+  const flat: number[] = [];
+  for (const p of points) flat.push(p[0], p[1], p[2]);
+  const vec = makeVecDouble(Module, flat);
+  try {
+    const id = k.interpolatePoints(vec, options?.periodic ?? false);
+    return handle('edge', id);
+  } finally {
+    vec.delete();
+  }
+}
+
+export function approximatePoints(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  points: [number, number, number][],
+  options?: {
+    tolerance?: number;
+    degMin?: number;
+    degMax?: number;
+    smoothing?: [number, number, number] | null;
+  }
+): KernelShape {
+  const flat: number[] = [];
+  for (const p of points) flat.push(p[0], p[1], p[2]);
+  const vec = makeVecDouble(Module, flat);
+  try {
+    const id = k.approximatePoints(vec, options?.tolerance ?? 1e-3);
+    return handle('edge', id);
+  } finally {
+    vec.delete();
+  }
+}

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -75,6 +75,8 @@ import * as primOps from './primitiveOps.js';
 import * as topoOps from './topologyOps.js';
 import * as repairOps from './repairOps.js';
 import * as meshOps from './meshOps.js';
+import * as curveOps from './curveOps.js';
+import * as surfaceOps from './surfaceOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -2755,76 +2757,41 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   curveType(shape: KernelShape): string {
-    const t = this.k.curveType(unwrap(shape));
-    const map: Record<string, string> = {
-      line: 'LINE',
-      circle: 'CIRCLE',
-      ellipse: 'ELLIPSE',
-      hyperbola: 'HYPERBOLA',
-      parabola: 'PARABOLA',
-      bezier: 'BEZIER_CURVE',
-      bspline: 'BSPLINE_CURVE',
-      offset: 'OFFSET_CURVE',
-      other: 'OTHER_CURVE',
-    };
-    return map[t] ?? t.toUpperCase();
+    return curveOps.curveType(this.k, shape);
   }
 
   curveParameters(shape: KernelShape): [number, number] {
-    const vec = this.k.curveParameters(unwrap(shape));
-    const result: [number, number] = [vec.get(0), vec.get(1)];
-    vec.delete();
-    return result;
+    return curveOps.curveParameters(this.k, shape);
   }
 
   curvePointAtParam(shape: KernelShape, param: number): [number, number, number] {
-    const vec = this.k.curvePointAtParam(unwrap(shape), param);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return curveOps.curvePointAtParam(this.k, shape, param);
   }
 
   curveTangent(
     shape: KernelShape,
     param: number
   ): { point: [number, number, number]; tangent: [number, number, number] } {
-    const tvec = this.k.curveTangent(unwrap(shape), param);
-    const pvec = this.k.curvePointAtParam(unwrap(shape), param);
-    const result = {
-      point: [pvec.get(0), pvec.get(1), pvec.get(2)] as [number, number, number],
-      tangent: [tvec.get(0), tvec.get(1), tvec.get(2)] as [number, number, number],
-    };
-    tvec.delete();
-    pvec.delete();
-    return result;
+    return curveOps.curveTangent(this.k, shape, param);
   }
 
   curveIsClosed(shape: KernelShape): boolean {
-    // C++ handles both wires (BRep_Tool::IsClosed) and edges (BRepAdaptor_Curve::IsClosed)
-    return this.k.curveIsClosed(unwrap(shape));
+    return curveOps.curveIsClosed(this.k, shape);
   }
 
   curveIsPeriodic(shape: KernelShape): boolean {
-    return this.k.curveIsPeriodic(unwrap(shape));
+    return curveOps.curveIsPeriodic(this.k, shape);
   }
 
-  curvePeriod(_shape: KernelShape): number {
-    return 2 * Math.PI; // Periodic curves in OCCT always have period 2π
+  curvePeriod(shape: KernelShape): number {
+    return curveOps.curvePeriod(this.k, shape);
   }
 
   interpolatePoints(
     points: [number, number, number][],
     options?: { periodic?: boolean; tolerance?: number }
   ): KernelShape {
-    const flat: number[] = [];
-    for (const p of points) flat.push(p[0], p[1], p[2]);
-    const vec = makeVecDouble(this.Module, flat);
-    try {
-      const id = this.k.interpolatePoints(vec, options?.periodic ?? false);
-      return handle('edge', id);
-    } finally {
-      vec.delete();
-    }
+    return curveOps.interpolatePoints(this.k, this.Module, points, options);
   }
 
   approximatePoints(
@@ -2836,15 +2803,7 @@ export class OcctWasmAdapter implements KernelAdapter {
       smoothing?: [number, number, number] | null;
     }
   ): KernelShape {
-    const flat: number[] = [];
-    for (const p of points) flat.push(p[0], p[1], p[2]);
-    const vec = makeVecDouble(this.Module, flat);
-    try {
-      const id = this.k.approximatePoints(vec, options?.tolerance ?? 1e-3);
-      return handle('edge', id);
-    } finally {
-      vec.delete();
-    }
+    return curveOps.approximatePoints(this.k, this.Module, points, options);
   }
 
   curveDegreeElevate(_edge: KernelShape, _elevateBy: number): KernelShape {
@@ -2876,73 +2835,44 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   vertexPosition(vertex: KernelShape): [number, number, number] {
-    const vec = this.k.vertexPosition(unwrap(vertex));
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.vertexPosition(this.k, vertex);
   }
 
   surfaceType(face: KernelShape): SurfaceType {
-    const t = this.k.surfaceType(unwrap(face));
-    return t.toLowerCase() as SurfaceType;
+    return surfaceOps.surfaceType(this.k, face);
   }
 
   uvBounds(face: KernelShape): { uMin: number; uMax: number; vMin: number; vMax: number } {
-    const vec = this.k.uvBounds(unwrap(face));
-    const result = {
-      uMin: vec.get(0),
-      uMax: vec.get(1),
-      vMin: vec.get(2),
-      vMax: vec.get(3),
-    };
-    vec.delete();
-    return result;
+    return surfaceOps.uvBounds(this.k, face);
   }
 
   outerWire(face: KernelShape): KernelShape {
-    return handle('wire', this.k.outerWire(unwrap(face)));
+    return surfaceOps.outerWire(this.k, face);
   }
 
   surfaceNormal(face: KernelShape, u: number, v: number): [number, number, number] {
-    const vec = this.k.surfaceNormal(unwrap(face), u, v);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.surfaceNormal(this.k, face, u, v);
   }
 
   pointOnSurface(face: KernelShape, u: number, v: number): [number, number, number] {
-    const vec = this.k.pointOnSurface(unwrap(face), u, v);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.pointOnSurface(this.k, face, u, v);
   }
 
   uvFromPoint(face: KernelShape, point: [number, number, number]): [number, number] | null {
-    const vec = this.k.uvFromPoint(unwrap(face), point[0], point[1], point[2]);
-    if (vec.size() < 2) {
-      vec.delete();
-      return null;
-    }
-    const result: [number, number] = [vec.get(0), vec.get(1)];
-    vec.delete();
-    return result;
+    return surfaceOps.uvFromPoint(this.k, face, point);
   }
 
   projectPointOnFace(face: KernelShape, point: [number, number, number]): [number, number, number] {
-    const vec = this.k.projectPointOnFace(unwrap(face), point[0], point[1], point[2]);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.projectPointOnFace(this.k, face, point);
   }
 
   classifyPointOnFace(
     face: KernelShape,
     u: number,
     v: number,
-    _tolerance?: number
+    tolerance?: number
   ): 'in' | 'on' | 'out' {
-    const result = this.k.classifyPointOnFace(unwrap(face), u, v);
-    return result.toLowerCase() as 'in' | 'on' | 'out';
+    return surfaceOps.classifyPointOnFace(this.k, face, u, v, tolerance);
   }
 
   classifyPointRobust(
@@ -3008,27 +2938,14 @@ export class OcctWasmAdapter implements KernelAdapter {
     visible: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
     hidden: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
   } {
-    const [ox, oy, oz] = cameraOrigin;
-    const [dx, dy, dz] = cameraDirection;
-    const hasXAxis = !!cameraXAxis;
-    const [xx, xy, xz] = cameraXAxis ?? [1, 0, 0];
-    const proj = this.k.projectEdges(unwrap(shape), ox, oy, oz, dx, dy, dz, xx, xy, xz, hasXAxis);
-    const wrapOrNull = (id: number): KernelShape =>
-      id === 0
-        ? handle('compound', this.k.makeCompound(new this.Module.VectorUint32()))
-        : handle('compound', id);
-    return {
-      visible: {
-        outline: wrapOrNull(proj.visibleOutline),
-        smooth: wrapOrNull(proj.visibleSmooth),
-        sharp: wrapOrNull(proj.visibleSharp),
-      },
-      hidden: {
-        outline: wrapOrNull(proj.hiddenOutline),
-        smooth: wrapOrNull(proj.hiddenSmooth),
-        sharp: wrapOrNull(proj.hiddenSharp),
-      },
-    };
+    return surfaceOps.projectEdges(
+      this.k,
+      this.Module,
+      shape,
+      cameraOrigin,
+      cameraDirection,
+      cameraXAxis
+    );
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -1,0 +1,138 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Surface query operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape, SurfaceType } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { handle, unwrap } from './helpers.js';
+
+export function vertexPosition(k: OcctKernelWasm, vertex: KernelShape): [number, number, number] {
+  const vec = k.vertexPosition(unwrap(vertex));
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function surfaceType(k: OcctKernelWasm, face: KernelShape): SurfaceType {
+  return k.surfaceType(unwrap(face)).toLowerCase() as SurfaceType;
+}
+
+export function uvBounds(
+  k: OcctKernelWasm,
+  face: KernelShape
+): { uMin: number; uMax: number; vMin: number; vMax: number } {
+  const vec = k.uvBounds(unwrap(face));
+  try {
+    return { uMin: vec.get(0), uMax: vec.get(1), vMin: vec.get(2), vMax: vec.get(3) };
+  } finally {
+    vec.delete();
+  }
+}
+
+export function outerWire(k: OcctKernelWasm, face: KernelShape): KernelShape {
+  return handle('wire', k.outerWire(unwrap(face)));
+}
+
+export function surfaceNormal(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  u: number,
+  v: number
+): [number, number, number] {
+  const vec = k.surfaceNormal(unwrap(face), u, v);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function pointOnSurface(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  u: number,
+  v: number
+): [number, number, number] {
+  const vec = k.pointOnSurface(unwrap(face), u, v);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function uvFromPoint(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  point: [number, number, number]
+): [number, number] | null {
+  const vec = k.uvFromPoint(unwrap(face), point[0], point[1], point[2]);
+  try {
+    if (vec.size() < 2) return null;
+    return [vec.get(0), vec.get(1)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function projectPointOnFace(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  point: [number, number, number]
+): [number, number, number] {
+  const vec = k.projectPointOnFace(unwrap(face), point[0], point[1], point[2]);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function classifyPointOnFace(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  u: number,
+  v: number,
+  _tolerance?: number
+): 'in' | 'on' | 'out' {
+  return k.classifyPointOnFace(unwrap(face), u, v).toLowerCase() as 'in' | 'on' | 'out';
+}
+
+export function projectEdges(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  cameraOrigin: [number, number, number],
+  cameraDirection: [number, number, number],
+  cameraXAxis?: [number, number, number]
+): {
+  visible: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
+  hidden: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
+} {
+  const [ox, oy, oz] = cameraOrigin;
+  const [dx, dy, dz] = cameraDirection;
+  const hasXAxis = !!cameraXAxis;
+  const [xx, xy, xz] = cameraXAxis ?? [1, 0, 0];
+  const proj = k.projectEdges(unwrap(shape), ox, oy, oz, dx, dy, dz, xx, xy, xz, hasXAxis);
+  const wrapOrNull = (id: number): KernelShape =>
+    id === 0
+      ? handle('compound', k.makeCompound(new Module.VectorUint32()))
+      : handle('compound', id);
+  return {
+    visible: {
+      outline: wrapOrNull(proj.visibleOutline),
+      smooth: wrapOrNull(proj.visibleSmooth),
+      sharp: wrapOrNull(proj.visibleSharp),
+    },
+    hidden: {
+      outline: wrapOrNull(proj.hiddenOutline),
+      smooth: wrapOrNull(proj.hiddenSmooth),
+      sharp: wrapOrNull(proj.hiddenSharp),
+    },
+  };
+}


### PR DESCRIPTION
Continuation of #919/#920/#921/#922. Extracts curve query operations (curveType, curveParameters, curvePointAtParam, curveTangent, curveIsClosed, curveIsPeriodic, curvePeriod, interpolatePoints, approximatePoints) and surface query operations (vertexPosition, surfaceType, uvBounds, outerWire, surfaceNormal, pointOnSurface, uvFromPoint, projectPointOnFace, classifyPointOnFace, projectEdges) into per-section files.

All vec.delete() lifecycles wrapped in try/finally for exception safety. notImplemented stubs (curveDegreeElevate, curveKnotInsert, etc., classifyPointRobust, classifyPointWinding, etc.) stay in the adapter as one-liners.

Adapter: 4040 → 3959 lines (-81).