### PR TITLE
refactor(occt-wasm): extract simple measure ops to measureOps.ts

### DIFF
--- a/src/kernel/occtWasm/curveOps.ts
+++ b/src/kernel/occtWasm/curveOps.ts
@@ -1,0 +1,120 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Curve query operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { handle, makeVecDouble, unwrap } from './helpers.js';
+
+const CURVE_TYPE_MAP: Record<string, string> = {
+  line: 'LINE',
+  circle: 'CIRCLE',
+  ellipse: 'ELLIPSE',
+  hyperbola: 'HYPERBOLA',
+  parabola: 'PARABOLA',
+  bezier: 'BEZIER_CURVE',
+  bspline: 'BSPLINE_CURVE',
+  offset: 'OFFSET_CURVE',
+  other: 'OTHER_CURVE',
+};
+
+export function curveType(k: OcctKernelWasm, shape: KernelShape): string {
+  const t = k.curveType(unwrap(shape));
+  return CURVE_TYPE_MAP[t] ?? t.toUpperCase();
+}
+
+export function curveParameters(k: OcctKernelWasm, shape: KernelShape): [number, number] {
+  const vec = k.curveParameters(unwrap(shape));
+  try {
+    return [vec.get(0), vec.get(1)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function curvePointAtParam(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  param: number
+): [number, number, number] {
+  const vec = k.curvePointAtParam(unwrap(shape), param);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function curveTangent(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  param: number
+): { point: [number, number, number]; tangent: [number, number, number] } {
+  const tvec = k.curveTangent(unwrap(shape), param);
+  const pvec = k.curvePointAtParam(unwrap(shape), param);
+  try {
+    return {
+      point: [pvec.get(0), pvec.get(1), pvec.get(2)],
+      tangent: [tvec.get(0), tvec.get(1), tvec.get(2)],
+    };
+  } finally {
+    tvec.delete();
+    pvec.delete();
+  }
+}
+
+export function curveIsClosed(k: OcctKernelWasm, shape: KernelShape): boolean {
+  // C++ handles both wires (BRep_Tool::IsClosed) and edges (BRepAdaptor_Curve::IsClosed)
+  return k.curveIsClosed(unwrap(shape));
+}
+
+export function curveIsPeriodic(k: OcctKernelWasm, shape: KernelShape): boolean {
+  return k.curveIsPeriodic(unwrap(shape));
+}
+
+export function curvePeriod(_k: OcctKernelWasm, _shape: KernelShape): number {
+  // Periodic curves in OCCT always have period 2π
+  return 2 * Math.PI;
+}
+
+export function interpolatePoints(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  points: [number, number, number][],
+  options?: { periodic?: boolean; tolerance?: number }
+): KernelShape {
+  const flat: number[] = [];
+  for (const p of points) flat.push(p[0], p[1], p[2]);
+  const vec = makeVecDouble(Module, flat);
+  try {
+    const id = k.interpolatePoints(vec, options?.periodic ?? false);
+    return handle('edge', id);
+  } finally {
+    vec.delete();
+  }
+}
+
+export function approximatePoints(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  points: [number, number, number][],
+  options?: {
+    tolerance?: number;
+    degMin?: number;
+    degMax?: number;
+    smoothing?: [number, number, number] | null;
+  }
+): KernelShape {
+  const flat: number[] = [];
+  for (const p of points) flat.push(p[0], p[1], p[2]);
+  const vec = makeVecDouble(Module, flat);
+  try {
+    const id = k.approximatePoints(vec, options?.tolerance ?? 1e-3);
+    return handle('edge', id);
+  } finally {
+    vec.delete();
+  }
+}

--- a/src/kernel/occtWasm/helpers.ts
+++ b/src/kernel/occtWasm/helpers.ts
@@ -110,6 +110,21 @@ export function readVecInt(vec: EmVectorInt): number[] {
 }
 
 /**
+ * Resolve a callback-style radius/distance to a uniform number.
+ * occt-wasm's fillet/chamfer take a single radius — uniform per call.
+ */
+export function resolveUniformRadius(
+  edges: KernelShape[],
+  radius: number | [number, number] | ((edge: KernelShape) => number | [number, number])
+): number {
+  if (typeof radius === 'number') return radius;
+  if (Array.isArray(radius)) return radius[0];
+  if (edges.length === 0) throw new Error('occt-wasm: no edges provided');
+  const val = radius(edges[0] as KernelShape);
+  return typeof val === 'number' ? val : val[0];
+}
+
+/**
  * Rotate a shape from the kernel's default Z-axis to an arbitrary direction.
  * Used by primitives whose creation API only takes a Z-aligned form.
  */

--- a/src/kernel/occtWasm/measureOps.ts
+++ b/src/kernel/occtWasm/measureOps.ts
@@ -1,0 +1,116 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Simple measurement operations for the occt-wasm adapter.
+ *
+ * Complex methods (`distance`, `surfaceCurvature`) remain in the adapter
+ * for now because they depend on private helpers (`collectDistanceSamples`,
+ * `computePrincipalDirections`, `surfaceDerivatives`) that are themselves
+ * 100+ lines and would bloat this PR.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { BulkMeasurement } from '@/kernel/interfaces/measureOps.js';
+import type { OcctKernelWasm } from './occtWasmTypes.js';
+import { noop, unwrap } from './helpers.js';
+
+export function volume(k: OcctKernelWasm, shape: KernelShape): number {
+  return k.getVolume(unwrap(shape));
+}
+
+export function area(k: OcctKernelWasm, shape: KernelShape): number {
+  return k.getSurfaceArea(unwrap(shape));
+}
+
+export function length(k: OcctKernelWasm, shape: KernelShape): number {
+  return k.getLength(unwrap(shape));
+}
+
+export function centerOfMass(k: OcctKernelWasm, shape: KernelShape): [number, number, number] {
+  const vec = k.getCenterOfMass(unwrap(shape));
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function linearCenterOfMass(
+  k: OcctKernelWasm,
+  shape: KernelShape
+): [number, number, number] {
+  const vec = k.getLinearCenterOfMass(unwrap(shape));
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function boundingBox(
+  k: OcctKernelWasm,
+  shape: KernelShape
+): { min: [number, number, number]; max: [number, number, number] } {
+  const bb = k.getBoundingBox(unwrap(shape), true);
+  return {
+    min: [bb.xmin, bb.ymin, bb.zmin],
+    max: [bb.xmax, bb.ymax, bb.zmax],
+  };
+}
+
+export function surfaceCenterOfMass(
+  k: OcctKernelWasm,
+  face: KernelShape
+): [number, number, number] {
+  // Delegates to occt-wasm's exact `BRepGProp::SurfaceProperties.CentreOfMass()`
+  // (added in occt-wasm 2.0). The previous tessellation-triangle centroid
+  // diverged from brepjs-occt for non-planar faces.
+  try {
+    const v = k.getSurfaceCenterOfMass(unwrap(face));
+    try {
+      return [v.get(0), v.get(1), v.get(2)];
+    } finally {
+      v.delete();
+    }
+  } catch {
+    // Degenerate or unmeshable face — preserve previous behavior of
+    // returning origin rather than propagating the WASM exception.
+    return [0, 0, 0];
+  }
+}
+
+export function measureBulk(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  includeLinear?: boolean
+): BulkMeasurement {
+  return {
+    volume: volume(k, shape),
+    area: area(k, shape),
+    length: includeLinear ? length(k, shape) : 0,
+    centerOfMass: centerOfMass(k, shape),
+    boundingBox: boundingBox(k, shape),
+  };
+}
+
+export function createDistanceQuery(
+  k: OcctKernelWasm,
+  referenceShape: KernelShape
+): {
+  distanceTo(shape: KernelShape): {
+    value: number;
+    point1: [number, number, number];
+    point2: [number, number, number];
+  };
+  dispose(): void;
+} {
+  const refId = unwrap(referenceShape);
+  return {
+    distanceTo(shape: KernelShape) {
+      const d = k.distanceBetween(refId, unwrap(shape));
+      return { value: d, point1: [0, 0, 0], point2: [0, 0, 0] };
+    },
+    dispose: noop,
+  };
+}

--- a/src/kernel/occtWasm/meshOps.ts
+++ b/src/kernel/occtWasm/meshOps.ts
@@ -1,0 +1,120 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Mesh tessellation operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type {
+  KernelEdgeMeshResult,
+  KernelMeshResult,
+  KernelShape,
+  MeshOptions,
+} from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { unwrap } from './helpers.js';
+
+export function mesh(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  options: MeshOptions
+): KernelMeshResult {
+  const meshData = k.tessellate(unwrap(shape), options.tolerance, options.angularTolerance);
+
+  const posCount = meshData.positionCount;
+  const normCount = meshData.normalCount;
+  const idxCount = meshData.indexCount;
+
+  const posPtr = meshData.getPositionsPtr() >> 2;
+  const normPtr = meshData.getNormalsPtr() >> 2;
+  const idxPtr = meshData.getIndicesPtr() >> 2;
+
+  const vertices = new Float32Array(posCount);
+  for (let i = 0; i < posCount; i++) {
+    vertices[i] = Module.HEAPF32[posPtr + i] ?? 0;
+  }
+
+  const normals = new Float32Array(normCount);
+  if (!options.skipNormals) {
+    for (let i = 0; i < normCount; i++) {
+      normals[i] = Module.HEAPF32[normPtr + i] ?? 0;
+    }
+  }
+
+  const triangles = new Uint32Array(idxCount);
+  for (let i = 0; i < idxCount; i++) {
+    triangles[i] = Module.HEAPU32[idxPtr + i] ?? 0;
+  }
+
+  const faceGroups: Array<{ start: number; count: number; faceHash: number }> = [];
+  const fgCount = meshData.faceGroupCount;
+  if (fgCount > 0) {
+    const fgPtr = meshData.getFaceGroupsPtr() >> 2;
+    for (let i = 0; i < fgCount; i += 3) {
+      faceGroups.push({
+        start: Module.HEAP32[fgPtr + i] ?? 0,
+        count: Module.HEAP32[fgPtr + i + 1] ?? 0,
+        faceHash: Module.HEAP32[fgPtr + i + 2] ?? 0,
+      });
+    }
+  }
+
+  meshData.delete();
+
+  return {
+    vertices,
+    normals: options.skipNormals ? new Float32Array(0) : normals,
+    triangles,
+    uvs: new Float32Array(0),
+    faceGroups,
+  };
+}
+
+export function meshEdges(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  tolerance: number,
+  _angularTolerance: number
+): KernelEdgeMeshResult {
+  const edgeData = k.wireframe(unwrap(shape), tolerance);
+  const pointCount = edgeData.pointCount;
+  const ptr = edgeData.getPointsPtr() >> 2;
+
+  const lines = new Float32Array(pointCount);
+  for (let i = 0; i < pointCount; i++) {
+    lines[i] = Module.HEAPF32[ptr + i] ?? 0;
+  }
+
+  const edgeGroups: Array<{ start: number; count: number; edgeHash: number }> = [];
+  const egCount = edgeData.edgeGroupCount;
+  if (egCount > 0) {
+    const egPtr = edgeData.getEdgeGroupsPtr() >> 2;
+    for (let i = 0; i < egCount; i += 3) {
+      edgeGroups.push({
+        start: Module.HEAP32[egPtr + i] ?? 0,
+        count: Module.HEAP32[egPtr + i + 1] ?? 0,
+        edgeHash: Module.HEAP32[egPtr + i + 2] ?? 0,
+      });
+    }
+  }
+
+  edgeData.delete();
+
+  return { lines, edgeGroups };
+}
+
+export function hasTriangulation(k: OcctKernelWasm, shape: KernelShape): boolean {
+  return k.hasTriangulation(unwrap(shape));
+}
+
+export function meshShape(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  tolerance: number,
+  angularTolerance: number
+): void {
+  const meshData = k.meshShape(unwrap(shape), tolerance, angularTolerance);
+  meshData.delete();
+}

--- a/src/kernel/occtWasm/modifierOps.ts
+++ b/src/kernel/occtWasm/modifierOps.ts
@@ -1,0 +1,168 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Shape modifier operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { makeVecU32, resolveUniformRadius, unwrap, wrapResult } from './helpers.js';
+
+export function fillet(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  edges: KernelShape[],
+  radius: number | [number, number] | ((edge: KernelShape) => number | [number, number])
+): KernelShape {
+  const r = resolveUniformRadius(edges, radius);
+  const vec = makeVecU32(Module, edges.map(unwrap));
+  try {
+    return wrapResult(k, k.fillet(unwrap(shape), vec, r));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function chamfer(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  edges: KernelShape[],
+  distance: number | [number, number] | ((edge: KernelShape) => number | [number, number])
+): KernelShape {
+  const d = resolveUniformRadius(edges, distance);
+  const vec = makeVecU32(Module, edges.map(unwrap));
+  try {
+    return wrapResult(k, k.chamfer(unwrap(shape), vec, d));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function chamferDistAngle(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  edges: KernelShape[],
+  distance: number,
+  angleDeg: number
+): KernelShape {
+  const vec = makeVecU32(Module, edges.map(unwrap));
+  try {
+    return wrapResult(k, k.chamferDistAngle(unwrap(shape), vec, distance, angleDeg));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function shell(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  faces: KernelShape[],
+  thickness: number,
+  tolerance?: number
+): KernelShape {
+  const vec = makeVecU32(Module, faces.map(unwrap));
+  try {
+    return wrapResult(k, k.shell(unwrap(shape), vec, thickness, tolerance ?? 1e-3));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function thicken(k: OcctKernelWasm, shape: KernelShape, thickness: number): KernelShape {
+  // 1e-3 matches OCCT's pre-3.0 hardcoded default; thicken's tolerance isn't
+  // exposed via brepjs's KernelInstance interface.
+  return wrapResult(k, k.thicken(unwrap(shape), thickness, 1e-3));
+}
+
+export function offset(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  distance: number,
+  tolerance?: number
+): KernelShape {
+  return wrapResult(k, k.offset(unwrap(shape), distance, tolerance ?? 1e-6));
+}
+
+export function filletVariable(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  spec: string
+): KernelShape {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON parse
+  const parsed: any = JSON.parse(spec);
+  if (
+    parsed.edgeId !== undefined &&
+    parsed.startRadius !== undefined &&
+    parsed.endRadius !== undefined
+  ) {
+    return wrapResult(
+      k,
+      k.filletVariable(unwrap(shape), parsed.edgeId, parsed.startRadius, parsed.endRadius)
+    );
+  }
+  throw new Error('occt-wasm: filletVariable (complex spec) not implemented');
+}
+
+export function draft(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  faces: KernelShape[],
+  pullDirection: [number, number, number],
+  _neutralPlane: [number, number, number],
+  angleDeg: number | ((face: KernelShape) => number)
+): KernelShape {
+  let currentId = unwrap(shape);
+  for (const face of faces) {
+    const angle = typeof angleDeg === 'function' ? angleDeg(face) : angleDeg;
+    const angleRad = (angle * Math.PI) / 180;
+    currentId = k.draft(
+      currentId,
+      unwrap(face),
+      angleRad,
+      pullDirection[0],
+      pullDirection[1],
+      pullDirection[2]
+    );
+  }
+  return wrapResult(k, currentId);
+}
+
+export function defeature(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  faces: KernelShape[]
+): KernelShape {
+  const vec = makeVecU32(Module, faces.map(unwrap));
+  try {
+    return wrapResult(k, k.defeature(unwrap(shape), vec, 1e-3));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function offsetWire2D(
+  k: OcctKernelWasm,
+  wire: KernelShape,
+  offset: number,
+  joinType?: number | 'arc' | 'intersection' | 'tangent'
+): KernelShape {
+  let jt = 0; // arc
+  if (joinType === 'intersection' || joinType === 1) jt = 1;
+  else if (joinType === 'tangent' || joinType === 2) jt = 2;
+  else if (typeof joinType === 'number') jt = joinType;
+  return wrapResult(k, k.offsetWire2D(unwrap(wire), offset, jt));
+}
+
+export function simplify(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  return wrapResult(k, k.simplify(unwrap(shape)));
+}
+
+export function reverseShape(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  return wrapResult(k, k.reverseShape(unwrap(shape)));
+}

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -75,6 +75,8 @@ import * as primOps from './primitiveOps.js';
 import * as topoOps from './topologyOps.js';
 import * as repairOps from './repairOps.js';
 import * as meshOps from './meshOps.js';
+import * as curveOps from './curveOps.js';
+import * as surfaceOps from './surfaceOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -2755,76 +2757,41 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   curveType(shape: KernelShape): string {
-    const t = this.k.curveType(unwrap(shape));
-    const map: Record<string, string> = {
-      line: 'LINE',
-      circle: 'CIRCLE',
-      ellipse: 'ELLIPSE',
-      hyperbola: 'HYPERBOLA',
-      parabola: 'PARABOLA',
-      bezier: 'BEZIER_CURVE',
-      bspline: 'BSPLINE_CURVE',
-      offset: 'OFFSET_CURVE',
-      other: 'OTHER_CURVE',
-    };
-    return map[t] ?? t.toUpperCase();
+    return curveOps.curveType(this.k, shape);
   }
 
   curveParameters(shape: KernelShape): [number, number] {
-    const vec = this.k.curveParameters(unwrap(shape));
-    const result: [number, number] = [vec.get(0), vec.get(1)];
-    vec.delete();
-    return result;
+    return curveOps.curveParameters(this.k, shape);
   }
 
   curvePointAtParam(shape: KernelShape, param: number): [number, number, number] {
-    const vec = this.k.curvePointAtParam(unwrap(shape), param);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return curveOps.curvePointAtParam(this.k, shape, param);
   }
 
   curveTangent(
     shape: KernelShape,
     param: number
   ): { point: [number, number, number]; tangent: [number, number, number] } {
-    const tvec = this.k.curveTangent(unwrap(shape), param);
-    const pvec = this.k.curvePointAtParam(unwrap(shape), param);
-    const result = {
-      point: [pvec.get(0), pvec.get(1), pvec.get(2)] as [number, number, number],
-      tangent: [tvec.get(0), tvec.get(1), tvec.get(2)] as [number, number, number],
-    };
-    tvec.delete();
-    pvec.delete();
-    return result;
+    return curveOps.curveTangent(this.k, shape, param);
   }
 
   curveIsClosed(shape: KernelShape): boolean {
-    // C++ handles both wires (BRep_Tool::IsClosed) and edges (BRepAdaptor_Curve::IsClosed)
-    return this.k.curveIsClosed(unwrap(shape));
+    return curveOps.curveIsClosed(this.k, shape);
   }
 
   curveIsPeriodic(shape: KernelShape): boolean {
-    return this.k.curveIsPeriodic(unwrap(shape));
+    return curveOps.curveIsPeriodic(this.k, shape);
   }
 
-  curvePeriod(_shape: KernelShape): number {
-    return 2 * Math.PI; // Periodic curves in OCCT always have period 2π
+  curvePeriod(shape: KernelShape): number {
+    return curveOps.curvePeriod(this.k, shape);
   }
 
   interpolatePoints(
     points: [number, number, number][],
     options?: { periodic?: boolean; tolerance?: number }
   ): KernelShape {
-    const flat: number[] = [];
-    for (const p of points) flat.push(p[0], p[1], p[2]);
-    const vec = makeVecDouble(this.Module, flat);
-    try {
-      const id = this.k.interpolatePoints(vec, options?.periodic ?? false);
-      return handle('edge', id);
-    } finally {
-      vec.delete();
-    }
+    return curveOps.interpolatePoints(this.k, this.Module, points, options);
   }
 
   approximatePoints(
@@ -2836,15 +2803,7 @@ export class OcctWasmAdapter implements KernelAdapter {
       smoothing?: [number, number, number] | null;
     }
   ): KernelShape {
-    const flat: number[] = [];
-    for (const p of points) flat.push(p[0], p[1], p[2]);
-    const vec = makeVecDouble(this.Module, flat);
-    try {
-      const id = this.k.approximatePoints(vec, options?.tolerance ?? 1e-3);
-      return handle('edge', id);
-    } finally {
-      vec.delete();
-    }
+    return curveOps.approximatePoints(this.k, this.Module, points, options);
   }
 
   curveDegreeElevate(_edge: KernelShape, _elevateBy: number): KernelShape {
@@ -2876,73 +2835,44 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   vertexPosition(vertex: KernelShape): [number, number, number] {
-    const vec = this.k.vertexPosition(unwrap(vertex));
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.vertexPosition(this.k, vertex);
   }
 
   surfaceType(face: KernelShape): SurfaceType {
-    const t = this.k.surfaceType(unwrap(face));
-    return t.toLowerCase() as SurfaceType;
+    return surfaceOps.surfaceType(this.k, face);
   }
 
   uvBounds(face: KernelShape): { uMin: number; uMax: number; vMin: number; vMax: number } {
-    const vec = this.k.uvBounds(unwrap(face));
-    const result = {
-      uMin: vec.get(0),
-      uMax: vec.get(1),
-      vMin: vec.get(2),
-      vMax: vec.get(3),
-    };
-    vec.delete();
-    return result;
+    return surfaceOps.uvBounds(this.k, face);
   }
 
   outerWire(face: KernelShape): KernelShape {
-    return handle('wire', this.k.outerWire(unwrap(face)));
+    return surfaceOps.outerWire(this.k, face);
   }
 
   surfaceNormal(face: KernelShape, u: number, v: number): [number, number, number] {
-    const vec = this.k.surfaceNormal(unwrap(face), u, v);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.surfaceNormal(this.k, face, u, v);
   }
 
   pointOnSurface(face: KernelShape, u: number, v: number): [number, number, number] {
-    const vec = this.k.pointOnSurface(unwrap(face), u, v);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.pointOnSurface(this.k, face, u, v);
   }
 
   uvFromPoint(face: KernelShape, point: [number, number, number]): [number, number] | null {
-    const vec = this.k.uvFromPoint(unwrap(face), point[0], point[1], point[2]);
-    if (vec.size() < 2) {
-      vec.delete();
-      return null;
-    }
-    const result: [number, number] = [vec.get(0), vec.get(1)];
-    vec.delete();
-    return result;
+    return surfaceOps.uvFromPoint(this.k, face, point);
   }
 
   projectPointOnFace(face: KernelShape, point: [number, number, number]): [number, number, number] {
-    const vec = this.k.projectPointOnFace(unwrap(face), point[0], point[1], point[2]);
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return surfaceOps.projectPointOnFace(this.k, face, point);
   }
 
   classifyPointOnFace(
     face: KernelShape,
     u: number,
     v: number,
-    _tolerance?: number
+    tolerance?: number
   ): 'in' | 'on' | 'out' {
-    const result = this.k.classifyPointOnFace(unwrap(face), u, v);
-    return result.toLowerCase() as 'in' | 'on' | 'out';
+    return surfaceOps.classifyPointOnFace(this.k, face, u, v, tolerance);
   }
 
   classifyPointRobust(
@@ -3008,27 +2938,14 @@ export class OcctWasmAdapter implements KernelAdapter {
     visible: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
     hidden: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
   } {
-    const [ox, oy, oz] = cameraOrigin;
-    const [dx, dy, dz] = cameraDirection;
-    const hasXAxis = !!cameraXAxis;
-    const [xx, xy, xz] = cameraXAxis ?? [1, 0, 0];
-    const proj = this.k.projectEdges(unwrap(shape), ox, oy, oz, dx, dy, dz, xx, xy, xz, hasXAxis);
-    const wrapOrNull = (id: number): KernelShape =>
-      id === 0
-        ? handle('compound', this.k.makeCompound(new this.Module.VectorUint32()))
-        : handle('compound', id);
-    return {
-      visible: {
-        outline: wrapOrNull(proj.visibleOutline),
-        smooth: wrapOrNull(proj.visibleSmooth),
-        sharp: wrapOrNull(proj.visibleSharp),
-      },
-      hidden: {
-        outline: wrapOrNull(proj.hiddenOutline),
-        smooth: wrapOrNull(proj.hiddenSmooth),
-        sharp: wrapOrNull(proj.hiddenSharp),
-      },
-    };
+    return surfaceOps.projectEdges(
+      this.k,
+      this.Module,
+      shape,
+      cameraOrigin,
+      cameraDirection,
+      cameraXAxis
+    );
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -74,6 +74,7 @@ import * as boolOps from './booleanOps.js';
 import * as primOps from './primitiveOps.js';
 import * as topoOps from './topologyOps.js';
 import * as repairOps from './repairOps.js';
+import * as meshOps from './meshOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -2174,99 +2175,19 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   mesh(shape: KernelShape, options: MeshOptions): KernelMeshResult {
-    const meshData = this.k.tessellate(unwrap(shape), options.tolerance, options.angularTolerance);
-
-    const posCount = meshData.positionCount;
-    const normCount = meshData.normalCount;
-    const idxCount = meshData.indexCount;
-
-    // Read from heap pointers
-    const posPtr = meshData.getPositionsPtr() >> 2; // byte offset to float32 index
-    const normPtr = meshData.getNormalsPtr() >> 2;
-    const idxPtr = meshData.getIndicesPtr() >> 2;
-
-    const vertices = new Float32Array(posCount);
-    for (let i = 0; i < posCount; i++) {
-      vertices[i] = this.Module.HEAPF32[posPtr + i] ?? 0;
-    }
-
-    const normals = new Float32Array(normCount);
-    if (!options.skipNormals) {
-      for (let i = 0; i < normCount; i++) {
-        normals[i] = this.Module.HEAPF32[normPtr + i] ?? 0;
-      }
-    }
-
-    const triangles = new Uint32Array(idxCount);
-    for (let i = 0; i < idxCount; i++) {
-      triangles[i] = this.Module.HEAPU32[idxPtr + i] ?? 0;
-    }
-
-    // Read face groups before deleting meshData
-    const faceGroups: Array<{ start: number; count: number; faceHash: number }> = [];
-    const fgCount = meshData.faceGroupCount;
-    if (fgCount > 0) {
-      const fgPtr = meshData.getFaceGroupsPtr() >> 2;
-      for (let i = 0; i < fgCount; i += 3) {
-        faceGroups.push({
-          start: this.Module.HEAP32[fgPtr + i] ?? 0,
-          count: this.Module.HEAP32[fgPtr + i + 1] ?? 0,
-          faceHash: this.Module.HEAP32[fgPtr + i + 2] ?? 0,
-        });
-      }
-    }
-
-    meshData.delete();
-
-    return {
-      vertices,
-      normals: options.skipNormals ? new Float32Array(0) : normals,
-      triangles,
-      uvs: new Float32Array(0),
-      faceGroups,
-    };
+    return meshOps.mesh(this.k, this.Module, shape, options);
   }
 
-  meshEdges(
-    shape: KernelShape,
-    tolerance: number,
-    _angularTolerance: number
-  ): KernelEdgeMeshResult {
-    const edgeData = this.k.wireframe(unwrap(shape), tolerance);
-    const pointCount = edgeData.pointCount;
-    const ptr = edgeData.getPointsPtr() >> 2;
-
-    const lines = new Float32Array(pointCount);
-    for (let i = 0; i < pointCount; i++) {
-      lines[i] = this.Module.HEAPF32[ptr + i] ?? 0;
-    }
-
-    // Read edge groups before deleting edgeData
-    const edgeGroups: Array<{ start: number; count: number; edgeHash: number }> = [];
-    const egCount = edgeData.edgeGroupCount;
-    if (egCount > 0) {
-      const egPtr = edgeData.getEdgeGroupsPtr() >> 2;
-      for (let i = 0; i < egCount; i += 3) {
-        edgeGroups.push({
-          start: this.Module.HEAP32[egPtr + i] ?? 0,
-          count: this.Module.HEAP32[egPtr + i + 1] ?? 0,
-          edgeHash: this.Module.HEAP32[egPtr + i + 2] ?? 0,
-        });
-      }
-    }
-
-    edgeData.delete();
-
-    return { lines, edgeGroups };
+  meshEdges(shape: KernelShape, tolerance: number, angularTolerance: number): KernelEdgeMeshResult {
+    return meshOps.meshEdges(this.k, this.Module, shape, tolerance, angularTolerance);
   }
 
   hasTriangulation(shape: KernelShape): boolean {
-    return this.k.hasTriangulation(unwrap(shape));
+    return meshOps.hasTriangulation(this.k, shape);
   }
 
   meshShape(shape: KernelShape, tolerance: number, angularTolerance: number): void {
-    const meshData = this.k.meshShape(unwrap(shape), tolerance, angularTolerance);
-    meshData.delete();
+    meshOps.meshShape(this.k, shape, tolerance, angularTolerance);
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -78,6 +78,7 @@ import * as meshOps from './meshOps.js';
 import * as curveOps from './curveOps.js';
 import * as surfaceOps from './surfaceOps.js';
 import * as measureOps from './measureOps.js';
+import * as modifierOps from './modifierOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -1370,13 +1371,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     edges: KernelShape[],
     radius: number | [number, number] | ((edge: KernelShape) => number | [number, number])
   ): KernelShape {
-    const r = resolveUniformRadius(edges, radius);
-    const vec = makeVecU32(this.Module, edges.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.fillet(unwrap(shape), vec, r));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.fillet(this.k, this.Module, shape, edges, radius);
   }
 
   chamfer(
@@ -1384,13 +1379,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     edges: KernelShape[],
     distance: number | [number, number] | ((edge: KernelShape) => number | [number, number])
   ): KernelShape {
-    const d = resolveUniformRadius(edges, distance);
-    const vec = makeVecU32(this.Module, edges.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.chamfer(unwrap(shape), vec, d));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.chamfer(this.k, this.Module, shape, edges, distance);
   }
 
   chamferDistAngle(
@@ -1399,12 +1388,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     distance: number,
     angleDeg: number
   ): KernelShape {
-    const vec = makeVecU32(this.Module, edges.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.chamferDistAngle(unwrap(shape), vec, distance, angleDeg));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.chamferDistAngle(this.k, this.Module, shape, edges, distance, angleDeg);
   }
 
   shell(
@@ -1413,74 +1397,33 @@ export class OcctWasmAdapter implements KernelAdapter {
     thickness: number,
     tolerance?: number
   ): KernelShape {
-    const vec = makeVecU32(this.Module, faces.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.shell(unwrap(shape), vec, thickness, tolerance ?? 1e-3));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.shell(this.k, this.Module, shape, faces, thickness, tolerance);
   }
 
   thicken(shape: KernelShape, thickness: number): KernelShape {
-    // 1e-3 matches OCCT's pre-3.0 hardcoded default; brepjs's KernelInstance
-    // interface doesn't expose tolerance for thicken, so we keep the prior
-    // behavior. Bump to 1e-6 if/when the interface widens to accept it.
-    return wrapResult(this.k, this.k.thicken(unwrap(shape), thickness, 1e-3));
+    return modifierOps.thicken(this.k, shape, thickness);
   }
 
   offset(shape: KernelShape, distance: number, tolerance?: number): KernelShape {
-    return wrapResult(this.k, this.k.offset(unwrap(shape), distance, tolerance ?? 1e-6));
+    return modifierOps.offset(this.k, shape, distance, tolerance);
   }
 
   filletVariable(shape: KernelShape, spec: string): KernelShape {
-    // Parse the spec JSON to get edge + radii
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON parse
-    const parsed: any = JSON.parse(spec);
-    if (
-      parsed.edgeId !== undefined &&
-      parsed.startRadius !== undefined &&
-      parsed.endRadius !== undefined
-    ) {
-      return wrapResult(
-        this.k,
-        this.k.filletVariable(unwrap(shape), parsed.edgeId, parsed.startRadius, parsed.endRadius)
-      );
-    }
-    notImplemented('filletVariable (complex spec)');
+    return modifierOps.filletVariable(this.k, shape, spec);
   }
 
   draft(
     shape: KernelShape,
     faces: KernelShape[],
     pullDirection: [number, number, number],
-    _neutralPlane: [number, number, number],
+    neutralPlane: [number, number, number],
     angleDeg: number | ((face: KernelShape) => number)
   ): KernelShape {
-    // Apply draft to each face sequentially
-    let currentId = unwrap(shape);
-    for (const face of faces) {
-      const angle = typeof angleDeg === 'function' ? angleDeg(face) : angleDeg;
-      const angleRad = (angle * Math.PI) / 180;
-      currentId = this.k.draft(
-        currentId,
-        unwrap(face),
-        angleRad,
-        pullDirection[0],
-        pullDirection[1],
-        pullDirection[2]
-      );
-    }
-    return wrapResult(this.k, currentId);
+    return modifierOps.draft(this.k, shape, faces, pullDirection, neutralPlane, angleDeg);
   }
 
   defeature(shape: KernelShape, faces: KernelShape[]): KernelShape {
-    const vec = makeVecU32(this.Module, faces.map(unwrap));
-    try {
-      // 1e-3 matches OCCT's pre-3.0 hardcoded default; see `thicken`.
-      return wrapResult(this.k, this.k.defeature(unwrap(shape), vec, 1e-3));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.defeature(this.k, this.Module, shape, faces);
   }
 
   offsetWire2D(
@@ -1488,19 +1431,15 @@ export class OcctWasmAdapter implements KernelAdapter {
     offset: number,
     joinType?: number | 'arc' | 'intersection' | 'tangent'
   ): KernelShape {
-    let jt = 0; // arc
-    if (joinType === 'intersection' || joinType === 1) jt = 1;
-    else if (joinType === 'tangent' || joinType === 2) jt = 2;
-    else if (typeof joinType === 'number') jt = joinType;
-    return wrapResult(this.k, this.k.offsetWire2D(unwrap(wire), offset, jt));
+    return modifierOps.offsetWire2D(this.k, wire, offset, joinType);
   }
 
   simplify(shape: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.simplify(unwrap(shape)));
+    return modifierOps.simplify(this.k, shape);
   }
 
   reverseShape(shape: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.reverseShape(unwrap(shape)));
+    return modifierOps.reverseShape(this.k, shape);
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -77,6 +77,7 @@ import * as repairOps from './repairOps.js';
 import * as meshOps from './meshOps.js';
 import * as curveOps from './curveOps.js';
 import * as surfaceOps from './surfaceOps.js';
+import * as measureOps from './measureOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -2529,40 +2530,30 @@ export class OcctWasmAdapter implements KernelAdapter {
   // =========================================================================
 
   volume(shape: KernelShape): number {
-    return this.k.getVolume(unwrap(shape));
+    return measureOps.volume(this.k, shape);
   }
 
   area(shape: KernelShape): number {
-    return this.k.getSurfaceArea(unwrap(shape));
+    return measureOps.area(this.k, shape);
   }
 
   length(shape: KernelShape): number {
-    return this.k.getLength(unwrap(shape));
+    return measureOps.length(this.k, shape);
   }
 
   centerOfMass(shape: KernelShape): [number, number, number] {
-    const vec = this.k.getCenterOfMass(unwrap(shape));
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return measureOps.centerOfMass(this.k, shape);
   }
 
   linearCenterOfMass(shape: KernelShape): [number, number, number] {
-    const vec = this.k.getLinearCenterOfMass(unwrap(shape));
-    const result: [number, number, number] = [vec.get(0), vec.get(1), vec.get(2)];
-    vec.delete();
-    return result;
+    return measureOps.linearCenterOfMass(this.k, shape);
   }
 
   boundingBox(shape: KernelShape): {
     min: [number, number, number];
     max: [number, number, number];
   } {
-    const bb = this.k.getBoundingBox(unwrap(shape), true);
-    return {
-      min: [bb.xmin, bb.ymin, bb.zmin],
-      max: [bb.xmax, bb.ymax, bb.zmax],
-    };
+    return measureOps.boundingBox(this.k, shape);
   }
 
   distance(shape1: KernelShape, shape2: KernelShape): DistanceResult {
@@ -2639,32 +2630,11 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   surfaceCenterOfMass(face: KernelShape): [number, number, number] {
-    // Delegates to occt-wasm's exact `BRepGProp::SurfaceProperties.CentreOfMass()`
-    // (added in occt-wasm 2.0). The previous tessellation-triangle centroid
-    // diverged from brepjs-occt for non-planar faces — for cylindrical faces
-    // it landed `+radius` off-axis (on the surface), and for holed planar
-    // faces it biased toward the holes' weighted x-position. See occt-wasm#90.
-    try {
-      const v = this.k.getSurfaceCenterOfMass(unwrap(face));
-      const result: [number, number, number] = [v.get(0), v.get(1), v.get(2)];
-      v.delete();
-      return result;
-    } catch {
-      // Degenerate or unmeshable face — preserve previous behavior of
-      // returning origin rather than propagating the WASM exception.
-      return [0, 0, 0];
-    }
+    return measureOps.surfaceCenterOfMass(this.k, face);
   }
 
   measureBulk(shape: KernelShape, includeLinear?: boolean): BulkMeasurement {
-    const bb = this.boundingBox(shape);
-    return {
-      volume: this.volume(shape),
-      area: this.area(shape),
-      length: includeLinear ? this.length(shape) : 0,
-      centerOfMass: this.centerOfMass(shape),
-      boundingBox: bb,
-    };
+    return measureOps.measureBulk(this.k, shape, includeLinear);
   }
 
   createDistanceQuery(referenceShape: KernelShape): {
@@ -2675,19 +2645,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     };
     dispose(): void;
   } {
-    const refId = unwrap(referenceShape);
-    const k = this.k;
-    return {
-      distanceTo(shape: KernelShape) {
-        const d = k.distanceBetween(refId, unwrap(shape));
-        return {
-          value: d,
-          point1: [0, 0, 0],
-          point2: [0, 0, 0],
-        };
-      },
-      dispose: noop,
-    };
+    return measureOps.createDistanceQuery(this.k, referenceShape);
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -1,0 +1,138 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Surface query operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape, SurfaceType } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { handle, unwrap } from './helpers.js';
+
+export function vertexPosition(k: OcctKernelWasm, vertex: KernelShape): [number, number, number] {
+  const vec = k.vertexPosition(unwrap(vertex));
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function surfaceType(k: OcctKernelWasm, face: KernelShape): SurfaceType {
+  return k.surfaceType(unwrap(face)).toLowerCase() as SurfaceType;
+}
+
+export function uvBounds(
+  k: OcctKernelWasm,
+  face: KernelShape
+): { uMin: number; uMax: number; vMin: number; vMax: number } {
+  const vec = k.uvBounds(unwrap(face));
+  try {
+    return { uMin: vec.get(0), uMax: vec.get(1), vMin: vec.get(2), vMax: vec.get(3) };
+  } finally {
+    vec.delete();
+  }
+}
+
+export function outerWire(k: OcctKernelWasm, face: KernelShape): KernelShape {
+  return handle('wire', k.outerWire(unwrap(face)));
+}
+
+export function surfaceNormal(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  u: number,
+  v: number
+): [number, number, number] {
+  const vec = k.surfaceNormal(unwrap(face), u, v);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function pointOnSurface(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  u: number,
+  v: number
+): [number, number, number] {
+  const vec = k.pointOnSurface(unwrap(face), u, v);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function uvFromPoint(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  point: [number, number, number]
+): [number, number] | null {
+  const vec = k.uvFromPoint(unwrap(face), point[0], point[1], point[2]);
+  try {
+    if (vec.size() < 2) return null;
+    return [vec.get(0), vec.get(1)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function projectPointOnFace(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  point: [number, number, number]
+): [number, number, number] {
+  const vec = k.projectPointOnFace(unwrap(face), point[0], point[1], point[2]);
+  try {
+    return [vec.get(0), vec.get(1), vec.get(2)];
+  } finally {
+    vec.delete();
+  }
+}
+
+export function classifyPointOnFace(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  u: number,
+  v: number,
+  _tolerance?: number
+): 'in' | 'on' | 'out' {
+  return k.classifyPointOnFace(unwrap(face), u, v).toLowerCase() as 'in' | 'on' | 'out';
+}
+
+export function projectEdges(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  cameraOrigin: [number, number, number],
+  cameraDirection: [number, number, number],
+  cameraXAxis?: [number, number, number]
+): {
+  visible: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
+  hidden: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
+} {
+  const [ox, oy, oz] = cameraOrigin;
+  const [dx, dy, dz] = cameraDirection;
+  const hasXAxis = !!cameraXAxis;
+  const [xx, xy, xz] = cameraXAxis ?? [1, 0, 0];
+  const proj = k.projectEdges(unwrap(shape), ox, oy, oz, dx, dy, dz, xx, xy, xz, hasXAxis);
+  const wrapOrNull = (id: number): KernelShape =>
+    id === 0
+      ? handle('compound', k.makeCompound(new Module.VectorUint32()))
+      : handle('compound', id);
+  return {
+    visible: {
+      outline: wrapOrNull(proj.visibleOutline),
+      smooth: wrapOrNull(proj.visibleSmooth),
+      sharp: wrapOrNull(proj.visibleSharp),
+    },
+    hidden: {
+      outline: wrapOrNull(proj.hiddenOutline),
+      smooth: wrapOrNull(proj.hiddenSmooth),
+      sharp: wrapOrNull(proj.hiddenSharp),
+    },
+  };
+}


### PR DESCRIPTION
Stacked on PR #923. Extracts simple measurement methods (volume, area, length, centerOfMass, linearCenterOfMass, boundingBox, surfaceCenterOfMass, measureBulk, createDistanceQuery) into measureOps.ts.

Complex measure methods (distance, surfaceCurvature) stay in the adapter — they depend on private helpers (collectDistanceSamples, computePrincipalDirections, surfaceDerivatives) that are themselves 100+ lines, worth their own follow-up PR.

All vec.delete() lifecycles wrapped in try/finally.