### PR TITLE
docs(csg): add concepts, walkthrough, caching, and migration pages

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -46,9 +46,7 @@ export default withMermaid(
         defaultDescription;
       const title = pageData.frontmatter.title ?? pageData.title ?? 'brepjs';
       const fullTitle = title === 'brepjs' ? 'brepjs' : `${title} | brepjs`;
-      const path = pageData.relativePath
-        .replace(/(^|\/)index\.md$/, '$1')
-        .replace(/\.md$/, '');
+      const path = pageData.relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '');
       const url = `${siteUrl}/${path}`;
 
       // VitePress emits `<meta name="description">` natively from
@@ -105,6 +103,7 @@ export default withMermaid(
             { text: 'Result<T,E> and Errors', link: '/concepts/result' },
             { text: 'Kernels & withKernel', link: '/concepts/kernels' },
             { text: 'Tolerance & Validity', link: '/concepts/tolerance' },
+            { text: 'CSG as an IR', link: '/concepts/csg-ir' },
           ],
         },
         {
@@ -118,6 +117,7 @@ export default withMermaid(
             { text: 'Finders & Queries', link: '/tasks/finders' },
             { text: 'Measurement', link: '/tasks/measurement' },
             { text: 'Import & Export', link: '/tasks/import-export' },
+            { text: 'Parametric CSG', link: '/tasks/parametric-csg' },
           ],
         },
         {
@@ -127,6 +127,7 @@ export default withMermaid(
             { text: 'Performance', link: '/advanced/performance' },
             { text: 'Web Workers', link: '/advanced/workers' },
             { text: 'Healing & Sewing', link: '/advanced/healing' },
+            { text: 'CSG Caching & Optimization', link: '/advanced/csg-caching' },
           ],
         },
         {
@@ -144,6 +145,7 @@ export default withMermaid(
             { text: 'Coming from Replicad', link: '/migration/replicad' },
             { text: 'Coming from OpenSCAD', link: '/migration/openscad' },
             { text: 'Coming from Three.js', link: '/migration/threejs' },
+            { text: 'From a Hand-Rolled Cache', link: '/migration/manual-csg-cache' },
           ],
         },
         {

--- a/apps/docs/advanced/csg-caching.md
+++ b/apps/docs/advanced/csg-caching.md
@@ -1,0 +1,225 @@
+---
+title: CSG Caching, Optimization, and Serialization
+description: 'What the evaluator cache key contains, how optimize() rewrites trees before evaluation, JSON round-trip, and the editing primitives for rebuilding trees from the bottom up.'
+---
+
+# CSG Caching, Optimization, and Serialization
+
+This page documents the parts of the `csg` namespace that the [walkthrough](/tasks/parametric-csg) doesn't get into: what the cache key actually contains, what `optimize()` rewrites, how serialization works, and how to edit trees programmatically. If you're using CSG for live preview or build-time geometry generation, the things on this page are what determine your performance ceiling.
+
+## What the cache key contains
+
+`ev.evaluate(node, env)` computes a string key per node:
+
+```
+{structuralHash}:{kernelId}:{projectedEnvHash}:{toleranceHash}
+```
+
+Four parts. Each one is a reason two evaluations might _not_ share a cache entry:
+
+- **`structuralHash`** — the Merkle hash of the node and everything beneath it. Different tree shape, different literal values, even different optional flags → different hash. Computed once at build time, stored on the node.
+- **`kernelId`** — the kernel id resolved at evaluator construction (e.g. `'occt'`, `'brepkit'`). Cache entries are not portable across kernels; an OCCT-evaluated `Solid` cannot be returned to a brepkit caller. The id is resolved once at `new Evaluator()` so cache keys stay stable even if the active kernel changes mid-run.
+- **`projectedEnvHash`** — the FNV hash of _only the env keys this node depends on_, in canonical (sorted) order. This is the mechanism behind incremental re-evaluation: a node whose `freeParams` doesn't contain `K` cannot see its key change when `K` does.
+- **`toleranceHash`** — the default tolerance configured on the evaluator, or a sentinel if undefined. Two evaluators with different tolerances cache independently.
+
+Two consequences worth internalizing:
+
+1. **Cache reuse is structural, not nominal.** Two separately-constructed but structurally identical trees share entries automatically. You don't need to memoize calls to `csg.box(10, 10, 10)` — every call returns a different object, but they all hash the same.
+2. **A parent hit short-circuits the whole subtree.** When a node hits, its children are never visited. That's why re-evaluating a tree is roughly free: the root usually hits, and that's the only `onStep` event you see.
+
+## Reading the cache stats
+
+`cacheStats()` returns `{ hits, misses, entries }` — running totals since the evaluator was constructed or `resetStats()` was last called.
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+using ev = new csg.Evaluator();
+const tree = csg.fuse(csg.box(10, 10, 10), csg.sphere(5));
+
+ev.evaluate(tree);
+ev.cacheStats(); // { hits: 0, misses: 3, entries: 3 }
+
+ev.evaluate(tree);
+ev.cacheStats(); // { hits: 1, misses: 3, entries: 3 }
+//  one new hit at the root; children short-circuited
+```
+
+For a finer-grained trace, install an `onStep` callback. It fires per visit with the node, the cache key, and whether it was a hit:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const events: { kind: string; hit: boolean }[] = [];
+using ev = new csg.Evaluator({
+  onStep: (info) => events.push({ kind: info.node.kind, hit: info.cacheHit }),
+});
+
+const tree = csg.cut(csg.box(10, 10, 10), csg.sphere(3));
+ev.evaluate(tree);
+ev.evaluate(tree);
+
+events;
+// [
+//   { kind: 'Box',    hit: false },
+//   { kind: 'Sphere', hit: false },
+//   { kind: 'Cut',    hit: false },
+//   { kind: 'Cut',    hit: true  }    // ← root hit on the second eval;
+// ]                                    //   Box and Sphere not re-visited
+```
+
+`onStep` is the hook for understanding _why_ something didn't hit when you expected it to. Wire it to a UI button that dumps the last evaluation's trace and the cache misses become obvious.
+
+## Tolerance and the cache
+
+Tolerance is part of the cache key, so two evaluators configured with different tolerances cache independently even on identical trees:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+using fine = new csg.Evaluator({ tolerance: 0.01 });
+using coarse = new csg.Evaluator({ tolerance: 0.1 });
+
+const tree = csg.box(1, 1, 1);
+fine.evaluate(tree);
+coarse.evaluate(tree);
+
+fine.cacheStats().entries; // 1
+coarse.cacheStats().entries; // 1
+```
+
+One tree, two cache entries — one per tolerance. Intentional: kernel output can differ at boundary tolerance, and miss-and-rebuild beats returning a shape that doesn't match what the caller asked for.
+
+Per-node `tolerance` overrides on `fuse`/`cut`/`intersect`/`fuseAll`/`cutAll` are mixed into the **structuralHash**, not the cache key's tolerance slot — the evaluator-level tolerance stays a global default, per-call overrides ride along in the tree.
+
+## `optimize()`: tree-level rewrites
+
+`csg.optimize(tree)` rewrites the IR before evaluation. It never touches the kernel; everything it does is constant folding and identity elimination. The current passes:
+
+| Pass                         | What it does                                                                                 |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| **Expression constant fold** | `2 + 3 * 4` → `14`, `cos(0)` → `1`, `[1, 2, 3][0]` → `1`                                     |
+| **Empty identity**           | `fuse(empty, x)` → `x`; `cut(x, empty)` → `x`; `cutAll` filters empties                      |
+| **Translate-by-zero**        | `translate(x, [0, 0, 0])` → `x`                                                              |
+| **Translate fusion**         | `translate(translate(x, [1,0,0]), [2,0,0])` → `translate(x, [3,0,0])` (literal vectors only) |
+| **Compound empty filter**    | `compound([a, empty, b])` → `compound([a, b])`                                               |
+| **N-ary collapse**           | `fuseAll([x])` → `x`; `cutAll(x, [])` → `x`                                                  |
+
+A worked example:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const tree = csg.translate(
+  csg.fuse(csg.emptySolid(), csg.box(csg.binOp('+', csg.numLit(2), csg.numLit(3)), 10, 10)),
+  [0, 0, 0]
+);
+
+const opt = csg.optimize(tree);
+opt.kind; // 'Box' — three rewrites collapsed to a single primitive
+```
+
+The `2 + 3` folded to `5`, the `fuse(empty, …)` short-circuited to its second argument, and the outer `translate(…, [0,0,0])` collapsed to its target — leaving a bare `Box(5, 10, 10)`.
+
+You don't have to call `optimize` — the evaluator works on any well-formed tree. But:
+
+- **It changes cache keys.** An optimized tree has a different `structuralHash` than the original (smaller tree = different hash), so the first post-optimize evaluation will miss even if you'd previously evaluated the un-optimized version.
+- **It's cheap.** Pure tree rewrites, no kernel calls, no allocation pressure. Run it once after the tree is built and you keep its smaller form for the rest of the session.
+- **It only fires on literal inputs.** `translate(x, [param('dx'), 0, 0])` will not collapse even if `dx` happens to be zero at runtime — `optimize` runs before evaluation, so it can't know.
+
+## Serialization — `toJSON` / `fromJSON`
+
+The IR serializes to a JSON envelope versioned by `CSG_VERSION` (currently `1`):
+
+```typescript
+import { csg, isOk, unwrap } from 'brepjs/quick';
+
+const tree = csg.cut(csg.box(csg.param('w'), 10, 10), csg.sphere(3));
+const envelope = csg.toJSON(tree);
+// { csgVersion: 1, root: { kind: 'Cut', a: { kind: 'Box', ... }, ... } }
+
+const restored = csg.fromJSON(envelope);
+isOk(restored); // true
+unwrap(restored).structuralHash === tree.structuralHash; // true
+```
+
+The round-trip preserves structural hashes, so a deserialized tree shares cache entries with the original. Useful for:
+
+- **Build pipelines** — serialize the tree at design time, materialize geometry at runtime against the deployed kernel.
+- **Undo/redo** — `JSON.stringify` snapshots are tiny next to materialized B-Rep data.
+- **Sharing builds** — paste a JSON envelope between users without shipping STEP files.
+
+A note on shape: `toJSON` _expands_ the DAG to a tree. If your IR has shared subtrees (the same `Box` node referenced under two `Translate` parents), the JSON contains the box twice. Sharing is rebuilt on `fromJSON` — the rebuilt nodes hash identically, so the evaluator's cache still dedupes them. The JSON is just bigger than it strictly needs to be.
+
+`fromJSON` is the trust boundary: every field is validated, every expression is reconstructed via builders so `structuralHash` and `freeParams` are correct. Invalid envelopes return `Result.err`, not throw.
+
+## Editing trees — `replaceNode`, `forEachNode`, `nodeCount`
+
+The IR is immutable. Edits rebuild from the bottom up via builders, which keeps hashes and free-params correct.
+
+`csg.replaceNode(root, predicate, replacement)` walks the tree and substitutes any node matching the predicate:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const original = csg.fuse(csg.box(10, 10, 10), csg.sphere(5));
+const swapped = csg.replaceNode(original, (n) => n.kind === 'Sphere', csg.cylinder(3, 8));
+// swapped is a new Fuse(Box, Cylinder); structuralHash differs from original
+```
+
+For traversal and metrics:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const tree = csg.fuse(csg.box(1, 1, 1), csg.cut(csg.sphere(1), csg.cylinder(0.5, 2)));
+
+csg.nodeCount(tree); // 5
+
+const kinds: string[] = [];
+csg.forEachNode(tree, (n) => kinds.push(n.kind));
+// ['Fuse', 'Box', 'Cut', 'Sphere', 'Cylinder']
+```
+
+`replaceNode` is structural — it can't reach into expressions to change a `Param` name, for instance. For parameter changes, just re-evaluate with a new env; that's what the cache is built for.
+
+## What doesn't cache
+
+A few things are deliberately _not_ cached, and it's worth knowing why:
+
+- **The kernel adapter's internal state.** Cached shapes are kernel handles, but cache entries don't persist across kernels. Re-binding the active kernel after evaluation builds a fresh cache if you construct a new `Evaluator`.
+- **Errors.** `Result.err` values aren't cached. A re-evaluation of a node that previously failed will retry — useful when the failure was transient (e.g. boolean tolerance issue resolved by a parent's tolerance override), but it does mean a persistently broken subtree will repeat its work each call.
+- **`Empty` nodes.** They have no kernel realization; trying to evaluate one alone returns `Result.err`. `Empty` exists as the identity element for booleans — `fuse`/`cut` short-circuit on it as a correctness invariant (not just an optimization), so `fuse(empty, x)` evaluates to `x` directly without needing `optimize()`. The optimizer can still strip them eagerly to shrink trees before they reach the cache.
+- **DOM-side mesh data.** The cache holds kernel handles, not tessellated meshes. If you tessellate after evaluation, that work isn't cached. Run your mesh cache on the same key the evaluator uses (`node.structuralHash` is a fine starting point).
+
+## Cache lifecycle
+
+`Evaluator` is a `Disposable`. The cache and all its borrowed kernel handles release when you dispose it — either explicitly via `[Symbol.dispose]()`, automatically via the `using` keyword, or implicitly inside `withEvaluator`.
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+// Pattern 1: long-lived evaluator (live UI, REPL)
+const ev = new csg.Evaluator();
+try {
+  /* many evaluations… */
+} finally {
+  ev[Symbol.dispose]();
+}
+
+// Pattern 2: scoped evaluator (one-off build)
+using ev = new csg.Evaluator(); // disposed at block exit
+
+// Pattern 3: one-shot
+csg.withEvaluator({}, (ev) => {
+  /* synchronous body */
+});
+```
+
+After disposal, every shape returned by `evaluate` is invalid — they were _borrowed_ from the evaluator's `DisposalScope`, not transferred out. Copy out any persistent data (volumes, mesh arrays, exported STEP strings) before the evaluator's lifetime ends.
+
+## Where to go next
+
+- **[The walkthrough](/tasks/parametric-csg)** — if you skipped here from the index, the gridfinity-bin walkthrough is where the surface API gets exercised end-to-end.
+- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)** — for projects that already built a `Map<key, Solid>` cache around the eager API.
+- **[Memory Management](/advanced/memory)** — for the `DisposalScope`/`using` pattern that `Evaluator` itself is built on.

--- a/apps/docs/advanced/csg-caching.md
+++ b/apps/docs/advanced/csg-caching.md
@@ -29,7 +29,7 @@ Two consequences worth internalizing:
 
 ## Reading the cache stats
 
-`cacheStats()` returns `{ hits, misses, entries }` — running totals since the evaluator was constructed or `resetStats()` was last called.
+`cacheStats()` returns `{ hits, misses, entries }`. `hits` and `misses` are running totals since the evaluator was constructed or `resetStats()` was last called. `entries` is a live snapshot of the current cache size — it is **not** reset by `resetStats()` and accumulates across the evaluator's lifetime.
 
 ```typescript
 import { csg } from 'brepjs/quick';

