### PR TITLE
docs(readme): add release-date and commit-activity badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # brepjs
 
 CAD modeling for JavaScript.
@@ -9,6 +11,8 @@ CAD modeling for JavaScript.
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
 **[Getting Started](./docs/getting-started.md)** · **[Cheat Sheet](./docs/cheat-sheet.md)** · **[Docs](https://brepjs.dev/)**
+
+</div>
 
 Shapes are exact mathematical boundaries - not triangle meshes - so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ CAD modeling for JavaScript.
 
 [![npm](https://img.shields.io/npm/v/brepjs)](https://www.npmjs.com/package/brepjs)
 [![CI](https://github.com/andymai/brepjs/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/brepjs/actions/workflows/ci.yml)
+[![Last release](https://img.shields.io/github/release-date/andymai/brepjs?label=last%20release)](https://github.com/andymai/brepjs/releases)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/andymai/brepjs?label=commits%2Fmonth)](https://github.com/andymai/brepjs/commits/main)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
 **[Getting Started](./docs/getting-started.md)** · **[Cheat Sheet](./docs/cheat-sheet.md)** · **[Docs](https://brepjs.dev/)**


### PR DESCRIPTION
## Summary

Add two GitHub recency badges to the README header:

- `last-release-date`
- `commits/month`

## Why

Inspired by [Rushi's "GitHub stars: what they measure and what they don't"](https://www.rushis.com/github-stars-what-they-measure-and-what-they-do-not/). The strongest critique in the piece is that star counts (and version numbers) don't decay — an abandoned repo can outshine an active one on a glance. These two badges surface signals that *do* decay if the project goes quiet, so visitors get an honest freshness read alongside the npm version.

No vanity metrics added (deliberately).

## Test plan

- [ ] CI passes
- [ ] Both shields.io URLs render on GitHub