### PR TITLE
feat(gear): expose samples knob for flank tessellation density

### DIFF
--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -61,6 +61,12 @@ export interface ExternalGearParams {
   flankThinning?: number;
   /** Diameter (mm) of central bore; 0 or omitted = no bore. */
   bore?: number;
+  /**
+   * Sample count per involute flank. Lower = faster mesh, coarser surface.
+   * Defaults to `adaptiveSampleCount(moduleSize)` (≈ 16 at module 2). Try
+   * 8 for previews, 24+ for 3D printing.
+   */
+  samples?: number;
 }
 
 export interface InternalGearParams {
@@ -73,6 +79,8 @@ export interface InternalGearParams {
   flankThinning?: number;
   /** Wall thickness from pitch radius outward; defaults to 2·moduleSize. */
   ringWallThickness?: number;
+  /** See {@link ExternalGearParams.samples}. */
+  samples?: number;
 }
 
 export interface PlanetaryGearParams {
@@ -100,6 +108,8 @@ export interface PlanetaryGearParams {
    * When supplied, lewisStress is computed.
    */
   appliedTorque?: number;
+  /** See {@link ExternalGearParams.samples}. Applied to sun, planet, and ring. */
+  samples?: number;
 }
 
 export interface GearResult {
@@ -141,6 +151,7 @@ export function makeExternalGear(params: ExternalGearParams): Result<GearResult>
     clearance = DEFAULT_CLEARANCE,
     flankThinning = 0,
     bore = 0,
+    samples,
   } = params;
   if (thickness <= 0)
     return err(validationError('GEAR_THICKNESS_NONPOSITIVE', 'thickness must be > 0'));
@@ -162,6 +173,7 @@ export function makeExternalGear(params: ExternalGearParams): Result<GearResult>
     shift,
     clearance,
     backlashHalf: flankThinning,
+    ...(samples !== undefined ? { samples } : {}),
   });
   if (isErr(wireResult)) return wireResult;
   return finalizeExternalSolid(wireResult.value, thickness, bore, geom);
@@ -177,6 +189,7 @@ export function makeInternalGear(params: InternalGearParams): Result<GearResult>
     clearance = DEFAULT_CLEARANCE,
     flankThinning = 0,
     ringWallThickness = 2 * params.moduleSize,
+    samples,
   } = params;
   if (thickness <= 0)
     return err(validationError('GEAR_THICKNESS_NONPOSITIVE', 'thickness must be > 0'));
@@ -191,6 +204,7 @@ export function makeInternalGear(params: InternalGearParams): Result<GearResult>
     shift,
     clearance,
     backlashHalf: flankThinning,
+    ...(samples !== undefined ? { samples } : {}),
   });
   if (isErr(innerWireResult)) return innerWireResult;
 
@@ -207,57 +221,18 @@ export function makePlanetaryGear(params: PlanetaryGearParams): Result<Planetary
   if (isErr(resolved)) return resolved;
   const cfg = resolved.value;
 
-  const sunResult = makeExternalGear({
-    teeth: cfg.sunTeeth,
-    moduleSize: cfg.moduleSize,
-    thickness: cfg.thickness,
-    pressureAngleDeg: cfg.pressureAngleDeg,
-    shift: cfg.sunShift,
-    clearance: cfg.clearance,
-    flankThinning: cfg.bHalf,
-    bore: cfg.sunBore,
-  });
-  if (isErr(sunResult)) return sunResult;
+  const stages = buildPlanetaryStages(cfg);
+  if (isErr(stages)) return stages;
+  const { sun, planet, ring } = stages.value;
 
-  const planetResult = makeExternalGear({
-    teeth: cfg.planetTeeth,
-    moduleSize: cfg.moduleSize,
-    thickness: cfg.thickness,
-    pressureAngleDeg: cfg.pressureAngleDeg,
-    shift: cfg.planetShift,
-    clearance: cfg.clearance,
-    flankThinning: cfg.bHalf,
-    bore: cfg.planetBore,
-  });
-  if (isErr(planetResult)) {
-    sunResult.value.solid.delete();
-    return planetResult;
-  }
-
-  const ringResult = makeInternalGear({
-    teeth: cfg.zr,
-    moduleSize: cfg.moduleSize,
-    thickness: cfg.thickness,
-    pressureAngleDeg: cfg.pressureAngleDeg,
-    shift: cfg.ringShift,
-    clearance: cfg.clearance,
-    flankThinning: cfg.bHalf,
-    ringWallThickness: cfg.ringWallThickness,
-  });
-  if (isErr(ringResult)) {
-    sunResult.value.solid.delete();
-    planetResult.value.solid.delete();
-    return ringResult;
-  }
-
-  const planets = placePlanets(planetResult.value.solid, cfg);
-  planetResult.value.solid.delete();
-  const ringPhased = applyRingPhase(ringResult.value.solid, cfg.zr);
-  const metrics = computeMeshMetrics(cfg, sunResult.value, planetResult.value, ringResult.value);
+  const planets = placePlanets(planet.solid, cfg);
+  planet.solid.delete();
+  const ringPhased = applyRingPhase(ring.solid, cfg.zr);
+  const metrics = computeMeshMetrics(cfg, sun, planet, ring);
   const diagnostics = collectDiagnostics(cfg, metrics);
 
   return ok({
-    sun: sunResult.value.solid,
+    sun: sun.solid,
     planets,
     ring: ringPhased,
     ringTeeth: cfg.zr,
@@ -268,6 +243,49 @@ export function makePlanetaryGear(params: PlanetaryGearParams): Result<Planetary
     ...(metrics.lewisStress ? { lewisStress: metrics.lewisStress } : {}),
     diagnostics,
   });
