### PR TITLE
fix(deps): bump brace-expansion 5.0.4 to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5418,9 +5418,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bumps top-level `brace-expansion` 5.0.4 → 5.0.6 (latest)
- Clears moderate-severity CVE [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) ("Zero-step sequence causes process hang and memory exhaustion"), vulnerable range `>=4.0.0 <5.0.5`

## Why
Identical lockfile-inertia shape to #1043. The top-level entry was written when 5.0.4 was the latest matching minimatch's `^5.0.2` range; 5.0.5 (the patch) shipped 2026-03-24, 5.0.6 on 2026-05-08. typedoc's nested copy is already on 5.0.5 (untouched here).

Surfaced by `npm audit` (`fixAvailable: True`) but **not** in the Dependabot dashboard — so this slipped past #1026's tracking.

## Fix shape
Surgical 3-field hand-edit (version + resolved + integrity). Avoids `npm update brace-expansion` because npm 11.6.1 strips `@emnapi/core` + `@emnapi/runtime` from the lockfile (separate known gotcha).

## Test plan
- [x] Verified via `npm ci --ignore-scripts` in a `/tmp` scratch clone — both top-level (5.0.6) and typedoc-nested (5.0.5) install correctly
- [ ] CI green (typecheck, lint, test, build, size, benchmark, CodeQL)