### PR TITLE
ci(setup): cache workspace node_modules so playground build resolves @tailwindcss/vite

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,10 +10,17 @@ runs:
     - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: cache
       with:
-        path: node_modules
-        key: node-24-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('packages/brepjs-opencascade/package.json') }}
+        # Include workspace node_modules so packages that can't be hoisted
+        # (e.g. apps/playground/node_modules/@tailwindcss/vite) survive
+        # cache restore — otherwise they vanish on cache hit and break
+        # workspace-scoped builds like `npm run build --workspace=apps/playground`.
+        path: |
+          node_modules
+          apps/*/node_modules
+          packages/*/node_modules
+        key: node-24-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('packages/brepjs-opencascade/package.json') }}
         restore-keys: |
-          node-24-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+          node-24-v2-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
## Summary

- Setup composite action now caches `apps/*/node_modules` and `packages/*/node_modules` in addition to root `node_modules`.
- Cache key bumped from `node-24-` to `node-24-v2-` to invalidate caches built under the old root-only path layout.

## Why

The `playground-build` job added in #975 ran on its own PR and immediately failed:

```
failed to load config from .../apps/playground/vite.config.ts
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@tailwindcss/vite'
```

`@tailwindcss/vite` is a `devDependencies` of `apps/playground`. With npm workspaces, packages that can't be hoisted (peer-dep conflicts, exact-version pins) live in the workspace's local `node_modules/`. The setup action only cached root `node_modules`, so on cache hit `apps/playground/node_modules/` was empty and `vite build` couldn't resolve workspace-local deps.

The existing root-only CI jobs (`typecheck`, `lint`, `quality`, `build`, `test`, `benchmark`) never noticed because they only use root `node_modules`. The `playground-build` job is the first thing that exercises a workspace-scoped install.

## Test plan

- [ ] `playground-build` job on this PR succeeds (the new caching is exercising itself).
- [ ] Cache restore on subsequent PRs hits the new `v2` key and includes workspace dirs.

## Notes

- The first run will rebuild caches under the new key, paying a one-time `npm ci` cost across all jobs.
- Old `node-24-` caches will go unused and eventually expire (default 7 days).