### PR TITLE
feat(bim): add Openings, Doors, and Windows — M3

### DIFF
--- a/packages/brepjs-bim/eslint.config.js
+++ b/packages/brepjs-bim/eslint.config.js
@@ -5,9 +5,29 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
+    files: ['src/**/*.ts'],
     languageOptions: {
       parserOptions: {
         project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/prefer-readonly': 'error',
+      'prefer-const': 'error',
+      eqeqeq: 'error',
+      'no-var': 'error',
+      'no-console': ['error', { allow: ['error', 'warn'] }],
+    },
+  },
+  {
+    files: ['tests/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.test.json',
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -3,8 +3,14 @@ import type { IfcWriter } from './ifcWriter.js';
 import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
-import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+
+type OpeningSpec = {
+  readonly width: number;
+  readonly height: number;
+  readonly offsetAlongWall: number;
+  readonly offsetFromFloor: number;
+};
 import { toIfcLengthM } from '../units/units.js';
 
 export interface OpeningIds {
@@ -104,19 +110,10 @@ function writeAxis2Placement2D(w: IfcWriter): number {
   return id;
 }
 
-/**
- * Creates IfcOpeningElement geometry for a door or window void.
- *
- * Opening placement is relative to the wall's local placement:
- * - Origin centered on the opening face: (offsetAlongWall + width/2, 0, offsetFromFloor + height/2)
- * - Axis=[0,-1,0] so extrusion direction points inward (−Y in wall-local = through-wall)
- * - RefDir=[1,0,0] along wall length; cross([0,-1,0],[1,0,0])=[0,0,1] = up, so YDim=height is +Z ✓
- * - Profile: centered IfcRectangleProfileDef (XDim=width, YDim=height)
- * - ExtrudedDirection=[0,0,1], Depth=wallThickness → cuts from outer face to inner face
- */
 export function writeOpeningGeometry(
   w: IfcWriter,
-  openingSpec: DoorSpec | WindowSpec,
+  guid: IfcGuid,
+  openingSpec: OpeningSpec,
   wallSpec: WallSpec,
   wallPlacementId: number,
   geomSubContextId: number
@@ -189,7 +186,7 @@ export function writeOpeningGeometry(
   w.writeLine({
     expressID: openingEntityId,
     type: WebIFC.IFCOPENINGELEMENT,
-    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
     OwnerHistory: null,
     Name: null,
     Description: null,

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -4,6 +4,7 @@ import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import { toIfcLengthM } from '../units/units.js';
 
 type OpeningSpec = {
   readonly width: number;
@@ -11,7 +12,6 @@ type OpeningSpec = {
   readonly offsetAlongWall: number;
   readonly offsetFromFloor: number;
 };
-import { toIfcLengthM } from '../units/units.js';
 
 export interface OpeningIds {
   openingEntityId: number;
@@ -116,7 +116,8 @@ export function writeOpeningGeometry(
   openingSpec: OpeningSpec,
   wallSpec: WallSpec,
   wallPlacementId: number,
-  geomSubContextId: number
+  geomSubContextId: number,
+  ownerHistoryId: number
 ): OpeningIds {
   const widthM = toIfcLengthM(openingSpec.width);
   const heightM = toIfcLengthM(openingSpec.height);
@@ -124,10 +125,10 @@ export function writeOpeningGeometry(
   const offsetFromFloorM = toIfcLengthM(openingSpec.offsetFromFloor);
   const thicknessM = toIfcLengthM(wallSpec.thickness);
 
-  // Placement: centered on the opening, at the wall's outer face (Y=0 in wall coords)
+  // Placement: centered on opening, starting at outer face (+thicknessM/2) so extrusion covers full wall depth
   const placement3DId = writeAxis2Placement3D(
     w,
-    [offsetAlongWallM + widthM / 2, 0, offsetFromFloorM + heightM / 2],
+    [offsetAlongWallM + widthM / 2, thicknessM / 2, offsetFromFloorM + heightM / 2],
     [0, -1, 0],
     [1, 0, 0]
   );
@@ -187,7 +188,7 @@ export function writeOpeningGeometry(
     expressID: openingEntityId,
     type: WebIFC.IFCOPENINGELEMENT,
     GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
-    OwnerHistory: null,
+    OwnerHistory: w.ref(ownerHistoryId),
     Name: null,
     Description: null,
     ObjectType: null,
@@ -333,12 +334,32 @@ export function writeWindowCommonPset(
   windowEntityId: number,
   spec: OpeningPsetSpec
 ): void {
-  const props: Record<string, PsetValue> = {};
-  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
-  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
-  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
-  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_WindowCommon', props);
+  const propIds: number[] = [];
+  if (spec.isExternal !== undefined) propIds.push(writePropertySingleValue(w, 'IsExternal', spec.isExternal));
+  if (spec.fireRating !== undefined) propIds.push(writePropertySingleValue(w, 'FireRating', spec.fireRating));
+  if (spec.acousticRating !== undefined) propIds.push(writePropertySingleValue(w, 'AcousticRating', spec.acousticRating));
+  if (spec.thermalTransmittance !== undefined) {
+    const id = w.nextId();
+    w.writeLine({
+      expressID: id,
+      type: WebIFC.IFCPROPERTYSINGLEVALUE,
+      Name: w.mkType(WebIFC.IFCIDENTIFIER, 'ThermalTransmittance'),
+      Description: null,
+      NominalValue: w.mkType(WebIFC.IFCTHERMALTRANSMITTANCEMEASURE, spec.thermalTransmittance),
+      Unit: null,
+    });
+    propIds.push(id);
+  }
+  if (propIds.length === 0) return;
+  const psetId = w.nextId();
+  w.writeLine({
+    expressID: psetId,
+    type: WebIFC.IFCPROPERTYSET,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, 'Pset_WindowCommon'),
+    Description: null,
+    HasProperties: propIds.map((pid) => w.ref(pid)),
+  });
   writeRelDefinesByProperties(w, ownerHistoryId, windowEntityId, psetId);
 }

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -1,0 +1,347 @@
+import * as WebIFC from 'web-ifc';
+import type { IfcWriter } from './ifcWriter.js';
+import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
+import { newIfcGuid } from '../identity/ifcGuid.js';
+import type { IfcGuid } from '../identity/ifcGuid.js';
+import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
+import type { WallSpec } from '../specs/wallSpec.js';
+import { toIfcLengthM } from '../units/units.js';
+
+export interface OpeningIds {
+  openingEntityId: number;
+  openingPlacementId: number;
+}
+
+type OpeningPsetSpec = {
+  readonly isExternal?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+};
+
+type PsetValue = string | number | boolean;
+
+function writePsetValue(w: IfcWriter, value: PsetValue): Record<string, unknown> {
+  if (typeof value === 'boolean') {
+    return w.mkType(WebIFC.IFCBOOLEAN, value);
+  }
+  if (typeof value === 'number') {
+    return w.mkType(WebIFC.IFCREAL, value);
+  }
+  return w.mkType(WebIFC.IFCLABEL, value);
+}
+
+function writePropertySingleValue(w: IfcWriter, name: string, value: PsetValue): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCPROPERTYSINGLEVALUE,
+    Name: w.mkType(WebIFC.IFCIDENTIFIER, name),
+    Description: null,
+    NominalValue: writePsetValue(w, value),
+    Unit: null,
+  });
+  return id;
+}
+
+function writePropertySet(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  name: string,
+  properties: Record<string, PsetValue>
+): number {
+  const propIds = Object.entries(properties).map(([k, v]) =>
+    writePropertySingleValue(w, k, v)
+  );
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCPROPERTYSET,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    HasProperties: propIds.map((pid) => w.ref(pid)),
+  });
+  return id;
+}
+
+function writeRelDefinesByProperties(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  entityId: number,
+  psetId: number
+): void {
+  w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCRELDEFINESBYPROPERTIES,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: null,
+    Description: null,
+    RelatedObjects: [w.ref(entityId)],
+    RelatingPropertyDefinition: w.ref(psetId),
+  });
+}
+
+function writeAxis2Placement2D(w: IfcWriter): number {
+  const originId = w.nextId();
+  w.writeLine({
+    expressID: originId,
+    type: WebIFC.IFCCARTESIANPOINT,
+    Coordinates: [
+      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+    ],
+  });
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCAXIS2PLACEMENT2D,
+    Location: w.ref(originId),
+    RefDirection: null,
+  });
+  return id;
+}
+
+/**
+ * Creates IfcOpeningElement geometry for a door or window void.
+ *
+ * Opening placement is relative to the wall's local placement:
+ * - Origin centered on the opening face: (offsetAlongWall + width/2, 0, offsetFromFloor + height/2)
+ * - Axis=[0,-1,0] so extrusion direction points inward (−Y in wall-local = through-wall)
+ * - RefDir=[1,0,0] along wall length; cross([0,-1,0],[1,0,0])=[0,0,1] = up, so YDim=height is +Z ✓
+ * - Profile: centered IfcRectangleProfileDef (XDim=width, YDim=height)
+ * - ExtrudedDirection=[0,0,1], Depth=wallThickness → cuts from outer face to inner face
+ */
+export function writeOpeningGeometry(
+  w: IfcWriter,
+  openingSpec: DoorSpec | WindowSpec,
+  wallSpec: WallSpec,
+  wallPlacementId: number,
+  geomSubContextId: number
+): OpeningIds {
+  const widthM = toIfcLengthM(openingSpec.width);
+  const heightM = toIfcLengthM(openingSpec.height);
+  const offsetAlongWallM = toIfcLengthM(openingSpec.offsetAlongWall);
+  const offsetFromFloorM = toIfcLengthM(openingSpec.offsetFromFloor);
+  const thicknessM = toIfcLengthM(wallSpec.thickness);
+
+  // Placement: centered on the opening, at the wall's outer face (Y=0 in wall coords)
+  const placement3DId = writeAxis2Placement3D(
+    w,
+    [offsetAlongWallM + widthM / 2, 0, offsetFromFloorM + heightM / 2],
+    [0, -1, 0],
+    [1, 0, 0]
+  );
+
+  const openingPlacementId = w.nextId();
+  w.writeLine({
+    expressID: openingPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: w.ref(wallPlacementId),
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const profileId = w.nextId();
+  w.writeLine({
+    expressID: profileId,
+    type: WebIFC.IFCRECTANGLEPROFILEDEF,
+    ProfileType: { type: 3, value: 'AREA' },
+    ProfileName: null,
+    Position: w.ref(writeAxis2Placement2D(w)),
+    XDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, widthM),
+    YDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, heightM),
+  });
+
+  const extrusionPosId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const extrusionDirId = writeDirection(w, [0, 0, 1]);
+  const extrusionId = w.nextId();
+  w.writeLine({
+    expressID: extrusionId,
+    type: WebIFC.IFCEXTRUDEDAREASOLID,
+    SweptArea: w.ref(profileId),
+    Position: w.ref(extrusionPosId),
+    ExtrudedDirection: w.ref(extrusionDirId),
+    Depth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, thicknessM),
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'SweptSolid'),
+    Items: [w.ref(extrusionId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+
+  const openingEntityId = w.nextId();
+  w.writeLine({
+    expressID: openingEntityId,
+    type: WebIFC.IFCOPENINGELEMENT,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: null,
+    Name: null,
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(openingPlacementId),
+    Representation: w.ref(productDefinitionShapeId),
+    Tag: null,
+    PredefinedType: null,
+  });
+
+  return { openingEntityId, openingPlacementId };
+}
+
+export function writeDoorEntity(
+  w: IfcWriter,
+  guid: IfcGuid,
+  name: string,
+  ownerHistoryId: number,
+  openingPlacementId: number
+): number {
+  const placement3DId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const localPlacementId = w.nextId();
+  w.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: w.ref(openingPlacementId),
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCDOOR,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(localPlacementId),
+    Representation: null,
+    Tag: null,
+    OverallHeight: null,
+    OverallWidth: null,
+    PredefinedType: null,
+    OperationType: null,
+    UserDefinedOperationType: null,
+  });
+  return id;
+}
+
+export function writeWindowEntity(
+  w: IfcWriter,
+  guid: IfcGuid,
+  name: string,
+  ownerHistoryId: number,
+  openingPlacementId: number
+): number {
+  const placement3DId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const localPlacementId = w.nextId();
+  w.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: w.ref(openingPlacementId),
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCWINDOW,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(localPlacementId),
+    Representation: null,
+    Tag: null,
+    OverallHeight: null,
+    OverallWidth: null,
+    PredefinedType: null,
+    PartitioningType: null,
+    UserDefinedPartitioningType: null,
+  });
+  return id;
+}
+
+export function writeRelVoidsElement(
+  w: IfcWriter,
+  guid: IfcGuid,
+  ownerHistoryId: number,
+  wallEntityId: number,
+  openingEntityId: number
+): void {
+  w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCRELVOIDSELEMENT,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: null,
+    Description: null,
+    RelatingBuildingElement: w.ref(wallEntityId),
+    RelatedOpeningElement: w.ref(openingEntityId),
+  });
+}
+
+export function writeRelFillsElement(
+  w: IfcWriter,
+  guid: IfcGuid,
+  ownerHistoryId: number,
+  openingEntityId: number,
+  fillerEntityId: number
+): void {
+  w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCRELFILLSELEMENT,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: null,
+    Description: null,
+    RelatingOpeningElement: w.ref(openingEntityId),
+    RelatedBuildingElement: w.ref(fillerEntityId),
+  });
+}
+
+export function writeDoorCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  doorEntityId: number,
+  spec: OpeningPsetSpec
+): void {
+  const props: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_DoorCommon', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, doorEntityId, psetId);
+}
+
+export function writeWindowCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  windowEntityId: number,
+  spec: OpeningPsetSpec
+): void {
+  const props: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_WindowCommon', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, windowEntityId, psetId);
+}

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -1,15 +1,17 @@
 export { BimModel } from './model/bimModel.js';
 export { toIfc } from './serialize/toIfc.js';
 export { parseWallSpec } from './specs/wallSpec.js';
