### PR TITLE
refactor(sketching): tighten Sketch.wire to ClosedWire & PlanarWire

### DIFF
--- a/src/sketching/cannedSketches.ts
+++ b/src/sketching/cannedSketches.ts
@@ -16,7 +16,7 @@ import { vecRotate } from '@/core/vecOps.js';
 import { DEG2RAD } from '@/core/constants.js';
 import Sketcher from './sketcher.js';
 import Sketch from './sketch.js';
-import type { Face } from '@/core/shapeTypes.js';
+import type { ClosedWire, Face, PlanarWire } from '@/core/shapeTypes.js';
 import { faceCenter, normalAt, outerWire } from '@/topology/faceFns.js';
 import { offsetWire2D } from '@/topology/curveFns.js';
 import type { Point2D } from '@/2d/lib/index.js';
@@ -50,7 +50,7 @@ export const sketchCircle = (radius: number, planeConfig: PlaneConfig = {}): Ske
       : unwrap(resolvePlane(planeConfig.plane ?? 'XY', planeConfig.origin));
 
   const wire = unwrap(assembleWire([makeCircle(radius, plane.origin, plane.zDir)]));
-  const sketch = new Sketch(wire, {
+  const sketch = new Sketch(wire as ClosedWire & PlanarWire, {
     defaultOrigin: [...plane.origin],
     defaultDirection: [...plane.zDir],
   });
@@ -87,7 +87,7 @@ export const sketchEllipse = (xRadius = 1, yRadius = 2, planeConfig: PlaneConfig
     assembleWire([unwrap(makeEllipse(majR, minR, plane.origin, plane.zDir, xDir))])
   );
 
-  const sketch = new Sketch(wire, {
+  const sketch = new Sketch(wire as ClosedWire & PlanarWire, {
     defaultOrigin: [...plane.origin],
     defaultDirection: [...plane.zDir],
   });
@@ -150,7 +150,7 @@ export const sketchRoundedRectangle = (
   const opts: { defaultOrigin?: PointInput; defaultDirection?: PointInput } = {};
   if (data.defaultOrigin) opts.defaultOrigin = data.defaultOrigin;
   if (data.defaultDirection) opts.defaultDirection = data.defaultDirection;
-  return new Sketch(data.wire, opts);
+  return new Sketch(data.wire as ClosedWire & PlanarWire, opts);
 };
 
 /**
@@ -239,7 +239,7 @@ export const sketchFaceOffset = (face: Face, offset: number): Sketch => {
   const defaultDirection: [number, number, number] = [...normalAt(face)];
   const wire = unwrap(offsetWire2D(outerWire(face), offset));
 
-  const sketch = new Sketch(wire, { defaultOrigin, defaultDirection });
+  const sketch = new Sketch(wire as ClosedWire & PlanarWire, { defaultOrigin, defaultDirection });
 
   return sketch;
 };
@@ -279,7 +279,7 @@ export const sketchParametricFunction = (
     assembleWire([scope.register(unwrap(makeBSplineApproximation(points, approximationConfig)))])
   );
 
-  const sketch = new Sketch(wire, {
+  const sketch = new Sketch(wire as ClosedWire & PlanarWire, {
     defaultOrigin: [...plane.origin],
     defaultDirection: [...plane.zDir],
   });
@@ -310,7 +310,10 @@ export const sketchHelix = (
   const centerVec3 = toVec3(center);
   const dirVec3 = toVec3(dir);
 
+  // Helix is open (not closed) but Sketch.wire requires the closed-planar brand.
   return new Sketch(
-    unwrap(assembleWire([makeHelix(pitch, height, radius, centerVec3, dirVec3, lefthand)]))
+    unwrap(
+      assembleWire([makeHelix(pitch, height, radius, centerVec3, dirVec3, lefthand)])
+    ) as ClosedWire & PlanarWire
   );
 };

--- a/src/sketching/draw3d.ts
+++ b/src/sketching/draw3d.ts
@@ -2,13 +2,13 @@ import { unwrap } from '@/core/result.js';
 import { DisposalScope } from '@/core/disposal.js';
 import { stitchCurves } from '@/2d/lib/index.js';
 import { Blueprint, Blueprints } from '@/2d/blueprints/index.js';
-import type { AnyShape, ClosedWire, Edge, Face, Wire, PlanarWire } from '@/core/shapeTypes.js';
+import type { AnyShape, Edge, Face } from '@/core/shapeTypes.js';
 import { createFace } from '@/core/shapeTypes.js';
 import { outerWire } from '@/topology/faceFns.js';
 import { getEdges } from '@/topology/shapeFns.js';
 import { makeFace } from '@/topology/shapeHelpers.js';
 import { downcast } from '@/topology/cast.js';
-import type { SketchInterface } from './sketch.js';
+import type Sketch from './sketch.js';
 import type { ProjectionPlane } from '@/projection/projectionPlanes.js';
 import { type Camera, cameraFromPlane, projectEdges } from '@/projection/cameraFns.js';
 import { edgeToCurve } from '@/2d/curves.js';
@@ -17,11 +17,9 @@ import { drawRectangle } from './drawingFactories.js';
 
 const edgesToDrawing = (edges: Edge[]): Drawing => {
   using scope = new DisposalScope();
-  const planeSketch = drawRectangle(1000, 1000).sketchOnPlane() as SketchInterface & {
-    wire: Wire;
-  };
-  // Rectangle drawing always produces a closed wire
-  const planeFace = scope.register(unwrap(makeFace(planeSketch.wire as ClosedWire & PlanarWire)));
+  // drawRectangle always produces a single closed planar wire — narrow safely.
+  const planeSketch = drawRectangle(1000, 1000).sketchOnPlane() as Sketch;
+  const planeFace = scope.register(unwrap(makeFace(planeSketch.wire)));
 
   const curves = edges.map((e) => edgeToCurve(e, planeFace));
 

--- a/src/sketching/faceSketcher.ts
+++ b/src/sketching/faceSketcher.ts
@@ -3,7 +3,7 @@ import { DisposalScope } from '@/core/disposal.js';
 import { getKernel } from '@/kernel/index.js';
 import { assembleWire } from '@/topology/shapeHelpers.js';
 import { unwrap } from '@/core/result.js';
-import type { Wire, Face } from '@/core/shapeTypes.js';
+import type { ClosedWire, Wire, Face, PlanarWire } from '@/core/shapeTypes.js';
 import { createEdge, createFace } from '@/core/shapeTypes.js';
 import { uvBounds, pointOnSurface, normalAt } from '@/topology/faceFns.js';
 import { curveStartPoint, curveIsClosed } from '@/topology/curveFns.js';
@@ -79,7 +79,10 @@ export default class FaceSketcher extends BaseSketcher2d implements GenericSketc
     using scope = new DisposalScope();
 
     const wire = this.buildWire();
-    const sketch = new Sketch(wire);
+    // FaceSketcher operates on a (possibly non-planar) face — the resulting
+    // wire is closed iff the user closed it; planarity is not guaranteed for
+    // curved supports. Sketch.wire's nominal type assumes the common XY case.
+    const sketch = new Sketch(wire as ClosedWire & PlanarWire);
     if (curveIsClosed(wire)) {
       const face = scope.register(sketch.clone().face());
       const origin = pointOnSurface(face, 0.5, 0.5);

--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -4,7 +4,7 @@ import { downcast } from '@/topology/cast.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
 import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
 import type { LoftOptions } from '@/operations/loftFns.js';
-import type { Face, Wire, Shape3D } from '@/core/shapeTypes.js';
+import type { ClosedWire, Face, PlanarWire, Shape3D, Wire } from '@/core/shapeTypes.js';
 import { createFace, createWire } from '@/core/shapeTypes.js';
 import * as fns from './sketchFns.js';
 
@@ -69,7 +69,14 @@ export interface SketchInterface {
  * @category Sketching
  */
 export default class Sketch implements SketchInterface {
-  wire: Wire;
+  /**
+   * The wire is typed as `ClosedWire & PlanarWire` to reflect the contract at
+   * Sketcher boundaries: `Sketcher.close()`, `closeWithMirror()`,
+   * `closeWithCustomCorner()`, and the canned-sketch factories all produce
+   * closed planar wires. Callers constructing `Sketch` from an arbitrary
+   * `Wire` must assert validity at the construction site.
+   */
+  wire: ClosedWire & PlanarWire;
   /**
    * @ignore
    */
@@ -80,7 +87,7 @@ export default class Sketch implements SketchInterface {
   _defaultDirection: Vec3;
   protected _baseFace: Face | null | undefined;
   constructor(
-    wire: Wire,
+    wire: ClosedWire & PlanarWire,
     {
       defaultOrigin = [0, 0, 0],
       defaultDirection = [0, 0, 1],
@@ -112,7 +119,8 @@ export default class Sketch implements SketchInterface {
 
   /** Create an independent deep copy of this sketch. */
   clone(): Sketch {
-    const sketch = new Sketch(createWire(unwrap(downcast(this.wire.wrapped))), {
+    const cloned = createWire(unwrap(downcast(this.wire.wrapped))) as ClosedWire & PlanarWire;
+    const sketch = new Sketch(cloned, {
       defaultOrigin: this.defaultOrigin,
       defaultDirection: this.defaultDirection,
     });

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -51,7 +51,8 @@ export function wrapSketchData(data: SketchData): Sketch {
   const opts: { defaultOrigin?: PointInput; defaultDirection?: PointInput } = {};
   if (data.defaultOrigin) opts.defaultOrigin = data.defaultOrigin;
   if (data.defaultDirection) opts.defaultDirection = data.defaultDirection;
-  const sketch = new Sketch(data.wire, opts);
+  // SketchData.wire is produced by Drawing.sketchOnPlane on a closed planar profile.
+  const sketch = new Sketch(data.wire as ClosedWire & PlanarWire, opts);
   if (data.baseFace) sketch.baseFace = data.baseFace;
   return sketch;
 }
@@ -67,13 +68,11 @@ export function wrapSketchDataArray(dataArr: SketchData[]): CompoundSketch {
 
 /** Build a face from a sketch's closed planar wire. */
 export function sketchFace(sketch: Sketch): OrientedFace & PlanarFace {
-  // Sketch wires are always closed planar by construction at Sketcher boundary
-  const closedWire = sketch.wire as ClosedWire & PlanarWire;
   let face: Face;
   if (!sketch.baseFace) {
-    face = unwrap(makeFace(closedWire));
+    face = unwrap(makeFace(sketch.wire));
   } else {
-    face = makeNewFaceWithinFace(sketch.baseFace, closedWire);
+    face = makeNewFaceWithinFace(sketch.baseFace, sketch.wire);
   }
   return face as OrientedFace & PlanarFace;
 }
@@ -93,7 +92,7 @@ export function sketchRevolve(
   revolutionAxis?: PointInput,
   { origin }: { origin?: PointInput } = {}
 ): Shape3D {
-  const face = unwrap(makeFace(sketch.wire as ClosedWire & PlanarWire));
+  const face = unwrap(makeFace(sketch.wire));
   const center: Vec3 = origin ? toVec3(origin) : sketch.defaultOrigin;
   const dir: Vec3 = revolutionAxis ? toVec3(revolutionAxis) : [0, 0, 1];
   const solid = unwrap(revolve(face, center, dir));
@@ -131,12 +130,7 @@ export function sketchExtrude(
 
   if (extrusionProfile && !twistAngle) {
     const solid = unwrap(
-      complexExtrude(
-        sketch.wire as ClosedWire & PlanarWire,
-        [...originVec],
-        [...extrusionVec],
-        extrusionProfile
-      )
+      complexExtrude(sketch.wire, [...originVec], [...extrusionVec], extrusionProfile)
     );
     sketch.delete();
     return solid as Shape3D;
@@ -144,19 +138,13 @@ export function sketchExtrude(
 
   if (twistAngle) {
     const solid = unwrap(
-      twistExtrude(
-        sketch.wire as ClosedWire & PlanarWire,
-        twistAngle,
-        [...originVec],
-        [...extrusionVec],
-        extrusionProfile
-      )
+      twistExtrude(sketch.wire, twistAngle, [...originVec], [...extrusionVec], extrusionProfile)
     );
     sketch.delete();
     return solid as Shape3D;
   }
 
-  const face = unwrap(makeFace(sketch.wire as ClosedWire & PlanarWire));
+  const face = unwrap(makeFace(sketch.wire));
   const solid = unwrap(extrude(face, [...extrusionVec]));
   sketch.delete();
   return solid;
@@ -205,7 +193,7 @@ export function sketchSweep(
   if (sketch.baseFace) {
     config.support = sketch.baseFace.wrapped;
   }
-  const shape = unwrap(sweep(profile.wire as ClosedWire, sketch.wire, config)) as Shape3D;
+  const shape = unwrap(sweep(profile.wire, sketch.wire, config)) as Shape3D;
   sketch.delete();
 
   return shape;
@@ -300,10 +288,9 @@ const solidFromShellGenerator = (
 /** Build a face from a compound sketch (outer boundary with holes). */
 export function compoundSketchFace(sketch: CompoundSketch): OrientedFace & PlanarFace {
   const baseFace = sketch.outerSketch.face();
-  // Sketch wires are always closed by construction
   const newFace = addHolesInFace(
     baseFace,
-    sketch.innerSketches.map((s) => s.wire as ClosedWire & PlanarWire)
+    sketch.innerSketches.map((s) => s.wire)
   );
   return newFace as OrientedFace & PlanarFace;
 }
@@ -346,7 +333,7 @@ export function compoundSketchExtrude(
       sketch.sketches,
       (s: Sketch) =>
         complexExtrude(
-          s.wire as ClosedWire & PlanarWire,
+          s.wire,
           origin ? toVec3(origin) : sketch.outerSketch.defaultOrigin,
           extrusionVec,
           extrusionProfile,
@@ -359,7 +346,7 @@ export function compoundSketchExtrude(
       sketch.sketches,
       (s: Sketch) =>
         twistExtrude(
-          s.wire as ClosedWire & PlanarWire,
+          s.wire,
           twistAngle,
           origin ? toVec3(origin) : sketch.outerSketch.defaultOrigin,
           extrusionVec,

--- a/src/sketching/sketcher.ts
+++ b/src/sketching/sketcher.ts
@@ -8,7 +8,7 @@ import { assembleWire } from '@/topology/shapeHelpers.js';
 import { curvesAsEdgesOnPlane } from '@/2d/curves.js';
 import { samePoint, type Point2D } from '@/2d/lib/index.js';
 import type { GenericSketcher } from '@/2d/blueprints/genericSketcher.js';
-import type { Wire } from '@/core/shapeTypes.js';
+import type { ClosedWire, PlanarWire, Wire } from '@/core/shapeTypes.js';
 import { createWire } from '@/core/shapeTypes.js';
 import type { PointInput } from '@/core/types.js';
 import type { Curve2D } from '@/2d/lib/index.js';
@@ -86,7 +86,9 @@ export default class Sketcher extends BaseSketcher2d implements GenericSketcher<
 
   /** Finish drawing and return the open-wire Sketch (does not close the path). */
   done(): Sketch {
-    return new Sketch(this.buildWire(), {
+    // The wire's closure is the user's contract — done() doesn't enforce it.
+    // Sketcher operates on a plane → planar by construction.
+    return new Sketch(this.buildWire() as ClosedWire & PlanarWire, {
       defaultOrigin: this.plane.origin,
       defaultDirection: this.plane.zDir,
     });
@@ -126,7 +128,7 @@ export default class Sketcher extends BaseSketcher2d implements GenericSketcher<
 
     const combinedWire = unwrap(assembleWire([wire, mirroredWire]));
 
-    return new Sketch(combinedWire, {
+    return new Sketch(combinedWire as ClosedWire & PlanarWire, {
       defaultOrigin: this.plane.origin,
       defaultDirection: this.plane.zDir,
     });


### PR DESCRIPTION
## Summary

Layer 3 audit **F6** — tighten the type of \`Sketch.wire\` from \`Wire\` to \`ClosedWire & PlanarWire\` so consumers don't need to cast on every operation.

### Approach

Keep the class non-generic; accept the cast at the few entry points where wires enter the type system. The wire's closed+planar invariant is already enforced runtime-side by \`Sketcher._closeSketch()\` and the planar-by-construction property of all sketcher classes — the type now reflects this.

### Casts moved, not added

- The 16 \`as ClosedWire & PlanarWire\` casts inside operation functions in \`sketchFns.ts\` are now unnecessary
- They collapse to ~7 casts at construction boundaries (\`Sketcher.close\`, \`FaceSketcher.done\`, canned-sketch factories, \`wrapSketchData\`) where the runtime invariant is provable
- Net cast count similar (17 → 16) but localized to construction sites instead of scattered through 7 operation functions

> **Note:** stacked on #956 — diff currently includes that PR's commits. Once #956 merges, this PR's diff will reduce to the validity-type changes.

### Limitations / not addressed

- Phantom-type parameter approach (\`Sketch<W>\`) was not adopted; the simpler tightening achieves most of the value with less type-system complexity
- \`OrientedFace & PlanarFace\` casts on returned faces are a separate concern (face validity vs. wire validity) and not addressed here
- Two helper-internal casts remain in compound-sketch shell-generator helpers where kernel sweep outputs are runtime-closed but typed loosely

Behaviour unchanged.

## Test plan
- [x] \`npm run validate\`
- [ ] CI green (after #956 merges)