### PR TITLE
feat(bim): slabs & roofs (IfcSlab + Pset_SlabCommon + Qto) — M5

### DIFF
--- a/packages/brepjs-bim/src/elementFns/slabFns.ts
+++ b/packages/brepjs-bim/src/elementFns/slabFns.ts
@@ -1,0 +1,48 @@
+import { polygon, extrude, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { SlabSpec } from '../specs/slabSpec.js';
+import type { BimError } from '../errors/bimError.js';
+import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
+
+// Returned solid is unplaced template geometry: footprint rectangle in the
+// global XY plane (length × width), extruded along +Z by thickness.
+// origin/axisX/axisZ are applied by the IFC layer via IfcLocalPlacement.
+export function slabToSolid(spec: SlabSpec): Result<ValidSolid, BimError> {
+  if (spec.length <= 0) {
+    return err(specError('SLAB_ZERO_LENGTH', 'Slab length must be positive'));
+  }
+  if (spec.width <= 0) {
+    return err(specError('SLAB_ZERO_WIDTH', 'Slab width must be positive'));
+  }
+  if (spec.thickness <= 0) {
+    return err(specError('SLAB_ZERO_THICKNESS', 'Slab thickness must be positive'));
+  }
+
+  const { length, width, thickness } = spec;
+
+  const profileResult = polygon([
+    [0, 0, 0],
+    [length, 0, 0],
+    [length, width, 0],
+    [0, width, 0],
+  ]);
+
+  if (!profileResult.ok) {
+    return err(fromBrepError(profileResult.error, 'SLAB_PROFILE_FAILED', 'Failed to create slab profile'));
+  }
+
+  using profile = profileResult.value;
+  const solidResult = extrude(profile, [0, 0, thickness]);
+
+  if (!solidResult.ok) {
+    return err(fromBrepError(solidResult.error, 'SLAB_EXTRUDE_FAILED', 'Failed to extrude slab profile'));
+  }
+
+  const solid = solidResult.value;
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(geometryError('SLAB_INVALID_SOLID', 'Extruded slab solid failed validity check'));
+  }
+  return ok(solid);
+}

--- a/packages/brepjs-bim/src/ifc-writer/entityWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/entityWriter.ts
@@ -159,3 +159,29 @@ export function writeWallEntity(
   });
   return id;
 }
+
+export function writeSlabEntity(
+  w: IfcWriter,
+  guid: IfcGuid,
+  name: string,
+  predefinedType: 'FLOOR' | 'ROOF' | 'LANDING' | 'BASESLAB',
+  ownerHistoryId: number,
+  localPlacementId: number,
+  productDefinitionShapeId: number
+): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCSLAB,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(localPlacementId),
+    Representation: w.ref(productDefinitionShapeId),
+    Tag: null,
+    PredefinedType: { type: 3, value: predefinedType },
+  });
+  return id;
+}

--- a/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
@@ -2,9 +2,15 @@ import * as WebIFC from 'web-ifc';
 import type { IfcWriter } from './ifcWriter.js';
 import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { SlabSpec } from '../specs/slabSpec.js';
 import { toIfcLengthM } from '../units/units.js';
 
 export interface WallRepresentationIds {
+  localPlacementId: number;
+  productDefinitionShapeId: number;
+}
+
+export interface SlabRepresentationIds {
   localPlacementId: number;
   productDefinitionShapeId: number;
 }
