### PR TITLE
feat(brepkit): land H section multi-wire + F evolution close-tied match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/opentype.js": "1.3.9",
         "@vitest/coverage-v8": "4.1.6",
         "brepjs-opencascade": "*",
-        "brepkit-wasm": "2.86.1",
+        "brepkit-wasm": "2.87.0",
         "eslint": "10.4.0",
         "fast-check": "4.8.0",
         "husky": "9.1.7",
@@ -1853,29 +1853,6 @@
         "search-insights": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -5476,9 +5453,9 @@
       "link": true
     },
     "node_modules/brepkit-wasm": {
-      "version": "2.86.1",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.86.1.tgz",
-      "integrity": "sha512-WEpa9/ECKaBGBHx4Vd0JUQXfMi4hMkuGtdZ6Ow+nrgUC73y/H0eMCWu0klNMcrmGl1OqfH517JgNHa40J9BC1Q==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.87.0.tgz",
+      "integrity": "sha512-DRDvl/0dKsjXKOxHmi/deC96mGz3LWqc5n5bt9olT126J45ZbBtHSGt6CFmNvA110QDsV7ylxd9dnmUYx5ihfg==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peer": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,6 +1855,29 @@
         }
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "@types/opentype.js": "1.3.9",
     "@vitest/coverage-v8": "4.1.6",
     "brepjs-opencascade": "*",
-    "brepkit-wasm": "2.86.1",
+    "brepkit-wasm": "2.87.0",
     "eslint": "10.4.0",
     "fast-check": "4.8.0",
     "husky": "9.1.7",

--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -24,6 +24,8 @@ import {
   toArray,
   warnOnce,
   hasBooleanOptions,
+  nextSyntheticId,
+  syntheticCompounds,
 } from './helpers.js';
 import { extractPlaneFromFace } from './internalOps.js';
 import { isValid as _isValid } from './repairOps.js';
@@ -119,8 +121,20 @@ export function section(
     return compoundHandle(bk.makeCompound([]));
   }
 
