### PR TITLE
fix(gear): dispose sun/planet solids on planetary error paths

### DIFF
--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -220,7 +220,10 @@ export function makePlanetaryGear(params: PlanetaryGearParams): Result<Planetary
     backlashHalf: cfg.bHalf,
     bore: cfg.bores.planet ?? 0,
   });
-  if (isErr(planetResult)) return planetResult;
+  if (isErr(planetResult)) {
+    sunResult.value.solid.delete();
+    return planetResult;
+  }
 
   const ringResult = makeInternalGear({
     teeth: cfg.zr,
@@ -232,7 +235,11 @@ export function makePlanetaryGear(params: PlanetaryGearParams): Result<Planetary
     backlashHalf: cfg.bHalf,
     ringWallThickness: cfg.ringWallThickness,
   });
-  if (isErr(ringResult)) return ringResult;
+  if (isErr(ringResult)) {
+    sunResult.value.solid.delete();
+    planetResult.value.solid.delete();
+    return ringResult;
+  }
 
   const planets = placePlanets(planetResult.value.solid, cfg);
   planetResult.value.solid.delete();


### PR DESCRIPTION
## Summary

`makePlanetaryGear` leaked WASM handles on three error branches:

1. Planet construction fails → sun solid orphaned
2. Ring construction fails → sun + planet solids orphaned

Each branch now `.delete()`s the survivors before returning the error.

## What's not fixed (deliberately)

A second class of leak exists in `finalizeExternalSolid` and `finalizeInternalSolid`: the input wires and intermediate face are never disposed. Disposing them at this layer is **unsafe** because brepkit's \`extrude\` shares topology with the input face — disposing the face corrupts the resulting solid (verified: doing so makes the OCCT-only \`bore reduces volume\` test pass while breaking brepkit's gear volume calculations).

A clean fix needs a kernel-level \`deepCopy\` operation so the gear solid can detach from its inputs before they go out of scope. That's a follow-up across the kernel abstraction layer, not a one-file change. FinalizationRegistry continues to reclaim those handles as a safety net.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npx vitest run tests/gearFns.test.ts` — OCCT 19/19 pass; brepkit 3 failures pre-exist on main (unrelated to this change, per project convention not held to parity)
- [x] Pre-commit hooks: layer boundaries, lint-staged, full changed-file tests pass