### PR TITLE
feat(bim): boolean-cut walls + net quantities — M4

### DIFF
--- a/packages/brepjs-bim/src/elementFns/openingFns.ts
+++ b/packages/brepjs-bim/src/elementFns/openingFns.ts
@@ -1,0 +1,77 @@
+import { polygon, extrude, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { OpeningSpec } from '../types/bimTypes.js';
+import type { BimError } from '../errors/bimError.js';
+import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
+
+// Overshoot the wall depth so the boolean cut tool has no coplanar faces with the
+// wall body — OCCT booleans are flaky when tool faces touch base faces exactly.
+const EPSILON_MM = 1;
+
+// Build the boolean tool used to subtract an opening from a wall.
+//
+// The wall is modeled in local coords with the profile in the YZ plane extruded
+// along +X (see wallFns.ts). The opening tool is a box at:
+//   X ∈ [offsetAlongWall, offsetAlongWall + width]
+//   Y ∈ [-ε, thickness + ε]   ← overshoots the wall depth on both sides
+//   Z ∈ [offsetFromFloor, offsetFromFloor + height]
+export function openingToSolid(
+  spec: OpeningSpec,
+  wallThickness: number
+): Result<ValidSolid, BimError> {
+  if (spec.width <= 0) {
+    return err(specError('OPENING_ZERO_WIDTH', 'Opening width must be positive'));
+  }
+  if (spec.height <= 0) {
+    return err(specError('OPENING_ZERO_HEIGHT', 'Opening height must be positive'));
+  }
+  if (wallThickness <= 0) {
+    return err(
+      specError('OPENING_ZERO_WALL_THICKNESS', 'Wall thickness must be positive')
+    );
+  }
+
+  const x0 = spec.offsetAlongWall;
+  const yLow = -EPSILON_MM;
+  const yHigh = wallThickness + EPSILON_MM;
+  const zLow = spec.offsetFromFloor;
+  const zHigh = spec.offsetFromFloor + spec.height;
+
+  const profileResult = polygon([
+    [x0, yLow, zLow],
+    [x0, yHigh, zLow],
+    [x0, yHigh, zHigh],
+    [x0, yLow, zHigh],
+  ]);
+  if (!profileResult.ok) {
+    return err(
+      fromBrepError(
+        profileResult.error,
+        'OPENING_PROFILE_FAILED',
+        'Failed to create opening profile'
+      )
+    );
+  }
+
+  using profile = profileResult.value;
+  const solidResult = extrude(profile, [spec.width, 0, 0]);
+  if (!solidResult.ok) {
+    return err(
+      fromBrepError(
+        solidResult.error,
+        'OPENING_EXTRUDE_FAILED',
+        'Failed to extrude opening profile'
+      )
+    );
+  }
+
+  const solid = solidResult.value;
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(
+      geometryError('OPENING_INVALID_SOLID', 'Extruded opening solid failed validity check')
+    );
+  }
+  return ok(solid);
+}

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -2,6 +2,7 @@ import * as WebIFC from 'web-ifc';
 import type { IfcWriter } from './ifcWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { OpeningSpec } from '../types/bimTypes.js';
 import { toIfcLengthM } from '../units/units.js';
 
 type PsetValue = string | number | boolean;
@@ -114,17 +115,37 @@ export function writeCustomPsets(
   }
 }
 
