### PR TITLE
refactor(kernel,io): replace remaining bounded-index eslint-disables with wasmIndex/vec3At

### DIFF
--- a/src/io/gltfExportFns.ts
+++ b/src/io/gltfExportFns.ts
@@ -7,6 +7,7 @@
 
 import type { ShapeMesh } from '@/topology/meshFns.js';
 import { getAtOrThrow } from '@/utils/arrayAccess.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -100,12 +101,9 @@ function computeMinMax(data: Float32Array): { min: number[]; max: number[] } {
   const max = [-Infinity, -Infinity, -Infinity];
   for (let i = 0; i < data.length; i += 3) {
     for (let j = 0; j < 3; j++) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- j < 3, typed array access
-      const v = data[i + j]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- j < 3, array has 3 elements
-      if (v < min[j]!) min[j] = v;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- j < 3, array has 3 elements
-      if (v > max[j]!) max[j] = v;
+      const v = wasmIndex(data, i + j);
+      if (v < wasmIndex(min, j)) min[j] = v;
+      if (v > wasmIndex(max, j)) max[j] = v;
     }
   }
   return { min, max };
@@ -403,8 +401,7 @@ function computeMaterialLayout(
     for (const gi of groupIndices) {
       const fg = getAtOrThrow(faceGroups, gi);
       for (let i = fg.start; i < fg.start + fg.count; i++) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- i within triangles bounds
-        indices[offset++] = triangles[i]!;
+        indices[offset++] = wasmIndex(triangles, i);
       }
     }
     primitiveData.push({ indices, materialIdx: matIdx });

--- a/src/io/objExportFns.ts
+++ b/src/io/objExportFns.ts
@@ -4,18 +4,16 @@
  */
 
 import type { ShapeMesh } from '@/topology/meshFns.js';
