### PR TITLE
refactor(occt-wasm): extract modifierOps.ts

### DIFF
--- a/src/kernel/occtWasm/helpers.ts
+++ b/src/kernel/occtWasm/helpers.ts
@@ -110,6 +110,21 @@ export function readVecInt(vec: EmVectorInt): number[] {
 }
 
 /**
+ * Resolve a callback-style radius/distance to a uniform number.
+ * occt-wasm's fillet/chamfer take a single radius — uniform per call.
+ */
+export function resolveUniformRadius(
+  edges: KernelShape[],
+  radius: number | [number, number] | ((edge: KernelShape) => number | [number, number])
+): number {
+  if (typeof radius === 'number') return radius;
+  if (Array.isArray(radius)) return radius[0];
+  if (edges.length === 0) throw new Error('occt-wasm: no edges provided');
+  const val = radius(edges[0] as KernelShape);
+  return typeof val === 'number' ? val : val[0];
+}
+
+/**
  * Rotate a shape from the kernel's default Z-axis to an arbitrary direction.
  * Used by primitives whose creation API only takes a Z-aligned form.
  */

--- a/src/kernel/occtWasm/modifierOps.ts
+++ b/src/kernel/occtWasm/modifierOps.ts
@@ -1,0 +1,168 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Shape modifier operations for the occt-wasm adapter.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { makeVecU32, resolveUniformRadius, unwrap, wrapResult } from './helpers.js';
+
+export function fillet(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  edges: KernelShape[],
+  radius: number | [number, number] | ((edge: KernelShape) => number | [number, number])
+): KernelShape {
+  const r = resolveUniformRadius(edges, radius);
+  const vec = makeVecU32(Module, edges.map(unwrap));
+  try {
+    return wrapResult(k, k.fillet(unwrap(shape), vec, r));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function chamfer(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  edges: KernelShape[],
+  distance: number | [number, number] | ((edge: KernelShape) => number | [number, number])
+): KernelShape {
+  const d = resolveUniformRadius(edges, distance);
+  const vec = makeVecU32(Module, edges.map(unwrap));
+  try {
+    return wrapResult(k, k.chamfer(unwrap(shape), vec, d));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function chamferDistAngle(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  edges: KernelShape[],
+  distance: number,
+  angleDeg: number
+): KernelShape {
+  const vec = makeVecU32(Module, edges.map(unwrap));
+  try {
+    return wrapResult(k, k.chamferDistAngle(unwrap(shape), vec, distance, angleDeg));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function shell(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  faces: KernelShape[],
+  thickness: number,
+  tolerance?: number
+): KernelShape {
+  const vec = makeVecU32(Module, faces.map(unwrap));
+  try {
+    return wrapResult(k, k.shell(unwrap(shape), vec, thickness, tolerance ?? 1e-3));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function thicken(k: OcctKernelWasm, shape: KernelShape, thickness: number): KernelShape {
+  // 1e-3 matches OCCT's pre-3.0 hardcoded default; thicken's tolerance isn't
+  // exposed via brepjs's KernelInstance interface.
+  return wrapResult(k, k.thicken(unwrap(shape), thickness, 1e-3));
+}
+
+export function offset(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  distance: number,
+  tolerance?: number
+): KernelShape {
+  return wrapResult(k, k.offset(unwrap(shape), distance, tolerance ?? 1e-6));
+}
+
+export function filletVariable(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  spec: string
+): KernelShape {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON parse
+  const parsed: any = JSON.parse(spec);
+  if (
+    parsed.edgeId !== undefined &&
+    parsed.startRadius !== undefined &&
+    parsed.endRadius !== undefined
+  ) {
+    return wrapResult(
+      k,
+      k.filletVariable(unwrap(shape), parsed.edgeId, parsed.startRadius, parsed.endRadius)
+    );
+  }
+  throw new Error('occt-wasm: filletVariable (complex spec) not implemented');
+}
+
+export function draft(
+  k: OcctKernelWasm,
+  shape: KernelShape,
+  faces: KernelShape[],
+  pullDirection: [number, number, number],
+  _neutralPlane: [number, number, number],
+  angleDeg: number | ((face: KernelShape) => number)
+): KernelShape {
+  let currentId = unwrap(shape);
+  for (const face of faces) {
+    const angle = typeof angleDeg === 'function' ? angleDeg(face) : angleDeg;
+    const angleRad = (angle * Math.PI) / 180;
+    currentId = k.draft(
+      currentId,
+      unwrap(face),
+      angleRad,
+      pullDirection[0],
+      pullDirection[1],
+      pullDirection[2]
+    );
+  }
+  return wrapResult(k, currentId);
+}
+
+export function defeature(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  shape: KernelShape,
+  faces: KernelShape[]
+): KernelShape {
+  const vec = makeVecU32(Module, faces.map(unwrap));
+  try {
+    return wrapResult(k, k.defeature(unwrap(shape), vec, 1e-3));
+  } finally {
+    vec.delete();
+  }
+}
+
+export function offsetWire2D(
+  k: OcctKernelWasm,
+  wire: KernelShape,
+  offset: number,
+  joinType?: number | 'arc' | 'intersection' | 'tangent'
+): KernelShape {
+  let jt = 0; // arc
+  if (joinType === 'intersection' || joinType === 1) jt = 1;
+  else if (joinType === 'tangent' || joinType === 2) jt = 2;
+  else if (typeof joinType === 'number') jt = joinType;
+  return wrapResult(k, k.offsetWire2D(unwrap(wire), offset, jt));
+}
+
+export function simplify(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  return wrapResult(k, k.simplify(unwrap(shape)));
+}
+
+export function reverseShape(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  return wrapResult(k, k.reverseShape(unwrap(shape)));
+}

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -78,6 +78,7 @@ import * as meshOps from './meshOps.js';
 import * as curveOps from './curveOps.js';
 import * as surfaceOps from './surfaceOps.js';
 import * as measureOps from './measureOps.js';
+import * as modifierOps from './modifierOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -1370,13 +1371,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     edges: KernelShape[],
     radius: number | [number, number] | ((edge: KernelShape) => number | [number, number])
   ): KernelShape {
-    const r = resolveUniformRadius(edges, radius);
-    const vec = makeVecU32(this.Module, edges.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.fillet(unwrap(shape), vec, r));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.fillet(this.k, this.Module, shape, edges, radius);
   }
 
   chamfer(
@@ -1384,13 +1379,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     edges: KernelShape[],
     distance: number | [number, number] | ((edge: KernelShape) => number | [number, number])
   ): KernelShape {
-    const d = resolveUniformRadius(edges, distance);
-    const vec = makeVecU32(this.Module, edges.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.chamfer(unwrap(shape), vec, d));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.chamfer(this.k, this.Module, shape, edges, distance);
   }
 
   chamferDistAngle(
@@ -1399,12 +1388,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     distance: number,
     angleDeg: number
   ): KernelShape {
-    const vec = makeVecU32(this.Module, edges.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.chamferDistAngle(unwrap(shape), vec, distance, angleDeg));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.chamferDistAngle(this.k, this.Module, shape, edges, distance, angleDeg);
   }
 
   shell(
@@ -1413,74 +1397,33 @@ export class OcctWasmAdapter implements KernelAdapter {
     thickness: number,
     tolerance?: number
   ): KernelShape {
-    const vec = makeVecU32(this.Module, faces.map(unwrap));
-    try {
-      return wrapResult(this.k, this.k.shell(unwrap(shape), vec, thickness, tolerance ?? 1e-3));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.shell(this.k, this.Module, shape, faces, thickness, tolerance);
   }
 
   thicken(shape: KernelShape, thickness: number): KernelShape {
-    // 1e-3 matches OCCT's pre-3.0 hardcoded default; brepjs's KernelInstance
-    // interface doesn't expose tolerance for thicken, so we keep the prior
-    // behavior. Bump to 1e-6 if/when the interface widens to accept it.
-    return wrapResult(this.k, this.k.thicken(unwrap(shape), thickness, 1e-3));
+    return modifierOps.thicken(this.k, shape, thickness);
   }
 
   offset(shape: KernelShape, distance: number, tolerance?: number): KernelShape {
-    return wrapResult(this.k, this.k.offset(unwrap(shape), distance, tolerance ?? 1e-6));
+    return modifierOps.offset(this.k, shape, distance, tolerance);
   }
 
   filletVariable(shape: KernelShape, spec: string): KernelShape {
-    // Parse the spec JSON to get edge + radii
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON parse
-    const parsed: any = JSON.parse(spec);
-    if (
-      parsed.edgeId !== undefined &&
-      parsed.startRadius !== undefined &&
-      parsed.endRadius !== undefined
-    ) {
-      return wrapResult(
-        this.k,
-        this.k.filletVariable(unwrap(shape), parsed.edgeId, parsed.startRadius, parsed.endRadius)
-      );
-    }
-    notImplemented('filletVariable (complex spec)');
+    return modifierOps.filletVariable(this.k, shape, spec);
   }
 
   draft(
     shape: KernelShape,
     faces: KernelShape[],
     pullDirection: [number, number, number],
-    _neutralPlane: [number, number, number],
+    neutralPlane: [number, number, number],
     angleDeg: number | ((face: KernelShape) => number)
   ): KernelShape {
-    // Apply draft to each face sequentially
-    let currentId = unwrap(shape);
-    for (const face of faces) {
-      const angle = typeof angleDeg === 'function' ? angleDeg(face) : angleDeg;
-      const angleRad = (angle * Math.PI) / 180;
-      currentId = this.k.draft(
-        currentId,
-        unwrap(face),
-        angleRad,
-        pullDirection[0],
-        pullDirection[1],
-        pullDirection[2]
-      );
-    }
-    return wrapResult(this.k, currentId);
+    return modifierOps.draft(this.k, shape, faces, pullDirection, neutralPlane, angleDeg);
   }
 
   defeature(shape: KernelShape, faces: KernelShape[]): KernelShape {
-    const vec = makeVecU32(this.Module, faces.map(unwrap));
-    try {
-      // 1e-3 matches OCCT's pre-3.0 hardcoded default; see `thicken`.
-      return wrapResult(this.k, this.k.defeature(unwrap(shape), vec, 1e-3));
-    } finally {
-      vec.delete();
-    }
+    return modifierOps.defeature(this.k, this.Module, shape, faces);
   }
 
   offsetWire2D(
@@ -1488,19 +1431,15 @@ export class OcctWasmAdapter implements KernelAdapter {
     offset: number,
     joinType?: number | 'arc' | 'intersection' | 'tangent'
   ): KernelShape {
-    let jt = 0; // arc
-    if (joinType === 'intersection' || joinType === 1) jt = 1;
-    else if (joinType === 'tangent' || joinType === 2) jt = 2;
-    else if (typeof joinType === 'number') jt = joinType;
-    return wrapResult(this.k, this.k.offsetWire2D(unwrap(wire), offset, jt));
+    return modifierOps.offsetWire2D(this.k, wire, offset, joinType);
   }
 
   simplify(shape: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.simplify(unwrap(shape)));
+    return modifierOps.simplify(this.k, shape);
   }
 
   reverseShape(shape: KernelShape): KernelShape {
-    return wrapResult(this.k, this.k.reverseShape(unwrap(shape)));
+    return modifierOps.reverseShape(this.k, shape);
   }
 
   // =========================================================================


### PR DESCRIPTION
Stacked on PR #924. Extracts: fillet, chamfer, chamferDistAngle, shell, thicken, offset, filletVariable, draft, defeature, offsetWire2D, simplify, reverseShape. resolveUniformRadius helper relocated from occtWasmAdapter.ts to helpers.ts.