### PR TITLE
chore(occt-wasm): extract hull helpers and getNurbsCurveData

### DIFF
--- a/src/kernel/occtWasm/curveOps.ts
+++ b/src/kernel/occtWasm/curveOps.ts
@@ -5,7 +5,7 @@
  * @module
  */
 
-import type { KernelShape } from '@/kernel/types.js';
+import type { KernelShape, NurbsCurveData } from '@/kernel/types.js';
 import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
 import { handle, makeVecDouble, unwrap } from './helpers.js';
 
@@ -119,5 +119,42 @@ export function approximatePoints(
     return handle('edge', id);
   } finally {
     vec.delete();
+  }
+}
+
+export function getNurbsCurveData(k: OcctKernelWasm, edge: KernelShape): NurbsCurveData | null {
+  try {
+    const data = k.getNurbsCurveData(unwrap(edge));
+    try {
+      const nPoles = data.poles.size() / 3;
+      const poles: [number, number, number][] = [];
+      for (let i = 0; i < nPoles; i++) {
+        poles.push([data.poles.get(i * 3), data.poles.get(i * 3 + 1), data.poles.get(i * 3 + 2)]);
+      }
+      const knots: number[] = [];
+      for (let i = 0; i < data.knots.size(); i++) knots.push(data.knots.get(i));
+      const multiplicities: number[] = [];
+      for (let i = 0; i < data.multiplicities.size(); i++)
+        multiplicities.push(data.multiplicities.get(i));
+      const weights: number[] = [];
+      if (data.rational) {
+        for (let i = 0; i < data.weights.size(); i++) weights.push(data.weights.get(i));
+      } else {
+        for (let i = 0; i < nPoles; i++) weights.push(1);
+      }
+      return {
+        degree: data.degree,
+        poles,
+        weights,
+        knots,
+        multiplicities,
+        isPeriodic: data.periodic,
+        isRational: data.rational,
+      };
+    } finally {
+      data.delete();
+    }
+  } catch {
+    return null;
   }
 }

--- a/src/kernel/occtWasm/hullOps.ts
+++ b/src/kernel/occtWasm/hullOps.ts
@@ -1,0 +1,108 @@
+/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
+/**
+ * Convex hull operations for the occt-wasm adapter.
+ *
+ * Implements an incremental gift-wrapping algorithm: start from a tetrahedron
+ * formed by 4 non-coplanar points, then for each remaining point find the
+ * faces visible from it, remove them, and stitch new faces along the horizon.
+ * The resulting face list is materialised into an OCCT solid via
+ * `buildSolidFromFaces`.
+ *
+ * @module
+ */
+
+import type { KernelShape } from '@/kernel/types.js';
+import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
+import { buildSolidFromFaces } from './constructionOps.js';
+
+function findHorizonEdges(
+  faces: [number, number, number][],
+  visible: number[]
+): [number, number][] {
+  const visSet = new Set(visible);
+  const horizon: [number, number][] = [];
+  for (const fi of visible) {
+    const f = faces[fi] as [number, number, number];
+    for (let ei = 0; ei < 3; ei++) {
+      const a = f[ei] as number,
+        b = f[(ei + 1) % 3] as number;
+      const hasAdjacentNonVisible = faces.some(
+        (g, fj) =>
+          fj !== fi &&
+          !visSet.has(fj) &&
+          [0, 1, 2].some((ej) => g[ej] === b && g[(ej + 1) % 3] === a)
+      );
+      if (hasAdjacentNonVisible) horizon.push([a, b]);
+    }
+  }
+  return horizon;
+}
+
+export function computeConvexHullFaces(
+  pts: Array<{ x: number; y: number; z: number }>
+): Array<readonly [number, number, number]> {
+  type V = { x: number; y: number; z: number };
+  const cross = (a: V, b: V): V => ({
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  });
+  const sub = (a: V, b: V): V => ({ x: a.x - b.x, y: a.y - b.y, z: a.z - b.z });
+  const dot = (a: V, b: V) => a.x * b.x + a.y * b.y + a.z * b.z;
+
+  const n = pts.length;
+  const faces: Array<[number, number, number]> = [];
+  const p0 = pts[0] as V;
+  let i1 = 1;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by i1 < n
+  while (i1 < n && Math.hypot(pts[i1]!.x - p0.x, pts[i1]!.y - p0.y, pts[i1]!.z - p0.z) < 1e-10)
+    i1++;
+  let i2 = i1 + 1;
+  const e01 = sub(pts[i1] as V, p0);
+  while (i2 < n) {
+    const c = cross(e01, sub(pts[i2] as V, p0));
+    if (Math.hypot(c.x, c.y, c.z) > 1e-10) break;
+    i2++;
+  }
+  let i3 = i2 + 1;
+  const norm = cross(e01, sub(pts[i2] as V, p0));
+  while (i3 < n) {
+    if (Math.abs(dot(norm, sub(pts[i3] as V, p0))) > 1e-10) break;
+    i3++;
+  }
+  if (i3 >= n) return [[0, 1, 2]];
+  const vol = dot(cross(sub(pts[i1] as V, p0), sub(pts[i2] as V, p0)), sub(pts[i3] as V, p0));
+  if (vol > 0) {
+    faces.push([0, i1, i2], [0, i2, i3], [0, i3, i1], [i1, i3, i2]);
+  } else {
+    faces.push([0, i2, i1], [0, i3, i2], [0, i1, i3], [i2, i3, i1]);
+  }
+  const used = new Set([0, i1, i2, i3]);
+  for (let pi = 0; pi < n; pi++) {
+    if (used.has(pi)) continue;
+    const p = pts[pi] as V;
+    const visible: number[] = [];
+    for (let fi = 0; fi < faces.length; fi++) {
+      const f = faces[fi] as [number, number, number];
+      const n2 = cross(sub(pts[f[1]] as V, pts[f[0]] as V), sub(pts[f[2]] as V, pts[f[0]] as V));
+      if (dot(n2, sub(p, pts[f[0]] as V)) > 1e-10) visible.push(fi);
+    }
+    if (visible.length === 0) continue;
+    const horizon = findHorizonEdges(faces, visible);
+    visible.sort((a2, b2) => b2 - a2);
+    for (const fi of visible) faces.splice(fi, 1);
+    for (const [a, b] of horizon) faces.push([a, b, pi]);
+  }
+  return faces;
+}
+
+export function hullFromPoints(
+  k: OcctKernelWasm,
+  Module: OcctWasmModule,
+  points: Array<{ x: number; y: number; z: number }>,
+  tolerance: number
+): KernelShape {
+  if (points.length < 4) throw new Error('hullFromPoints: need at least 4 points');
+  const faces = computeConvexHullFaces(points);
+  return buildSolidFromFaces(k, Module, points, faces, tolerance);
+}

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -67,6 +67,7 @@ import * as ioOps from './ioOps.js';
 import * as constructionOps from './constructionOps.js';
 import * as kernel2dOps from './kernel2dOps.js';
 import * as evolutionOps from './evolutionOps.js';
