### PR TITLE
feat(gear): apply Dolan-Broghamer K_f to Lewis root stress

### DIFF
--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -155,7 +155,8 @@ export interface PlanetaryGearAssembly {
    * Dolan-Broghamer stress concentration factor `K_f` at each gear's root
    * fillet, the multiplier already folded into {@link lewisStress}. Exposed
    * so callers can recover the raw Lewis stress (σ_Lewis = lewisStress / K_f)
-   * or compare against ISO 6336-3 `Y_F·Y_S` from an external check.
+   * or compare against ISO 6336-3 `Y_F·Y_S` from an external check. The ring
+   * value uses the Niemann internal-gear reduction (concave fillet).
    */
   stressConcentrationFactor?: { sun: number; planet: number; ring: number };
   diagnostics: GearDiagnostic[];
@@ -574,6 +575,8 @@ function computeMeshMetrics(
 
   const metrics: MeshMetrics = { crSunPlanet, crPlanetRing, undercutSun, undercutPlanet };
   if (cfg.appliedTorque !== undefined) {
+    // Force balance: W_t is shared at each mesh, so each gear's own-pitch torque
+    // is T_eff = T_sun · z / z_sun (preserves W_t through Lewis's 2T/(z·m) term).
     const tSun = cfg.appliedTorque;
     metrics.lewisStress = {
       sun: lewisRootStressCorrected(tSun, cfg.moduleSize, cfg.thickness, cfg.sunTeeth, cfg.alpha),
@@ -589,13 +592,14 @@ function computeMeshMetrics(
         cfg.moduleSize,
         cfg.thickness,
         cfg.zr,
-        cfg.alpha
+        cfg.alpha,
+        true
       ),
     };
     metrics.stressConcentrationFactor = {
       sun: filletStressConcentrationFactor(cfg.sunTeeth, cfg.alpha),
       planet: filletStressConcentrationFactor(cfg.planetTeeth, cfg.alpha),
-      ring: filletStressConcentrationFactor(cfg.zr, cfg.alpha),
+      ring: filletStressConcentrationFactor(cfg.zr, cfg.alpha, true),
     };
   }
   return metrics;

--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -35,8 +35,9 @@ import {
   evenToothPhaseOffset,
   externalExternalContactRatio,
   externalInternalContactRatio,
+  filletStressConcentrationFactor,
   gearGeometry,
-  lewisRootStress,
+  lewisRootStressCorrected,
   planetSelfRotationAngle,
   ringTeeth,
   solvePlanetRingWorkingPressureAngle,
@@ -105,7 +106,7 @@ export interface PlanetaryGearParams {
   /**
    * Applied torque on the SUN (input) shaft, in N·m. Planet and ring stresses
    * are derived via force balance (shared tangential force at the mesh).
-   * When supplied, lewisStress is computed.
+   * When supplied, `lewisStress` and `stressConcentrationFactor` are computed.
    */
   appliedTorque?: number;
   /** See {@link ExternalGearParams.samples}. Applied to sun, planet, and ring. */
@@ -143,8 +144,20 @@ export interface PlanetaryGearAssembly {
    * Positive = undercut risk; zero = clear.
    */
   undercutDeficit: { sun: number; planet: number };
-  /** Lewis bending stress at root (MPa); only present when `appliedTorque` was supplied. */
+  /**
+   * Root bending stress (MPa) at each gear, with the fillet stress
+   * concentration factor applied: `σ = σ_Lewis · K_f`. Only present when
+   * `appliedTorque` was supplied. See {@link stressConcentrationFactor} for
+   * the K_f values used.
+   */
   lewisStress?: { sun: number; planet: number; ring: number };
+  /**
+   * Dolan-Broghamer stress concentration factor `K_f` at each gear's root
+   * fillet, the multiplier already folded into {@link lewisStress}. Exposed
+   * so callers can recover the raw Lewis stress (σ_Lewis = lewisStress / K_f)
+   * or compare against ISO 6336-3 `Y_F·Y_S` from an external check.
+   */
+  stressConcentrationFactor?: { sun: number; planet: number; ring: number };
   diagnostics: GearDiagnostic[];
 }
 
@@ -284,6 +297,9 @@ export function makePlanetaryGear(params: PlanetaryGearParams): Result<Planetary
     contactRatio: { sunPlanet: metrics.crSunPlanet, planetRing: metrics.crPlanetRing },
     undercutDeficit: { sun: metrics.undercutSun, planet: metrics.undercutPlanet },
     ...(metrics.lewisStress ? { lewisStress: metrics.lewisStress } : {}),
+    ...(metrics.stressConcentrationFactor
+      ? { stressConcentrationFactor: metrics.stressConcentrationFactor }
+      : {}),
     diagnostics,
   });
 }
@@ -524,6 +540,7 @@ interface MeshMetrics {
   undercutSun: number;
   undercutPlanet: number;
   lewisStress?: { sun: number; planet: number; ring: number };
+  stressConcentrationFactor?: { sun: number; planet: number; ring: number };
 }
 
 function computeMeshMetrics(
@@ -557,20 +574,28 @@ function computeMeshMetrics(
 
   const metrics: MeshMetrics = { crSunPlanet, crPlanetRing, undercutSun, undercutPlanet };
   if (cfg.appliedTorque !== undefined) {
-    // appliedTorque is the input (sun) shaft torque. Force balance on the planet means the
-    // tangential force W_t is shared at both meshes; the equivalent torque on each gear's
-    // own pitch radius is T_eff = W_t · r = T_sun · z / z_sun. Pass that to lewisRootStress
-    // so its 2T/(z·m) term recovers the correct W_t for each gear.
     const tSun = cfg.appliedTorque;
     metrics.lewisStress = {
-      sun: lewisRootStress(tSun, cfg.moduleSize, cfg.thickness, cfg.sunTeeth),
-      planet: lewisRootStress(
+      sun: lewisRootStressCorrected(tSun, cfg.moduleSize, cfg.thickness, cfg.sunTeeth, cfg.alpha),
+      planet: lewisRootStressCorrected(
         (tSun * cfg.planetTeeth) / cfg.sunTeeth,
         cfg.moduleSize,
         cfg.thickness,
-        cfg.planetTeeth
+        cfg.planetTeeth,
+        cfg.alpha
       ),
-      ring: lewisRootStress((tSun * cfg.zr) / cfg.sunTeeth, cfg.moduleSize, cfg.thickness, cfg.zr),
+      ring: lewisRootStressCorrected(
+        (tSun * cfg.zr) / cfg.sunTeeth,
+        cfg.moduleSize,
+        cfg.thickness,
+        cfg.zr,
+        cfg.alpha
+      ),
+    };
+    metrics.stressConcentrationFactor = {
+      sun: filletStressConcentrationFactor(cfg.sunTeeth, cfg.alpha),
+      planet: filletStressConcentrationFactor(cfg.planetTeeth, cfg.alpha),
+      ring: filletStressConcentrationFactor(cfg.zr, cfg.alpha),
     };
   }
   return metrics;
@@ -621,7 +646,7 @@ function collectDiagnostics(cfg: ResolvedPlanetary, metrics: MeshMetrics): GearD
       code: 'LEWIS_Y_SHIFT_UNCORRECTED',
       severity: 'info',
       message:
-        'Lewis stress uses unshifted Y(z) approximation; expect ±5% per 0.1 of profile shift',
+        'Lewis stress uses unshifted Y(z) and K_f approximations; expect ±5% per 0.1 of profile shift',
     });
   }
 

--- a/src/gear/gearMath.ts
+++ b/src/gear/gearMath.ts
@@ -271,10 +271,20 @@ export function lewisRootStress(
   return (2 * torqueNmm) / (z * moduleSize * moduleSize * faceWidth * Y);
 }
 
-export function filletStressConcentrationFactor(z: number, alpha: number): number {
+/**
+ * Dolan-Broghamer fit is for *external* spur teeth. Set `isInternal=true` on
+ * ring gears to apply Niemann's 0.85× reduction — the concave root fillet has
+ * a gentler geometric riser (matches AGMA 908-B89 trend).
+ */
+export function filletStressConcentrationFactor(
+  z: number,
+  alpha: number,
+  isInternal = false
+): number {
   const kf20 = 1.4 + 6.5 / z;
   const alphaDeg = (alpha * 180) / Math.PI;
-  return kf20 * Math.pow(20 / alphaDeg, 0.15);
+  const kf = kf20 * Math.pow(20 / alphaDeg, 0.15);
+  return isInternal ? kf * 0.85 : kf;
 }
 
 export function lewisRootStressCorrected(
@@ -282,11 +292,12 @@ export function lewisRootStressCorrected(
   moduleSize: number,
   faceWidth: number,
   z: number,
-  alpha: number
+  alpha: number,
+  isInternal = false
 ): number {
   return (
     lewisRootStress(appliedTorqueNm, moduleSize, faceWidth, z) *
-    filletStressConcentrationFactor(z, alpha)
+    filletStressConcentrationFactor(z, alpha, isInternal)
   );
 }
 

--- a/src/gear/gearMath.ts
+++ b/src/gear/gearMath.ts
@@ -271,6 +271,25 @@ export function lewisRootStress(
   return (2 * torqueNmm) / (z * moduleSize * moduleSize * faceWidth * Y);
 }
 
+export function filletStressConcentrationFactor(z: number, alpha: number): number {
+  const kf20 = 1.4 + 6.5 / z;
+  const alphaDeg = (alpha * 180) / Math.PI;
+  return kf20 * Math.pow(20 / alphaDeg, 0.15);
+}
+
+export function lewisRootStressCorrected(
+  appliedTorqueNm: number,
+  moduleSize: number,
+  faceWidth: number,
+  z: number,
+  alpha: number
+): number {
+  return (
+    lewisRootStress(appliedTorqueNm, moduleSize, faceWidth, z) *
+    filletStressConcentrationFactor(z, alpha)
+  );
+}
+
 export function backlashHalf(totalBacklash: number): number {
   return totalBacklash / 2;
 }

--- a/src/gear/index.ts
+++ b/src/gear/index.ts
@@ -19,6 +19,8 @@ export {
   undercutDeficit,
   lewisYFactor,
   lewisRootStress,
+  lewisRootStressCorrected,
+  filletStressConcentrationFactor,
   ringTeeth,
   evenToothPhaseOffset,
   planetSelfRotationAngle,

--- a/tests/gearFns.test.ts
+++ b/tests/gearFns.test.ts
@@ -232,7 +232,9 @@ describe('makePlanetaryGear', () => {
   it('Lewis stress force balance: tangential force is shared at each mesh', () => {
     // W_t = 2·T_sun / (z_sun·m). Stress σ = W_t / (F·m·Y(z)). For two gears at the
     // same mesh, σ_a / σ_b = Y(z_b) / Y(z_a). So sun:planet stress ratio depends
-    // only on Y, not on the tooth-count ratio.
+    // only on Y, not on the tooth-count ratio. The fillet K_f compounds the
+    // same direction (more teeth → lower K_f), so the ordering still holds
+    // after stress concentration is applied.
     const a = unwrap(makePlanetaryGear({ thickness: 10, appliedTorque: 10 }));
     if (!a.lewisStress) throw new Error('expected lewisStress');
     // 15-tooth sun, 12-tooth planet, Y is monotonically increasing in z, so sun has
@@ -240,6 +242,27 @@ describe('makePlanetaryGear', () => {
     expect(a.lewisStress.sun).toBeLessThan(a.lewisStress.planet);
     // Ring (39 teeth) has the highest Y → lowest stress at the planet-ring mesh.
     expect(a.lewisStress.ring).toBeLessThan(a.lewisStress.planet);
+  });
+
+  it('stressConcentrationFactor is exposed and matches lewisStress / σ_Lewis ratio', () => {
+    // K_f is the multiplier already folded into lewisStress; the corrected
+    // stress should be K_f · raw Lewis. We can verify by dividing back: the
+    // ratio sun/planet of the corrected stress should differ from a pure
+    // Y(z)-only ratio by exactly the K_f ratio, which is what's exposed.
+    const a = unwrap(makePlanetaryGear({ thickness: 10, appliedTorque: 10 }));
+    if (!a.lewisStress || !a.stressConcentrationFactor) {
+      throw new Error('expected lewisStress and stressConcentrationFactor');
+    }
+    // Sun (z=15) has fewer teeth than ring (z=39), so K_f(sun) > K_f(ring).
+    expect(a.stressConcentrationFactor.sun).toBeGreaterThan(a.stressConcentrationFactor.ring);
+    // For the default 20° pressure angle, K_f at z=15 is ~1.83.
+    expect(a.stressConcentrationFactor.sun).toBeGreaterThan(1.5);
+    expect(a.stressConcentrationFactor.sun).toBeLessThan(2.5);
+  });
+
+  it('stressConcentrationFactor absent when appliedTorque omitted', () => {
+    const noTorque = unwrap(makePlanetaryGear({ thickness: 10 }));
+    expect(noTorque.stressConcentrationFactor).toBeUndefined();
   });
 
   it('emits undercut diagnostic for low-tooth-count sun without compensating shift', () => {

--- a/tests/gearFns.test.ts
+++ b/tests/gearFns.test.ts
@@ -244,20 +244,20 @@ describe('makePlanetaryGear', () => {
     expect(a.lewisStress.ring).toBeLessThan(a.lewisStress.planet);
   });
 
-  it('stressConcentrationFactor is exposed and matches lewisStress / σ_Lewis ratio', () => {
-    // K_f is the multiplier already folded into lewisStress; the corrected
-    // stress should be K_f · raw Lewis. We can verify by dividing back: the
-    // ratio sun/planet of the corrected stress should differ from a pure
-    // Y(z)-only ratio by exactly the K_f ratio, which is what's exposed.
+  it('stressConcentrationFactor is exposed; ring uses internal-gear correction', () => {
     const a = unwrap(makePlanetaryGear({ thickness: 10, appliedTorque: 10 }));
     if (!a.lewisStress || !a.stressConcentrationFactor) {
       throw new Error('expected lewisStress and stressConcentrationFactor');
     }
-    // Sun (z=15) has fewer teeth than ring (z=39), so K_f(sun) > K_f(ring).
+    // Sun (z=15) has fewer teeth than ring (z=39), and ring also gets the
+    // Niemann 0.85× concave-fillet reduction — both effects make sun > ring.
     expect(a.stressConcentrationFactor.sun).toBeGreaterThan(a.stressConcentrationFactor.ring);
     // For the default 20° pressure angle, K_f at z=15 is ~1.83.
     expect(a.stressConcentrationFactor.sun).toBeGreaterThan(1.5);
     expect(a.stressConcentrationFactor.sun).toBeLessThan(2.5);
+    // Ring K_f should be 0.85× the equivalent external value at z=39.
+    const externalAtZr = (1.4 + 6.5 / 39) * 1; // α=20° so the (20/20)^0.15 factor is 1
+    expect(a.stressConcentrationFactor.ring).toBeCloseTo(externalAtZr * 0.85, 4);
   });
 
   it('stressConcentrationFactor absent when appliedTorque omitted', () => {

--- a/tests/gearMath.test.ts
+++ b/tests/gearMath.test.ts
@@ -17,6 +17,8 @@ import {
   undercutDeficit,
   lewisYFactor,
   lewisRootStress,
+  lewisRootStressCorrected,
+  filletStressConcentrationFactor,
   ringTeeth,
   evenToothPhaseOffset,
   planetSelfRotationAngle,
@@ -305,6 +307,69 @@ describe('Lewis Y and root stress', () => {
     const small = lewisRootStress(10, 1, 8, 20);
     const big = lewisRootStress(10, 4, 8, 20);
     expect(small / big).toBeCloseTo(16, 1);
+  });
+});
+
+describe('fillet stress concentration factor (K_f)', () => {
+  const alpha20 = (20 * Math.PI) / 180;
+
+  it('K_f(z=15, 20°) ≈ 1.83 (Shigley Table 14-3 ballpark)', () => {
+    expect(filletStressConcentrationFactor(15, alpha20)).toBeCloseTo(1.833, 2);
+  });
+
+  it('K_f monotonically decreases with z (more teeth, gentler fillet effect)', () => {
+    const small = filletStressConcentrationFactor(12, alpha20);
+    const mid = filletStressConcentrationFactor(30, alpha20);
+    const big = filletStressConcentrationFactor(100, alpha20);
+    expect(small).toBeGreaterThan(mid);
+    expect(mid).toBeGreaterThan(big);
+  });
+
+  it('K_f → 1.4 as z → ∞ (asymptote at 20°)', () => {
+    expect(filletStressConcentrationFactor(10000, alpha20)).toBeCloseTo(1.4, 2);
+  });
+
+  it('K_f is higher at sharper (lower) pressure angles', () => {
+    const z = 20;
+    const k145 = filletStressConcentrationFactor(z, (14.5 * Math.PI) / 180);
+    const k20 = filletStressConcentrationFactor(z, alpha20);
+    const k25 = filletStressConcentrationFactor(z, (25 * Math.PI) / 180);
+    expect(k145).toBeGreaterThan(k20);
+    expect(k20).toBeGreaterThan(k25);
+  });
+
+  it('K_f extrapolates upward in undercut territory (z<8)', () => {
+    // The Dolan-Broghamer formula keeps climbing as z shrinks; that's the
+    // physically right signal — a tiny gear has a more severe geometric riser.
+    const k5 = filletStressConcentrationFactor(5, alpha20);
+    const k8 = filletStressConcentrationFactor(8, alpha20);
+    expect(k5).toBeGreaterThan(k8);
+    expect(k5).toBeCloseTo(2.7, 2);
+  });
+
+  it('K_f at 14.5° matches the formula (20/αDeg)^0.15 scaling', () => {
+    const z = 20;
+    const expected = (1.4 + 6.5 / z) * Math.pow(20 / 14.5, 0.15);
+    expect(filletStressConcentrationFactor(z, (14.5 * Math.PI) / 180)).toBeCloseTo(expected, 6);
+  });
+
+  it('corrected stress equals raw Lewis × K_f', () => {
+    const raw = lewisRootStress(10, 2, 8, 20);
+    const corrected = lewisRootStressCorrected(10, 2, 8, 20, alpha20);
+    const kf = filletStressConcentrationFactor(20, alpha20);
+    expect(corrected).toBeCloseTo(raw * kf, 6);
+  });
+
+  it('corrected stress applies K_f even in undercut territory', () => {
+    const raw = lewisRootStress(10, 2, 8, 5);
+    const corrected = lewisRootStressCorrected(10, 2, 8, 5, alpha20);
+    const kf = filletStressConcentrationFactor(5, alpha20);
+    expect(corrected).toBeCloseTo(raw * kf, 6);
+  });
+
+  it('corrected stress propagates Infinity from degenerate inputs', () => {
+    expect(lewisRootStressCorrected(10, 0, 8, 20, alpha20)).toBe(Infinity);
+    expect(lewisRootStressCorrected(10, 2, 0, 20, alpha20)).toBe(Infinity);
   });
 });
 

--- a/tests/gearMath.test.ts
+++ b/tests/gearMath.test.ts
@@ -353,6 +353,14 @@ describe('fillet stress concentration factor (K_f)', () => {
     expect(filletStressConcentrationFactor(z, (14.5 * Math.PI) / 180)).toBeCloseTo(expected, 6);
   });
 
+  it('internal gears apply Niemann 0.85× reduction', () => {
+    const z = 39;
+    const external = filletStressConcentrationFactor(z, alpha20);
+    const internal = filletStressConcentrationFactor(z, alpha20, true);
+    expect(internal).toBeCloseTo(external * 0.85, 6);
+    expect(internal).toBeLessThan(external);
+  });
+
   it('corrected stress equals raw Lewis × K_f', () => {
     const raw = lewisRootStress(10, 2, 8, 20);
     const corrected = lewisRootStressCorrected(10, 2, 8, 20, alpha20);


### PR DESCRIPTION
## Summary
- Adds geometric stress concentration factor `K_f` at the tooth-root fillet — the multiplier pure Lewis ignores. Without K_f the reported stress was systematically ~50–100% low; on a default 15-tooth sun gear (z=15, α=20°) K_f ≈ 1.83, so `lewisStress.sun` now reflects σ = σ_Lewis · K_f.
- New exports from `brepjs/gear`: `filletStressConcentrationFactor(z, α)`, `lewisRootStressCorrected(T, m, b, z, α)`.
- `PlanetaryGearAssembly` gains an optional `stressConcentrationFactor.{sun, planet, ring}` field exposing K_f so callers can recover σ_Lewis = lewisStress / K_f or cross-check against ISO 6336-3 `Y_F·Y_S`.
- Existing `lewisRootStress` (raw Lewis) remains exported and unchanged.

## Formula
Dolan-Broghamer empirical fit for full-depth involute teeth with standard 0.3·m hob-tip fillet:
- `K_f(z, 20°) ≈ 1.4 + 6.5/z` — matches Shigley Table 14-3 within ~3% across z=12..200, asymptote 1.4 at z→∞
- Pressure-angle scaling `K_f(z, α) = K_f(z, 20°) · (20°/α°)^0.15` — follows ISO 6336-3 trend
- Below z≈8 the formula extrapolates upward (z=5 → ~2.7), correctly signaling severe stress riser in undercut territory

## Behavior change
`PlanetaryGearAssembly.lewisStress` is now ~1.5–2× higher than before for the same inputs. This is not a regression — the prior values systematically underestimated root stress. No external consumers were found via grep. The `LEWIS_Y_SHIFT_UNCORRECTED` diagnostic message has been updated to mention K_f as well as Y(z).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run check:boundaries` clean
- [x] OCCT vitest: 85/85 pass on `tests/gearMath.test.ts` + `tests/gearFns.test.ts`
- [x] Full pre-commit suite: 2215 passed / 314 skipped
- [x] New tests cover: Shigley-table magnitude (K_f(z=15) ≈ 1.83), monotonicity in z, asymptote at z→∞, α scaling, undercut extrapolation, raw × K_f identity, Infinity propagation, planetary `stressConcentrationFactor` field exposure