### PR TITLE
refactor(brepkit): replace WASM-index eslint-disable annotations with helpers

### DIFF
--- a/src/kernel/brepkit/geometryOps.ts
+++ b/src/kernel/brepkit/geometryOps.ts
@@ -19,15 +19,14 @@ import {
 } from './helpers.js';
 import { iterShapes } from './topologyOps.js';
 import { extractNurbsFromEdge } from './internalOps.js';
+import { vec3At, wasmIndex } from '@/utils/vec3.js';
 
 // ═══════════════════════════════════════════════════════════════════════
 // Vertex geometry
 // ═══════════════════════════════════════════════════════════════════════
 
 export function vertexPosition(bk: BrepkitKernel, vertex: KernelShape): [number, number, number] {
-  const pos = bk.getVertexPosition(unwrap(vertex, 'vertex'));
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [pos[0]!, pos[1]!, pos[2]!];
+  return vec3At(bk.getVertexPosition(unwrap(vertex, 'vertex')));
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -44,8 +43,12 @@ export function uvBounds(
   face: KernelShape
 ): { uMin: number; uMax: number; vMin: number; vMax: number } {
   const domain = bk.getSurfaceDomain(unwrap(face, 'face'));
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return { uMin: domain[0]!, uMax: domain[1]!, vMin: domain[2]!, vMax: domain[3]! };
+  return {
+    uMin: wasmIndex(domain, 0),
+    uMax: wasmIndex(domain, 1),
+    vMin: wasmIndex(domain, 2),
+    vMax: wasmIndex(domain, 3),
+  };
 }
 
 export function outerWire(bk: BrepkitKernel, face: KernelShape): KernelShape {
@@ -59,9 +62,7 @@ export function surfaceNormal(
   u: number,
   v: number
 ): [number, number, number] {
-  const n = bk.evaluateSurfaceNormal(unwrap(face, 'face'), u, v);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [n[0]!, n[1]!, n[2]!];
+  return vec3At(bk.evaluateSurfaceNormal(unwrap(face, 'face'), u, v));
 }
 
 export function pointOnSurface(
@@ -70,9 +71,7 @@ export function pointOnSurface(
   u: number,
   v: number
 ): [number, number, number] {
-  const p = bk.evaluateSurface(unwrap(face, 'face'), u, v);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [p[0]!, p[1]!, p[2]!];
+  return vec3At(bk.evaluateSurface(unwrap(face, 'face'), u, v));
 }
 
 export function uvFromPoint(
@@ -82,8 +81,7 @@ export function uvFromPoint(
 ): [number, number] | null {
   try {
     const result = bk.projectPointOnSurface(unwrap(face, 'face'), point[0], point[1], point[2]);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    return [result[0]!, result[1]!];
+    return [wasmIndex(result, 0), wasmIndex(result, 1)];
   } catch (e: unknown) {
     console.warn('brepkit: uvFromPoint failed:', e);
     return null;
@@ -95,9 +93,7 @@ export function projectPointOnFace(
   face: KernelShape,
   point: [number, number, number]
 ): [number, number, number] {
-  const result = bk.projectPointOnSurface(unwrap(face, 'face'), point[0], point[1], point[2]);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [result[2]!, result[3]!, result[4]!];
+  return vec3At(bk.projectPointOnSurface(unwrap(face, 'face'), point[0], point[1], point[2]), 2);
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -116,17 +112,14 @@ export function curveTangent(
   if (h.type === 'wire') {
     // Walk edges to find the right one for the composite parameter
     const edgeIds: number[] = toArray(bk.getWireEdges(h.id));
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid after bounds check
-    edgeId = edgeIds[edgeIds.length - 1]!; // fallback to last edge
+    edgeId = wasmIndex(edgeIds, edgeIds.length - 1); // fallback to last edge
     let cumulative = 0;
     for (const eid of edgeIds) {
       const p = bk.getEdgeCurveParameters(eid);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      const span = p[1]! - p[0]!;
+      const span = wasmIndex(p, 1) - wasmIndex(p, 0);
       if (param <= cumulative + span || eid === edgeId) {
         edgeId = eid;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-        evalParam = Math.min(p[0]! + (param - cumulative), p[1]!);
+        evalParam = Math.min(wasmIndex(p, 0) + (param - cumulative), wasmIndex(p, 1));
         break;
       }
       cumulative += span;
@@ -137,10 +130,8 @@ export function curveTangent(
 
   const result = bk.evaluateEdgeCurveD1(edgeId, evalParam);
   return {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    point: [result[0]!, result[1]!, result[2]!],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    tangent: [result[3]!, result[4]!, result[5]!],
+    point: vec3At(result, 0),
+    tangent: vec3At(result, 3),
   };
 }
 
@@ -153,15 +144,12 @@ export function curveParameters(bk: BrepkitKernel, shape: KernelShape): [number,
     let total = 0;
     for (const eid of edgeIds) {
       const p = bk.getEdgeCurveParameters(eid);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      total += p[1]! - p[0]!;
+      total += wasmIndex(p, 1) - wasmIndex(p, 0);
     }
     return [0, total];
   }
-  const edgeId = unwrap(shape, 'edge');
-  const params = bk.getEdgeCurveParameters(edgeId);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [params[0]!, params[1]!];
+  const params = bk.getEdgeCurveParameters(unwrap(shape, 'edge'));
+  return [wasmIndex(params, 0), wasmIndex(params, 1)];
 }
 
 export function curvePointAtParam(
@@ -176,28 +164,17 @@ export function curvePointAtParam(
     let cumulative = 0;
     for (const eid of edgeIds) {
       const p = bk.getEdgeCurveParameters(eid);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      const span = p[1]! - p[0]!;
+      const span = wasmIndex(p, 1) - wasmIndex(p, 0);
       if (param <= cumulative + span || eid === edgeIds[edgeIds.length - 1]) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-        const localParam = p[0]! + (param - cumulative);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-        const pt = bk.evaluateEdgeCurve(eid, Math.min(localParam, p[1]!));
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-        return [pt[0]!, pt[1]!, pt[2]!];
+        const localParam = wasmIndex(p, 0) + (param - cumulative);
+        return vec3At(bk.evaluateEdgeCurve(eid, Math.min(localParam, wasmIndex(p, 1))));
       }
       cumulative += span;
     }
     // Fallback: evaluate first edge at param
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const pt = bk.evaluateEdgeCurve(edgeIds[0]!, param);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    return [pt[0]!, pt[1]!, pt[2]!];
+    return vec3At(bk.evaluateEdgeCurve(wasmIndex(edgeIds, 0), param));
   }
-  const edgeId = unwrap(shape, 'edge');
-  const p = bk.evaluateEdgeCurve(edgeId, param);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [p[0]!, p[1]!, p[2]!];
+  return vec3At(bk.evaluateEdgeCurve(unwrap(shape, 'edge'), param));
 }
 
 export function curveIsClosed(bk: BrepkitKernel, shape: KernelShape): boolean {
@@ -208,20 +185,16 @@ export function curveIsClosed(bk: BrepkitKernel, shape: KernelShape): boolean {
 
     // For a single-edge wire, check if edge start == edge end
     if (edgeIds.length === 1) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      const verts = bk.getEdgeVertices(edgeIds[0]!);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      return dist3(verts[0]!, verts[1]!, verts[2]!, verts[3]!, verts[4]!, verts[5]!) < 1e-7;
+      const verts = bk.getEdgeVertices(wasmIndex(edgeIds, 0));
+      return edgeIsClosed(verts);
     }
 
     // For multi-edge wires, collect all endpoints and check each has a partner
     const endpoints: Array<[number, number, number]> = [];
     for (const eid of edgeIds) {
       const verts = bk.getEdgeVertices(eid);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      endpoints.push([verts[0]!, verts[1]!, verts[2]!]);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      endpoints.push([verts[3]!, verts[4]!, verts[5]!]);
+      endpoints.push(vec3At(verts, 0));
+      endpoints.push(vec3At(verts, 3));
     }
     // Each vertex should appear exactly twice in a closed wire
     const unmatched: Array<[number, number, number]> = [];
@@ -238,9 +211,20 @@ export function curveIsClosed(bk: BrepkitKernel, shape: KernelShape): boolean {
     return unmatched.length === 0;
   }
   // Check if edge start == end vertex
-  const verts = bk.getEdgeVertices(unwrap(shape, 'edge'));
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return dist3(verts[0]!, verts[1]!, verts[2]!, verts[3]!, verts[4]!, verts[5]!) < 1e-7;
+  return edgeIsClosed(bk.getEdgeVertices(unwrap(shape, 'edge')));
+}
+
+function edgeIsClosed(verts: ArrayLike<number>): boolean {
+  return (
+    dist3(
+      wasmIndex(verts, 0),
+      wasmIndex(verts, 1),
+      wasmIndex(verts, 2),
+      wasmIndex(verts, 3),
+      wasmIndex(verts, 4),
+      wasmIndex(verts, 5)
+    ) < 1e-7
+  );
 }
 
 export function curveIsPeriodic(bk: BrepkitKernel, shape: KernelShape): boolean {
@@ -322,8 +306,7 @@ export function curveSplit(
 ): [KernelShape, KernelShape] {
   const edgeId = unwrap(edge, 'edge');
   const result = bk.curveSplit(edgeId, param);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  return [edgeHandle(result[0]!), edgeHandle(result[1]!)];
+  return [edgeHandle(wasmIndex(result, 0)), edgeHandle(wasmIndex(result, 1))];
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -383,15 +366,7 @@ export function getBezierPenultimatePole(
   const nurbsData = extractNurbsFromEdge(bk, edge);
   if (!nurbsData || nurbsData.controlPoints.length < 6) return null;
   // Penultimate = second-to-last control point
-  const n = nurbsData.controlPoints.length;
-  return [
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    nurbsData.controlPoints[n - 6]!,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    nurbsData.controlPoints[n - 5]!,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    nurbsData.controlPoints[n - 4]!,
-  ];
+  return vec3At(nurbsData.controlPoints, nurbsData.controlPoints.length - 6);
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -436,8 +411,12 @@ export function classifyPointOnFace(
   const faceId = unwrap(face, 'face');
   const domain = bk.getSurfaceDomain(faceId);
   // domain = [uMin, uMax, vMin, vMax]
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  if (u < domain[0]! || u > domain[1]! || v < domain[2]! || v > domain[3]!) {
+  if (
+    u < wasmIndex(domain, 0) ||
+    u > wasmIndex(domain, 1) ||
+    v < wasmIndex(domain, 2) ||
+    v > wasmIndex(domain, 3)
+  ) {
     return 'out';
   }
   return 'in';

--- a/src/kernel/brepkit/kernel2dOps.ts
+++ b/src/kernel/brepkit/kernel2dOps.ts
@@ -27,6 +27,7 @@ import {
 } from './helpers.js';
 import { makeLineEdge, interpolatePoints, makeNonPlanarFace } from './constructionOps.js';
 import { iterShapes } from './topologyOps.js';
+import { vec3At, wasmIndex } from '@/utils/vec3.js';
 
 // ═══════════════════════════════════════════════════════════════════════
 // Primitive 2D geometry constructors
@@ -387,10 +388,8 @@ export function createAffinityGTrsf2d(
     py = dx / len; // perpendicular to axis
   const k = ratio - 1;
   const m = [1 + k * px * px, k * px * py, 0, k * py * px, 1 + k * py * py, 0, 0, 0, 1];
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const txv = ox - m[0]! * ox - m[1]! * oy;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const tyv = oy - m[3]! * ox - m[4]! * oy;
+  const txv = ox - wasmIndex(m, 0) * ox - wasmIndex(m, 1) * oy;
+  const tyv = oy - wasmIndex(m, 3) * ox - wasmIndex(m, 4) * oy;
   return _gtrsf(m, txv, tyv);
 }
 
@@ -417,10 +416,8 @@ export function createMirrorGTrsf2d(
     const px = ox ?? cx,
       py = oy ?? cy;
     // Translation: p - R*p
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const txv = px - m[0]! * px - m[1]! * py;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const tyv = py - m[3]! * px - m[4]! * py;
+    const txv = px - wasmIndex(m, 0) * px - wasmIndex(m, 1) * py;
+    const tyv = py - wasmIndex(m, 3) * px - wasmIndex(m, 4) * py;
     return _gtrsf(m, txv, tyv);
   }
   // Point mirror at (cx, cy)
@@ -446,28 +443,25 @@ export function multiplyGTrsf2d(base: KernelType, other: KernelType): void {
   // Full 3x3 matrix multiply: base = base * other
   const a = base.m as number[],
     b = other.m as number[];
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
-  const r = [
-    a[0]! * b[0]! + a[1]! * b[3]! + a[2]! * b[6]!,
-    a[0]! * b[1]! + a[1]! * b[4]! + a[2]! * b[7]!,
-    a[0]! * b[2]! + a[1]! * b[5]! + a[2]! * b[8]!,
-    a[3]! * b[0]! + a[4]! * b[3]! + a[5]! * b[6]!,
-    a[3]! * b[1]! + a[4]! * b[4]! + a[5]! * b[7]!,
-    a[3]! * b[2]! + a[4]! * b[5]! + a[5]! * b[8]!,
-    a[6]! * b[0]! + a[7]! * b[3]! + a[8]! * b[6]!,
-    a[6]! * b[1]! + a[7]! * b[4]! + a[8]! * b[7]!,
-    a[6]! * b[2]! + a[7]! * b[5]! + a[8]! * b[8]!,
+  const ai = (i: number) => wasmIndex(a, i);
+  const bi = (i: number) => wasmIndex(b, i);
+  base.m = [
+    ai(0) * bi(0) + ai(1) * bi(3) + ai(2) * bi(6),
+    ai(0) * bi(1) + ai(1) * bi(4) + ai(2) * bi(7),
+    ai(0) * bi(2) + ai(1) * bi(5) + ai(2) * bi(8),
+    ai(3) * bi(0) + ai(4) * bi(3) + ai(5) * bi(6),
+    ai(3) * bi(1) + ai(4) * bi(4) + ai(5) * bi(7),
+    ai(3) * bi(2) + ai(4) * bi(5) + ai(5) * bi(8),
+    ai(6) * bi(0) + ai(7) * bi(3) + ai(8) * bi(6),
+    ai(6) * bi(1) + ai(7) * bi(4) + ai(8) * bi(7),
+    ai(6) * bi(2) + ai(7) * bi(5) + ai(8) * bi(8),
   ];
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
-  base.m = r;
   const oldTx = base.tx as number,
     oldTy = base.ty as number;
   const otx = Number(other.tx) || 0,
     oty = Number(other.ty) || 0;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  base.tx = a[0]! * otx + a[1]! * oty + oldTx;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  base.ty = a[3]! * otx + a[4]! * oty + oldTy;
+  base.tx = ai(0) * otx + ai(1) * oty + oldTx;
+  base.ty = ai(3) * otx + ai(4) * oty + oldTy;
 }
 
 export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType): Curve2dHandle {
@@ -477,13 +471,15 @@ export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType)
   const tx = Number(gtrsf.tx) || 0,
     ty = Number(gtrsf.ty) || 0;
   // If transform is just a translation, use fast path
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
+  const m0 = wasmIndex(m, 0),
+    m1 = wasmIndex(m, 1),
+    m3 = wasmIndex(m, 3),
+    m4 = wasmIndex(m, 4);
   const isIdentityMatrix =
-    Math.abs(m[0]! - 1) < 1e-12 &&
-    Math.abs(m[4]! - 1) < 1e-12 &&
-    Math.abs(m[1]!) < 1e-12 &&
-    Math.abs(m[3]!) < 1e-12;
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    Math.abs(m0 - 1) < 1e-12 &&
+    Math.abs(m4 - 1) < 1e-12 &&
+    Math.abs(m1) < 1e-12 &&
+    Math.abs(m3) < 1e-12;
   if (isIdentityMatrix) {
     return bk2d.translateCurve2d(c, tx, ty);
   }
@@ -494,8 +490,7 @@ export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType)
   for (let i = 0; i <= N; i++) {
     const t = bounds.first + ((bounds.last - bounds.first) * i) / N;
     const [px, py] = bk2d.evaluateCurve2d(c, t);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    pts.push([m[0]! * px + m[1]! * py + tx, m[3]! * px + m[4]! * py + ty]);
+    pts.push([m0 * px + m1 * py + tx, m3 * px + m4 * py + ty]);
   }
   return bk2d.makeBezier2d(pts);
 }
@@ -677,10 +672,8 @@ export function approximateCurve2dAsBSpline(
       const tMid = bounds.first + ((bounds.last - bounds.first) * (i + 0.5)) / N;
       const [ex, ey] = bk2d.evaluateCurve2d(c, tMid);
       // Linear interp between adjacent samples
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      const p0 = poles[i]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      const p1 = poles[i + 1]!;
+      const p0 = wasmIndex(poles, i);
+      const p1 = wasmIndex(poles, i + 1);
       const mx = (p0[0] + p1[0]) / 2;
       const my = (p0[1] + p1[1]) / 2;
       const err = Math.sqrt((ex - mx) ** 2 + (ey - my) ** 2);
@@ -716,10 +709,8 @@ export function decomposeBSpline2dToBeziers(curve: Curve2dHandle): Curve2dHandle
   const breakpoints = [first, ...internalKnots, last];
   const result: Curve2dHandle[] = [];
   for (let i = 0; i < breakpoints.length - 1; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const t0 = breakpoints[i]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const t1 = breakpoints[i + 1]!;
+    const t0 = wasmIndex(breakpoints, i);
+    const t1 = wasmIndex(breakpoints, i + 1);
     const span = t1 - t0;
     if (span < 1e-15) continue;
     const p0 = bk2d.evaluateCurve2d(c, t0);
@@ -940,8 +931,7 @@ export function liftCurve2dToPlane(
         const [eu, ev] = bk2d.evaluateCurve2d(c, bounds.first + (seg + 1) * segmentSpan);
         edgeIds.push(bk.makeCircleArc3d(...lift(su, sv), ...lift(eu, ev), ...center3d, ...axis));
       }
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      if (edgeIds.length === 1) return edgeHandle(edgeIds[0]!);
+      if (edgeIds.length === 1) return edgeHandle(wasmIndex(edgeIds, 0));
       return wireHandle(bk.makeWire(edgeIds, false));
     }
 
@@ -953,8 +943,8 @@ export function liftCurve2dToPlane(
   // For Bezier/BSpline: lift control points exactly (preserves NURBS structure)
   if (c.__bk2d === 'bezier' || c.__bk2d === 'bspline') {
     const points3d = c.poles.map(([u, v]) => lift(u, v));
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    if (points3d.length === 2) return makeLineEdge(bk, points3d[0]!, points3d[1]!);
+    if (points3d.length === 2)
+      return makeLineEdge(bk, wasmIndex(points3d, 0), wasmIndex(points3d, 1));
     const degree = Math.min(3, points3d.length - 1);
     const coords = points3d.flatMap(([px, py, pz]) => [px, py, pz]);
     const id = bk.interpolatePoints(coords, degree);
@@ -993,15 +983,54 @@ export function buildEdgeOnSurface(
   for (let i = 0; i <= N; i++) {
     const t = bounds.first + ((bounds.last - bounds.first) * i) / N;
     const [u, v] = bk2d.evaluateCurve2d(c, t);
-    const p = bk.evaluateSurface(fid, u, v);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    points.push([p[0]!, p[1]!, p[2]!]);
+    points.push(vec3At(bk.evaluateSurface(fid, u, v)));
   }
   return interpolatePoints(bk, points);
 }
 
 export function extractSurfaceFromFace(face: KernelShape): KernelType {
   return face; /* brepkit face IS its surface */
+}
+
+type UVSample = { t: number; uv: [number, number] };
+
+/**
+ * Adaptively refine a UV sample list by inserting midpoints whenever the
+ * sampled UV midpoint deviates from the linear interpolation of its
+ * neighbors by more than `threshold`. Stops at `maxSamples` or when no
+ * pair exceeds the threshold; cap of 3 refinement passes overall.
+ */
+function refineUVSamples(
+  uvSamples: UVSample[],
+  evaluateUV: (t: number) => [number, number],
+  maxSamples: number,
+  threshold: number
+): void {
+  let refinements = 0;
+  while (uvSamples.length < maxSamples) {
+    const insertions: Array<{ index: number; t: number; uv: [number, number] }> = [];
+    for (let i = 0; i < uvSamples.length - 1; i++) {
+      const a = wasmIndex(uvSamples, i);
+      const b = wasmIndex(uvSamples, i + 1);
+      const tMid = (a.t + b.t) / 2;
+      const uvMid = evaluateUV(tMid);
+      const interpU = (a.uv[0] + b.uv[0]) / 2;
+      const interpV = (a.uv[1] + b.uv[1]) / 2;
+      const deviation = Math.sqrt((uvMid[0] - interpU) ** 2 + (uvMid[1] - interpV) ** 2);
+      if (deviation > threshold) {
+        insertions.push({ index: i + 1, t: tMid, uv: uvMid });
+      }
+    }
+    if (insertions.length === 0) break;
+    let budget = maxSamples - uvSamples.length;
+    for (let j = insertions.length - 1; j >= 0 && budget > 0; j--) {
+      const ins = wasmIndex(insertions, j);
+      uvSamples.splice(ins.index, 0, { t: ins.t, uv: ins.uv });
+      budget--;
+    }
+    refinements++;
+    if (refinements > 3) break;
+  }
 }
 
 export function extractCurve2dFromEdge(
@@ -1032,49 +1061,13 @@ export function extractCurve2dFromEdge(
   // Evaluate 3D points -> UV
   const evaluateUV = (t: number): [number, number] => {
     const pt = bk.evaluateEdgeCurve(eid, t);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const uv = bk.projectPointOnSurface(fid, pt[0]!, pt[1]!, pt[2]!);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    return [uv[0]!, uv[1]!];
+    const uv = bk.projectPointOnSurface(fid, wasmIndex(pt, 0), wasmIndex(pt, 1), wasmIndex(pt, 2));
+    return [wasmIndex(uv, 0), wasmIndex(uv, 1)];
   };
 
-  const uvSamples: Array<{ t: number; uv: [number, number] }> = tValues.map((t) => ({
-    t,
-    uv: evaluateUV(t),
-  }));
+  const uvSamples: UVSample[] = tValues.map((t) => ({ t, uv: evaluateUV(t) }));
 
-  // Adaptive refinement: insert midpoints where the UV midpoint deviates
-  // significantly from the linear interpolation of its neighbors.
-  let refinements = 0;
-  while (uvSamples.length < MAX_N) {
-    const insertions: Array<{ index: number; t: number; uv: [number, number] }> = [];
-    for (let i = 0; i < uvSamples.length - 1; i++) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      const a = uvSamples[i]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      const b = uvSamples[i + 1]!;
-      const tMid = (a.t + b.t) / 2;
-      const uvMid = evaluateUV(tMid);
-      // Linear interpolation of UV
-      const interpU = (a.uv[0] + b.uv[0]) / 2;
-      const interpV = (a.uv[1] + b.uv[1]) / 2;
-      const deviation = Math.sqrt((uvMid[0] - interpU) ** 2 + (uvMid[1] - interpV) ** 2);
-      if (deviation > REFINE_THRESHOLD) {
-        insertions.push({ index: i + 1, t: tMid, uv: uvMid });
-      }
-    }
-    if (insertions.length === 0) break;
-    // Insert in reverse order to preserve indices; cap at MAX_N total samples
-    let budget = MAX_N - uvSamples.length;
-    for (let j = insertions.length - 1; j >= 0 && budget > 0; j--) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      const ins = insertions[j]!;
-      uvSamples.splice(ins.index, 0, { t: ins.t, uv: ins.uv });
-      budget--;
-    }
-    refinements++;
-    if (refinements > 3) break; // cap refinement passes
-  }
+  refineUVSamples(uvSamples, evaluateUV, MAX_N, REFINE_THRESHOLD);
 
   const uvPoints: [number, number][] = uvSamples.map((s) => s.uv);
 
@@ -1085,12 +1078,24 @@ export function extractCurve2dFromEdge(
   // Fallback: use edge vertices projected to UV
   const verts = bk.getEdgeVertices(eid);
   if (verts.length >= 6) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const uv1 = bk.projectPointOnSurface(fid, verts[0]!, verts[1]!, verts[2]!);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const uv2 = bk.projectPointOnSurface(fid, verts[3]!, verts[4]!, verts[5]!);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    return bk2d.makeLine2d(uv1[0]!, uv1[1]!, uv2[0]!, uv2[1]!);
+    const uv1 = bk.projectPointOnSurface(
+      fid,
+      wasmIndex(verts, 0),
+      wasmIndex(verts, 1),
+      wasmIndex(verts, 2)
+    );
+    const uv2 = bk.projectPointOnSurface(
+      fid,
+      wasmIndex(verts, 3),
+      wasmIndex(verts, 4),
+      wasmIndex(verts, 5)
+    );
+    return bk2d.makeLine2d(
+      wasmIndex(uv1, 0),
+      wasmIndex(uv1, 1),
+      wasmIndex(uv2, 0),
+      wasmIndex(uv2, 1)
+    );
   }
   throw new Error(`brepkit: extractCurve2dFromEdge: degenerate edge (${verts.length} coords)`);
 }
@@ -1122,17 +1127,14 @@ export function fillSurface(
       for (const edge of wireEdges) {
         const edgeId = unwrap(edge, 'edge');
         const params = bk.getEdgeCurveParameters(edgeId);
-        /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
-        const tMin = params[0]!,
-          tMax = params[1]!;
-        /* eslint-enable @typescript-eslint/no-non-null-assertion */
+        const tMin = wasmIndex(params, 0);
+        const tMax = wasmIndex(params, 1);
         const N = 10;
         const pts: number[] = [];
         for (let i = 0; i <= N; i++) {
           const t = tMin + ((tMax - tMin) * i) / N;
           const p = bk.evaluateEdgeCurve(edgeId, t);
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-          pts.push(p[0]!, p[1]!, p[2]!);
+          pts.push(wasmIndex(p, 0), wasmIndex(p, 1), wasmIndex(p, 2));
         }
         allCoords.push(...pts);
         curveLengths.push(N + 1);

--- a/src/kernel/brepkit/measureOps.ts
+++ b/src/kernel/brepkit/measureOps.ts
@@ -8,6 +8,7 @@ import type { KernelShape, DistanceResult } from '@/kernel/types.js';
 import { type BrepkitHandle, unwrap, DEFAULT_DEFLECTION } from './helpers.js';
 import { iterShapes } from './topologyOps.js';
 import { vertexPosition, uvBounds, pointOnSurface } from './geometryOps.js';
+import { vec3At, wasmIndex } from '@/utils/vec3.js';
 
 export function volume(bk: BrepkitKernel, shape: KernelShape): number {
   const h = shape as BrepkitHandle;
@@ -60,12 +61,19 @@ export function length(bk: BrepkitKernel, shape: KernelShape): number {
   throw new Error('brepkit: length() requires an edge, wire, or face');
 }
 
+function edgeMidpoint(bk: BrepkitKernel, edgeId: number): [number, number, number] {
+  const v = bk.getEdgeVertices(edgeId);
+  return [
+    (wasmIndex(v, 0) + wasmIndex(v, 3)) / 2,
+    (wasmIndex(v, 1) + wasmIndex(v, 4)) / 2,
+    (wasmIndex(v, 2) + wasmIndex(v, 5)) / 2,
+  ];
+}
+
 export function centerOfMass(bk: BrepkitKernel, shape: KernelShape): [number, number, number] {
   const h = shape as BrepkitHandle;
   if (h.type === 'solid') {
-    const result = bk.centerOfMass(unwrap(shape), DEFAULT_DEFLECTION);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    return [result[0]!, result[1]!, result[2]!];
+    return vec3At(bk.centerOfMass(unwrap(shape), DEFAULT_DEFLECTION));
   }
   if (h.type === 'face') {
     // Evaluate surface at the center of the UV domain
@@ -75,10 +83,7 @@ export function centerOfMass(bk: BrepkitKernel, shape: KernelShape): [number, nu
     return pointOnSurface(bk, shape, uMid, vMid);
   }
   if (h.type === 'edge') {
-    // Use midpoint of edge vertices
-    const verts = bk.getEdgeVertices(h.id);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    return [(verts[0]! + verts[3]!) / 2, (verts[1]! + verts[4]!) / 2, (verts[2]! + verts[5]!) / 2];
+    return edgeMidpoint(bk, h.id);
   }
   if (h.type === 'vertex') {
     return vertexPosition(bk, shape);
@@ -107,9 +112,7 @@ export function linearCenterOfMass(
   // Average of edge endpoints (approximation for straight edges)
   const h = shape as BrepkitHandle;
   if (h.type === 'edge') {
-    const verts = bk.getEdgeVertices(h.id);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    return [(verts[0]! + verts[3]!) / 2, (verts[1]! + verts[4]!) / 2, (verts[2]! + verts[5]!) / 2];
+    return edgeMidpoint(bk, h.id);
   }
   // For wires/solids, fall back to volumetric CoM
   return centerOfMass(bk, shape);
@@ -125,12 +128,7 @@ export function boundingBox(
   const h = shape as BrepkitHandle;
   if (h.type === 'solid') {
     const bb = bk.boundingBox(unwrap(shape));
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      min: [bb[0]!, bb[1]!, bb[2]!],
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      max: [bb[3]!, bb[4]!, bb[5]!],
-    };
+    return { min: vec3At(bb, 0), max: vec3At(bb, 3) };
   }
   if (h.type === 'vertex') {
     const pos = vertexPosition(bk, shape);
@@ -171,72 +169,42 @@ export function distance(
   if (h1.type === 'solid' && h2.type === 'solid') {
     const buf = bk.solidToSolidDistance(h1.id, h2.id);
     return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      value: buf[0]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point1: [buf[1]!, buf[2]!, buf[3]!],
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point2: [buf[4]!, buf[5]!, buf[6]!],
+      value: wasmIndex(buf, 0),
+      point1: vec3At(buf, 1),
+      point2: vec3At(buf, 4),
     };
   }
 
-  // Point to solid
-  if (h1.type === 'vertex' && h2.type === 'solid') {
-    const pos = bk.getVertexPosition(h1.id);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const result = bk.pointToSolidDistance(pos[0]!, pos[1]!, pos[2]!, h2.id);
+  // Point-to-{solid,face,edge}: same shape — fetch the vertex position then
+  // call the appropriate native distance function on it.
+  if (h1.type === 'vertex' && (h2.type === 'solid' || h2.type === 'face' || h2.type === 'edge')) {
+    const point1 = vec3At(bk.getVertexPosition(h1.id));
+    const result =
+      h2.type === 'solid'
+        ? bk.pointToSolidDistance(point1[0], point1[1], point1[2], h2.id)
+        : h2.type === 'face'
+          ? bk.pointToFaceDistance(point1[0], point1[1], point1[2], h2.id)
+          : bk.pointToEdgeDistance(point1[0], point1[1], point1[2], h2.id);
     return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      value: result[0]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point1: [pos[0]!, pos[1]!, pos[2]!],
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point2: [result[1]!, result[2]!, result[3]!],
-    };
-  }
-
-  // Point-to-face distance
-  if (h1.type === 'vertex' && h2.type === 'face') {
-    const pos = bk.getVertexPosition(h1.id);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const result = bk.pointToFaceDistance(pos[0]!, pos[1]!, pos[2]!, h2.id);
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      value: result[0]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point1: [pos[0]!, pos[1]!, pos[2]!],
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point2: [result[1]!, result[2]!, result[3]!],
-    };
-  }
-
-  // Point-to-edge distance
-  if (h1.type === 'vertex' && h2.type === 'edge') {
-    const pos = bk.getVertexPosition(h1.id);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const result = bk.pointToEdgeDistance(pos[0]!, pos[1]!, pos[2]!, h2.id);
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      value: result[0]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point1: [pos[0]!, pos[1]!, pos[2]!],
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      point2: [result[1]!, result[2]!, result[3]!],
+      value: wasmIndex(result, 0),
+      point1,
+      point2: vec3At(result, 1),
     };
   }
 
   // Fallback: use vertex positions for unsupported pairs
   const getPos = (s: BrepkitHandle): [number, number, number] => {
     if (s.type === 'vertex') {
-      const p = bk.getVertexPosition(s.id);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      return [p[0]!, p[1]!, p[2]!];
+      return vec3At(bk.getVertexPosition(s.id));
     }
     // Use bounding box center as approximation
     if (s.type === 'solid') {
       const bb = bk.boundingBox(s.id);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      return [(bb[0]! + bb[3]!) / 2, (bb[1]! + bb[4]!) / 2, (bb[2]! + bb[5]!) / 2];
+      return [
+        (wasmIndex(bb, 0) + wasmIndex(bb, 3)) / 2,
+        (wasmIndex(bb, 1) + wasmIndex(bb, 4)) / 2,
+        (wasmIndex(bb, 2) + wasmIndex(bb, 5)) / 2,
+      ];
     }
     return [0, 0, 0];
   };
@@ -269,21 +237,15 @@ export function surfaceCurvature(
       `brepkit: measureCurvatureAtSurface returned ${data.length} values, expected 8`
     );
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  const k1 = data[0]!;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-  const k2 = data[1]!;
-  const gaussian = k1 * k2;
-  const mean = (k1 + k2) / 2;
+  const k1 = wasmIndex(data, 0);
+  const k2 = wasmIndex(data, 1);
   return {
-    gaussian,
-    mean,
+    gaussian: k1 * k2,
+    mean: (k1 + k2) / 2,
     max: Math.max(k1, k2),
     min: Math.min(k1, k2),
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    maxDirection: [data[2]!, data[3]!, data[4]!],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    minDirection: [data[5]!, data[6]!, data[7]!],
+    maxDirection: vec3At(data, 2),
+    minDirection: vec3At(data, 5),
   };
 }
 
@@ -300,30 +262,27 @@ export function surfaceCenterOfMass(
     cz = 0,
     totalArea = 0;
   for (let t = 0; t < idx.length; t += 3) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const i0 = idx[t]! * 3,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      i1 = idx[t + 1]! * 3,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      i2 = idx[t + 2]! * 3;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const tcx = (pos[i0]! + pos[i1]! + pos[i2]!) / 3;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const tcy = (pos[i0 + 1]! + pos[i1 + 1]! + pos[i2 + 1]!) / 3;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const tcz = (pos[i0 + 2]! + pos[i1 + 2]! + pos[i2 + 2]!) / 3;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const ux = pos[i1]! - pos[i0]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      uy = pos[i1 + 1]! - pos[i0 + 1]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      uz = pos[i1 + 2]! - pos[i0 + 2]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    const vx = pos[i2]! - pos[i0]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      vy = pos[i2 + 1]! - pos[i0 + 1]!,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      vz = pos[i2 + 2]! - pos[i0 + 2]!;
+    const i0 = wasmIndex(idx, t) * 3;
+    const i1 = wasmIndex(idx, t + 1) * 3;
+    const i2 = wasmIndex(idx, t + 2) * 3;
+    const p0x = wasmIndex(pos, i0);
+    const p0y = wasmIndex(pos, i0 + 1);
+    const p0z = wasmIndex(pos, i0 + 2);
+    const p1x = wasmIndex(pos, i1);
+    const p1y = wasmIndex(pos, i1 + 1);
+    const p1z = wasmIndex(pos, i1 + 2);
+    const p2x = wasmIndex(pos, i2);
+    const p2y = wasmIndex(pos, i2 + 1);
+    const p2z = wasmIndex(pos, i2 + 2);
+    const tcx = (p0x + p1x + p2x) / 3;
+    const tcy = (p0y + p1y + p2y) / 3;
+    const tcz = (p0z + p1z + p2z) / 3;
+    const ux = p1x - p0x,
+      uy = p1y - p0y,
+      uz = p1z - p0z;
+    const vx = p2x - p0x,
+      vy = p2y - p0y,
+      vz = p2z - p0z;
     const faceArea =
       0.5 *
       Math.sqrt((uy * vz - uz * vy) ** 2 + (uz * vx - ux * vz) ** 2 + (ux * vy - uy * vx) ** 2);

--- a/src/utils/vec3.ts
+++ b/src/utils/vec3.ts
@@ -25,3 +25,14 @@ export type Vec3 = readonly [number, number, number];
 export function wasmIndex<T>(arr: ArrayLike<T>, i: number): T {
   return arr[i] as T;
 }
+
+/**
+ * Extract a 3-element tuple from a numeric array starting at `offset`.
+ * Equivalent to `[arr[offset]!, arr[offset+1]!, arr[offset+2]!]` but typed
+ * as `[T, T, T]` so no eslint-disable comments are needed at the call site.
+ *
+ * Common use cases: WASM result buffers (xyz, bbox min/max, witness points).
+ */
+export function vec3At<T>(arr: ArrayLike<T>, offset = 0): [T, T, T] {
+  return [arr[offset] as T, arr[offset + 1] as T, arr[offset + 2] as T];
+}


### PR DESCRIPTION
## Summary

The codebase had 127 \`// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index\` annotations because \`noUncheckedIndexedAccess\` types every \`arr[i]\` as \`T | undefined\`.

This adds a small \`vec3At(arr, offset?)\` helper to \`utils/vec3.ts\` and uses it (together with the existing \`wasmIndex\`) to delete the annotation noise from the three heaviest offenders:

- \`brepkit/measureOps.ts\`: **38 → 0** disables
- \`brepkit/geometryOps.ts\`: **29 → 0** disables
- \`brepkit/kernel2dOps.ts\`: **26 → 0** disables (also extracted \`refineUVSamples\` to keep \`extractCurve2dFromEdge\` under the pattern checker's function-line limit)

Net: **93 fewer disable annotations** across \`src/\`, **49 fewer lines of code**, no behavior change.

## Test plan

- [x] typecheck / lint / format / patterns / boundaries
- [x] \`npx vitest run --project occt\` measureFns/curvature/sketcher2d/kernel2d: 129/129 pass
- [x] \`TEST_KERNEL=brepkit\` measureFns/curvature: 24/24 pass + skips