### PR TITLE
feat(gear): add per-gear diagnostics for solo external/internal gears

### DIFF
--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -118,6 +118,13 @@ export interface GearResult {
   baseDiameter: number;
   tipDiameter: number;
   rootDiameter: number;
+  /**
+   * Diagnostics specific to this gear in isolation (e.g. undercut risk for
+   * low-tooth-count gears with no profile shift). Empty when the gear is
+   * geometrically clean. Planetary assemblies emit additional cross-mesh
+   * diagnostics on `PlanetaryGearAssembly.diagnostics`.
+   */
+  diagnostics: GearDiagnostic[];
 }
 
 export interface PlanetaryGearAssembly {
@@ -176,7 +183,8 @@ export function makeExternalGear(params: ExternalGearParams): Result<GearResult>
     ...(samples !== undefined ? { samples } : {}),
   });
   if (isErr(wireResult)) return wireResult;
-  return finalizeExternalSolid(wireResult.value, thickness, bore, geom);
+  const diagnostics = soloGearDiagnostics(teeth, alpha, shift);
+  return finalizeExternalSolid(wireResult.value, thickness, bore, geom, diagnostics);
 }
 
 export function makeInternalGear(params: InternalGearParams): Result<GearResult> {
@@ -213,7 +221,27 @@ export function makeInternalGear(params: InternalGearParams): Result<GearResult>
   const outerWireResult = makeOuterCircleWire(outerRadius);
   if (isErr(outerWireResult)) return outerWireResult;
 
-  return finalizeInternalSolid(outerWireResult.value, innerWireResult.value, thickness, geom);
+  const diagnostics = soloGearDiagnostics(teeth, alpha, shift);
+  return finalizeInternalSolid(
+    outerWireResult.value,
+    innerWireResult.value,
+    thickness,
+    geom,
+    diagnostics
+  );
+}
+
+function soloGearDiagnostics(teeth: number, alpha: number, shift: number): GearDiagnostic[] {
+  const deficit = undercutDeficit(teeth, alpha, shift);
+  if (deficit <= 0) return [];
+  return [
+    {
+      code: 'UNDERCUT_RISK',
+      severity: 'warning',
+      message: `gear is undercut: increase shift by ${deficit.toFixed(3)} to avoid (z=${teeth})`,
+      context: { deficit, teeth },
+    },
+  ];
 }
 
 export function makePlanetaryGear(params: PlanetaryGearParams): Result<PlanetaryGearAssembly> {
@@ -383,13 +411,14 @@ function finalizeExternalSolid(
   wire: ClosedWire & PlanarWire,
   thickness: number,
   bore: number,
-  geom: ReturnType<typeof gearGeometry>
+  geom: ReturnType<typeof gearGeometry>,
+  diagnostics: GearDiagnostic[]
 ): Result<GearResult> {
   const faceResult = makeFace(wire);
   if (isErr(faceResult)) return faceResult;
   const solidResult = extrude(faceResult.value, [0, 0, thickness]);
   if (isErr(solidResult)) return solidResult;
-  if (bore <= 0) return ok(buildGearResult(solidResult.value, geom));
+  if (bore <= 0) return ok(buildGearResult(solidResult.value, geom, diagnostics));
 
   // Bore overshoots both ends (z = -0.5 to thickness + 0.5) so no faces are coplanar.
   using boreScope = new DisposalScope();
@@ -402,7 +431,7 @@ function finalizeExternalSolid(
   const boreSolid = boreScope.register(translate(boreRaw.value, [0, 0, -0.5]));
   const cutResult = cut(solidResult.value, boreSolid);
   if (isErr(cutResult)) return cutResult;
-  return ok(buildGearResult(cutResult.value, geom));
+  return ok(buildGearResult(cutResult.value, geom, diagnostics));
 }
 
 function makeBoreFace(radius: number): Result<Parameters<typeof extrude>[0]> {
@@ -415,18 +444,24 @@ function finalizeInternalSolid(
   outerWire: ClosedWire & PlanarWire,
   innerToothedWire: ClosedWire & PlanarWire,
   thickness: number,
-  geom: ReturnType<typeof gearGeometry>
+  geom: ReturnType<typeof gearGeometry>,
+  diagnostics: GearDiagnostic[]
 ): Result<GearResult> {
   const faceResult = makeFace(outerWire, [innerToothedWire]);
   if (isErr(faceResult)) return faceResult;
   const solidResult = extrude(faceResult.value, [0, 0, thickness]);
   if (isErr(solidResult)) return solidResult;
-  return ok(buildGearResult(solidResult.value, geom));
+  return ok(buildGearResult(solidResult.value, geom, diagnostics));
 }
 
-function buildGearResult(solid: ValidSolid, geom: ReturnType<typeof gearGeometry>): GearResult {
+function buildGearResult(
+  solid: ValidSolid,
+  geom: ReturnType<typeof gearGeometry>,
+  diagnostics: GearDiagnostic[] = []
+): GearResult {
   return {
     solid,
+    diagnostics,
     pitchDiameter: 2 * geom.rPitch,
     baseDiameter: 2 * geom.rb,
     tipDiameter: 2 * geom.rTip,

--- a/src/gear/gearMath.ts
+++ b/src/gear/gearMath.ts
@@ -10,6 +10,7 @@ export type GearDiagnosticSeverity = 'warning' | 'info';
 export type GearDiagnosticCode =
   | 'CONTACT_RATIO_LOW_SUN_PLANET'
   | 'CONTACT_RATIO_LOW_PLANET_RING'
+  | 'UNDERCUT_RISK'
   | 'UNDERCUT_RISK_SUN'
   | 'UNDERCUT_RISK_PLANET'
   | 'LEWIS_Y_SHIFT_UNCORRECTED'

--- a/tests/gearFns.test.ts
+++ b/tests/gearFns.test.ts
@@ -69,6 +69,24 @@ describe('makeExternalGear', () => {
     );
   });
 
+  it('emits UNDERCUT_RISK diagnostic for low-z gear without compensating shift', () => {
+    // 12 teeth at α=20° with no shift: undercutMinimumShift ≈ 0.30, deficit > 0.
+    const r = unwrap(makeExternalGear({ teeth: 12, moduleSize: 2, thickness: 8 }));
+    const undercut = r.diagnostics.find((d) => d.code === 'UNDERCUT_RISK');
+    expect(undercut).toBeDefined();
+    expect(undercut?.severity).toBe('warning');
+  });
+
+  it('positive shift suppresses UNDERCUT_RISK on low-z gear', () => {
+    const r = unwrap(makeExternalGear({ teeth: 12, moduleSize: 2, thickness: 8, shift: 0.5 }));
+    expect(r.diagnostics.find((d) => d.code === 'UNDERCUT_RISK')).toBeUndefined();
+  });
+
+  it('high-z gear has no diagnostics by default', () => {
+    const r = unwrap(makeExternalGear({ teeth: 30, moduleSize: 2, thickness: 8 }));
+    expect(r.diagnostics).toEqual([]);
+  });
+
   it('samples override produces a valid solid; volume converges as samples grow', () => {
     // Coarse and fine samples should both build valid solids; the fine-sample
     // gear approximates the true involute more closely, so its volume sits


### PR DESCRIPTION
## Summary

E9 from the ergonomics review. Solo gears (\`makeExternalGear\`, \`makeInternalGear\`) now emit a \`diagnostics\` array on the result, mirroring what \`PlanetaryGearAssembly\` already exposes.

\`\`\`ts
const r = unwrap(makeExternalGear({ teeth: 12, moduleSize: 2, thickness: 8 }));
// r.diagnostics now contains:
// [{ code: 'UNDERCUT_RISK', severity: 'warning',
//    message: 'gear is undercut: increase shift by 0.296 to avoid (z=12)', ... }]
\`\`\`

Previously, a user passing a low tooth count silently got an undercut gear. Now they're warned without losing the result.

## Changes

- New \`UNDERCUT_RISK\` member in \`GearDiagnosticCode\` (single-gear variant; the planetary builder still emits \`UNDERCUT_RISK_SUN\`/\`UNDERCUT_RISK_PLANET\` since those carry assembly-level role context)
- New \`diagnostics: GearDiagnostic[]\` field on \`GearResult\`
- Internal helper \`soloGearDiagnostics(teeth, alpha, shift)\` shared between external and internal builders

## Non-breaking

Adds a field; doesn't rename or remove anything. Existing destructuring of \`{ solid, pitchDiameter, ... }\` is unchanged.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] 3 new tests: low-z gear emits UNDERCUT_RISK, positive shift suppresses it, high-z gear has empty diagnostics
- [x] OCCT 22/22 gear tests pass (66 in total across both kernels excluding pre-existing brepkit divergence)