### PR TITLE
chore(deps): bump brepkit-wasm 2.87.0 → 2.87.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/opentype.js": "1.3.9",
         "@vitest/coverage-v8": "4.1.6",
         "brepjs-opencascade": "*",
-        "brepkit-wasm": "2.87.0",
+        "brepkit-wasm": "2.87.1",
         "eslint": "10.4.0",
         "fast-check": "4.8.0",
         "husky": "9.1.7",
@@ -5476,9 +5476,9 @@
       "link": true
     },
     "node_modules/brepkit-wasm": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.87.0.tgz",
-      "integrity": "sha512-DRDvl/0dKsjXKOxHmi/deC96mGz3LWqc5n5bt9olT126J45ZbBtHSGt6CFmNvA110QDsV7ylxd9dnmUYx5ihfg==",
+      "version": "2.87.1",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-2.87.1.tgz",
+      "integrity": "sha512-FMvEsFw95wFN8ZUz4k6mpMikD2VM4qimTE7jPOHGrEUGgH8iHZAnuWshJdFg6KlQ6hd97wisNSgslBhuP2G1yA==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peer": true

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "@types/opentype.js": "1.3.9",
     "@vitest/coverage-v8": "4.1.6",
     "brepjs-opencascade": "*",
-    "brepkit-wasm": "2.87.0",
+    "brepkit-wasm": "2.87.1",
     "eslint": "10.4.0",
     "fast-check": "4.8.0",
     "husky": "9.1.7",


### PR DESCRIPTION
## Summary

Picks up the `aabb_strictly_contains` follow-up fix from [andymai/brepkit#675](https://github.com/andymai/brepkit/pull/675) — restores the all-3-dims check that #1016 intended but my CI bisect inadvertently reverted in the brepkit-side PR, unblocking `rectangularPattern() > creates a 2x3 grid of shapes`.

## Verification

- `npm run test:brepkit` → **21 expected residuals** (4 cleanroom + 17 parity/*), down from 22
- All 12 `rectangularPattern()` tests pass (was 11/12 with 2.87.0)
- No other test movement vs 2.87.0

## Notes

- Lockfile carries the surgical `@emnapi/{core,runtime,wasi-threads}` entries (per the npm < 11.11 workaround we landed in #1016).