### PR TITLE
fix(gear+ci): hoist threshold const, scope undercut to external, validate samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,12 @@ jobs:
               mainByName[b.name] = b;
             }
 
+            // 25% threshold: shared CI runners (different machines for main
+            // vs PR sides) show ~9-15% run-to-run variance even on
+            // semantically identical code. Tightening below 25% produces
+            // more false positives than real regressions caught.
+            const REGRESSION_THRESHOLD_PCT = 25;
+
             let hasRegression = false;
             const rows = [];
 
@@ -215,11 +221,6 @@ jobs:
                 continue;
               }
 
-              // 25% threshold: shared CI runners (different machines for main
-              // vs PR sides) show ~9-15% run-to-run variance even on
-              // semantically identical code. Tightening below 25% produces
-              // more false positives than real regressions caught.
-              const REGRESSION_THRESHOLD_PCT = 25;
               const pctChange = ((pr.median - main.median) / main.median) * 100;
               let icon;
               if (pctChange > REGRESSION_THRESHOLD_PCT) {

--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -162,6 +162,13 @@ export function makeExternalGear(params: ExternalGearParams): Result<GearResult>
   } = params;
   if (thickness <= 0)
     return err(validationError('GEAR_THICKNESS_NONPOSITIVE', 'thickness must be > 0'));
+  if (samples !== undefined && (!Number.isInteger(samples) || samples < 1))
+    return err(
+      validationError(
+        'GEAR_SAMPLES_INVALID',
+        `samples must be a positive integer; got ${String(samples)}`
+      )
+    );
 
   const alpha = (pressureAngleDeg * Math.PI) / 180;
   const geom = gearGeometry(teeth, moduleSize, alpha, shift, clearance, flankThinning, false);
@@ -183,7 +190,7 @@ export function makeExternalGear(params: ExternalGearParams): Result<GearResult>
     ...(samples !== undefined ? { samples } : {}),
   });
   if (isErr(wireResult)) return wireResult;
-  const diagnostics = soloGearDiagnostics(teeth, alpha, shift);
+  const diagnostics = externalGearDiagnostics(teeth, alpha, shift);
   return finalizeExternalSolid(wireResult.value, thickness, bore, geom, diagnostics);
 }
 
@@ -203,6 +210,13 @@ export function makeInternalGear(params: InternalGearParams): Result<GearResult>
     return err(validationError('GEAR_THICKNESS_NONPOSITIVE', 'thickness must be > 0'));
   if (ringWallThickness <= 0)
     return err(validationError('GEAR_WALL_NONPOSITIVE', 'ringWallThickness must be > 0'));
