### PR TITLE
chore(deps): drop dead minimatch override

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,8 +285,5 @@
   "dependencies": {
     "flatbush": "4.5.1",
     "opentype.js": "1.3.4"
-  },
-  "overrides": {
-    "minimatch@>=10.0.0 <10.2.3": "10.2.3"
   }
 }


### PR DESCRIPTION
## Summary
- Removes the now-dead `minimatch@>=10.0.0 <10.2.3 → 10.2.3` override from `package.json`
- No lockfile changes — the override matches nothing in the current tree

## Why dead?
Added in #305 (2026-03-01) to patch CVE-2026-27903 (ReDoS in minimatch <10.2.3). Current minimatch versions in the tree:

- `node_modules/minimatch` → 10.2.4 (from eslint@10.4.0)
- `node_modules/typedoc/node_modules/minimatch` → 10.2.5

Neither falls in the `<10.2.3` range, so the override has no effect. Keeping it gives a false impression that there's still a security override in place.

## Test plan
- [x] Verified `npm ci` installs cleanly with the override removed (in /tmp scratch)
- [ ] CI green