+// Openings whose floor offset is within this many metres of 0 are treated as
+// reaching the floor (i.e. they reduce the wall footprint), e.g. doors.
+const FLOOR_TOUCH_EPSILON_M = 1e-3;
+
 export function writeWallBaseQuantities(
   w: IfcWriter,
   ownerHistoryId: number,
   wallExpressId: number,
-  spec: WallSpec
+  spec: WallSpec,
+  openings: readonly OpeningSpec[]
 ): void {
   const lengthM = toIfcLengthM(spec.length);
   const widthM = toIfcLengthM(spec.thickness);
   const heightM = toIfcLengthM(spec.height);
-  const footprintM2 = lengthM * widthM;
-  const volumeM3 = lengthM * widthM * heightM;
+  const grossFootprintM2 = lengthM * widthM;
+  const grossSideAreaM2 = lengthM * heightM;
+  const grossVolumeM3 = lengthM * widthM * heightM;
+
+  let sumOpeningAreaM2 = 0;
+  let sumFloorTouchingFootprintM2 = 0;
+  for (const op of openings) {
+    const opWidthM = toIfcLengthM(op.width);
+    const opHeightM = toIfcLengthM(op.height);
+    sumOpeningAreaM2 += opWidthM * opHeightM;
+    if (toIfcLengthM(op.offsetFromFloor) < FLOOR_TOUCH_EPSILON_M) {
+      sumFloorTouchingFootprintM2 += opWidthM * widthM;
+    }
+  }
+  const netSideAreaM2 = grossSideAreaM2 - sumOpeningAreaM2;
+  const netVolumeM3 = grossVolumeM3 - sumOpeningAreaM2 * widthM;
+  const netFootprintM2 = grossFootprintM2 - sumFloorTouchingFootprintM2;
 
   const qtyLength = (name: string, value: number): number => {
     const id = w.nextId();
@@ -172,10 +193,12 @@ export function writeWallBaseQuantities(
     qtyLength('Length', lengthM),
     qtyLength('Width', widthM),
     qtyLength('Height', heightM),
-    qtyArea('GrossFootprintArea', footprintM2),
-    qtyVolume('GrossVolume', volumeM3),
-    // NetVolume equals GrossVolume until opening geometry is tracked (M3+).
-    qtyVolume('NetVolume', volumeM3),
+    qtyArea('GrossFootprintArea', grossFootprintM2),
+    qtyArea('NetFootprintArea', netFootprintM2),
+    qtyArea('GrossSideArea', grossSideAreaM2),
+    qtyArea('NetSideArea', netSideAreaM2),
+    qtyVolume('GrossVolume', grossVolumeM3),
+    qtyVolume('NetVolume', netVolumeM3),
   ];
 
   const qtoId = w.nextId();

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -88,9 +88,9 @@ export class BimModel {
 
     const cutResult = this.#cutWallGeometry(wall, openingSpec);
     if (!cutResult.ok) return err(cutResult.error);
+    this.#replaceWallGeometry(wall, cutResult.value);
 
     const openingId = this.#makeElement('OPENING', openingSpec, null);
-    this.#replaceWallGeometry(spec.wallLocalId, cutResult.value);
     this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
     const doorId = this.#makeElement('DOOR', spec, null);
     this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: doorId });
@@ -122,9 +122,9 @@ export class BimModel {
 
     const cutResult = this.#cutWallGeometry(wall, openingSpec);
     if (!cutResult.ok) return err(cutResult.error);
+    this.#replaceWallGeometry(wall, cutResult.value);
 
     const openingId = this.#makeElement('OPENING', openingSpec, null);
-    this.#replaceWallGeometry(spec.wallLocalId, cutResult.value);
     this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
     const windowId = this.#makeElement('WINDOW', spec, null);
     this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: windowId });
@@ -152,15 +152,10 @@ export class BimModel {
     return ok(cutResult.value);
   }
 
-  #replaceWallGeometry(wallId: LocalId, newGeometry: ValidSolid): void {
-    const wall = this.#elements.get(wallId);
-    if (wall === undefined || wall.category !== 'WALL') {
-      newGeometry[Symbol.dispose]();
-      throw new Error(`replaceWallGeometry: ${wallId} is not a wall`);
-    }
+  #replaceWallGeometry(wall: BimElement<'WALL'>, newGeometry: ValidSolid): void {
     const oldGeometry = wall.geometry;
     const replaced: BimElement<'WALL'> = { ...wall, geometry: newGeometry };
