### PR TITLE
refactor(brepkit): drop 11 baseline entries (evolutionOps + topologyOps + sweepOps)

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated": "2026-05-25T15:40:37.401Z",
+  "generated": "2026-05-25T15:58:38.287Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -41,61 +41,6 @@
       "file": "src/kernel/brepkit/constructionOps.ts",
       "rule": "max-function-lines",
       "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|makeEllipseNurbs|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/evolutionOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-function-lines|matchFacesGeometrically|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/evolutionOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/evolutionOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#1"
-    },
-    {
-      "file": "src/kernel/brepkit/evolutionOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/evolutionOps.ts|max-nesting-depth|booleanWithHistoryImpl/if@5|#2"
-    },
-    {
-      "file": "src/kernel/brepkit/sweepOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-function-lines|sweepPipeShell|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/sweepOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-nesting-depth|sweepPipeShell/try@5|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/sweepOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/sweepOps.ts|max-nesting-depth|sweepPipeShell/if@6|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/topologyOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-function-lines|iterShapes|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/topologyOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|iterShapes/if@5|#0"
-    },
-    {
-      "file": "src/kernel/brepkit/topologyOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|iterShapes/if@5|#1"
-    },
-    {
-      "file": "src/kernel/brepkit/topologyOps.ts",
-      "rule": "max-nesting-depth",
-      "fingerprint": "src/kernel/brepkit/topologyOps.ts|max-nesting-depth|sew/for-of@5|#0"
     },
     {
       "file": "src/kernel/geometry2d.ts",

--- a/src/kernel/brepkit/evolutionOps.ts
+++ b/src/kernel/brepkit/evolutionOps.ts
@@ -113,6 +113,80 @@ function faceCentroidById(bk: BrepkitKernel, faceId: number): [number, number, n
   }
 }
 
