### PR TITLE
refactor(sketching): invert OO/Fns for CompoundSketch

### DIFF
--- a/src/sketching/compoundSketch.ts
+++ b/src/sketching/compoundSketch.ts
@@ -1,84 +1,12 @@
-import { makeCompound, addHolesInFace, makeSolid, makeFace } from '@/topology/shapeHelpers.js';
-import { firstOrThrow, getAtOrThrow } from '@/utils/arrayAccess.js';
+import { firstOrThrow } from '@/utils/arrayAccess.js';
 import type Sketch from './sketch.js';
-
-import type { Vec3, PointInput } from '@/core/types.js';
-import { toVec3 } from '@/core/types.js';
-import { vecNormalize, vecScale } from '@/core/vecOps.js';
-import { extrude, revolve } from '@/operations/extrudeFns.js';
-import { complexExtrude, twistExtrude } from '@/operations/sweepFns.js';
+import type { PointInput } from '@/core/types.js';
 import type { ExtrusionProfile } from '@/operations/extrudeUtils.js';
 import type { LoftOptions } from '@/operations/loftFns.js';
 import type { SketchInterface } from './sketch.js';
-import { cast, downcast } from '@/topology/cast.js';
-import { type Result, unwrap, isOk } from '@/core/result.js';
 import { bug } from '@/core/errors.js';
-import type {
-  ClosedWire,
-  OrientedFace,
-  Face,
-  Shape3D,
-  Shell,
-  Wire,
-  PlanarWire,
-} from '@/core/shapeTypes.js';
-import type { PlanarFace } from '@/core/validityTypes.js';
-import { createFace, createWire, isFace } from '@/core/shapeTypes.js';
-import { getKernel } from '@/kernel/index.js';
-
-const guessFaceFromWires = (wires: Wire[]): Face => {
-  const wireShapes = wires.map((w) => w.wrapped);
-  const newFace = unwrap(cast(getKernel().fillSurface(wireShapes)));
-
-  if (!isFace(newFace)) {
-    bug('guessFaceFromWires', 'Failed to create a face');
-  }
-  return newFace as Face;
-};
-
-const fixWire = (wire: Wire, baseFace: Face): Wire => {
-  const fixedWire = getKernel().fixWireOnFace(wire.wrapped, baseFace.wrapped, 1e-9);
-  return createWire(fixedWire);
-};
-
-const faceFromWires = (wires: Wire[]): Face => {
-  let baseFace: Face;
-  let holeWires: ClosedWire[];
-
-  // Sweep end-cap wires are always closed boundaries
-  const faceResult = makeFace(firstOrThrow(wires) as ClosedWire & PlanarWire);
-  if (isOk(faceResult)) {
-    baseFace = faceResult.value;
-    holeWires = wires.slice(1) as ClosedWire[];
-  } else {
-    baseFace = guessFaceFromWires(wires);
-    holeWires = wires.slice(1).map((w) => fixWire(w, baseFace)) as ClosedWire[];
-  }
-
-  return addHolesInFace(baseFace, holeWires);
-};
-
-const solidFromShellGenerator = (
-  sketches: Sketch[],
-  shellGenerator: (sketch: Sketch) => Result<[Shape3D, Wire, Wire]>
-): Shape3D => {
-  const shells: Shell[] = [];
-  const startWires: Wire[] = [];
-  const endWires: Wire[] = [];
-
-  sketches.forEach((sketch) => {
-    const [shell, startWire, endWire] = unwrap(shellGenerator(sketch));
-    shells.push(shell as Shell);
-    startWires.push(startWire);
-    endWires.push(endWire);
-  });
-
-  const startFace = faceFromWires(startWires);
-  const endFace = faceFromWires(endWires);
-  const solid = unwrap(makeSolid([startFace, ...shells, endFace]));
-
-  return solid;
-};
+import type { Face, Shape3D } from '@/core/shapeTypes.js';
+import * as fns from './sketchFns.js';
 
 /**
  * Represent a face with holes as a group of sketches (one outer + zero or more inner).
@@ -87,6 +15,9 @@ const solidFromShellGenerator = (
  * treated as the outer boundary; subsequent sketches define holes.
  *
  * Typically produced from a {@link CompoundBlueprint} via `sketchOnPlane`.
+ *
+ * The class methods are thin delegations to the canonical functions in
+ * `sketchFns.ts` (`compoundSketchExtrude`, `compoundSketchRevolve`, etc.).
  *
  * @see {@link Sketch} for single-wire profiles without holes.
  * @category Sketching
@@ -119,20 +50,12 @@ export default class CompoundSketch implements SketchInterface {
 
   /** Return all wires (outer + holes) combined into a compound shape. */
   get wires() {
-    const wires = this.sketches.map((s) => s.wire);
-    return makeCompound(wires);
+    return fns.compoundSketchWires(this);
   }
 
   /** Build a face from the outer boundary with inner wires subtracted as holes. */
