### PR TITLE
fix(playground): alias react/react-dom to workspace copy for vite 8

### DIFF
--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -79,6 +79,16 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['brepjs-opencascade'],
   },
+  resolve: {
+    // npm hoisting puts react in apps/playground/node_modules (workspace local) but
+    // packages like @vercel/analytics and @monaco-editor/react are hoisted to root,
+    // so their relative `react` resolution fails under vite 8 + rolldown's stricter
+    // module resolution. Force both to find this workspace's react copy.
+    alias: {
+      react: fileURLToPath(new URL('./node_modules/react', import.meta.url)),
+      'react-dom': fileURLToPath(new URL('./node_modules/react-dom', import.meta.url)),
+    },
+  },
   build: {
     chunkSizeWarningLimit: 1100,
     rollupOptions: {


### PR DESCRIPTION
## Summary

Aliases `react` and `react-dom` to the playground workspace's `node_modules` copies in `apps/playground/vite.config.ts` so vite 8 + rolldown's stricter peer-dep resolution can find them.

## Why

Every Vercel main deploy since #963 has failed. Local repro with the same install command (`npm install --legacy-peer-deps`) produces:

```
[MISSING_EXPORT] Error: "useEffect" is not exported by
  "__vite-optional-peer-dep:react:@vercel/analytics"
```

(Same error pattern hits `@monaco-editor/react` once `@vercel/analytics` is fixed.)

Root cause: npm workspaces hoists `@vercel/analytics` and `@monaco-editor/react` to root `node_modules/` but `react` stays pinned in `apps/playground/node_modules/react`. Both hoisted packages declare `react` as an *optional* peer dep. Vite 8 + rolldown walks up from each hoisted package looking for `react`, doesn't find it (because workspaces don't put it at root), and emits a `__vite-optional-peer-dep:react:<consumer>` placeholder that lacks the actual exports.

The `playground-build` CI job added in #975 doesn't catch this because it uses `npm ci` (deterministic, different hoisting than `--legacy-peer-deps`). PR #973 pinned `@types/three` back but that addressed a different symptom.

## Fix

```ts
resolve: {
  alias: {
    react: fileURLToPath(new URL('./node_modules/react', import.meta.url)),
    'react-dom': fileURLToPath(new URL('./node_modules/react-dom', import.meta.url)),
  },
}
```

Forces both `react` and `react-dom` to resolve from the workspace, regardless of which hoisted package issued the import.

## Test plan

- [x] Local repro: `npm install --legacy-peer-deps && npm run build --workspace=apps/playground` fails on `main`, passes with this branch.
- [x] Docs build (`npm run build --workspace=apps/docs`) still passes.
- [ ] Vercel preview deploy on this PR succeeds.