### PR TITLE
feat(bim): add Psets, Qtos, and material grouping — M2

### DIFF
--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -174,6 +174,7 @@ export function writeWallBaseQuantities(
     qtyLength('Height', heightM),
     qtyArea('GrossFootprintArea', footprintM2),
     qtyVolume('GrossVolume', volumeM3),
+    // NetVolume equals GrossVolume until opening geometry is tracked (M3+).
     qtyVolume('NetVolume', volumeM3),
   ];
 

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -1,0 +1,193 @@
+import * as WebIFC from 'web-ifc';
+import type { IfcWriter } from './ifcWriter.js';
+import { newIfcGuid } from '../identity/ifcGuid.js';
+import type { WallSpec } from '../specs/wallSpec.js';
+import { toIfcLengthM } from '../units/units.js';
+
+type PsetValue = string | number | boolean;
+
+function writePsetValue(w: IfcWriter, value: PsetValue): Record<string, unknown> {
+  if (typeof value === 'boolean') {
+    return w.mkType(WebIFC.IFCBOOLEAN, value);
+  }
+  if (typeof value === 'number') {
+    return w.mkType(WebIFC.IFCREAL, value);
+  }
+  return w.mkType(WebIFC.IFCLABEL, value);
+}
+
+function writePropertySingleValue(w: IfcWriter, name: string, value: PsetValue): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCPROPERTYSINGLEVALUE,
+    Name: w.mkType(WebIFC.IFCIDENTIFIER, name),
+    Description: null,
+    NominalValue: writePsetValue(w, value),
+    Unit: null,
+  });
+  return id;
+}
+
+function writePropertySet(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  name: string,
+  properties: Record<string, PsetValue>
+): number {
+  const propIds = Object.entries(properties).map(([k, v]) =>
+    writePropertySingleValue(w, k, v)
+  );
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCPROPERTYSET,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    HasProperties: propIds.map((pid) => w.ref(pid)),
+  });
+  return id;
+}
+
+function writeRelDefinesByProperties(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  wallExpressId: number,
+  psetId: number
+): void {
+  w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCRELDEFINESBYPROPERTIES,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: null,
+    Description: null,
+    RelatedObjects: [w.ref(wallExpressId)],
+    RelatingPropertyDefinition: w.ref(psetId),
+  });
+}
+
+export function writeWallCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  wallExpressId: number,
+  spec: WallSpec
+): void {
+  const props: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
+  if (spec.loadBearing !== undefined) props['LoadBearing'] = spec.loadBearing;
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_WallCommon', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
+}
+
+export function writeManufacturerPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  wallExpressId: number,
+  spec: WallSpec
+): void {
+  const props: Record<string, PsetValue> = {};
+  if (spec.manufacturerName !== undefined) props['Manufacturer'] = spec.manufacturerName;
+  if (spec.manufacturerModel !== undefined) props['ModelLabel'] = spec.manufacturerModel;
+  if (spec.manufacturerProductionYear !== undefined) props['ProductionYear'] = spec.manufacturerProductionYear;
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_ManufacturerTypeInformation', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
+}
+
+export function writeCustomPsets(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  wallExpressId: number,
+  customProperties: Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+): void {
+  for (const [psetName, props] of Object.entries(customProperties)) {
+    if (Object.keys(props).length === 0) continue;
+    const psetId = writePropertySet(w, ownerHistoryId, psetName, { ...props });
+    writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
+  }
+}
+
+export function writeWallBaseQuantities(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  wallExpressId: number,
+  spec: WallSpec
+): void {
+  const lengthM = toIfcLengthM(spec.length);
+  const widthM = toIfcLengthM(spec.thickness);
+  const heightM = toIfcLengthM(spec.height);
+  const footprintM2 = lengthM * widthM;
+  const volumeM3 = lengthM * widthM * heightM;
+
+  const qtyLength = (name: string, value: number): number => {
+    const id = w.nextId();
+    w.writeLine({
+      expressID: id,
+      type: WebIFC.IFCQUANTITYLENGTH,
+      Name: w.mkType(WebIFC.IFCLABEL, name),
+      Description: null,
+      Unit: null,
+      LengthValue: w.mkType(WebIFC.IFCLENGTHMEASURE, value),
+      Formula: null,
+    });
+    return id;
+  };
+
+  const qtyArea = (name: string, value: number): number => {
+    const id = w.nextId();
+    w.writeLine({
+      expressID: id,
+      type: WebIFC.IFCQUANTITYAREA,
+      Name: w.mkType(WebIFC.IFCLABEL, name),
+      Description: null,
+      Unit: null,
+      AreaValue: w.mkType(WebIFC.IFCAREAMEASURE, value),
+      Formula: null,
+    });
+    return id;
+  };
+
+  const qtyVolume = (name: string, value: number): number => {
+    const id = w.nextId();
+    w.writeLine({
+      expressID: id,
+      type: WebIFC.IFCQUANTITYVOLUME,
+      Name: w.mkType(WebIFC.IFCLABEL, name),
+      Description: null,
+      Unit: null,
+      VolumeValue: w.mkType(WebIFC.IFCVOLUMEMEASURE, value),
+      Formula: null,
+    });
+    return id;
+  };
+
+  const qtyIds = [
+    qtyLength('Length', lengthM),
+    qtyLength('Width', widthM),
+    qtyLength('Height', heightM),
+    qtyArea('GrossFootprintArea', footprintM2),
+    qtyVolume('GrossVolume', volumeM3),
+    qtyVolume('NetVolume', volumeM3),
+  ];
+
+  const qtoId = w.nextId();
+  w.writeLine({
+    expressID: qtoId,
+    type: WebIFC.IFCELEMENTQUANTITY,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, 'Qto_WallBaseQuantities'),
+    Description: null,
+    MethodOfMeasurement: null,
+    Quantities: qtyIds.map((id) => w.ref(id)),
+  });
+
+  writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, qtoId);
+}

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -21,7 +21,6 @@ import {
   writeCustomPsets,
   writeWallBaseQuantities,
 } from '../ifc-writer/psetWriter.js';
