### PR TITLE
fix(deps): bump nested mermaid → dompurify 3.4.2 to 3.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8466,9 +8466,9 @@
       }
     },
     "node_modules/mermaid/node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {


### PR DESCRIPTION
## Summary
- Surgical lockfile bump: `node_modules/mermaid/node_modules/dompurify` from 3.4.2 → 3.4.5
- Chases the resolution "mystery" called out in #1026

## Why was it stuck at 3.4.2?
The lockfile entry was written by Dependabot's mermaid 11.14.0 → 11.15.0 bump on **2026-05-11**. At that moment, the latest dompurify satisfying mermaid's `^3.3.1` range was 3.4.2 — 3.4.3 didn't ship until 2026-05-13, 3.4.5 not until 2026-05-18. Since dompurify is a transitive of a transitive, nothing has forced npm to re-resolve it; the lockfile is just sticky.

Verified end-to-end:
- Standalone mermaid in /tmp picks 3.4.5 today
- Deleting the brepjs lockfile and regenerating picks 3.4.5 (and flips the hoist topology — root becomes 3.4.5, monaco-editor's 3.2.7 gets nested)
- Hand-edited current lockfile (this PR's diff) installs cleanly via `npm ci` in /tmp scratch

3.4.4 is deprecated ("Fixed a security issue introduced in 3.4.4"). 3.4.5 is the current `latest` dist-tag.

## Why a hand-edit instead of `npm update dompurify`?
Local npm 11.6.1 strips `@emnapi/core` + `@emnapi/runtime` from the top-level lockfile (known issue tracked in memory; CI rejects this). The hand-edit avoids that side-effect entirely — only the three lines for the nested dompurify change.

## Impact on #1026
Clears the 4 dompurify advisories on the mermaid path. The other 4 dompurify advisories (monaco-editor's exact-pinned 3.2.7) are still blocked upstream until monaco-editor ships a stable 0.56+.

## Test plan
- [ ] CI `npm ci` succeeds
- [ ] Docs build still renders mermaid diagrams
- [ ] Dependabot alerts on mermaid path drop from 10 → ~6