### PR TITLE
feat(gear): add planetPlacements for instanced planet rendering

### DIFF
--- a/src/gear/gearMath.ts
+++ b/src/gear/gearMath.ts
@@ -1,5 +1,5 @@
 import type { Vec3 } from '@/core/types.js';
-import { type Result, ok, err } from '@/core/result.js';
+import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError } from '@/core/errors.js';
 
 export const DEFAULT_PRESSURE_ANGLE_DEG = 20;
@@ -284,4 +284,63 @@ export function evenToothPhaseOffset(z: number): number {
 
 export function planetSelfRotationAngle(orbitalAngle: number, zs: number, zp: number): number {
   return orbitalAngle * (1 + zs / zp) + evenToothPhaseOffset(zp);
+}
+
+/** Pure-kinematics inputs for {@link planetPlacements}; subset of `PlanetaryGearParams`. */
+export interface PlanetPlacementParams {
+  moduleSize?: number;
+  sunTeeth?: number;
+  planetTeeth?: number;
+  numPlanets?: number;
+  pressureAngleDeg?: number;
+  sunShift?: number;
+  planetShift?: number;
+}
+
+export interface PlanetPlacement {
+  /** Self-rotation around the planet's own Z axis, in degrees. */
+  rotationDeg: number;
+  /** Center of the planet in the assembly frame: `[x, y, 0]`. */
+  position: Vec3;
+}
+
+/**
+ * Compute the rigid placement of each planet without building any solid.
+ *
+ * Pairs with one materialized planet from `makeExternalGear` to support
+ * GPU-instanced rendering: mesh once, draw N times under these transforms.
+ * Defaults match {@link PlanetaryGearParams}.
+ */
+export function planetPlacements(params: PlanetPlacementParams = {}): Result<PlanetPlacement[]> {
+  const moduleSize = params.moduleSize ?? 3;
+  const sunTeeth = params.sunTeeth ?? 15;
+  const planetTeeth = params.planetTeeth ?? 12;
+  const numPlanets = params.numPlanets ?? 3;
+  const alpha = ((params.pressureAngleDeg ?? DEFAULT_PRESSURE_ANGLE_DEG) * Math.PI) / 180;
+  const sunShift = params.sunShift ?? 0;
+  const planetShift = params.planetShift ?? 0;
+
+  const validation = validatePlanetary(sunTeeth, planetTeeth, numPlanets, planetShift);
+  if (isErr(validation)) return validation;
+
+  const sp = solveSunPlanetWorkingPressureAngle(
+    alpha,
+    sunShift,
+    planetShift,
+    sunTeeth,
+    planetTeeth
+  );
+  if (isErr(sp)) return sp;
+  const centerDistance = workingCenterDistance(sunTeeth, planetTeeth, moduleSize, alpha, sp.value);
+
+  const placements: PlanetPlacement[] = [];
+  for (let i = 0; i < numPlanets; i++) {
+    const orbital = (i * 2 * Math.PI) / numPlanets;
+    const selfRot = planetSelfRotationAngle(orbital, sunTeeth, planetTeeth);
+    placements.push({
+      rotationDeg: (selfRot * 180) / Math.PI,
+      position: [centerDistance * Math.cos(orbital), centerDistance * Math.sin(orbital), 0],
+    });
+  }
+  return ok(placements);
 }

--- a/src/gear/index.ts
+++ b/src/gear/index.ts
@@ -22,6 +22,9 @@ export {
   ringTeeth,
   evenToothPhaseOffset,
   planetSelfRotationAngle,
+  planetPlacements,
+  type PlanetPlacement,
+  type PlanetPlacementParams,
 } from './gearMath.js';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1022,11 +1022,14 @@ export {
   type GearDiagnosticCode,
   type GearDiagnosticSeverity,
   type GearGeometry,
+  type PlanetPlacement,
+  type PlanetPlacementParams,
   makeExternalGear,
   makeInternalGear,
   makePlanetaryGear,
   gearGeometry,
   validatePlanetary,
+  planetPlacements,
 } from './gear/index.js';
 
 // ── Namespace re-exports (grouped API) ──

--- a/tests/gearMath.test.ts
+++ b/tests/gearMath.test.ts
@@ -21,7 +21,9 @@ import {
   evenToothPhaseOffset,
   planetSelfRotationAngle,
   backlashHalf,
+  planetPlacements,
 } from '@/gear/gearMath.js';
+import { unwrap } from '@/core/result.js';
 
 describe('inv (involute function)', () => {
   it('inv(0) = 0', () => {
@@ -325,5 +327,35 @@ describe('planetary kinematics', () => {
   it('backlashHalf = b/2', () => {
     expect(backlashHalf(0.4)).toBe(0.2);
     expect(backlashHalf(0)).toBe(0);
+  });
+});
+
+describe('planetPlacements', () => {
+  it('default config returns 3 placements with equal orbital spacing', () => {
+    const placements = unwrap(planetPlacements());
+    expect(placements).toHaveLength(3);
+    // 3 planets at 0°, 120°, 240° around sun-planet center distance.
+    // Default zs=15, zp=12, m=3 → centerDistance = (15+12)·3/2 = 40.5.
+    const r = 40.5;
+    expect(placements[0]?.position).toEqual([r, 0, 0]);
+    expect(placements[1]?.position[0]).toBeCloseTo(r * Math.cos((2 * Math.PI) / 3), 8);
+    expect(placements[2]?.position[1]).toBeCloseTo(r * Math.sin((4 * Math.PI) / 3), 8);
+  });
+
+  it('honours numPlanets', () => {
+    expect(unwrap(planetPlacements({ sunTeeth: 20, planetTeeth: 16, numPlanets: 4 }))).toHaveLength(
+      4
+    );
+  });
+
+  it('rejects invalid assemblies (planet collision)', () => {
+    // 5 planets, sun=8, planet=12 — same case the high-level builder rejects.
+    expect(isErr(planetPlacements({ sunTeeth: 8, planetTeeth: 12, numPlanets: 5 }))).toBe(true);
+  });
+
+  it('rotation angles match planetSelfRotationAngle', () => {
+    const placements = unwrap(planetPlacements({ sunTeeth: 20, planetTeeth: 16, numPlanets: 4 }));
+    // i=0 → orbital=0, selfRot = 0·(1+20/16) + π/16 (zp even). In degrees: 180/16.
+    expect(placements[0]?.rotationDeg).toBeCloseTo(180 / 16, 6);
   });
 });

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -492,6 +492,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'pivotPlane',
   'planarFace',
   'planarWire',
+  'planetPlacements',
   'pocket',
   'pointOnSurface',
   'polygon',


### PR DESCRIPTION
## Summary

R2 from the rendering-performance review. Adds a pure-kinematics helper that returns the rigid placement of each planet in a planetary assembly without building any solid.

\`\`\`ts
import { makeExternalGear, planetPlacements, unwrap } from 'brepjs';

const planet = unwrap(makeExternalGear({ teeth: 12, moduleSize: 3, thickness: 10 })).solid;
const placements = unwrap(planetPlacements({ sunTeeth: 15, planetTeeth: 12, numPlanets: 3 }));

// Renderer: mesh \`planet\` once, instance N times under these transforms.
for (const { rotationDeg, position } of placements) {
  drawInstance(planetMesh, { rotateZ: rotationDeg, translate: position });
}
\`\`\`

## Why this beats \`PlanetaryGearAssembly.planets[]\`

The high-level builder still returns N independent solids — useful when you want STEP export, per-planet boolean ops, or independent disposal. For pure rendering, every planet is geometrically identical up to a rigid transform. \`planets[]\` forces N kernel meshing calls (50-200ms each on WASM) and N GPU uploads. With \`planetPlacements\` you mesh once and let the GPU instance the rest.

## API shape

- \`PlanetPlacementParams\`: subset of \`PlanetaryGearParams\` with only the kinematic fields (no \`thickness\`, no bores, no torque).
- \`PlanetPlacement\`: \`{ rotationDeg: number; position: Vec3 }\`.
- Defaults match \`PlanetaryGearParams\` (sun=15, planet=12, N=3, m=3, α=20°).
- Validates the assembly via the existing \`validatePlanetary\` so misconfigured inputs surface the same error codes the high-level builder uses.

## Non-breaking

Purely additive. \`PlanetaryGearAssembly.planets[]\` unchanged.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] 4 new tests in \`tests/gearMath.test.ts\` (default config, custom numPlanets, collision rejection, rotation-angle correctness)
- [x] Public API snapshot updated for \`planetPlacements\` export
- [x] All 324 non-WASM tests pass

## Stack

Sits on top of #983 (samples knob); both branched from main. If #983 lands first this PR rebases trivially; if this lands first, #983's pattern-checker extraction still holds.