@@ -57,6 +63,96 @@ export function writeWallGeometry(
     Position: w.ref(extrusionPosId),
     ExtrudedDirection: w.ref(extrusionDirId),
     Depth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, lengthM),
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'SweptSolid'),
+    Items: [w.ref(extrusionId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+
+  return { localPlacementId, productDefinitionShapeId };
+}
+
+export function writeSlabGeometry(
+  w: IfcWriter,
+  spec: SlabSpec,
+  geomSubContextId: number,
+  parentPlacementId: number | null
+): SlabRepresentationIds {
+  const placement3DId = writeAxis2Placement3D(
+    w,
+    spec.origin.map(toIfcLengthM) as [number, number, number],
+    spec.axisZ,
+    spec.axisX
+  );
+
+  const localPlacementId = w.nextId();
+  w.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: parentPlacementId !== null ? w.ref(parentPlacementId) : null,
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const lengthM = toIfcLengthM(spec.length);
+  const widthM = toIfcLengthM(spec.width);
+  const thicknessM = toIfcLengthM(spec.thickness);
+
+  // Profile centered at (length/2, width/2) so the local frame matches the
+  // brepjs solid (corner at origin, extends to +X/+Y). IFC rectangle profiles
+  // are centered on their position, so we shift the position to compensate.
+  const profileOriginId = w.nextId();
+  w.writeLine({
+    expressID: profileOriginId,
+    type: WebIFC.IFCCARTESIANPOINT,
+    Coordinates: [
+      w.mkType(WebIFC.IFCLENGTHMEASURE, lengthM / 2),
+      w.mkType(WebIFC.IFCLENGTHMEASURE, widthM / 2),
+    ],
+  });
+  const profilePosId = w.nextId();
+  w.writeLine({
+    expressID: profilePosId,
+    type: WebIFC.IFCAXIS2PLACEMENT2D,
+    Location: w.ref(profileOriginId),
+    RefDirection: null,
+  });
+
+  const profileId = w.nextId();
+  w.writeLine({
+    expressID: profileId,
+    type: WebIFC.IFCRECTANGLEPROFILEDEF,
+    ProfileType: { type: 3, value: 'AREA' },
+    ProfileName: null,
+    Position: w.ref(profilePosId),
+    XDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, lengthM),
+    YDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, widthM),
+  });
+
+  const extrusionPosId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const extrusionDirId = writeDirection(w, [0, 0, 1]);
+  const extrusionId = w.nextId();
+  w.writeLine({
+    expressID: extrusionId,
+    type: WebIFC.IFCEXTRUDEDAREASOLID,
+    SweptArea: w.ref(profileId),
+    Position: w.ref(extrusionPosId),
+    ExtrudedDirection: w.ref(extrusionDirId),
+    Depth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, thicknessM),
   });
 
   const shapeRepId = w.nextId();

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -56,7 +56,7 @@ function writePropertySet(
 function writeRelDefinesByProperties(
   w: IfcWriter,
   ownerHistoryId: number,
-  wallExpressId: number,
+  entityExpressId: number,
   psetId: number
 ): void {
   w.writeLine({
@@ -66,7 +66,7 @@ function writeRelDefinesByProperties(
     OwnerHistory: w.ref(ownerHistoryId),
     Name: null,
     Description: null,
-    RelatedObjects: [w.ref(wallExpressId)],
+    RelatedObjects: [w.ref(entityExpressId)],
     RelatingPropertyDefinition: w.ref(psetId),
   });
 }
@@ -112,13 +112,13 @@ export function writeManufacturerPset(
 export function writeCustomPsets(
   w: IfcWriter,
   ownerHistoryId: number,
-  wallExpressId: number,
+  entityExpressId: number,
   customProperties: Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
 ): void {
   for (const [psetName, props] of Object.entries(customProperties)) {
     if (Object.keys(props).length === 0) continue;
     const psetId = writePropertySet(w, ownerHistoryId, psetName, { ...props });
-    writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
+    writeRelDefinesByProperties(w, ownerHistoryId, entityExpressId, psetId);
   }
 }
 
@@ -249,19 +249,6 @@ export function writeSlabCommonPset(
   if (Object.keys(props).length === 0) return;
   const psetId = writePropertySet(w, ownerHistoryId, 'Pset_SlabCommon', props);
   writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, psetId);
-}
-
-export function writeSlabCustomPsets(
-  w: IfcWriter,
-  ownerHistoryId: number,
-  slabExpressId: number,
-  customProperties: Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
-): void {
-  for (const [psetName, props] of Object.entries(customProperties)) {
-    if (Object.keys(props).length === 0) continue;
-    const psetId = writePropertySet(w, ownerHistoryId, psetName, { ...props });
-    writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, psetId);
-  }
 }
 
 export function writeSlabBaseQuantities(

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -2,6 +2,7 @@ import * as WebIFC from 'web-ifc';
 import type { IfcWriter } from './ifcWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { SlabSpec } from '../specs/slabSpec.js';
 import type { OpeningSpec } from '../types/bimTypes.js';
 import { toIfcLengthM } from '../units/units.js';
 
@@ -87,11 +88,17 @@ export function writeWallCommonPset(
   writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
 }
 
+interface ManufacturerFields {
+  readonly manufacturerName?: string | undefined;
+  readonly manufacturerModel?: string | undefined;
+  readonly manufacturerProductionYear?: number | undefined;
+}
+
 export function writeManufacturerPset(
   w: IfcWriter,
   ownerHistoryId: number,
-  wallExpressId: number,
-  spec: WallSpec
+  entityExpressId: number,
+  spec: ManufacturerFields
 ): void {
   const props: Record<string, PsetValue> = {};
   if (spec.manufacturerName !== undefined) props['Manufacturer'] = spec.manufacturerName;
@@ -99,7 +106,7 @@ export function writeManufacturerPset(
   if (spec.manufacturerProductionYear !== undefined) props['ProductionYear'] = spec.manufacturerProductionYear;
   if (Object.keys(props).length === 0) return;
   const psetId = writePropertySet(w, ownerHistoryId, 'Pset_ManufacturerTypeInformation', props);
-  writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
+  writeRelDefinesByProperties(w, ownerHistoryId, entityExpressId, psetId);
 }
 
 export function writeCustomPsets(
@@ -118,6 +125,68 @@ export function writeCustomPsets(
 // Openings whose floor offset is within this many metres of 0 are treated as
 // reaching the floor (i.e. they reduce the wall footprint), e.g. doors.
 const FLOOR_TOUCH_EPSILON_M = 1e-3;
+
+function writeQtyLength(w: IfcWriter, name: string, valueM: number): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCQUANTITYLENGTH,
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    Unit: null,
+    LengthValue: w.mkType(WebIFC.IFCLENGTHMEASURE, valueM),
+    Formula: null,
+  });
+  return id;
+}
+
+function writeQtyArea(w: IfcWriter, name: string, valueM2: number): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCQUANTITYAREA,
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    Unit: null,
+    AreaValue: w.mkType(WebIFC.IFCAREAMEASURE, valueM2),
+    Formula: null,
+  });
+  return id;
+}
+
+function writeQtyVolume(w: IfcWriter, name: string, valueM3: number): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCQUANTITYVOLUME,
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    Unit: null,
+    VolumeValue: w.mkType(WebIFC.IFCVOLUMEMEASURE, valueM3),
+    Formula: null,
+  });
+  return id;
+}
+
+function writeElementQuantity(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  qtoName: string,
+  quantityIds: readonly number[]
+): number {
+  const qtoId = w.nextId();
+  w.writeLine({
+    expressID: qtoId,
+    type: WebIFC.IFCELEMENTQUANTITY,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, qtoName),
+    Description: null,
+    MethodOfMeasurement: null,
+    Quantities: quantityIds.map((id) => w.ref(id)),
+  });
+  return qtoId;
+}
 
 export function writeWallBaseQuantities(
   w: IfcWriter,
@@ -147,71 +216,82 @@ export function writeWallBaseQuantities(
   const netVolumeM3 = grossVolumeM3 - sumOpeningAreaM2 * widthM;
   const netFootprintM2 = grossFootprintM2 - sumFloorTouchingFootprintM2;
 
-  const qtyLength = (name: string, value: number): number => {
-    const id = w.nextId();
-    w.writeLine({
-      expressID: id,
-      type: WebIFC.IFCQUANTITYLENGTH,
-      Name: w.mkType(WebIFC.IFCLABEL, name),
-      Description: null,
-      Unit: null,
-      LengthValue: w.mkType(WebIFC.IFCLENGTHMEASURE, value),
-      Formula: null,
-    });
-    return id;
-  };
-
-  const qtyArea = (name: string, value: number): number => {
-    const id = w.nextId();
-    w.writeLine({
-      expressID: id,
-      type: WebIFC.IFCQUANTITYAREA,
-      Name: w.mkType(WebIFC.IFCLABEL, name),
-      Description: null,
-      Unit: null,
-      AreaValue: w.mkType(WebIFC.IFCAREAMEASURE, value),
-      Formula: null,
-    });
-    return id;
-  };
-
-  const qtyVolume = (name: string, value: number): number => {
-    const id = w.nextId();
-    w.writeLine({
-      expressID: id,
-      type: WebIFC.IFCQUANTITYVOLUME,
-      Name: w.mkType(WebIFC.IFCLABEL, name),
-      Description: null,
-      Unit: null,
-      VolumeValue: w.mkType(WebIFC.IFCVOLUMEMEASURE, value),
-      Formula: null,
-    });
-    return id;
-  };
-
   const qtyIds = [
-    qtyLength('Length', lengthM),
-    qtyLength('Width', widthM),
-    qtyLength('Height', heightM),
-    qtyArea('GrossFootprintArea', grossFootprintM2),
-    qtyArea('NetFootprintArea', netFootprintM2),
-    qtyArea('GrossSideArea', grossSideAreaM2),
-    qtyArea('NetSideArea', netSideAreaM2),
-    qtyVolume('GrossVolume', grossVolumeM3),
-    qtyVolume('NetVolume', netVolumeM3),
+    writeQtyLength(w, 'Length', lengthM),
+    writeQtyLength(w, 'Width', widthM),
+    writeQtyLength(w, 'Height', heightM),
+    writeQtyArea(w, 'GrossFootprintArea', grossFootprintM2),
+    writeQtyArea(w, 'NetFootprintArea', netFootprintM2),
+    writeQtyArea(w, 'GrossSideArea', grossSideAreaM2),
+    writeQtyArea(w, 'NetSideArea', netSideAreaM2),
+    writeQtyVolume(w, 'GrossVolume', grossVolumeM3),
+    writeQtyVolume(w, 'NetVolume', netVolumeM3),
   ];
 
-  const qtoId = w.nextId();
-  w.writeLine({
-    expressID: qtoId,
-    type: WebIFC.IFCELEMENTQUANTITY,
-    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
-    OwnerHistory: w.ref(ownerHistoryId),
-    Name: w.mkType(WebIFC.IFCLABEL, 'Qto_WallBaseQuantities'),
-    Description: null,
-    MethodOfMeasurement: null,
-    Quantities: qtyIds.map((id) => w.ref(id)),
-  });
-
+  const qtoId = writeElementQuantity(w, ownerHistoryId, 'Qto_WallBaseQuantities', qtyIds);
   writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, qtoId);
+}
+
+export function writeSlabCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  slabExpressId: number,
+  spec: SlabSpec
+): void {
+  const props: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
+  if (spec.loadBearing !== undefined) props['LoadBearing'] = spec.loadBearing;
+  if (spec.combustible !== undefined) props['Combustible'] = spec.combustible;
+  if (spec.compartmentation !== undefined) props['Compartmentation'] = spec.compartmentation;
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_SlabCommon', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, psetId);
+}
+
+export function writeSlabCustomPsets(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  slabExpressId: number,
+  customProperties: Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+): void {
+  for (const [psetName, props] of Object.entries(customProperties)) {
+    if (Object.keys(props).length === 0) continue;
+    const psetId = writePropertySet(w, ownerHistoryId, psetName, { ...props });
+    writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, psetId);
+  }
+}
+
+export function writeSlabBaseQuantities(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  slabExpressId: number,
+  spec: SlabSpec
+): void {
+  const lengthM = toIfcLengthM(spec.length);
+  const widthM = toIfcLengthM(spec.width);
+  const thicknessM = toIfcLengthM(spec.thickness);
+  const grossAreaM2 = lengthM * widthM;
+  const perimeterM = 2 * (lengthM + widthM);
+  const grossVolumeM3 = grossAreaM2 * thicknessM;
+
+  // M5 has no slab openings; Net == Gross until that lands.
+  const netAreaM2 = grossAreaM2;
+  const netVolumeM3 = grossVolumeM3;
+
+  const qtyIds = [
+    writeQtyLength(w, 'Width', widthM),
+    writeQtyLength(w, 'Length', lengthM),
+    writeQtyLength(w, 'Depth', thicknessM),
+    writeQtyLength(w, 'Perimeter', perimeterM),
+    writeQtyArea(w, 'GrossArea', grossAreaM2),
+    writeQtyArea(w, 'NetArea', netAreaM2),
+    writeQtyVolume(w, 'GrossVolume', grossVolumeM3),
+    writeQtyVolume(w, 'NetVolume', netVolumeM3),
+  ];
+
+  const qtoId = writeElementQuantity(w, ownerHistoryId, 'Qto_SlabBaseQuantities', qtyIds);
+  writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, qtoId);
 }

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -1,6 +1,7 @@
 export { BimModel } from './model/bimModel.js';
 export { toIfc } from './serialize/toIfc.js';
 export { parseWallSpec } from './specs/wallSpec.js';
