### PR TITLE
test(gear): cover surface area + ring rotate-and-delete path

### DIFF
--- a/tests/gearFns.test.ts
+++ b/tests/gearFns.test.ts
@@ -4,6 +4,7 @@ import {
   isOk,
   isErr,
   isSolid,
+  measureArea,
   measureVolume,
   unwrap,
   makeExternalGear,
@@ -33,6 +34,22 @@ describe('makeExternalGear', () => {
     const upper = Math.PI * rTip * rTip * 10;
     expect(vol).toBeGreaterThan(lower);
     expect(vol).toBeLessThan(upper);
+  });
+
+  it('surface area is bounded between root- and tip-cylinder envelopes', () => {
+    // For an external spur gear: 2 caps + lateral flank surface. The lateral
+    // area sits between the root cylinder (lower bound, smooth) and the tip
+    // cylinder (upper bound, smooth) for the lateral component, plus 2 caps
+    // contributing 2·π·(rTip² − bore²/4) per cap. Loose envelope: between two
+    // cylinders' surface areas — confirms geometry-construction sanity.
+    const r = unwrap(makeExternalGear({ teeth: 20, moduleSize: 2, thickness: 10 }));
+    const area = unwrap(measureArea(r.solid));
+    const rRoot = (20 * 2 - 2 * 1.25 * 2) / 2; // 17.5
+    const rTip = (20 * 2 + 2 * 2) / 2; // 22
+    const lower = 2 * Math.PI * rRoot * 10 + 2 * (Math.PI * rRoot * rRoot);
+    const upper = 2 * Math.PI * rTip * 10 + 2 * (Math.PI * rTip * rTip) * 1.5; // tooth wiggle padding
+    expect(area).toBeGreaterThan(lower);
+    expect(area).toBeLessThan(upper);
   });
 
   it('bore reduces volume', () => {
@@ -169,6 +186,18 @@ describe('makePlanetaryGear', () => {
       makePlanetaryGear({ thickness: 10, sunTeeth: 20, planetTeeth: 16, numPlanets: 4 })
     );
     expect(a.centerDistance).toBeCloseTo(((20 + 16) * 3) / 2, 6);
+  });
+
+  it('ring solid is intact after applyRingPhase rotation (even zr)', () => {
+    // zr = 20 + 2·16 = 52 (even) → applyRingPhase rotates by π/zr and deletes
+    // the original handle. Cover the rotate-and-delete branch with a real
+    // assertion on the returned solid.
+    const a = unwrap(
+      makePlanetaryGear({ thickness: 10, sunTeeth: 20, planetTeeth: 16, numPlanets: 4 })
+    );
+    expect(a.ringTeeth).toBe(52);
+    expect(isSolid(a.ring)).toBe(true);
+    expect(unwrap(measureVolume(a.ring))).toBeGreaterThan(0);
   });
 
   it('rejects assembly violation (zs+zp not divisible by N appropriately)', () => {


### PR DESCRIPTION
## Summary

Two coverage gaps from the original gear review.

### L4 — No \`measureArea\` test on a gear

Volume tests catch some geometry regressions but miss area-preserving distortions (e.g. an inverted flank). Adds a loose envelope bound: the surface area of a 20-tooth m=2 thickness=10 gear must sit between two cylinder approximations.

### M1 — \`applyRingPhase\` rotate path was barely tested

\`applyRingPhase\` rotates the ring by π/zr and deletes the original handle only when zr is even (\`evenToothPhaseOffset(zr) !== 0\`). Default planetary has zr=39 (odd) and skips that branch entirely. The existing \`sunTeeth: 20, planetTeeth: 16\` test exercises the rotate-and-delete branch but only asserts \`centerDistance\`, never that the resulting ring solid is valid afterward.

New test: \`isSolid(a.ring)\` + \`measureVolume(a.ring) > 0\` on the same even-zr config.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] OCCT all 22 gear tests pass (24 with the new ones)
- [x] surface-area test joins the existing brepkit geometry-divergence set; ring-rotate test passes on both kernels