### PR TITLE
feat(api): add text and projection subpath barrels

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,26 @@
         "default": "./dist/sketching.cjs"
       }
     },
+    "./text": {
+      "import": {
+        "types": "./dist/text.d.ts",
+        "default": "./dist/text.js"
+      },
+      "require": {
+        "types": "./dist/text.d.ts",
+        "default": "./dist/text.cjs"
+      }
+    },
+    "./projection": {
+      "import": {
+        "types": "./dist/projection.d.ts",
+        "default": "./dist/projection.js"
+      },
+      "require": {
+        "types": "./dist/projection.d.ts",
+        "default": "./dist/projection.cjs"
+      }
+    },
     "./query": {
       "import": {
         "types": "./dist/query.d.ts",

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,0 +1,26 @@
+/**
+ * brepjs/projection — 3D-to-2D projection cameras and edge extraction.
+ *
+ * @example
+ * ```typescript
+ * import { createCamera, projectEdges } from 'brepjs/projection';
+ * ```
+ */
+
+export {
+  createCamera,
+  cameraLookAt,
+  cameraFromPlane,
+  projectEdges,
+  type Camera,
+} from './projection/cameraFns.js';
+
+export {
+  isProjectionPlane,
+  type ProjectionPlane,
+  type CubeFace,
+  type PlaneConfig,
+  PROJECTION_PLANES,
+} from './projection/projectionPlanes.js';
+
+export { makeProjectedEdges } from './projection/makeProjectedEdges.js';

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,0 +1,19 @@
+/**
+ * brepjs/text — Font loading and text-to-geometry conversion.
+ *
+ * @example
+ * ```typescript
+ * import { loadFont, sketchText } from 'brepjs/text';
+ * ```
+ */
+
+export {
+  loadFont,
+  getFont,
+  textBlueprints,
+  sketchText,
+  textMetrics,
+  fontMetrics,
+  type TextMetricsResult,
+  type FontMetricsResult,
+} from './text/textBlueprints.js';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
         operations: resolve(__dirname, 'src/operations.ts'),
         '2d': resolve(__dirname, 'src/2d.ts'),
         sketching: resolve(__dirname, 'src/sketching.ts'),
+        text: resolve(__dirname, 'src/text.ts'),
+        projection: resolve(__dirname, 'src/projection.ts'),
         query: resolve(__dirname, 'src/query.ts'),
         measurement: resolve(__dirname, 'src/measurement.ts'),
         io: resolve(__dirname, 'src/io.ts'),


### PR DESCRIPTION
## Summary

Layer 3 audit F11 — adds `brepjs/text` and `brepjs/projection` import paths to match the existing `brepjs/sketching` subpath. Brings Layer 3 in line with all Layer 2 subpath modules (`2d`, `operations`, `topology`, `io`, `query`, `measurement`, `worker`).

```ts
// Now possible
import { loadFont, sketchText } from 'brepjs/text';
import { createCamera, projectEdges } from 'brepjs/projection';
```

Pure additive: no existing imports break, root `brepjs` exports unchanged.

## Context

Part of the broader Layer 3 audit identified in chat — first of ~8-10 PRs. Other findings (sketcher2d.ts split, validity-type tightening, OO/Fns reconciliation, layer-boundary fix for `cannedBlueprints.ts`) will follow in their own PRs.

## Test plan
- [x] `npm run validate` (typecheck + lint + boundaries + format + changed tests)
- [x] `npm run build` (subpath bundles emit `dist/text.{js,cjs,d.ts}` and `dist/projection.{js,cjs,d.ts}`)
- [ ] CI green