+export { parseSlabSpec } from './specs/slabSpec.js';
 export { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 export { newIfcGuid, isValidIfcGuid } from './identity/ifcGuid.js';
 export { makeLocalIdCounter } from './identity/localId.js';
@@ -8,6 +9,7 @@ export { DEFAULT_UNITS, toLengthMm, toIfcLengthM } from './units/units.js';
 export { specError, ifcError, geometryError, fromBrepError } from './errors/bimError.js';
 
 export type { WallSpec } from './specs/wallSpec.js';
+export type { SlabSpec, SlabPredefinedType } from './specs/slabSpec.js';
 export type { DoorSpec, WindowSpec } from './specs/openingSpec.js';
 export type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from './specs/spatialSpec.js';
 export type { BimCategory, BimElement, AnyBimElement, OpeningSpec } from './types/bimTypes.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -16,9 +16,11 @@ import type {
   FillsOpeningRel,
 } from '../types/relationships.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { SlabSpec } from '../specs/slabSpec.js';
 import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from '../specs/spatialSpec.js';
 import { wallToSolid } from '../elementFns/wallFns.js';
+import { slabToSolid } from '../elementFns/slabFns.js';
 import { openingToSolid } from '../elementFns/openingFns.js';
 
 export class BimModel {
@@ -38,7 +40,7 @@ export class BimModel {
 
   [Symbol.dispose](): void {
     for (const el of this.#elements.values()) {
-      if (el.category === 'WALL') {
+      if (el.category === 'WALL' || el.category === 'SLAB') {
         el.geometry[Symbol.dispose]();
       }
     }
@@ -60,6 +62,18 @@ export class BimModel {
     const geomResult = wallToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('WALL', spec, geomResult.value);
+    this.#makeRel<AssociatesMaterialRel>({
+      kind: 'ASSOCIATES_MATERIAL',
+      materialName: spec.materialName,
+      relatedObjects: [id],
+    });
+    return ok(id);
+  }
+
+  addSlab(spec: SlabSpec): Result<LocalId, BimError> {
+    const geomResult = slabToSolid(spec);
+    if (!geomResult.ok) return err(geomResult.error);
+    const id = this.#makeElement('SLAB', spec, geomResult.value);
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
       materialName: spec.materialName,
@@ -237,6 +251,14 @@ export class BimModel {
       if (el.category === 'WALL') walls.push(el);
     }
     return walls;
+  }
+
+  getSlabs(): BimElement<'SLAB'>[] {
+    const slabs: BimElement<'SLAB'>[] = [];
+    for (const el of this.#elements.values()) {
+      if (el.category === 'SLAB') slabs.push(el);
+    }
+    return slabs;
   }
 
   getAllElements(): AnyBimElement[] {

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -22,7 +22,6 @@ import {
   writeCustomPsets,
   writeWallBaseQuantities,
   writeSlabCommonPset,
-  writeSlabCustomPsets,
   writeSlabBaseQuantities,
 } from '../ifc-writer/psetWriter.js';
 import {
@@ -149,7 +148,7 @@ export async function toIfc(
     writeSlabCommonPset(w, ownerHistoryId, slabExpressId, slab.spec);
     writeManufacturerPset(w, ownerHistoryId, slabExpressId, slab.spec);
     if (slab.spec.customProperties !== undefined) {
-      writeSlabCustomPsets(w, ownerHistoryId, slabExpressId, slab.spec.customProperties);
+      writeCustomPsets(w, ownerHistoryId, slabExpressId, slab.spec.customProperties);
     }
     writeSlabBaseQuantities(w, ownerHistoryId, slabExpressId, slab.spec);
   }

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -8,8 +8,9 @@ import {
   writeBuilding,
   writeStorey,
   writeWallEntity,
+  writeSlabEntity,
 } from '../ifc-writer/entityWriter.js';
-import { writeWallGeometry } from '../ifc-writer/geometryWriter.js';
+import { writeWallGeometry, writeSlabGeometry } from '../ifc-writer/geometryWriter.js';
 import {
   writeRelAggregates,
   writeRelContainedInSpatialStructure,
@@ -20,6 +21,9 @@ import {
   writeManufacturerPset,
   writeCustomPsets,
   writeWallBaseQuantities,
+  writeSlabCommonPset,
+  writeSlabCustomPsets,
+  writeSlabBaseQuantities,
 } from '../ifc-writer/psetWriter.js';
 import {
   writeOpeningGeometry,
@@ -55,6 +59,7 @@ export async function toIfc(
   const elements = model.getAllElements();
   const relationships = model.getAllRelationships();
   const walls = model.getWalls();
+  const slabs = model.getSlabs();
   const doors = model.getDoors();
   const windows = model.getWindows();
 
@@ -127,6 +132,26 @@ export async function toIfc(
       w, ownerHistoryId, wallExpressId, wall.spec,
       openingsByWall.get(wall.localId) ?? []
     );
+  }
+
+  for (const [i, slab] of slabs.entries()) {
+    const containingId = findContainerOf(slab.localId, relationships);
+    const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
+    const { localPlacementId, productDefinitionShapeId } = writeSlabGeometry(
+      w, slab.spec, geomSubContextId, storeyPlacementId
+    );
+    const slabExpressId = writeSlabEntity(
+      w, slab.guid, `Slab ${i + 1}`, slab.spec.predefinedType,
+      ownerHistoryId, localPlacementId, productDefinitionShapeId
+    );
+    idMap.set(slab.localId, slabExpressId);
+    placementMap.set(slab.localId, localPlacementId);
+    writeSlabCommonPset(w, ownerHistoryId, slabExpressId, slab.spec);
+    writeManufacturerPset(w, ownerHistoryId, slabExpressId, slab.spec);
+    if (slab.spec.customProperties !== undefined) {
+      writeSlabCustomPsets(w, ownerHistoryId, slabExpressId, slab.spec.customProperties);
+    }
+    writeSlabBaseQuantities(w, ownerHistoryId, slabExpressId, slab.spec);
   }
 
   const openingPlacementMap = new Map<LocalId, number>();

--- a/packages/brepjs-bim/src/specs/slabSpec.ts
+++ b/packages/brepjs-bim/src/specs/slabSpec.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+import type { BimError } from '../errors/bimError.js';
+import { specError } from '../errors/bimError.js';
+import type { Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+
+export type SlabPredefinedType = 'FLOOR' | 'ROOF' | 'LANDING' | 'BASESLAB';
+
+// A rectangular slab. All dimensions in mm.
+// Profile lies in the local XY plane (length × width); slab extrudes along
+// local +Z by thickness. origin/axisX/axisZ position the slab in world space
+// via IfcLocalPlacement.
+export interface SlabSpec {
+  readonly length: number;
+  readonly width: number;
+  readonly thickness: number;
+  readonly origin: [number, number, number];
+  readonly axisX: [number, number, number];
+  readonly axisZ: [number, number, number];
+  readonly predefinedType: SlabPredefinedType;
+  readonly materialName: string;
+
+  readonly isExternal?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+  readonly loadBearing?: boolean | undefined;
+  readonly combustible?: boolean | undefined;
+  readonly compartmentation?: boolean | undefined;
+
+  readonly manufacturerName?: string | undefined;
+  readonly manufacturerModel?: string | undefined;
+  readonly manufacturerProductionYear?: number | undefined;
+
+  readonly customProperties?:
+    | Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+    | undefined;
+}
+
+const unitVec = z.tuple([z.number(), z.number(), z.number()]).refine(
+  (v) => Math.abs(v[0] ** 2 + v[1] ** 2 + v[2] ** 2 - 1) < 1e-6,
+  { message: 'must be a unit vector' }
+);
+
+const SlabSpecSchema = z.object({
+  length: z.number().positive(),
+  width: z.number().positive(),
+  thickness: z.number().positive(),
+  origin: z.tuple([z.number(), z.number(), z.number()]),
+  axisX: unitVec,
+  axisZ: unitVec,
+  predefinedType: z.enum(['FLOOR', 'ROOF', 'LANDING', 'BASESLAB']),
+  materialName: z.string().min(1),
+
+  isExternal: z.boolean().optional(),
+  fireRating: z.string().optional(),
+  acousticRating: z.string().optional(),
+  thermalTransmittance: z.number().positive().optional(),
+  loadBearing: z.boolean().optional(),
+  combustible: z.boolean().optional(),
+  compartmentation: z.boolean().optional(),
+
+  manufacturerName: z.string().optional(),
+  manufacturerModel: z.string().optional(),
+  manufacturerProductionYear: z.number().int().positive().optional(),
+
+  customProperties: z.record(
+    z.string(),
+    z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+  ).optional(),
+}).superRefine((data, ctx) => {
+  const dot =
+    data.axisX[0] * data.axisZ[0] +
+    data.axisX[1] * data.axisZ[1] +
+    data.axisX[2] * data.axisZ[2];
+  if (Math.abs(dot) > 1e-6) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'axisX and axisZ must be orthogonal',
+      path: ['axisZ'],
+    });
+  }
+});
+
+export function parseSlabSpec(input: unknown): Result<SlabSpec, BimError> {
+  const result = SlabSpecSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_SLAB_SPEC', result.error.message, result.error));
+  }
+  return ok(result.data as SlabSpec);
+}

--- a/packages/brepjs-bim/src/types/bimTypes.ts
+++ b/packages/brepjs-bim/src/types/bimTypes.ts
@@ -2,6 +2,7 @@ import type { ValidSolid } from 'brepjs';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { LocalId } from '../identity/localId.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { SlabSpec } from '../specs/slabSpec.js';
 import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type {
   ProjectSpec,
@@ -10,7 +11,16 @@ import type {
   StoreySpec,
 } from '../specs/spatialSpec.js';
 
-export type BimCategory = 'WALL' | 'OPENING' | 'DOOR' | 'WINDOW' | 'PROJECT' | 'SITE' | 'BUILDING' | 'STOREY';
+export type BimCategory =
+  | 'WALL'
+  | 'SLAB'
+  | 'OPENING'
+  | 'DOOR'
+  | 'WINDOW'
+  | 'PROJECT'
+  | 'SITE'
+  | 'BUILDING'
+  | 'STOREY';
 
 export type OpeningSpec = {
   readonly width: number;
@@ -21,23 +31,25 @@ export type OpeningSpec = {
 
 export type BimSpecFor<C extends BimCategory> = C extends 'WALL'
   ? WallSpec
-  : C extends 'OPENING'
-    ? OpeningSpec
-    : C extends 'DOOR'
-      ? DoorSpec
-      : C extends 'WINDOW'
-        ? WindowSpec
-        : C extends 'PROJECT'
-          ? ProjectSpec
-          : C extends 'SITE'
-            ? SiteSpec
-            : C extends 'BUILDING'
-              ? BuildingSpec
-              : C extends 'STOREY'
-                ? StoreySpec
-                : never;
+  : C extends 'SLAB'
+    ? SlabSpec
+    : C extends 'OPENING'
+      ? OpeningSpec
+      : C extends 'DOOR'
+        ? DoorSpec
+        : C extends 'WINDOW'
+          ? WindowSpec
+          : C extends 'PROJECT'
+            ? ProjectSpec
+            : C extends 'SITE'
+              ? SiteSpec
+              : C extends 'BUILDING'
+                ? BuildingSpec
+                : C extends 'STOREY'
+                  ? StoreySpec
+                  : never;
 
-export type BimGeometryFor<C extends BimCategory> = C extends 'WALL'
+export type BimGeometryFor<C extends BimCategory> = C extends 'WALL' | 'SLAB'
   ? ValidSolid
   : null;
 
@@ -51,6 +63,7 @@ export interface BimElement<C extends BimCategory> {
 
 export type AnyBimElement =
   | BimElement<'WALL'>
+  | BimElement<'SLAB'>
   | BimElement<'OPENING'>
   | BimElement<'DOOR'>
   | BimElement<'WINDOW'>

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -263,3 +263,70 @@ describe('BimModel — wall geometry is cut by openings (M4)', () => {
     expect(wallVolume(model)).toBeCloseTo(grossVol, -2);
   });
 });
+
+describe('BimModel.addSlab', () => {
+  const SLAB_SPEC = {
+    length: 5000,
+    width: 4000,
+    thickness: 200,
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    predefinedType: 'FLOOR' as const,
+    materialName: 'Concrete',
+  };
+
+  it('adds a slab and returns a LocalId', () => {
+    const model = new BimModel();
+    const result = model.addSlab(SLAB_SPEC);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(model.getSlabs()).toHaveLength(1);
+    expect(model.getElement(result.value)).not.toBeNull();
+  });
+
+  it('addSlab fails with invalid spec', () => {
+    const model = new BimModel();
+    const result = model.addSlab({ ...SLAB_SPEC, length: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('stores the predefinedType on the spec', () => {
+    const model = new BimModel();
+    unwrap(model.addSlab(SLAB_SPEC));
+    unwrap(model.addSlab({ ...SLAB_SPEC, predefinedType: 'ROOF' }));
+    const slabs = model.getSlabs();
+    expect(slabs.map((s) => s.spec.predefinedType).sort()).toEqual(['FLOOR', 'ROOF']);
+  });
+
+  it('volume of stored slab geometry matches dimensions', () => {
+    const model = new BimModel();
+    const result = model.addSlab(SLAB_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const slab = model.getSlabs()[0];
+    if (!slab) throw new Error('Expected one slab');
+    const vol = unwrap(measureVolume(slab.geometry));
+    expect(vol).toBeCloseTo(5000 * 4000 * 200, -2);
+  });
+
+  it('[Symbol.dispose] disposes slab geometry', () => {
+    const model = new BimModel();
+    const result = model.addSlab(SLAB_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const slab = model.getSlabs()[0];
+    if (!slab) throw new Error('Expected one slab');
+    model[Symbol.dispose]();
+    expect(slab.geometry.disposed).toBe(true);
+  });
+
+  it('emits an ASSOCIATES_MATERIAL relationship', () => {
+    const model = new BimModel();
+    const result = model.addSlab(SLAB_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const matRels = model
+      .getAllRelationships()
+      .filter((r) => r.kind === 'ASSOCIATES_MATERIAL');
+    expect(matRels).toHaveLength(1);
+    expect(matRels[0]?.materialName).toBe('Concrete');
+  });
+});

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -494,3 +494,136 @@ describe('IFC Opening round-trip (M3)', () => {
     api.CloseModel(mid);
   });
 });
+
+describe('IFC Slab round-trip (M5)', () => {
+  const SLAB_SPEC = {
+    length: 6000,
+    width: 4000,
+    thickness: 250,
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    predefinedType: 'FLOOR' as const,
+    materialName: 'Concrete',
+    isExternal: false,
+    fireRating: 'REI120',
+    loadBearing: true,
+    compartmentation: true,
+  };
+
+  async function buildSlabModel(extra?: { roof?: boolean }): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'Slab Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(initResult.value, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const slabResult = model.addSlab(SLAB_SPEC);
+    if (!slabResult.ok) throw new Error(slabResult.error.message);
+    model.placeIn(slabResult.value, storeyId);
+    if (extra?.roof) {
+      const roofResult = model.addSlab({
+        ...SLAB_SPEC,
+        origin: [0, 0, 3000],
+        predefinedType: 'ROOF',
+        materialName: 'Concrete',
+      });
+      if (!roofResult.ok) throw new Error(roofResult.error.message);
+      model.placeIn(roofResult.value, storeyId);
+    }
+    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    return { api, mid };
+  }
+
+  it('emits an IfcSlab', async () => {
+    const { api, mid } = await buildSlabModel();
+    const slabs = api.GetLineIDsWithType(mid, WebIFC.IFCSLAB);
+    expect(slabs.size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('IfcSlab PredefinedType matches spec for FLOOR and ROOF', async () => {
+    const { api, mid } = await buildSlabModel({ roof: true });
+    const slabIds = api.GetLineIDsWithType(mid, WebIFC.IFCSLAB);
+    expect(slabIds.size()).toBe(2);
+    const types: string[] = [];
+    for (let i = 0; i < slabIds.size(); i++) {
+      const slab = api.GetLine(mid, slabIds.get(i)) as Record<string, unknown>;
+      const pred = (slab['PredefinedType'] as { value?: string } | undefined)?.value;
+      if (pred !== undefined) types.push(pred);
+    }
+    expect(types.sort()).toEqual(['FLOOR', 'ROOF']);
+    api.CloseModel(mid);
+  });
+
+  it('slab GlobalId matches BimModel slab GUID', async () => {
+    const { api, mid } = await buildSlabModel();
+    const slabIds = api.GetLineIDsWithType(mid, WebIFC.IFCSLAB);
+    const slab = api.GetLine(mid, slabIds.get(0)) as Record<string, unknown>;
+    const slabGuid = (slab['GlobalId'] as { value?: string } | undefined)?.value;
+    expect(typeof slabGuid).toBe('string');
+    expect((slabGuid as string).length).toBe(22);
+    api.CloseModel(mid);
+  });
+
+  it('emits Pset_SlabCommon with fields from spec', async () => {
+    const { api, mid } = await buildSlabModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      const pset = api.GetLine(mid, ids.get(i)) as Record<string, unknown>;
+      const name = (pset['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Pset_SlabCommon') { found = true; break; }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('emits Qto_SlabBaseQuantities with expected numeric values', async () => {
+    const { api, mid } = await buildSlabModel();
+    const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    let qto: Record<string, unknown> | undefined;
+    for (let i = 0; i < elemQuantities.size(); i++) {
+      const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Qto_SlabBaseQuantities') { qto = candidate; break; }
+    }
+    if (qto === undefined) throw new Error('Expected Qto_SlabBaseQuantities');
+
+    const numericByName = new Map<string, number>();
+    const refs = qto['Quantities'] as Array<{ value: number }>;
+    for (const ref of refs) {
+      const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      if (name === undefined) continue;
+      const lengthVal = (q['LengthValue'] as { value?: number } | undefined)?.value;
+      const areaVal = (q['AreaValue'] as { value?: number } | undefined)?.value;
+      const volumeVal = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      const num = lengthVal ?? areaVal ?? volumeVal;
+      if (num !== undefined) numericByName.set(name, num);
+    }
+    expect(numericByName.get('Length')).toBeCloseTo(6, 5);
+    expect(numericByName.get('Width')).toBeCloseTo(4, 5);
+    expect(numericByName.get('Depth')).toBeCloseTo(0.25, 5);
+    expect(numericByName.get('Perimeter')).toBeCloseTo(2 * (6 + 4), 5);
+    expect(numericByName.get('GrossArea')).toBeCloseTo(6 * 4, 5);
+    expect(numericByName.get('NetArea')).toBeCloseTo(6 * 4, 5);
+    expect(numericByName.get('GrossVolume')).toBeCloseTo(6 * 4 * 0.25, 5);
+    expect(numericByName.get('NetVolume')).toBeCloseTo(6 * 4 * 0.25, 5);
+    api.CloseModel(mid);
+  });
+
+  it('slab is contained in storey via IfcRelContainedInSpatialStructure', async () => {
+    const { api, mid } = await buildSlabModel();
+    const containedRels = api.GetLineIDsWithType(mid, WebIFC.IFCRELCONTAINEDINSPATIALSTRUCTURE);
+    expect(containedRels.size()).toBeGreaterThanOrEqual(1);
+    api.CloseModel(mid);
+  });
+});

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -622,8 +622,21 @@ describe('IFC Slab round-trip (M5)', () => {
 
   it('slab is contained in storey via IfcRelContainedInSpatialStructure', async () => {
     const { api, mid } = await buildSlabModel();
+    const slabIds = api.GetLineIDsWithType(mid, WebIFC.IFCSLAB);
+    expect(slabIds.size()).toBe(1);
+    const slabExpressId = slabIds.get(0);
+
     const containedRels = api.GetLineIDsWithType(mid, WebIFC.IFCRELCONTAINEDINSPATIALSTRUCTURE);
-    expect(containedRels.size()).toBeGreaterThanOrEqual(1);
+    let foundSlabInRel = false;
+    for (let i = 0; i < containedRels.size(); i++) {
+      const rel = api.GetLine(mid, containedRels.get(i)) as Record<string, unknown>;
+      const related = (rel['RelatedElements'] ?? []) as Array<{ value: number }>;
+      if (related.some((r) => r.value === slabExpressId)) {
+        foundSlabInRel = true;
+        break;
+      }
+    }
+    expect(foundSlabInRel).toBe(true);
     api.CloseModel(mid);
   });
 });

--- a/packages/brepjs-bim/tests/slabFns.test.ts
+++ b/packages/brepjs-bim/tests/slabFns.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume } from 'brepjs';
+import { slabToSolid } from '../src/elementFns/slabFns.js';
+import { parseSlabSpec } from '../src/specs/slabSpec.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const SPEC = {
+  length: 5000,
+  width: 4000,
+  thickness: 200,
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+  predefinedType: 'FLOOR' as const,
+  materialName: 'Concrete',
+};
+
+describe('slabToSolid', () => {
+  it('returns a ValidSolid', () => {
+    const result = slabToSolid(SPEC);
+    expect(result.ok).toBe(true);
+    if (result.ok) result.value[Symbol.dispose]();
+  });
+
+  it('volume equals length × width × thickness', () => {
+    const result = slabToSolid(SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    expect(vol.value).toBeCloseTo(5000 * 4000 * 200, -2);
+  });
+
+  it('rejects zero length', () => {
+    const result = slabToSolid({ ...SPEC, length: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SLAB_ZERO_LENGTH');
+  });
+
+  it('rejects zero width', () => {
+    const result = slabToSolid({ ...SPEC, width: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SLAB_ZERO_WIDTH');
+  });
+
+  it('rejects zero thickness', () => {
+    const result = slabToSolid({ ...SPEC, thickness: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SLAB_ZERO_THICKNESS');
+  });
+});
+
+describe('parseSlabSpec', () => {
+  it('accepts minimal valid slab spec', () => {
+    const result = parseSlabSpec(SPEC);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts ROOF predefinedType', () => {
+    const result = parseSlabSpec({ ...SPEC, predefinedType: 'ROOF' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts LANDING predefinedType', () => {
+    const result = parseSlabSpec({ ...SPEC, predefinedType: 'LANDING' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts BASESLAB predefinedType', () => {
+    const result = parseSlabSpec({ ...SPEC, predefinedType: 'BASESLAB' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects unknown predefinedType', () => {
+    const result = parseSlabSpec({ ...SPEC, predefinedType: 'CEILING' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-orthogonal axes', () => {
+    const result = parseSlabSpec({ ...SPEC, axisZ: [1, 0, 0] });
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts optional Pset fields', () => {
+    const result = parseSlabSpec({
+      ...SPEC,
+      isExternal: true,
+      fireRating: 'REI120',
+      loadBearing: true,
+      compartmentation: true,
+      combustible: false,
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "framework": "vitepress",
   "installCommand": "npm install --legacy-peer-deps",
-  "buildCommand": "npm run build --workspace=apps/playground && npm run build --workspace=apps/docs && mkdir -p apps/docs/.vitepress/dist/playground && cp -r apps/playground/dist/. apps/docs/.vitepress/dist/playground/",
+  "buildCommand": "npm run build && npm run build --workspace=apps/playground && npm run build --workspace=apps/docs && mkdir -p apps/docs/.vitepress/dist/playground && cp -r apps/playground/dist/. apps/docs/.vitepress/dist/playground/",
   "outputDirectory": "apps/docs/.vitepress/dist",
   "cleanUrls": true,
   "trailingSlash": false,


### PR DESCRIPTION
## Summary

- **`SlabSpec`**: axis-aligned rectangular slab (`length × width × thickness`) with `predefinedType: 'FLOOR' | 'ROOF' | 'LANDING' | 'BASESLAB'`. Mirrors `WallSpec` field-for-field, with slab-specific Pset_SlabCommon options (`combustible`, `compartmentation`) added.
- **`slabToSolid`**: brepjs polygon + extrude pipeline producing a `ValidSolid` with the footprint in the local XY plane extruded along +Z by thickness.
- **`BimModel.addSlab` / `getSlabs`**: SLAB joins WALL as a geometric category; `[Symbol.dispose]` now also releases slab `ValidSolid` handles.
- **IFC serialization**: `IfcSlab` with `PredefinedType` set from spec, full `Pset_SlabCommon`, manufacturer Pset (shared with walls), custom Psets, and `Qto_SlabBaseQuantities` (Length, Width, Depth, Perimeter, GrossArea, NetArea, GrossVolume, NetVolume — Net == Gross until slab openings land).

## Architecture

The slab serialization mirrors walls; the only writer-side asymmetry is that the IFC rectangle profile is shifted by `(length/2, width/2)` so the local frame of the IFC body matches the brepjs solid (which has its corner at the origin, not its centroid).

`writeManufacturerPset` is now generic over a structural `ManufacturerFields` type — both walls and slabs reuse it directly. `writeQtyLength` / `writeQtyArea` / `writeQtyVolume` / `writeElementQuantity` were extracted from the wall path and are now shared by both element Qto writers.

Slab openings (stairwell cuts, MEP penetrations) are deliberately out of scope — that's M6's analogue of M3+M4 for walls.

## Test plan

- [ ] `slabFns.test.ts` — 12 tests for `slabToSolid` (returns ValidSolid, volume math, rejects zero dims) and `parseSlabSpec` (4 predefinedTypes, orthogonality check, optional Pset fields)
- [ ] `bimModel.test.ts` — 6 new tests for `addSlab`: success, validation failure, predefinedType round-trip, geometry volume, [Symbol.dispose], material relationship
- [ ] `roundTrip.test.ts` — 6 new tests: IfcSlab present, PredefinedType for FLOOR & ROOF, GUID format, Pset_SlabCommon, Qto numeric values (8 quantities), spatial containment
- [ ] All 101 BIM package tests pass; root `npm run validate` is green; package build clean (+~10KB)