--- a/apps/docs/concepts/csg-ir.md
+++ b/apps/docs/concepts/csg-ir.md
@@ -1,0 +1,166 @@
+---
+title: CSG as an Intermediate Representation
+description: 'Build a content-addressed DAG of primitives, booleans, and transforms — then evaluate it against the kernel with subtree-level caching for incremental parametric edits.'
+---
+
+# CSG as an Intermediate Representation
+
+Most code-CAD libraries hand you eager geometry: `box(10, 10, 10)` immediately calls into the kernel, returns a real B-Rep solid, and that solid sits in WASM memory until you `.delete()` it. Chain a few operations and you've allocated and freed dozens of intermediate shapes whose only purpose was to feed the next call.
+
+brepjs's `csg` namespace offers a different surface for the same operations. Instead of materializing geometry, the builders construct a **content-addressed DAG** — a tree of `IRNode` values, each describing what to build without actually building it. Geometry is produced on demand by an `Evaluator`, which caches by structural hash so re-evaluating the same subtree is free.
+
+## A tree, not a shape
+
+Every builder returns a plain data object:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const node = csg.box(10, 20, 30);
+// {
+//   kind: 'Box',
+//   x: NumLitExpr(10), y: NumLitExpr(20), z: NumLitExpr(30),
+//   structuralHash: 0x9f3a...n,
+//   freeParams: Set(0) {},
+// }
+```
+
+No kernel call, no WASM allocation. Same for every builder — `cylinder`, `sphere`, `fuse`, `cut`, `translate`, even `compound`. The tree is just description.
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const tree = csg.cut(csg.box(100, 100, 100), csg.sphere(40));
+// kind: 'Cut'
+//   a: kind: 'Box' (100×100×100)
+//   b: kind: 'Sphere' (radius 40)
+```
+
+```mermaid
+graph TD
+  Cut["Cut"] --> Box["Box(100,100,100)"]
+  Cut --> Sphere["Sphere(40)"]
+```
+
+The structure of the tree is the structure of the computation. Nothing has been computed yet.
+
+## Content-addressed hashing
+
+Every node carries a `structuralHash` — a 64-bit FNV-1a Merkle hash of its kind plus its children's hashes. Two trees that describe the _same_ geometry hash identically, regardless of how they were built:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const a = csg.fuse(csg.box(10, 10, 10), csg.sphere(5));
+const b = csg.fuse(csg.box(10, 10, 10), csg.sphere(5));
+
+a.structuralHash === b.structuralHash; // true
+```
+
+Change _any_ literal anywhere in the tree and the hash changes:
+
+```typescript
+csg.box(10, 10, 10).structuralHash === csg.box(10, 10, 11).structuralHash;
+// false — last dimension differs
+```
+
+The hash is computed once at build time and stored on the node, so cache lookups during evaluation are O(1) per node rather than O(subtree-size). The hash also normalizes `-0` to `+0` and serializes floats bit-exactly via `DataView.setFloat64`, so identical doubles always hash the same.
+
+## Free parameters propagate upward
+
+Builders accept literal numbers or expressions. Expressions parameterize the tree — `csg.param('w')` is a placeholder bound at evaluation time. Each node tracks the set of parameter names it transitively depends on:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const tree = csg.translate(csg.fuse(csg.box(csg.param('w'), 10, 10), csg.sphere(csg.param('r'))), [
+  csg.param('dx'),
+  0,
+  0,
+]);
+
+[...tree.freeParams].sort(); // ['dx', 'r', 'w']
+```
+
+`freeParams` is computed bottom-up by the builders at build time. The evaluator uses it to project the env before computing the cache key — a node that doesn't reference `dx` will never see `dx` enter its cache key, so unrelated env edits cannot invalidate it. This is the core mechanism behind incremental re-evaluation:
+
+```mermaid
+graph TD
+  Translate["Translate · deps={dx,r,w}"] --> Fuse["Fuse · deps={r,w}"]
+  Fuse --> Box["Box · deps={w}"]
+  Fuse --> Sphere["Sphere · deps={r}"]
+```
+
+When `dx` changes, only `Translate` invalidates. When `r` changes, `Sphere` + `Fuse` + `Translate` invalidate but `Box` survives. The granularity is structural: the cost of a parameter edit is proportional to the size of the subtrees that depend on it, not the size of the whole tree.
+
+## Output kinds and structural validity
+
+The IR doesn't have separate node types for solids vs faces vs edges — there's one `IRNode` union with a `kind` discriminator. Output kind is derived structurally via `outputKindOf`:
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+csg.outputKindOf(csg.box(10, 10, 10)); // 'Solid'
+csg.outputKindOf(csg.translate(csg.box(10, 10, 10), [1, 0, 0])); // 'Solid'
+csg.outputKindOf(csg.cut(csg.box(10, 10, 10), csg.sphere(3))); // 'Solid'
+csg.outputKindOf(csg.circle(5)); // 'Edge'
+csg.outputKindOf(
+  csg.polygon([
+    [0, 0, 0],
+    [1, 0, 0],
+    [0, 1, 0],
+  ])
+); // 'Face'
+```
+
+Booleans inherit the kind of their `a` argument; transforms inherit from `target`; primitives are fixed. There's no cross-kind boolean — `fuse(box, circle)` is rejected at the kernel boundary, not by the TypeScript types at v1.
+
+## Two equivalent ways to compute the same geometry
+
+Both snippets produce the same 1000 - π·125 ≈ 477 mm³ solid:
+
+::: code-group
+
+```typescript [Eager — topology API]
+import { box, sphere, cut, measureVolume, unwrap } from 'brepjs/quick';
+
+const cube = box(10, 10, 10);
+const ball = sphere(2.5);
+const part = unwrap(cut(cube, ball));
+const v = unwrap(measureVolume(part));
+// 3 kernel allocations: cube, ball, part — all live until disposed
+```
+
+```typescript [CSG IR]
+import { csg, measureVolume, unwrap } from 'brepjs/quick';
+
+const tree = csg.cut(csg.box(10, 10, 10), csg.sphere(2.5));
+using ev = new csg.Evaluator();
+const v = unwrap(measureVolume(unwrap(ev.evaluate(tree))));
+// 3 kernel allocations the first time. 0 on every subsequent ev.evaluate(tree).
+```
+
+:::
+
+The eager API is the right answer when you build a part once. The IR is the right answer when:
+
+- the same tree shape gets re-evaluated with different parameter bindings (slider UIs, optimizer sweeps),
+- multiple branches of a build share common subtrees that would otherwise be recomputed,
+- you want to serialize the build recipe to JSON without serializing materialized B-Rep data,
+- you want to inspect, simplify, or edit the build graph before evaluation.
+
+If none of those apply, the topology API is leaner. The IR is a tool, not a replacement.
+
+## Where this fits in brepjs
+
+The IR is purely a build-time abstraction layered on top of the kernel adapter — `csg.Evaluator` calls the same `getKernel().fuseSolids(...)` that the topology API does. Everything that works on a `Solid` works on the result of `ev.evaluate(tree)`: finders, fillets, measurement, export. The IR is the parametric _front_ of the pipeline; the topology API picks up where it leaves off.
+
+## The rest of the surface
+
+The examples above touch `box`, `sphere`, `cylinder`, `cut`, `fuse`, and `translate`. The full builder set adds `cone`, `torus`, `polygon`, `circle`, `line`, `vertex`, `mirror`, `scale`, `rotate`, `compound`, plus the N-ary booleans `fuseAll` and `cutAll`. Expression helpers include `add`/`mul` shortcuts, `unaryOp` (sin, cos, sqrt, abs, neg), `component` for indexing vectors, and `buildVec` for constructing them from scalars. All exported from `'brepjs'` under the `csg.*` namespace; see the [API reference](https://andymai.github.io/brepjs/) for type signatures.
+
+## Next steps
+
+- **[Parametric CSG walkthrough](/tasks/parametric-csg)** — build a gridfinity-style bin with named parameters, change a slider, watch the cache absorb the unchanged subtrees.
+- **[CSG caching internals](/advanced/csg-caching)** — `cacheStats`, `optimize`, serialization, what the cache key actually contains, and what _doesn't_ cache.
+- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)** — if you've built your own `Map<key, Solid>` cache around eager geometry, here's the IR equivalent and what you'd inherit by switching.

--- a/apps/docs/migration/manual-csg-cache.md
+++ b/apps/docs/migration/manual-csg-cache.md
@@ -1,0 +1,170 @@
+---
+title: Migrating from a Hand-Rolled Cache
+description: 'If you built your own Map<key, Solid> around the eager fuse/cut API, here is the side-by-side translation to the CSG IR — what you keep, what you replace, and what you inherit by switching.'
+---
+
+# Migrating from a Hand-Rolled Cache
+
+A common pattern in code-CAD apps: wrap the eager `box`/`fuse`/`cut` API in a `Map<string, Solid>` keyed by the input parameters, so re-renders during a slider drag don't recompute identical geometry. It works, but it has rough edges — every cache key is hand-derived, invalidation is all-or-nothing per top-level entry, and you own a `.delete()` lifecycle that's easy to leak.
+
+The `csg` namespace gives you the same caching semantics without the bookkeeping.
+
+If you haven't read **[CSG as an IR](/concepts/csg-ir)** yet, do that first — this page focuses on the diff, not the model.
+
+## The scenario
+
+A live-preview UI lets the user tweak the radius of a hole drilled through a fixed-size cube. The naive eager version recomputes everything on every slider event; the manual-cache version memoizes by stringified parameters; the IR version replaces the cache plumbing entirely.
+
+## Version A — eager, no cache
+
+```typescript
+import { box, sphere, cut, unwrap, measureVolume } from 'brepjs/quick';
+
+function makePart(r: number) {
+  const cube = box(20, 20, 20);
+  const ball = sphere(r);
+  return unwrap(cut(cube, ball));
+}
+
+// onSliderChange:
+const part = makePart(slider.value);
+const v = unwrap(measureVolume(part));
+```
+
+Every slider event allocates one new cube, one new sphere, one new cut — three live B-Rep solids in WASM memory. The cube has nothing to do with the slider but gets rebuilt anyway. Repeat 30× per second during a drag and you're allocating a thousand intermediate handles a minute.
+
+## Version B — manual `Map` cache
+
+Most projects converge on this pattern once Version A's allocation rate shows up in the profiler. Keys are stringified parameters, values are materialized solids, and you carry an explicit dispose path because the cache owns the handles.
+
+```typescript
+import { box, sphere, cut, unwrap, measureVolume } from 'brepjs/quick';
+import type { Solid } from 'brepjs';
+
+const cubeCache = new Map<string, Solid>();
+const sphereCache = new Map<string, Solid>();
+const partCache = new Map<string, Solid>();
+
+function cachedCube(L: number, W: number, H: number): Solid {
+  const key = `${L},${W},${H}`;
+  let s = cubeCache.get(key);
+  if (!s) {
+    s = box(L, W, H);
+    cubeCache.set(key, s);
+  }
+  return s;
+}
+
+function cachedSphere(r: number): Solid {
+  const key = `${r}`;
+  let s = sphereCache.get(key);
+  if (!s) {
+    s = sphere(r);
+    sphereCache.set(key, s);
+  }
+  return s;
+}
+
+function cachedPart(r: number): Solid {
+  const key = `cube20_sphere${r}`;
+  let s = partCache.get(key);
+  if (!s) {
+    s = unwrap(cut(cachedCube(20, 20, 20), cachedSphere(r)));
+    partCache.set(key, s);
+  }
+  return s;
+}
+
+// onSliderChange:
+const part = cachedPart(slider.value);
+const v = unwrap(measureVolume(part));
+
+// On unmount: dispose everything (don't forget any cache!)
+for (const s of [...cubeCache.values(), ...sphereCache.values(), ...partCache.values()]) {
+  s[Symbol.dispose]();
+}
+```
+
+This works, but look at what it costs:
+
+1. **One cache per primitive plus one per composite.** Three caches here; add a fillet, a translate, and a fuse and you're up to six.
+2. **Manual key derivation.** `${L},${W},${H}` works until floats need precision normalization, until you forget to include the tolerance, until you add a parameter and miss a key site.
+3. **Manual invalidation.** Change the cube size and you need to know which composite cache entries depended on it. The cache structure doesn't capture the dependency graph; you do.
+4. **Lifetime is your problem.** Every cache entry is a live kernel handle. Forget to dispose one cache on unmount → leak. Dispose twice → kernel error.
+5. **Edges of the cache key.** Did you remember the kernel id? The boolean tolerance? Two evaluators with different tolerance settings should not share entries — but the manual cache happily returns the wrong shape if you don't think to include it in the key.
+
+Each one is solvable individually, but each one is also a place where the next engineer to touch the file makes a subtle mistake. The CSG IR makes the whole class go away.
+
+## Version C — CSG IR
+
+```typescript
+import { csg, unwrap, measureVolume } from 'brepjs/quick';
+
+const tree = csg.cut(csg.box(20, 20, 20), csg.sphere(csg.param('r')));
+
+using ev = new csg.Evaluator();
+
+// onSliderChange:
+const shape = unwrap(ev.evaluate(tree, { r: slider.value }));
+const v = unwrap(measureVolume(shape));
+```
+
+That's the whole file. Compare what disappeared:
+
+- **Three caches collapsed into one.** The evaluator caches every node by structural hash, so the cube, the sphere, and the cut each get their own entry automatically.
+- **No string keys.** The cache key is `(structuralHash, kernelId, projectedEnvHash, toleranceHash)` — derived from the tree, not from your formatting choices. Floats are hashed bit-exactly via `DataView.setFloat64` with `-0` normalized; the kernel id is captured at evaluator construction; tolerance is a first-class field.
+- **Invalidation is automatic and granular.** When `r` changes, only the sphere and the cut invalidate. The cube hits the cache because `r` isn't in its `freeParams`. You didn't have to think about which composites depend on which primitives.
+- **Lifetime is structural.** `using ev = new csg.Evaluator()` releases every cached handle when the block exits. No per-cache iteration, no risk of double-dispose, no risk of partial cleanup.
+
+The behavior on a slider drag — which is what you actually care about:
+
+```mermaid
+graph TD
+  subgraph "r changes 5 → 6"
+    direction LR
+    Cut1["Cut · MISS"] --> Box1["Box(20,20,20) · HIT ✓"]
+    Cut1 --> Sphere1["Sphere(r) · MISS"]
+  end
+```
+
+The cube subtree hits; only the sphere re-materializes and the cut recomputes. Same end-to-end as Version B, without the bookkeeping surface area.
+
+## What you inherit by switching
+
+A few things the IR gives you on top of the cache that the manual version doesn't have:
+
+- **`csg.optimize(tree)`** — pure tree rewrites: constant folding, identity elimination, translate fusion. Run once after building; the rest of the session works on a smaller tree. See [CSG caching internals](/advanced/csg-caching#optimize-tree-level-rewrites).
+- **`csg.toJSON` / `csg.fromJSON`** — serialize the build recipe to JSON. The deserialized tree shares cache entries with the original because structural hashes are reconstructed correctly. Useful for build pipelines, undo/redo snapshots, or sharing models without shipping STEP files.
+- **`csg.replaceNode`** — swap a subtree by predicate. The rebuild walks bottom-up via builders so hashes stay correct.
+- **`onStep` instrumentation** — install a callback to trace every cache hit/miss per node. The thing you want when the profiler says "still too slow" and you need to know which subtree's cache key keeps changing.
+
+The manual version can grow all of these — but each one is its own subsystem in your codebase that the IR gives you in 50 lines.
+
+## When the manual cache is still the right answer
+
+Switching costs aren't zero. Stay on the manual cache when:
+
+- **Your tree never changes shape, only inputs.** If the user can only resize a single primitive (no add/remove features, no swap operations, no per-feature toggles), Version B's three-line `cachedFoo` wrappers are easy to skim and your team already understands them.
+- **You need fine-grained control over what's kept hot.** The CSG cache is bounded by the evaluator's lifetime, not a configurable size; large trees with many distinct parameter values can grow it large. (LRU caps are on the [roadmap](https://github.com/andymai/brepjs/issues) — file an issue if this would unblock you.)
+- **You're integrating with code that already speaks `Solid`.** The manual cache returns `Solid` values directly; the IR returns them through `ev.evaluate(node, env)`. Adapting the call sites can be more work than the win for a small project.
+
+For the gridfinity-style live-preview case — slider drag rebuilds a multi-feature parametric tree — the IR wins decisively. For a one-shot CAD batch where you build, export, and exit, neither cache matters.
+
+## Migration checklist
+
+If you've decided to migrate:
+
+1. **Translate primitives.** `box(...)` → `csg.box(...)`, `sphere(...)` → `csg.sphere(...)`, etc. Same arguments. The return type changes from `Solid` to `SolidNode`.
+2. **Translate composites.** `unwrap(cut(a, b))` → `csg.cut(aNode, bNode)`. Same for `fuse`, `intersect`. No `unwrap` — the IR builders never fail.
+3. **Translate transforms.** `translate(s, [x,y,z])` → `csg.translate(node, [x,y,z])`. Same for `rotate`, `scale`, `mirror`. Note that `csg.rotate` takes its axis/anchor via an options object, not positional args.
+4. **Wrap with an evaluator.** `using ev = new csg.Evaluator()` once at the top of your render loop, then `unwrap(ev.evaluate(tree))` (or with `env` for parametric trees) at each render.
+5. **Drop the cache plumbing.** Remove your `Map<string, Solid>` declarations, your stringified-key helpers, and your `dispose-all-on-unmount` loops. The `using` keyword on the evaluator handles the lifetime.
+6. **Drop the per-call unwraps that no longer apply.** Builders return nodes directly; only `evaluate` returns `Result`.
+
+End state: a single tree built once, a single evaluator reused across renders. A few-hundred-line manual cache file usually shrinks to a few dozen.
+
+## See also
+
+- **[CSG as an IR](/concepts/csg-ir)** — the mental model this migration assumes you have.
+- **[The walkthrough](/tasks/parametric-csg)** — a multi-parameter gridfinity-style bin if you want a fuller example before committing to a migration.
+- **[CSG caching internals](/advanced/csg-caching)** — for the full surface of the IR you're inheriting.

--- a/apps/docs/tasks/parametric-csg.md
+++ b/apps/docs/tasks/parametric-csg.md
@@ -1,0 +1,170 @@
+---
+title: Parametric CSG — a Gridfinity-Style Bin
+description: 'Build a parametric model with named parameters, evaluate it against the kernel, edit a parameter, and watch the evaluator skip the subtrees that did not change.'
+---
+
+# Parametric CSG — a Gridfinity-Style Bin
+
+This walkthrough builds a simplified gridfinity-style bin — an outer block with a pocket cut from the top — using `csg` builders and named parameters. By the end you'll have a tree you can re-evaluate with different parameter values, and you'll see directly how the evaluator's cache spares the unchanged subtrees.
+
+If you haven't read **[CSG as an IR](/concepts/csg-ir)** yet, do that first — this page assumes you already know that builders return data, not geometry.
+
+## The shape we're building
+
+Think of a single gridfinity-compatible bin as two pieces:
+
+- an **outer block** of size `L × W × H`,
+- a **pocket** centered inside it, inset by `wall` on the four sides and `floor` on the bottom.
+
+The pocket gets cut from the outer block. We'll skip the base lips, magnet holes, and label tabs — they distract from the point of this page, which is the parameterization.
+
+Real-world gridfinity dimensions: `L = W = 42 mm`, `H = 30 mm`, `wall = 1.2 mm`, `floor = 1.5 mm`.
+
+## Step 1 — Pick what's parametric
+
+A live-preview UI lets the user drag sliders for length, width, height, and wall thickness; floor thickness is fixed. So `L`, `W`, `H`, and `wall` get `csg.param()` calls; `floor` is a literal.
+
+A subtle but important detail: **`wall` is a separate parameter, not derived from `L`**. If the pocket dimensions were `L - 2*wall` for a hard-coded wall, changing `L` would invalidate every subtree that touched the pocket. By making `wall` its own parameter, the outer box only depends on `{L, W, H}` and survives wall-thickness edits untouched. This is the kind of decision the IR's cache structure rewards — worth thinking about up front.
+
+## Step 2 — Write the builder
+
+```typescript
+import { csg } from 'brepjs/quick';
+
+const FLOOR = 1.5;
+
+function bin(L: csg.Expr, W: csg.Expr, H: csg.Expr, wall: csg.Expr): csg.SolidNode {
+  const outer = csg.box(L, W, H);
+
+  const innerL = csg.binOp('-', L, csg.binOp('*', csg.numLit(2), wall));
+  const innerW = csg.binOp('-', W, csg.binOp('*', csg.numLit(2), wall));
+  const innerH = csg.binOp('-', H, csg.numLit(FLOOR));
+
+  const pocket = csg.translate(csg.box(innerL, innerW, innerH), [wall, wall, FLOOR]);
+
+  return csg.cut(outer, pocket);
+}
+```
+
+Two things to notice:
+
+1. **Expression arithmetic is explicit.** `csg.binOp('-', L, ...)` is verbose compared to `L - 2*wall`, but that's the price of keeping the math in the IR — the subtraction is part of the tree and gets folded by `optimize()` when its operands turn into literals. There's no operator overloading in TypeScript, so this is as ergonomic as it gets. For the two common cases, `csg.add(a, b)` and `csg.mul(a, b)` are shortcuts for `binOp('+', ...)` and `binOp('*', ...)`; subtraction and division still need the full form.
+2. **Type narrowing falls out for free.** `csg.box` always returns a `SolidNode`, `csg.cut` of two solids returns a solid, and the function signature says so. You don't lose the "I know this is a solid" knowledge crossing into the IR.
+
+The resulting tree:
+
+```mermaid
+graph TD
+  Cut --> OuterBox["Box(L, W, H)"]
+  Cut --> Translate["Translate([wall, wall, FLOOR])"]
+  Translate --> InnerBox["Box(L-2·wall, W-2·wall, H-FLOOR)"]
+```
+
+## Step 3 — Build the tree and evaluate it
+
+Create the parametric tree once, then evaluate it with an env binding:
+
+```typescript
+import { csg, measureVolume, unwrap } from 'brepjs/quick';
+
+const tree = bin(csg.param('L'), csg.param('W'), csg.param('H'), csg.param('wall'));
+
+[...tree.freeParams].sort();
+// ['H', 'L', 'W', 'wall']
+
+using ev = new csg.Evaluator();
+const shape = unwrap(ev.evaluate(tree, { L: 42, W: 42, H: 30, wall: 1.2 }));
+const volume = unwrap(measureVolume(shape));
+// outer (42·42·30) − pocket ((42−2.4)·(42−2.4)·(30−1.5)) ≈ 8227 mm³
+```
+
+A few subtleties worth flagging:
+
+- **`using ev = new csg.Evaluator()`** — `Evaluator` is a `Disposable`. The `using` keyword (TypeScript 5.2+) ensures the evaluator's cached shapes are released when the block exits. If you're targeting an older runtime, call `ev[Symbol.dispose]()` manually in a `finally`.
+- **`ev.evaluate(tree, env)` returns `Result<AnyShape>`** — `unwrap` throws on error. In production code, prefer `isOk(r)` and explicit handling. See [Result\<T,E\> and Errors](/concepts/result).
+- **The returned shape is borrowed.** It lives until the evaluator is disposed. Do NOT call `[Symbol.dispose]()` on it directly; that would corrupt the cache for the next call returning the same handle.
+
+## Step 4 — Edit a parameter
+
+The reason to put work into the IR upfront is moments like this:
+
+```typescript
+ev.resetStats();
+const taller = unwrap(ev.evaluate(tree, { L: 42, W: 42, H: 42, wall: 1.2 }));
+ev.cacheStats();
+// { hits: 0, misses: 4, entries: 8 }
+```
+
+Every subtree references `H` (outer box directly, inner box as `H - FLOOR`, translate and cut transitively), so every cache key changes. Four misses. The cache holds eight entries — four for `H = 30`, four for `H = 42`.
+
+Now change `wall` instead:
+
+```typescript
+ev.resetStats();
+unwrap(ev.evaluate(tree, { L: 42, W: 42, H: 42, wall: 2.0 }));
+ev.cacheStats();
+// { hits: 1, misses: 3, entries: 11 }
+```
+
+One hit. The outer `Box(L, W, H)` only depends on `{L, W, H}` — `wall` isn't in its `freeParams`, so its cache key is unchanged. The pocket box, the translate, and the cut all depend on `wall` and miss. Three new misses, eleven entries total.
+
+In a live-preview UI, this is the difference between "drag the wall slider → entire bin re-renders" and "drag the wall slider → only the pocket subtree re-renders." On non-trivial models with dozens of features, that ratio matters a lot.
+
+## Step 5 — Unrelated env keys are free
+
+The evaluator projects the env to only the keys a node actually depends on, so you can stuff debug tags, UI state, or anything else into the env without invalidating anything:
+
+```typescript
+ev.evaluate(tree, { L: 42, W: 42, H: 30, wall: 1.2, sliderTouched: 'L' });
+ev.resetStats();
+ev.evaluate(tree, { L: 42, W: 42, H: 30, wall: 1.2, sliderTouched: 'wall' });
+ev.cacheStats();
+// { hits: 4, misses: 0, entries: 11 }
+```
+
+No node has `sliderTouched` in its `freeParams`, so no cache key changes — everything hits. Wire the env directly to your application state; no filtering required.
+
+## When you don't need the cache across calls
+
+If you only want to evaluate a tree once and let everything get disposed when you're done, `withEvaluator` handles the lifecycle:
+
+```typescript
+import { csg, measureVolume, unwrap } from 'brepjs/quick';
+
+const volume = csg.withEvaluator({}, (ev) => {
+  const shape = unwrap(ev.evaluate(csg.box(10, 10, 10)));
+  return unwrap(measureVolume(shape));
+});
+// Evaluator disposed at function exit; volume is a primitive that escapes safely.
+```
+
+`withEvaluator` is **sync-only**. If your callback returns a `Promise`, the evaluator disposes before the promise resolves and any borrowed shapes point at freed WASM memory. The runtime throws if you try.
+
+## Errors you'll hit and how to read them
+
+A few things will reliably trip the evaluator:
+
+```typescript
+import { csg, isErr } from 'brepjs/quick';
+
+// 1. Forgetting to bind a param
+using ev = new csg.Evaluator();
+const r1 = ev.evaluate(csg.box(csg.param('missing'), 10, 10), {});
+isErr(r1); // true — "unbound param: missing"
+
+// 2. Evaluating an Empty alone (it has no kernel realization)
+const r2 = ev.evaluate(csg.emptySolid());
+isErr(r2); // true
+
+// 3. Cut(empty, x) — empty has nothing for the kernel to subtract from
+const r3 = ev.evaluate(csg.cut(csg.emptySolid(), csg.box(1, 1, 1)));
+isErr(r3); // true
+```
+
+`fuse(empty, x)` _does_ work — it short-circuits to `x` directly without calling the kernel's union. `Empty` nodes exist as the identity element of `optimize()`'s simplifications; they're meant to disappear before evaluation.
+
+## Where to go next
+
+- **[CSG caching internals](/advanced/csg-caching)** — `cacheStats`, what's in the cache key, when to call `optimize()`, JSON round-trip, and tree-editing primitives like `replaceNode`.
+- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)** — if you've already built `Map<key, Solid>` plumbing around the eager API, here's the side-by-side translation.
+- **[The eager topology API](/tasks/booleans)** — when you build a single part and don't need re-evaluation, plain `fuse`/`cut`/`intersect` is leaner.

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -42,7 +42,7 @@ export interface EvaluatorOptions {
   readonly kernel?: string | undefined;
   /** Default boolean tolerance applied when a node doesn't override it. */
   readonly tolerance?: number | undefined;
-  /** Optional callback fired after each node is materialized (cache hits not reported). */
+  /** Optional callback fired after every node visit, including cache hits (`info.cacheHit` discriminates). */
   readonly onStep?: ((info: StepInfo) => void) | undefined;
 }
 


### PR DESCRIPTION
## Summary

Four new CSG documentation pages covering the namespace end-to-end:

- **`apps/docs/concepts/csg-ir.md`** — the mental model: content-addressed DAG, `structuralHash`, `freeParams`, output kinds, and an eager-vs-IR side-by-side.
- **`apps/docs/tasks/parametric-csg.md`** — a gridfinity-style bin walkthrough with `L/W/H/wall` params, demonstrating `Evaluator`, `withEvaluator`, cache hits on wall edits, unrelated-env-key safety, and the error paths.
- **`apps/docs/advanced/csg-caching.md`** — cache key anatomy (`structuralHash:kernelId:projectedEnvHash:toleranceHash`), `cacheStats` / `onStep`, all six `optimize()` passes with a worked example, `toJSON`/`fromJSON` round-trip, `replaceNode`/`forEachNode`/`nodeCount`, and what *doesn't* cache.
- **`apps/docs/migration/manual-csg-cache.md`** — three-version side-by-side (eager → manual `Map` cache → IR), plus an honest "when to stay on the manual cache" section.

Sidebar updated in `apps/docs/.vitepress/config.ts` with entries under Core Concepts, Common Tasks, Advanced, and Migration. Mermaid DAG diagrams in two of the pages (the plugin is already wired up).

Also fixes a stale JSDoc on `EvaluatorOptions.onStep` in `src/csg/evaluate.ts` — the comment claimed cache hits weren't reported but the implementation does fire `onStep` with `cacheHit: true`.

## Verification

Every code snippet was exercised against the real API via a temporary `tests/_docCsgVerify.test.ts` (since deleted) that ran 63 assertions across all three kernels (OCCT, brepkit, occt-wasm). Three real divergences were caught during the verification pass and fixed before publish:

- `onStep` short-circuits on parent cache hits — my initial trace was wrong
- brepkit's boolean output drifts ~2% from OCCT — loosened the volume assertion
- An "incremental re-eval" example had every node depending on the changed param, so I redesigned the `wall` parameter to be independent of `L/W/H` so the demo actually shows cache hits

Then three review agents (`context-auditor`, `gap-finder`, `reviewer`) and the code simplifier ran in passes; the resulting fixes addressed a broken anchor link, the `fuse(empty, x)` short-circuit story (which lives in both the evaluator and the optimizer as a correctness invariant), and a handful of prose tightenings.

## Test plan

- [x] `npm run test` — full vitest suite (2517 tests passed on the pre-commit hook)
- [x] `cd apps/docs && npm run build` — VitePress build clean, no broken internal links
- [x] `npx prettier --check` — formatting clean
- [x] Verified the `#optimize-tree-level-rewrites` anchor matches the generated slug
- [x] Verified `csg.add` / `csg.mul` / `csg.binOp` / `csg.numLit` are all reachable from `'brepjs/quick'` under the `csg.*` namespace