### PR TITLE
refactor(patterns): drop 9 baseline entries (modifierOps + mateFns + trustAsWrappedT)

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated": "2026-05-25T15:10:03.071Z",
+  "generated": "2026-05-25T15:40:37.401Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -63,31 +63,6 @@
       "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#2"
     },
     {
-      "file": "src/kernel/brepkit/modifierOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-function-lines|shell|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/modifierOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-function-lines|<anonymous>|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/modifierOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|<anonymous>/if@5|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/modifierOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|<anonymous>/for-of@5|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/modifierOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/modifierOps.ts|max-nesting-depth|<anonymous>/if@5|#1"
-    },
-    {
       "file": "src/kernel/brepkit/sweepOps.ts",
       "rule": "max-function-lines",
       "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-function-lines|sweepPipeShell|#0"
@@ -141,26 +116,6 @@
       "file": "src/kernel/occt/hullOps.ts",
       "rule": "max-function-lines",
       "fingerprint": "src/kernel/occt/hullOps.ts|max-function-lines|quickHull|#0"
-    },
-    {
-      "file": "src/operations/mateFns.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@5|#0"
-    },
-    {
-      "file": "src/operations/mateFns.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@5|#1"
-    },
-    {
-      "file": "src/operations/mateFns.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@6|#0"
-    },
-    {
-      "file": "src/operations/mateFns.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/operations/mateFns.ts|max-nesting-depth|solveAssembly/if@6|#1"
     },
     {
       "file": "src/operations/straightSkeleton.ts",

--- a/src/kernel/brepkit/modifierOps.ts
+++ b/src/kernel/brepkit/modifierOps.ts
@@ -124,6 +124,103 @@ export function chamferDistAngle(
   return solidHandle(bk.chamfer(solidId, edgeIds, (distance + d2) / 2));
 }
 
+function faceCentroid(
+  bk: BrepkitKernel,
+  faceId: number
+): { x: number; y: number; z: number } | null {
+  const verts = toArray(bk.getFaceVertices(faceId));
+  if (verts.length < 1) return null;
+  let x = 0,
+    y = 0,
+    z = 0;
+  for (const vid of verts) {
+    const pos = bk.getVertexPosition(vid);
+    x += wasmIndex(pos, 0);
+    y += wasmIndex(pos, 1);
+    z += wasmIndex(pos, 2);
+  }
+  const n = verts.length;
+  return { x: x / n, y: y / n, z: z / n };
+}
+
+function findBestNormalMatch(
+  bk: BrepkitKernel,
+  origFaceId: number,
+  solidFaces: number[]
+): number | null {
+  try {
+    const origNormal = bk.getFaceNormal(origFaceId);
+    let bestMatch = -1;
+    let bestDot = -2;
+    for (const sf of solidFaces) {
+      try {
+        const sn = bk.getFaceNormal(sf);
+        const dot =
+          (origNormal[0] ?? 0) * (sn[0] ?? 0) +
+          (origNormal[1] ?? 0) * (sn[1] ?? 0) +
+          (origNormal[2] ?? 0) * (sn[2] ?? 0);
+        if (dot > bestDot) {
+          bestDot = dot;
+          bestMatch = sf;
+        }
+      } catch {
+        // non-planar face, skip
+      }
+    }
+    if (bestMatch >= 0 && bestDot > 0.99) return bestMatch;
+  } catch {
+    // original face lookup failed
+  }
+  return null;
+}
+
+function findBestCentroidMatch(
+  bk: BrepkitKernel,
+  origFaceId: number,
+  solidFaces: number[]
+): number | null {
+  try {
+    const origCentroid = faceCentroid(bk, origFaceId);
+    if (origCentroid === null) return null;
+
+    let bestMatch = -1;
+    let bestDist = Infinity;
+    for (const sf of solidFaces) {
+      try {
+        const sc = faceCentroid(bk, sf);
+        if (sc === null) continue;
+        const dist = Math.sqrt(
+          (origCentroid.x - sc.x) ** 2 + (origCentroid.y - sc.y) ** 2 + (origCentroid.z - sc.z) ** 2
+        );
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestMatch = sf;
+        }
+      } catch {
+        // vertex lookup failed for this face
+      }
+    }
+    if (bestMatch >= 0 && bestDist < 1e-3) return bestMatch;
+  } catch {
+    // original face vertex lookup failed
+  }
+  return null;
+}
+
+function resolveShellFaceId(
+  bk: BrepkitKernel,
+  fid: number,
+  solidFaces: number[],
+  solidFaceSet: Set<number>
+): number {
+  if (solidFaceSet.has(fid)) return fid;
+  const normalMatch = findBestNormalMatch(bk, fid, solidFaces);
+  if (normalMatch !== null) return normalMatch;
+  const centroidMatch = findBestCentroidMatch(bk, fid, solidFaces);
+  if (centroidMatch !== null) return centroidMatch;
+  return fid;
+}
+
 export function shell(
   bk: BrepkitKernel,
   shape: KernelShape,
@@ -141,88 +238,9 @@ export function shell(
   const solidFaces = toArray(bk.getSolidFaces(solidId));
   const solidFaceSet = new Set(solidFaces);
 
-  const resolvedFaceIds = faces.map((f) => {
-    const fid = unwrap(f, 'face');
-    if (solidFaceSet.has(fid)) return fid;
-
-    try {
-      const origNormal = bk.getFaceNormal(fid);
-      let bestMatch = -1;
-      let bestDot = -2;
-      for (const sf of solidFaces) {
-        try {
-          const sn = bk.getFaceNormal(sf);
-          const dot =
-            (origNormal[0] ?? 0) * (sn[0] ?? 0) +
-            (origNormal[1] ?? 0) * (sn[1] ?? 0) +
-            (origNormal[2] ?? 0) * (sn[2] ?? 0);
-          if (dot > bestDot) {
-            bestDot = dot;
-            bestMatch = sf;
-          }
-        } catch {
-          // non-planar face, skip
-        }
-      }
-      if (bestMatch >= 0 && bestDot > 0.99) return bestMatch;
-    } catch {
-      // original face lookup failed
-    }
-
-    // Centroid-proximity fallback: compare average vertex positions
-    try {
-      const origVerts = toArray(bk.getFaceVertices(fid));
-      if (origVerts.length >= 1) {
-        let ox = 0,
-          oy = 0,
-          oz = 0;
-        for (const vid of origVerts) {
-          const pos = bk.getVertexPosition(vid);
-          ox += wasmIndex(pos, 0);
-          oy += wasmIndex(pos, 1);
-          oz += wasmIndex(pos, 2);
-        }
-        const n = origVerts.length;
-        ox /= n;
-        oy /= n;
-        oz /= n;
-
-        let bestCentroidMatch = -1;
-        let bestCentroidDist = Infinity;
-        for (const sf of solidFaces) {
-          try {
-            const sv = toArray(bk.getFaceVertices(sf));
-            if (sv.length < 1) continue;
-            let sx = 0,
-              sy = 0,
-              sz = 0;
-            for (const svid of sv) {
-              const spos = bk.getVertexPosition(svid);
-              sx += wasmIndex(spos, 0);
-              sy += wasmIndex(spos, 1);
-              sz += wasmIndex(spos, 2);
-            }
-            const sn = sv.length;
-            sx /= sn;
-            sy /= sn;
-            sz /= sn;
-            const dist = Math.sqrt((ox - sx) ** 2 + (oy - sy) ** 2 + (oz - sz) ** 2);
-            if (dist < bestCentroidDist) {
-              bestCentroidDist = dist;
-              bestCentroidMatch = sf;
-            }
-          } catch {
-            // vertex lookup failed for this face
-          }
-        }
-        if (bestCentroidMatch >= 0 && bestCentroidDist < 1e-3) return bestCentroidMatch;
-      }
-    } catch {
-      // original face vertex lookup failed
-    }
-
-    return fid;
-  });
+  const resolvedFaceIds = faces.map((f) =>
+    resolveShellFaceId(bk, unwrap(f, 'face'), solidFaces, solidFaceSet)
+  );
 
   const id = bk.shell(solidId, thickness, resolvedFaceIds);
   return solidHandle(id);

--- a/src/operations/mateFns.ts
+++ b/src/operations/mateFns.ts
@@ -81,6 +81,37 @@ function extractPair(
   });
 }
 