-import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { BimError } from '../errors/bimError.js';
 import { ifcError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
@@ -125,18 +124,22 @@ export async function toIfc(
     );
   }
 
-  const byMaterial = new Map<string, number[]>();
+  const byMaterial = new Map<string, { guid: string; ids: number[] }>();
   for (const rel of relationships) {
     if (rel.kind !== 'ASSOCIATES_MATERIAL') continue;
     const objectExpressIds = rel.relatedObjects
       .map((id) => idMap.get(id))
       .filter((id): id is number => id !== undefined);
-    const existing = byMaterial.get(rel.materialName) ?? [];
-    byMaterial.set(rel.materialName, [...existing, ...objectExpressIds]);
+    const existing = byMaterial.get(rel.materialName);
+    if (existing !== undefined) {
+      byMaterial.set(rel.materialName, { guid: existing.guid, ids: [...existing.ids, ...objectExpressIds] });
+    } else {
+      byMaterial.set(rel.materialName, { guid: rel.guid, ids: objectExpressIds });
+    }
   }
-  for (const [materialName, wallIds] of byMaterial) {
-    if (wallIds.length === 0) continue;
-    writeRelAssociatesMaterial(w, newIfcGuid(), ownerHistoryId, materialName, wallIds);
+  for (const [materialName, { guid, ids }] of byMaterial) {
+    if (ids.length === 0) continue;
+    writeRelAssociatesMaterial(w, guid, ownerHistoryId, materialName, ids);
   }
 
   return w.save();

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -15,6 +15,13 @@ import {
   writeRelContainedInSpatialStructure,
   writeRelAssociatesMaterial,
 } from '../ifc-writer/relWriter.js';
+import {
+  writeWallCommonPset,
+  writeManufacturerPset,
+  writeCustomPsets,
+  writeWallBaseQuantities,
+} from '../ifc-writer/psetWriter.js';
+import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { BimError } from '../errors/bimError.js';
 import { ifcError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
@@ -88,6 +95,12 @@ export async function toIfc(
       w, wall.guid, `Wall ${i + 1}`, ownerHistoryId, localPlacementId, productDefinitionShapeId
     );
     idMap.set(wall.localId, wallExpressId);
+    writeWallCommonPset(w, ownerHistoryId, wallExpressId, wall.spec);
+    writeManufacturerPset(w, ownerHistoryId, wallExpressId, wall.spec);
+    if (wall.spec.customProperties !== undefined) {
+      writeCustomPsets(w, ownerHistoryId, wallExpressId, wall.spec.customProperties);
+    }
+    writeWallBaseQuantities(w, ownerHistoryId, wallExpressId, wall.spec);
   }
 
   for (const rel of relationships) {
@@ -112,15 +125,18 @@ export async function toIfc(
     );
   }
 
+  const byMaterial = new Map<string, number[]>();
   for (const rel of relationships) {
     if (rel.kind !== 'ASSOCIATES_MATERIAL') continue;
     const objectExpressIds = rel.relatedObjects
       .map((id) => idMap.get(id))
       .filter((id): id is number => id !== undefined);
-    if (objectExpressIds.length === 0) continue;
-    writeRelAssociatesMaterial(
-      w, rel.guid, ownerHistoryId, rel.materialName, objectExpressIds
-    );
+    const existing = byMaterial.get(rel.materialName) ?? [];
+    byMaterial.set(rel.materialName, [...existing, ...objectExpressIds]);
+  }
+  for (const [materialName, wallIds] of byMaterial) {
+    if (wallIds.length === 0) continue;
+    writeRelAssociatesMaterial(w, newIfcGuid(), ownerHistoryId, materialName, wallIds);
   }
 
   return w.save();

--- a/packages/brepjs-bim/src/specs/wallSpec.ts
+++ b/packages/brepjs-bim/src/specs/wallSpec.ts
@@ -4,7 +4,6 @@ import { specError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 
-/** A straight wall aligned along an arbitrary axis in 3D. All dimensions in mm. */
 export interface WallSpec {
   readonly length: number;
   readonly height: number;
@@ -13,6 +12,20 @@ export interface WallSpec {
   readonly axisX: [number, number, number];
   readonly axisZ: [number, number, number];
   readonly materialName: string;
+
+  readonly isExternal?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+  readonly loadBearing?: boolean | undefined;
+
+  readonly manufacturerName?: string | undefined;
+  readonly manufacturerModel?: string | undefined;
+  readonly manufacturerProductionYear?: number | undefined;
+
+  readonly customProperties?:
+    | Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+    | undefined;
 }
 
 const unitVec = z.tuple([z.number(), z.number(), z.number()]).refine(
@@ -28,10 +41,32 @@ const WallSpecSchema = z.object({
   axisX: unitVec,
   axisZ: unitVec,
   materialName: z.string().min(1),
+
+  isExternal: z.boolean().optional(),
+  fireRating: z.string().optional(),
+  acousticRating: z.string().optional(),
+  thermalTransmittance: z.number().positive().optional(),
+  loadBearing: z.boolean().optional(),
+
+  manufacturerName: z.string().optional(),
+  manufacturerModel: z.string().optional(),
+  manufacturerProductionYear: z.number().int().positive().optional(),
+
+  customProperties: z.record(
+    z.string(),
+    z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+  ).optional(),
 }).superRefine((data, ctx) => {
-  const dot = data.axisX[0] * data.axisZ[0] + data.axisX[1] * data.axisZ[1] + data.axisX[2] * data.axisZ[2];
+  const dot =
+    data.axisX[0] * data.axisZ[0] +
+    data.axisX[1] * data.axisZ[1] +
+    data.axisX[2] * data.axisZ[2];
   if (Math.abs(dot) > 1e-6) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'axisX and axisZ must be orthogonal', path: ['axisZ'] });
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'axisX and axisZ must be orthogonal',
+      path: ['axisZ'],
+    });
   }
 });
 

