### PR TITLE
fix(playground): pin @types/three to 0.184.0 to dedupe with transitive copies

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -31,7 +31,7 @@
     "@tailwindcss/vite": "4.3.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "@types/three": "0.184.1",
+    "@types/three": "0.184.0",
     "@vitejs/plugin-react": "6.0.1",
     "puppeteer": "24.43.0",
     "tailwindcss": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "@tailwindcss/vite": "4.3.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
-        "@types/three": "0.184.1",
+        "@types/three": "0.184.0",
         "@vitejs/plugin-react": "6.0.1",
         "puppeteer": "24.43.0",
         "tailwindcss": "4.3.0",
@@ -424,21 +424,6 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
-    "apps/playground/node_modules/@types/three": {
-      "version": "0.184.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
-      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@dimforge/rapier3d-compat": "~0.12.0",
-        "@tweenjs/tween.js": "~23.1.3",
-        "@types/stats.js": "*",
-        "@types/webxr": ">=0.5.17",
-        "fflate": "~0.8.2",
-        "meshoptimizer": "~1.1.1"
       }
     },
     "apps/playground/node_modules/react": {


### PR DESCRIPTION
## Summary

- Pin `@types/three` from `0.184.1` back to `0.184.0` in `apps/playground/package.json`.
- Removes the duplicate workspace-local install that was breaking `tsc -b` in the playground.

## Why

Vercel deploys have been failing on `main` ever since #963 merged. The build error was:

```
TS2345: Argument of type 'Camera' is not assignable to parameter of type 'Camera'.
  Property 'isMatrix4' is missing in type 'Matrix4' but required in type 'Matrix4'.
```

— two `Camera` types from two different `@types/three` paths.

## Root cause

`#963`'s minor-and-patch group bumped `@types/three` from `0.184.0` → `0.184.1`. But `three@0.184.1` was **never published to npm** — only the types changed. Meanwhile, `@react-three/drei → maath` and `@react-three/drei → stats-gl` transitively depend on `@types/three@0.184.0`, so npm couldn't dedupe and produced two copies in the tree:

- `node_modules/@types/three@0.184.0` (hoisted, used by `@react-three/fiber`'s typings)
- `apps/playground/node_modules/@types/three@0.184.1` (direct, workspace-local)

TypeScript treats declaration files at different paths as nominally distinct types, so `Camera` from each copy was no longer interchangeable. The playground's `tsc -b` then failed, which broke the Vercel build (`npm run build --workspace=apps/playground` is the first step).

Local builds were passing because nobody had run `npm install` against the post-#963 lockfile yet.

## Test plan

- [x] `npm run build --workspace=apps/playground` passes locally with the pinned version.
- [x] Verified single `@types/three` install at `node_modules/@types/three@0.184.0` after fresh install.
- [ ] CI green.
- [ ] Vercel preview deploy succeeds (currently failing on main).

## Follow-up

When `three@0.184.1` (or a matching version pair) eventually ships, bump both `three` and `@types/three` together.