+/** Convert a single mate into a solver constraint. */
+function mateToSolverConstraint(mate: MateConstraint): Result<SolverConstraint> {
+  switch (mate.type) {
+    case 'fixed':
+      return ok({
+        type: 'fixed',
+        entityA: { node: mate.entity.node, entity: { type: 'point', origin: [0, 0, 0] } },
+      });
+    case 'coincident': {
+      const pair = extractPair(mate.entityA, mate.entityB);
+      if (!pair.ok) return pair;
+      return ok({ type: 'coincident', ...pair.value });
+    }
+    case 'distance': {
+      const pair = extractPair(mate.entityA, mate.entityB);
+      if (!pair.ok) return pair;
+      return ok({ type: 'distance', ...pair.value, value: mate.distance });
+    }
+    case 'angle': {
+      const pair = extractPair(mate.entityA, mate.entityB);
+      if (!pair.ok) return pair;
+      return ok({ type: 'angle', ...pair.value, value: mate.angle });
+    }
+    case 'concentric': {
+      const pair = extractPair(mate.axisA, mate.axisB);
+      if (!pair.ok) return pair;
+      return ok({ type: 'concentric', ...pair.value });
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -116,32 +147,9 @@ export function solveAssembly(assembly: AssemblyNode): Result<AssemblySolveResul
     const solverConstraints: SolverConstraint[] = [];
 
     for (const mate of mates) {
-      if (mate.type === 'fixed') {
-        solverConstraints.push({
-          type: 'fixed',
-          entityA: { node: mate.entity.node, entity: { type: 'point', origin: [0, 0, 0] } },
-        });
-        continue;
-      }
-
-      if (mate.type === 'coincident') {
-        const pair = extractPair(mate.entityA, mate.entityB);
-        if (!pair.ok) return pair;
-        solverConstraints.push({ type: 'coincident', ...pair.value });
-      } else if (mate.type === 'distance') {
-        const pair = extractPair(mate.entityA, mate.entityB);
-        if (!pair.ok) return pair;
-        solverConstraints.push({ type: 'distance', ...pair.value, value: mate.distance });
-      } else if (mate.type === 'angle') {
-        const pair = extractPair(mate.entityA, mate.entityB);
-        if (!pair.ok) return pair;
-        solverConstraints.push({ type: 'angle', ...pair.value, value: mate.angle });
-      } else {
-        // concentric — only remaining type after fixed/coincident/distance/angle
-        const pair = extractPair(mate.axisA, mate.axisB);
-        if (!pair.ok) return pair;
-        solverConstraints.push({ type: 'concentric', ...pair.value });
-      }
+      const result = mateToSolverConstraint(mate);
+      if (!result.ok) return result;
+      solverConstraints.push(result.value);
     }
 
     const result = solveConstraints(nodes, solverConstraints);

--- a/src/topology/wrapperFns.ts
+++ b/src/topology/wrapperFns.ts
@@ -199,16 +199,6 @@ function trustAsT<T extends Shape3D>(s: Shape3D): T {
   return s as unknown as T;
 }
 
-/**
- * Trust-cast a concrete Wrapped<Face> back to the dispatch helper's generic
- * `Wrapped<T>`. After `isFace(val)` narrows the runtime type, T is statically
- * Face, but TypeScript cannot propagate the narrowing through the generic.
- */
-function trustAsWrappedT<T extends AnyShape>(w: Wrapped<Face>): Wrapped<T> {
-  // brepjs-patterns-disable: no-double-cast
-  return w as unknown as Wrapped<T>;
-}
-
 // ---------------------------------------------------------------------------
 // Wrapped interfaces (exported for type annotations)
 // ---------------------------------------------------------------------------
@@ -559,7 +549,12 @@ function createWrappedFace(val: Face): WrappedFace {
 
 function wrapAny<T extends AnyShape>(val: T): Wrapped<T> {
   if (isShape3D(val)) return createWrapped3D(val);
-  if (isFace(val)) return trustAsWrappedT<T>(createWrappedFace(val));
+  if (isFace(val)) {
+    // isFace(val) narrows val to Face at runtime, so T is Face here. TS can't
+    // propagate that into the generic, so the cast is safe by construction.
+    // brepjs-patterns-disable: no-double-cast
+    return createWrappedFace(val) as unknown as Wrapped<T>;
+  }
   if (isEdge(val) || isWire(val)) return createWrappedCurve(val);
   return createWrappedBase(val);
 }


### PR DESCRIPTION
## Summary

Pay down `.pattern-baseline.json` from **38 → 29 entries** (-9). Three focused commits:

1. **`refactor(brepkit): extract face-resolution helpers from shell()`** — The `faces.map((f) => {...})` callback inside `shell()` was 62 lines of nested fallback logic resolving each requested face via three strategies (direct membership → normal-direction match → centroid proximity). Extract `faceCentroid`, `findBestNormalMatch`, `findBestCentroidMatch`, and a `resolveShellFaceId` orchestrator. Tolerances (`bestDot > 0.99`, `bestCentroidDist < 1e-3`) and every `try`/`catch` boundary preserved byte-identical. Drops 5 entries (`shell` long function, anonymous callback long function, 3× depth-5 nesting).
2. **`refactor(operations): flatten solveAssembly mate-to-constraint loop`** — The `for (const mate of mates)` loop inside `solveAssembly` branched on `mate.type` ('fixed' / 'coincident' / 'distance' / 'angle' / 'concentric') with chained `if/else if` plus inner `Result`-unwrap guards reaching depth 5–6. Extract `mateToSolverConstraint(mate): Result<SolverConstraint>` with a `switch` statement; the loop collapses to a flat result-check + push. Drops 4 max-nesting-depth entries.
3. **`refactor(topology): inline trustAsWrappedT to remove loose type bound`** — Addresses Greptile P2 nit from #1053: `trustAsWrappedT<T extends AnyShape>` would let a future caller construct a `Wrapped<Solid>` from a `WrappedFace`. The helper had one call site and runtime safety lived entirely in the caller's `isFace(val)` narrowing. Inline back to `wrapAny` with the `brepjs-patterns-disable` and a one-line justification — no other call site can now exist.

## Baseline impact

| Rule                 | Before | After | Δ   |
| -------------------- | ------ | ----- | --- |
| `no-double-cast`     | 4      | 4     | 0   |
| `max-function-lines` | 18     | 16    | -2  |
| `max-nesting-depth`  | 16     | 9     | -7  |
| **Total**            | **38** | **29**| **-9** |

Cumulative pay-down across this and PR #1053: **53 → 29 entries** (-24, ~45% reduction).

## Test plan

- [x] `npm run validate` (typecheck + lint + boundaries + format + changed tests) passes locally
- [x] Pre-push: full `test:full` + `knip` passes — 2517+ OCCT tests pass, 0 fail
- [x] No behavior, API, or export changes — purely internal restructuring
- [ ] CI passes on the PR

## Follow-up to PR #1053 record-keeping

Greptile also noted on #1053 that the PR description misattributed 4 baselined `evolutionOps.ts` nesting entries to my `createWrapped3D` decomposition. Those entries had been resolved in a prior independent commit and were just captured by the baseline regen — the misattribution didn't affect the code but is worth flagging for future readers.