-  face() {
-    const baseFace = this.outerSketch.face();
-    // Sketch wires are always closed by construction
-    const newFace = addHolesInFace(
-      baseFace,
-      this.innerSketches.map((s) => s.wire as ClosedWire & PlanarWire)
-    );
-
-    return newFace;
+  face(): Face {
+    return fns.compoundSketchFace(this);
   }
 
   /**
@@ -143,88 +66,26 @@ export default class CompoundSketch implements SketchInterface {
    */
   extrude(
     extrusionDistance: number,
-    {
-      extrusionDirection,
-      extrusionProfile,
-      twistAngle,
-      origin,
-    }: {
+    config: {
       extrusionDirection?: PointInput;
       extrusionProfile?: ExtrusionProfile;
       twistAngle?: number;
       origin?: PointInput;
     } = {}
   ): Shape3D {
-    const rawVec: Vec3 = extrusionDirection
-      ? toVec3(extrusionDirection)
-      : this.outerSketch.defaultDirection;
-    const normVec = vecNormalize(rawVec);
-    const extrusionVec = vecScale(normVec, extrusionDistance);
-
-    let result: Shape3D;
-    if (extrusionProfile && !twistAngle) {
-      result = solidFromShellGenerator(
-        this.sketches,
-        (sketch: Sketch) =>
-          complexExtrude(
-            sketch.wire as ClosedWire & PlanarWire,
-            origin ? toVec3(origin) : this.outerSketch.defaultOrigin,
-            extrusionVec,
-            extrusionProfile,
-            true
-          ) as Result<[Shape3D, Wire, Wire]>
-      );
-    } else if (twistAngle) {
-      result = solidFromShellGenerator(
-        this.sketches,
-        (sketch: Sketch) =>
-          twistExtrude(
-            sketch.wire as ClosedWire & PlanarWire,
-            twistAngle,
-            origin ? toVec3(origin) : this.outerSketch.defaultOrigin,
-            extrusionVec,
-            extrusionProfile,
-            true
-          ) as Result<[Shape3D, Wire, Wire]>
-      );
-    } else {
-      // planar by construction: sketch operates on XY plane
-      result = unwrap(extrude(this.face() as OrientedFace & PlanarFace, extrusionVec));
-    }
-
-    return result;
+    return fns.compoundSketchExtrude(this, extrusionDistance, config);
   }
 
   /**
    * Revolves the drawing on an axis (defined by its direction and an origin
    * (defaults to the sketch origin)
    */
-  revolve(revolutionAxis?: PointInput, { origin }: { origin?: PointInput } = {}): Shape3D {
-    const center = origin ? toVec3(origin) : this.outerSketch.defaultOrigin;
-    const dir = revolutionAxis ? toVec3(revolutionAxis) : ([0, 0, 1] as Vec3);
-    // planar by construction: sketch operates on XY plane
-    return unwrap(revolve(this.face() as OrientedFace & PlanarFace, center, dir));
+  revolve(revolutionAxis?: PointInput, config: { origin?: PointInput } = {}): Shape3D {
+    return fns.compoundSketchRevolve(this, revolutionAxis, config);
   }
 
   /** Loft between this compound sketch and another with matching sub-sketch counts. */
   loftWith(otherCompound: this, loftConfig: LoftOptions): Shape3D {
-    if (this.sketches.length !== otherCompound.sketches.length)
-      bug(
-        'CompoundSketch.loftWith',
-        'You need to loft with another compound with the same number of sketches'
-      );
-
-    const shells: Array<Shell | Face> = this.sketches.map((base, cIndex) => {
-      const outer = getAtOrThrow(otherCompound.sketches, cIndex);
-      const loftOpts: LoftOptions = {};
-      if (loftConfig.ruled !== undefined) loftOpts.ruled = loftConfig.ruled;
-      return base.clone().loftWith(outer.clone(), loftOpts, true) as Shell;
-    });
-
-    const baseFaceRaw = this.face();
-    const baseFace = createFace(unwrap(downcast(baseFaceRaw.wrapped)));
-    shells.push(baseFace, otherCompound.face());
-
-    return unwrap(makeSolid(shells));
+    return fns.compoundSketchLoft(this, otherCompound, loftConfig);
   }
 }

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -7,13 +7,22 @@
 
 import type { Plane } from '@/core/planeTypes.js';
 import { createPlane } from '@/core/planeOps.js';
-import { makeFace, makeNewFaceWithinFace } from '@/topology/shapeHelpers.js';
-import { unwrap } from '@/core/result.js';
-import { downcast } from '@/topology/cast.js';
+import {
+  addHolesInFace,
+  makeCompound,
+  makeFace,
+  makeNewFaceWithinFace,
+  makeSolid,
+} from '@/topology/shapeHelpers.js';
+import { isOk, type Result, unwrap } from '@/core/result.js';
+import { cast, downcast } from '@/topology/cast.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
 import { vecScale, vecNormalize, vecCross } from '@/core/vecOps.js';
 import { extrude, revolve } from '@/operations/extrudeFns.js';
 import { sweep, complexExtrude, twistExtrude } from '@/operations/sweepFns.js';
+import { firstOrThrow, getAtOrThrow } from '@/utils/arrayAccess.js';
+import { bug } from '@/core/errors.js';
+import { getKernel } from '@/kernel/index.js';
 import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
 import { loft } from '@/operations/loftFns.js';
 import type { LoftOptions } from '@/operations/loftFns.js';
@@ -22,10 +31,11 @@ import type {
   Face,
   OrientedFace,
   Shape3D,
+  Shell,
   Wire,
   PlanarWire,
 } from '@/core/shapeTypes.js';
-import { createWire } from '@/core/shapeTypes.js';
+import { createFace, createWire, isFace } from '@/core/shapeTypes.js';
 import type { PlanarFace } from '@/core/validityTypes.js';
 import type { SketchData } from '@/2d/blueprints/lib.js';
 import { curveStartPoint, curveTangentAt } from '@/topology/curveFns.js';
@@ -230,58 +240,170 @@ export function sketchLoft(
 }
 
 // ---------------------------------------------------------------------------
-// CompoundSketch operations (delegate — implementation still in class for now)
+// CompoundSketch operations (canonical implementations)
 // ---------------------------------------------------------------------------
 
+const guessFaceFromWires = (wires: Wire[]): Face => {
+  const wireShapes = wires.map((w) => w.wrapped);
+  const newFace = unwrap(cast(getKernel().fillSurface(wireShapes)));
+
+  if (!isFace(newFace)) {
+    bug('guessFaceFromWires', 'Failed to create a face');
+  }
+  return newFace as Face;
+};
+
+const fixWire = (wire: Wire, baseFace: Face): Wire => {
+  const fixedWire = getKernel().fixWireOnFace(wire.wrapped, baseFace.wrapped, 1e-9);
+  return createWire(fixedWire);
+};
+
+const faceFromWires = (wires: Wire[]): Face => {
+  let baseFace: Face;
+  let holeWires: ClosedWire[];
+
+  // Sweep end-cap wires are always closed boundaries
+  const faceResult = makeFace(firstOrThrow(wires) as ClosedWire & PlanarWire);
+  if (isOk(faceResult)) {
+    baseFace = faceResult.value;
+    holeWires = wires.slice(1) as ClosedWire[];
+  } else {
+    baseFace = guessFaceFromWires(wires);
+    holeWires = wires.slice(1).map((w) => fixWire(w, baseFace)) as ClosedWire[];
+  }
+
+  return addHolesInFace(baseFace, holeWires);
+};
+
+const solidFromShellGenerator = (
+  sketches: Sketch[],
+  shellGenerator: (sketch: Sketch) => Result<[Shape3D, Wire, Wire]>
+): Shape3D => {
+  const shells: Shell[] = [];
+  const startWires: Wire[] = [];
+  const endWires: Wire[] = [];
+
+  sketches.forEach((sketch) => {
+    const [shell, startWire, endWire] = unwrap(shellGenerator(sketch));
+    shells.push(shell as Shell);
+    startWires.push(startWire);
+    endWires.push(endWire);
+  });
+
+  const startFace = faceFromWires(startWires);
+  const endFace = faceFromWires(endWires);
+  const solid = unwrap(makeSolid([startFace, ...shells, endFace]));
+
+  return solid;
+};
+
+/** Build a face from a compound sketch (outer boundary with holes). */
+export function compoundSketchFace(sketch: CompoundSketch): OrientedFace & PlanarFace {
+  const baseFace = sketch.outerSketch.face();
+  // Sketch wires are always closed by construction
+  const newFace = addHolesInFace(
+    baseFace,
+    sketch.innerSketches.map((s) => s.wire as ClosedWire & PlanarWire)
+  );
+  return newFace as OrientedFace & PlanarFace;
+}
+
+/** Return all wires (outer + holes) combined into a compound shape. */
+export function compoundSketchWires(sketch: CompoundSketch) {
+  const wires = sketch.sketches.map((s) => s.wire);
+  return makeCompound(wires);
+}
+
 /**
- * Extrude a compound sketch (outer + holes) to a given distance.
+ * Extrude a compound sketch (outer + holes) along the default or given direction.
  *
- * @see {@link CompoundSketch.extrude} for the OOP equivalent.
+ * Supports twist and profile extrusions. For twist/profile modes each
+ * sub-sketch is extruded as a shell, then capped into a solid.
  */
 export function compoundSketchExtrude(
   sketch: CompoundSketch,
-  height: number,
-  config?: {
+  extrusionDistance: number,
+  {
+    extrusionDirection,
+    extrusionProfile,
+    twistAngle,
+    origin,
+  }: {
     extrusionDirection?: PointInput;
     extrusionProfile?: ExtrusionProfile;
     twistAngle?: number;
     origin?: PointInput;
-  }
+  } = {}
 ): Shape3D {
-  return sketch.extrude(height, config);
+  const rawVec: Vec3 = extrusionDirection
+    ? toVec3(extrusionDirection)
+    : sketch.outerSketch.defaultDirection;
+  const normVec = vecNormalize(rawVec);
+  const extrusionVec = vecScale(normVec, extrusionDistance);
+
+  if (extrusionProfile && !twistAngle) {
+    return solidFromShellGenerator(
+      sketch.sketches,
+      (s: Sketch) =>
+        complexExtrude(
+          s.wire as ClosedWire & PlanarWire,
+          origin ? toVec3(origin) : sketch.outerSketch.defaultOrigin,
+          extrusionVec,
+          extrusionProfile,
+          true
+        ) as Result<[Shape3D, Wire, Wire]>
+    );
+  }
+  if (twistAngle) {
+    return solidFromShellGenerator(
+      sketch.sketches,
+      (s: Sketch) =>
+        twistExtrude(
+          s.wire as ClosedWire & PlanarWire,
+          twistAngle,
+          origin ? toVec3(origin) : sketch.outerSketch.defaultOrigin,
+          extrusionVec,
+          extrusionProfile,
+          true
+        ) as Result<[Shape3D, Wire, Wire]>
+    );
+  }
+  return unwrap(extrude(compoundSketchFace(sketch), extrusionVec));
 }
 
-/**
- * Revolve a compound sketch around an axis to produce a solid of revolution.
- *
- * @see {@link CompoundSketch.revolve} for the OOP equivalent.
- */
+/** Revolve a compound sketch (outer + holes) around an axis. */
 export function compoundSketchRevolve(
   sketch: CompoundSketch,
   revolutionAxis?: PointInput,
-  options?: { origin?: PointInput }
+  { origin }: { origin?: PointInput } = {}
 ): Shape3D {
-  return sketch.revolve(revolutionAxis, options);
+  const center = origin ? toVec3(origin) : sketch.outerSketch.defaultOrigin;
+  const dir = revolutionAxis ? toVec3(revolutionAxis) : ([0, 0, 1] as Vec3);
+  return unwrap(revolve(compoundSketchFace(sketch), center, dir));
 }
 
-/**
- * Build a face from a compound sketch (outer boundary with holes).
- *
- * @see {@link CompoundSketch.face} for the OOP equivalent.
- */
-export function compoundSketchFace(sketch: CompoundSketch): OrientedFace & PlanarFace {
-  return sketch.face() as OrientedFace & PlanarFace;
-}
-
-/**
- * Loft between two compound sketches with matching sub-sketch counts.
- *
- * @see {@link CompoundSketch.loftWith} for the OOP equivalent.
- */
+/** Loft between two compound sketches with matching sub-sketch counts. */
 export function compoundSketchLoft(
   sketch: CompoundSketch,
   other: CompoundSketch,
   loftConfig: LoftOptions
 ): Shape3D {
-  return sketch.loftWith(other, loftConfig);
+  if (sketch.sketches.length !== other.sketches.length)
+    bug(
+      'CompoundSketch.loftWith',
+      'You need to loft with another compound with the same number of sketches'
+    );
+
+  const shells: Array<Shell | Face> = sketch.sketches.map((base, cIndex) => {
+    const outer = getAtOrThrow(other.sketches, cIndex);
+    const loftOpts: LoftOptions = {};
+    if (loftConfig.ruled !== undefined) loftOpts.ruled = loftConfig.ruled;
+    return base.clone().loftWith(outer.clone(), loftOpts, true) as Shell;
+  });
+
+  const baseFaceRaw = compoundSketchFace(sketch);
+  const baseFace = createFace(unwrap(downcast(baseFaceRaw.wrapped)));
+  shells.push(baseFace, compoundSketchFace(other));
+
+  return unwrap(makeSolid(shells));
 }


### PR DESCRIPTION
## Summary

Layer 3 audit **F5 (CompoundSketch portion)** — same inversion as #955 applied to CompoundSketch. The shell-generator helpers (\`faceFromWires\`, \`guessFaceFromWires\`, \`fixWire\`, \`solidFromShellGenerator\`) and all four operations (\`face\`, \`extrude\`, \`revolve\`, \`loftWith\`) move into \`sketchFns.ts\`. Class methods become 1-line delegations.

> **Note:** stacked on #955 — diff currently includes #955's commits. Once #955 merges, this PR's diff will reduce to just the CompoundSketch changes.

Behaviour unchanged.

## Test plan
- [x] \`npm run validate\`
- [ ] CI green