+interface FaceSignature {
+  hash: number;
+  normal: ArrayLike<number>;
+  centroid: [number, number, number];
+}
+
+/**
+ * Snapshot a face's signature (hash + normal + centroid). Non-planar faces
+ * fall back to a zero normal so they still participate in centroid-only matching.
+ */
+function snapshotFaceSignature(bk: BrepkitKernel, faceId: number, hash: number): FaceSignature {
+  try {
+    return { hash, normal: bk.getFaceNormal(faceId), centroid: faceCentroidById(bk, faceId) };
+  } catch {
+    return { hash, normal: [0, 0, 0], centroid: faceCentroidById(bk, faceId) };
+  }
+}
+
+const NORMAL_THRESHOLD = 0.707; // cos(45deg)
+const CENTROID_DIST_SQ_MAX = 100.0;
+// Tolerance for "close-enough" matches — when multiple input faces score
+// within this band of the best, record all of them. Mirrors the same
+// relaxation applied in brepkit Rust's `boolean_with_evolution`. Without
+// this, an output face that legitimately inherits metadata from several
+// inputs (e.g., the bottom face of a filleted box — close-tied with the
+// input bottom — that should keep the input's "bottom" tag) only picks
+// up one input's metadata and drops the rest.
+const SCORE_TIE_TOL = 0.05;
+
+/**
+ * Score every input face against `out` by combined normal/centroid similarity,
+ * returning the candidate matches above thresholds plus the best observed score.
+ */
+function collectOutputMatches(
+  out: FaceSignature,
+  inputSigs: FaceSignature[]
+): { matches: { idx: number; score: number }[]; bestScore: number } {
+  let bestScore = -Infinity;
+  const matches: { idx: number; score: number }[] = [];
+  for (let i = 0; i < inputSigs.length; i++) {
+    const inp = wasmIndex(inputSigs, i);
+    const dot =
+      (out.normal[0] ?? 0) * (inp.normal[0] ?? 0) +
+      (out.normal[1] ?? 0) * (inp.normal[1] ?? 0) +
+      (out.normal[2] ?? 0) * (inp.normal[2] ?? 0);
+    if (dot < NORMAL_THRESHOLD) continue;
+
+    const distSq = centroidDistSq(out.centroid, inp.centroid);
+    if (distSq > CENTROID_DIST_SQ_MAX) continue;
+
+    const score = dot - distSq / CENTROID_DIST_SQ_MAX;
+    if (score > bestScore) bestScore = score;
+    matches.push({ idx: i, score });
+  }
+  return { matches, bestScore };
+}
+
+/** Pick the input signature whose centroid is closest to `out`, or undefined if none. */
+function findNearestInputByCentroid(
+  out: FaceSignature,
+  inputSigs: FaceSignature[]
+): FaceSignature | undefined {
+  let bestDistSq = Infinity;
+  let nearest: FaceSignature | undefined;
+  for (const inp of inputSigs) {
+    const distSq = centroidDistSq(out.centroid, inp.centroid);
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq;
+      nearest = inp;
+    }
+  }
+  return nearest;
+}
+
 /**
  * Match input->output faces geometrically using normal dot product and centroid distance.
  * Mirrors the algorithm in brepkit's `boolean_with_evolution`.
@@ -133,79 +207,20 @@ function matchFacesGeometrically(
   const inputFaceIds = toArray(bk.getSolidFaces(orig.id));
   const hashCount = Math.min(inputFaceIds.length, inputFaceHashes.length);
 
-  // Snapshot input face signatures (skip faces where normal can't be computed)
-  const inputSigs: {
-    hash: number;
-    normal: ArrayLike<number>;
-    centroid: [number, number, number];
-  }[] = [];
+  const inputSigs: FaceSignature[] = [];
   for (let i = 0; i < hashCount; i++) {
     const fid = wasmIndex(inputFaceIds, i);
-    try {
-      const normal = bk.getFaceNormal(fid);
-      const centroid = faceCentroidById(bk, fid);
-      inputSigs.push({ hash: inputFaceHashes[i] ?? fid % hashUpperBound, normal, centroid });
-    } catch {
-      // Non-planar faces can't compute normal via getFaceNormal -- skip
-      inputSigs.push({
-        hash: inputFaceHashes[i] ?? fid % hashUpperBound,
-        normal: [0, 0, 0],
-        centroid: faceCentroidById(bk, fid),
-      });
-    }
+    inputSigs.push(snapshotFaceSignature(bk, fid, inputFaceHashes[i] ?? fid % hashUpperBound));
   }
 
-  // Snapshot output face signatures (skip faces where normal can't be computed)
-  const outputSigs: {
-    hash: number;
-    normal: ArrayLike<number>;
-    centroid: [number, number, number];
-  }[] = [];
-  for (const fid of outputFaceIds) {
-    try {
-      const normal = bk.getFaceNormal(fid);
-      const centroid = faceCentroidById(bk, fid);
-      outputSigs.push({ hash: fid % hashUpperBound, normal, centroid });
-    } catch {
-      outputSigs.push({
-        hash: fid % hashUpperBound,
-        normal: [0, 0, 0],
-        centroid: faceCentroidById(bk, fid),
-      });
-    }
-  }
+  const outputSigs: FaceSignature[] = outputFaceIds.map((fid) =>
+    snapshotFaceSignature(bk, fid, fid % hashUpperBound)
+  );
 
-  const NORMAL_THRESHOLD = 0.707; // cos(45deg)
-  const CENTROID_DIST_SQ_MAX = 100.0;
-  // Tolerance for "close-enough" matches — when multiple input faces score
-  // within this band of the best, record all of them. Mirrors the same
-  // relaxation applied in brepkit Rust's `boolean_with_evolution`. Without
-  // this, an output face that legitimately inherits metadata from several
-  // inputs (e.g., the bottom face of a filleted box — close-tied with the
-  // input bottom — that should keep the input's "bottom" tag) only picks
-  // up one input's metadata and drops the rest.
-  const SCORE_TIE_TOL = 0.05;
   const matchedInputIndices = new Set<number>();
 
   for (const out of outputSigs) {
-    let bestScore = -Infinity;
-    const matches: { idx: number; score: number }[] = [];
-
-    for (let i = 0; i < inputSigs.length; i++) {
-      const inp = wasmIndex(inputSigs, i);
-      const dot =
-        (out.normal[0] ?? 0) * (inp.normal[0] ?? 0) +
-        (out.normal[1] ?? 0) * (inp.normal[1] ?? 0) +
-        (out.normal[2] ?? 0) * (inp.normal[2] ?? 0);
-      if (dot < NORMAL_THRESHOLD) continue;
-
-      const distSq = centroidDistSq(out.centroid, inp.centroid);
-      if (distSq > CENTROID_DIST_SQ_MAX) continue;
-
-      const score = dot - distSq / CENTROID_DIST_SQ_MAX;
-      if (score > bestScore) bestScore = score;
-      matches.push({ idx: i, score });
-    }
+    const { matches, bestScore } = collectOutputMatches(out, inputSigs);
 
     if (matches.length > 0) {
       for (const m of matches) {
@@ -218,16 +233,7 @@ function matchFacesGeometrically(
         }
       }
     } else {
-      // Unmatched output -> generated from nearest input
-      let bestDistSq = Infinity;
-      let nearestInput: (typeof inputSigs)[0] | undefined;
-      for (const inp of inputSigs) {
-        const distSq = centroidDistSq(out.centroid, inp.centroid);
-        if (distSq < bestDistSq) {
-          bestDistSq = distSq;
-          nearestInput = inp;
-        }
-      }
+      const nearestInput = findNearestInputByCentroid(out, inputSigs);
       if (nearestInput) {
         const existing = generated.get(nearestInput.hash) ?? [];
         existing.push(out.hash);
@@ -236,7 +242,6 @@ function matchFacesGeometrically(
     }
   }
 
-  // Input faces not matched -> deleted
   for (let i = 0; i < inputSigs.length; i++) {
     if (!matchedInputIndices.has(i)) {
       deleted.add(wasmIndex(inputSigs, i).hash);
@@ -458,10 +463,87 @@ function chainEvolutionMap(
   }
 }
 
+interface CompoundBooleanAccum {
+  combinedModified: Map<number, number[]>;
+  combinedGenerated: Map<number, number[]>;
+  combinedDeleted: Set<number>;
+  inputFaceHashSet: ReadonlySet<number>;
+}
+
+/**
+ * Fold one child solid of a compound tool into the running boolean accumulator.
+ * Chains existing modified/generated outputs through this step's evolution,
+ * then merges in any step entries not already covered by the chain.
+ */
+function mergeCompoundChildStep(result: OperationResult, accum: CompoundBooleanAccum): void {
+  const intermediateOutputs = new Set<number>();
+
+  chainEvolutionMap(
+    accum.combinedModified,
+    result.evolution.modified,
+    result.evolution.deleted,
+    intermediateOutputs,
+    accum.combinedDeleted
+  );
+  chainEvolutionMap(
+    accum.combinedGenerated,
+    result.evolution.modified,
+    result.evolution.deleted,
+    intermediateOutputs
+  );
+
+  for (const [k, v] of result.evolution.modified) {
+    if (accum.combinedModified.has(k) || intermediateOutputs.has(k)) continue;
+    accum.combinedModified.set(k, [...v]);
+  }
+
+  for (const [k, v] of result.evolution.generated) {
+    if (intermediateOutputs.has(k)) continue;
+    const existing = accum.combinedGenerated.get(k) ?? [];
+    accum.combinedGenerated.set(k, [...existing, ...v]);
+  }
+
+  for (const d of result.evolution.deleted) {
+    if (!accum.inputFaceHashSet.has(d)) continue;
+    accum.combinedDeleted.add(d);
+  }
+}
+
+/**
+ * Iteratively apply native evolution for each solid in a compound tool, chaining
+ * evolution maps so the original input face hashes resolve to final output hashes
+ * rather than intermediates.
+ */
+function applyCompoundBooleanWithHistory(
+  bk: BrepkitKernel,
+  shape: KernelShape,
+  compoundToolId: number,
+  inputFaceHashes: number[],
+  hashUpperBound: number,
+  nativeFn: (a: number, b: number) => string
+): { shape: KernelShape; accum: CompoundBooleanAccum } {
+  const childSolidIds: number[] = toArray(bk.getCompoundSolids(compoundToolId));
+  let currentShape: KernelShape = shape;
+  const accum: CompoundBooleanAccum = {
+    combinedModified: new Map<number, number[]>(),
+    combinedGenerated: new Map<number, number[]>(),
+    combinedDeleted: new Set<number>(),
+    inputFaceHashSet: new Set(inputFaceHashes),
+  };
+  for (const childId of childSolidIds) {
+    const ch = currentShape as BrepkitHandle;
+    if (ch.type !== 'solid') break;
+    const json = nativeFn(ch.id, childId);
+    const result = parseNativeEvolution(json, hashUpperBound);
+    currentShape = result.shape;
+    mergeCompoundChildStep(result, accum);
+  }
+  return { shape: currentShape, accum };
+}
+
 /**
  * Shared implementation for boolean-with-history operations (fuse, cut, intersect).
  */
