### PR TITLE
fix(ci): install tsx directly in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,10 +33,11 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      # tsx is not in root devDependencies; force npx to install it
-      # explicitly so the script can run. Without -p, npx auto-download
-      # has been unreliable on the CI runner.
-      - run: npx -p tsx@4.22.1 -y -- tsx scripts/generate-function-lookup.ts
+      # tsx is not in root devDependencies; install it directly in the
+      # workspace's node_modules instead of relying on npx auto-download,
+      # which has been unreliable on the CI runner.
+      - run: npm install --no-save tsx@4.22.1
+      - run: ./node_modules/.bin/tsx scripts/generate-function-lookup.ts
       - run: npm run docs:api
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

PR #1020 attempted to fix Deploy API Docs by pinning tsx with `npx -p tsx@4.22.1 -y -- tsx ...`. That works locally but **still fails on CI** with `sh: 1: tsx: not found` — npx's tmp-prefix install + PATH addition is unreliable on the CI runner.

## Fix

Replace npx with a direct install + direct binary call:
- `npm install --no-save tsx@4.22.1` puts tsx in `node_modules/.bin/`
- `./node_modules/.bin/tsx scripts/...` runs it via explicit path, no PATH lookup

The `--no-save` flag means package.json/lockfile aren't touched — same rationale as before for avoiding the @emnapi lockfile-drop trap.

## Verified locally
- [x] `npm install --no-save tsx@4.22.1` succeeds
- [x] `./node_modules/.bin/tsx scripts/generate-function-lookup.ts` runs and produces `Generated /var/home/andy/Git/brepjs/docs/function-lookup.md (463 symbols)`