### PR TITLE
perf(csg): add benchmarks + assertion-grade perf invariants

### DIFF
--- a/benchmarks/csg.bench.test.ts
+++ b/benchmarks/csg.bench.test.ts
@@ -1,0 +1,183 @@
+// Demonstrates the perf gains from CSG IR's content-addressed cache:
+//   - warm vs cold evaluation of the same tree
+//   - param-driven re-eval (only subtrees that depend on the changed param re-run)
+//   - DAG sharing (same structural hash → one kernel call regardless of references)
+
+import { describe, it, beforeAll } from 'vitest';
+import {
+  box,
+  sphere,
+  cylinder,
+  translate as eagerTranslate,
+  fuse as eagerFuse,
+  fuseAll as eagerFuseAll,
+  compound as eagerCompound,
+  csg,
+  unwrap,
+} from '../src/index.js';
+import { initBenchKernels, benchBoth } from './setup.js';
+import { collectResults, printResults, type BenchResult } from './harness.js';
+
+beforeAll(async () => {
+  await initBenchKernels();
+}, 30000);
+
+// ---------------------------------------------------------------------------
+// 1. Cold vs warm cache — repeat eval of the same tree
+// ---------------------------------------------------------------------------
+
+describe('CSG perf — cold vs warm cache', () => {
+  const results: BenchResult[] = [];
+
+  const buildEager = () => {
+    const a = box(10, 10, 10);
+    const b = eagerTranslate(sphere(3), [5, 5, 5]);
+    const c = eagerTranslate(cylinder(2, 12), [0, 0, 0]);
+    return unwrap(eagerFuse(unwrap(eagerFuse(a, b)), c));
+  };
+
+  const buildCsgTree = () =>
+    csg.fuse(
+      csg.fuse(csg.box(10, 10, 10), csg.translate(csg.sphere(3), [5, 5, 5])),
+      csg.translate(csg.cylinder(2, 12), [0, 0, 0])
+    );
+
+  it('eager (no cache): full kernel work every call', async () => {
+    collectResults(
+      results,
+      await benchBoth('eager: build + fuse', () => {
+        buildEager();
+      })
+    );
+  });
+
+  it('csg cold cache: same kernel work', async () => {
+    collectResults(
+      results,
+      await benchBoth('csg: fresh evaluator (cold)', () => {
+        using ev = new csg.Evaluator();
+        unwrap(ev.evaluate(buildCsgTree()));
+      })
+    );
+  });
+
+  it('csg warm cache: 100 repeats of the same tree', async () => {
+    collectResults(
+      results,
+      await benchBoth('csg: 100x warm-cache eval', () => {
+        using ev = new csg.Evaluator();
+        const tree = buildCsgTree();
+        unwrap(ev.evaluate(tree));
+        for (let i = 0; i < 100; i++) unwrap(ev.evaluate(tree));
+      })
+    );
+  });
+
+  it('prints cold-vs-warm results', () => {
+    printResults(results);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Param-driven incremental re-eval — change one param of N
+// ---------------------------------------------------------------------------
+
+describe('CSG perf — incremental param re-eval', () => {
+  const results: BenchResult[] = [];
+
+  // Compound of 8 subtrees; only the first depends on Param('w'). A param change
+  // should re-evaluate just that one subtree; the other 7 must hit the cache.
+  const buildParametricTree = () =>
+    csg.compound([
+      csg.box(csg.param('w'), 10, 10),
+      csg.translate(csg.sphere(2), [10, 0, 0]),
+      csg.translate(csg.sphere(2), [20, 0, 0]),
+      csg.translate(csg.sphere(2), [30, 0, 0]),
+      csg.translate(csg.sphere(2), [40, 0, 0]),
+      csg.translate(csg.sphere(2), [50, 0, 0]),
+      csg.translate(csg.sphere(2), [60, 0, 0]),
+      csg.translate(csg.sphere(2), [70, 0, 0]),
+    ]);
+
+  const buildEagerEquivalent = (w: number) =>
+    eagerCompound([
+      box(w, 10, 10),
+      eagerTranslate(sphere(2), [10, 0, 0]),
+      eagerTranslate(sphere(2), [20, 0, 0]),
+      eagerTranslate(sphere(2), [30, 0, 0]),
+      eagerTranslate(sphere(2), [40, 0, 0]),
+      eagerTranslate(sphere(2), [50, 0, 0]),
+      eagerTranslate(sphere(2), [60, 0, 0]),
+      eagerTranslate(sphere(2), [70, 0, 0]),
+    ]);
+
+  it('eager: changing w forces full rebuild of all 8 children', async () => {
+    collectResults(
+      results,
+      await benchBoth('eager: rebuild 8-child compound on param change', () => {
+        buildEagerEquivalent(5);
+        buildEagerEquivalent(7);
+      })
+    );
+  });
+
+  it('csg: changing Param("w") re-evaluates only the 1 dependent child', async () => {
+    collectResults(
+      results,
+      await benchBoth('csg: incremental re-eval (1 of 8)', () => {
+        using ev = new csg.Evaluator();
+        const tree = buildParametricTree();
+        unwrap(ev.evaluate(tree, { w: 5 }));
+        unwrap(ev.evaluate(tree, { w: 7 }));
+      })
+    );
+  });
+
+  it('prints incremental re-eval results', () => {
+    printResults(results);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. DAG sharing — a parametric assembly with a shared sub-component
+// ---------------------------------------------------------------------------
+// Placing N copies of the same widget at different positions. Each placement
+// has a distinct cache key (different translate vector), but the widget
+// materialization is shared across all N — one kernel build, N reuses.
+
+describe('CSG perf — DAG sharing via structural hash', () => {
+  const results: BenchResult[] = [];
+
+  const N = 12;
+
+  it(`eager: ${N} placements → ${N} widget builds`, async () => {
+    collectResults(
+      results,
+      await benchBoth(`eager: ${N}x widget @ different positions`, () => {
+        const placements = Array.from({ length: N }, (_, i) => {
+          const widget = unwrap(eagerFuse(box(6, 6, 6), sphere(3)));
+          return eagerTranslate(widget, [i * 20, 0, 0]);
+        });
+        eagerCompound(placements);
+      })
+    );
+  });
+
+  it(`csg: ${N} placements → 1 widget build + ${N} cheap translates`, async () => {
+    collectResults(
+      results,
+      await benchBoth(`csg: ${N}x widget @ different positions`, () => {
+        using ev = new csg.Evaluator();
+        const widget = csg.fuse(csg.box(6, 6, 6), csg.sphere(3));
+        const placements = Array.from({ length: N }, (_, i) =>
+          csg.translate(widget, [i * 20, 0, 0])
+        );
+        unwrap(ev.evaluate(csg.compound(placements)));
+      })
+    );
+  });
+
+  it('prints DAG-sharing results', () => {
+    printResults(results);
+  });
+});

--- a/benchmarks/csg.bench.test.ts
+++ b/benchmarks/csg.bench.test.ts
@@ -2,6 +2,11 @@
 //   - warm vs cold evaluation of the same tree
 //   - param-driven re-eval (only subtrees that depend on the changed param re-run)
 //   - DAG sharing (same structural hash → one kernel call regardless of references)
+//
+// Eager paths wrap every iteration in a DisposalScope so the WASM heap doesn't
+// accumulate handles across iterations (which would slow later iterations and
+// overstate CSG's win). The CSG path's cleanup is already covered by the
+// Evaluator's own DisposalScope.
 
 import { describe, it, beforeAll } from 'vitest';
 import {
@@ -10,10 +15,10 @@ import {
   cylinder,
   translate as eagerTranslate,
   fuse as eagerFuse,
-  fuseAll as eagerFuseAll,
   compound as eagerCompound,
   csg,
   unwrap,
+  DisposalScope,
 } from '../src/index.js';
 import { initBenchKernels, benchBoth } from './setup.js';
 import { collectResults, printResults, type BenchResult } from './harness.js';
@@ -29,13 +34,6 @@ beforeAll(async () => {
 describe('CSG perf — cold vs warm cache', () => {
   const results: BenchResult[] = [];
 
-  const buildEager = () => {
-    const a = box(10, 10, 10);
-    const b = eagerTranslate(sphere(3), [5, 5, 5]);
-    const c = eagerTranslate(cylinder(2, 12), [0, 0, 0]);
-    return unwrap(eagerFuse(unwrap(eagerFuse(a, b)), c));
-  };
-
   const buildCsgTree = () =>
     csg.fuse(
       csg.fuse(csg.box(10, 10, 10), csg.translate(csg.sphere(3), [5, 5, 5])),
@@ -46,7 +44,14 @@ describe('CSG perf — cold vs warm cache', () => {
     collectResults(
       results,
       await benchBoth('eager: build + fuse', () => {
-        buildEager();
+        using scope = new DisposalScope();
+        const a = scope.register(box(10, 10, 10));
+        const sph = scope.register(sphere(3));
+        const b = scope.register(eagerTranslate(sph, [5, 5, 5]));
+        const cyl = scope.register(cylinder(2, 12));
+        const c = scope.register(eagerTranslate(cyl, [0, 0, 0]));
+        const ab = scope.register(unwrap(eagerFuse(a, b)));
+        scope.register(unwrap(eagerFuse(ab, c)));
       })
     );
   });
@@ -99,24 +104,24 @@ describe('CSG perf — incremental param re-eval', () => {
       csg.translate(csg.sphere(2), [70, 0, 0]),
     ]);
 
-  const buildEagerEquivalent = (w: number) =>
-    eagerCompound([
-      box(w, 10, 10),
-      eagerTranslate(sphere(2), [10, 0, 0]),
-      eagerTranslate(sphere(2), [20, 0, 0]),
-      eagerTranslate(sphere(2), [30, 0, 0]),
-      eagerTranslate(sphere(2), [40, 0, 0]),
-      eagerTranslate(sphere(2), [50, 0, 0]),
-      eagerTranslate(sphere(2), [60, 0, 0]),
-      eagerTranslate(sphere(2), [70, 0, 0]),
-    ]);
+  function buildEagerEquivalent(scope: DisposalScope, w: number): void {
+    const children = [
+      scope.register(box(w, 10, 10)),
+      ...Array.from({ length: 7 }, (_, i) => {
+        const s = scope.register(sphere(2));
+        return scope.register(eagerTranslate(s, [(i + 1) * 10, 0, 0]));
+      }),
+    ];
+    scope.register(eagerCompound(children));
+  }
 
   it('eager: changing w forces full rebuild of all 8 children', async () => {
     collectResults(
       results,
       await benchBoth('eager: rebuild 8-child compound on param change', () => {
-        buildEagerEquivalent(5);
-        buildEagerEquivalent(7);
+        using scope = new DisposalScope();
+        buildEagerEquivalent(scope, 5);
+        buildEagerEquivalent(scope, 7);
       })
     );
   });
@@ -154,11 +159,14 @@ describe('CSG perf — DAG sharing via structural hash', () => {
     collectResults(
       results,
       await benchBoth(`eager: ${N}x widget @ different positions`, () => {
+        using scope = new DisposalScope();
         const placements = Array.from({ length: N }, (_, i) => {
-          const widget = unwrap(eagerFuse(box(6, 6, 6), sphere(3)));
-          return eagerTranslate(widget, [i * 20, 0, 0]);
+          const b = scope.register(box(6, 6, 6));
+          const s = scope.register(sphere(3));
+          const widget = scope.register(unwrap(eagerFuse(b, s)));
+          return scope.register(eagerTranslate(widget, [i * 20, 0, 0]));
         });
-        eagerCompound(placements);
+        scope.register(eagerCompound(placements));
       })
     );
   });

--- a/tests/csg/csgPerf.test.ts
+++ b/tests/csg/csgPerf.test.ts
@@ -1,0 +1,94 @@
+// Perf invariants for the CSG IR cache. Uses Evaluator.cacheStats() to
+// assert exact hit/miss counts so regressions (e.g. a botched env-projection
+// hash or a missed identity short-circuit) are caught without flaky timings.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from '../setup.js';
+import { Evaluator, box, sphere, fuse, translate, compound, param } from '@/csg/index.js';
+import { unwrap } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('CSG perf invariants — warm cache', () => {
+  it('repeating the same tree N times produces N hits, 0 misses on cached subtrees', () => {
+    using ev = new Evaluator();
+    const tree = fuse(box(10, 10, 10), translate(sphere(3), [5, 5, 5]));
+    unwrap(ev.evaluate(tree));
+    const cold = ev.cacheStats();
+    expect(cold.misses).toBeGreaterThan(0);
+    expect(cold.hits).toBe(0);
+
+    ev.resetStats();
+    for (let i = 0; i < 50; i++) unwrap(ev.evaluate(tree));
+    const warm = ev.cacheStats();
+    expect(warm.misses).toBe(0);
+    expect(warm.hits).toBe(50);
+  });
+});
+
+describe('CSG perf invariants — incremental param re-eval', () => {
+  it('changing one Param re-runs only subtrees that depend on it', () => {
+    using ev = new Evaluator();
+    // 4 independent children, only one references Param('w').
+    const tree = compound([
+      box(param('w'), 10, 10),
+      translate(sphere(2), [10, 0, 0]),
+      translate(sphere(2), [20, 0, 0]),
+      translate(sphere(2), [30, 0, 0]),
+    ]);
+
+    unwrap(ev.evaluate(tree, { w: 5 }));
+    ev.resetStats();
+    unwrap(ev.evaluate(tree, { w: 7 }));
+
+    // Misses: box{w=7} and compound{w=7} — both depend on w so their keys
+    // change. Hits: the three translates (env-independent) short-circuit
+    // descent into their cached spheres.
+    expect(ev.cacheStats()).toMatchObject({ hits: 3, misses: 2 });
+  });
+
+  it('changing an unrelated env key invalidates nothing', () => {
+    using ev = new Evaluator();
+    const tree = compound([box(param('w'), 10, 10), translate(sphere(2), [10, 0, 0])]);
+    unwrap(ev.evaluate(tree, { w: 5, unrelated: 999 }));
+    ev.resetStats();
+    unwrap(ev.evaluate(tree, { w: 5, unrelated: 42 }));
+    expect(ev.cacheStats().misses).toBe(0);
+  });
+});
+
+describe('CSG perf invariants — DAG sharing', () => {
+  it('shared subtree at multiple placements: one materialization, N reuses', () => {
+    using ev = new Evaluator();
+    const widget = fuse(box(6, 6, 6), sphere(3));
+    const N = 5;
+    const tree = compound(Array.from({ length: N }, (_, i) => translate(widget, [i * 20, 0, 0])));
+
+    unwrap(ev.evaluate(tree));
+    const stats = ev.cacheStats();
+
+    // Distinct cache entries: box + sphere + widget(fuse) + N translates + compound = N + 4.
+    expect(stats.entries).toBe(N + 4);
+    expect(stats.misses).toBe(N + 4);
+    // The widget materializes once on the first translate's descent; the
+    // other N-1 translates hit the cache when they ask for their target —
+    // that's the DAG-sharing win.
+    expect(stats.hits).toBe(N - 1);
+  });
+
+  it('re-evaluating the assembly: every node is a hit', () => {
+    using ev = new Evaluator();
+    const widget = fuse(box(6, 6, 6), sphere(3));
+    const N = 5;
+    const tree = compound(Array.from({ length: N }, (_, i) => translate(widget, [i * 20, 0, 0])));
+    unwrap(ev.evaluate(tree));
+    const firstEntries = ev.cacheStats().entries;
+
+    ev.resetStats();
+    unwrap(ev.evaluate(tree));
+    expect(ev.cacheStats()).toEqual({ hits: 1, misses: 0, entries: firstEntries });
+    // Only one hit because the root cache lookup short-circuits the descent.
+  });
+});

--- a/tests/csg/csgPerf.test.ts
+++ b/tests/csg/csgPerf.test.ts
@@ -88,7 +88,7 @@ describe('CSG perf invariants — DAG sharing', () => {
 
     ev.resetStats();
     unwrap(ev.evaluate(tree));
-    expect(ev.cacheStats()).toEqual({ hits: 1, misses: 0, entries: firstEntries });
+    expect(ev.cacheStats()).toMatchObject({ hits: 1, misses: 0, entries: firstEntries });
     // Only one hit because the root cache lookup short-circuits the descent.
   });
 });


### PR DESCRIPTION
## Summary

Adds two layers of CSG IR performance verification, both run on every kernel via `TEST_KERNEL` (and `BENCH_KERNELS`).

**`benchmarks/csg.bench.test.ts`** — wall-clock measurements producing numbers in the bench report. Sample OCCT medians on the dev machine:

| Scenario | Eager | CSG | Speedup |
|---|---|---|---|
| cold vs warm cache (3-op tree, 100 repeats) | 15.1 ms (build+fuse once) | 13.9 ms (101 evaluations) | warm hits are ~free |
| incremental param re-eval (8-child compound, change 1 param) | 0.9 ms | 0.7 ms | ~1.3× |
| DAG sharing (12 widget placements) | 91.6 ms | 8.4 ms | **10.9×** |

**`tests/csg/csgPerf.test.ts`** — assertion-grade regression tests. Uses `Evaluator.cacheStats()` to assert exact hit/miss counts; no flaky timings:

- Warm cache: 50 repeats → `{hits: 50, misses: 0}`
- Param change with 4 independent children: only Param-touching child + Compound re-run; the 3 translates short-circuit descent into their cached spheres (`{hits: 3, misses: 2}`)
- Unrelated env keys don't invalidate any cache entry (`{misses: 0}` after env edit)
- N=5 widget placements: 1 widget materialization + N-1 cache reuses (`{hits: 4}`)
- Identical re-eval: root cache short-circuits the descent (`{hits: 1, misses: 0}`)

The assertion tests are the regression-prevention layer — they fail loudly if the cache-key composition, env projection, or identity short-circuits ever drift.

## Test plan

- [x] `npm run validate` passes (typecheck, lint, boundaries, format, changed-file tests)
- [x] Benchmarks run successfully on OCCT (`npm run bench -- benchmarks/csg.bench.test.ts`)
- [x] 15 perf assertion tests pass on OCCT, brepkit, and occt-wasm