+import * as hullOps from './hullOps.js';
 
 // Helpers (handle wrapping, vector marshalling) live in ./helpers.ts so
 // per-section files like ./booleanOps.ts can share them without depending
@@ -740,9 +741,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     points: Array<{ x: number; y: number; z: number }>,
     tolerance: number
   ): KernelShape {
-    if (points.length < 4) throw new Error('hullFromPoints: need at least 4 points');
-    const faces = computeConvexHullFaces(points);
-    return constructionOps.buildSolidFromFaces(this.k, this.Module, points, faces, tolerance);
+    return hullOps.hullFromPoints(this.k, this.Module, points, tolerance);
   }
 
   buildSolidFromFaces(
@@ -2276,141 +2275,14 @@ export class OcctWasmAdapter implements KernelAdapter {
 
   // KernelRepairOps.validationDetails is not on the interface but brepkit has it
   getNurbsCurveData(edge: KernelShape): NurbsCurveData | null {
-    try {
-      const data = this.k.getNurbsCurveData(unwrap(edge));
-      try {
-        const nPoles = data.poles.size() / 3;
-        const poles: [number, number, number][] = [];
-        for (let i = 0; i < nPoles; i++) {
-          poles.push([data.poles.get(i * 3), data.poles.get(i * 3 + 1), data.poles.get(i * 3 + 2)]);
-        }
-        const knots: number[] = [];
-        for (let i = 0; i < data.knots.size(); i++) knots.push(data.knots.get(i));
-        const multiplicities: number[] = [];
-        for (let i = 0; i < data.multiplicities.size(); i++)
-          multiplicities.push(data.multiplicities.get(i));
-        const weights: number[] = [];
-        if (data.rational) {
-          for (let i = 0; i < data.weights.size(); i++) weights.push(data.weights.get(i));
-        } else {
-          for (let i = 0; i < nPoles; i++) weights.push(1);
-        }
-        const result: NurbsCurveData = {
-          degree: data.degree,
-          poles,
-          weights,
-          knots,
-          multiplicities,
-          isPeriodic: data.periodic,
-          isRational: data.rational,
-        };
-        return result;
-      } finally {
-        data.delete();
-      }
-    } catch {
-      return null;
-    }
+    return curveOps.getNurbsCurveData(this.k, edge);
   }
   // KernelSurfaceOps.getNurbsSurfaceData is optional
 }
 
-// ---------------------------------------------------------------------------
-// Matrix multiplication helper (4x4 row-major)
-// ---------------------------------------------------------------------------
-
-// multiplyMatrices4x4 has moved to helpers.ts
-
-// --- Convex hull helpers (at module scope) ---
-function findHorizonEdges(
-  faces: [number, number, number][],
-  visible: number[]
-): [number, number][] {
-  const visSet = new Set(visible);
-  const horizon: [number, number][] = [];
-  for (const fi of visible) {
-    const f = faces[fi] as [number, number, number];
-    for (let ei = 0; ei < 3; ei++) {
-      const a = f[ei] as number,
-        b = f[(ei + 1) % 3] as number;
-      const hasAdjacentNonVisible = faces.some(
-        (g, fj) =>
-          fj !== fi &&
-          !visSet.has(fj) &&
-          [0, 1, 2].some((ej) => g[ej] === b && g[(ej + 1) % 3] === a)
-      );
-      if (hasAdjacentNonVisible) horizon.push([a, b]);
-    }
-  }
-  return horizon;
-}
-
-function computeConvexHullFaces(
-  pts: Array<{ x: number; y: number; z: number }>
-): Array<readonly [number, number, number]> {
-  type V = { x: number; y: number; z: number };
-  const cross = (a: V, b: V): V => ({
-    x: a.y * b.z - a.z * b.y,
-    y: a.z * b.x - a.x * b.z,
-    z: a.x * b.y - a.y * b.x,
-  });
-  const sub = (a: V, b: V): V => ({ x: a.x - b.x, y: a.y - b.y, z: a.z - b.z });
-  const dot = (a: V, b: V) => a.x * b.x + a.y * b.y + a.z * b.z;
-
-  // Start with initial tetrahedron
-  const n = pts.length;
-  const faces: Array<[number, number, number]> = [];
-  // Find 4 non-coplanar points
-  const p0 = pts[0] as V;
-  let i1 = 1;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by i1 < n
-  while (i1 < n && Math.hypot(pts[i1]!.x - p0.x, pts[i1]!.y - p0.y, pts[i1]!.z - p0.z) < 1e-10)
-    i1++;
-  let i2 = i1 + 1;
-  const e01 = sub(pts[i1] as V, p0);
-  while (i2 < n) {
-    const c = cross(e01, sub(pts[i2] as V, p0));
-    if (Math.hypot(c.x, c.y, c.z) > 1e-10) break;
-    i2++;
-  }
-  let i3 = i2 + 1;
-  const norm = cross(e01, sub(pts[i2] as V, p0));
-  while (i3 < n) {
-    if (Math.abs(dot(norm, sub(pts[i3] as V, p0))) > 1e-10) break;
-    i3++;
-  }
-  if (i3 >= n) return [[0, 1, 2]]; // degenerate
-  // Orient initial tetrahedron
-  const vol = dot(cross(sub(pts[i1] as V, p0), sub(pts[i2] as V, p0)), sub(pts[i3] as V, p0));
-  if (vol > 0) {
-    faces.push([0, i1, i2], [0, i2, i3], [0, i3, i1], [i1, i3, i2]);
-  } else {
-    faces.push([0, i2, i1], [0, i3, i2], [0, i1, i3], [i2, i3, i1]);
-  }
-  // Incrementally add remaining points
-  const used = new Set([0, i1, i2, i3]);
-  for (let pi = 0; pi < n; pi++) {
-    if (used.has(pi)) continue;
-    const p = pts[pi] as V;
-    // Find visible faces
-    const visible: number[] = [];
-    for (let fi = 0; fi < faces.length; fi++) {
-      const f = faces[fi] as [number, number, number];
-      const n2 = cross(sub(pts[f[1]] as V, pts[f[0]] as V), sub(pts[f[2]] as V, pts[f[0]] as V));
-      if (dot(n2, sub(p, pts[f[0]] as V)) > 1e-10) visible.push(fi);
-    }
-    if (visible.length === 0) continue;
-    // Find horizon edges (edges between visible and non-visible faces)
-    const horizon = findHorizonEdges(faces, visible);
-    // Remove visible faces (reverse order)
-    visible.sort((a2, b2) => b2 - a2);
-    for (const fi of visible) faces.splice(fi, 1);
-    // Add new faces
-    for (const [a, b] of horizon) faces.push([a, b, pi]);
-  }
-  return faces;
-}
-
-// 2D curve helpers (c2d, c2dWrap) moved to kernel2dOps.ts
+// Module-scope helpers extracted:
+// - multiplyMatrices4x4 → ./helpers.ts
+// - computeConvexHullFaces, findHorizonEdges → ./hullOps.ts
+// - 2D curve helpers (c2d, c2dWrap) → ./kernel2dOps.ts
 
 export type { OcctWasmModule, OcctKernelWasm } from './occtWasmTypes.js';


### PR DESCRIPTION
## Summary

Continues the `occtWasmAdapter.ts` decomposition — moves the last two module-scope helper sections out of the adapter:

- `computeConvexHullFaces`, `findHorizonEdges`, `hullFromPoints` → new `hullOps.ts`
- `getNurbsCurveData` (Optional interfaces section) → `curveOps.ts`

Adapter now `2416 → 2288` lines and only carries `wrapKernelExceptions` + `notImplemented` at module scope.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run check:patterns`
- [x] `npm run check:boundaries`
- [x] `TEST_KERNEL=occt-wasm` hull/curve tests — failures match `main` (no regressions)