### PR TITLE
fix(brepkit): restore try/catch fallback in resolveContactModeEdge (#1055 follow-up)

### DIFF
--- a/src/kernel/brepkit/sweepOps.ts
+++ b/src/kernel/brepkit/sweepOps.ts
@@ -300,7 +300,11 @@ function resolveContactModeEdge(
       'sweepPipeShell transition mode not supported for multi-edge wires; ignored.'
     );
     return undefined;
-  } catch {
+  } catch (e: unknown) {
+    console.warn(
+      'brepkit: resolveContactModeEdge failed for unexpected spine type, falling through:',
+      e
+    );
     return undefined;
   }
 }

--- a/src/kernel/brepkit/sweepOps.ts
+++ b/src/kernel/brepkit/sweepOps.ts
@@ -281,21 +281,28 @@ function resolveContactModeEdge(
   bk: BrepkitKernel,
   spine: KernelShape
 ): { edgeId: number } | undefined {
-  const spineHandle = spine as BrepkitHandle;
-  if (spineHandle.type !== 'wire') {
-    return { edgeId: unwrap(spine, 'edge') };
-  }
-  const edges = iterShapes(bk, spine, 'edge');
-  if (edges.length === 1) {
-    const first = edges[0];
-    if (first) return { edgeId: unwrap(first, 'edge') };
+  // The original sweepPipeShell wrapped both the unwrap and the kernel call
+  // in one try/catch so any unexpected spine type silently fell through to
+  // sweepSmooth / simplePipe. The wrap must stay here to preserve that.
+  try {
+    const spineHandle = spine as BrepkitHandle;
+    if (spineHandle.type !== 'wire') {
+      return { edgeId: unwrap(spine, 'edge') };
+    }
+    const edges = iterShapes(bk, spine, 'edge');
+    if (edges.length === 1) {
+      const first = edges[0];
+      if (first) return { edgeId: unwrap(first, 'edge') };
+      return undefined;
+    }
+    warnOnce(
+      'sweepPipeShell-transition-multi-edge',
+      'sweepPipeShell transition mode not supported for multi-edge wires; ignored.'
+    );
+    return undefined;
+  } catch {
     return undefined;
   }
-  warnOnce(
-    'sweepPipeShell-transition-multi-edge',
-    'sweepPipeShell transition mode not supported for multi-edge wires; ignored.'
-  );
-  return undefined;
 }
 
 function tryContactModePipeShell(


### PR DESCRIPTION
## Summary

Fixes the P1 regression Greptile flagged on #1055 (post-merge).

The original `sweepPipeShell` wrapped both `unwrap(spine, 'edge')` and `sweepWithOptions` in a single `try/catch`, so any unexpected spine type (e.g. solid, face, compound) was silently absorbed and execution fell through to `sweepSmooth` / `simplePipe`. The wave-2 refactor in #1055 extracted `unwrap` into `resolveContactModeEdge` without that guard, so a non-edge / non-wire handle now throws past `tryContactModePipeShell` all the way to the caller, bypassing the fallback entirely.

Restore the `try/catch` inside `resolveContactModeEdge`, with an inline comment so future refactors don't strip it again.

## Why this slipped through

I armed automerge on #1055 the moment CI checks went green, which fired before Greptile's review completed (branch protection only requires `ci-pass`). The review came back 3/5 with this P1 finding ~2 minutes after merge. New workflow memory: wait for Greptile review **before** arming automerge.

## Test plan

- [x] Inline comment in `resolveContactModeEdge` documents the contract for future refactors
- [x] `npm run validate` passes locally
- [x] `npx tsx scripts/check-patterns.ts src/kernel/brepkit/sweepOps.ts --no-baseline` → still clean (the try/catch wrap doesn't add nesting depth past the existing limit)
- [ ] CI passes on the PR

No regression test added — the bug only manifests at the kernel layer with handle types the public `sweep` API can't produce (the type signatures prevent passing a `Face` or `Solid` as a spine). The inline comment is the durable guard.