### PR TITLE
refactor(gear)!: finish the flankThinning rename — GearWireParams + JSDoc

### DIFF
--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -172,7 +172,7 @@ export function makeExternalGear(params: ExternalGearParams): Result<GearResult>
     pressureAngle: alpha,
     shift,
     clearance,
-    backlashHalf: flankThinning,
+    flankThinning,
     ...(samples !== undefined ? { samples } : {}),
   });
   if (isErr(wireResult)) return wireResult;
@@ -203,7 +203,7 @@ export function makeInternalGear(params: InternalGearParams): Result<GearResult>
     pressureAngle: alpha,
     shift,
     clearance,
-    backlashHalf: flankThinning,
+    flankThinning,
     ...(samples !== undefined ? { samples } : {}),
   });
   if (isErr(innerWireResult)) return innerWireResult;

--- a/src/gear/gearMath.ts
+++ b/src/gear/gearMath.ts
@@ -57,7 +57,7 @@ export interface GearGeometry {
   /** Inner radius for external, outer for internal. */
   rRoot: number;
   alphaPitch: number;
-  /** Half-tooth angular width at the pitch circle, with shift + backlash applied. */
+  /** Half-tooth angular width at the pitch circle, with shift and flank thinning applied. */
   halfToothAngle: number;
   /** Involute parameter α at the radius the flank reaches (rTip ext, rRoot int). */
   alphaTip: number;

--- a/src/gear/gearProfile.ts
+++ b/src/gear/gearProfile.ts
@@ -98,7 +98,8 @@ export interface GearWireParams {
   pressureAngle: number;
   shift: number;
   clearance: number;
-  backlashHalf: number;
+  /** Per-gear flank thinning (mm); see {@link ExternalGearParams.flankThinning}. */
+  flankThinning: number;
   /** Override sample count per flank; defaults to adaptiveSampleCount(moduleSize). */
   samples?: number;
 }
@@ -125,7 +126,7 @@ function makeProfileWire(
     pressureAngle,
     shift,
     clearance,
-    backlashHalf,
+    flankThinning,
     samples = adaptiveSampleCount(moduleSize),
   } = params;
 
@@ -140,7 +141,7 @@ function makeProfileWire(
     pressureAngle,
     shift,
     clearance,
-    backlashHalf,
+    flankThinning,
     isInternal
   );
 


### PR DESCRIPTION
## Summary

Greptile review on #981 flagged two leftover \"backlash\" references that should have moved to \"flank thinning\" for consistency with the rest of the gear public API.

## Changes

| Where | Before | After |
|---|---|---|
| \`src/gear/gearProfile.ts\` (\`GearWireParams.backlashHalf\`) | \`backlashHalf: number\` | \`flankThinning: number\` |
| \`src/gear/gearMath.ts\` (\`GearGeometry.halfToothAngle\` JSDoc) | "shift + backlash applied" | "shift and flank thinning applied" |

\`GearWireParams\` is exported from \`src/gear/index.ts\`, so it's part of the gear module's addressable public surface. \`GearGeometry\` was promoted to top-level via the barrel re-export in #981, so its JSDoc is now visible to consumers.

## Migration

Anyone using the lower-level wire API:

\`\`\`ts
// before
makeExternalGearProfileWire({ teeth: 12, moduleSize: 2, pressureAngle: 0.349, shift: 0, clearance: 0.25, backlashHalf: 0.05 });

// after
makeExternalGearProfileWire({ teeth: 12, moduleSize: 2, pressureAngle: 0.349, shift: 0, clearance: 0.25, flankThinning: 0.05 });
\`\`\`

The \`backlashHalf(totalBacklash)\` *function* in \`gearMath.ts\` (b/2 utility) is unchanged — it's a math helper, not a parameter name.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] OCCT all gear tests pass; brepkit 3 failures pre-exist on main (unrelated)

## Stack

Independent of #987 (per-gear diagnostics). Whichever lands first, the other rebases trivially — different fields/types touched.