-    this.#elements.set(wallId, replaced);
+    this.#elements.set(wall.localId, replaced);
     oldGeometry[Symbol.dispose]();
   }
 

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -1,12 +1,12 @@
-import type { Result } from 'brepjs';
-import { ok, err } from 'brepjs';
+import type { Result, ValidSolid } from 'brepjs';
+import { ok, err, cut } from 'brepjs';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { LocalId } from '../identity/localId.js';
 import { makeLocalIdCounter } from '../identity/localId.js';
 import type { BimError } from '../errors/bimError.js';
-import { specError } from '../errors/bimError.js';
-import type { AnyBimElement, BimElement } from '../types/bimTypes.js';
+import { specError, fromBrepError } from '../errors/bimError.js';
+import type { AnyBimElement, BimElement, OpeningSpec } from '../types/bimTypes.js';
 import type {
   BimRelationship,
   AggregatesRel,
@@ -19,6 +19,7 @@ import type { WallSpec } from '../specs/wallSpec.js';
 import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from '../specs/spatialSpec.js';
 import { wallToSolid } from '../elementFns/wallFns.js';
+import { openingToSolid } from '../elementFns/openingFns.js';
 
 export class BimModel {
   readonly #elements = new Map<LocalId, AnyBimElement>();
@@ -78,13 +79,18 @@ export class BimModel {
     if (spec.offsetFromFloor + spec.height > wall.spec.height) {
       return err(specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetFromFloor + height) exceeds wall height'));
     }
-    const openingSpec = {
+    const openingSpec: OpeningSpec = {
       width: spec.width,
       height: spec.height,
       offsetAlongWall: spec.offsetAlongWall,
       offsetFromFloor: spec.offsetFromFloor,
     };
+
+    const cutResult = this.#cutWallGeometry(wall, openingSpec);
+    if (!cutResult.ok) return err(cutResult.error);
+
     const openingId = this.#makeElement('OPENING', openingSpec, null);
+    this.#replaceWallGeometry(spec.wallLocalId, cutResult.value);
     this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
     const doorId = this.#makeElement('DOOR', spec, null);
     this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: doorId });
@@ -107,13 +113,18 @@ export class BimModel {
     if (spec.offsetFromFloor + spec.height > wall.spec.height) {
       return err(specError('WINDOW_EXCEEDS_WALL_BOUNDS', 'Window (offsetFromFloor + height) exceeds wall height'));
     }
-    const openingSpec = {
+    const openingSpec: OpeningSpec = {
       width: spec.width,
       height: spec.height,
       offsetAlongWall: spec.offsetAlongWall,
       offsetFromFloor: spec.offsetFromFloor,
     };
+
+    const cutResult = this.#cutWallGeometry(wall, openingSpec);
+    if (!cutResult.ok) return err(cutResult.error);
+
     const openingId = this.#makeElement('OPENING', openingSpec, null);
+    this.#replaceWallGeometry(spec.wallLocalId, cutResult.value);
     this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
     const windowId = this.#makeElement('WINDOW', spec, null);
     this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: windowId });
@@ -123,6 +134,34 @@ export class BimModel {
       relatedObjects: [windowId],
     });
     return ok(windowId);
+  }
+
+  #cutWallGeometry(
+    wall: BimElement<'WALL'>,
+    openingSpec: OpeningSpec
+  ): Result<ValidSolid, BimError> {
+    const toolResult = openingToSolid(openingSpec, wall.spec.thickness);
+    if (!toolResult.ok) return err(toolResult.error);
+    using tool = toolResult.value;
+    const cutResult = cut(wall.geometry, tool);
+    if (!cutResult.ok) {
+      return err(
+        fromBrepError(cutResult.error, 'WALL_CUT_FAILED', 'Boolean cut of wall with opening failed')
+      );
+    }
+    return ok(cutResult.value);
+  }
+
+  #replaceWallGeometry(wallId: LocalId, newGeometry: ValidSolid): void {
+    const wall = this.#elements.get(wallId);
+    if (wall === undefined || wall.category !== 'WALL') {
+      newGeometry[Symbol.dispose]();
+      throw new Error(`replaceWallGeometry: ${wallId} is not a wall`);
+    }
+    const oldGeometry = wall.geometry;
+    const replaced: BimElement<'WALL'> = { ...wall, geometry: newGeometry };
+    this.#elements.set(wallId, replaced);
+    oldGeometry[Symbol.dispose]();
   }
 
   getDoors(): BimElement<'DOOR'>[] {

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -36,7 +36,7 @@ import type { Result } from 'brepjs';
 import { err } from 'brepjs';
 import type { LocalId } from '../identity/localId.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
-import type { BimElement } from '../types/bimTypes.js';
+import type { BimElement, OpeningSpec } from '../types/bimTypes.js';
 import type { BimRelationship } from '../types/relationships.js';
 
 export async function toIfc(
@@ -97,6 +97,16 @@ export async function toIfc(
     placementMap.set(el.localId, placementId);
   }
 
+  const openingsByWall = new Map<LocalId, OpeningSpec[]>();
+  for (const rel of relationships) {
+    if (rel.kind !== 'VOIDS_WALL') continue;
+    const opening = elements.find((el) => el.localId === rel.openingLocalId);
+    if (opening === undefined || opening.category !== 'OPENING') continue;
+    const list = openingsByWall.get(rel.wallLocalId) ?? [];
+    list.push(opening.spec);
+    openingsByWall.set(rel.wallLocalId, list);
+  }
+
   for (const [i, wall] of walls.entries()) {
     const containingId = findContainerOf(wall.localId, relationships);
     const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
@@ -113,7 +123,10 @@ export async function toIfc(
     if (wall.spec.customProperties !== undefined) {
       writeCustomPsets(w, ownerHistoryId, wallExpressId, wall.spec.customProperties);
     }
-    writeWallBaseQuantities(w, ownerHistoryId, wallExpressId, wall.spec);
+    writeWallBaseQuantities(
+      w, ownerHistoryId, wallExpressId, wall.spec,
+      openingsByWall.get(wall.localId) ?? []
+    );
   }
 
   const openingPlacementMap = new Map<LocalId, number>();

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { unwrap } from 'brepjs';
+import { unwrap, measureVolume } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
 
@@ -177,5 +177,89 @@ describe('BimModel.addWindow', () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('WINDOW_EXCEEDS_WALL_BOUNDS');
+  });
+});
+
+describe('BimModel — wall geometry is cut by openings (M4)', () => {
+  function buildWallModel() {
+    const model = new BimModel();
+    unwrap(model.init({ name: 'Test' }));
+    const wallId = unwrap(model.addWall(WALL_SPEC));
+    return { model, wallId };
+  }
+
+  function wallVolume(model: BimModel): number {
+    const wall = model.getWalls()[0];
+    if (!wall) throw new Error('Expected one wall');
+    return unwrap(measureVolume(wall.geometry));
+  }
+
+  it('wall volume drops by door volume after addDoor', () => {
+    const { model, wallId } = buildWallModel();
+    const grossVol = wallVolume(model);
+
+    const doorResult = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 1000, offsetFromFloor: 0,
+      wallLocalId: wallId, materialName: 'Wood',
+    });
+    expect(doorResult.ok).toBe(true);
+
+    const netVol = wallVolume(model);
+    const expectedDelta = 900 * 2100 * WALL_SPEC.thickness;
+    expect(grossVol - netVol).toBeCloseTo(expectedDelta, -2);
+  });
+
+  it('wall volume drops by combined opening volumes after door + window', () => {
+    const { model, wallId } = buildWallModel();
+    const grossVol = wallVolume(model);
+
+    unwrap(model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
+      wallLocalId: wallId, materialName: 'Wood',
+    }));
+    unwrap(model.addWindow({
+      width: 1200, height: 1500, offsetAlongWall: 2500, offsetFromFloor: 900,
+      wallLocalId: wallId, materialName: 'Glass',
+    }));
+
+    const netVol = wallVolume(model);
+    const expectedDelta = (900 * 2100 + 1200 * 1500) * WALL_SPEC.thickness;
+    expect(grossVol - netVol).toBeCloseTo(expectedDelta, -2);
+  });
+
+  it('addDoor with bounds violation does not mutate the model', () => {
+    const { model, wallId } = buildWallModel();
+    const elementsBefore = model.getAllElements().length;
+    const relsBefore = model.getAllRelationships().length;
+    const grossVol = wallVolume(model);
+
+    const result = model.addDoor({
+      width: WALL_SPEC.length + 100, height: 2100,
+      offsetAlongWall: 0, offsetFromFloor: 0,
+      wallLocalId: wallId, materialName: 'Wood',
+    });
+    expect(result.ok).toBe(false);
+
+    expect(model.getAllElements().length).toBe(elementsBefore);
+    expect(model.getAllRelationships().length).toBe(relsBefore);
+    expect(wallVolume(model)).toBeCloseTo(grossVol, -2);
+  });
+
+  it('addDoor with invalid wall reference does not mutate the model', () => {
+    const { model } = buildWallModel();
+    const elementsBefore = model.getAllElements().length;
+    const relsBefore = model.getAllRelationships().length;
+    const grossVol = wallVolume(model);
+
+    const result = model.addDoor({
+      width: 900, height: 2100, offsetAlongWall: 0, offsetFromFloor: 0,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- testing invalid input
+      wallLocalId: 9999 as any, materialName: 'Wood',
+    });
+    expect(result.ok).toBe(false);
+
+    expect(model.getAllElements().length).toBe(elementsBefore);
+    expect(model.getAllRelationships().length).toBe(relsBefore);
+    expect(wallVolume(model)).toBeCloseTo(grossVol, -2);
   });
 });

