### PR TITLE
fix(gear): clean up planet handles on mid-loop failure in placePlanets

### DIFF
--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -483,19 +483,28 @@ function buildGearResult(
 
 function placePlanets(planetProto: ValidSolid, cfg: ResolvedPlanetary): ValidSolid[] {
   const planets: ValidSolid[] = [];
-  for (let i = 0; i < cfg.numPlanets; i++) {
-    const orbital = (i * 2 * Math.PI) / cfg.numPlanets;
-    const selfRot = planetSelfRotationAngle(orbital, cfg.sunTeeth, cfg.planetTeeth);
-    const rotated = rotate(planetProto, (selfRot * 180) / Math.PI);
-    const offset: Vec3 = [
-      cfg.centerDistance * Math.cos(orbital),
-      cfg.centerDistance * Math.sin(orbital),
-      0,
-    ];
-    planets.push(translate(rotated, offset));
-    rotated.delete();
+  try {
+    for (let i = 0; i < cfg.numPlanets; i++) {
+      const orbital = (i * 2 * Math.PI) / cfg.numPlanets;
+      const selfRot = planetSelfRotationAngle(orbital, cfg.sunTeeth, cfg.planetTeeth);
+      const rotated = rotate(planetProto, (selfRot * 180) / Math.PI);
+      try {
+        const offset: Vec3 = [
+          cfg.centerDistance * Math.cos(orbital),
+          cfg.centerDistance * Math.sin(orbital),
+          0,
+        ];
+        planets.push(translate(rotated, offset));
+      } finally {
+        rotated.delete();
+      }
+    }
+    return planets;
+  } catch (e) {
+    // Mid-loop failure: clean up the planets that did succeed before rethrowing.
+    for (const p of planets) p.delete();
+    throw e;
   }
-  return planets;
 }
 
 function applyRingPhase(ring: ValidSolid, zr: number): ValidSolid {


### PR DESCRIPTION
## Summary

M2 from the original gear review. \`placePlanets\` rotates and translates the planet prototype N times. If the kernel throws mid-loop, the planet handles already translated into the array were orphaned — the original code only released the per-iteration \`rotated\` intermediate.

\`\`\`ts
// before
for (let i = 0; i < cfg.numPlanets; i++) {
  const rotated = rotate(planetProto, ...);
  planets.push(translate(rotated, offset));  // throw here → rotated leaks
  rotated.delete();                          // never reached
}                                            // earlier planets[] also leaked

// after
try {
  for (let i = 0; i < cfg.numPlanets; i++) {
    const rotated = rotate(planetProto, ...);
    try {
      planets.push(translate(rotated, offset));
    } finally {
      rotated.delete();
    }
  }
  return planets;
} catch (e) {
  for (const p of planets) p.delete();
  throw e;
}
\`\`\`

## Likelihood

Low — rotate and translate don't throw on valid solids in either kernel under tested inputs. But the cleanup is cheap and makes the function exception-safe, so a future kernel change or unexpected input doesn't quietly leak handles.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] OCCT all 22 gear tests pass; brepkit 3 failures pre-exist on main