### PR TITLE
refactor(sketching): invert OO/Fns for Sketch — functions are canonical

### DIFF
--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -1,18 +1,12 @@
 import type { Plane } from '@/core/planeTypes.js';
-import { createPlane } from '@/core/planeOps.js';
-import { makeFace, makeNewFaceWithinFace } from '@/topology/shapeHelpers.js';
 import { unwrap } from '@/core/result.js';
 import { downcast } from '@/topology/cast.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
-import { vecScale, vecNormalize, vecCross } from '@/core/vecOps.js';
-import { extrude, revolve } from '@/operations/extrudeFns.js';
-import { sweep, complexExtrude, twistExtrude } from '@/operations/sweepFns.js';
 import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
-import { loft } from '@/operations/loftFns.js';
 import type { LoftOptions } from '@/operations/loftFns.js';
-import type { ClosedWire, Face, Wire, Shape3D, PlanarWire } from '@/core/shapeTypes.js';
+import type { Face, Wire, Shape3D } from '@/core/shapeTypes.js';
 import { createFace, createWire } from '@/core/shapeTypes.js';
-import { curveStartPoint, curveTangentAt } from '@/topology/curveFns.js';
+import * as fns from './sketchFns.js';
 
 /** Common interface for sketch-like objects that can be extruded, revolved, or lofted. */
 export interface SketchInterface {
@@ -64,6 +58,10 @@ export interface SketchInterface {
  * {@link Sketch.revolve}, {@link Sketch.sweepSketch}, and {@link Sketch.loftWith}
  * know how to act on it without extra arguments.
  *
+ * The class methods are thin delegations to the canonical functions in
+ * `sketchFns.ts` (`sketchExtrude`, `sketchRevolve`, etc.). New functionality
+ * should be added there.
+ *
  * @remarks Most operations consume (delete) the sketch after producing a solid.
  *
  * @see {@link Sketcher} to build a Sketch interactively.
@@ -109,7 +107,6 @@ export default class Sketch implements SketchInterface {
   /** Release all kernel resources held by this sketch. */
   delete(): void {
     this.wire.delete();
-    // _defaultOrigin and _defaultDirection are Vec3 tuples - no need to delete
     if (this.baseFace) this.baseFace.delete();
   }
 
@@ -143,24 +140,14 @@ export default class Sketch implements SketchInterface {
     this._defaultDirection = toVec3(newDirection);
   }
 
-  /**
-   * Transforms the lines into a face. The lines should be closed.
-   */
+  /** Transforms the lines into a face. The lines should be closed. */
   face(): Face {
-    let face;
-    // Sketch wires are always closed by construction
-    const closedWire = this.wire as ClosedWire & PlanarWire;
-    if (!this.baseFace) {
-      face = unwrap(makeFace(closedWire));
-    } else {
-      face = makeNewFaceWithinFace(this.baseFace, closedWire);
-    }
-    return face;
+    return fns.sketchFace(this);
   }
 
   /** Return a clone of the underlying wire. */
   wires(): Wire {
-    return createWire(unwrap(downcast(this.wire.wrapped)));
+    return fns.sketchWires(this);
   }
 
   /** Alias for {@link Sketch.face}. */
@@ -174,14 +161,8 @@ export default class Sketch implements SketchInterface {
    *
    * @remarks Consumes the sketch — calling this twice throws on the second call.
    */
-  revolve(revolutionAxis?: PointInput, { origin }: { origin?: PointInput } = {}): Shape3D {
-    const face = unwrap(makeFace(this.wire as ClosedWire & PlanarWire));
-    const center: Vec3 = origin ? toVec3(origin) : this.defaultOrigin;
-    const dir: Vec3 = revolutionAxis ? toVec3(revolutionAxis) : [0, 0, 1];
-    const solid = unwrap(revolve(face, center, dir));
-    face.delete();
-    this.delete();
-    return solid;
+  revolve(revolutionAxis?: PointInput, config: { origin?: PointInput } = {}): Shape3D {
+    return fns.sketchRevolve(this, revolutionAxis, config);
   }
 
   /** Extrudes the sketch to a certain distance (along the default direction
@@ -198,55 +179,14 @@ export default class Sketch implements SketchInterface {
    */
   extrude(
     extrusionDistance: number,
-    {
-      extrusionDirection,
-      extrusionProfile,
-      twistAngle,
-      origin,
-    }: {
+    config: {
       extrusionDirection?: PointInput;
       extrusionProfile?: ExtrusionProfile;
       twistAngle?: number;
       origin?: PointInput;
     } = {}
   ): Shape3D {
-    const direction: Vec3 = extrusionDirection ? toVec3(extrusionDirection) : this.defaultDirection;
-    const extrusionVec = vecScale(vecNormalize(direction), extrusionDistance);
-
-    const originVec: Vec3 = origin ? toVec3(origin) : this.defaultOrigin;
-
-    if (extrusionProfile && !twistAngle) {
-      const solid = unwrap(
-        complexExtrude(
-          this.wire as ClosedWire & PlanarWire,
-          [...originVec],
-          [...extrusionVec],
-          extrusionProfile
-        )
-      );
-      this.delete();
-      return solid as Shape3D;
-    }
-
-    if (twistAngle) {
-      const solid = unwrap(
-        twistExtrude(
-          this.wire as ClosedWire & PlanarWire,
-          twistAngle,
-          [...originVec],
-          [...extrusionVec],
-          extrusionProfile
-        )
-      );
-      this.delete();
-      return solid as Shape3D;
-    }
-
-    const face = unwrap(makeFace(this.wire as ClosedWire & PlanarWire));
-    const solid = unwrap(extrude(face, [...extrusionVec]));
-
-    this.delete();
-    return solid;
+    return fns.sketchExtrude(this, extrusionDistance, config);
   }
 
   /**
@@ -260,42 +200,7 @@ export default class Sketch implements SketchInterface {
     sketchOnPlane: (plane: Plane, origin: Vec3) => this,
     sweepConfig: SweepOptions = {}
   ): Shape3D {
-    const startPoint = curveStartPoint(this.wire);
-    const tangent = curveTangentAt(this.wire, 1e-9);
-    const normal = vecNormalize(vecScale(tangent, -1));
-    const defaultDir: Vec3 = this.defaultDirection;
-    const xDir = vecScale(vecCross(normal, defaultDir), -1);
-
-    const result = sketchOnPlane(createPlane([...startPoint], [...xDir], [...normal]), [
-      ...startPoint,
-    ]);
-
-    // The callback may return a Sketches (plural) when the Drawing used a
-    // 2D boolean that split the profile into multiple pieces. Extract the
-    // first sketch's wire and dispose the rest to prevent WASM leaks.
-    // Duck-type check avoids circular import (sketches.ts imports Sketch).
-    let sketch: Sketch;
-    if ('sketches' in result && Array.isArray((result as { sketches: unknown[] }).sketches)) {
-      const pieces = (result as { sketches: Sketch[] }).sketches;
-      sketch = pieces[0] as Sketch;
-      for (let i = 1; i < pieces.length; i++) {
-        pieces[i]?.delete();
-      }
-    } else {
-      sketch = result;
-    }
-
-    const config: SweepOptions = {
-      forceProfileSpineOthogonality: true,
-      ...sweepConfig,
-    };
-    if (this.baseFace) {
-      config.support = this.baseFace.wrapped;
-    }
-    const shape = unwrap(sweep(sketch.wire as ClosedWire, this.wire, config)) as Shape3D;
-    this.delete();
-
-    return shape;
+    return fns.sketchSweep(this, sketchOnPlane, sweepConfig);
   }
 
   /** Loft between this sketch and another sketch (or an array of them)
@@ -312,20 +217,6 @@ export default class Sketch implements SketchInterface {
     loftConfig: LoftOptions = {},
     returnShell = false
   ): Shape3D {
-    const sketchArray = Array.isArray(otherSketches)
-      ? [this, ...otherSketches]
-      : [this, otherSketches];
-    const shape = unwrap(
-      loft(
-        sketchArray.map((s) => s.wire),
-        loftConfig,
-        returnShell
-      )
-    );
-
-    sketchArray.forEach((s) => {
-      s.delete();
-    });
-    return shape;
+    return fns.sketchLoft(this, otherSketches, loftConfig, returnShell);
   }
 }

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -1,14 +1,34 @@
 /**
  * Standalone functions for Sketch and CompoundSketch operations.
- * Delegates to existing Sketch/CompoundSketch class methods and operations/ functions.
+ *
+ * These functions hold the canonical implementations; the matching class
+ * methods (`Sketch.extrude`, `CompoundSketch.face`, etc.) delegate here.
  */
 
-import type { PointInput } from '@/core/types.js';
-import type { OrientedFace, Shape3D, Wire } from '@/core/shapeTypes.js';
+import type { Plane } from '@/core/planeTypes.js';
+import { createPlane } from '@/core/planeOps.js';
+import { makeFace, makeNewFaceWithinFace } from '@/topology/shapeHelpers.js';
+import { unwrap } from '@/core/result.js';
+import { downcast } from '@/topology/cast.js';
+import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
+import { vecScale, vecNormalize, vecCross } from '@/core/vecOps.js';
+import { extrude, revolve } from '@/operations/extrudeFns.js';
+import { sweep, complexExtrude, twistExtrude } from '@/operations/sweepFns.js';
+import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
+import { loft } from '@/operations/loftFns.js';
+import type { LoftOptions } from '@/operations/loftFns.js';
+import type {
+  ClosedWire,
+  Face,
+  OrientedFace,
+  Shape3D,
+  Wire,
+  PlanarWire,
+} from '@/core/shapeTypes.js';
+import { createWire } from '@/core/shapeTypes.js';
 import type { PlanarFace } from '@/core/validityTypes.js';
 import type { SketchData } from '@/2d/blueprints/lib.js';
-import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
-import type { LoftOptions } from '@/operations/loftFns.js';
+import { curveStartPoint, curveTangentAt } from '@/topology/curveFns.js';
 import Sketch from './sketch.js';
 import CompoundSketch from './compoundSketch.js';
 
@@ -32,124 +52,189 @@ export function wrapSketchDataArray(dataArr: SketchData[]): CompoundSketch {
 }
 
 // ---------------------------------------------------------------------------
-// Sketch operations
+// Sketch operations (canonical implementations)
 // ---------------------------------------------------------------------------
 
-/**
- * Extrude a sketch to a given distance along its default (or overridden) direction.
- *
- * @param sketch - The sketch to extrude. Consumed (deleted) by this call.
- * @param height - Extrusion distance.
- * @param config - Optional direction, profile, twist angle, or origin overrides.
- * @returns The extruded 3D solid.
- *
- * @see {@link Sketch.extrude} for the OOP equivalent.
- */
-export function sketchExtrude(
-  sketch: Sketch,
-  height: number,
-  config?: {
-    extrusionDirection?: PointInput;
-    extrusionProfile?: ExtrusionProfile;
-    twistAngle?: number;
-    origin?: PointInput;
+/** Build a face from a sketch's closed planar wire. */
+export function sketchFace(sketch: Sketch): OrientedFace & PlanarFace {
+  // Sketch wires are always closed planar by construction at Sketcher boundary
+  const closedWire = sketch.wire as ClosedWire & PlanarWire;
+  let face: Face;
+  if (!sketch.baseFace) {
+    face = unwrap(makeFace(closedWire));
+  } else {
+    face = makeNewFaceWithinFace(sketch.baseFace, closedWire);
   }
-): Shape3D {
-  return sketch.extrude(height, config);
+  return face as OrientedFace & PlanarFace;
+}
+
+/** Return an independent clone of the sketch's wire. */
+export function sketchWires(sketch: Sketch): Wire {
+  return createWire(unwrap(downcast(sketch.wire.wrapped)));
 }
 
 /**
  * Revolve a sketch around an axis to produce a solid of revolution.
  *
- * @param sketch - The sketch to revolve. Consumed (deleted) by this call.
- * @param revolutionAxis - Axis direction (defaults to sketch default direction).
- * @param options - Optional origin override.
- * @returns The revolved 3D solid.
- *
- * @see {@link Sketch.revolve} for the OOP equivalent.
+ * @remarks Consumes the sketch — calling twice throws on the second call.
  */
 export function sketchRevolve(
   sketch: Sketch,
   revolutionAxis?: PointInput,
-  options?: { origin?: PointInput }
+  { origin }: { origin?: PointInput } = {}
 ): Shape3D {
-  return sketch.revolve(revolutionAxis, options);
+  const face = unwrap(makeFace(sketch.wire as ClosedWire & PlanarWire));
+  const center: Vec3 = origin ? toVec3(origin) : sketch.defaultOrigin;
+  const dir: Vec3 = revolutionAxis ? toVec3(revolutionAxis) : [0, 0, 1];
+  const solid = unwrap(revolve(face, center, dir));
+  face.delete();
+  sketch.delete();
+  return solid;
+}
+
+/**
+ * Extrude a sketch to a given distance.
+ *
+ * Supports profile (taper) extrusion via `extrusionProfile`, twist extrusion
+ * via `twistAngle`, and direction/origin overrides.
+ *
+ * @remarks Consumes the sketch — calling twice throws on the second call.
+ */
+export function sketchExtrude(
+  sketch: Sketch,
+  extrusionDistance: number,
+  {
+    extrusionDirection,
+    extrusionProfile,
+    twistAngle,
+    origin,
+  }: {
+    extrusionDirection?: PointInput;
+    extrusionProfile?: ExtrusionProfile;
+    twistAngle?: number;
+    origin?: PointInput;
+  } = {}
+): Shape3D {
+  const direction: Vec3 = extrusionDirection ? toVec3(extrusionDirection) : sketch.defaultDirection;
+  const extrusionVec = vecScale(vecNormalize(direction), extrusionDistance);
+  const originVec: Vec3 = origin ? toVec3(origin) : sketch.defaultOrigin;
+
+  if (extrusionProfile && !twistAngle) {
+    const solid = unwrap(
+      complexExtrude(
+        sketch.wire as ClosedWire & PlanarWire,
+        [...originVec],
+        [...extrusionVec],
+        extrusionProfile
+      )
+    );
+    sketch.delete();
+    return solid as Shape3D;
+  }
+
+  if (twistAngle) {
+    const solid = unwrap(
+      twistExtrude(
+        sketch.wire as ClosedWire & PlanarWire,
+        twistAngle,
+        [...originVec],
+        [...extrusionVec],
+        extrusionProfile
+      )
+    );
+    sketch.delete();
+    return solid as Shape3D;
+  }
+
+  const face = unwrap(makeFace(sketch.wire as ClosedWire & PlanarWire));
+  const solid = unwrap(extrude(face, [...extrusionVec]));
+  sketch.delete();
+  return solid;
+}
+
+/**
+ * Sweep a profile sketch (built by `sketchOnPlane`) along this sketch's wire path.
+ *
+ * @remarks Consumes both this sketch and the one returned by `sketchOnPlane` —
+ * calling either twice throws on the second call.
+ */
+export function sketchSweep(
+  sketch: Sketch,
+  sketchOnPlane: (plane: Plane, origin: Vec3) => Sketch,
+  sweepConfig: SweepOptions = {}
+): Shape3D {
+  const startPoint = curveStartPoint(sketch.wire);
+  const tangent = curveTangentAt(sketch.wire, 1e-9);
+  const normal = vecNormalize(vecScale(tangent, -1));
+  const defaultDir: Vec3 = sketch.defaultDirection;
+  const xDir = vecScale(vecCross(normal, defaultDir), -1);
+
+  const result = sketchOnPlane(createPlane([...startPoint], [...xDir], [...normal]), [
+    ...startPoint,
+  ]);
+
+  // The callback may return a Sketches (plural) when the Drawing used a
+  // 2D boolean that split the profile into multiple pieces. Extract the
+  // first sketch's wire and dispose the rest to prevent WASM leaks.
+  // Duck-type check avoids circular import (sketches.ts imports Sketch).
+  let profile: Sketch;
+  if ('sketches' in result && Array.isArray((result as { sketches: unknown[] }).sketches)) {
+    const pieces = (result as { sketches: Sketch[] }).sketches;
+    profile = pieces[0] as Sketch;
+    for (let i = 1; i < pieces.length; i++) {
+      pieces[i]?.delete();
+    }
+  } else {
+    profile = result;
+  }
+
+  const config: SweepOptions = {
+    forceProfileSpineOthogonality: true,
+    ...sweepConfig,
+  };
+  if (sketch.baseFace) {
+    config.support = sketch.baseFace.wrapped;
+  }
+  const shape = unwrap(sweep(profile.wire as ClosedWire, sketch.wire, config)) as Shape3D;
+  sketch.delete();
+
+  return shape;
 }
 
 /**
  * Loft between this sketch and one or more other sketches.
  *
- * @param sketch - The starting sketch. Consumed by this call.
- * @param otherSketches - Target sketch(es) to loft toward.
- * @param loftConfig - Loft options (ruled surface, start/end points, etc.).
- * @param returnShell - If true, return a shell instead of a solid.
- * @returns The lofted 3D shape.
- *
- * @see {@link Sketch.loftWith} for the OOP equivalent.
+ * @remarks Consumes all input sketches — calling twice throws on the second call.
  */
 export function sketchLoft(
   sketch: Sketch,
   otherSketches: Sketch | Sketch[],
-  loftConfig?: LoftOptions,
-  returnShell?: boolean
+  loftConfig: LoftOptions = {},
+  returnShell = false
 ): Shape3D {
-  return sketch.loftWith(otherSketches, loftConfig, returnShell);
-}
+  const sketchArray = Array.isArray(otherSketches)
+    ? [sketch, ...otherSketches]
+    : [sketch, otherSketches];
+  const shape = unwrap(
+    loft(
+      sketchArray.map((s) => s.wire),
+      loftConfig,
+      returnShell
+    )
+  );
 
-/**
- * Sweep a profile sketch along this sketch's wire path.
- *
- * @param sketch - The path sketch. Consumed by this call.
- * @param sketchOnPlane - Function that builds the profile sketch at the sweep start.
- * @param sweepConfig - Sweep options (auxiliary spine, orthogonality, etc.).
- * @returns The swept 3D shape.
- *
- * @see {@link Sketch.sweepSketch} for the OOP equivalent.
- */
-export function sketchSweep(
-  sketch: Sketch,
-  sketchOnPlane: Parameters<Sketch['sweepSketch']>[0],
-  sweepConfig?: SweepOptions
-): Shape3D {
-  return sketch.sweepSketch(sketchOnPlane, sweepConfig);
-}
-
-/**
- * Build a face from a sketch's closed wire.
- *
- * @param sketch - A sketch with a closed wire.
- * @returns The planar face.
- *
- * @see {@link Sketch.face} for the OOP equivalent.
- */
-export function sketchFace(sketch: Sketch): OrientedFace & PlanarFace {
-  // planar by construction: sketch operates on XY plane
-  return sketch.face() as OrientedFace & PlanarFace;
-}
-
-/**
- * Get a clone of the wire from a sketch.
- *
- * @param sketch - The source sketch.
- * @returns A cloned wire.
- *
- * @see {@link Sketch.wires} for the OOP equivalent.
- */
-export function sketchWires(sketch: Sketch): Wire {
-  return sketch.wires();
+  sketchArray.forEach((s) => {
+    s.delete();
+  });
+  return shape;
 }
 
 // ---------------------------------------------------------------------------
-// CompoundSketch operations
+// CompoundSketch operations (delegate — implementation still in class for now)
 // ---------------------------------------------------------------------------
 
 /**
  * Extrude a compound sketch (outer + holes) to a given distance.
- *
- * @param sketch - The compound sketch to extrude.
- * @param height - Extrusion distance.
- * @param config - Optional direction, profile, twist angle, or origin overrides.
- * @returns The extruded 3D solid.
  *
  * @see {@link CompoundSketch.extrude} for the OOP equivalent.
  */
@@ -169,11 +254,6 @@ export function compoundSketchExtrude(
 /**
  * Revolve a compound sketch around an axis to produce a solid of revolution.
  *
- * @param sketch - The compound sketch to revolve.
- * @param revolutionAxis - Axis direction.
- * @param options - Optional origin override.
- * @returns The revolved 3D solid.
- *
  * @see {@link CompoundSketch.revolve} for the OOP equivalent.
  */
 export function compoundSketchRevolve(
@@ -187,23 +267,14 @@ export function compoundSketchRevolve(
 /**
  * Build a face from a compound sketch (outer boundary with holes).
  *
- * @param sketch - The compound sketch.
- * @returns A face with inner wires subtracted as holes.
- *
  * @see {@link CompoundSketch.face} for the OOP equivalent.
  */
 export function compoundSketchFace(sketch: CompoundSketch): OrientedFace & PlanarFace {
-  // planar by construction: sketch operates on XY plane
   return sketch.face() as OrientedFace & PlanarFace;
 }
 
 /**
- * Loft between two compound sketches that have the same number of sub-sketches.
- *
- * @param sketch - Starting compound sketch.
- * @param other - Target compound sketch.
- * @param loftConfig - Loft options (ruled surface, etc.).
- * @returns The lofted 3D solid.
+ * Loft between two compound sketches with matching sub-sketch counts.
  *
  * @see {@link CompoundSketch.loftWith} for the OOP equivalent.
  */


### PR DESCRIPTION
## Summary

Layer 3 audit **F5 (Sketch portion)** — \`sketchFns.ts\` was a pure delegation shim where \`sketchExtrude(sketch, ...)\` just called \`sketch.extrude(...)\`. CLAUDE.md mandates new functionality goes in \`*Fns.ts\` files, but with the implementation in the class the function file was vestigial.

Invert the relationship: move every Sketch operation body (\`face\`, \`wires\`, \`revolve\`, \`extrude\`, \`sweepSketch\`, \`loftWith\`) into \`sketchFns.ts\`. Class methods become 1-line delegations to the canonical functions.

CompoundSketch is left as-is in this PR — its operations have non-trivial shell-generator logic and will move in a follow-up.

Behaviour unchanged. ESM circular import (\`sketch.ts\` ↔ \`sketchFns.ts\`) is safe because all access happens at call time, not module evaluation.

## Test plan
- [x] \`npm run validate\`
- [ ] CI green