### PR TITLE
chore: harden supply chain against npm + actions attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       actions-minor-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Mirrors the npm min-release-age cooldown — see SECURITY.md.
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -25,7 +24,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Action tag-retag defense — see SECURITY.md.
     cooldown:
       default-days: 7
       semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Mirrors the npm min-release-age cooldown — see SECURITY.md.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     ignore:
       # opentype.js 1.3.5 and 2.0.0 throw on GSUB lookup type 6 substFormat 2 used by
       # DejaVu Sans / Noto Sans for ccmp glyph composition — breaks textBlueprints /
@@ -21,6 +25,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Action tag-retag defense — see SECURITY.md.
+    cooldown:
+      default-days: 7
     groups:
       actions-minor-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
     # Action tag-retag defense — see SECURITY.md.
     cooldown:
       default-days: 7
+      semver-major-days: 14
     groups:
       actions-minor-patch:
         update-types:

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,43 @@
+name: OSV Scan
+
+# Complements the npm min-release-age cooldown: cooldown blocks
+# fresh-but-untrusted, OSV blocks old-but-known-bad.
+# PRs are report-only (transitive deps can't always be updated atomically with
+# a feature PR); main + weekly schedule fail closed.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-pr:
+    name: OSV Scan (report-only)
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=package-lock.json
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+  scan-main:
+    name: OSV Scan (blocking)
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=package-lock.json
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -15,7 +15,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't cancel in-progress main/schedule scans — a rapid second push would
+  # otherwise leave the older commit's lockfile unscanned. Matches the pattern
+  # used in ci.yml.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   scan-pr:

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,9 +1,8 @@
 name: OSV Scan
 
-# Complements the npm min-release-age cooldown: cooldown blocks
-# fresh-but-untrusted, OSV blocks old-but-known-bad.
-# PRs are report-only (transitive deps can't always be updated atomically with
-# a feature PR); main + weekly schedule fail closed.
+# Complements the Dependabot cooldown: cooldown blocks fresh-but-untrusted
+# in PR proposals, OSV catches old-but-known-bad in the lockfile.
+# PRs are report-only; main + weekly schedule fail closed.
 
 on:
   pull_request:
@@ -16,8 +15,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Don't cancel in-progress main/schedule scans — a rapid second push would
-  # otherwise leave the older commit's lockfile unscanned. Matches the pattern
-  # used in ci.yml.
+  # otherwise leave the older commit's lockfile unscanned.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,6 @@ access=public
 provenance=true
 save-exact=true
 engine-strict=true
+
+# Supply-chain cooldown — see SECURITY.md. npm reads min-release-age in days.
+min-release-age=7

--- a/.npmrc
+++ b/.npmrc
@@ -2,6 +2,3 @@ access=public
 provenance=true
 save-exact=true
 engine-strict=true
-
-# Supply-chain cooldown — see SECURITY.md. npm reads min-release-age in days.
-min-release-age=7

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,10 +47,13 @@ attacks (Shai-Hulud worm, chalk/debug compromise, tj-actions tag retag,
 prt-scan AI campaign), the build is configured to fail closed on the
 patterns those attacks exploited:
 
