### PR TITLE
fix(sketching): restore runtime exports for Sketcher classes

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "241 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "245 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "55 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,10 +225,10 @@ export {
 
 // ── Layer 3: sketching ──
 
-export type { default as Sketcher } from './sketching/sketcher.js';
-export type { default as FaceSketcher } from './sketching/faceSketcher.js';
-export type { BaseSketcher2d } from './2d/blueprints/baseSketcher2d.js';
-export type { BlueprintSketcher } from './2d/blueprints/blueprintSketcher.js';
+export { default as Sketcher } from './sketching/sketcher.js';
+export { default as FaceSketcher } from './sketching/faceSketcher.js';
+export { BaseSketcher2d } from './2d/blueprints/baseSketcher2d.js';
+export { BlueprintSketcher } from './2d/blueprints/blueprintSketcher.js';
 export type { GenericSketcher, SplineOptions } from './2d/blueprints/genericSketcher.js';
 export type { SketchInterface } from './sketching/sketch.js';
 

--- a/tests/apiSketcherExports.test.ts
+++ b/tests/apiSketcherExports.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import * as brepjs from '@/index.js';
+
+describe('public Sketcher exports', () => {
+  it.each(['Sketcher', 'FaceSketcher', 'BaseSketcher2d', 'BlueprintSketcher'] as const)(
+    '%s is a runtime value (constructor)',
+    (name) => {
+      expect(typeof (brepjs as Record<string, unknown>)[name]).toBe('function');
+    }
+  );
+});

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -139,6 +139,8 @@ import type {
  * tests in the sections that follow.
  */
 const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
+  'BaseSketcher2d',
+  'BlueprintSketcher',
   'BrepBugError',
   'BrepErrorCode',
   'BrepWrapperError',
@@ -146,11 +148,13 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'CompoundSketch',
   'DEG2RAD',
   'DisposalScope',
+  'FaceSketcher',
   'HASH_CODE_MAX',
   'OK',
   'OcctWasmAdapter',
   'RAD2DEG',
   'Sketch',
+  'Sketcher',
   'Sketches',
   'addChild',
   'addHoles',


### PR DESCRIPTION
## Summary

- Closes #959
- `Sketcher`, `FaceSketcher`, `BaseSketcher2d`, `BlueprintSketcher` were converted to type-only exports in #547. Because they are classes, this erased their runtime value, breaking the documented `new Sketcher('XY')` API used throughout the docs (`apps/docs/tasks/sketching.md`) and the brepjs.dev editor — module consumers got `does not provide an export named 'Sketcher'`.
- Restore them as value+type exports. `GenericSketcher` (interface) and `SplineOptions` (type alias) stay correctly type-only.
- Add a regression test using a namespace import (`import * as brepjs`) — named imports of erased type-only exports silently resolve to `undefined` and would not catch this. Also update the `EXPECTED_RUNTIME_EXPORTS` allowlist in `tests/public-api-types.test.ts`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check:boundaries`
- [x] `npx vitest run tests/apiSketcherExports.test.ts tests/public-api-types.test.ts` (passes; fails when fix is reverted)
- [x] Pre-existing `tests/sketcher3d.test.ts` failures verified unrelated (present on main)