+import { vec3At as readVec3 } from '@/utils/vec3.js';
 
 /** Read a vec3 from a typed array at the given vertex index. */
 function vec3At(arr: Float32Array, i: number): [number, number, number] {
-  const off = i * 3;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
-  return [arr[off]!, arr[off + 1]!, arr[off + 2]!];
+  return readVec3(arr, i * 3);
 }
 
 /** Read a triangle's three vertex indices from the triangles array. */
 function triAt(arr: Uint32Array, offset: number): [number, number, number] {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
-  return [arr[offset]!, arr[offset + 1]!, arr[offset + 2]!];
+  return readVec3(arr, offset);
 }
 
 /**

--- a/src/kernel/brepkit/evolutionOps.ts
+++ b/src/kernel/brepkit/evolutionOps.ts
@@ -139,8 +139,7 @@ function matchFacesGeometrically(
     centroid: [number, number, number];
   }[] = [];
   for (let i = 0; i < hashCount; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-    const fid = inputFaceIds[i]!;
+    const fid = wasmIndex(inputFaceIds, i);
     try {
       const normal = bk.getFaceNormal(fid);
       const centroid = faceCentroidById(bk, fid);
@@ -184,8 +183,7 @@ function matchFacesGeometrically(
     let bestIdx = -1;
 
     for (let i = 0; i < inputSigs.length; i++) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-      const inp = inputSigs[i]!;
+      const inp = wasmIndex(inputSigs, i);
       const dot =
         (out.normal[0] ?? 0) * (inp.normal[0] ?? 0) +
         (out.normal[1] ?? 0) * (inp.normal[1] ?? 0) +
@@ -203,8 +201,7 @@ function matchFacesGeometrically(
     }
 
     if (bestIdx >= 0) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-      const bestInput = inputSigs[bestIdx]!;
+      const bestInput = wasmIndex(inputSigs, bestIdx);
       const existing = modified.get(bestInput.hash) ?? [];
       existing.push(out.hash);
       modified.set(bestInput.hash, existing);
@@ -231,8 +228,7 @@ function matchFacesGeometrically(
   // Input faces not matched -> deleted
   for (let i = 0; i < inputSigs.length; i++) {
     if (!matchedInputIndices.has(i)) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-      deleted.add(inputSigs[i]!.hash);
+      deleted.add(wasmIndex(inputSigs, i).hash);
     }
   }
 }
@@ -264,8 +260,7 @@ function buildEvolution(
     if (isTransform) {
       // Transforms: 1:1 mapping -- each input face maps to the corresponding output face
       for (let i = 0; i < inputFaceHashes.length && i < outputHashes.length; i++) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-        modified.set(inputFaceHashes[i]!, [outputHashes[i]!]);
+        modified.set(wasmIndex(inputFaceHashes, i), [wasmIndex(outputHashes, i)]);
       }
     } else {
       // Boolean/modifier: compare face hash sets
@@ -290,8 +285,7 @@ function buildEvolution(
         }
         const newFaces = outputHashes.filter((fh) => !inputSet.has(fh));
         if (newFaces.length > 0 && inputFaceHashes.length > 0) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-          generated.set(inputFaceHashes[0]!, newFaces);
+          generated.set(wasmIndex(inputFaceHashes, 0), newFaces);
         }
         for (const hash of inputFaceHashes) {
           if (!outputSet.has(hash)) {
@@ -313,12 +307,10 @@ function buildEvolution(
       } else {
         // No original shape available -- positional fallback
         for (let i = 0; i < inputFaceHashes.length && i < outputHashes.length; i++) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-          modified.set(inputFaceHashes[i]!, [outputHashes[i]!]);
+          modified.set(wasmIndex(inputFaceHashes, i), [wasmIndex(outputHashes, i)]);
         }
         if (outputHashes.length > inputFaceHashes.length && inputFaceHashes.length > 0) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-          generated.set(inputFaceHashes[0]!, outputHashes.slice(inputFaceHashes.length));
+          generated.set(wasmIndex(inputFaceHashes, 0), outputHashes.slice(inputFaceHashes.length));
         }
       }
     }

--- a/src/kernel/brepkit/modifierOps.ts
+++ b/src/kernel/brepkit/modifierOps.ts
@@ -177,12 +177,9 @@ export function shell(
           oz = 0;
         for (const vid of origVerts) {
           const pos = bk.getVertexPosition(vid);
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-          ox += pos[0]!;
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-          oy += pos[1]!;
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-          oz += pos[2]!;
+          ox += wasmIndex(pos, 0);
+          oy += wasmIndex(pos, 1);
+          oz += wasmIndex(pos, 2);
         }
         const n = origVerts.length;
         ox /= n;
@@ -200,12 +197,9 @@ export function shell(
               sz = 0;
             for (const svid of sv) {
               const spos = bk.getVertexPosition(svid);
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-              sx += spos[0]!;
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-              sy += spos[1]!;
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-              sz += spos[2]!;
+              sx += wasmIndex(spos, 0);
+              sy += wasmIndex(spos, 1);
+              sz += wasmIndex(spos, 2);
             }
             const sn = sv.length;
             sx /= sn;
@@ -315,8 +309,7 @@ export function offsetWire2D(
   const coords2d: number[] = [];
   for (const edge of edges) {
     const verts = bk.getEdgeVertices(unwrap(edge, 'edge'));
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- WASM return value
-    coords2d.push(verts[0]!, verts[1]!);
+    coords2d.push(wasmIndex(verts, 0), wasmIndex(verts, 1));
   }
   if (coords2d.length < 6) return wire;
 

--- a/src/kernel/geometry2d.ts
+++ b/src/kernel/geometry2d.ts
@@ -15,6 +15,8 @@
  * @module
  */
 
+import { wasmIndex } from '@/utils/vec3.js';
+
 // ---------------------------------------------------------------------------
 // 2D Curve types
 // ---------------------------------------------------------------------------
