### PR TITLE
refactor(kernel): finish WASM-index eslint-disable cleanup

### DIFF
--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -25,6 +25,7 @@ import {
   hasBooleanOptions,
 } from './helpers.js';
 import { extractPlaneFromFace } from './internalOps.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 export function fuse(
   bk: BrepkitKernel,
@@ -116,8 +117,7 @@ export function section(
     return compoundHandle(bk.makeCompound([]));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const firstWireId = bk.getFaceOuterWire(faceIds[0]!);
+  const firstWireId = bk.getFaceOuterWire(wasmIndex(faceIds, 0));
   return wireHandle(firstWireId);
 }
 
@@ -127,8 +127,7 @@ export function fuseAll(
   options?: BooleanOptions
 ): KernelShape {
   if (shapes.length === 0) throw new Error('brepkit: fuseAll requires at least one shape');
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  if (shapes.length === 1) return shapes[0]!;
+  if (shapes.length === 1) return wasmIndex(shapes, 0);
 
   if (bk.compoundFuse) {
     const solidIds: number[] = [];
@@ -159,8 +158,7 @@ export function fuseAll(
     }
     current = next;
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  return current[0]!;
+  return wasmIndex(current, 0);
 }
 
 export function cutAll(
@@ -267,13 +265,11 @@ export function hull(bk: BrepkitKernel, shapes: KernelShape[], _tolerance: numbe
       const vertIds = toArray(bk.getSolidVertices(h.id));
       for (const vid of vertIds) {
         const pos = bk.getVertexPosition(vid);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-        coords.push(pos[0]!, pos[1]!, pos[2]!);
+        coords.push(wasmIndex(pos, 0), wasmIndex(pos, 1), wasmIndex(pos, 2));
       }
     } else if (h.type === 'vertex') {
       const pos = bk.getVertexPosition(h.id);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-      coords.push(pos[0]!, pos[1]!, pos[2]!);
+      coords.push(wasmIndex(pos, 0), wasmIndex(pos, 1), wasmIndex(pos, 2));
     }
   }
   if (coords.length < 12) throw new Error('brepkit: hull requires enough points');
@@ -303,16 +299,14 @@ export function buildSolidFromFaces(
 ): KernelShape {
   const positions = new Float64Array(points.length * 3);
   for (let i = 0; i < points.length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const p = points[i]!;
+    const p = wasmIndex(points, i);
     positions[i * 3] = p.x;
     positions[i * 3 + 1] = p.y;
     positions[i * 3 + 2] = p.z;
   }
   const indices = new Uint32Array(faces.length * 3);
   for (let i = 0; i < faces.length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const f = faces[i]!;
+    const f = wasmIndex(faces, i);
     indices[i * 3] = f[0];
     indices[i * 3 + 1] = f[1];
     indices[i * 3 + 2] = f[2];

--- a/src/kernel/brepkit/evolutionOps.ts
+++ b/src/kernel/brepkit/evolutionOps.ts
@@ -26,6 +26,7 @@ import {
 } from './helpers.js';
 import { applyMatrix } from './internalOps.js';
 import { translate, rotate, mirror, scale, generalTransform } from './transformOps.js';
+import { wasmIndex } from '@/utils/vec3.js';
 import { fuse, cut, intersect } from './booleanOps.js';
 import { fillet, chamfer, shell, thicken, offset, draft } from './modifierOps.js';
 
@@ -101,12 +102,9 @@ function faceCentroidById(bk: BrepkitKernel, faceId: number): [number, number, n
     let cz = 0;
     const nVerts = pos.length / 3;
     for (let i = 0; i < pos.length; i += 3) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      cx += pos[i]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      cy += pos[i + 1]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-      cz += pos[i + 2]!;
+      cx += wasmIndex(pos, i);
+      cy += wasmIndex(pos, i + 1);
+      cz += wasmIndex(pos, i + 2);
     }
     return [cx / nVerts, cy / nVerts, cz / nVerts];
   } catch {

--- a/src/kernel/brepkit/helpers.ts
+++ b/src/kernel/brepkit/helpers.ts
@@ -11,6 +11,7 @@ import type { KernelShape, ShapeType } from '@/kernel/types.js';
 import type { BrepkitKernel } from './brepkitWasmTypes.js';
 import type { Curve2dHandle, BBox2dHandle } from '@/kernel/kernel2dTypes.js';
 import type { Curve2dObj, BBox2d as BkBBox2d } from '../geometry2d.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 // ---------------------------------------------------------------------------
 // Handle types
@@ -245,15 +246,14 @@ export function affineMatrix(
   linear: readonly number[],
   translation: readonly [number, number, number]
 ): number[] {
+  const li = (i: number) => wasmIndex(linear, i);
   // prettier-ignore
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
   return [
-    linear[0]!, linear[1]!, linear[2]!, translation[0],
-    linear[3]!, linear[4]!, linear[5]!, translation[1],
-    linear[6]!, linear[7]!, linear[8]!, translation[2],
-    0,          0,          0,          1,
+    li(0), li(1), li(2), translation[0],
+    li(3), li(4), li(5), translation[1],
+    li(6), li(7), li(8), translation[2],
+    0,     0,     0,     1,
   ];
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
 }
 
 /** Build a 4x4 reflection matrix for a plane defined by origin + normal. */

--- a/src/kernel/brepkit/internalOps.ts
+++ b/src/kernel/brepkit/internalOps.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_DEFLECTION,
 } from './helpers.js';
 import { iterShapes } from './topologyOps.js';
+import { vec3At, wasmIndex } from '@/utils/vec3.js';
 
 /** Apply a 4x4 row-major matrix to a shape (copy + transform). */
 export function applyMatrix(bk: BrepkitKernel, shape: KernelShape, matrix: number[]): KernelShape {
@@ -147,15 +148,12 @@ export function extractPlaneFromFace(
   } else {
     faceId = unwrap(faceShape, 'face');
   }
-  const n = bk.getFaceNormal(faceId);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const normal: [number, number, number] = [n[0]!, n[1]!, n[2]!];
+  const normal: [number, number, number] = vec3At(bk.getFaceNormal(faceId));
 
   const mesh = bk.tessellateFace(faceId, 1.0);
   const positions = mesh.positions;
   if (positions.length >= 3) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    return { point: [positions[0]!, positions[1]!, positions[2]!], normal };
+    return { point: vec3At(positions), normal };
   }
 
   return { point: [0, 0, 0], normal };
@@ -188,8 +186,14 @@ export function extractNurbsFromEdge(
   return {
     degree: 1,
     knots: [0, 0, 1, 1],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    controlPoints: [verts[0]!, verts[1]!, verts[2]!, verts[3]!, verts[4]!, verts[5]!],
+    controlPoints: [
+      wasmIndex(verts, 0),
+      wasmIndex(verts, 1),
+      wasmIndex(verts, 2),
+      wasmIndex(verts, 3),
+      wasmIndex(verts, 4),
+      wasmIndex(verts, 5),
+    ],
     weights: [1, 1],
   };
 }

--- a/src/kernel/brepkit/ioOps.ts
+++ b/src/kernel/brepkit/ioOps.ts
@@ -16,6 +16,7 @@ import {
   warnOnce,
   DEFAULT_DEFLECTION,
 } from './helpers.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 export function exportSTEP(bk: BrepkitKernel, shapes: KernelShape[]): string {
   if (shapes.length === 0) return '';
@@ -39,12 +40,10 @@ export function exportSTL(
   const solidIds = unwrapSolidsForExport(bk, shape, 'exportSTL');
   // Use the first solid; STL format doesn't natively support multi-solid
   if (binary) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const bytes: Uint8Array = bk.exportStl(solidIds[0]!, DEFAULT_DEFLECTION);
+    const bytes: Uint8Array = bk.exportStl(wasmIndex(solidIds, 0), DEFAULT_DEFLECTION);
     return bytes.buffer as ArrayBuffer;
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const bytes: Uint8Array = bk.exportStlAscii(solidIds[0]!, DEFAULT_DEFLECTION);
+  const bytes: Uint8Array = bk.exportStlAscii(wasmIndex(solidIds, 0), DEFAULT_DEFLECTION);
   return new TextDecoder().decode(bytes);
 }
 

--- a/src/kernel/brepkit/meshOps.ts
+++ b/src/kernel/brepkit/meshOps.ts
@@ -11,6 +11,7 @@ import type {
   MeshOptions,
 } from '@/kernel/types.js';
 import { type BrepkitHandle, unwrap, toArray, warnOnce, DEFAULT_DEFLECTION } from './helpers.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 export function mesh(
   bk: BrepkitKernel,
@@ -71,10 +72,8 @@ export function meshEdges(
 
   const edgeGroups: Array<{ start: number; count: number; edgeHash: number }> = [];
   for (let i = 0; i < edgeCount; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const startIdx = offsets[i]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const endIdx = i + 1 < edgeCount ? offsets[i + 1]! : positions.length;
+    const startIdx = wasmIndex(offsets, i);
+    const endIdx = i + 1 < edgeCount ? wasmIndex(offsets, i + 1) : positions.length;
     const pointCount = (endIdx - startIdx) / 3;
     edgeGroups.push({ start: startIdx / 3, count: pointCount, edgeHash: i });
   }
@@ -150,10 +149,8 @@ function meshSolidGrouped(
   }
   const faceGroups: Array<{ start: number; count: number; faceHash: number }> = [];
   for (let i = 0; i < data.faceOffsets.length - 1; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const start = data.faceOffsets[i]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const count = data.faceOffsets[i + 1]! - start;
+    const start = wasmIndex(data.faceOffsets, i);
+    const count = wasmIndex(data.faceOffsets, i + 1) - start;
     if (count === 0) continue; // degenerate face -- skip
     faceGroups.push({
       start,

--- a/src/kernel/brepkit/modifierOps.ts
+++ b/src/kernel/brepkit/modifierOps.ts
@@ -16,6 +16,7 @@ import {
   warnOnce,
 } from './helpers.js';
 import { iterShapes } from './topologyOps.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 export function fillet(
   bk: BrepkitKernel,
@@ -322,8 +323,7 @@ export function offsetWire2D(
   const result = bk.offsetPolygon2d(coords2d, offsetVal, 1e-10);
   const coords3d: number[] = [];
   for (let i = 0; i < result.length; i += 2) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index
-    coords3d.push(result[i]!, result[i + 1]!, 0);
+    coords3d.push(wasmIndex(result, i), wasmIndex(result, i + 1), 0);
   }
   const wireId: number = bk.makePolygonWire(coords3d);
   return wireHandle(wireId);

--- a/src/kernel/brepkit/topologyOps.ts
+++ b/src/kernel/brepkit/topologyOps.ts
@@ -17,6 +17,7 @@ import {
   toArray,
   syntheticCompounds,
 } from './helpers.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 export function iterShapes(bk: BrepkitKernel, shape: KernelShape, type: ShapeType): KernelShape[] {
   const h = unwrap(shape);
@@ -102,12 +103,10 @@ export function iterShapes(bk: BrepkitKernel, shape: KernelShape, type: ShapeTyp
         const results: KernelShape[] = [];
         for (const eid of edgeIds) {
           const verts = bk.getEdgeVertices(eid);
-          /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
           const coords = [
-            [verts[0]!, verts[1]!, verts[2]!],
-            [verts[3]!, verts[4]!, verts[5]!],
+            [wasmIndex(verts, 0), wasmIndex(verts, 1), wasmIndex(verts, 2)],
+            [wasmIndex(verts, 3), wasmIndex(verts, 4), wasmIndex(verts, 5)],
           ] as const;
-          /* eslint-enable @typescript-eslint/no-non-null-assertion */
           for (const [x, y, z] of coords) {
             const key = `${x},${y},${z}`;
             if (!seen.has(key)) {
@@ -125,10 +124,8 @@ export function iterShapes(bk: BrepkitKernel, shape: KernelShape, type: ShapeTyp
       if (type === 'edge') return [shape];
       if (type === 'vertex') {
         const verts = bk.getEdgeVertices(h);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-        const v1 = bk.makeVertex(verts[0]!, verts[1]!, verts[2]!);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-        const v2 = bk.makeVertex(verts[3]!, verts[4]!, verts[5]!);
+        const v1 = bk.makeVertex(wasmIndex(verts, 0), wasmIndex(verts, 1), wasmIndex(verts, 2));
+        const v2 = bk.makeVertex(wasmIndex(verts, 3), wasmIndex(verts, 4), wasmIndex(verts, 5));
         return [vertexHandle(v1), vertexHandle(v2)];
       }
       return [];

--- a/src/kernel/occt/kernel2dOps.ts
+++ b/src/kernel/occt/kernel2dOps.ts
@@ -13,6 +13,7 @@ import type { Curve2dHandle, BBox2dHandle } from '@/kernel/kernel2dTypes.js';
 import type { Curve2dObj, BBox2d } from '../geometry2d.js';
 import * as g2d from '../geometry2d.js';
 import { iterShapes } from './topologyOps.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 // ---------------------------------------------------------------------------
 // Local helpers (no imports from brepkit)
@@ -377,10 +378,8 @@ export function createAffinityGTrsf2d(
     py = dx / len;
   const k = ratio - 1;
   const m = [1 + k * px * px, k * px * py, 0, k * py * px, 1 + k * py * py, 0, 0, 0, 1];
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const txv = ox - m[0]! * ox - m[1]! * oy;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  const tyv = oy - m[3]! * ox - m[4]! * oy;
+  const txv = ox - wasmIndex(m, 0) * ox - wasmIndex(m, 1) * oy;
+  const tyv = oy - wasmIndex(m, 3) * ox - wasmIndex(m, 4) * oy;
   return _gtrsf(m, txv, tyv);
 }
 
@@ -404,10 +403,8 @@ export function createMirrorGTrsf2d(
     const m = [2 * nx * nx - 1, 2 * nx * ny, 0, 2 * nx * ny, 2 * ny * ny - 1, 0, 0, 0, 1];
     const apx = ox ?? cx,
       apy = oy ?? cy;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const txv = apx - m[0]! * apx - m[1]! * apy;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    const tyv = apy - m[3]! * apx - m[4]! * apy;
+    const txv = apx - wasmIndex(m, 0) * apx - wasmIndex(m, 1) * apy;
+    const tyv = apy - wasmIndex(m, 3) * apx - wasmIndex(m, 4) * apy;
     return _gtrsf(m, txv, tyv);
   }
   return _gtrsf([-1, 0, 0, 0, -1, 0, 0, 0, 1], 2 * cx, 2 * cy);
@@ -431,28 +428,25 @@ export function setGTrsf2dTranslationPart(gtrsf: KernelType, dx: number, dy: num
 export function multiplyGTrsf2d(base: KernelType, other: KernelType): void {
   const a = base.m as number[],
     b = other.m as number[];
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
-  const r = [
-    a[0]! * b[0]! + a[1]! * b[3]! + a[2]! * b[6]!,
-    a[0]! * b[1]! + a[1]! * b[4]! + a[2]! * b[7]!,
-    a[0]! * b[2]! + a[1]! * b[5]! + a[2]! * b[8]!,
-    a[3]! * b[0]! + a[4]! * b[3]! + a[5]! * b[6]!,
-    a[3]! * b[1]! + a[4]! * b[4]! + a[5]! * b[7]!,
-    a[3]! * b[2]! + a[4]! * b[5]! + a[5]! * b[8]!,
-    a[6]! * b[0]! + a[7]! * b[3]! + a[8]! * b[6]!,
-    a[6]! * b[1]! + a[7]! * b[4]! + a[8]! * b[7]!,
-    a[6]! * b[2]! + a[7]! * b[5]! + a[8]! * b[8]!,
+  const ai = (i: number) => wasmIndex(a, i);
+  const bi = (i: number) => wasmIndex(b, i);
+  base.m = [
+    ai(0) * bi(0) + ai(1) * bi(3) + ai(2) * bi(6),
+    ai(0) * bi(1) + ai(1) * bi(4) + ai(2) * bi(7),
+    ai(0) * bi(2) + ai(1) * bi(5) + ai(2) * bi(8),
+    ai(3) * bi(0) + ai(4) * bi(3) + ai(5) * bi(6),
+    ai(3) * bi(1) + ai(4) * bi(4) + ai(5) * bi(7),
+    ai(3) * bi(2) + ai(4) * bi(5) + ai(5) * bi(8),
+    ai(6) * bi(0) + ai(7) * bi(3) + ai(8) * bi(6),
+    ai(6) * bi(1) + ai(7) * bi(4) + ai(8) * bi(7),
+    ai(6) * bi(2) + ai(7) * bi(5) + ai(8) * bi(8),
   ];
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
-  base.m = r;
   const oldTx = base.tx as number,
     oldTy = base.ty as number;
   const otx = Number(other.tx) || 0,
     oty = Number(other.ty) || 0;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  base.tx = a[0]! * otx + a[1]! * oty + oldTx;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-  base.ty = a[3]! * otx + a[4]! * oty + oldTy;
+  base.tx = ai(0) * otx + ai(1) * oty + oldTx;
+  base.ty = ai(3) * otx + ai(4) * oty + oldTy;
 }
 
 export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType): Curve2dHandle {
@@ -460,13 +454,15 @@ export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType)
   const m = (gtrsf.m as number[] | undefined) ?? [1, 0, 0, 0, 1, 0, 0, 0, 1];
   const tx = Number(gtrsf.tx) || 0,
     ty = Number(gtrsf.ty) || 0;
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM index */
+  const m0 = wasmIndex(m, 0),
+    m1 = wasmIndex(m, 1),
+    m3 = wasmIndex(m, 3),
+    m4 = wasmIndex(m, 4);
   const isIdentityMatrix =
-    Math.abs(m[0]! - 1) < 1e-12 &&
-    Math.abs(m[4]! - 1) < 1e-12 &&
-    Math.abs(m[1]!) < 1e-12 &&
-    Math.abs(m[3]!) < 1e-12;
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    Math.abs(m0 - 1) < 1e-12 &&
+    Math.abs(m4 - 1) < 1e-12 &&
+    Math.abs(m1) < 1e-12 &&
+    Math.abs(m3) < 1e-12;
   if (isIdentityMatrix) {
     return g2d.translateCurve2d(c, tx, ty);
   }
@@ -476,8 +472,7 @@ export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType)
   for (let i = 0; i <= N; i++) {
     const t = bounds.first + ((bounds.last - bounds.first) * i) / N;
     const [px, py] = g2d.evaluateCurve2d(c, t);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM index
-    pts.push([m[0]! * px + m[1]! * py + tx, m[3]! * px + m[4]! * py + ty]);
+    pts.push([m0 * px + m1 * py + tx, m3 * px + m4 * py + ty]);
   }
   return g2d.makeBezier2d(pts);
 }


### PR DESCRIPTION
## Summary

Follow-up to #938. Applies \`wasmIndex\`/\`vec3At\` to the **remaining** files that still carried \`// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM array index\` annotations:

- \`occt/kernel2dOps.ts\` (-9 disables)
- \`brepkit/booleanOps.ts\` (-7)
- \`brepkit/meshOps.ts\` (-4)
- \`brepkit/topologyOps.ts\` (-3)
- \`brepkit/internalOps.ts\` (-3)
- \`brepkit/evolutionOps.ts\` (-3)
- \`brepkit/ioOps.ts\` (-2)
- \`brepkit/helpers.ts\` (-1 block-disable on \`affineMatrix\`)
- \`brepkit/modifierOps.ts\` (-1)

\`src/\` now has **zero** \`WASM index\` eslint-disable annotations remaining. Every site is a structurally-equivalent rewrite using the helpers introduced in #938.

## Test plan

- [x] typecheck / lint / format / patterns / boundaries
- [x] occt-wasm: 181/181 pass (measureFns/curvature/booleanFns/sketcher2d)
- [x] brepkit: 57/57 pass on measureFns; 3 pre-existing booleanFns failures match main (unrelated to this change)