### PR TITLE
ci: add playground-build job that mirrors Vercel's bundler step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      playground: ${{ steps.filter.outputs.playground }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Release-please PRs only touch CHANGELOG.md, package.json versions,
@@ -50,6 +51,14 @@ jobs:
               - 'eslint.config.*'
               - 'knip.config.*'
               - '.prettierrc*'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/**'
+            playground:
+              - 'src/**'
+              - 'packages/**'
+              - 'apps/playground/**'
+              - 'package.json'
+              - 'package-lock.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
 
@@ -95,6 +104,23 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm run build
       - run: npm run docs:api
+
+  playground-build:
+    # Mirrors what Vercel runs (`npm run build --workspace=apps/playground`).
+    # Catches type-resolution and bundler regressions in the playground
+    # before they break Preview deploys — e.g. the duplicate `@types/three`
+    # install in #963 that broke `tsc -b` only inside apps/playground.
+    needs: changes
+    if: needs.changes.outputs.playground == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup
+      # The playground resolves `brepjs` via package exports → `dist/`. Build
+      # the library first so `tsc -b` and `vite build` see real type files.
+      - run: npm run build
+      - run: npm run build --workspace=apps/playground
 
   test:
     needs: changes
@@ -244,7 +270,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, typecheck, lint, quality, build, test, size, benchmark]
+    needs: [changes, typecheck, lint, quality, build, playground-build, test, size, benchmark]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary

- New `playground-build` CI job: `npm run build && npm run build --workspace=apps/playground`
- New `playground` path filter so the job runs on lockfile / root code / playground changes
- Wired into `ci-pass` so a broken playground build fails the required check

## Why

#963 bumped \`@types/three\` to 0.184.1 in the playground while transitive deps (`@react-three/drei → maath`, `stats-gl`) stayed on 0.184.0. npm couldn't dedupe and produced two parallel installs:

\`\`\`
node_modules/@types/three                       → 0.184.0
apps/playground/node_modules/@types/three       → 0.184.1
\`\`\`

TypeScript treats declaration files from different paths as nominally distinct, so \`tsc -b\` failed only inside \`apps/playground\`. The break was invisible to the existing \`build\` job (it only builds the brepjs library + typedoc). The first place it surfaced was a red Vercel deploy on \`main\` — an after-the-fact, non-blocking signal.

This job catches the same class of failure pre-merge, mirroring Vercel's \`buildCommand\`:

\`\`\`
npm install --legacy-peer-deps && npm run build --workspace=apps/playground && npm run build --workspace=apps/docs && ...
\`\`\`

(Docs build is intentionally not added — it's a much narrower vitepress build with fewer cross-workspace gotchas. Can be added separately if a similar incident shows up there.)

## Notes

- Runs `npm run build` (root) first because the playground resolves \`brepjs\` via package exports → \`dist/\` and \`tsc -b\` needs the real .d.ts files.
- The \`playground\` filter is intentionally permissive — anything that can shift the hoisted node_modules tree (lockfile, root package.json, \`packages/**\`) retriggers.
- \`Playground Smoke\` (post-deploy headless puppeteer smoke) stays as the runtime gate; this PR adds the missing build-time gate.

## Test plan

- [x] YAML parses (\`python3 -c 'yaml.safe_load(...)'\`)
- [x] \`npm run build && npm run build --workspace=apps/playground\` passes locally on a fresh \`npm ci\`
- [ ] CI green on this PR (the new job is exercising itself)
- [ ] Verify \`playground-build\` shows up in \`ci-pass\` aggregator