-  const firstWireId = bk.getFaceOuterWire(wasmIndex(faceIds, 0));
-  return wireHandle(firstWireId);
+  const allWireHandles: BrepkitHandle[] = [];
+  for (let i = 0; i < faceIds.length; i++) {
+    const wireIds = toArray(bk.getFaceWires(wasmIndex(faceIds, i)));
+    for (let j = 0; j < wireIds.length; j++) {
+      allWireHandles.push(wireHandle(wasmIndex(wireIds, j)));
+    }
+  }
+  const [firstWire] = allWireHandles;
+  if (allWireHandles.length === 1 && firstWire !== undefined) {
+    return firstWire;
+  }
+  const syntheticId = nextSyntheticId();
+  syntheticCompounds.set(syntheticId, allWireHandles);
+  return compoundHandle(syntheticId);
 }
 
 export function fuseAll(

--- a/src/kernel/brepkit/evolutionOps.ts
+++ b/src/kernel/brepkit/evolutionOps.ts
@@ -177,11 +177,19 @@ function matchFacesGeometrically(
 
   const NORMAL_THRESHOLD = 0.707; // cos(45deg)
   const CENTROID_DIST_SQ_MAX = 100.0;
+  // Tolerance for "close-enough" matches — when multiple input faces score
+  // within this band of the best, record all of them. Mirrors the same
+  // relaxation applied in brepkit Rust's `boolean_with_evolution`. Without
+  // this, an output face that legitimately inherits metadata from several
+  // inputs (e.g., the bottom face of a filleted box — close-tied with the
+  // input bottom — that should keep the input's "bottom" tag) only picks
+  // up one input's metadata and drops the rest.
+  const SCORE_TIE_TOL = 0.05;
   const matchedInputIndices = new Set<number>();
 
   for (const out of outputSigs) {
     let bestScore = -Infinity;
-    let bestIdx = -1;
+    const matches: { idx: number; score: number }[] = [];
 
     for (let i = 0; i < inputSigs.length; i++) {
       const inp = wasmIndex(inputSigs, i);
@@ -195,18 +203,20 @@ function matchFacesGeometrically(
       if (distSq > CENTROID_DIST_SQ_MAX) continue;
 
       const score = dot - distSq / CENTROID_DIST_SQ_MAX;
-      if (score > bestScore) {
-        bestScore = score;
-        bestIdx = i;
-      }
+      if (score > bestScore) bestScore = score;
+      matches.push({ idx: i, score });
     }
 
-    if (bestIdx >= 0) {
-      const bestInput = wasmIndex(inputSigs, bestIdx);
-      const existing = modified.get(bestInput.hash) ?? [];
-      existing.push(out.hash);
-      modified.set(bestInput.hash, existing);
-      matchedInputIndices.add(bestIdx);
+    if (matches.length > 0) {
+      for (const m of matches) {
+        if (m.score >= bestScore - SCORE_TIE_TOL) {
+          const inp = wasmIndex(inputSigs, m.idx);
+          const existing = modified.get(inp.hash) ?? [];
+          existing.push(out.hash);
+          modified.set(inp.hash, existing);
+          matchedInputIndices.add(m.idx);
+        }
+      }
     } else {
       // Unmatched output -> generated from nearest input
       let bestDistSq = Infinity;
@@ -230,6 +240,138 @@ function matchFacesGeometrically(
   for (let i = 0; i < inputSigs.length; i++) {
     if (!matchedInputIndices.has(i)) {
       deleted.add(wasmIndex(inputSigs, i).hash);
+    }
+  }
+}
+
+/**
+ * Apply geometric matching to the unmatched input/output residuals from a
+ * hash-overlap evolution, then derive the deleted set as inputs that were
+ * never matched and never attributed to a generated output.
+ */
+function reconcileUnmatchedResiduals(
+  bk: BrepkitKernel,
+  originalShape: KernelShape,
+  unmatchedInputHashes: number[],
+  unmatchedOutputFaces: number[],
+  hashUpperBound: number,
+  modified: Map<number, number[]>,
+  generated: Map<number, number[]>,
+  deleted: Set<number>
+): void {
+  const beforeDeleted = new Set(deleted);
+  const beforeModified = new Map(modified);
+  matchFacesGeometrically(
+    bk,
+    originalShape,
+    unmatchedInputHashes,
+    unmatchedOutputFaces,
+    hashUpperBound,
+    modified,
+    generated,
+    deleted
+  );
+  deleted.clear();
+  for (const old of beforeDeleted) deleted.add(old);
+  for (const h of unmatchedInputHashes) {
+    const isModified =
+      !beforeModified.has(h) && modified.has(h) && (modified.get(h)?.length ?? 0) > 0;
+    const isGenerated = generated.has(h) && (generated.get(h)?.length ?? 0) > 0;
+    if (!isModified && !isGenerated) {
+      deleted.add(h);
+    }
+  }
+}
+
+/**
+ * Hash-only evolution fallback when no original shape is available for
+ * geometric matching: every new output hash becomes "generated", every
+ * input hash that didn't survive becomes "deleted".
+ */
+function fallbackHashOnlyEvolution(
+  inputFaceHashes: number[],
+  outputHashes: number[],
+  inputSet: Set<number>,
+  outputSet: Set<number>,
+  generated: Map<number, number[]>,
+  deleted: Set<number>
+): void {
+  const newFaces = outputHashes.filter((fh) => !inputSet.has(fh));
+  if (newFaces.length > 0 && inputFaceHashes.length > 0) {
+    generated.set(wasmIndex(inputFaceHashes, 0), newFaces);
+  }
+  for (const hash of inputFaceHashes) {
+    if (!outputSet.has(hash)) {
+      deleted.add(hash);
+    }
+  }
+}
+
+/**
+ * Boolean/modifier evolution: compare input and output face hashes, fall
+ * back to geometric matching for the residuals brepkit re-IDs.
+ */
+function buildBooleanEvolution(
+  bk: BrepkitKernel,
+  outputFaces: number[],
+  outputHashes: number[],
+  inputFaceHashes: number[],
+  hashUpperBound: number,
+  modified: Map<number, number[]>,
+  generated: Map<number, number[]>,
+  deleted: Set<number>,
+  originalShape?: KernelShape
+): void {
+  const inputSet = new Set(inputFaceHashes);
+  const hasOverlap = outputHashes.some((hash) => inputSet.has(hash));
+
+  if (hasOverlap) {
+    const outputSet = new Set(outputHashes);
+    for (const hash of outputHashes) {
+      if (inputSet.has(hash)) modified.set(hash, [hash]);
+    }
+    const unmatchedInputHashes = inputFaceHashes.filter((h) => !outputSet.has(h));
+    const unmatchedOutputFaces = outputFaces.filter((fid) => !inputSet.has(fid % hashUpperBound));
+    const canGeometricMatch =
+      originalShape && unmatchedInputHashes.length > 0 && unmatchedOutputFaces.length > 0;
+    if (canGeometricMatch) {
+      reconcileUnmatchedResiduals(
+        bk,
+        originalShape,
+        unmatchedInputHashes,
+        unmatchedOutputFaces,
+        hashUpperBound,
+        modified,
+        generated,
+        deleted
+      );
+    } else {
+      fallbackHashOnlyEvolution(
+        inputFaceHashes,
+        outputHashes,
+        inputSet,
+        outputSet,
+        generated,
+        deleted
+      );
+    }
+  } else if (originalShape) {
+    matchFacesGeometrically(
+      bk,
+      originalShape,
+      inputFaceHashes,
+      outputFaces,
+      hashUpperBound,
+      modified,
+      generated,
+      deleted
+    );
+  } else {
+    for (let i = 0; i < inputFaceHashes.length && i < outputHashes.length; i++) {
+      modified.set(wasmIndex(inputFaceHashes, i), [wasmIndex(outputHashes, i)]);
+    }
+    if (outputHashes.length > inputFaceHashes.length && inputFaceHashes.length > 0) {
+      generated.set(wasmIndex(inputFaceHashes, 0), outputHashes.slice(inputFaceHashes.length));
     }
   }
 }
@@ -259,61 +401,21 @@ function buildEvolution(
     const outputHashes = outputFaces.map((fid) => fid % hashUpperBound);
 
     if (isTransform) {
-      // Transforms: 1:1 mapping -- each input face maps to the corresponding output face
       for (let i = 0; i < inputFaceHashes.length && i < outputHashes.length; i++) {
         modified.set(wasmIndex(inputFaceHashes, i), [wasmIndex(outputHashes, i)]);
       }
     } else {
-      // Boolean/modifier: compare face hash sets
-      const inputSet = new Set(inputFaceHashes);
-
-      // Check if any output hash matches an input hash
-      let hasOverlap = false;
-      for (const hash of outputHashes) {
-        if (inputSet.has(hash)) {
-          hasOverlap = true;
-          break;
-        }
-      }
-
-      if (hasOverlap) {
-        // Hash-based matching (OCCT-like behavior)
-        const outputSet = new Set(outputHashes);
-        for (const hash of outputHashes) {
-          if (inputSet.has(hash)) {
-            modified.set(hash, [hash]);
-          }
-        }
-        const newFaces = outputHashes.filter((fh) => !inputSet.has(fh));
-        if (newFaces.length > 0 && inputFaceHashes.length > 0) {
-          generated.set(wasmIndex(inputFaceHashes, 0), newFaces);
-        }
-        for (const hash of inputFaceHashes) {
-          if (!outputSet.has(hash)) {
-            deleted.add(hash);
-          }
-        }
-      } else if (originalShape) {
-        // No hash overlap -- use geometric matching (normal + centroid)
-        matchFacesGeometrically(
-          bk,
-          originalShape,
-          inputFaceHashes,
-          outputFaces,
-          hashUpperBound,
-          modified,
-          generated,
-          deleted
-        );
-      } else {
-        // No original shape available -- positional fallback
-        for (let i = 0; i < inputFaceHashes.length && i < outputHashes.length; i++) {
-          modified.set(wasmIndex(inputFaceHashes, i), [wasmIndex(outputHashes, i)]);
-        }
-        if (outputHashes.length > inputFaceHashes.length && inputFaceHashes.length > 0) {
-          generated.set(wasmIndex(inputFaceHashes, 0), outputHashes.slice(inputFaceHashes.length));
-        }
-      }
+      buildBooleanEvolution(
+        bk,
+        outputFaces,
+        outputHashes,
+        inputFaceHashes,
+        hashUpperBound,
+        modified,
+        generated,
+        deleted,
+        originalShape
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- **H — sectionToFace multi-wire**: `section()` now packages every wire (outer + every inner of each face produced by sectioning) into a synthetic compound so `sectionToFace` can reassemble the outer + hole faces. The prior path returned only the first face's outer wire, dropping inner holes.
- **F — evolution close-tied match**: `matchFacesGeometrically` now records every input whose geometric score is within `SCORE_TIE_TOL = 0.05` of the best, instead of taking only the unique top scorer. The hash-overlap path also runs geometric matching on the unmatched input/output residuals, so coincident-plane fuses preserve every origin's metadata (e.g., the bottom face of a filleted box keeps the input's "bottom" tag).
- **Refactor**: extracted `reconcileUnmatchedResiduals`, `fallbackHashOnlyEvolution`, and `buildBooleanEvolution` so `buildEvolution` stays under the project's line / nesting limits.
- **Version bump**: `brepkit-wasm` 2.86.1 → 2.87.0 (brepkit-side fixes shipped in andymai/brepkit#673, released by andymai/brepkit#674 as 2.87.0).

## Depends on

- [andymai/brepkit#673](https://github.com/andymai/brepkit/pull/673) — landed and published as `brepkit-wasm@2.87.0`.

## Verification

- `npm run test:brepkit` → **2872 / 2940 passed**, 21 expected residuals (4 cleanroom + 17 parity/*) — identical failure set on both 2.86.1 and 2.87.0, confirming no regressions from the version bump.
- `npm run typecheck` clean.
- `npm run lint` clean.
- `npx tsx scripts/check-patterns.ts` clean (no new violations).