### PR TITLE
feat(docs): animate exploded Hill-tetrahedron cube in the home hero

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -3,6 +3,7 @@ import DefaultTheme from 'vitepress/theme';
 import { onMounted, nextTick, watch } from 'vue';
 import { useRoute } from 'vitepress';
 import { decorateCodeBlocks } from './playgroundLink';
+import HeroCube from './components/HeroCube.vue';
 
 const { Layout } = DefaultTheme;
 const route = useRoute();
@@ -16,5 +17,11 @@ watch(() => route.path, decorate);
 </script>
 
 <template>
-  <Layout />
+  <Layout>
+    <template #home-hero-image>
+      <ClientOnly>
+        <HeroCube />
+      </ClientOnly>
+    </template>
+  </Layout>
 </template>

--- a/apps/docs/.vitepress/theme/components/HeroCube.vue
+++ b/apps/docs/.vitepress/theme/components/HeroCube.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import type { HeroCubeHandle } from './heroCubeRenderer';
+
+const canvasEl = ref<HTMLCanvasElement | null>(null);
+const ready = ref(false);
+let handle: HeroCubeHandle | null = null;
+let darkObserver: MutationObserver | null = null;
+
+function isDark(): boolean {
+  return document.documentElement.classList.contains('dark');
+}
+
+onMounted(async () => {
+  const canvas = canvasEl.value;
+  if (!canvas) return;
+  const { mountHeroCube } = await import('./heroCubeRenderer');
+  handle = mountHeroCube(canvas, isDark());
+  ready.value = true;
+
+  darkObserver = new MutationObserver(() => handle?.setColorScheme(isDark()));
+  darkObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+});
+
+onBeforeUnmount(() => {
+  handle?.destroy();
+  handle = null;
+  darkObserver?.disconnect();
+  darkObserver = null;
+});
+
+function onHover(paused: boolean): void {
+  handle?.setHoverPaused(paused);
+}
+</script>
+
+<template>
+  <div class="hero-cube">
+    <img
+      v-show="!ready"
+      class="hero-cube__poster"
+      src="/hero-poster.svg"
+      alt="Six tetrahedra exploded apart, the scissors-congruent decomposition of a unit cube"
+    />
+    <canvas
+      ref="canvasEl"
+      class="hero-cube__canvas"
+      :class="{ 'hero-cube__canvas--ready': ready }"
+      aria-hidden="true"
+      @pointerenter="onHover(true)"
+      @pointerleave="onHover(false)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.hero-cube {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.hero-cube__poster,
+.hero-cube__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.hero-cube__canvas {
+  opacity: 0;
+  transition: opacity 320ms ease;
+  touch-action: pan-y;
+  cursor: grab;
+}
+
+.hero-cube__canvas:active {
+  cursor: grabbing;
+}
+
+.hero-cube__canvas--ready {
+  opacity: 1;
+}
+</style>

--- a/apps/docs/.vitepress/theme/components/heroCubeGeometry.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeGeometry.ts
@@ -67,6 +67,26 @@ export function cubeTiling(L: number): Tet[] {
   });
 }
 