-// brepjs-patterns-disable: max-function-lines
 function booleanWithHistoryImpl(
   bk: BrepkitKernel,
   shape: KernelShape,
@@ -487,64 +569,20 @@ function booleanWithHistoryImpl(
       }
     }
     if (th.type === 'compound') {
-      // Iteratively apply native evolution for each solid in the compound,
-      // chaining evolution maps so that original input face hashes map to
-      // final output face hashes (not intermediate ones).
-      const childSolidIds: number[] = toArray(bk.getCompoundSolids(th.id));
-      let currentShape: KernelShape = shape;
-      const combinedModified = new Map<number, number[]>();
-      const combinedGenerated = new Map<number, number[]>();
-      const combinedDeleted = new Set<number>();
-      const inputFaceHashSet = new Set(inputFaceHashes);
-      for (const childId of childSolidIds) {
-        const ch = currentShape as BrepkitHandle;
-        if (ch.type !== 'solid') break;
-        const json = nativeFn(ch.id, childId);
-        const result = parseNativeEvolution(json, hashUpperBound);
-        currentShape = result.shape;
-
-        const intermediateOutputs = new Set<number>();
-
-        // Chain combinedModified and combinedGenerated through this step.
-        chainEvolutionMap(
-          combinedModified,
-          result.evolution.modified,
-          result.evolution.deleted,
-          intermediateOutputs,
-          combinedDeleted
-        );
-        chainEvolutionMap(
-          combinedGenerated,
-          result.evolution.modified,
-          result.evolution.deleted,
-          intermediateOutputs
-        );
-
-        // Add new entries from this step that aren't already chained
-        for (const [k, v] of result.evolution.modified) {
-          if (!combinedModified.has(k) && !intermediateOutputs.has(k)) {
-            combinedModified.set(k, [...v]);
-          }
-        }
-
-        for (const [k, v] of result.evolution.generated) {
-          if (!intermediateOutputs.has(k)) {
-            const existing = combinedGenerated.get(k) ?? [];
-            combinedGenerated.set(k, [...existing, ...v]);
-          }
-        }
-        for (const d of result.evolution.deleted) {
-          if (inputFaceHashSet.has(d)) {
-            combinedDeleted.add(d);
-          }
-        }
-      }
+      const { shape: resultShape, accum } = applyCompoundBooleanWithHistory(
+        bk,
+        shape,
+        th.id,
+        inputFaceHashes,
+        hashUpperBound,
+        nativeFn
+      );
       return {
-        shape: currentShape,
+        shape: resultShape,
         evolution: {
-          modified: combinedModified,
-          generated: combinedGenerated,
-          deleted: combinedDeleted,
+          modified: accum.combinedModified,
+          generated: accum.combinedGenerated,
+          deleted: accum.combinedDeleted,
         },
         diagnostics: noDiagnostics,
       };

--- a/src/kernel/brepkit/sweepOps.ts
+++ b/src/kernel/brepkit/sweepOps.ts
@@ -250,85 +250,110 @@ function mapStringTransitionMode(mode: string): string | undefined {
   }
 }
 
