### PR TITLE
fix(build): exclude declaration source maps from npm package

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   plugins: [
     dts({
       rollupTypes: false,
+      compilerOptions: { declarationMap: false },
     }),
   ],
   build: {


### PR DESCRIPTION
## Summary

The `publish-brepjs` job on `main` has been failing with `Too many files in package (684 > 650)` from `scripts/validate-pack.sh`, blocking release-please from publishing 18.14.2.

The bloat comes from 290 `.d.ts.map` declaration source maps emitted alongside their `.d.ts` files. These are useless to consumers — they only help map a `.d.ts` back into a `.ts` source for "Go to Definition", but the published package doesn't ship `.ts` sources, so the maps point to files that don't exist.

The fix passes `compilerOptions: { declarationMap: false }` to `vite-plugin-dts` so the published build skips emitting `.map` sidecars. The root `tsconfig.json` still has `declarationMap: true`, so in-workspace IDE navigation continues to work.

**Before:** 684 files, 829.1 kB tarball
**After:** 394 files, 748.5 kB tarball

## Test plan

- [x] `npm run build` succeeds and emits `.d.ts` but no `.d.ts.map`
- [x] `bash scripts/validate-pack.sh` passes locally (394 files, max 650)
- [x] `npm run typecheck` passes
- [x] Pre-push hook (full `test:full` + `knip`) passes
- [ ] Release Please's `publish-brepjs` succeeds on the next release commit

## Failed run

https://github.com/andymai/brepjs/actions/runs/26063651937