+export function shrunkTets(pieces: readonly Tet[], inset: number): Tet[] {
+  if (inset <= 0) return pieces.map((p) => ({ ...p }));
+  const s = 1 - inset;
+  return pieces.map((p) => {
+    const [v0, v1, v2, v3] = p.verts;
+    const cx = (v0[0] + v1[0] + v2[0] + v3[0]) / 4;
+    const cy = (v0[1] + v1[1] + v2[1] + v3[1]) / 4;
+    const cz = (v0[2] + v1[2] + v2[2] + v3[2]) / 4;
+    const shrink = (v: Vec3): Vec3 => [
+      cx + (v[0] - cx) * s,
+      cy + (v[1] - cy) * s,
+      cz + (v[2] - cz) * s,
+    ];
+    return {
+      verts: [shrink(v0), shrink(v1), shrink(v2), shrink(v3)],
+      faces: p.faces,
+    };
+  });
+}
+
 export function explodeTets(pieces: readonly Tet[], amount: number): Tet[] {
   if (amount === 0) return pieces.map((p) => ({ ...p }));
   let cx = 0;

--- a/apps/docs/.vitepress/theme/components/heroCubeGeometry.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeGeometry.ts
@@ -54,11 +54,12 @@ export function cubeTiling(L: number): Tet[] {
     [2, 0, 1],
     [2, 1, 0],
   ];
+  const h = L / 2;
   return perms.map(([a, b, c]) => {
     const ea = e[a] as Vec3;
     const eb = e[b] as Vec3;
     const ec = e[c] as Vec3;
-    const v0: Vec3 = [0, 0, 0];
+    const v0: Vec3 = [-h, -h, -h];
     const v1: Vec3 = [v0[0] + ea[0], v0[1] + ea[1], v0[2] + ea[2]];
     const v2: Vec3 = [v1[0] + eb[0], v1[1] + eb[1], v1[2] + eb[2]];
     const v3: Vec3 = [v2[0] + ec[0], v2[1] + ec[1], v2[2] + ec[2]];

--- a/apps/docs/.vitepress/theme/components/heroCubeGeometry.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeGeometry.ts
@@ -1,0 +1,110 @@
+export type Vec3 = readonly [number, number, number];
+export type TriIdx = readonly [number, number, number];
+
+export interface Tet {
+  verts: readonly [Vec3, Vec3, Vec3, Vec3];
+  faces: readonly [TriIdx, TriIdx, TriIdx, TriIdx];
+}
+
+const RING_IDX: ReadonlyArray<TriIdx> = [
+  [1, 2, 3],
+  [0, 3, 2],
+  [0, 1, 3],
+  [0, 2, 1],
+];
+
+function tetFromPts(pts: readonly [Vec3, Vec3, Vec3, Vec3]): Tet {
+  const [v0, v1, v2, v3] = pts;
+  const cx = (v0[0] + v1[0] + v2[0] + v3[0]) / 4;
+  const cy = (v0[1] + v1[1] + v2[1] + v3[1]) / 4;
+  const cz = (v0[2] + v1[2] + v2[2] + v3[2]) / 4;
+  const faces = RING_IDX.map(([i, j, k]) => {
+    const vi = pts[i] as Vec3;
+    const vj = pts[j] as Vec3;
+    const vk = pts[k] as Vec3;
+    const ux = vj[0] - vi[0];
+    const uy = vj[1] - vi[1];
+    const uz = vj[2] - vi[2];
+    const wx = vk[0] - vi[0];
+    const wy = vk[1] - vi[1];
+    const wz = vk[2] - vi[2];
+    const nx = uy * wz - uz * wy;
+    const ny = uz * wx - ux * wz;
+    const nz = ux * wy - uy * wx;
+    const fx = (vi[0] + vj[0] + vk[0]) / 3;
+    const fy = (vi[1] + vj[1] + vk[1]) / 3;
+    const fz = (vi[2] + vj[2] + vk[2]) / 3;
+    const outward = (fx - cx) * nx + (fy - cy) * ny + (fz - cz) * nz >= 0;
+    return outward ? ([i, j, k] as TriIdx) : ([i, k, j] as TriIdx);
+  }) as unknown as readonly [TriIdx, TriIdx, TriIdx, TriIdx];
+  return { verts: pts, faces };
+}
+
+export function cubeTiling(L: number): Tet[] {
+  const e: readonly [Vec3, Vec3, Vec3] = [
+    [L, 0, 0],
+    [0, L, 0],
+    [0, 0, L],
+  ];
+  const perms: ReadonlyArray<readonly [number, number, number]> = [
+    [0, 1, 2],
+    [0, 2, 1],
+    [1, 0, 2],
+    [1, 2, 0],
+    [2, 0, 1],
+    [2, 1, 0],
+  ];
+  return perms.map(([a, b, c]) => {
+    const ea = e[a] as Vec3;
+    const eb = e[b] as Vec3;
+    const ec = e[c] as Vec3;
+    const v0: Vec3 = [0, 0, 0];
+    const v1: Vec3 = [v0[0] + ea[0], v0[1] + ea[1], v0[2] + ea[2]];
+    const v2: Vec3 = [v1[0] + eb[0], v1[1] + eb[1], v1[2] + eb[2]];
+    const v3: Vec3 = [v2[0] + ec[0], v2[1] + ec[1], v2[2] + ec[2]];
+    return tetFromPts([v0, v1, v2, v3]);
+  });
+}
+
+export function explodeTets(pieces: readonly Tet[], amount: number): Tet[] {
+  if (amount === 0) return pieces.map((p) => ({ ...p }));
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  let n = 0;
+  for (const p of pieces) {
+    for (const v of p.verts) {
+      cx += v[0];
+      cy += v[1];
+      cz += v[2];
+      n++;
+    }
+  }
+  cx /= n;
+  cy /= n;
+  cz /= n;
+  return pieces.map((p) => {
+    let pcx = 0;
+    let pcy = 0;
+    let pcz = 0;
+    for (const v of p.verts) {
+      pcx += v[0];
+      pcy += v[1];
+      pcz += v[2];
+    }
+    pcx /= 4;
+    pcy /= 4;
+    pcz /= 4;
+    const dx = pcx - cx;
+    const dy = pcy - cy;
+    const dz = pcz - cz;
+    const len = Math.hypot(dx, dy, dz) || 1;
+    const ox = (dx / len) * amount;
+    const oy = (dy / len) * amount;
+    const oz = (dz / len) * amount;
+    const newVerts = p.verts.map(
+      (v) => [v[0] + ox, v[1] + oy, v[2] + oz] as Vec3
+    ) as unknown as readonly [Vec3, Vec3, Vec3, Vec3];
+    return { verts: newVerts, faces: p.faces };
+  });
+}

--- a/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
@@ -16,7 +16,7 @@ import {
   WebGLRenderer,
 } from 'three';
 import { OrbitControls } from 'three-stdlib';
-import { cubeTiling, explodeTets, type Tet, type Vec3 } from './heroCubeGeometry';
+import { cubeTiling, explodeTets, shrunkTets, type Tet, type Vec3 } from './heroCubeGeometry';
 
 const L = 1;
 const PIECE_COUNT = 6;
@@ -51,6 +51,7 @@ const LIGHT_EDGE = '#ffffff';
 const DARK_EDGE = '#ffffff';
 const LIGHT_BG_RIM = '#4ACECC';
 const DARK_BG_RIM = '#7ADBDD';
+const TET_INSET = 0.035;
 
 export interface HeroCubeHandle {
   destroy(): void;
@@ -92,10 +93,12 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   scene.add(root);
 
   const tiling = cubeTiling(L);
-  const pieces: PieceObjects[] = tiling.map((tet, i) => {
+  const initialShrunk = shrunkTets(tiling, TET_INSET);
+  const pieces: PieceObjects[] = tiling.map((_tet, i) => {
+    const shrunk = initialShrunk[i] as Tet;
     const positions = new Float32Array(POSITION_FLOATS);
     const normals = new Float32Array(NORMAL_FLOATS);
-    writeTetMesh(tet, positions, normals);
+    writeTetMesh(shrunk, positions, normals);
     const geom = new BufferGeometry();
     geom.setAttribute('position', new BufferAttribute(positions, 3));
     geom.setAttribute('normal', new BufferAttribute(normals, 3));
@@ -112,7 +115,7 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
     root.add(mesh);
 
     const edgePositions = new Float32Array(EDGE_FLOATS);
-    writeTetEdges(tet, edgePositions);
+    writeTetEdges(shrunk, edgePositions);
     const edgeGeom = new BufferGeometry();
     edgeGeom.setAttribute('position', new Float32BufferAttribute(edgePositions, 3));
     const edgeMat = new LineBasicMaterial({
@@ -206,7 +209,7 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
 
     if (Math.abs(breathe - lastBreathe) > 1e-4) {
       const amount = breathe * MAX_EXPLODE;
-      const exploded = explodeTets(tiling, amount);
+      const exploded = shrunkTets(explodeTets(tiling, amount), TET_INSET);
       for (let i = 0; i < PIECE_COUNT; i++) {
         const piece = pieces[i] as PieceObjects;
         const tet = exploded[i] as Tet;

--- a/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
@@ -51,7 +51,7 @@ const LIGHT_EDGE = '#ffffff';
 const DARK_EDGE = '#ffffff';
 const LIGHT_BG_RIM = '#4ACECC';
 const DARK_BG_RIM = '#7ADBDD';
-const TET_INSET = 0.02;
+const TET_INSET = 0.04;
 
 export interface HeroCubeHandle {
   destroy(): void;
@@ -155,7 +155,7 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   const SWAY_Z_AMPLITUDE = 0.022;
   const RIM_BASE = 0.9;
   const RIM_PULSE = 0.55;
-  const MIN_EXPLODE = L * 0.4;
+  const MIN_EXPLODE = 0;
   const MAX_EXPLODE = L * 0.7;
 
   function applyColorScheme(dark: boolean): void {
@@ -253,9 +253,9 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   };
 }
 
-const BREATHE_HOLD_LOW_END = 0.12;
+const BREATHE_HOLD_LOW_END = 0.03;
 const BREATHE_OPEN_END = 0.42;
-const BREATHE_HOLD_HIGH_END = 0.62;
+const BREATHE_HOLD_HIGH_END = 0.65;
 const EASE_OUT_BACK_C1 = 1.5;
 
 function easeOutBack(u: number): number {

--- a/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
@@ -1,0 +1,281 @@
+import {
+  AmbientLight,
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  DirectionalLight,
+  Float32BufferAttribute,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  PointLight,
+  Scene,
+  WebGLRenderer,
+} from 'three';
+import { OrbitControls } from 'three-stdlib';
+import { cubeTiling, explodeTets, type Tet, type Vec3 } from './heroCubeGeometry';
+
+const L = 1;
+const PIECE_COUNT = 6;
+const TRIS_PER_PIECE = 4;
+const VERTS_PER_TRI = 3;
+const POSITION_FLOATS = TRIS_PER_PIECE * VERTS_PER_TRI * 3;
+const NORMAL_FLOATS = POSITION_FLOATS;
+const EDGE_PAIRS: ReadonlyArray<readonly [number, number]> = [
+  [0, 1],
+  [0, 2],
+  [0, 3],
+  [1, 2],
+  [1, 3],
+  [2, 3],
+];
+const EDGE_FLOATS = EDGE_PAIRS.length * 2 * 3;
+
+interface PieceObjects {
+  mesh: Mesh;
+  edges: LineSegments;
+  positions: Float32Array;
+  normals: Float32Array;
+  edgePositions: Float32Array;
+  fillMaterial: MeshStandardMaterial;
+}
+
+const LIGHT_PALETTE = ['#07606F', '#0C8698', '#03B0AD', '#4ACECC', '#7ADBDD', '#A8E8E8'];
+
+const DARK_PALETTE = ['#0C8698', '#03B0AD', '#4ACECC', '#7ADBDD', '#A8E8E8', '#D0F2F2'];
+
+const LIGHT_EDGE = '#ffffff';
+const DARK_EDGE = '#ffffff';
+const LIGHT_BG_RIM = '#4ACECC';
+const DARK_BG_RIM = '#7ADBDD';
+
+export interface HeroCubeHandle {
+  destroy(): void;
+  setColorScheme(dark: boolean): void;
+  setHoverPaused(paused: boolean): void;
+}
+
+export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): HeroCubeHandle {
+  const renderer = new WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+    powerPreference: 'low-power',
+  });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+  const scene = new Scene();
+
+  const camera = new PerspectiveCamera(35, 1, 0.1, 100);
+  camera.position.set(1.8, 1.4, 2.2);
+  camera.lookAt(0, 0, 0);
+
+  const keyLight = new DirectionalLight('#ffffff', 1.4);
+  keyLight.position.set(-2, 3, 2);
+  scene.add(keyLight);
+
+  const fillLight = new DirectionalLight('#bae6fd', 0.5);
+  fillLight.position.set(2, -1.5, 1.5);
+  scene.add(fillLight);
+
+  const rimLight = new PointLight(LIGHT_BG_RIM, 0.9, 8, 1.6);
+  rimLight.position.set(0.5, -0.6, -1.8);
+  scene.add(rimLight);
+
+  const ambient = new AmbientLight('#ffffff', 0.35);
+  scene.add(ambient);
+
+  const root = new Group();
+  root.position.set(-L / 2, -L / 2, -L / 2);
+  scene.add(root);
+
+  const tiling = cubeTiling(L);
+  const pieces: PieceObjects[] = tiling.map((tet, i) => {
+    const positions = new Float32Array(POSITION_FLOATS);
+    const normals = new Float32Array(NORMAL_FLOATS);
+    writeTetMesh(tet, positions, normals);
+    const geom = new BufferGeometry();
+    geom.setAttribute('position', new BufferAttribute(positions, 3));
+    geom.setAttribute('normal', new BufferAttribute(normals, 3));
+    const fillMaterial = new MeshStandardMaterial({
+      color: new Color(LIGHT_PALETTE[i]),
+      flatShading: true,
+      roughness: 0.55,
+      metalness: 0.08,
+      polygonOffset: true,
+      polygonOffsetFactor: 1,
+      polygonOffsetUnits: 1,
+    });
+    const mesh = new Mesh(geom, fillMaterial);
+    root.add(mesh);
+
+    const edgePositions = new Float32Array(EDGE_FLOATS);
+    writeTetEdges(tet, edgePositions);
+    const edgeGeom = new BufferGeometry();
+    edgeGeom.setAttribute('position', new Float32BufferAttribute(edgePositions, 3));
+    const edgeMat = new LineBasicMaterial({
+      color: new Color(LIGHT_EDGE),
+      transparent: true,
+      opacity: 0.85,
+    });
+    const edges = new LineSegments(edgeGeom, edgeMat);
+    root.add(edges);
+
+    return { mesh, edges, positions, normals, edgePositions, fillMaterial };
+  });
+
+  const controls = new OrbitControls(camera, canvas);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+  controls.enableZoom = false;
+  controls.enablePan = false;
+  controls.rotateSpeed = 0.8;
+  controls.target.set(0, 0, 0);
+
+  let rafId = 0;
+  let lastT = performance.now();
+  let phase = 0;
+  let yaw = 0;
+  let hoverPaused = false;
+  let lastBreathe = 0;
+
+  const ROTATE_SPEED = (Math.PI * 2) / 12;
+  const BREATHE_SPEED = (Math.PI * 2) / 6;
+  const MAX_EXPLODE = L * 1.1;
+
+  function applyColorScheme(dark: boolean): void {
+    const fills = dark ? DARK_PALETTE : LIGHT_PALETTE;
+    const edgeHex = dark ? DARK_EDGE : LIGHT_EDGE;
+    const rimHex = dark ? DARK_BG_RIM : LIGHT_BG_RIM;
+    pieces.forEach((p, i) => {
+      p.fillMaterial.color.set(fills[i] as string);
+      const edgeMat = p.edges.material as LineBasicMaterial;
+      edgeMat.color.set(edgeHex);
+    });
+    rimLight.color.set(rimHex);
+  }
+
+  applyColorScheme(initialDark);
+
+  function resize(): void {
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    if (w === 0 || h === 0) return;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+  }
+
+  const ro = new ResizeObserver(() => resize());
+  ro.observe(canvas);
+  resize();
+
+  function tick(now: number): void {
+    rafId = requestAnimationFrame(tick);
+    const dt = Math.min((now - lastT) / 1000, 0.05);
+    lastT = now;
+
+    if (!hoverPaused) {
+      phase += dt * BREATHE_SPEED;
+    }
+    yaw += dt * ROTATE_SPEED;
+    root.rotation.y = yaw;
+
+    const breathe = 0.5 - 0.5 * Math.cos(phase);
+    if (Math.abs(breathe - lastBreathe) > 1e-4 || hoverPaused === false) {
+      const amount = breathe * MAX_EXPLODE;
+      const exploded = explodeTets(tiling, amount);
+      for (let i = 0; i < PIECE_COUNT; i++) {
+        const piece = pieces[i] as PieceObjects;
+        const tet = exploded[i] as Tet;
+        writeTetMesh(tet, piece.positions, piece.normals);
+        writeTetEdges(tet, piece.edgePositions);
+        const pos = piece.mesh.geometry.getAttribute('position');
+        const nrm = piece.mesh.geometry.getAttribute('normal');
+        (pos as BufferAttribute).needsUpdate = true;
+        (nrm as BufferAttribute).needsUpdate = true;
+        const epos = piece.edges.geometry.getAttribute('position');
+        (epos as BufferAttribute).needsUpdate = true;
+      }
+      lastBreathe = breathe;
+    }
+
+    controls.update();
+    renderer.render(scene, camera);
+  }
+
+  rafId = requestAnimationFrame(tick);
+
+  return {
+    destroy(): void {
+      cancelAnimationFrame(rafId);
+      ro.disconnect();
+      controls.dispose();
+      pieces.forEach((p) => {
+        p.mesh.geometry.dispose();
+        p.fillMaterial.dispose();
+        p.edges.geometry.dispose();
+        (p.edges.material as LineBasicMaterial).dispose();
+      });
+      renderer.dispose();
+    },
+    setColorScheme: applyColorScheme,
+    setHoverPaused(paused: boolean): void {
+      hoverPaused = paused;
+    },
+  };
+}
+
+function writeTetMesh(tet: Tet, positions: Float32Array, normals: Float32Array): void {
+  let pi = 0;
+  let ni = 0;
+  for (const [a, b, c] of tet.faces) {
+    const va = tet.verts[a] as Vec3;
+    const vb = tet.verts[b] as Vec3;
+    const vc = tet.verts[c] as Vec3;
+    const ux = vb[0] - va[0];
+    const uy = vb[1] - va[1];
+    const uz = vb[2] - va[2];
+    const wx = vc[0] - va[0];
+    const wy = vc[1] - va[1];
+    const wz = vc[2] - va[2];
+    let nx = uy * wz - uz * wy;
+    let ny = uz * wx - ux * wz;
+    let nz = ux * wy - uy * wx;
+    const len = Math.hypot(nx, ny, nz) || 1;
+    nx /= len;
+    ny /= len;
+    nz /= len;
+    positions[pi++] = va[0];
+    positions[pi++] = va[1];
+    positions[pi++] = va[2];
+    positions[pi++] = vb[0];
+    positions[pi++] = vb[1];
+    positions[pi++] = vb[2];
+    positions[pi++] = vc[0];
+    positions[pi++] = vc[1];
+    positions[pi++] = vc[2];
+    for (let k = 0; k < 3; k++) {
+      normals[ni++] = nx;
+      normals[ni++] = ny;
+      normals[ni++] = nz;
+    }
+  }
+}
+
+function writeTetEdges(tet: Tet, out: Float32Array): void {
+  let i = 0;
+  for (const [a, b] of EDGE_PAIRS) {
+    const va = tet.verts[a] as Vec3;
+    const vb = tet.verts[b] as Vec3;
+    out[i++] = va[0];
+    out[i++] = va[1];
+    out[i++] = va[2];
+    out[i++] = vb[0];
+    out[i++] = vb[1];
+    out[i++] = vb[2];
+  }
+}

--- a/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
@@ -51,7 +51,7 @@ const LIGHT_EDGE = '#ffffff';
 const DARK_EDGE = '#ffffff';
 const LIGHT_BG_RIM = '#4ACECC';
 const DARK_BG_RIM = '#7ADBDD';
-const TET_INSET = 0.035;
+const TET_INSET = 0.02;
 
 export interface HeroCubeHandle {
   destroy(): void;
@@ -93,7 +93,8 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   scene.add(root);
 
   const tiling = cubeTiling(L);
-  const initialShrunk = shrunkTets(tiling, TET_INSET);
+  const INITIAL_EXPLODE = L * 0.55;
+  const initialShrunk = shrunkTets(explodeTets(tiling, INITIAL_EXPLODE), TET_INSET);
   const pieces: PieceObjects[] = tiling.map((_tet, i) => {
     const shrunk = initialShrunk[i] as Tet;
     const positions = new Float32Array(POSITION_FLOATS);
@@ -154,7 +155,8 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   const SWAY_Z_AMPLITUDE = 0.022;
   const RIM_BASE = 0.9;
   const RIM_PULSE = 0.55;
-  const MAX_EXPLODE = L * 0.6;
+  const MIN_EXPLODE = L * 0.4;
+  const MAX_EXPLODE = L * 0.7;
 
   function applyColorScheme(dark: boolean): void {
     const fills = dark ? DARK_PALETTE : LIGHT_PALETTE;
@@ -208,7 +210,7 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
     rimLight.intensity = rimIntensity;
 
     if (Math.abs(breathe - lastBreathe) > 1e-4) {
-      const amount = breathe * MAX_EXPLODE;
+      const amount = MIN_EXPLODE + breathe * (MAX_EXPLODE - MIN_EXPLODE);
       const exploded = shrunkTets(explodeTets(tiling, amount), TET_INSET);
       for (let i = 0; i < PIECE_COUNT; i++) {
         const piece = pieces[i] as PieceObjects;

--- a/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
+++ b/apps/docs/.vitepress/theme/components/heroCubeRenderer.ts
@@ -70,7 +70,7 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   const scene = new Scene();
 
   const camera = new PerspectiveCamera(35, 1, 0.1, 100);
-  camera.position.set(1.8, 1.4, 2.2);
+  camera.position.set(3.2, 2.5, 3.95);
   camera.lookAt(0, 0, 0);
 
   const keyLight = new DirectionalLight('#ffffff', 1.4);
@@ -89,7 +89,6 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
   scene.add(ambient);
 
   const root = new Group();
-  root.position.set(-L / 2, -L / 2, -L / 2);
   scene.add(root);
 
   const tiling = cubeTiling(L);
@@ -137,14 +136,22 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
 
   let rafId = 0;
   let lastT = performance.now();
-  let phase = 0;
-  let yaw = 0;
+  let phase = 0.32;
+  let yaw = -0.4;
   let hoverPaused = false;
-  let lastBreathe = 0;
+  let lastBreathe = -1;
+  let rimIntensity = 0.9;
 
-  const ROTATE_SPEED = (Math.PI * 2) / 12;
-  const BREATHE_SPEED = (Math.PI * 2) / 6;
-  const MAX_EXPLODE = L * 1.1;
+  const BREATHE_PERIOD_SEC = 6.8;
+  const ROTATE_PERIOD_SEC = 16;
+  const ROTATE_BASE = (Math.PI * 2) / ROTATE_PERIOD_SEC;
+  const ROTATE_SLOWDOWN_AT_PEAK = 0.55;
+  const SWAY_PERIOD_RATIO = 0.41;
+  const SWAY_X_AMPLITUDE = 0.045;
+  const SWAY_Z_AMPLITUDE = 0.022;
+  const RIM_BASE = 0.9;
+  const RIM_PULSE = 0.55;
+  const MAX_EXPLODE = L * 0.6;
 
   function applyColorScheme(dark: boolean): void {
     const fills = dark ? DARK_PALETTE : LIGHT_PALETTE;
@@ -179,13 +186,25 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
     lastT = now;
 
     if (!hoverPaused) {
-      phase += dt * BREATHE_SPEED;
+      phase += dt / BREATHE_PERIOD_SEC;
     }
-    yaw += dt * ROTATE_SPEED;
-    root.rotation.y = yaw;
+    const tw = phase - Math.floor(phase);
+    const breathe = breatheCurve(tw);
 
-    const breathe = 0.5 - 0.5 * Math.cos(phase);
-    if (Math.abs(breathe - lastBreathe) > 1e-4 || hoverPaused === false) {
+    if (!hoverPaused) {
+      const rotSpeed = ROTATE_BASE * (1 - ROTATE_SLOWDOWN_AT_PEAK * breathe);
+      yaw += dt * rotSpeed;
+    }
+    root.rotation.y = yaw;
+    const swayPhase = phase * Math.PI * 2 * SWAY_PERIOD_RATIO;
+    root.rotation.x = Math.sin(swayPhase) * SWAY_X_AMPLITUDE;
+    root.rotation.z = Math.sin(swayPhase * 0.73 + 1.3) * SWAY_Z_AMPLITUDE;
+
+    const targetRim = RIM_BASE + RIM_PULSE * breathe;
+    rimIntensity += (targetRim - rimIntensity) * Math.min(1, dt * 6);
+    rimLight.intensity = rimIntensity;
+
+    if (Math.abs(breathe - lastBreathe) > 1e-4) {
       const amount = breathe * MAX_EXPLODE;
       const exploded = explodeTets(tiling, amount);
       for (let i = 0; i < PIECE_COUNT; i++) {
@@ -227,6 +246,32 @@ export function mountHeroCube(canvas: HTMLCanvasElement, initialDark: boolean): 
       hoverPaused = paused;
     },
   };
+}
+
+const BREATHE_HOLD_LOW_END = 0.12;
+const BREATHE_OPEN_END = 0.42;
+const BREATHE_HOLD_HIGH_END = 0.62;
+const EASE_OUT_BACK_C1 = 1.5;
+
+function easeOutBack(u: number): number {
+  const c3 = EASE_OUT_BACK_C1 + 1;
+  const k = u - 1;
+  return 1 + c3 * k * k * k + EASE_OUT_BACK_C1 * k * k;
+}
+
+function easeInOutSine(u: number): number {
+  return -(Math.cos(Math.PI * u) - 1) / 2;
+}
+
+function breatheCurve(t: number): number {
+  if (t < BREATHE_HOLD_LOW_END) return 0;
+  if (t < BREATHE_OPEN_END) {
+    const u = (t - BREATHE_HOLD_LOW_END) / (BREATHE_OPEN_END - BREATHE_HOLD_LOW_END);
+    return easeOutBack(u);
+  }
+  if (t < BREATHE_HOLD_HIGH_END) return 1;
+  const u = (t - BREATHE_HOLD_HIGH_END) / (1 - BREATHE_HOLD_HIGH_END);
+  return 1 - easeInOutSine(u);
 }
 
 function writeTetMesh(tet: Tet, positions: Float32Array, normals: Float32Array): void {

--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -1,17 +1,26 @@
 :root {
-  --vp-c-brand-1: #2563eb;
-  --vp-c-brand-2: #3b82f6;
-  --vp-c-brand-3: #60a5fa;
-  --vp-c-brand-soft: rgba(59, 130, 246, 0.14);
+  --vp-c-brand-1: #03b0ad;
+  --vp-c-brand-2: #4acecc;
+  --vp-c-brand-3: #7adbdd;
+  --vp-c-brand-soft: rgba(74, 206, 204, 0.16);
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(120deg, #2563eb 30%, #06b6d4);
+  --vp-home-hero-name-background: linear-gradient(120deg, #07606f 10%, #03b0ad 45%, #4acecc 80%);
   --vp-home-hero-image-background-image: radial-gradient(
     circle at 50% 50%,
-    rgba(37, 99, 235, 0.32),
-    rgba(6, 182, 212, 0.18) 45%,
+    rgba(3, 176, 173, 0.34),
+    rgba(122, 219, 221, 0.22) 45%,
     transparent 75%
   );
   --vp-home-hero-image-filter: blur(72px);
+}
+
+.dark {
+  --vp-home-hero-image-background-image: radial-gradient(
+    circle at 50% 50%,
+    rgba(74, 206, 204, 0.28),
+    rgba(122, 219, 221, 0.16) 45%,
+    transparent 75%
+  );
 }
 
 .VPHero .image-container {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,14 +8,17 @@
     "build": "vitepress build .",
     "preview": "vitepress preview ."
   },
+  "dependencies": {
+    "@vercel/analytics": "2.0.1",
+    "three": "0.184.0",
+    "three-stdlib": "2.36.0"
+  },
   "devDependencies": {
+    "@types/three": "0.184.0",
     "lz-string": "1.5.0",
     "mermaid": "11.15.0",
     "vitepress": "1.6.4",
     "vitepress-plugin-mermaid": "2.0.17",
     "vue": "3.5.34"
-  },
-  "dependencies": {
-    "@vercel/analytics": "2.0.1"
   }
 }

--- a/apps/docs/public/hero-poster.svg
+++ b/apps/docs/public/hero-poster.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 440 440" width="440" height="440" role="img" aria-label="Six tetrahedra exploded apart, the scissors-congruent decomposition of a unit cube">
+  <defs>
+    <linearGradient id="hcA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A8E8E8"/>
+      <stop offset="100%" stop-color="#4ACECC"/>
+    </linearGradient>
+    <linearGradient id="hcB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7ADBDD"/>
+      <stop offset="100%" stop-color="#03B0AD"/>
+    </linearGradient>
+    <linearGradient id="hcC" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4ACECC"/>
+      <stop offset="100%" stop-color="#0C8698"/>
+    </linearGradient>
+    <linearGradient id="hcD" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0C8698"/>
+      <stop offset="100%" stop-color="#03B0AD"/>
+    </linearGradient>
+    <linearGradient id="hcE" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#03B0AD"/>
+      <stop offset="100%" stop-color="#07606F"/>
+    </linearGradient>
+    <linearGradient id="hcF" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7ADBDD"/>
+      <stop offset="100%" stop-color="#0C8698"/>
+    </linearGradient>
+  </defs>
+  <g stroke="#ffffff" stroke-width="3" stroke-linejoin="round" stroke-linecap="round">
+    <!-- top-front-left piece -->
+    <polygon points="158,108 232,86 196,162 138,178" fill="url(#hcA)"/>
+    <!-- top-back-right piece -->
+    <polygon points="246,76 322,128 282,164 224,144" fill="url(#hcB)"/>
+    <!-- right-mid piece -->
+    <polygon points="318,176 372,222 322,272 290,222" fill="url(#hcC)"/>
+    <!-- bottom-front-right piece -->
+    <polygon points="248,278 304,308 258,366 218,322" fill="url(#hcD)"/>
+    <!-- bottom-front-left piece -->
+    <polygon points="116,272 188,260 198,330 134,344" fill="url(#hcE)"/>
+    <!-- left-mid piece -->
+    <polygon points="76,178 142,196 158,254 92,250" fill="url(#hcF)"/>
+    <!-- center connector (assembled-cube ghost hint) -->
+    <polygon points="206,196 246,188 256,228 240,254 200,250 188,222" fill="#03B0AD" fill-opacity="0.18"/>
+  </g>
+</svg>

--- a/apps/docs/public/hero-poster.svg
+++ b/apps/docs/public/hero-poster.svg
@@ -38,7 +38,5 @@
     <polygon points="116,272 188,260 198,330 134,344" fill="url(#hcE)"/>
     <!-- left-mid piece -->
     <polygon points="76,178 142,196 158,254 92,250" fill="url(#hcF)"/>
-    <!-- center connector (assembled-cube ghost hint) -->
-    <polygon points="206,196 246,188 256,228 240,254 200,250 188,222" fill="#03B0AD" fill-opacity="0.18"/>
   </g>
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,6 +1855,29 @@
         }
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,14 +68,40 @@
       "name": "brepjs-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@vercel/analytics": "2.0.1"
+        "@vercel/analytics": "2.0.1",
+        "three": "0.184.0",
+        "three-stdlib": "2.36.0"
       },
       "devDependencies": {
+        "@types/three": "0.184.0",
         "lz-string": "1.5.0",
         "mermaid": "11.15.0",
         "vitepress": "1.6.4",
         "vitepress-plugin-mermaid": "2.0.17",
         "vue": "3.5.34"
+      }
+    },
+    "apps/docs/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
+    "apps/docs/node_modules/three-stdlib": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.0.tgz",
+      "integrity": "sha512-kv0Byb++AXztEGsULgMAs8U2jgUdz6HPpAB/wDJnLiLlaWQX2APHhiTJIN7rqW+Of0eRgcp7jn05U1BsCP3xBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
       }
     },
     "apps/playground": {
@@ -948,6 +974,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -957,6 +984,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1190,6 +1218,7 @@
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -1824,29 +1853,6 @@
         "search-insights": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2932,6 +2938,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -4209,6 +4216,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4243,6 +4251,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
       "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -4324,6 +4333,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -4593,6 +4603,7 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -5076,6 +5087,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5116,6 +5128,7 @@
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -5444,7 +5457,8 @@
       "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.86.1.tgz",
       "integrity": "sha512-WEpa9/ECKaBGBHx4Vd0JUQXfMi4hMkuGtdZ6Ow+nrgUC73y/H0eMCWu0klNMcrmGl1OqfH517JgNHa40J9BC1Q==",
       "devOptional": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -5848,6 +5862,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5931,6 +5946,7 @@
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6375,6 +6391,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6566,7 +6583,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -6727,6 +6745,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7114,6 +7133,7 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -8644,6 +8664,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -8737,6 +8758,7 @@
       "integrity": "sha512-IU08VT+mL+PbqoH9LrBT29gVCQHMJLvwxJJobwuvlbcUCRKAMVClOCjhNdPRt10oYLx7Znrl2poo1t59rYeNMA==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "comlink": "^4.4.2"
       }
@@ -9397,6 +9419,7 @@
       "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.130.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -9570,6 +9593,7 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -9955,7 +9979,8 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -10230,8 +10255,9 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10293,8 +10319,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
@@ -10517,6 +10542,7 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11219,6 +11245,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11279,6 +11306,7 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -11376,6 +11404,7 @@
       "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.34",
         "@vue/compiler-sfc": "3.5.34",


### PR DESCRIPTION
## Summary

- Replaces the static blue gradient hero on `/` with a live Three.js scene: six Hill T₁ tetrahedra (the scissors-congruent decomposition of a unit cube, adapted from planckton's `CubeScene`) breathing apart and rotating slowly.
- Pulls the palette and white seams from the favicon (`#4ACECC` family) rather than the prior `#2563eb` brand tokens, and retunes the hero name gradient + radial-bg to match. Dark mode is observed via `html.dark` and re-tints fills/edges/rim in place.
- Lazy-loaded canvas: an SVG poster (`/public/hero-poster.svg`) paints first so there's no layout shift; Three.js is dynamic-imported after hydration. Animation always runs (no `prefers-reduced-motion` gate).
- Interactivity: `OrbitControls` allow drag-rotate only (no zoom/pan); hover pauses the breathe so users can read the assembled shape.

### Files

- `apps/docs/.vitepress/theme/components/HeroCube.vue` — Vue island, `<ClientOnly>`, poster ↔ canvas crossfade
- `apps/docs/.vitepress/theme/components/heroCubeGeometry.ts` — `tetFromPts`, `cubeTiling`, `explodeTets` (ported from planckton)
- `apps/docs/.vitepress/theme/components/heroCubeRenderer.ts` — scene, lighting, materials, animation loop, dark-mode reactor
- `apps/docs/public/hero-poster.svg` — half-exploded snapshot in the favicon's faceted style
- `apps/docs/.vitepress/theme/Layout.vue` — fills the `home-hero-image` slot
- `apps/docs/.vitepress/theme/custom.css` — retuned brand vars and radial-bg
- `apps/docs/package.json` — adds `three@0.184.0`, `three-stdlib@2.36.0`, `@types/three@0.184.0` (matching `apps/playground`)

## Test plan

- [x] `npm run build` inside `apps/docs/` — VitePress SSR passes (`build complete in 13.19s`)
- [x] Pre-commit hook — typecheck + boundary check + 2737 OCCT tests pass
- [x] Pre-push hook — full `test:full` + `knip` pass
- [x] SSR check on built `index.html` — `VPHero has-image` class is set; `home-hero-image` slot collapses to empty during prerender (correct `<ClientOnly>` behavior)
- [ ] Manual eyeball on the Vercel deploy preview: breathe + rotate animate, drag-to-rotate works, dark/light mode toggle re-tints in place, poster→canvas crossfade is smooth