@@ -140,10 +142,8 @@ export function tangentCurve2d(c: Curve2dObj, t: number): [number, number] {
     }
     case 'bspline': {
       const h = 1e-8;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-      const kFirst = c.knots[0]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-      const kLast = c.knots[c.knots.length - 1]!;
+      const kFirst = wasmIndex(c.knots, 0);
+      const kLast = wasmIndex(c.knots, c.knots.length - 1);
       const p0 = evaluateBSpline2d(c, Math.max(kFirst, t - h));
       const p1 = evaluateBSpline2d(c, Math.min(kLast, t + h));
       const dt = Math.min(kLast, t + h) - Math.max(kFirst, t - h);
@@ -168,8 +168,7 @@ export function curveBounds(c: Curve2dObj): { first: number; last: number } {
     case 'bezier':
       return { first: 0, last: 1 };
     case 'bspline':
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- known-valid
-      return { first: c.knots[0]!, last: c.knots[c.knots.length - 1]! };
+      return { first: wasmIndex(c.knots, 0), last: wasmIndex(c.knots, c.knots.length - 1) };
     case 'trimmed':
       return { first: 0, last: 1 };
   }
@@ -661,10 +660,8 @@ function numericalIntersect(
   const crossTol = Math.max(tolerance * 100, 0.5);
   const seg2Bounds = new Float64Array(N * 6); // xmin, xmax, ymin, ymax, tmid, _pad per segment
   for (let j = 0; j < N; j++) {
-    /* eslint-disable @typescript-eslint/no-non-null-assertion -- known array index */
-    const a = pts2[j]!,
-      b = pts2[j + 1]!;
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    const a = wasmIndex(pts2, j);
+    const b = wasmIndex(pts2, j + 1);
     const off = j * 6;
     seg2Bounds[off] = Math.min(a.x, b.x);
     seg2Bounds[off + 1] = Math.max(a.x, b.x);
@@ -677,10 +674,8 @@ function numericalIntersect(
   const candidates: { t1: number; t2: number }[] = [];
   const selfMinSep = (b1.last - b1.first) / 5;
   for (let i = 0; i < N; i++) {
-    /* eslint-disable @typescript-eslint/no-non-null-assertion -- known array index */
-    const p1a = pts1[i]!;
-    const p1b = pts1[i + 1]!;
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    const p1a = wasmIndex(pts1, i);
+    const p1b = wasmIndex(pts1, i + 1);
     // Hoist outer segment AABB (computed once per outer iteration)
     const x1min = Math.min(p1a.x, p1b.x) - crossTol;
     const x1max = Math.max(p1a.x, p1b.x) + crossTol;
@@ -689,11 +684,10 @@ function numericalIntersect(
     const t1mid = (p1a.t + p1b.t) / 2;
     for (let j = 0; j < N; j++) {
       const off = j * 6;
-      /* eslint-disable @typescript-eslint/no-non-null-assertion -- typed array indices known valid */
-      if (x1max < seg2Bounds[off]! || seg2Bounds[off + 1]! < x1min) continue;
-      if (y1max < seg2Bounds[off + 2]! || seg2Bounds[off + 3]! < y1min) continue;
-      const t2mid = seg2Bounds[off + 4]!;
-      /* eslint-enable @typescript-eslint/no-non-null-assertion */
+      if (x1max < wasmIndex(seg2Bounds, off) || wasmIndex(seg2Bounds, off + 1) < x1min) continue;
+      if (y1max < wasmIndex(seg2Bounds, off + 2) || wasmIndex(seg2Bounds, off + 3) < y1min)
+        continue;
+      const t2mid = wasmIndex(seg2Bounds, off + 4);
       if (isSelf && Math.abs(t1mid - t2mid) < selfMinSep) continue;
       candidates.push({ t1: t1mid, t2: t2mid });
     }
@@ -844,27 +838,24 @@ function evaluateBezier(poles: [number, number][], t: number): [number, number] 
   // De Casteljau
   const n = poles.length;
   const work = poles.map(([x, y]) => [x, y] as [number, number]);
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM array indices */
   for (let r = 1; r < n; r++) {
     for (let i = 0; i < n - r; i++) {
-      const wi = work[i]!;
-      const wi1 = work[i + 1]!;
+      const wi = wasmIndex(work, i);
+      const wi1 = wasmIndex(work, i + 1);
       wi[0] = (1 - t) * wi[0] + t * wi1[0];
       wi[1] = (1 - t) * wi[1] + t * wi1[1];
     }
   }
-  return work[0]!;
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+  return wasmIndex(work, 0);
 }
 
 function evaluateBSpline2d(c: BSpline2d, t: number): [number, number] {
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM array indices */
   // Expand knots with multiplicities
   const fullKnots: number[] = [];
   for (let i = 0; i < c.knots.length; i++) {
     const mult = c.multiplicities[i] ?? 1;
     for (let j = 0; j < mult; j++) {
-      fullKnots.push(c.knots[i]!);
+      fullKnots.push(wasmIndex(c.knots, i));
     }
   }
 
@@ -874,23 +865,23 @@ function evaluateBSpline2d(c: BSpline2d, t: number): [number, number] {
   const k = fullKnots.length;
 
   // Clamp t to domain
-  const tClamped = Math.max(fullKnots[p]!, Math.min(fullKnots[k - p - 1]!, t));
+  const tClamped = Math.max(wasmIndex(fullKnots, p), Math.min(wasmIndex(fullKnots, k - p - 1), t));
 
   // Find span
   let span = p;
   for (let i = p; i < k - p - 1; i++) {
-    if (tClamped >= fullKnots[i]! && tClamped < fullKnots[i + 1]!) {
+    if (tClamped >= wasmIndex(fullKnots, i) && tClamped < wasmIndex(fullKnots, i + 1)) {
       span = i;
       break;
     }
   }
-  if (tClamped >= fullKnots[k - p - 1]!) span = k - p - 2;
+  if (tClamped >= wasmIndex(fullKnots, k - p - 1)) span = k - p - 2;
 
   // Extract relevant control points
   const d: [number, number][] = [];
   for (let j = 0; j <= p; j++) {
     const idx = Math.min(span - p + j, n - 1);
-    const pole = c.poles[Math.max(0, idx)]!;
+    const pole = wasmIndex(c.poles, Math.max(0, idx));
     d.push([pole[0], pole[1]]);
   }
 
@@ -902,13 +893,12 @@ function evaluateBSpline2d(c: BSpline2d, t: number): [number, number] {
       const right = fullKnots[i + p - r + 1] ?? 1;
       const denom = right - left;
       const alpha = denom > 1e-15 ? (tClamped - left) / denom : 0;
-      const dj = d[j]!;
-      const djPrev = d[j - 1]!;
+      const dj = wasmIndex(d, j);
+      const djPrev = wasmIndex(d, j - 1);
       dj[0] = (1 - alpha) * djPrev[0] + alpha * dj[0];
       dj[1] = (1 - alpha) * djPrev[1] + alpha * dj[1];
     }
   }
 
-  return d[p]!;
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+  return wasmIndex(d, p);
 }

--- a/src/kernel/occt/advancedOps.ts
+++ b/src/kernel/occt/advancedOps.ts
@@ -11,6 +11,7 @@
 import type { KernelInstance, KernelShape, KernelType, OperationResult } from '@/kernel/types.js';
 import { transformWithEvolution } from './evolutionOps.js';
 import { uniqueIOFilename } from '@/utils/ioFilename.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 // ---------------------------------------------------------------------------
 // Non-orthogonal general transform (gp_GTrsf path)
@@ -527,8 +528,7 @@ export function bsplineSurface(
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       const idx = r * cols + c;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounded by rows*cols
-      const pt = points[idx]!;
+      const pt = wasmIndex(points, idx);
       const pnt = new oc.gp_Pnt_3(pt[0], pt[1], pt[2]);
       arr.SetValue_1(r + 1, c + 1, pnt);
       pnt.delete();
@@ -569,14 +569,10 @@ export function triangulatedSurface(
       const i01 = r * cols + (c + 1);
       const i11 = (r + 1) * cols + (c + 1);
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounded by grid
-      const p00 = points[i00]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounded by grid
-      const p10 = points[i10]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounded by grid
-      const p01 = points[i01]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounded by grid
-      const p11 = points[i11]!;
+      const p00 = wasmIndex(points, i00);
+      const p10 = wasmIndex(points, i10);
+      const p01 = wasmIndex(points, i01);
+      const p11 = wasmIndex(points, i11);
 
       // Triangle 1: p00, p10, p01
       const face1 = makeTriFace(oc, p00, p10, p01);

--- a/src/kernel/occt/booleanOps.ts
+++ b/src/kernel/occt/booleanOps.ts
@@ -15,6 +15,7 @@ import type {
 } from '@/kernel/types.js';
 import { perfTimer } from '../perfStats.js';
 import { cppFuseAll, cppCutAll } from './booleanBatchOps.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 /** Tolerance passed to OCCT SimplifyResult (ShapeUpgrade_UnifySameDomain). */
 const SIMPLIFY_TOLERANCE = 1e-3;
@@ -276,8 +277,7 @@ function fuseAllPairwiseRange(
 ): KernelShape {
   options.signal?.throwIfAborted();
   const count = end - start;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked by caller
-  if (count === 1) return shapes[start]!;
+  if (count === 1) return wasmIndex(shapes, start);
   if (count === 2) {
     return fuse(oc, shapes[start], shapes[start + 1], { ...options, simplify: false });
   }
@@ -317,8 +317,7 @@ export function fuseAll(
   options: BooleanOptions = {}
 ): KernelShape {
   if (shapes.length === 0) throw new Error('fuseAll requires at least one shape');
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length checked above
-  if (shapes.length === 1) return shapes[0]!;
+  if (shapes.length === 1) return wasmIndex(shapes, 0);
 
   const { strategy = 'native' } = options;
   if (strategy === 'pairwise') {

--- a/src/kernel/occt/kernel2dOps.ts
+++ b/src/kernel/occt/kernel2dOps.ts
@@ -644,10 +644,8 @@ export function approximateCurve2dAsBSpline(
     for (let i = 0; i < curN; i++) {
       const tMid = bounds.first + ((bounds.last - bounds.first) * (i + 0.5)) / curN;
       const [ex, ey] = g2d.evaluateCurve2d(c, tMid);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- loop index
-      const p0 = poles[i]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- loop index
-      const p1 = poles[i + 1]!;
+      const p0 = wasmIndex(poles, i);
+      const p1 = wasmIndex(poles, i + 1);
       const mx = (p0[0] + p1[0]) / 2;
       const my = (p0[1] + p1[1]) / 2;
       const err = Math.sqrt((ex - mx) ** 2 + (ey - my) ** 2);
@@ -677,10 +675,8 @@ export function decomposeBSpline2dToBeziers(curve: Curve2dHandle): Curve2dHandle
   const breakpoints = [first, ...internalKnots, last];
   const result: Curve2dHandle[] = [];
   for (let i = 0; i < breakpoints.length - 1; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- loop index
-    const t0 = breakpoints[i]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- loop index
-    const t1 = breakpoints[i + 1]!;
+    const t0 = wasmIndex(breakpoints, i);
+    const t1 = wasmIndex(breakpoints, i + 1);
     const span = t1 - t0;
     if (span < 1e-15) continue;
     const p0 = g2d.evaluateCurve2d(c, t0);
@@ -881,8 +877,7 @@ function interpolatePoints3d(oc: KernelInstance, points: [number, number, number
   const pnts = new oc.TColgp_Array1OfPnt_2(1, points.length);
   const reusePnt = new oc.gp_Pnt_1();
   for (let i = 0; i < points.length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- loop index
-    const p = points[i]!;
+    const p = wasmIndex(points, i);
     reusePnt.SetCoord_2(p[0], p[1], p[2]);
     pnts.SetValue_1(i + 1, reusePnt);
   }
@@ -977,8 +972,7 @@ export function liftCurve2dToPlane(
   // Bezier/BSpline: lift control points directly
   if (c.__bk2d === 'bezier' || c.__bk2d === 'bspline') {
     const pts3d = c.poles.map(([u, v]) => lift(u, v));
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- loop index
-    if (pts3d.length === 2) return makeLineEdge3d(oc, pts3d[0]!, pts3d[1]!);
+    if (pts3d.length === 2) return makeLineEdge3d(oc, wasmIndex(pts3d, 0), wasmIndex(pts3d, 1));
     return interpolatePoints3d(oc, pts3d);
   }
 

--- a/src/kernel/occtWasm/topologyOps.ts
+++ b/src/kernel/occtWasm/topologyOps.ts
@@ -16,6 +16,7 @@ import {
   unwrap,
   wrapResult,
 } from './helpers.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 export function iterShapes(k: OcctKernelWasm, shape: KernelShape, type: ShapeType): KernelShape[] {
   const vec = k.getSubShapes(unwrap(shape), type);
@@ -76,10 +77,8 @@ export function edgeToFaceMap(k: OcctKernelWasm, shape: KernelShape): string {
   }
   const map: Record<number, number[]> = {};
   for (let i = 0; i + 1 < data.length; i += 2) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
-    const edgeHash = data[i]!;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- pairs
-    const faceHash = data[i + 1]!;
+    const edgeHash = wasmIndex(data, i);
+    const faceHash = wasmIndex(data, i + 1);
     if (!map[edgeHash]) map[edgeHash] = [];
     map[edgeHash].push(faceHash);
   }

--- a/src/measurement/interferenceFns.ts
+++ b/src/measurement/interferenceFns.ts
@@ -11,6 +11,7 @@ import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { type Result, ok, err, unwrap } from '@/core/result.js';
 import { validationError, BrepErrorCode } from '@/core/errors.js';
 import { getBounds, type Bounds3D } from '@/topology/shapeFns.js';
+import { wasmIndex } from '@/utils/vec3.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -124,10 +125,8 @@ export function checkAllInterferences(
 
   shapes.forEach((si, i) => {
     for (let j = i + 1; j < shapes.length; j++) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- j is bounds-checked
-      if (aabbDisjoint(boxes[i]!, boxes[j]!, tolerance)) continue;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- j is bounds-checked
-      const result = unwrap(checkInterference(si, shapes[j]!, tolerance));
+      if (aabbDisjoint(wasmIndex(boxes, i), wasmIndex(boxes, j), tolerance)) continue;
+      const result = unwrap(checkInterference(si, wasmIndex(shapes, j), tolerance));
       if (result.hasInterference) {
         pairs.push({ i, j, result });
       }


### PR DESCRIPTION
## Summary

Continues the cleanup from #938/#939 — sweeps non-WASM bounded-array-index disables (loops, fixed-size grids, paired data, splitAt outputs) using the same \`wasmIndex\`/\`vec3At\` helpers from \`utils/vec3.js\`.

Files touched and disables removed:

- \`kernel/geometry2d.ts\` (-13)
- \`kernel/brepkit/evolutionOps.ts\` (-8)
- \`kernel/brepkit/modifierOps.ts\` (-7)
- \`kernel/occt/kernel2dOps.ts\` (-6)
- \`kernel/occt/advancedOps.ts\` (-5)
- \`io/gltfExportFns.ts\` (-4)
- \`io/objExportFns.ts\` (-2)
- \`measurement/interferenceFns.ts\` (-2)
- \`kernel/occtWasm/topologyOps.ts\` (-2)
- \`kernel/occt/booleanOps.ts\` (-2)

Total: **51** fewer eslint-disable annotations across 10 files. \`src/\` now has 35 remaining non-null-assertion disables, most of which are legitimate linked-list or \`splitAt\` invariants (e.g. straightSkeleton's circular LAV).

## Test plan

- [x] typecheck / lint / format / patterns / boundaries
- [x] occt-wasm: 181/181 pass (measureFns / booleanFns / sketcher2d / curvature)