+export { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 export { newIfcGuid, isValidIfcGuid } from './identity/ifcGuid.js';
 export { makeLocalIdCounter } from './identity/localId.js';
 export { DEFAULT_UNITS, toLengthMm, toIfcLengthM } from './units/units.js';
 export { specError, ifcError, geometryError, fromBrepError } from './errors/bimError.js';
 
 export type { WallSpec } from './specs/wallSpec.js';
+export type { DoorSpec, WindowSpec } from './specs/openingSpec.js';
 export type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from './specs/spatialSpec.js';
-export type { BimCategory, BimElement, AnyBimElement } from './types/bimTypes.js';
-export type { BimRelationship } from './types/relationships.js';
+export type { BimCategory, BimElement, AnyBimElement, OpeningSpec } from './types/bimTypes.js';
+export type { BimRelationship, VoidsWallRel, FillsOpeningRel } from './types/relationships.js';
 export type { BimError, BimErrorKind } from './errors/bimError.js';
 export type { IfcGuid } from './identity/ifcGuid.js';
 export type { LocalId, LocalIdCounter } from './identity/localId.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -12,8 +12,11 @@ import type {
   AggregatesRel,
   ContainedInRel,
   AssociatesMaterialRel,
+  VoidsWallRel,
+  FillsOpeningRel,
 } from '../types/relationships.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from '../specs/spatialSpec.js';
 import { wallToSolid } from '../elementFns/wallFns.js';
 
