### PR TITLE
refactor(sketching): tighten Sketches return types + document consumption

### DIFF
--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -171,6 +171,8 @@ export default class Sketch implements SketchInterface {
   /**
    * Revolves the drawing on an axis (defined by its direction and an origin
    * (defaults to the sketch origin)
+   *
+   * @remarks Consumes the sketch — calling this twice throws on the second call.
    */
   revolve(revolutionAxis?: PointInput, { origin }: { origin?: PointInput } = {}): Shape3D {
     const face = unwrap(makeFace(this.wire as ClosedWire & PlanarWire));
@@ -191,6 +193,8 @@ export default class Sketch implements SketchInterface {
    * give a profile to the extrusion (the endFactor will scale the face, and
    * the profile will define how the scale is applied (either linearly or with
    * a s-shape).
+   *
+   * @remarks Consumes the sketch — calling this twice throws on the second call.
    */
   extrude(
     extrusionDistance: number,
@@ -248,6 +252,9 @@ export default class Sketch implements SketchInterface {
   /**
    * Sweep along this sketch another sketch defined in the function
    * `sketchOnPlane`.
+   *
+   * @remarks Consumes both this sketch and the one returned by `sketchOnPlane` —
+   * calling either consumer twice throws on the second call.
    */
   sweepSketch(
     sketchOnPlane: (plane: Plane, origin: Vec3) => this,

--- a/src/sketching/sketches.ts
+++ b/src/sketching/sketches.ts
@@ -1,7 +1,7 @@
 import type { PointInput } from '@/core/types.js';
 import { makeCompound } from '@/topology/shapeHelpers.js';
 import type { ExtrusionProfile } from '@/operations/extrudeUtils.js';
-import type { AnyShape } from '@/core/shapeTypes.js';
+import type { Compound } from '@/core/shapeTypes.js';
 
 import type CompoundSketch from './compoundSketch.js';
 import Sketch from './sketch.js';
@@ -22,13 +22,13 @@ export default class Sketches {
   }
 
   /** Return all wires combined into a single compound shape. */
-  wires(): AnyShape {
+  wires(): Compound {
     const wires = this.sketches.map((s) => (s instanceof Sketch ? s.wire : s.wires));
     return makeCompound(wires);
   }
 
   /** Return all sketch faces combined into a single compound shape. */
-  faces(): AnyShape {
+  faces(): Compound {
     const faces = this.sketches.map((s) => s.face());
     return makeCompound(faces);
   }
@@ -51,7 +51,7 @@ export default class Sketches {
       twistAngle?: number;
       origin?: PointInput;
     } = {}
-  ): AnyShape {
+  ): Compound {
     const extruded = this.sketches.map((s) => s.extrude(extrusionDistance, extrusionConfig));
 
     return makeCompound(extruded);
@@ -61,7 +61,7 @@ export default class Sketches {
    * Revolves the drawing on an axis (defined by its direction and an origin
    * (defaults to the sketch origin)
    */
-  revolve(revolutionAxis?: PointInput, config?: { origin?: PointInput }): AnyShape {
+  revolve(revolutionAxis?: PointInput, config?: { origin?: PointInput }): Compound {
     return makeCompound(this.sketches.map((s) => s.revolve(revolutionAxis, config)));
   }
 }


### PR DESCRIPTION
## Summary

Two small audit cleanups bundled:

**F7** — \`Sketches.{wires,faces,extrude,revolve}\` returned \`AnyShape\` even though \`makeCompound()\` returns \`Compound\`. Tighten public return types to \`Compound\` so consumers don't need to narrow.

**F12** — \`Sketch.{revolve,extrude,sweepSketch}\` silently call \`this.delete()\` mid-method. Calling any twice throws on the second call — a footgun without documentation. Added \`@remarks Consumes the sketch — calling this twice throws on the second call.\` to each. \`loftWith\` already documented this; aligned the wording.

No behaviour changes — just type narrowing and JSDoc.

## Test plan
- [x] \`npm run validate\`
- [ ] CI green