--- a/packages/brepjs-bim/tests/openingFns.test.ts
+++ b/packages/brepjs-bim/tests/openingFns.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume } from 'brepjs';
 import { parseDoorSpec, parseWindowSpec } from '../src/specs/openingSpec.js';
+import { openingToSolid } from '../src/elementFns/openingFns.js';
 
 describe('parseDoorSpec', () => {
   const BASE = {
@@ -52,5 +55,58 @@ describe('parseWindowSpec', () => {
   it('rejects non-positive thermalTransmittance', () => {
     const result = parseWindowSpec({ ...BASE, thermalTransmittance: 0 });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe('openingToSolid', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  const WALL_THICKNESS = 200;
+  const SPEC = {
+    width: 900,
+    height: 2100,
+    offsetAlongWall: 1000,
+    offsetFromFloor: 0,
+  };
+
+  it('returns a ValidSolid for a typical door-sized opening', () => {
+    const result = openingToSolid(SPEC, WALL_THICKNESS);
+    expect(result.ok).toBe(true);
+    if (result.ok) result.value[Symbol.dispose]();
+  });
+
+  it('volume slightly exceeds width × height × thickness due to ε overshoot', () => {
+    const result = openingToSolid(SPEC, WALL_THICKNESS);
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    const nominal = SPEC.width * SPEC.height * WALL_THICKNESS;
+    expect(vol.value).toBeGreaterThan(nominal);
+    expect(vol.value).toBeLessThan(nominal * 1.05);
+  });
+
+  it('rejects zero width', () => {
+    const result = openingToSolid({ ...SPEC, width: 0 }, WALL_THICKNESS);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe('BIM_SPEC');
+    expect(result.error.code).toBe('OPENING_ZERO_WIDTH');
+  });
+
+  it('rejects zero height', () => {
+    const result = openingToSolid({ ...SPEC, height: 0 }, WALL_THICKNESS);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe('BIM_SPEC');
+  });
+
+  it('rejects zero wall thickness', () => {
+    const result = openingToSolid(SPEC, 0);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe('BIM_SPEC');
   });
 });

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -354,7 +354,7 @@ describe('IFC Opening round-trip (M3)', () => {
     api.CloseModel(mid);
   });
 
-  it('emits all six wall base quantities including Gross/Net Side & Footprint areas', async () => {
+  it('emits all nine wall base quantities including Gross/Net Side & Footprint areas', async () => {
     const { api, mid } = await buildOpeningModel();
     const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
     let qto: Record<string, unknown> | undefined;
@@ -431,8 +431,16 @@ describe('IFC Opening round-trip (M3)', () => {
     const mid = api.OpenModel(result.value);
 
     const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
-     
-    const qto = api.GetLine(mid, elemQuantities.get(0)) as Record<string, unknown>;
+    let qto: Record<string, unknown> | undefined;
+    for (let i = 0; i < elemQuantities.size(); i++) {
+      const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Qto_WallBaseQuantities') {
+        qto = candidate;
+        break;
+      }
+    }
+    if (qto === undefined) throw new Error('Expected Qto_WallBaseQuantities');
     let gross = 0;
     let net = 0;
     const refs = qto['Quantities'] as Array<{ value: number }>;

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -354,6 +354,101 @@ describe('IFC Opening round-trip (M3)', () => {
     api.CloseModel(mid);
   });
 
+  it('emits all six wall base quantities including Gross/Net Side & Footprint areas', async () => {
+    const { api, mid } = await buildOpeningModel();
+    const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    let qto: Record<string, unknown> | undefined;
+    for (let i = 0; i < elemQuantities.size(); i++) {
+       
+      const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Qto_WallBaseQuantities') {
+        qto = candidate;
+        break;
+      }
+    }
+    if (qto === undefined) throw new Error('Expected Qto_WallBaseQuantities');
+
+    const quantityNames = new Set<string>();
+    const numericByName = new Map<string, number>();
+    const refs = qto['Quantities'] as Array<{ value: number }>;
+    for (const ref of refs) {
+       
+      const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      if (name === undefined) continue;
+      quantityNames.add(name);
+      const lengthVal = (q['LengthValue'] as { value?: number } | undefined)?.value;
+      const areaVal = (q['AreaValue'] as { value?: number } | undefined)?.value;
+      const volumeVal = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      const num = lengthVal ?? areaVal ?? volumeVal;
+      if (num !== undefined) numericByName.set(name, num);
+    }
+    expect(quantityNames.has('Length')).toBe(true);
+    expect(quantityNames.has('Width')).toBe(true);
+    expect(quantityNames.has('Height')).toBe(true);
+    expect(quantityNames.has('GrossFootprintArea')).toBe(true);
+    expect(quantityNames.has('NetFootprintArea')).toBe(true);
+    expect(quantityNames.has('GrossSideArea')).toBe(true);
+    expect(quantityNames.has('NetSideArea')).toBe(true);
+    expect(quantityNames.has('GrossVolume')).toBe(true);
+    expect(quantityNames.has('NetVolume')).toBe(true);
+
+    // 5 m × 3 m wall, 250 mm thick. Door 0.9×2.1, Window 1.2×1.4.
+    const totalOpeningAreaM2 = 0.9 * 2.1 + 1.2 * 1.4;
+    expect(numericByName.get('GrossSideArea')).toBeCloseTo(5 * 3, 5);
+    expect(numericByName.get('NetSideArea')).toBeCloseTo(5 * 3 - totalOpeningAreaM2, 5);
+    expect(numericByName.get('GrossVolume')).toBeCloseTo(5 * 3 * 0.25, 5);
+    expect(numericByName.get('NetVolume')).toBeCloseTo(5 * 3 * 0.25 - totalOpeningAreaM2 * 0.25, 5);
+    // Only the door reaches the floor (offsetFromFloor 0); window starts at 0.9 m.
+    expect(numericByName.get('GrossFootprintArea')).toBeCloseTo(5 * 0.25, 5);
+    expect(numericByName.get('NetFootprintArea')).toBeCloseTo(5 * 0.25 - 0.9 * 0.25, 5);
+
+    api.CloseModel(mid);
+  });
+
+  it('wall without openings emits NetVolume === GrossVolume', async () => {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'No-Op Wall' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(initResult.value, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const wallResult = model.addWall({
+      length: 4000, height: 2800, thickness: 200,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1], materialName: 'Concrete',
+    });
+    if (!wallResult.ok) throw new Error(wallResult.error.message);
+    model.placeIn(wallResult.value, storeyId);
+
+    const result = await toIfc(model, { applicationName: 'test', applicationVersion: '0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+
+    const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+     
+    const qto = api.GetLine(mid, elemQuantities.get(0)) as Record<string, unknown>;
+    let gross = 0;
+    let net = 0;
+    const refs = qto['Quantities'] as Array<{ value: number }>;
+    for (const ref of refs) {
+       
+      const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      const vol = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      if (name === 'GrossVolume' && vol !== undefined) gross = vol;
+      if (name === 'NetVolume' && vol !== undefined) net = vol;
+    }
+    expect(gross).toBeGreaterThan(0);
+    expect(net).toBeCloseTo(gross, 6);
+    api.CloseModel(mid);
+  });
+
   it('door GlobalId matches BimModel door GUID', async () => {
     const model = new BimModel();
     const initResult = model.init({ name: 'GUID Test' });


### PR DESCRIPTION
## Summary

- **Boolean-cut wall geometry**: `addDoor`/`addWindow` now subtract the opening void from the wall's `ValidSolid` eagerly. `wall.geometry` always reflects the as-built net body — what you'd see if an IFC viewer applied the `IfcRelVoidsElement` cuts.
- **Atomic rollback**: the cut runs *before* any model state mutates. If it fails (or if any spec/bounds check fails), no element or relationship is registered and `wall.geometry` is unchanged. Returns `BIM_GEOMETRY` `Result.Err` on cut failure.
- **Accurate net quantities**: `Qto_WallBaseQuantities` now emits true `NetVolume`, `NetSideArea`, `NetFootprintArea` computed analytically from the opening list, plus the previously-missing `GrossSideArea`. Closes the M3 follow-up flagged in the wall-base-quantities comment.

## Architecture

`openingToSolid(spec, wallThickness)` builds the boolean tool in wall-local coords with a 1 mm ε overshoot on the Y (thickness) axis to avoid coplanar-face hazards in OCCT. `BimModel.#cutWallGeometry` uses brepjs `cut()`; `BimModel.#replaceWallGeometry` swaps the element record and disposes the old solid.

IFC representation is **unchanged** — walls remain `IfcExtrudedAreaSolid` with `IfcRelVoidsElement` references to `IfcOpeningElement` voids. The cut only affects the brepjs solid and the analytical quantities. No CSG / `IfcBooleanClippingResult` / faceted-BREP geometry.

`NetFootprintArea` only subtracts openings whose `offsetFromFloor` is within 1 mm of the floor (i.e. doors); windows do not reduce footprint.

## Test plan

- [ ] `openingFns.test.ts` — 5 new tests for `openingToSolid` (returns ValidSolid, volume bounds, rejects zero dims)
- [ ] `bimModel.test.ts` — 4 new tests: wall volume drops after addDoor; combined door + window volume; rollback on bounds violation; rollback on invalid wall ref
- [ ] `roundTrip.test.ts` — 2 new tests: emits all 6 wall base quantities with correct numeric values; wall without openings has NetVolume === GrossVolume
- [ ] All 77 BIM package tests pass; root `npm run validate` is green; package build clean