--- a/packages/brepjs-bim/src/specs/wallSpec.ts
+++ b/packages/brepjs-bim/src/specs/wallSpec.ts
@@ -4,6 +4,7 @@ import { specError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 
+/** A straight wall aligned along an arbitrary axis in 3D. All dimensions in mm. */
 export interface WallSpec {
   readonly length: number;
   readonly height: number;

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -86,3 +86,164 @@ describe('IFC round-trip (M1)', () => {
     api.CloseModel(modelId);
   });
 });
+
+describe('IFC Pset/Qto round-trip (M2)', () => {
+  const PSET_SPEC = {
+    length: 4000,
+    height: 3000,
+    thickness: 300,
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    materialName: 'Concrete',
+    isExternal: true,
+    fireRating: 'REI90',
+    thermalTransmittance: 0.3,
+    loadBearing: true,
+    manufacturerName: 'Wienerberger',
+    customProperties: {
+      'Pset_Acoustic': { SoundReductionIndex: 45 },
+    },
+  };
+
+  async function buildPsetModel(): Promise<{ bytes: Uint8Array; api: WebIFC.IfcAPI; mid: number }> {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'Pset Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const projectLocalId = initResult.value;
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(projectLocalId, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const wallResult = model.addWall(PSET_SPEC);
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    model.placeIn(wallResult.value, storeyId);
+
+    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    if (!result.ok) throw new Error(result.error.message);
+
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    return { bytes: result.value, api, mid };
+  }
+
+  it('emits at least one IfcPropertySet', async () => {
+    const { api, mid } = await buildPsetModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    expect(ids.size()).toBeGreaterThan(0);
+    api.CloseModel(mid);
+  });
+
+  it('emits Pset_WallCommon', async () => {
+    const { api, mid } = await buildPsetModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+      const pset = api.GetLine(mid, ids.get(i));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+      if ((pset.Name?.value as string | undefined) === 'Pset_WallCommon') {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('emits Pset_ManufacturerTypeInformation', async () => {
+    const { api, mid } = await buildPsetModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+      const pset = api.GetLine(mid, ids.get(i));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+      if ((pset.Name?.value as string | undefined) === 'Pset_ManufacturerTypeInformation') {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('emits custom Pset_Acoustic', async () => {
+    const { api, mid } = await buildPsetModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+      const pset = api.GetLine(mid, ids.get(i));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+      if ((pset.Name?.value as string | undefined) === 'Pset_Acoustic') {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('emits Qto_WallBaseQuantities', async () => {
+    const { api, mid } = await buildPsetModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+      const qto = api.GetLine(mid, ids.get(i));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+      if ((qto.Name?.value as string | undefined) === 'Qto_WallBaseQuantities') {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('emits IfcRelDefinesByProperties linking wall to Psets', async () => {
+    const { api, mid } = await buildPsetModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCRELDEFINESBYPROPERTIES);
+    expect(ids.size()).toBeGreaterThan(0);
+    api.CloseModel(mid);
+  });
+
+  it('wall without Pset fields emits no IfcPropertySet but always emits Qto', async () => {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'No-Pset Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const projectLocalId = initResult.value;
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(projectLocalId, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const wallResult = model.addWall({
+      length: 3000, height: 2700, thickness: 200,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    model.placeIn(wallResult.value, storeyId);
+
+    const result = await toIfc(model, { applicationName: 'test', applicationVersion: '0' });
+    if (!result.ok) throw new Error(result.error.message);
+
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+
+    const psetIds = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    expect(psetIds.size()).toBe(0);
+
+    const qtoIds = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    expect(qtoIds.size()).toBe(1);
+
+    api.CloseModel(mid);
+  });
+});

--- a/packages/brepjs-bim/tests/wallFns.test.ts
+++ b/packages/brepjs-bim/tests/wallFns.test.ts
@@ -98,4 +98,49 @@ describe('parseWallSpec', () => {
     const { materialName: _, ...noMaterial } = valid;
     expect(parseWallSpec(noMaterial).ok).toBe(false);
   });
+
+  it('accepts spec with Pset_WallCommon fields', () => {
+    const result = parseWallSpec({
+      ...valid,
+      isExternal: true,
+      fireRating: 'REI90',
+      acousticRating: 'Rw55',
+      thermalTransmittance: 0.3,
+      loadBearing: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.isExternal).toBe(true);
+    expect(result.value.thermalTransmittance).toBe(0.3);
+  });
+
+  it('accepts spec with manufacturer fields', () => {
+    const result = parseWallSpec({
+      ...valid,
+      manufacturerName: 'Wienerberger',
+      manufacturerModel: 'Porotherm 20 DF',
+      manufacturerProductionYear: 2024,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts spec with customProperties', () => {
+    const result = parseWallSpec({
+      ...valid,
+      customProperties: {
+        'Pset_AcousticPerformance': { SoundReductionIndex: 45 },
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects non-positive thermalTransmittance', () => {
+    const result = parseWallSpec({ ...valid, thermalTransmittance: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-integer manufacturerProductionYear', () => {
+    const result = parseWallSpec({ ...valid, manufacturerProductionYear: 2024.5 });
+    expect(result.ok).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Extend `WallSpec` with optional typed fields for `Pset_WallCommon` (isExternal, fireRating, acousticRating, thermalTransmittance, loadBearing), `Pset_ManufacturerTypeInformation`, and arbitrary custom Psets via `customProperties`
- Add `psetWriter.ts`: emits `IfcPropertySet`, `IfcPropertySingleValue`, `IfcElementQuantity` (Qto), and `IfcRelDefinesByProperties` for each wall
- `Qto_WallBaseQuantities` (Length, Width, Height, GrossFootprintArea, GrossVolume, NetVolume) auto-computed from spec dimensions — no API surface needed
- Fix material grouping: one `IfcRelAssociatesMaterial` per unique material name instead of one per wall

## Test Plan
- [ ] 44 tests pass across 5 test files (`wallFns`, `bimModel`, `bimError`, `ifcGuid`, `roundTrip`)
- [ ] 7 new round-trip tests verify `IfcPropertySet`, `IfcElementQuantity`, and `IfcRelDefinesByProperties` entities are present and parseable by web-ifc
- [ ] Wall without any Pset fields emits no `IfcPropertySet` but always emits `Qto_WallBaseQuantities`