+  if (samples !== undefined && (!Number.isInteger(samples) || samples < 1))
+    return err(
+      validationError(
+        'GEAR_SAMPLES_INVALID',
+        `samples must be a positive integer; got ${String(samples)}`
+      )
+    );
 
   const alpha = (pressureAngleDeg * Math.PI) / 180;
   const innerWireResult = makeInternalGearProfileWire({
@@ -221,17 +235,15 @@ export function makeInternalGear(params: InternalGearParams): Result<GearResult>
   const outerWireResult = makeOuterCircleWire(outerRadius);
   if (isErr(outerWireResult)) return outerWireResult;
 
-  const diagnostics = soloGearDiagnostics(teeth, alpha, shift);
-  return finalizeInternalSolid(
-    outerWireResult.value,
-    innerWireResult.value,
-    thickness,
-    geom,
-    diagnostics
-  );
+  // Internal gears use a different undercut criterion (involute-cutter geometry,
+  // shift sign inverted), so the rack-cut formula that drives external-gear
+  // diagnostics doesn't apply here. Leave diagnostics empty until a ring-specific
+  // check exists.
+  return finalizeInternalSolid(outerWireResult.value, innerWireResult.value, thickness, geom, []);
 }
 
-function soloGearDiagnostics(teeth: number, alpha: number, shift: number): GearDiagnostic[] {
+/** Diagnostics for an external (rack-cut) gear in isolation. Not valid for internal gears. */
+function externalGearDiagnostics(teeth: number, alpha: number, shift: number): GearDiagnostic[] {
   const deficit = undercutDeficit(teeth, alpha, shift);
   if (deficit <= 0) return [];
   return [

--- a/tests/gearFns.test.ts
+++ b/tests/gearFns.test.ts
@@ -87,6 +87,18 @@ describe('makeExternalGear', () => {
     expect(r.diagnostics).toEqual([]);
   });
 
+  it('rejects samples that is zero, negative, or non-integer', () => {
+    expect(isErr(makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8, samples: 0 }))).toBe(
+      true
+    );
+    expect(isErr(makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8, samples: -3 }))).toBe(
+      true
+    );
+    expect(isErr(makeExternalGear({ teeth: 24, moduleSize: 2, thickness: 8, samples: 4.5 }))).toBe(
+      true
+    );
+  });
+
   it('samples override produces a valid solid; volume converges as samples grow', () => {
     // Coarse and fine samples should both build valid solids; the fine-sample
     // gear approximates the true involute more closely, so its volume sits
@@ -129,6 +141,14 @@ describe('makeInternalGear (ring)', () => {
     expect(
       isErr(makeInternalGear({ teeth: 30, moduleSize: 2, thickness: 8, ringWallThickness: 0 }))
     ).toBe(true);
+  });
+
+  it('does not emit UNDERCUT_RISK (rack-cut formula does not apply to ring gears)', () => {
+    // Low-z ring with no shift — the external-gear rack-cut undercut formula
+    // would mistakenly flag this; internal-gear undercut geometry is different
+    // and we don't have a ring-specific check yet, so diagnostics stay empty.
+    const r = unwrap(makeInternalGear({ teeth: 16, moduleSize: 2, thickness: 8 }));
+    expect(r.diagnostics).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Three review-feedback fixes from Greptile on recently-merged PRs.

### 1. \`REGRESSION_THRESHOLD_PCT\` ReferenceError on real regression (#985)

The constant was \`const\`-declared inside the \`for (const pr of prResults)\` loop body, but referenced after the loop on lines 246 (\`hasRegression\` template literal) and 273 (\`core.setFailed\`). On runs with no regression the bug is invisible; the moment a real regression is detected, the script throws \`ReferenceError\` instead of posting the failure comment and failing the job cleanly — silently breaking the alert that PR #985 was meant to keep working.

Fix: hoist the constant above the loop.

### 2. Internal-gear undercut diagnostic uses wrong formula (#987)

\`soloGearDiagnostics\` (now renamed to \`externalGearDiagnostics\`) uses \`undercutDeficit\` whose underlying formula \`1 − z·sin²α/2\` is the rack-cut undercut threshold for external gears. Internal (ring) gears are cut by a pinion-shaped cutter, with inverted shift sign — positive shift on a ring \`deepens\` the dedendum, so the message "increase shift by X to avoid undercut" actively misleads.

Fix: stop emitting the diagnostic from \`makeInternalGear\` (returns empty diagnostics until a ring-specific check is added). External-gear behavior unchanged.

### 3. \`samples\` parameter unguarded against zero/negative/non-integer (#983)

\`samples: 0\` produces NaN involute coordinates (\`0/0\` in cosine spacing); negatives produce empty arrays that crash \`firstOrThrow\`; floats produce off-by-one BSpline interpolation behavior. Currently silently propagates to the WASM layer.

Fix: fast-path \`GEAR_SAMPLES_INVALID\` validation error in \`makeExternalGear\` and \`makeInternalGear\` for \`samples !== undefined && (!Number.isInteger || samples < 1)\`.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] 4 new tests covering the three fixes (samples=0/-3/4.5 rejected, internal gear emits no diagnostics on low-z)
- [x] OCCT all gear tests pass; brepkit 3 failures pre-exist on main (unrelated)

## Impact

The \`REGRESSION_THRESHOLD_PCT\` fix is silently load-bearing: before this PR, the benchmark gate only posts results on PRs without regressions. With the fix, real regressions also post properly. The undercut fix removes a misleading warning. The \`samples\` validation surfaces user errors at the API boundary instead of as cryptic WASM exceptions.