-| Defense                                   | Where                            | What it blocks                                                                                                             |
-| ----------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `min-release-age=7` (7d cooldown)         | `.npmrc`                         | Fresh malicious uploads — most are detected & taken down within hours. Would have blocked axios, chalk/debug, durabletask. |
-| All GitHub Actions pinned to commit SHA   | `.github/workflows/*.yml`        | Tag-retag attacks (tj-actions class). Tags are mutable; commit SHAs are not.                                               |
-| OSV scan (PRs report-only, main blocking) | `.github/workflows/osv-scan.yml` | Known-CVE versions in the lockfile.                                                                                        |
-| Dependabot cooldown (7d / 14d major)      | `.github/dependabot.yml`         | Dependabot suggesting fresh-from-publish versions that would fail install anyway.                                          |
-| Provenance + trusted-publisher OIDC       | `.npmrc` + npm settings          | NPM_TOKEN exposure. Publishes are signed and attested from CI.                                                             |
+| Defense                                   | Where                            | What it blocks                                                                                                                      |
+| ----------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| All GitHub Actions pinned to commit SHA   | `.github/workflows/*.yml`        | Tag-retag attacks (tj-actions class). Tags are mutable; commit SHAs are not.                                                        |
+| OSV scan (PRs report-only, main blocking) | `.github/workflows/osv-scan.yml` | Known-CVE versions in the lockfile.                                                                                                 |
+| Dependabot cooldown (7d / 14d major)      | `.github/dependabot.yml`         | Fresh malicious uploads. Would have blocked axios, chalk/debug, durabletask. Stops Dependabot from suggesting compromised versions. |
+| Provenance + trusted-publisher OIDC       | `.npmrc` + npm settings          | NPM_TOKEN exposure. Publishes are signed and attested from CI.                                                                      |
+
+Direct install-time cooldown via `.npmrc` `min-release-age` is deliberately
+not configured here: npm bundled with Node 24 is 11.6.1, which silently
+ignores the field (added in npm 11.10). Add it once Node ships a newer npm.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,3 +39,18 @@ We follow responsible disclosure. Once a fix is released, we will:
 1. Credit the reporter (unless they prefer anonymity)
 2. Publish a security advisory
 3. Update the changelog with security notes
+
+## Supply Chain
+
+In response to the 2025–2026 wave of npm and GitHub Actions supply-chain
+attacks (Shai-Hulud worm, chalk/debug compromise, tj-actions tag retag,
+prt-scan AI campaign), the build is configured to fail closed on the
+patterns those attacks exploited:
+
+| Defense                                   | Where                            | What it blocks                                                                                                             |
+| ----------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `min-release-age=7` (7d cooldown)         | `.npmrc`                         | Fresh malicious uploads — most are detected & taken down within hours. Would have blocked axios, chalk/debug, durabletask. |
+| All GitHub Actions pinned to commit SHA   | `.github/workflows/*.yml`        | Tag-retag attacks (tj-actions class). Tags are mutable; commit SHAs are not.                                               |
+| OSV scan (PRs report-only, main blocking) | `.github/workflows/osv-scan.yml` | Known-CVE versions in the lockfile.                                                                                        |
+| Dependabot cooldown (7d / 14d major)      | `.github/dependabot.yml`         | Dependabot suggesting fresh-from-publish versions that would fail install anyway.                                          |
+| Provenance + trusted-publisher OIDC       | `.npmrc` + npm settings          | NPM_TOKEN exposure. Publishes are signed and attested from CI.                                                             |


### PR DESCRIPTION
## Summary

Defense-in-depth against the 2025-2026 wave of supply-chain attacks (Shai-Hulud worm, chalk/debug, tj-actions, durabletask, prt-scan). Each defense maps to a specific attack class.

This PR is the same hardening pattern landed in gridfinity-layout-tool#1868, adapted for an npm-based publisher.

| Defense | What it blocks |
|---|---|
| Dependabot cooldown (7d / 14d major) in `.github/dependabot.yml` | Fresh malicious version proposals. Would have blocked axios, chalk/debug, durabletask. |
| OSV scan workflow (PRs report-only, main blocking) in `.github/workflows/osv-scan.yml` | Known-CVE versions in `package-lock.json`. |
| All Actions already SHA-pinned | tj-actions tag-retag class. No workflow changes needed — brepjs was already pinned. |
| Provenance + OIDC trusted publishing (pre-existing) | NPM_TOKEN exposure. |

## Why no `.npmrc` `min-release-age=7`

npm bundled with Node 24 is 11.6.1, which silently ignores `min-release-age` (added in npm 11.10). Setting it would be a no-op and create false confidence. SECURITY.md notes this so it can be added once Node ships a newer npm. The Dependabot cooldown covers the same attack class in the meantime.

## Changes

- `.npmrc`: unchanged (kept publish settings).
- `.github/dependabot.yml`: added `cooldown` blocks for both npm and github-actions ecosystems.
- `.github/workflows/osv-scan.yml`: new — runs osv-scanner-action against `package-lock.json`.
- `SECURITY.md`: new "Supply Chain" section documenting the defense matrix.

## Test plan

- [ ] CI green
- [ ] Greptile review
- [ ] OSV scan workflow runs (first invocation)