+type PipeShellResult =
+  | KernelShape
+  | { shape: KernelShape; firstShape: KernelShape; lastShape: KernelShape };
+
+function wrapPipeShellResult(
+  shape: KernelShape,
+  profile: KernelShape,
+  shellMode: boolean
+): PipeShellResult {
+  if (shellMode) return { shape, firstShape: profile, lastShape: profile };
+  return shape;
+}
+
+function tryContactModeSweep(
+  bk: BrepkitKernel,
+  faceId: number,
+  edgeId: number,
+  contactMode: string
+): KernelShape | undefined {
+  try {
+    return solidHandle(bk.sweepWithOptions(faceId, edgeId, contactMode, [], 0, 'transformed'));
+  } catch (e: unknown) {
+    console.warn('brepkit: sweepWithOptions failed, falling back to sweepSmooth/simplePipe:', e);
+    return undefined;
+  }
+}
+
+function resolveContactModeEdge(
+  bk: BrepkitKernel,
+  spine: KernelShape
+): { edgeId: number } | undefined {
+  const spineHandle = spine as BrepkitHandle;
+  if (spineHandle.type !== 'wire') {
+    return { edgeId: unwrap(spine, 'edge') };
+  }
+  const edges = iterShapes(bk, spine, 'edge');
+  if (edges.length === 1) {
+    const first = edges[0];
+    if (first) return { edgeId: unwrap(first, 'edge') };
+    return undefined;
+  }
+  warnOnce(
+    'sweepPipeShell-transition-multi-edge',
+    'sweepPipeShell transition mode not supported for multi-edge wires; ignored.'
+  );
+  return undefined;
+}
+
+function tryContactModePipeShell(
+  bk: BrepkitKernel,
+  faceId: number,
+  spine: KernelShape,
+  contactMode: string
+): KernelShape | undefined {
+  const resolved = resolveContactModeEdge(bk, spine);
+  if (!resolved) return undefined;
+  return tryContactModeSweep(bk, faceId, resolved.edgeId, contactMode);
+}
+
+function trySmoothPipeShell(
+  bk: BrepkitKernel,
+  faceId: number,
+  spine: KernelShape
+): KernelShape | undefined {
+  const nurbsData = extractNurbsFromEdge(bk, spine);
+  if (!nurbsData || nurbsData.degree <= 1) return undefined;
+  try {
+    const id = bk.sweepSmooth(
+      faceId,
+      nurbsData.degree,
+      nurbsData.knots,
+      nurbsData.controlPoints,
+      nurbsData.weights
+    );
+    return solidHandle(id);
+  } catch (e: unknown) {
+    console.warn('brepkit: sweepSmooth failed, falling back to simplePipe:', e);
+    return undefined;
+  }
+}
+
 export function sweepPipeShell(
   bk: BrepkitKernel,
   profile: KernelShape,
   spine: KernelShape,
   options?: Record<string, unknown>
-): KernelShape | { shape: KernelShape; firstShape: KernelShape; lastShape: KernelShape } {
+): PipeShellResult {
   const profileHandle = profile as BrepkitHandle;
   const faceId =
     profileHandle.type === 'wire' ? bk.makeFaceFromWire(profileHandle.id) : unwrap(profile, 'face');
 
   const shellMode = !!(options && options['shellMode']);
-
   const transitionMode = options?.['transitionMode'] as string | undefined;
   const contactMode = transitionMode ? mapStringTransitionMode(transitionMode) : undefined;
 
   if (contactMode) {
-    const spineHandle = spine as BrepkitHandle;
-    if (spineHandle.type !== 'wire') {
-      try {
-        const edgeId = unwrap(spine, 'edge');
-        const shape = solidHandle(
-          bk.sweepWithOptions(faceId, edgeId, contactMode, [], 0, 'transformed')
-        );
-        if (shellMode) return { shape, firstShape: profile, lastShape: profile };
-        return shape;
-      } catch (e: unknown) {
-        console.warn(
-          'brepkit: sweepWithOptions failed, falling back to sweepSmooth/simplePipe:',
-          e
-        );
-      }
-    } else {
-      const edges = iterShapes(bk, spine, 'edge');
-      if (edges.length === 1) {
-        const first = edges[0];
-        if (first) {
-          try {
-            const edgeId = unwrap(first, 'edge');
-            const shape = solidHandle(
-              bk.sweepWithOptions(faceId, edgeId, contactMode, [], 0, 'transformed')
-            );
-            if (shellMode) return { shape, firstShape: profile, lastShape: profile };
-            return shape;
-          } catch (e: unknown) {
-            console.warn(
-              'brepkit: sweepWithOptions failed, falling back to sweepSmooth/simplePipe:',
-              e
-            );
-          }
-        }
-      } else {
-        warnOnce(
-          'sweepPipeShell-transition-multi-edge',
-          'sweepPipeShell transition mode not supported for multi-edge wires; ignored.'
-        );
-      }
-    }
+    const shape = tryContactModePipeShell(bk, faceId, spine, contactMode);
+    if (shape) return wrapPipeShellResult(shape, profile, shellMode);
   }
 
-  const nurbsData = extractNurbsFromEdge(bk, spine);
-  if (nurbsData && nurbsData.degree > 1) {
-    try {
-      const id = bk.sweepSmooth(
-        faceId,
-        nurbsData.degree,
-        nurbsData.knots,
-        nurbsData.controlPoints,
-        nurbsData.weights
-      );
-      const shape = solidHandle(id);
-      if (shellMode) return { shape, firstShape: profile, lastShape: profile };
-      return shape;
-    } catch (e: unknown) {
-      console.warn('brepkit: sweepSmooth failed, falling back to simplePipe:', e);
-    }
-  }
-  const shape = simplePipe(bk, profile, spine);
-  if (shellMode) return { shape, firstShape: profile, lastShape: profile };
-  return shape;
+  const smoothShape = trySmoothPipeShell(bk, faceId, spine);
+  if (smoothShape) return wrapPipeShellResult(smoothShape, profile, shellMode);
+
+  return wrapPipeShellResult(simplePipe(bk, profile, spine), profile, shellMode);
 }
 
 export function loftAdvanced(

--- a/src/kernel/brepkit/topologyOps.ts
+++ b/src/kernel/brepkit/topologyOps.ts
@@ -14,124 +14,147 @@ import {
   edgeHandle,
   wireHandle,
   vertexHandle,
+  shellHandle,
   unwrap,
+  unwrapSolidOrThrow,
   toArray,
   syntheticCompounds,
 } from './helpers.js';
 import { wasmIndex } from '@/utils/vec3.js';
+
+function iterCompound(bk: BrepkitKernel, h: number, type: ShapeType): KernelShape[] {
+  const children = syntheticCompounds.get(h);
+  if (children) {
+    return children.flatMap((child) =>
+      child.type === type ? [child] : iterShapes(bk, child, type)
+    );
+  }
+  if (type === 'solid') {
+    return toArray(bk.getCompoundSolids(h)).map(solidHandle);
+  }
+  if (type === 'face' || type === 'edge' || type === 'vertex' || type === 'wire') {
+    const solids = toArray(bk.getCompoundSolids(h)).map(solidHandle);
+    return solids.flatMap((s) => iterShapes(bk, s, type));
+  }
+  return [];
+}
+
+function iterSolid(bk: BrepkitKernel, h: number, type: ShapeType): KernelShape[] {
+  switch (type) {
+    case 'face':
+      return toArray(bk.getSolidFaces(h)).map(faceHandle);
+    case 'edge':
+      return toArray(bk.getSolidEdges(h)).map(edgeHandle);
+    case 'vertex':
+      return toArray(bk.getSolidVertices(h)).map(vertexHandle);
+    case 'wire':
+      return toArray(bk.getSolidFaces(h)).flatMap((faceId: number) =>
+        toArray(bk.getFaceWires(faceId)).map(wireHandle)
+      );
+    default:
+      return [];
+  }
+}
+
+function iterShellChildren(bk: BrepkitKernel, h: number, type: 'edge' | 'vertex'): KernelShape[] {
+  const faces = toArray(bk.getShellFaces(h)).map(faceHandle);
+  const seen = new Set<number>();
+  const results: KernelShape[] = [];
+  for (const face of faces) {
+    for (const child of iterShapes(bk, face, type)) {
+      const childId = unwrap(child);
+      if (seen.has(childId)) continue;
+      seen.add(childId);
+      results.push(child);
+    }
+  }
+  return results;
+}
+
+function iterShell(bk: BrepkitKernel, h: number, type: ShapeType): KernelShape[] {
+  if (type === 'face') return toArray(bk.getShellFaces(h)).map(faceHandle);
+  if (type === 'edge' || type === 'vertex') return iterShellChildren(bk, h, type);
+  return [];
+}
+
+function iterFace(
+  bk: BrepkitKernel,
+  shape: KernelShape,
+  h: number,
+  type: ShapeType
+): KernelShape[] {
+  if (type === 'face') return [shape];
+  if (type === 'edge') return toArray(bk.getFaceEdges(h)).map(edgeHandle);
+  if (type === 'vertex') return toArray(bk.getFaceVertices(h)).map(vertexHandle);
+  if (type === 'wire') return toArray(bk.getFaceWires(h)).map(wireHandle);
+  return [];
+}
+
+function uniqueWireVertices(bk: BrepkitKernel, h: number): KernelShape[] {
+  const edgeIds = toArray(bk.getWireEdges(h));
+  const seen = new Set<string>();
+  const results: KernelShape[] = [];
+  for (const eid of edgeIds) {
+    const verts = bk.getEdgeVertices(eid);
+    const coords = [
+      [wasmIndex(verts, 0), wasmIndex(verts, 1), wasmIndex(verts, 2)],
+      [wasmIndex(verts, 3), wasmIndex(verts, 4), wasmIndex(verts, 5)],
+    ] as const;
+    for (const [x, y, z] of coords) {
+      const key = `${x},${y},${z}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push(vertexHandle(bk.makeVertex(x, y, z)));
+    }
+  }
+  return results;
+}
+
+function iterWire(
+  bk: BrepkitKernel,
+  shape: KernelShape,
+  h: number,
+  type: ShapeType
+): KernelShape[] {
+  if (type === 'wire') return [shape];
+  if (type === 'edge') return toArray(bk.getWireEdges(h)).map(edgeHandle);
+  if (type === 'vertex') return uniqueWireVertices(bk, h);
+  return [];
+}
+
+function iterEdge(
+  bk: BrepkitKernel,
+  shape: KernelShape,
+  h: number,
+  type: ShapeType
+): KernelShape[] {
+  if (type === 'edge') return [shape];
+  if (type === 'vertex') {
+    const verts = bk.getEdgeVertices(h);
+    const v1 = bk.makeVertex(wasmIndex(verts, 0), wasmIndex(verts, 1), wasmIndex(verts, 2));
+    const v2 = bk.makeVertex(wasmIndex(verts, 3), wasmIndex(verts, 4), wasmIndex(verts, 5));
+    return [vertexHandle(v1), vertexHandle(v2)];
+  }
+  return [];
+}
 
 export function iterShapes(bk: BrepkitKernel, shape: KernelShape, type: ShapeType): KernelShape[] {
   const h = unwrap(shape);
   const bkHandle = shape as BrepkitHandle;
 
   switch (bkHandle.type) {
-    case 'compound': {
-      const children = syntheticCompounds.get(h);
-      if (children) {
-        const results: KernelShape[] = [];
-        for (const child of children) {
-          if (child.type === type) {
-            results.push(child);
-          } else {
-            results.push(...iterShapes(bk, child, type));
-          }
-        }
-        return results;
-      }
-      if (type === 'solid') {
-        return toArray(bk.getCompoundSolids(h)).map(solidHandle);
-      }
-      if (type === 'face' || type === 'edge' || type === 'vertex' || type === 'wire') {
-        const solids = toArray(bk.getCompoundSolids(h)).map(solidHandle);
-        return solids.flatMap((s) => iterShapes(bk, s, type));
-      }
-      return [];
-    }
-
-    case 'solid': {
-      switch (type) {
-        case 'face':
-          return toArray(bk.getSolidFaces(h)).map(faceHandle);
-        case 'edge':
-          return toArray(bk.getSolidEdges(h)).map(edgeHandle);
-        case 'vertex':
-          return toArray(bk.getSolidVertices(h)).map(vertexHandle);
-        case 'wire':
-          return toArray(bk.getSolidFaces(h)).flatMap((faceId: number) =>
-            toArray(bk.getFaceWires(faceId)).map(wireHandle)
-          );
-        default:
-          return [];
-      }
-    }
-
-    case 'shell': {
-      if (type === 'face') {
-        return toArray(bk.getShellFaces(h)).map(faceHandle);
-      }
-      if (type === 'edge' || type === 'vertex') {
-        const faces = toArray(bk.getShellFaces(h)).map(faceHandle);
-        const seen = new Set<number>();
-        const results: KernelShape[] = [];
-        for (const face of faces) {
-          for (const child of iterShapes(bk, face, type)) {
-            const childId = unwrap(child);
-            if (!seen.has(childId)) {
-              seen.add(childId);
-              results.push(child);
-            }
-          }
-        }
-        return results;
-      }
-      return [];
-    }
-
-    case 'face': {
-      if (type === 'face') return [shape];
-      if (type === 'edge') return toArray(bk.getFaceEdges(h)).map(edgeHandle);
-      if (type === 'vertex') return toArray(bk.getFaceVertices(h)).map(vertexHandle);
-      if (type === 'wire') return toArray(bk.getFaceWires(h)).map(wireHandle);
-      return [];
-    }
-
-    case 'wire': {
-      if (type === 'wire') return [shape];
-      if (type === 'edge') return toArray(bk.getWireEdges(h)).map(edgeHandle);
-      if (type === 'vertex') {
-        const edgeIds = toArray(bk.getWireEdges(h));
-        const seen = new Set<string>();
-        const results: KernelShape[] = [];
-        for (const eid of edgeIds) {
-          const verts = bk.getEdgeVertices(eid);
-          const coords = [
-            [wasmIndex(verts, 0), wasmIndex(verts, 1), wasmIndex(verts, 2)],
-            [wasmIndex(verts, 3), wasmIndex(verts, 4), wasmIndex(verts, 5)],
-          ] as const;
-          for (const [x, y, z] of coords) {
-            const key = `${x},${y},${z}`;
-            if (!seen.has(key)) {
-              seen.add(key);
-              results.push(vertexHandle(bk.makeVertex(x, y, z)));
-            }
-          }
-        }
-        return results;
-      }
-      return [];
-    }
-
-    case 'edge': {
-      if (type === 'edge') return [shape];
-      if (type === 'vertex') {
-        const verts = bk.getEdgeVertices(h);
-        const v1 = bk.makeVertex(wasmIndex(verts, 0), wasmIndex(verts, 1), wasmIndex(verts, 2));
-        const v2 = bk.makeVertex(wasmIndex(verts, 3), wasmIndex(verts, 4), wasmIndex(verts, 5));
-        return [vertexHandle(v1), vertexHandle(v2)];
-      }
-      return [];
-    }
-
+    case 'compound':
+      return iterCompound(bk, h, type);
+    case 'solid':
+      return iterSolid(bk, h, type);
+    case 'shell':
+      return iterShell(bk, h, type);
+    case 'face':
+      return iterFace(bk, shape, h, type);
+    case 'wire':
+      return iterWire(bk, shape, h, type);
+    case 'edge':
+      return iterEdge(bk, shape, h, type);
     default:
       return [];
   }
@@ -204,22 +227,16 @@ export function adjacentFaces(
   return Array.from(bk.adjacentFaces(solidId, faceId)).map((id) => faceHandle(id));
 }
 
+function faceIdsForSew(bk: BrepkitKernel, shape: KernelShape): number[] {
+  const h = shape as BrepkitHandle;
+  if (h.type === 'face') return [h.id];
+  if (h.type === 'solid') return toArray(bk.getSolidFaces(h.id));
+  if (h.type === 'shell') return toArray(bk.getShellFaces(h.id));
+  return [];
+}
+
 export function sew(bk: BrepkitKernel, shapes: KernelShape[], tolerance?: number): KernelShape {
-  const faceIds: number[] = [];
-  for (const s of shapes) {
-    const h = s as BrepkitHandle;
-    if (h.type === 'face') {
-      faceIds.push(h.id);
-    } else if (h.type === 'solid') {
-      for (const fid of toArray(bk.getSolidFaces(h.id))) {
-        faceIds.push(fid);
-      }
-    } else if (h.type === 'shell') {
-      for (const fid of toArray(bk.getShellFaces(h.id))) {
-        faceIds.push(fid);
-      }
-    }
-  }
+  const faceIds = shapes.flatMap((s) => faceIdsForSew(bk, s));
   const tol = tolerance ?? 1e-7;
   try {
     const id = bk.weldShellsAndFaces(faceIds, tol);
@@ -230,9 +247,6 @@ export function sew(bk: BrepkitKernel, shapes: KernelShape[], tolerance?: number
   const id = bk.sewFaces(faceIds, tol);
   return shellHandle(id);
 }
-
-// Import needed by edgeToFaceMap, adjacentFaces
-import { unwrapSolidOrThrow, shellHandle } from './helpers.js';
 
 /** Co-located factory: returns the topology-iteration slice of {@link KernelAdapter} bound to `bk`. */
 export function makeTopologyOps(bk: BrepkitKernel) {


### PR DESCRIPTION
## Summary

Wave 2 of the `.pattern-baseline.json` pay-down. Three focused commits, all in the brepkit kernel adapter (Layer 0):

1. **`refactor(brepkit): extract helpers from matchFacesGeometrically and flatten booleanWithHistoryImpl`**
   - `matchFacesGeometrically` (80 effective lines): extract `snapshotFaceSignature`, `collectOutputMatches`, `findNearestInputByCentroid`, plus a `FaceSignature` interface. Main function shrinks to ~39 lines.
   - `booleanWithHistoryImpl` (3× depth-5 nesting): extract `mergeCompoundChildStep` + `applyCompoundBooleanWithHistory`; use early-`continue` instead of inverted-`if` wrapping. All three deep-nesting sites resolved.
   - Drops 4 entries.

2. **`refactor(brepkit): flatten iterShapes via dispatch + extract sew loop body`**
   - `iterShapes` (85 effective lines, 2× depth-5): extract per-type handlers (`iterCompound`, `iterSolid`, `iterShell`, `iterFace`, `iterWire`, `iterEdge`) plus dedup sub-helpers (`iterShellChildren`, `uniqueWireVertices`). Main function becomes a flat switch dispatch.
   - `sew` (depth-5 for-of): extract `faceIdsForSew(bk, shape)`; loop collapses to `shapes.flatMap(...)`.
   - Drops 4 entries.

3. **`refactor(brepkit): decompose sweepPipeShell into transition + per-segment helpers`**
   - `sweepPipeShell` (62 effective lines, depth-5 try + depth-6 if): extract `wrapPipeShellResult`, `tryContactModeSweep`, `resolveContactModeEdge`, `tryContactModePipeShell`, `trySmoothPipeShell`. The depth-6 site at line 294 (contact-mode → wire-spine → single-edge → first → try → shellMode) is fully flattened.
   - Function body 62 → 13 effective lines.
   - Drops 3 entries.

## Baseline impact

| Rule                 | Before | After | Δ   |
| -------------------- | ------ | ----- | --- |
| `no-double-cast`     | 4      | 4     | 0   |
| `max-function-lines` | 16     | 13    | -3  |
| `max-nesting-depth`  | 9      | 1     | -8  |
| **Total**            | **29** | **18**| **-11** |

Cumulative pay-down across PRs #1053, #1054, and this one: **53 → 18 entries (~66% reduction)**. The remaining 18 are scattered across 13 files (no file has more than 2 entries left).

## Test plan

- [x] `npm run validate` (typecheck + lint + boundaries + format + changed tests) passes locally
- [x] Pre-push: full `test:full` + `knip` passes
- [x] All three target functions: pattern checker `--no-baseline` reports zero violations
- [x] No behavior, API, or export changes — purely internal restructuring
- [ ] CI passes on the PR