### PR TITLE
chore(build): tighten package file ceiling and ban .d.ts.map

### DIFF
--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-MAX_FILES=650
+MAX_FILES=420
 
 PACK_OUTPUT=$(npm pack --dry-run --ignore-scripts 2>&1)
 TOTAL_FILES=$(echo "$PACK_OUTPUT" | grep "total files" | awk '{print $NF}')
@@ -16,6 +16,16 @@ echo "Package files: $TOTAL_FILES (max: $MAX_FILES)"
 if [ "$TOTAL_FILES" -gt "$MAX_FILES" ]; then
   echo "ERROR: Too many files in package ($TOTAL_FILES > $MAX_FILES)"
   echo "Run 'npm pack --dry-run' to inspect"
+  exit 1
+fi
+
+# Reject .d.ts.map sidecars: they have no consumer value because .ts sources
+# are not shipped, and they previously caused publish failures by inflating
+# the file count (see vite.config.ts declarationMap setting).
+MAP_COUNT=$(echo "$PACK_OUTPUT" | grep -c '\.d\.ts\.map' || true)
+if [ "$MAP_COUNT" -gt 0 ]; then
+  echo "ERROR: Package contains $MAP_COUNT .d.ts.map files; expected 0"
+  echo "Disable declarationMap in the build (see vite.config.ts)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two regression-guard improvements to `scripts/validate-pack.sh`:

1. **Lower `MAX_FILES` from 650 to 420.** Current count is 394 (after #1024). The 650 ceiling left ~256 files of headroom — far more than any organic growth justifies, which is why the recent bloat regression went unnoticed until release-please tried to publish and the publish failed.
2. **Add explicit `.d.ts.map` ban (count must be 0).** The `declarationMap` escape hatch in `vite-plugin-dts` is a single config option that can be re-enabled by accident. The file-count check alone would only trip once that crossed 420 files; this catches it the moment it appears.

## Why now

The publish-blocking regression on `main` (#1024) shipped because the guardrail's headroom was generous enough to absorb 290 unintended `.d.ts.map` files before tripping. Tightening the ratchet against the *current* clean baseline turns the guardrail into a useful tripwire instead of a backstop.

## Test plan

- [x] `bash scripts/validate-pack.sh` passes locally (394 files, 0 .d.ts.map, max 420)
- [x] Pre-push hook (`test:full` + `knip`) passes
- [x] Pattern test: `grep -c '\.d\.ts\.map'` against a string containing `foo.d.ts` and `foo.d.ts.map` correctly counts 1 (not the false-positive of matching plain `.d.ts`)
- [ ] CI green on this PR

## Related

- #1024 — fixed the underlying publish bloat (removed `.d.ts.map` emission)
- #1026 — tracking issue for deferred Dependabot alerts (independent work)