+}
+
+function buildPlanetaryStages(
+  cfg: ResolvedPlanetary
+): Result<{ sun: GearResult; planet: GearResult; ring: GearResult }> {
+  const samplesField = cfg.samples !== undefined ? { samples: cfg.samples } : {};
+  const common = {
+    moduleSize: cfg.moduleSize,
+    thickness: cfg.thickness,
+    pressureAngleDeg: cfg.pressureAngleDeg,
+    clearance: cfg.clearance,
+    flankThinning: cfg.bHalf,
+    ...samplesField,
+  };
+  const sun = makeExternalGear({
+    ...common,
+    teeth: cfg.sunTeeth,
+    shift: cfg.sunShift,
+    bore: cfg.sunBore,
+  });
+  if (isErr(sun)) return sun;
+  const planet = makeExternalGear({
+    ...common,
+    teeth: cfg.planetTeeth,
+    shift: cfg.planetShift,
+    bore: cfg.planetBore,
+  });
+  if (isErr(planet)) {
+    sun.value.solid.delete();
+    return planet;
+  }
+  const ring = makeInternalGear({
+    ...common,
+    teeth: cfg.zr,
+    shift: cfg.ringShift,
+    ringWallThickness: cfg.ringWallThickness,
+  });
+  if (isErr(ring)) {
+    sun.value.solid.delete();
+    planet.value.solid.delete();
+    return ring;
+  }
+  return ok({ sun: sun.value, planet: planet.value, ring: ring.value });
 }
 
 interface ResolvedPlanetary {
@@ -291,6 +309,7 @@ interface ResolvedPlanetary {
   sunBore: number;
   planetBore: number;
   appliedTorque?: number;
+  samples?: number;
   zr: number;
   centerDistance: number;
 }
@@ -345,6 +364,7 @@ function resolvePlanetaryParams(params: PlanetaryGearParams): Result<ResolvedPla
     sunBore: params.sunBore ?? 0,
     planetBore: params.planetBore ?? 0,
     ...(params.appliedTorque !== undefined ? { appliedTorque: params.appliedTorque } : {}),
+    ...(params.samples !== undefined ? { samples: params.samples } : {}),
     zr,
     centerDistance,
   });

--- a/tests/gearFns.test.ts
+++ b/tests/gearFns.test.ts
@@ -68,6 +68,20 @@ describe('makeExternalGear', () => {
       true
     );
   });
+
+  it('samples override produces a valid solid; volume converges as samples grow', () => {
+    // Coarse and fine samples should both build valid solids; the fine-sample
+    // gear approximates the true involute more closely, so its volume sits
+    // between coarse (under-sampled) and analytic (effectively unreachable).
+    const coarse = unwrap(makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8, samples: 4 }));
+    const fine = unwrap(makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8, samples: 32 }));
+    expect(isSolid(coarse.solid)).toBe(true);
+    expect(isSolid(fine.solid)).toBe(true);
+    const vCoarse = unwrap(measureVolume(coarse.solid));
+    const vFine = unwrap(measureVolume(fine.solid));
+    // Within 5% — flank approximation noise; mostly to assert sane geometry both sides.
+    expect(Math.abs(vCoarse - vFine) / vFine).toBeLessThan(0.05);
+  });
 });
 
 describe('makeInternalGear (ring)', () => {


### PR DESCRIPTION
## Summary

R1 from the rendering-performance review: expose the existing `samples` parameter on the public gear API so callers can tune flank tessellation without dropping to internal helpers.

\`\`\`ts
makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8, samples: 8 });   // preview
makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8 });               // adaptive default
makePlanetaryGear({ thickness: 10, samples: 24 });                          // 3D-printable
\`\`\`

The internal `makeExternalGearProfileWire` / `makeInternalGearProfileWire` already accepted `samples`; nothing in the math changes.

## Why now

A 24-tooth gear has 48 BSpline flank surfaces. At default density each gets ~20-60 triangles, so a planetary assembly easily reaches 15k-30k triangles. The dominant cost is meshing on the WASM side (50-200ms), not GPU draws — which is why a samples knob beats GPU-side tweaks for CAD rendering.

## Refactor along for the ride

`makePlanetaryGear` was at 60 lines and added a few more for `samples` propagation, tripping the 60-line pattern-checker limit. Extracted `buildPlanetaryStages(cfg)` which also collapses the three repeated param dicts into a shared `common` spread. Net: clearer call site, no behavior change.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] New test: \`samples override produces a valid solid; volume converges as samples grow\` (passes on OCCT, brepkit)
- [x] OCCT 19/19 gear tests pass; the 3 brepkit failures are pre-existing on main (unrelated, project not held to parity)
- [x] Pre-commit hooks pass (layer boundaries, lint-staged with extracted helper, typecheck)