### PR TITLE
refactor(patterns): drop 8 baseline entries (wave 3 — io + topology + occt long functions)

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated": "2026-05-25T15:58:38.287Z",
+  "generated": "2026-05-25T16:47:45.082Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -18,26 +18,6 @@
       "fingerprint": "src/core/disposal.ts|no-double-cast|class NoOpFinalizationRegistry { register(_target: object, _heldValue: unknow...|#0"
     },
     {
-      "file": "src/io/gltfExportFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/io/gltfExportFns.ts|max-function-lines|buildGltfDocument|#0"
-    },
-    {
-      "file": "src/io/gltfExportFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/io/gltfExportFns.ts|max-function-lines|buildGltfDocFromLayout|#0"
-    },
-    {
-      "file": "src/io/threemfExportFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/io/threemfExportFns.ts|max-function-lines|buildZip|#0"
-    },
-    {
-      "file": "src/io/threemfExportFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/io/threemfExportFns.ts|max-function-lines|build3MFModel|#0"
-    },
-    {
       "file": "src/kernel/brepkit/constructionOps.ts",
       "rule": "max-function-lines",
       "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|makeEllipseNurbs|#0"
@@ -46,16 +26,6 @@
       "file": "src/kernel/geometry2d.ts",
       "rule": "max-function-lines",
       "fingerprint": "src/kernel/geometry2d.ts|max-function-lines|numericalIntersect|#0"
-    },
-    {
-      "file": "src/kernel/occt/advancedOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|surfaceCurvature|#0"
-    },
-    {
-      "file": "src/kernel/occt/advancedOps.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/advancedOps.ts|max-function-lines|exportSTEPConfigured|#0"
     },
     {
       "file": "src/kernel/occt/hullOps.ts",
@@ -71,16 +41,6 @@
       "file": "src/topology/metadata/originTrackingFns.ts",
       "rule": "max-nesting-depth",
       "fingerprint": "src/topology/metadata/originTrackingFns.ts|max-nesting-depth|propagateOriginsByHash/if@5|#0"
-    },
-    {
-      "file": "src/topology/modifierFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|fillet|#0"
-    },
-    {
-      "file": "src/topology/modifierFns.ts",
-      "rule": "max-function-lines",
-      "fingerprint": "src/topology/modifierFns.ts|max-function-lines|draft|#0"
     },
     {
       "file": "src/topology/surfaceFns.ts",

--- a/src/io/gltfExportFns.ts
+++ b/src/io/gltfExportFns.ts
@@ -223,6 +223,64 @@ export function exportGlb(mesh: ShapeMesh, options?: GltfExportOptions): ArrayBu
 // Internal: build the glTF document
 // ---------------------------------------------------------------------------
 
+function buildSingleAccessors(
+  triangles: Uint32Array,
+  vertices: Float32Array,
+  normals: Float32Array,
+  min: number[],
+  max: number[]
+): GltfDocument['accessors'] {
+  return [
+    {
+      bufferView: 0,
+      componentType: UNSIGNED_INT,
+      count: triangles.length,
+      type: 'SCALAR',
+    },
+    {
+      bufferView: 1,
+      componentType: FLOAT,
+      count: vertices.length / 3,
+      type: 'VEC3',
+      min,
+      max,
+    },
+    {
+      bufferView: 2,
+      componentType: FLOAT,
+      count: normals.length / 3,
+      type: 'VEC3',
+    },
+  ];
+}
+
+function buildSingleBufferViews(
+  indicesByteLength: number,
+  verticesByteLength: number,
+  normalsByteLength: number
+): GltfDocument['bufferViews'] {
+  return [
+    {
+      buffer: 0,
+      byteOffset: 0,
+      byteLength: indicesByteLength,
+      target: ELEMENT_ARRAY_BUFFER,
+    },
+    {
+      buffer: 0,
+      byteOffset: align4(indicesByteLength),
+      byteLength: verticesByteLength,
+      target: ARRAY_BUFFER,
+    },
+    {
+      buffer: 0,
+      byteOffset: align4(indicesByteLength) + verticesByteLength,
+      byteLength: normalsByteLength,
+      target: ARRAY_BUFFER,
+    },
+  ];
+}
+
 function buildGltfDocument(
   mesh: ShapeMesh,
   mode: 'base64' | 'glb',
@@ -258,48 +316,8 @@ function buildGltfDocument(
         ],
       },
     ],