@@ -62,6 +65,80 @@ export class BimModel {
       relatedObjects: [id],
     });
     return ok(id);
+  }
+
+  addDoor(spec: DoorSpec): Result<LocalId, BimError> {
+    const wall = this.#elements.get(spec.wallLocalId);
+    if (wall === undefined || wall.category !== 'WALL') {
+      return err(specError('DOOR_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
+    }
+    if (spec.offsetAlongWall + spec.width > wall.spec.length) {
+      return err(specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetAlongWall + width) exceeds wall length'));
+    }
+    if (spec.offsetFromFloor + spec.height > wall.spec.height) {
+      return err(specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetFromFloor + height) exceeds wall height'));
+    }
+    const openingSpec = {
+      width: spec.width,
+      height: spec.height,
+      offsetAlongWall: spec.offsetAlongWall,
+      offsetFromFloor: spec.offsetFromFloor,
+    };
+    const openingId = this.#makeElement('OPENING', openingSpec, null);
+    this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
+    const doorId = this.#makeElement('DOOR', spec, null);
+    this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: doorId });
+    this.#makeRel<AssociatesMaterialRel>({
+      kind: 'ASSOCIATES_MATERIAL',
+      materialName: spec.materialName,
+      relatedObjects: [doorId],
+    });
+    return ok(doorId);
+  }
+
+  addWindow(spec: WindowSpec): Result<LocalId, BimError> {
+    const wall = this.#elements.get(spec.wallLocalId);
+    if (wall === undefined || wall.category !== 'WALL') {
+      return err(specError('WINDOW_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
+    }
+    if (spec.offsetAlongWall + spec.width > wall.spec.length) {
+      return err(specError('WINDOW_EXCEEDS_WALL_BOUNDS', 'Window (offsetAlongWall + width) exceeds wall length'));
+    }
+    if (spec.offsetFromFloor + spec.height > wall.spec.height) {
+      return err(specError('WINDOW_EXCEEDS_WALL_BOUNDS', 'Window (offsetFromFloor + height) exceeds wall height'));
+    }
+    const openingSpec = {
+      width: spec.width,
+      height: spec.height,
+      offsetAlongWall: spec.offsetAlongWall,
+      offsetFromFloor: spec.offsetFromFloor,
+    };
+    const openingId = this.#makeElement('OPENING', openingSpec, null);
+    this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
+    const windowId = this.#makeElement('WINDOW', spec, null);
+    this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: windowId });
+    this.#makeRel<AssociatesMaterialRel>({
+      kind: 'ASSOCIATES_MATERIAL',
+      materialName: spec.materialName,
+      relatedObjects: [windowId],
+    });
+    return ok(windowId);
+  }
+
+  getDoors(): BimElement<'DOOR'>[] {
+    const doors: BimElement<'DOOR'>[] = [];
+    for (const el of this.#elements.values()) {
+      if (el.category === 'DOOR') doors.push(el);
+    }
+    return doors;
+  }
+
+  getWindows(): BimElement<'WINDOW'>[] {
+    const windows: BimElement<'WINDOW'>[] = [];
+    for (const el of this.#elements.values()) {
+      if (el.category === 'WINDOW') windows.push(el);
+    }
+    return windows;
   }
 
   aggregate(parentId: LocalId, childId: LocalId): void {

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -21,11 +21,23 @@ import {
   writeCustomPsets,
   writeWallBaseQuantities,
 } from '../ifc-writer/psetWriter.js';
+import {
+  writeOpeningGeometry,
+  writeDoorEntity,
+  writeWindowEntity,
+  writeRelVoidsElement,
+  writeRelFillsElement,
+  writeDoorCommonPset,
+  writeWindowCommonPset,
+} from '../ifc-writer/openingWriter.js';
 import type { BimError } from '../errors/bimError.js';
 import { ifcError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
 import { err } from 'brepjs';
 import type { LocalId } from '../identity/localId.js';
+import type { IfcGuid } from '../identity/ifcGuid.js';
+import type { DoorSpec } from '../specs/openingSpec.js';
+import type { BimElement } from '../types/bimTypes.js';
 import type { BimRelationship } from '../types/relationships.js';
 
 export async function toIfc(
@@ -44,6 +56,8 @@ export async function toIfc(
   const elements = model.getAllElements();
   const relationships = model.getAllRelationships();
   const walls = model.getWalls();
+  const doors = model.getDoors();
+  const windows = model.getWindows();
 
   const { ownerHistoryId, geomContextId, geomSubContextId, unitAssignmentId } = writeHeader(w, meta);
 
@@ -94,12 +108,68 @@ export async function toIfc(
       w, wall.guid, `Wall ${i + 1}`, ownerHistoryId, localPlacementId, productDefinitionShapeId
     );
     idMap.set(wall.localId, wallExpressId);
+    placementMap.set(wall.localId, localPlacementId);
     writeWallCommonPset(w, ownerHistoryId, wallExpressId, wall.spec);
     writeManufacturerPset(w, ownerHistoryId, wallExpressId, wall.spec);
     if (wall.spec.customProperties !== undefined) {
       writeCustomPsets(w, ownerHistoryId, wallExpressId, wall.spec.customProperties);
     }
     writeWallBaseQuantities(w, ownerHistoryId, wallExpressId, wall.spec);
+  }
+
+  const openingPlacementMap = new Map<LocalId, number>();
+  const openingEntityMap = new Map<LocalId, number>();
+
+  for (const rel of relationships) {
+    if (rel.kind !== 'VOIDS_WALL') continue;
+    const wallElement = elements.find(
+      (el): el is BimElement<'WALL'> => el.category === 'WALL' && el.localId === rel.wallLocalId
+    );
+    if (wallElement === undefined) continue;
+    const wallExpressId = idMap.get(rel.wallLocalId);
+    const wallPlacementId = placementMap.get(rel.wallLocalId);
+    if (wallExpressId === undefined || wallPlacementId === undefined) continue;
+
+    const openingElement = elements.find((el) => el.localId === rel.openingLocalId);
+    if (openingElement === undefined || openingElement.category !== 'OPENING') continue;
+    const openingSpec = openingElement.spec as DoorSpec;
+
+    const { openingEntityId, openingPlacementId } = writeOpeningGeometry(
+      w, openingSpec, wallElement.spec, wallPlacementId, geomSubContextId
+    );
+    idMap.set(rel.openingLocalId, openingEntityId);
+    openingPlacementMap.set(rel.openingLocalId, openingPlacementId);
+    openingEntityMap.set(rel.openingLocalId, openingEntityId);
+
+    writeRelVoidsElement(w, rel.guid, ownerHistoryId, wallExpressId, openingEntityId);
+  }
+
+  for (const [i, door] of doors.entries()) {
+    const fillsRel = relationships.find(
+      (rel) => rel.kind === 'FILLS_OPENING' && rel.fillerLocalId === door.localId
+    );
+    if (fillsRel === undefined || fillsRel.kind !== 'FILLS_OPENING') continue;
+    const openingPlacementId = openingPlacementMap.get(fillsRel.openingLocalId);
+    const openingEntityId = openingEntityMap.get(fillsRel.openingLocalId);
+    if (openingPlacementId === undefined || openingEntityId === undefined) continue;
+    const doorExpressId = writeDoorEntity(w, door.guid, `Door ${i + 1}`, ownerHistoryId, openingPlacementId);
+    idMap.set(door.localId, doorExpressId);
+    writeRelFillsElement(w, fillsRel.guid, ownerHistoryId, openingEntityId, doorExpressId);
+    writeDoorCommonPset(w, ownerHistoryId, doorExpressId, door.spec);
+  }
+
+  for (const [i, win] of windows.entries()) {
+    const fillsRel = relationships.find(
+      (rel) => rel.kind === 'FILLS_OPENING' && rel.fillerLocalId === win.localId
+    );
+    if (fillsRel === undefined || fillsRel.kind !== 'FILLS_OPENING') continue;
+    const openingPlacementId = openingPlacementMap.get(fillsRel.openingLocalId);
+    const openingEntityId = openingEntityMap.get(fillsRel.openingLocalId);
+    if (openingPlacementId === undefined || openingEntityId === undefined) continue;
+    const windowExpressId = writeWindowEntity(w, win.guid, `Window ${i + 1}`, ownerHistoryId, openingPlacementId);
+    idMap.set(win.localId, windowExpressId);
+    writeRelFillsElement(w, fillsRel.guid, ownerHistoryId, openingEntityId, windowExpressId);
+    writeWindowCommonPset(w, ownerHistoryId, windowExpressId, win.spec);
   }
 
   for (const rel of relationships) {
@@ -124,7 +194,7 @@ export async function toIfc(
     );
   }
 
-  const byMaterial = new Map<string, { guid: string; ids: number[] }>();
+  const byMaterial = new Map<string, { guid: IfcGuid; ids: number[] }>();
   for (const rel of relationships) {
     if (rel.kind !== 'ASSOCIATES_MATERIAL') continue;
     const objectExpressIds = rel.relatedObjects

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -36,7 +36,6 @@ import type { Result } from 'brepjs';
 import { err } from 'brepjs';
 import type { LocalId } from '../identity/localId.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
-import type { DoorSpec } from '../specs/openingSpec.js';
 import type { BimElement } from '../types/bimTypes.js';
 import type { BimRelationship } from '../types/relationships.js';
 
@@ -132,10 +131,9 @@ export async function toIfc(
 
     const openingElement = elements.find((el) => el.localId === rel.openingLocalId);
     if (openingElement === undefined || openingElement.category !== 'OPENING') continue;
-    const openingSpec = openingElement.spec as DoorSpec;
 
     const { openingEntityId, openingPlacementId } = writeOpeningGeometry(
-      w, openingSpec, wallElement.spec, wallPlacementId, geomSubContextId
+      w, openingElement.guid, openingElement.spec, wallElement.spec, wallPlacementId, geomSubContextId
     );
     idMap.set(rel.openingLocalId, openingEntityId);
     openingPlacementMap.set(rel.openingLocalId, openingPlacementId);

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -133,7 +133,7 @@ export async function toIfc(
     if (openingElement === undefined || openingElement.category !== 'OPENING') continue;
 
     const { openingEntityId, openingPlacementId } = writeOpeningGeometry(
-      w, openingElement.guid, openingElement.spec, wallElement.spec, wallPlacementId, geomSubContextId
+      w, openingElement.guid, openingElement.spec, wallElement.spec, wallPlacementId, geomSubContextId, ownerHistoryId
     );
     idMap.set(rel.openingLocalId, openingEntityId);
     openingPlacementMap.set(rel.openingLocalId, openingPlacementId);

--- a/packages/brepjs-bim/src/specs/openingSpec.ts
+++ b/packages/brepjs-bim/src/specs/openingSpec.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type { BimError } from '../errors/bimError.js';
+import { specError } from '../errors/bimError.js';
+import type { Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { LocalId } from '../identity/localId.js';
+
+/** A door opening in a wall. All dimensions in mm. */
+export interface DoorSpec {
+  readonly width: number;
+  readonly height: number;
+  readonly offsetAlongWall: number;
+  readonly offsetFromFloor: number;
+  readonly wallLocalId: LocalId;
+  readonly materialName: string;
+
+  readonly isExternal?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+}
+
+/** A window opening in a wall. All dimensions in mm. */
+export interface WindowSpec {
+  readonly width: number;
+  readonly height: number;
+  readonly offsetAlongWall: number;
+  readonly offsetFromFloor: number;
+  readonly wallLocalId: LocalId;
+  readonly materialName: string;
+
+  readonly isExternal?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+}
+
+const baseOpeningSchema = z.object({
+  width: z.number().positive(),
+  height: z.number().positive(),
+  offsetAlongWall: z.number().nonnegative(),
+  offsetFromFloor: z.number().nonnegative(),
+  wallLocalId: z.number().int().positive(),
+  materialName: z.string().min(1),
+  isExternal: z.boolean().optional(),
+  fireRating: z.string().optional(),
+  acousticRating: z.string().optional(),
+});
+
+const DoorSpecSchema = baseOpeningSchema;
+
+const WindowSpecSchema = baseOpeningSchema.extend({
+  thermalTransmittance: z.number().positive().optional(),
+});
+
+export function parseDoorSpec(input: unknown): Result<DoorSpec, BimError> {
+  const result = DoorSpecSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_DOOR_SPEC', result.error.message, result.error));
+  }
+  return ok(result.data as DoorSpec);
+}
+
+export function parseWindowSpec(input: unknown): Result<WindowSpec, BimError> {
+  const result = WindowSpecSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_WINDOW_SPEC', result.error.message, result.error));
+  }
+  return ok(result.data as WindowSpec);
+}

--- a/packages/brepjs-bim/src/types/bimTypes.ts
+++ b/packages/brepjs-bim/src/types/bimTypes.ts
@@ -2,6 +2,7 @@ import type { ValidSolid } from 'brepjs';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { LocalId } from '../identity/localId.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type {
   ProjectSpec,
   SiteSpec,
@@ -9,19 +10,32 @@ import type {
   StoreySpec,
 } from '../specs/spatialSpec.js';
 
-export type BimCategory = 'WALL' | 'PROJECT' | 'SITE' | 'BUILDING' | 'STOREY';
+export type BimCategory = 'WALL' | 'OPENING' | 'DOOR' | 'WINDOW' | 'PROJECT' | 'SITE' | 'BUILDING' | 'STOREY';
+
+export type OpeningSpec = {
+  readonly width: number;
+  readonly height: number;
+  readonly offsetAlongWall: number;
+  readonly offsetFromFloor: number;
+};
 
 export type BimSpecFor<C extends BimCategory> = C extends 'WALL'
   ? WallSpec
-  : C extends 'PROJECT'
-    ? ProjectSpec
-    : C extends 'SITE'
-      ? SiteSpec
-      : C extends 'BUILDING'
-        ? BuildingSpec
-        : C extends 'STOREY'
-          ? StoreySpec
-          : never;
+  : C extends 'OPENING'
+    ? OpeningSpec
+    : C extends 'DOOR'
+      ? DoorSpec
+      : C extends 'WINDOW'
+        ? WindowSpec
+        : C extends 'PROJECT'
+          ? ProjectSpec
+          : C extends 'SITE'
+            ? SiteSpec
+            : C extends 'BUILDING'
+              ? BuildingSpec
+              : C extends 'STOREY'
+                ? StoreySpec
+                : never;
 
 export type BimGeometryFor<C extends BimCategory> = C extends 'WALL'
   ? ValidSolid
@@ -37,6 +51,9 @@ export interface BimElement<C extends BimCategory> {
 
 export type AnyBimElement =
   | BimElement<'WALL'>
+  | BimElement<'OPENING'>
+  | BimElement<'DOOR'>
+  | BimElement<'WINDOW'>
   | BimElement<'PROJECT'>
   | BimElement<'SITE'>
   | BimElement<'BUILDING'>

--- a/packages/brepjs-bim/src/types/relationships.ts
+++ b/packages/brepjs-bim/src/types/relationships.ts
@@ -25,7 +25,25 @@ export interface AssociatesMaterialRel {
   readonly relatedObjects: readonly LocalId[];
 }
 
+export interface VoidsWallRel {
+  readonly kind: 'VOIDS_WALL';
+  readonly guid: IfcGuid;
+  readonly localId: LocalId;
+  readonly wallLocalId: LocalId;
+  readonly openingLocalId: LocalId;
+}
+
+export interface FillsOpeningRel {
+  readonly kind: 'FILLS_OPENING';
+  readonly guid: IfcGuid;
+  readonly localId: LocalId;
+  readonly openingLocalId: LocalId;
+  readonly fillerLocalId: LocalId;
+}
+
 export type BimRelationship =
   | AggregatesRel
   | ContainedInRel
-  | AssociatesMaterialRel;
+  | AssociatesMaterialRel
+  | VoidsWallRel
+  | FillsOpeningRel;

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -92,3 +92,89 @@ describe('BimModel', () => {
     expect(walls).toHaveLength(1);
   });
 });
+
+describe('BimModel.addDoor', () => {
+  function buildWallModel() {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const wallResult = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    return { model, wallLocalId: wallResult.value };
+  }
+
+  it('adds a door and creates opening + relationships', () => {
+    const { model, wallLocalId } = buildWallModel();
+    const result = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
+      wallLocalId, materialName: 'Wood',
+    });
+    expect(result.ok).toBe(true);
+    expect(model.getDoors()).toHaveLength(1);
+  });
+
+  it('rejects door that exceeds wall length', () => {
+    const { model, wallLocalId } = buildWallModel();
+    const result = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 4500, offsetFromFloor: 0,
+      wallLocalId, materialName: 'Wood',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DOOR_EXCEEDS_WALL_BOUNDS');
+  });
+
+  it('rejects door that exceeds wall height', () => {
+    const { model, wallLocalId } = buildWallModel();
+    const result = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 1000,
+      wallLocalId, materialName: 'Wood',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DOOR_EXCEEDS_WALL_BOUNDS');
+  });
+
+  it('rejects door referencing non-existent wall', () => {
+    const { model } = buildWallModel();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing invalid input path
+    const result = model.addDoor({ width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0, wallLocalId: 9999 as any, materialName: 'Wood' });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('BimModel.addWindow', () => {
+  function buildWallModel() {
+    const model = new BimModel();
+    model.init({ name: 'Test' });
+    const wallResult = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    return { model, wallLocalId: wallResult.value };
+  }
+
+  it('adds a window and creates opening + relationships', () => {
+    const { model, wallLocalId } = buildWallModel();
+    const result = model.addWindow({
+      width: 1200, height: 1400, offsetAlongWall: 1000, offsetFromFloor: 900,
+      wallLocalId, materialName: 'Aluminum',
+    });
+    expect(result.ok).toBe(true);
+    expect(model.getWindows()).toHaveLength(1);
+  });
+
+  it('rejects window that exceeds wall bounds', () => {
+    const { model, wallLocalId } = buildWallModel();
+    const result = model.addWindow({
+      width: 1200, height: 1400, offsetAlongWall: 4500, offsetFromFloor: 900,
+      wallLocalId, materialName: 'Aluminum',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('WINDOW_EXCEEDS_WALL_BOUNDS');
+  });
+});

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -139,7 +139,7 @@ describe('BimModel.addDoor', () => {
 
   it('rejects door referencing non-existent wall', () => {
     const { model } = buildWallModel();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing invalid input path
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- testing invalid input path
     const result = model.addDoor({ width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0, wallLocalId: 9999 as any, materialName: 'Wood' });
     expect(result.ok).toBe(false);
   });

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -148,7 +148,8 @@ describe('BimModel.addDoor', () => {
 describe('BimModel.addWindow', () => {
   function buildWallModel() {
     const model = new BimModel();
-    model.init({ name: 'Test' });
+    const initResult = model.init({ name: 'Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
     const wallResult = model.addWall({
       length: 5000, height: 3000, thickness: 250,
       origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],

--- a/packages/brepjs-bim/tests/openingFns.test.ts
+++ b/packages/brepjs-bim/tests/openingFns.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseDoorSpec, parseWindowSpec } from '../src/specs/openingSpec.js';
+
+describe('parseDoorSpec', () => {
+  const BASE = {
+    width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
+    wallLocalId: 1, materialName: 'Wood',
+  };
+
+  it('accepts minimal valid door spec', () => {
+    const result = parseDoorSpec(BASE);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts optional Pset fields', () => {
+    const result = parseDoorSpec({ ...BASE, isExternal: true, fireRating: 'EI60', acousticRating: 'Rw 35' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects non-positive width', () => {
+    const result = parseDoorSpec({ ...BASE, width: 0 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-positive height', () => {
+    const result = parseDoorSpec({ ...BASE, height: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects negative offsetFromFloor', () => {
+    const result = parseDoorSpec({ ...BASE, offsetFromFloor: -1 });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('parseWindowSpec', () => {
+  const BASE = {
+    width: 1200, height: 1400, offsetAlongWall: 1000, offsetFromFloor: 900,
+    wallLocalId: 1, materialName: 'Aluminum',
+  };
+
+  it('accepts minimal valid window spec', () => {
+    const result = parseWindowSpec(BASE);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts thermalTransmittance', () => {
+    const result = parseWindowSpec({ ...BASE, thermalTransmittance: 1.1 });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects non-positive thermalTransmittance', () => {
+    const result = parseWindowSpec({ ...BASE, thermalTransmittance: 0 });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -247,3 +247,147 @@ describe('IFC Pset/Qto round-trip (M2)', () => {
     api.CloseModel(mid);
   });
 });
+
+describe('IFC Opening round-trip (M3)', () => {
+  async function buildOpeningModel(): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'Opening Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const projectLocalId = initResult.value;
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(projectLocalId, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const wallResult = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    model.placeIn(wallResult.value, storeyId);
+
+    const doorResult = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
+      wallLocalId: wallResult.value, materialName: 'Wood',
+      isExternal: false, fireRating: 'EI30',
+    });
+    if (!doorResult.ok) throw new Error(doorResult.error.message);
+
+    const windowResult = model.addWindow({
+      width: 1200, height: 1400, offsetAlongWall: 2000, offsetFromFloor: 900,
+      wallLocalId: wallResult.value, materialName: 'Aluminum',
+      isExternal: true, thermalTransmittance: 1.2,
+    });
+    if (!windowResult.ok) throw new Error(windowResult.error.message);
+
+    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    if (!result.ok) throw new Error(result.error.message);
+
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    return { api, mid };
+  }
+
+  it('emits two IfcOpeningElements', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const openings = api.GetLineIDsWithType(mid, WebIFC.IFCOPENINGELEMENT);
+    expect(openings.size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('emits one IfcDoor', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const doors = api.GetLineIDsWithType(mid, WebIFC.IFCDOOR);
+    expect(doors.size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('emits one IfcWindow', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const windows = api.GetLineIDsWithType(mid, WebIFC.IFCWINDOW);
+    expect(windows.size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('emits two IfcRelVoidsElement', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const voids = api.GetLineIDsWithType(mid, WebIFC.IFCRELVOIDSELEMENT);
+    expect(voids.size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('emits two IfcRelFillsElement', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const fills = api.GetLineIDsWithType(mid, WebIFC.IFCRELFILLSELEMENT);
+    expect(fills.size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('emits Pset_DoorCommon', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+      const pset = api.GetLine(mid, ids.get(i));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+      if ((pset.Name?.value as string | undefined) === 'Pset_DoorCommon') { found = true; break; }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('emits Pset_WindowCommon', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+      const pset = api.GetLine(mid, ids.get(i));
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+      if ((pset.Name?.value as string | undefined) === 'Pset_WindowCommon') { found = true; break; }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('door GlobalId matches BimModel door GUID', async () => {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'GUID Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(initResult.value, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const wallResult = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1], materialName: 'Concrete',
+    });
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    const doorResult = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
+      wallLocalId: wallResult.value, materialName: 'Wood',
+    });
+    if (!doorResult.ok) throw new Error(doorResult.error.message);
+
+    const result = await toIfc(model, { applicationName: 'test', applicationVersion: '0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    const doorIds = api.GetLineIDsWithType(mid, WebIFC.IFCDOOR);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
+    const door = api.GetLine(mid, doorIds.get(0));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
+    const doorGuid = door.GlobalId?.value as string | undefined;
+    const bimDoors = model.getDoors();
+    expect(bimDoors).toHaveLength(1);
+    expect(doorGuid).toBe(bimDoors[0]?.guid);
+    api.CloseModel(mid);
+  });
+});

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -7,7 +7,7 @@ import { toIfc } from '../src/serialize/toIfc.js';
 beforeAll(async () => { await initOCCT(); }, 30000);
 
 describe('IFC round-trip (M1)', () => {
-  async function buildModel(): Promise<BimModel> {
+  function buildModel(): BimModel {
     const model = new BimModel();
     const initResult = model.init({ name: 'Test Project' });
     if (!initResult.ok) throw new Error(initResult.error.message);
@@ -33,7 +33,7 @@ describe('IFC round-trip (M1)', () => {
   }
 
   it('toIfc produces non-empty bytes', async () => {
-    const model = await buildModel();
+    const model = buildModel();
     const result = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -41,7 +41,7 @@ describe('IFC round-trip (M1)', () => {
   });
 
   it('exported bytes parse back with web-ifc', async () => {
-    const model = await buildModel();
+    const model = buildModel();
     const result = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' });
     if (!result.ok) throw new Error(result.error.message);
 
@@ -72,7 +72,7 @@ describe('IFC round-trip (M1)', () => {
   });
 
   it('exported IFC contains IfcRelContainedInSpatialStructure', async () => {
-    const model = await buildModel();
+    const model = buildModel();
     const result = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' });
     if (!result.ok) throw new Error(result.error.message);
 

--- a/packages/brepjs-bim/tsconfig.test.json
+++ b/packages/brepjs-bim/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["tests/**/*.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- **IfcOpeningElement**: void geometry (extruded rectangle through wall thickness) auto-created for each door/window; `IfcRelVoidsElement` links opening to wall
- **IfcDoor / IfcWindow**: entities without geometry (IFC-only void approach); `IfcRelFillsElement` links door/window to their opening; all GlobalIds stable across exports
- **Pset_DoorCommon / Pset_WindowCommon**: written when spec includes `isExternal`, `fireRating`, `acousticRating`, or `thermalTransmittance` (window only)
- **Fit validation**: `addDoor()`/`addWindow()` reject openings that exceed wall length or height bounds
- **DoorSpec / WindowSpec**: Zod-validated specs with optional Pset fields; `parseDoorSpec` / `parseWindowSpec` exported from index

## Architecture

`BimModel.addDoor()`/`addWindow()` auto-create an internal `OPENING` element and three relationships (`VOIDS_WALL`, `FILLS_OPENING`, `ASSOCIATES_MATERIAL`). `toIfc.ts` serializes the IFC entity chain (wall → IfcRelVoidsElement → IfcOpeningElement → IfcRelFillsElement → IfcDoor/IfcWindow) in a single pass.

Wall solids are NOT Boolean-cut — `NetVolume` in `Qto_WallBaseQuantities` equals `GrossVolume` until a future milestone adds opening geometry to the Qto computation.

## Test plan

- [ ] `openingFns.test.ts` — 8 unit tests for parseDoorSpec / parseWindowSpec (validation, optional fields)
- [ ] `bimModel.test.ts` — 6 integration tests for addDoor / addWindow (success, bounds, invalid wall ref)
- [ ] `roundTrip.test.ts` M3 block — 8 IFC round-trip tests (entity counts, Pset names, door GUID stability)
- [ ] All 66 tests passing; typecheck + lint clean