### PR TITLE
fix(ci): pin tsx version in docs workflow to fix npx auto-download failure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,10 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npx tsx scripts/generate-function-lookup.ts
+      # tsx is not in root devDependencies; force npx to install it
+      # explicitly so the script can run. Without -p, npx auto-download
+      # has been unreliable on the CI runner.
+      - run: npx -p tsx@4.22.1 -y -- tsx scripts/generate-function-lookup.ts
       - run: npm run docs:api
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

`Deploy API Docs` has been failing on main with `sh: 1: tsx: not found` for at least the last two runs (20:53:57 and 21:27:25). Root cause: `tsx` is only declared in `apps/playground/node_modules/devDependencies`, not at root, so `npm ci` at the workflow's root doesn't install it. The bare `npx tsx ...` then relies on npx auto-download, which is failing.

## Fix

Pin tsx explicitly in the workflow step: `npx -p tsx@4.22.1 -y -- tsx scripts/...`. This forces npx to install tsx@4.22.1 (matching what the playground workspace already uses in the lockfile) and run it.

## Why this approach (vs adding tsx to root devDeps)

Touching package.json + package-lock.json triggers the `@emnapi` lockfile-drop trap on any contributor running npm < 11.11 locally. A workflow-only change avoids that entirely.

## Verified locally
- [x] `npx -p tsx@4.22.1 -y -- tsx scripts/generate-function-lookup.ts` runs and regenerates `docs/function-lookup.md` cleanly.