### PR TITLE
chore(deps): pin opentype.js to 1.x — 2.0.0 has same ccmp bug as 1.3.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,12 @@ updates:
     schedule:
       interval: weekly
     ignore:
-      # 1.3.5 throws on GSUB lookup type 6 substFormat 2 used by DejaVu Sans / Noto Sans
-      # for ccmp glyph composition — breaks textBlueprints/textMetrics with system fonts.
-      # Re-allow once opentype.js supports this lookup format.
+      # opentype.js 1.3.5 and 2.0.0 throw on GSUB lookup type 6 substFormat 2 used by
+      # DejaVu Sans / Noto Sans for ccmp glyph composition — breaks textBlueprints /
+      # textMetrics with system fonts. (1.3.5 was an accidental prerelease of 2.0.0;
+      # both ship the same code.) Re-allow once opentype.js supports this lookup format.
       - dependency-name: opentype.js
-        versions: ['1.3.5']
+        versions: ['1.3.5', '2.x']
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary

- Add `2.x` to the `opentype.js` ignore list in `.github/dependabot.yml`.
- Update the rationale comment to capture that 1.3.5 and 2.0.0 ship the same broken code.

## Why

Dependabot opened #967 to bump `opentype.js` 1.3.4 → 2.0.0. Empirically, 2.0.0 throws the **same** error 1.3.5 did when parsing DejaVu Sans / Noto Sans:

```
Error: substitutionType : 62 lookupType: 6 - substFormat: 2 is not yet supported
  at FeatureQuery.getLookupMethod node_modules/opentype.js/dist/opentype.js:14539:15
  at Bidi.ccmpReplacementLigatures node_modules/opentype.js/dist/opentype.js:14908:38
  at Bidi.applyCcmpReplacement node_modules/opentype.js/dist/opentype.js:15219:40
  at Font.stringToGlyphs node_modules/opentype.js/dist/opentype.js:15449:26
```

Per the upstream release notes, `1.3.5` was an accidental prerelease that shipped the same code as `2.0.0`. So our existing `1.3.5` ignore is necessary but not sufficient — the next major also needs to be pinned out until upstream supports lookup type 6 / format 2.

#967 has been closed via `@dependabot ignore this major version`; this PR makes the same intent durable in the manifest.

## Test plan

- [ ] CI: lint / typecheck / build / tests all green.
- [ ] No further Dependabot PRs for `opentype.js@2.x` until the manifest is updated.