### PR TITLE
docs(examples): fix `cup` shell snippets to use `atDistance` instead of nonexistent `withZ`

### DIFF
--- a/apps/docs/tasks/lofts-sweeps.md
+++ b/apps/docs/tasks/lofts-sweeps.md
@@ -210,7 +210,8 @@ After building a solid, hollow it out by removing one or more faces and offsetti
 import { sketchCircle, faceFinder, shell, unwrap } from 'brepjs/quick';
 
 const closed = sketchCircle(20).extrude(40);
-const topFaces = faceFinder().inDirection('Z').withZ({ min: 39 }).findAll(closed);
+// Top face is the only one whose minimum distance from the origin is 40 (the cylinder's height).
+const topFaces = faceFinder().atDistance(40, [0, 0, 0]).findAll(closed);
 const cup = unwrap(shell(closed, topFaces, 2)); // 2mm wall, top open
 export default cup;
 ```
@@ -223,7 +224,7 @@ The fluent equivalent:
 import { shape, sketchCircle } from 'brepjs/quick';
 
 const cup = shape(sketchCircle(20).extrude(40)).shell(
-  (f) => f.inDirection('Z').withZ({ min: 39 }),
+  (f) => f.atDistance(40, [0, 0, 0]),
   2
 ).val;
 export default cup;


### PR DESCRIPTION
## Summary

`faceFinder().withZ({...})` is not a method on `FaceFinderFn` (verified against `src/query/shapeFinders.ts` — only `inDirection`, `parallelTo`, `ofSurfaceType`, `ofArea`, and `atDistance` exist). Both `cup` shell examples in `apps/docs/tasks/lofts-sweeps.md` would throw `TypeError: ... withZ is not a function` if the doc-test runner actually executed them.

This is the same `withZ` issue I flagged in #962's "out-of-scope follow-ups" section. Picking it up now as a small standalone fix.

Switched both the **functional** and **fluent** versions to `atDistance(40, [0, 0, 0])`, which uniquely matches the top face of the 40 mm cylinder (the planar foot of perpendicular from origin to the top plane lies inside the disk → distance = 40; bottom face = 0; cylindrical side rim = 20).

## Verification

Standalone OCCT run with both fixed snippets:

```
functional cup vol: 11586.19 mm³
fluent     cup vol: 11586.19 mm³
expected ~11585 (outer cyl − inner cyl, top-open)
```

Matches `π·20²·40 − π·18²·38` ≈ 11585 (outer cylinder minus top-open inner cylinder with 2 mm wall offset).

`npm run typecheck` passes.

## Test plan

- [x] Geometry verified via standalone OCCT
- [x] `npm run typecheck` clean
- [ ] Remote CI green
- [ ] Greptile review