-    accessors: [
-      {
-        bufferView: 0,
-        componentType: UNSIGNED_INT,
-        count: triangles.length,
-        type: 'SCALAR',
-      },
-      {
-        bufferView: 1,
-        componentType: FLOAT,
-        count: vertices.length / 3,
-        type: 'VEC3',
-        min,
-        max,
-      },
-      {
-        bufferView: 2,
-        componentType: FLOAT,
-        count: normals.length / 3,
-        type: 'VEC3',
-      },
-    ],
-    bufferViews: [
-      {
-        buffer: 0,
-        byteOffset: 0,
-        byteLength: indicesByteLength,
-        target: ELEMENT_ARRAY_BUFFER,
-      },
-      {
-        buffer: 0,
-        byteOffset: align4(indicesByteLength),
-        byteLength: verticesByteLength,
-        target: ARRAY_BUFFER,
-      },
-      {
-        buffer: 0,
-        byteOffset: align4(indicesByteLength) + verticesByteLength,
-        byteLength: normalsByteLength,
-        target: ARRAY_BUFFER,
-      },
-    ],
+    accessors: buildSingleAccessors(triangles, vertices, normals, min, max),
+    bufferViews: buildSingleBufferViews(indicesByteLength, verticesByteLength, normalsByteLength),
     buffers: [
       {
         byteLength: totalByteLength,
@@ -422,20 +440,15 @@ function computeMaterialLayout(
   return { primitiveData, indexBufferInfos, verticesOffset, totalByteLength, uniqueMaterials };
 }
 
-/**
- * Build a glTF document from material layout.
- */
-function buildGltfDocFromLayout(mesh: ShapeMesh, layout: MaterialPrimitiveLayout): GltfDocument {
+function appendVertexNormalSections(
+  mesh: ShapeMesh,
+  verticesOffset: number,
+  accessors: GltfDocument['accessors'],
+  bufferViews: GltfDocument['bufferViews']
+): { verticesAccIdx: number; normalsAccIdx: number } {
   const { vertices, normals } = mesh;
-  const { primitiveData, indexBufferInfos, verticesOffset, totalByteLength, uniqueMaterials } =
-    layout;
   const { min, max } = computeMinMax(vertices);
 
-  const accessors: GltfDocument['accessors'] = [];
-  const bufferViews: GltfDocument['bufferViews'] = [];
-  const primitives: GltfPrimitive[] = [];
-
-  // Vertices buffer view + accessor
   const verticesBvIdx = 0;
   bufferViews.push({
     buffer: 0,
@@ -453,7 +466,6 @@ function buildGltfDocFromLayout(mesh: ShapeMesh, layout: MaterialPrimitiveLayout
     max,
   });
 
-  // Normals buffer view + accessor
   const normalsBvIdx = 1;
   bufferViews.push({
     buffer: 0,
@@ -469,7 +481,18 @@ function buildGltfDocFromLayout(mesh: ShapeMesh, layout: MaterialPrimitiveLayout
     type: 'VEC3',
   });
 
-  // Per-primitive index buffer views + accessors
+  return { verticesAccIdx, normalsAccIdx };
+}
+
+function appendIndexPrimitives(
+  primitiveData: MaterialPrimitiveLayout['primitiveData'],
+  indexBufferInfos: MaterialPrimitiveLayout['indexBufferInfos'],
+  verticesAccIdx: number,
+  normalsAccIdx: number,
+  accessors: GltfDocument['accessors'],
+  bufferViews: GltfDocument['bufferViews']
+): GltfPrimitive[] {
+  const primitives: GltfPrimitive[] = [];
   for (let pi = 0; pi < primitiveData.length; pi++) {
     const pd = getAtOrThrow(primitiveData, pi);
     const info = getAtOrThrow(indexBufferInfos, pi);
@@ -495,6 +518,34 @@ function buildGltfDocFromLayout(mesh: ShapeMesh, layout: MaterialPrimitiveLayout
     if (pd.materialIdx >= 0) prim.material = pd.materialIdx;
     primitives.push(prim);
   }
+  return primitives;
+}
+
+/**
+ * Build a glTF document from material layout.
+ */
+function buildGltfDocFromLayout(mesh: ShapeMesh, layout: MaterialPrimitiveLayout): GltfDocument {
+  const { primitiveData, indexBufferInfos, verticesOffset, totalByteLength, uniqueMaterials } =
+    layout;
+
+  const accessors: GltfDocument['accessors'] = [];
+  const bufferViews: GltfDocument['bufferViews'] = [];
+
+  const { verticesAccIdx, normalsAccIdx } = appendVertexNormalSections(
+    mesh,
+    verticesOffset,
+    accessors,
+    bufferViews
+  );
+
+  const primitives = appendIndexPrimitives(
+    primitiveData,
+    indexBufferInfos,
+    verticesAccIdx,
+    normalsAccIdx,
+    accessors,
+    bufferViews
+  );
 
   return {
     asset: { version: '2.0', generator: 'brepjs' },

--- a/src/io/gltfExportFns.ts
+++ b/src/io/gltfExportFns.ts
@@ -449,14 +449,14 @@ function appendVertexNormalSections(
   const { vertices, normals } = mesh;
   const { min, max } = computeMinMax(vertices);
 
-  const verticesBvIdx = 0;
+  const verticesBvIdx = bufferViews.length;
   bufferViews.push({
     buffer: 0,
     byteOffset: verticesOffset,
     byteLength: vertices.byteLength,
     target: ARRAY_BUFFER,
   });
-  const verticesAccIdx = 0;
+  const verticesAccIdx = accessors.length;
   accessors.push({
     bufferView: verticesBvIdx,
     componentType: FLOAT,
@@ -466,14 +466,14 @@ function appendVertexNormalSections(
     max,
   });
 
-  const normalsBvIdx = 1;
+  const normalsBvIdx = bufferViews.length;
   bufferViews.push({
     buffer: 0,
     byteOffset: verticesOffset + vertices.byteLength,
     byteLength: normals.byteLength,
     target: ARRAY_BUFFER,
   });
-  const normalsAccIdx = 1;
+  const normalsAccIdx = accessors.length;
   accessors.push({
     bufferView: normalsBvIdx,
     componentType: FLOAT,

--- a/src/io/threemfExportFns.ts
+++ b/src/io/threemfExportFns.ts
@@ -63,8 +63,107 @@ interface ZipEntry {
   crc: number;
 }
 
+function writeLocalHeader(view: DataView, bytes: Uint8Array, pos: number, entry: ZipEntry): number {
+  view.setUint32(pos, 0x04034b50, true);
+  pos += 4; // signature
+  view.setUint16(pos, 20, true);
+  pos += 2; // version needed
+  view.setUint16(pos, 0, true);
+  pos += 2; // flags
+  view.setUint16(pos, 0, true);
+  pos += 2; // compression (store)
+  view.setUint16(pos, 0, true);
+  pos += 2; // mod time
+  view.setUint16(pos, 0, true);
+  pos += 2; // mod date
+  view.setUint32(pos, entry.crc, true);
+  pos += 4; // crc32
+  view.setUint32(pos, entry.data.length, true);
+  pos += 4; // compressed size
+  view.setUint32(pos, entry.data.length, true);
+  pos += 4; // uncompressed size
+  view.setUint16(pos, entry.name.length, true);
+  pos += 2; // name length
+  view.setUint16(pos, 0, true);
+  pos += 2; // extra length
+  bytes.set(entry.name, pos);
+  pos += entry.name.length;
+  bytes.set(entry.data, pos);
+  pos += entry.data.length;
+  return pos;
+}
+
+function writeCentralDirEntry(
+  view: DataView,
+  bytes: Uint8Array,
+  pos: number,
+  localOff: number,
+  entry: ZipEntry
+): number {
+  view.setUint32(pos, 0x02014b50, true);
+  pos += 4; // signature
+  view.setUint16(pos, 20, true);
+  pos += 2; // version made by
+  view.setUint16(pos, 20, true);
+  pos += 2; // version needed
+  view.setUint16(pos, 0, true);
+  pos += 2; // flags
+  view.setUint16(pos, 0, true);
+  pos += 2; // compression
+  view.setUint16(pos, 0, true);
+  pos += 2; // mod time
+  view.setUint16(pos, 0, true);
+  pos += 2; // mod date
+  view.setUint32(pos, entry.crc, true);
+  pos += 4; // crc32
+  view.setUint32(pos, entry.data.length, true);
+  pos += 4; // compressed
+  view.setUint32(pos, entry.data.length, true);
+  pos += 4; // uncompressed
+  view.setUint16(pos, entry.name.length, true);
+  pos += 2; // name length
+  view.setUint16(pos, 0, true);
+  pos += 2; // extra length
+  view.setUint16(pos, 0, true);
+  pos += 2; // comment length
+  view.setUint16(pos, 0, true);
+  pos += 2; // disk start
+  view.setUint16(pos, 0, true);
+  pos += 2; // internal attrs
+  view.setUint32(pos, 0, true);
+  pos += 4; // external attrs
+  view.setUint32(pos, localOff, true);
+  pos += 4; // local header offset
+  bytes.set(entry.name, pos);
+  pos += entry.name.length;
+  return pos;
+}
+
+function writeEndOfCentralDir(
+  view: DataView,
+  pos: number,
+  entryCount: number,
+  centralStart: number,
+  centralSize: number
+): void {
+  view.setUint32(pos, 0x06054b50, true);
+  pos += 4;
+  view.setUint16(pos, 0, true);
+  pos += 2; // disk number
+  view.setUint16(pos, 0, true);
+  pos += 2; // central dir disk
+  view.setUint16(pos, entryCount, true);
+  pos += 2; // entries on disk
+  view.setUint16(pos, entryCount, true);
+  pos += 2; // total entries
+  view.setUint32(pos, centralSize, true);
+  pos += 4; // central dir size
+  view.setUint32(pos, centralStart, true);
+  pos += 4; // central dir offset
+  view.setUint16(pos, 0, true); // comment length
+}
+
 function buildZip(entries: ZipEntry[]): ArrayBuffer {
-  // Calculate sizes
   let offset = 0;
   const localHeaders: { offset: number; entry: ZipEntry }[] = [];
 
@@ -85,92 +184,15 @@ function buildZip(entries: ZipEntry[]): ArrayBuffer {
   const bytes = new Uint8Array(buf);
   let pos = 0;
 
-  // Local file headers + data
   for (const { entry } of localHeaders) {
-    view.setUint32(pos, 0x04034b50, true);
-    pos += 4; // signature
-    view.setUint16(pos, 20, true);
-    pos += 2; // version needed
-    view.setUint16(pos, 0, true);
-    pos += 2; // flags
-    view.setUint16(pos, 0, true);
-    pos += 2; // compression (store)
-    view.setUint16(pos, 0, true);
-    pos += 2; // mod time
-    view.setUint16(pos, 0, true);
-    pos += 2; // mod date
-    view.setUint32(pos, entry.crc, true);
-    pos += 4; // crc32
-    view.setUint32(pos, entry.data.length, true);
-    pos += 4; // compressed size
-    view.setUint32(pos, entry.data.length, true);
-    pos += 4; // uncompressed size
-    view.setUint16(pos, entry.name.length, true);
-    pos += 2; // name length
-    view.setUint16(pos, 0, true);
-    pos += 2; // extra length
-    bytes.set(entry.name, pos);
-    pos += entry.name.length;
-    bytes.set(entry.data, pos);
-    pos += entry.data.length;
+    pos = writeLocalHeader(view, bytes, pos, entry);
   }
 
-  // Central directory
   for (const { offset: localOff, entry } of localHeaders) {
-    view.setUint32(pos, 0x02014b50, true);
-    pos += 4; // signature
-    view.setUint16(pos, 20, true);
-    pos += 2; // version made by
-    view.setUint16(pos, 20, true);
-    pos += 2; // version needed
-    view.setUint16(pos, 0, true);
-    pos += 2; // flags
-    view.setUint16(pos, 0, true);
-    pos += 2; // compression
-    view.setUint16(pos, 0, true);
-    pos += 2; // mod time
-    view.setUint16(pos, 0, true);
-    pos += 2; // mod date
-    view.setUint32(pos, entry.crc, true);
-    pos += 4; // crc32
-    view.setUint32(pos, entry.data.length, true);
-    pos += 4; // compressed
-    view.setUint32(pos, entry.data.length, true);
-    pos += 4; // uncompressed
-    view.setUint16(pos, entry.name.length, true);
-    pos += 2; // name length
-    view.setUint16(pos, 0, true);
-    pos += 2; // extra length
-    view.setUint16(pos, 0, true);
-    pos += 2; // comment length
-    view.setUint16(pos, 0, true);
-    pos += 2; // disk start
-    view.setUint16(pos, 0, true);
-    pos += 2; // internal attrs
-    view.setUint32(pos, 0, true);
-    pos += 4; // external attrs
-    view.setUint32(pos, localOff, true);
-    pos += 4; // local header offset
-    bytes.set(entry.name, pos);
-    pos += entry.name.length;
+    pos = writeCentralDirEntry(view, bytes, pos, localOff, entry);
   }
 
-  // End of central directory
-  view.setUint32(pos, 0x06054b50, true);
-  pos += 4;
-  view.setUint16(pos, 0, true);
-  pos += 2; // disk number
-  view.setUint16(pos, 0, true);
-  pos += 2; // central dir disk
-  view.setUint16(pos, entries.length, true);
-  pos += 2; // entries on disk
-  view.setUint16(pos, entries.length, true);
-  pos += 2; // total entries
-  view.setUint32(pos, centralSize, true);
-  pos += 4; // central dir size
-  view.setUint32(pos, centralStart, true);
-  pos += 4; // central dir offset
-  view.setUint16(pos, 0, true); // comment length
+  writeEndOfCentralDir(view, pos, entries.length, centralStart, centralSize);
 
   return buf;
 }
@@ -202,13 +224,7 @@ interface TriangleAttrs {
   p1: number;
 }
 
-function build3MFModel(
-  mesh: ShapeMesh,
-  name: string,
-  unit: string,
-  colors?: Map<number, [number, number, number, number]>,
-  materials?: Map<number, ThreeMFMaterial>
-): string {
+function buildVertexLines(mesh: ShapeMesh): string[] {
   const vertices: string[] = [];
   for (let i = 0; i < mesh.vertices.length; i += 3) {
     const x = mesh.vertices[i] ?? 0;
@@ -216,8 +232,14 @@ function build3MFModel(
     const z = mesh.vertices[i + 2] ?? 0;
     vertices.push(`        <vertex x="${x}" y="${y}" z="${z}" />`);
   }
+  return vertices;
+}
 
-  // Build deduped color palette (hex → index), resource id=2
+// Build deduped color palette (hex → index), resource id=2
+function buildColorPalette(colors?: Map<number, [number, number, number, number]>): {
+  colorIndexByHex: Map<string, number>;
+  colorHexList: string[];
+} {
   const colorIndexByHex = new Map<string, number>();
   const colorHexList: string[] = [];
   if (colors !== undefined && colors.size > 0) {
@@ -229,9 +251,15 @@ function build3MFModel(
       }
     }
   }
+  return { colorIndexByHex, colorHexList };
+}
 
-  // Build deduped materials list (name → index), resource id=3
-  // Use material name as dedup key since ThreeMFMaterial has no id.
+// Build deduped materials list (name → index), resource id=3
+// Use material name as dedup key since ThreeMFMaterial has no id.
+function buildMaterialList(materials?: Map<number, ThreeMFMaterial>): {
+  materialIndexByName: Map<string, number>;
+  materialList: ThreeMFMaterial[];
+} {
   const materialIndexByName = new Map<string, number>();
   const materialList: ThreeMFMaterial[] = [];
   if (materials !== undefined && materials.size > 0) {
@@ -242,9 +270,18 @@ function build3MFModel(
       }
     }
   }
+  return { materialIndexByName, materialList };
+}
 
-  // Build per-triangle pid/p1 lookup.
-  // Materials take priority over colors when both are present.
+// Build per-triangle pid/p1 lookup.
+// Materials take priority over colors when both are present.
+function buildTriangleAttrs(
+  mesh: ShapeMesh,
+  colors: Map<number, [number, number, number, number]> | undefined,
+  materials: Map<number, ThreeMFMaterial> | undefined,
+  colorIndexByHex: Map<string, number>,
+  materialIndexByName: Map<string, number>
+): Map<number, TriangleAttrs> {
   const triangleAttrs = new Map<number, TriangleAttrs>();
   for (const group of mesh.faceGroups) {
     const triStart = group.start / 3; // group.start is index offset into triangles array
@@ -282,7 +319,10 @@ function build3MFModel(
       }
     }
   }
+  return triangleAttrs;
+}
 
+function buildTriangleLines(mesh: ShapeMesh, triangleAttrs: Map<number, TriangleAttrs>): string[] {
   const triangles: string[] = [];
   for (let i = 0; i < mesh.triangles.length; i += 3) {
     const triIdx = i / 3;
@@ -298,8 +338,10 @@ function build3MFModel(
       triangles.push(`        <triangle v1="${v1}" v2="${v2}" v3="${v3}" />`);
     }
   }
+  return triangles;
+}
 
-  // Build resource blocks
+function buildResourceBlocks(colorHexList: string[], materialList: ThreeMFMaterial[]): string[] {
   const resourceBlocks: string[] = [];
 
   if (colorHexList.length > 0) {
@@ -317,6 +359,29 @@ function build3MFModel(
       .join('\n');
     resourceBlocks.push(`    <basematerials id="3">\n${matItems}\n    </basematerials>`);
   }
+
+  return resourceBlocks;
+}
+
+function build3MFModel(
+  mesh: ShapeMesh,
+  name: string,
+  unit: string,
+  colors?: Map<number, [number, number, number, number]>,
+  materials?: Map<number, ThreeMFMaterial>
+): string {
+  const vertices = buildVertexLines(mesh);
+  const { colorIndexByHex, colorHexList } = buildColorPalette(colors);
+  const { materialIndexByName, materialList } = buildMaterialList(materials);
+  const triangleAttrs = buildTriangleAttrs(
+    mesh,
+    colors,
+    materials,
+    colorIndexByHex,
+    materialIndexByName
+  );
+  const triangles = buildTriangleLines(mesh, triangleAttrs);
+  const resourceBlocks = buildResourceBlocks(colorHexList, materialList);
 
   const hasMaterials = materialList.length > 0;
   const materialsNs = hasMaterials

--- a/src/kernel/occt/advancedOps.ts
+++ b/src/kernel/occt/advancedOps.ts
@@ -693,121 +693,108 @@ export function fixSelfIntersection(oc: KernelInstance, wire: KernelShape): Kern
 // Measurement
 // ---------------------------------------------------------------------------
 
-/** Compute surface curvature at a UV point on a face. */
-export function surfaceCurvature(
-  oc: KernelInstance,
-  face: KernelShape,
-  u: number,
-  v: number
-): {
+type CurvatureResult = {
   gaussian: number;
   mean: number;
   max: number;
   min: number;
   maxDirection: [number, number, number];
   minDirection: [number, number, number];
-} {
-  const adaptor = new oc.BRepAdaptor_Surface_2(face, false);
+};
 
+function degenerateCurvature(): CurvatureResult {
+  return {
+    gaussian: 0,
+    mean: 0,
+    max: 0,
+    min: 0,
+    maxDirection: [1, 0, 0],
+    minDirection: [0, 1, 0],
+  };
+}
+
+/**
+ * Solve principal curvatures and one principal direction in (du, dv) coords
+ * from the first and second fundamental forms. Returns null if the system is
+ * degenerate (E*G - F*F ≈ 0).
+ */
+function solvePrincipalCurvatures(
+  E: number,
+  F: number,
+  G: number,
+  L: number,
+  M: number,
+  N2: number
+): { mean: number; gaussian: number; k1: number; k2: number; du1: number; dv1: number } | null {
+  const denom = E * G - F * F;
+  if (Math.abs(denom) < 1e-15) return null;
+
+  const mean = (E * N2 - 2 * F * M + G * L) / (2 * denom);
+  const gaussian = (L * N2 - M * M) / denom;
+  const sqrtDisc = Math.sqrt(Math.max(0, mean * mean - gaussian));
+  const k1 = mean + sqrtDisc;
+  const k2 = mean - sqrtDisc;
+
+  const a12 = (G * M - F * N2) / denom;
+  const a21 = (E * M - F * L) / denom;
+  const a11 = (G * L - F * M) / denom;
+
+  let du1: number, dv1: number;
+  if (Math.abs(a12) > 1e-15) {
+    du1 = a12;
+    dv1 = k1 - a11;
+  } else if (Math.abs(a21) > 1e-15) {
+    const a22 = (E * N2 - F * M) / denom;
+    du1 = k1 - a22;
+    dv1 = a21;
+  } else {
+    du1 = 1;
+    dv1 = 0;
+  }
+
+  return { mean, gaussian, k1, k2, du1, dv1 };
+}
+
+/** Compute surface curvature at a UV point on a face. */
+export function surfaceCurvature(
+  oc: KernelInstance,
+  face: KernelShape,
+  u: number,
+  v: number
+): CurvatureResult {
+  const adaptor = new oc.BRepAdaptor_Surface_2(face, false);
   const P = new oc.gp_Pnt_1();
   const D1U = new oc.gp_Vec_1();
   const D1V = new oc.gp_Vec_1();
   const D2U = new oc.gp_Vec_1();
   const D2V = new oc.gp_Vec_1();
   const D2UV = new oc.gp_Vec_1();
-
   adaptor.D2(u, v, P, D1U, D1V, D2U, D2V, D2UV);
 
-  // First fundamental form
   const E = D1U.Dot(D1U);
   const F = D1U.Dot(D1V);
   const G = D1V.Dot(D1V);
 
-  // Surface normal
   const N = D1U.Crossed(D1V);
   const nLen = N.Magnitude();
 
-  let result: {
-    gaussian: number;
-    mean: number;
-    max: number;
-    min: number;
-    maxDirection: [number, number, number];
-    minDirection: [number, number, number];
-  };
-
-  if (nLen < 1e-15) {
-    result = {
-      gaussian: 0,
-      mean: 0,
-      max: 0,
-      min: 0,
-      maxDirection: [1, 0, 0],
-      minDirection: [0, 1, 0],
-    };
-  } else {
+  let result: CurvatureResult = degenerateCurvature();
+  if (nLen >= 1e-15) {
     N.Divide(nLen);
-
     const L = D2U.Dot(N);
     const M = D2UV.Dot(N);
     const N2 = D2V.Dot(N);
-    const denom = E * G - F * F;
-
-    if (Math.abs(denom) < 1e-15) {
-      P.delete();
-      D1U.delete();
-      D1V.delete();
-      D2U.delete();
-      D2V.delete();
-      D2UV.delete();
-      N.delete();
-      adaptor.delete();
-      return {
-        gaussian: 0,
-        mean: 0,
-        max: 0,
-        min: 0,
-        maxDirection: [1, 0, 0],
-        minDirection: [0, 1, 0],
+    const solved = solvePrincipalCurvatures(E, F, G, L, M, N2);
+    if (solved) {
+      result = {
+        gaussian: solved.gaussian,
+        mean: solved.mean,
+        max: solved.k1,
+        min: solved.k2,
+        maxDirection: dirFromUV(D1U, D1V, solved.du1, solved.dv1),
+        minDirection: dirFromUV(D1U, D1V, -solved.dv1, solved.du1),
       };
     }
-
-    const mean = (E * N2 - 2 * F * M + G * L) / (2 * denom);
-    const gaussian = (L * N2 - M * M) / denom;
-    const disc = Math.max(0, mean * mean - gaussian);
-    const sqrtDisc = Math.sqrt(disc);
-    const k1 = mean + sqrtDisc;
-    const k2 = mean - sqrtDisc;
-
-    // Principal directions via Weingarten map
-    const a12 = (G * M - F * N2) / denom;
-    const a21 = (E * M - F * L) / denom;
-    const a11 = (G * L - F * M) / denom;
-
-    let du1: number, dv1: number;
-    if (Math.abs(a12) > 1e-15) {
-      du1 = a12;
-      dv1 = k1 - a11;
-    } else if (Math.abs(a21) > 1e-15) {
-      const a22 = (E * N2 - F * M) / denom;
-      du1 = k1 - a22;
-      dv1 = a21;
-    } else {
-      du1 = 1;
-      dv1 = 0;
-    }
-
-    const maxDir = dirFromUV(D1U, D1V, du1, dv1);
-    const minDir = dirFromUV(D1U, D1V, -dv1, du1);
-
-    result = {
-      gaussian,
-      mean,
-      max: k1,
-      min: k2,
-      maxDirection: maxDir,
-      minDirection: minDir,
-    };
   }
 
   P.delete();
@@ -1093,91 +1080,69 @@ export function writeXCAFToSTEP(
 // Export: STEP configured
 // ---------------------------------------------------------------------------
 
-/** Export shapes to STEP with full configuration. */
-export function exportSTEPConfigured(
-  oc: KernelInstance,
-  shapes: Array<{
-    shape: KernelShape;
-    name?: string | undefined;
-    color?: [number, number, number, number] | undefined;
-  }>,
-  options: {
-    unit?: string | undefined;
-    modelUnit?: string | undefined;
-    schema?: number | undefined;
-  } = {}
-): string {
-  const unit = options.unit ?? 'MM';
-  const modelUnit = options.modelUnit ?? unit;
-  const schema = options.schema ?? 5;
+type ConfiguredStepPart = {
+  shape: KernelShape;
+  name?: string | undefined;
+  color?: [number, number, number, number] | undefined;
+};
 
-  oc.Interface_Static.SetCVal('xstep.cascade.unit', modelUnit);
-  oc.Interface_Static.SetCVal('write.step.unit', unit);
-  oc.Interface_Static.SetIVal('write.surfacecurve.mode', true);
-  oc.Interface_Static.SetIVal('write.precision.mode', 0);
-  oc.Interface_Static.SetIVal('write.step.assembly', 2);
-  oc.Interface_Static.SetIVal('write.step.schema', schema);
+function exportStepConfiguredXCAF(oc: KernelInstance, shapes: ConfiguredStepPart[]): string {
+  const initWriter = new oc.STEPCAFControl_Writer_1();
+  initWriter.delete();
 
-  const hasMetadata = shapes.some((s) => s.name || s.color);
+  const nameStr = new oc.TCollection_ExtendedString_2('XmlOcaf', true);
+  const doc = new oc.TDocStd_Document(nameStr);
+  nameStr.delete();
 
-  if (hasMetadata) {
-    // Use XCAF path for named/colored parts
-    const initWriter = new oc.STEPCAFControl_Writer_1();
-    initWriter.delete();
+  const mainLabel = doc.Main();
+  const shapeTool = oc.XCAFDoc_DocumentTool.ShapeTool(mainLabel).get();
+  const colorTool = oc.XCAFDoc_DocumentTool.ColorTool(mainLabel).get();
+  oc.XCAFDoc_ShapeTool.SetAutoNaming(false);
 
-    const nameStr = new oc.TCollection_ExtendedString_2('XmlOcaf', true);
-    const doc = new oc.TDocStd_Document(nameStr);
-    nameStr.delete();
+  for (const part of shapes) {
+    const shapeNode = shapeTool.AddShape(part.shape, false, true);
 
-    const mainLabel = doc.Main();
-    const shapeTool = oc.XCAFDoc_DocumentTool.ShapeTool(mainLabel).get();
-    const colorTool = oc.XCAFDoc_DocumentTool.ColorTool(mainLabel).get();
-    oc.XCAFDoc_ShapeTool.SetAutoNaming(false);
-
-    for (const part of shapes) {
-      const shapeNode = shapeTool.AddShape(part.shape, false, true);
-
-      if (part.name) {
-        const partName = new oc.TCollection_ExtendedString_2(part.name, true);
-        oc.TDataStd_Name.Set_1(shapeNode, partName);
-        partName.delete();
-      }
-
-      if (part.color) {
-        const [r, g, b, a] = part.color;
-        const rgba = new oc.Quantity_ColorRGBA_5(r / 255, g / 255, b / 255, a / 255);
-        colorTool.SetColor_3(shapeNode, rgba, oc.XCAFDoc_ColorType.XCAFDoc_ColorSurf);
-        rgba.delete();
-      }
+    if (part.name) {
+      const partName = new oc.TCollection_ExtendedString_2(part.name, true);
+      oc.TDataStd_Name.Set_1(shapeNode, partName);
+      partName.delete();
     }
 
-    const session = new oc.XSControl_WorkSession();
-    const sessionHandle = new oc.Handle_XSControl_WorkSession_2(session);
-    const writer = new oc.STEPCAFControl_Writer_2(sessionHandle, false);
-    const docHandle = new oc.Handle_TDocStd_Document_2(doc);
-    const progress = new oc.Message_ProgressRange_1();
-    writer.Transfer_1(docHandle, oc.STEPControl_StepModelType.STEPControl_AsIs, null, progress);
-    progress.delete();
-
-    const filename = uniqueIOFilename('_step_cfg_export', 'step');
-    const status = writer.Write(filename);
-
-    let result = '';
-    if (status === oc.IFSelect_ReturnStatus.IFSelect_RetDone) {
-      const content = oc.FS.readFile('/' + filename);
-      result = new TextDecoder().decode(content);
-      oc.FS.unlink('/' + filename);
+    if (part.color) {
+      const [r, g, b, a] = part.color;
+      const rgba = new oc.Quantity_ColorRGBA_5(r / 255, g / 255, b / 255, a / 255);
+      colorTool.SetColor_3(shapeNode, rgba, oc.XCAFDoc_ColorType.XCAFDoc_ColorSurf);
+      rgba.delete();
     }
-
-    writer.delete();
-    sessionHandle.delete();
-    docHandle.delete();
-    doc.delete();
-
-    return result;
   }
 
-  // Simple path: no metadata
+  const session = new oc.XSControl_WorkSession();
+  const sessionHandle = new oc.Handle_XSControl_WorkSession_2(session);
+  const writer = new oc.STEPCAFControl_Writer_2(sessionHandle, false);
+  const docHandle = new oc.Handle_TDocStd_Document_2(doc);
+  const progress = new oc.Message_ProgressRange_1();
+  writer.Transfer_1(docHandle, oc.STEPControl_StepModelType.STEPControl_AsIs, null, progress);
+  progress.delete();
+
+  const filename = uniqueIOFilename('_step_cfg_export', 'step');
+  const status = writer.Write(filename);
+
+  let result = '';
+  if (status === oc.IFSelect_ReturnStatus.IFSelect_RetDone) {
+    const content = oc.FS.readFile('/' + filename);
+    result = new TextDecoder().decode(content);
+    oc.FS.unlink('/' + filename);
+  }
+
+  writer.delete();
+  sessionHandle.delete();
+  docHandle.delete();
+  doc.delete();
+
+  return result;
+}
+
+function exportStepConfiguredSimple(oc: KernelInstance, shapes: ConfiguredStepPart[]): string {
   const writer = new oc.STEPControl_Writer_1();
   writer.Model(true).delete();
   const progress = new oc.Message_ProgressRange_1();
@@ -1197,6 +1162,33 @@ export function exportSTEPConfigured(
     return new TextDecoder().decode(file);
   }
   throw new Error('STEP configured export failed: writer did not complete successfully');
+}
+
+/** Export shapes to STEP with full configuration. */
+export function exportSTEPConfigured(
+  oc: KernelInstance,
+  shapes: ConfiguredStepPart[],
+  options: {
+    unit?: string | undefined;
+    modelUnit?: string | undefined;
+    schema?: number | undefined;
+  } = {}
+): string {
+  const unit = options.unit ?? 'MM';
+  const modelUnit = options.modelUnit ?? unit;
+  const schema = options.schema ?? 5;
+
+  oc.Interface_Static.SetCVal('xstep.cascade.unit', modelUnit);
+  oc.Interface_Static.SetCVal('write.step.unit', unit);
+  oc.Interface_Static.SetIVal('write.surfacecurve.mode', true);
+  oc.Interface_Static.SetIVal('write.precision.mode', 0);
+  oc.Interface_Static.SetIVal('write.step.assembly', 2);
+  oc.Interface_Static.SetIVal('write.step.schema', schema);
+
+  const hasMetadata = shapes.some((s) => s.name || s.color);
+  return hasMetadata
+    ? exportStepConfiguredXCAF(oc, shapes)
+    : exportStepConfiguredSimple(oc, shapes);
 }
 
 /** Co-located factory: returns the advanced-ops slice of {@link KernelAdapter} bound to `oc`. */

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -189,19 +189,22 @@ export function thicken(shape: Face | Shell, thickness: number): Result<Solid> {
 // Fillet
 // ---------------------------------------------------------------------------
 
+type FilletRadiusArg =
+  | number
+  | [number, number]
+  | ((edge: Edge) => number | [number, number] | null);
+
+type FilletKernelRadius = number | [number, number] | KernelHashCallback<number | [number, number]>;
+
 /**
- * Apply a fillet (rounded edge) to selected edges of a 3D shape.
- *
- * @param shape - The shape to modify.
- * @param edges - Edges to fillet. Pass `undefined` to fillet all edges.
- * @param radius - Constant radius, variable radius `[r1, r2]`, or per-edge callback.
+ * Validate fillet inputs and resolve the user-supplied radius into a
+ * kernel-ready value paired with the filtered edge list.
  */
-export function fillet(
+function normalizeFilletInputs(
   shape: ValidSolid,
   edges: ReadonlyArray<Edge> | undefined,
-  radius: number | [number, number] | ((edge: Edge) => number | [number, number] | null),
-  { trackEvolution = true }: { trackEvolution?: boolean | undefined } = {}
-): Result<ValidSolid> {
+  radius: FilletRadiusArg
+): Result<{ filteredEdges: Edge[]; kernelRadius: FilletKernelRadius; selectedCount: number }> {
   const check = validateNotNull(shape, 'fillet: shape');
   if (isErr(check)) return check;
   const paramErr = validatePositiveParam(radius, {
@@ -226,36 +229,55 @@ export function fillet(
     );
   }
 
-  try {
-    let filteredEdges: Edge[];
-    let kernelRadius: number | [number, number] | KernelHashCallback<number | [number, number]>;
-
-    if (typeof radius === 'function') {
-      const resolved = resolveEdgeCallback(selectedEdges, radius);
-      if (!resolved) {
-        return err(
-          validationError(
-            BrepErrorCode.FILLET_NO_EDGES,
-            'No edges with positive radius for fillet',
-            undefined,
-            undefined,
-            'Check that the radius callback returns positive values'
-          )
-        );
-      }
-      filteredEdges = resolved.edges;
-      kernelRadius = resolved.kernelParam;
-    } else {
-      filteredEdges = [...selectedEdges];
-      kernelRadius = radius;
+  if (typeof radius === 'function') {
+    const resolved = resolveEdgeCallback(selectedEdges, radius);
+    if (!resolved) {
+      return err(
+        validationError(
+          BrepErrorCode.FILLET_NO_EDGES,
+          'No edges with positive radius for fillet',
+          undefined,
+          undefined,
+          'Check that the radius callback returns positive values'
+        )
+      );
     }
+    return ok({
+      filteredEdges: resolved.edges,
+      kernelRadius: resolved.kernelParam,
+      selectedCount: selectedEdges.length,
+    });
+  }
+
+  return ok({
+    filteredEdges: [...selectedEdges],
+    kernelRadius: radius,
+    selectedCount: selectedEdges.length,
+  });
+}
+
+/**
+ * Apply a fillet (rounded edge) to selected edges of a 3D shape.
+ *
+ * @param shape - The shape to modify.
+ * @param edges - Edges to fillet. Pass `undefined` to fillet all edges.
+ * @param radius - Constant radius, variable radius `[r1, r2]`, or per-edge callback.
+ */
+export function fillet(
+  shape: ValidSolid,
+  edges: ReadonlyArray<Edge> | undefined,
+  radius: number | [number, number] | ((edge: Edge) => number | [number, number] | null),
+  { trackEvolution = true }: { trackEvolution?: boolean | undefined } = {}
+): Result<ValidSolid> {
+  const normalized = normalizeFilletInputs(shape, edges, radius);
+  if (isErr(normalized)) return normalized;
+  const { filteredEdges, kernelRadius, selectedCount } = normalized.value;
+
+  try {
+    const edgeShapes = filteredEdges.map((e) => e.wrapped);
 
     if (!trackEvolution) {
-      const resultShape = getKernel().fillet(
-        shape.wrapped,
-        filteredEdges.map((e) => e.wrapped),
-        kernelRadius
-      );
+      const resultShape = getKernel().fillet(shape.wrapped, edgeShapes, kernelRadius);
       const cast = castShape(resultShape);
       if (!isShape3D(cast)) {
         return err(kernelError(BrepErrorCode.FILLET_NOT_3D, 'Fillet result is not a 3D shape'));
@@ -266,7 +288,7 @@ export function fillet(
     const inputFaceHashes = collectInputFaceHashes([shape]);
     const { shape: resultShape, evolution } = getKernel().filletWithHistory(
       shape.wrapped,
-      filteredEdges.map((e) => e.wrapped),
+      edgeShapes,
       kernelRadius,
       inputFaceHashes,
       HASH_CODE_MAX
@@ -283,7 +305,7 @@ export function fillet(
     return err(
       kernelError('FILLET_FAILED', `Fillet operation failed: ${raw}`, e, {
         operation: 'fillet',
-        edgeCount: selectedEdges.length,
+        edgeCount: selectedCount,
         radius,
       })
     );
@@ -484,25 +506,14 @@ export function offset(shape: ValidSolid, distance: number, tolerance = 1e-6): R
 // ---------------------------------------------------------------------------
 
 /**
- * Apply a draft (taper) to selected faces of a 3D shape.
- *
- * Draft tilts faces by a specified angle relative to a pull direction,
- * pivoting about a neutral plane. This is essential for injection molding
- * and casting workflows where parts must release from a mold.
- *
- * @param shape - The solid to modify.
- * @param faces - Faces to draft.
- * @param pullDirection - Mold opening direction vector.
- * @param neutralPlane - A point on the plane where faces are not displaced.
- * @param angle - Constant angle in degrees, or per-face callback returning degrees (null to skip).
+ * Validate draft inputs (null shape, scalar angle bounds, faces non-empty).
+ * Returns an Err Result on failure, `undefined` on success.
  */
-export function draft(
+function validateDraftInputs(
   shape: ValidSolid,
   faces: ReadonlyArray<Face>,
-  pullDirection: Vec3,
-  neutralPlane: Vec3,
   angle: DraftAngle
-): Result<ValidSolid> {
+): Err<BrepError> | undefined {
   const check = validateNotNull(shape, 'draft: shape');
   if (isErr(check)) return check;
 
@@ -542,6 +553,32 @@ export function draft(
       )
     );
   }
+
+  return undefined;
+}
+
+/**
+ * Apply a draft (taper) to selected faces of a 3D shape.
+ *
+ * Draft tilts faces by a specified angle relative to a pull direction,
+ * pivoting about a neutral plane. This is essential for injection molding
+ * and casting workflows where parts must release from a mold.
+ *
+ * @param shape - The solid to modify.
+ * @param faces - Faces to draft.
+ * @param pullDirection - Mold opening direction vector.
+ * @param neutralPlane - A point on the plane where faces are not displaced.
+ * @param angle - Constant angle in degrees, or per-face callback returning degrees (null to skip).
+ */
+export function draft(
+  shape: ValidSolid,
+  faces: ReadonlyArray<Face>,
+  pullDirection: Vec3,
+  neutralPlane: Vec3,
+  angle: DraftAngle
+): Result<ValidSolid> {
+  const inputErr = validateDraftInputs(shape, faces, angle);
+  if (inputErr) return inputErr;
 
   try {
     const { filteredFaces, kernelAngle } = resolveDraftCallback(faces, angle);


### PR DESCRIPTION
## Summary

Wave 3 of `.pattern-baseline.json` pay-down. Four focused commits, all pure `max-function-lines` decomposition — no behavior or API changes.

1. **`refactor(io): decompose 3mf builders into per-zip-entry and per-section helpers`** — `buildZip` (95 → ~25 effective lines) extracts `writeLocalHeader`, `writeCentralDirEntry`, `writeEndOfCentralDir`. `build3MFModel` (93 → ~22 lines) extracts `buildVertexLines`, `buildColorPalette`, `buildMaterialList`, `buildTriangleAttrs`, `buildTriangleLines`, `buildResourceBlocks`. Drops 2 entries.

2. **`refactor(topology): extract argument normalization from fillet and draft`** — `fillet` (76 → under 60) extracts `normalizeFilletInputs` (null check + radius validation + edge selection + per-edge callback filtering). `draft` (72 → under 60) extracts `validateDraftInputs` (matches sibling `validatePositiveParam` style). All overload signatures preserved verbatim. Drops 2 entries.

3. **`refactor(occt): extract helpers from surfaceCurvature and exportSTEPConfigured`** — `surfaceCurvature` (93 → ~33) extracts `degenerateCurvature` and `solvePrincipalCurvatures`. `exportSTEPConfigured` (65 → ~22) extracts `exportStepConfiguredXCAF` and `exportStepConfiguredSimple`. All 8 OCCT WASM `.delete()` calls preserved inside their owning function — no lifetime changes. Drops 2 entries.

4. **`refactor(io): decompose gltf builder functions into per-section helpers`** — `buildGltfDocument` (71 → under 60) extracts `buildSingleAccessors`, `buildSingleBufferViews`. `buildGltfDocFromLayout` (72 → under 60) extracts `appendVertexNormalSections`, `appendIndexPrimitives`. Byte offset expressions and write ordering preserved verbatim so binary buffer is byte-identical. Drops 2 entries.

## Baseline impact

| Rule                 | Before | After | Δ   |
| -------------------- | ------ | ----- | --- |
| `no-double-cast`     | 4      | 4     | 0   |
| `max-function-lines` | 13     | 5     | -8  |
| `max-nesting-depth`  | 1      | 1     | 0   |
| **Total**            | **18** | **10**| **-8** |

Cumulative pay-down across PRs #1053, #1054, #1055, and this one: **53 → 10 entries (~81% reduction)**. Remaining 10 are spread across 9 files (no file has more than 1, except `core/dimensionTypes.ts` with 2 `no-double-cast`).

## Test plan

- [x] `npm run validate` (typecheck + lint + boundaries + format + changed tests) passes locally
- [x] Pre-push: full `test:full` + `knip` passes
- [x] All four target files: pattern checker `--no-baseline` reports zero violations
- [x] No behavior, API, or export changes — purely internal restructuring
- [ ] CI passes on the PR

(Will not arm automerge until Greptile review completes — per the workflow learned the hard way on #1055.)