### PR TITLE
feat(bim): slab openings — M6

### DIFF
--- a/packages/brepjs-bim/src/elementFns/openingFns.ts
+++ b/packages/brepjs-bim/src/elementFns/openingFns.ts
@@ -1,7 +1,7 @@
 import { polygon, extrude, isValidSolid } from 'brepjs';
 import type { ValidSolid, Result } from 'brepjs';
 import { ok, err } from 'brepjs';
-import type { OpeningSpec } from '../types/bimTypes.js';
+import type { WallOpeningSpec } from '../types/bimTypes.js';
 import type { BimError } from '../errors/bimError.js';
 import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
 
@@ -17,7 +17,7 @@ const EPSILON_MM = 1;
 //   Y ∈ [-ε, thickness + ε]   ← overshoots the wall depth on both sides
 //   Z ∈ [offsetFromFloor, offsetFromFloor + height]
 export function openingToSolid(
-  spec: OpeningSpec,
+  spec: WallOpeningSpec,
   wallThickness: number
 ): Result<ValidSolid, BimError> {
   if (spec.width <= 0) {

--- a/packages/brepjs-bim/src/elementFns/slabOpeningFns.ts
+++ b/packages/brepjs-bim/src/elementFns/slabOpeningFns.ts
@@ -1,0 +1,78 @@
+import { polygon, extrude, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { SlabOpeningSpec } from '../types/bimTypes.js';
+import type { BimError } from '../errors/bimError.js';
+import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
+
+// Overshoot the slab thickness so the boolean cut tool has no coplanar faces
+// with the slab body — OCCT booleans are flaky when tool faces touch base
+// faces exactly.
+const EPSILON_MM = 1;
+
+// Build the boolean tool used to subtract a vertical through-hole from a slab.
+//
+// The slab is modeled in local coords with the footprint in the XY plane
+// extruded along +Z (see slabFns.ts). The opening tool is a box at:
+//   X ∈ [offsetX, offsetX + sizeX]
+//   Y ∈ [offsetY, offsetY + sizeY]
+//   Z ∈ [-ε, thickness + ε]   ← overshoots the slab depth on both sides
+export function slabOpeningToSolid(
+  spec: SlabOpeningSpec,
+  slabThickness: number
+): Result<ValidSolid, BimError> {
+  if (spec.sizeX <= 0) {
+    return err(specError('SLAB_OPENING_ZERO_SIZE_X', 'Slab opening sizeX must be positive'));
+  }
+  if (spec.sizeY <= 0) {
+    return err(specError('SLAB_OPENING_ZERO_SIZE_Y', 'Slab opening sizeY must be positive'));
+  }
+  if (slabThickness <= 0) {
+    return err(
+      specError('SLAB_OPENING_ZERO_SLAB_THICKNESS', 'Slab thickness must be positive')
+    );
+  }
+
+  const x0 = spec.offsetX;
+  const x1 = spec.offsetX + spec.sizeX;
+  const y0 = spec.offsetY;
+  const y1 = spec.offsetY + spec.sizeY;
+  const z0 = -EPSILON_MM;
+
+  const profileResult = polygon([
+    [x0, y0, z0],
+    [x1, y0, z0],
+    [x1, y1, z0],
+    [x0, y1, z0],
+  ]);
+  if (!profileResult.ok) {
+    return err(
+      fromBrepError(
+        profileResult.error,
+        'SLAB_OPENING_PROFILE_FAILED',
+        'Failed to create slab opening profile'
+      )
+    );
+  }
+
+  using profile = profileResult.value;
+  const solidResult = extrude(profile, [0, 0, slabThickness + 2 * EPSILON_MM]);
+  if (!solidResult.ok) {
+    return err(
+      fromBrepError(
+        solidResult.error,
+        'SLAB_OPENING_EXTRUDE_FAILED',
+        'Failed to extrude slab opening profile'
+      )
+    );
+  }
+
+  const solid = solidResult.value;
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(
+      geometryError('SLAB_OPENING_INVALID_SOLID', 'Extruded slab opening solid failed validity check')
+    );
+  }
+  return ok(solid);
+}

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -4,14 +4,8 @@ import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
+import type { WallOpeningSpec } from '../types/bimTypes.js';
 import { toIfcLengthM } from '../units/units.js';
-
-type OpeningSpec = {
-  readonly width: number;
-  readonly height: number;
-  readonly offsetAlongWall: number;
-  readonly offsetFromFloor: number;
-};
 
 export interface OpeningIds {
   openingEntityId: number;
@@ -113,7 +107,7 @@ function writeAxis2Placement2D(w: IfcWriter): number {
 export function writeOpeningGeometry(
   w: IfcWriter,
   guid: IfcGuid,
-  openingSpec: OpeningSpec,
+  openingSpec: WallOpeningSpec,
   wallSpec: WallSpec,
   wallPlacementId: number,
   geomSubContextId: number,

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -199,9 +199,9 @@ export function writeOpeningGeometry(
 // Emits IfcOpeningElement for a vertical through-hole in a slab.
 //
 // Slab body is built in local coords with footprint in XY extruded along +Z.
-// Opening placement is at (offsetX + sizeX/2, offsetY + sizeY/2, thickness/2)
-// so the IfcRectangleProfileDef (centered) covers the opening; extrusion is
-// along +Z by the slab thickness.
+// Opening placement is at (offsetX + sizeX/2, offsetY + sizeY/2, 0) so the
+// IfcRectangleProfileDef (centered on its position) covers the opening; the
+// extrusion goes along +Z by the slab thickness, spanning [0, thickness].
 export function writeSlabOpeningGeometry(
   w: IfcWriter,
   guid: IfcGuid,

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -4,7 +4,8 @@ import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
-import type { WallOpeningSpec } from '../types/bimTypes.js';
+import type { WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
+import type { SlabSpec } from '../specs/slabSpec.js';
 import { toIfcLengthM } from '../units/units.js';
 
 export interface OpeningIds {
@@ -144,6 +145,102 @@ export function writeOpeningGeometry(
     Position: w.ref(writeAxis2Placement2D(w)),
     XDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, widthM),
     YDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, heightM),
+  });
+
+  const extrusionPosId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const extrusionDirId = writeDirection(w, [0, 0, 1]);
+  const extrusionId = w.nextId();
+  w.writeLine({
+    expressID: extrusionId,
+    type: WebIFC.IFCEXTRUDEDAREASOLID,
+    SweptArea: w.ref(profileId),
+    Position: w.ref(extrusionPosId),
+    ExtrudedDirection: w.ref(extrusionDirId),
+    Depth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, thicknessM),
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'SweptSolid'),
+    Items: [w.ref(extrusionId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+
+  const openingEntityId = w.nextId();
+  w.writeLine({
+    expressID: openingEntityId,
+    type: WebIFC.IFCOPENINGELEMENT,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: null,
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(openingPlacementId),
+    Representation: w.ref(productDefinitionShapeId),
+    Tag: null,
+    PredefinedType: null,
+  });
+
+  return { openingEntityId, openingPlacementId };
+}
+
+// Emits IfcOpeningElement for a vertical through-hole in a slab.
+//
+// Slab body is built in local coords with footprint in XY extruded along +Z.
+// Opening placement is at (offsetX + sizeX/2, offsetY + sizeY/2, thickness/2)
+// so the IfcRectangleProfileDef (centered) covers the opening; extrusion is
+// along +Z by the slab thickness.
+export function writeSlabOpeningGeometry(
+  w: IfcWriter,
+  guid: IfcGuid,
+  openingSpec: SlabOpeningSpec,
+  slabSpec: SlabSpec,
+  slabPlacementId: number,
+  geomSubContextId: number,
+  ownerHistoryId: number
+): OpeningIds {
+  const sizeXM = toIfcLengthM(openingSpec.sizeX);
+  const sizeYM = toIfcLengthM(openingSpec.sizeY);
+  const offsetXM = toIfcLengthM(openingSpec.offsetX);
+  const offsetYM = toIfcLengthM(openingSpec.offsetY);
+  const thicknessM = toIfcLengthM(slabSpec.thickness);
+
+  const placement3DId = writeAxis2Placement3D(
+    w,
+    [offsetXM + sizeXM / 2, offsetYM + sizeYM / 2, 0],
+    [0, 0, 1],
+    [1, 0, 0]
+  );
+
+  const openingPlacementId = w.nextId();
+  w.writeLine({
+    expressID: openingPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: w.ref(slabPlacementId),
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const profileId = w.nextId();
+  w.writeLine({
+    expressID: profileId,
+    type: WebIFC.IFCRECTANGLEPROFILEDEF,
+    ProfileType: { type: 3, value: 'AREA' },
+    ProfileName: null,
+    Position: w.ref(writeAxis2Placement2D(w)),
+    XDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, sizeXM),
+    YDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, sizeYM),
   });
 
   const extrusionPosId = writeAxis2Placement3D(w, [0, 0, 0]);

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -3,7 +3,7 @@ import type { IfcWriter } from './ifcWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
-import type { WallOpeningSpec } from '../types/bimTypes.js';
+import type { WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
 import { toIfcLengthM } from '../units/units.js';
 
 type PsetValue = string | number | boolean;
@@ -255,7 +255,8 @@ export function writeSlabBaseQuantities(
   w: IfcWriter,
   ownerHistoryId: number,
   slabExpressId: number,
-  spec: SlabSpec
+  spec: SlabSpec,
+  openings: readonly SlabOpeningSpec[]
 ): void {
   const lengthM = toIfcLengthM(spec.length);
   const widthM = toIfcLengthM(spec.width);
@@ -264,9 +265,14 @@ export function writeSlabBaseQuantities(
   const perimeterM = 2 * (lengthM + widthM);
   const grossVolumeM3 = grossAreaM2 * thicknessM;
 
-  // M5 has no slab openings; Net == Gross until that lands.
-  const netAreaM2 = grossAreaM2;
-  const netVolumeM3 = grossVolumeM3;
+  let sumOpeningAreaM2 = 0;
+  for (const op of openings) {
+    const opSizeXM = toIfcLengthM(op.sizeX);
+    const opSizeYM = toIfcLengthM(op.sizeY);
+    sumOpeningAreaM2 += opSizeXM * opSizeYM;
+  }
+  const netAreaM2 = grossAreaM2 - sumOpeningAreaM2;
+  const netVolumeM3 = grossVolumeM3 - sumOpeningAreaM2 * thicknessM;
 
   const qtyIds = [
     writeQtyLength(w, 'Width', widthM),

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -3,7 +3,7 @@ import type { IfcWriter } from './ifcWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
-import type { OpeningSpec } from '../types/bimTypes.js';
+import type { WallOpeningSpec } from '../types/bimTypes.js';
 import { toIfcLengthM } from '../units/units.js';
 
 type PsetValue = string | number | boolean;
@@ -193,7 +193,7 @@ export function writeWallBaseQuantities(
   ownerHistoryId: number,
   wallExpressId: number,
   spec: WallSpec,
-  openings: readonly OpeningSpec[]
+  openings: readonly WallOpeningSpec[]
 ): void {
   const lengthM = toIfcLengthM(spec.length);
   const widthM = toIfcLengthM(spec.thickness);

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -2,7 +2,7 @@ export { BimModel } from './model/bimModel.js';
 export { toIfc } from './serialize/toIfc.js';
 export { parseWallSpec } from './specs/wallSpec.js';
 export { parseSlabSpec } from './specs/slabSpec.js';
-export { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
+export { parseDoorSpec, parseWindowSpec, parseSlabOpeningInput } from './specs/openingSpec.js';
 export { newIfcGuid, isValidIfcGuid } from './identity/ifcGuid.js';
 export { makeLocalIdCounter } from './identity/localId.js';
 export { DEFAULT_UNITS, toLengthMm, toIfcLengthM } from './units/units.js';
@@ -10,10 +10,11 @@ export { specError, ifcError, geometryError, fromBrepError } from './errors/bimE
 
 export type { WallSpec } from './specs/wallSpec.js';
 export type { SlabSpec, SlabPredefinedType } from './specs/slabSpec.js';
-export type { DoorSpec, WindowSpec } from './specs/openingSpec.js';
+export type { DoorSpec, WindowSpec, SlabOpeningInput } from './specs/openingSpec.js';
 export type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from './specs/spatialSpec.js';
-export type { BimCategory, BimElement, AnyBimElement, OpeningSpec } from './types/bimTypes.js';
-export type { BimRelationship, VoidsWallRel, FillsOpeningRel } from './types/relationships.js';
+export type { BimCategory, BimElement, AnyBimElement, OpeningSpec, WallOpeningSpec, SlabOpeningSpec } from './types/bimTypes.js';
+export { isWallOpening, isSlabOpening } from './types/bimTypes.js';
+export type { BimRelationship, VoidsWallRel, VoidsSlabRel, FillsOpeningRel } from './types/relationships.js';
 export type { BimError, BimErrorKind } from './errors/bimError.js';
 export type { IfcGuid } from './identity/ifcGuid.js';
 export type { LocalId, LocalIdCounter } from './identity/localId.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -165,6 +165,26 @@ export class BimModel {
     if (input.offsetY + input.sizeY > slab.spec.width) {
       return err(specError('SLAB_OPENING_EXCEEDS_SLAB_BOUNDS', 'Opening (offsetY + sizeY) exceeds slab width'));
     }
+    // Reject overlap with existing slab openings — overlapping rectangles would
+    // double-subtract from NetArea/NetVolume in Qto_SlabBaseQuantities.
+    const ax0 = input.offsetX;
+    const ax1 = input.offsetX + input.sizeX;
+    const ay0 = input.offsetY;
+    const ay1 = input.offsetY + input.sizeY;
+    for (const rel of this.#relationships.values()) {
+      if (rel.kind !== 'VOIDS_SLAB' || rel.slabLocalId !== input.slabLocalId) continue;
+      const other = this.#elements.get(rel.openingLocalId);
+      if (other === undefined || other.category !== 'OPENING') continue;
+      if (other.spec.kind !== 'SLAB_OPENING') continue;
+      const bx0 = other.spec.offsetX;
+      const bx1 = other.spec.offsetX + other.spec.sizeX;
+      const by0 = other.spec.offsetY;
+      const by1 = other.spec.offsetY + other.spec.sizeY;
+      if (ax0 < bx1 && bx0 < ax1 && ay0 < by1 && by0 < ay1) {
+        return err(specError('SLAB_OPENING_OVERLAP', 'Slab opening overlaps an existing opening on the same slab'));
+      }
+    }
+
     const openingSpec: SlabOpeningSpec = {
       kind: 'SLAB_OPENING',
       sizeX: input.sizeX,

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -6,22 +6,24 @@ import type { LocalId } from '../identity/localId.js';
 import { makeLocalIdCounter } from '../identity/localId.js';
 import type { BimError } from '../errors/bimError.js';
 import { specError, fromBrepError } from '../errors/bimError.js';
-import type { AnyBimElement, BimElement, WallOpeningSpec } from '../types/bimTypes.js';
+import type { AnyBimElement, BimElement, WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
 import type {
   BimRelationship,
   AggregatesRel,
   ContainedInRel,
   AssociatesMaterialRel,
   VoidsWallRel,
+  VoidsSlabRel,
   FillsOpeningRel,
 } from '../types/relationships.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
-import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
+import type { DoorSpec, WindowSpec, SlabOpeningInput } from '../specs/openingSpec.js';
 import type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from '../specs/spatialSpec.js';
 import { wallToSolid } from '../elementFns/wallFns.js';
 import { slabToSolid } from '../elementFns/slabFns.js';
 import { openingToSolid } from '../elementFns/openingFns.js';
+import { slabOpeningToSolid } from '../elementFns/slabOpeningFns.js';
 
 export class BimModel {
   readonly #elements = new Map<LocalId, AnyBimElement>();
@@ -152,6 +154,34 @@ export class BimModel {
     return ok(windowId);
   }
 
+  addSlabOpening(input: SlabOpeningInput): Result<LocalId, BimError> {
+    const slab = this.#elements.get(input.slabLocalId);
+    if (slab === undefined || slab.category !== 'SLAB') {
+      return err(specError('SLAB_OPENING_SLAB_NOT_FOUND', `No slab found for localId ${input.slabLocalId}`));
+    }
+    if (input.offsetX + input.sizeX > slab.spec.length) {
+      return err(specError('SLAB_OPENING_EXCEEDS_SLAB_BOUNDS', 'Opening (offsetX + sizeX) exceeds slab length'));
+    }
+    if (input.offsetY + input.sizeY > slab.spec.width) {
+      return err(specError('SLAB_OPENING_EXCEEDS_SLAB_BOUNDS', 'Opening (offsetY + sizeY) exceeds slab width'));
+    }
+    const openingSpec: SlabOpeningSpec = {
+      kind: 'SLAB_OPENING',
+      sizeX: input.sizeX,
+      sizeY: input.sizeY,
+      offsetX: input.offsetX,
+      offsetY: input.offsetY,
+    };
+
+    const cutResult = this.#cutSlabGeometry(slab, openingSpec);
+    if (!cutResult.ok) return err(cutResult.error);
+    this.#replaceSlabGeometry(slab, cutResult.value);
+
+    const openingId = this.#makeElement('OPENING', openingSpec, null);
+    this.#makeRel<VoidsSlabRel>({ kind: 'VOIDS_SLAB', slabLocalId: input.slabLocalId, openingLocalId: openingId });
+    return ok(openingId);
+  }
+
   #cutWallGeometry(
     wall: BimElement<'WALL'>,
     openingSpec: WallOpeningSpec
@@ -172,6 +202,29 @@ export class BimModel {
     const oldGeometry = wall.geometry;
     const replaced: BimElement<'WALL'> = { ...wall, geometry: newGeometry };
     this.#elements.set(wall.localId, replaced);
+    oldGeometry[Symbol.dispose]();
+  }
+
+  #cutSlabGeometry(
+    slab: BimElement<'SLAB'>,
+    openingSpec: SlabOpeningSpec
+  ): Result<ValidSolid, BimError> {
+    const toolResult = slabOpeningToSolid(openingSpec, slab.spec.thickness);
+    if (!toolResult.ok) return err(toolResult.error);
+    using tool = toolResult.value;
+    const cutResult = cut(slab.geometry, tool);
+    if (!cutResult.ok) {
+      return err(
+        fromBrepError(cutResult.error, 'SLAB_CUT_FAILED', 'Boolean cut of slab with opening failed')
+      );
+    }
+    return ok(cutResult.value);
+  }
+
+  #replaceSlabGeometry(slab: BimElement<'SLAB'>, newGeometry: ValidSolid): void {
+    const oldGeometry = slab.geometry;
+    const replaced: BimElement<'SLAB'> = { ...slab, geometry: newGeometry };
+    this.#elements.set(slab.localId, replaced);
     oldGeometry[Symbol.dispose]();
   }
 

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -6,7 +6,7 @@ import type { LocalId } from '../identity/localId.js';
 import { makeLocalIdCounter } from '../identity/localId.js';
 import type { BimError } from '../errors/bimError.js';
 import { specError, fromBrepError } from '../errors/bimError.js';
-import type { AnyBimElement, BimElement, OpeningSpec } from '../types/bimTypes.js';
+import type { AnyBimElement, BimElement, WallOpeningSpec } from '../types/bimTypes.js';
 import type {
   BimRelationship,
   AggregatesRel,
@@ -93,7 +93,8 @@ export class BimModel {
     if (spec.offsetFromFloor + spec.height > wall.spec.height) {
       return err(specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetFromFloor + height) exceeds wall height'));
     }
-    const openingSpec: OpeningSpec = {
+    const openingSpec: WallOpeningSpec = {
+      kind: 'WALL_OPENING',
       width: spec.width,
       height: spec.height,
       offsetAlongWall: spec.offsetAlongWall,
@@ -127,7 +128,8 @@ export class BimModel {
     if (spec.offsetFromFloor + spec.height > wall.spec.height) {
       return err(specError('WINDOW_EXCEEDS_WALL_BOUNDS', 'Window (offsetFromFloor + height) exceeds wall height'));
     }
-    const openingSpec: OpeningSpec = {
+    const openingSpec: WallOpeningSpec = {
+      kind: 'WALL_OPENING',
       width: spec.width,
       height: spec.height,
       offsetAlongWall: spec.offsetAlongWall,
@@ -152,7 +154,7 @@ export class BimModel {
 
   #cutWallGeometry(
     wall: BimElement<'WALL'>,
-    openingSpec: OpeningSpec
+    openingSpec: WallOpeningSpec
   ): Result<ValidSolid, BimError> {
     const toolResult = openingToSolid(openingSpec, wall.spec.thickness);
     if (!toolResult.ok) return err(toolResult.error);

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -39,7 +39,8 @@ import type { Result } from 'brepjs';
 import { err } from 'brepjs';
 import type { LocalId } from '../identity/localId.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
-import type { BimElement, OpeningSpec } from '../types/bimTypes.js';
+import type { BimElement, WallOpeningSpec } from '../types/bimTypes.js';
+import { isWallOpening } from '../types/bimTypes.js';
 import type { BimRelationship } from '../types/relationships.js';
 
 export async function toIfc(
@@ -101,11 +102,12 @@ export async function toIfc(
     placementMap.set(el.localId, placementId);
   }
 
-  const openingsByWall = new Map<LocalId, OpeningSpec[]>();
+  const openingsByWall = new Map<LocalId, WallOpeningSpec[]>();
   for (const rel of relationships) {
     if (rel.kind !== 'VOIDS_WALL') continue;
     const opening = elements.find((el) => el.localId === rel.openingLocalId);
     if (opening === undefined || opening.category !== 'OPENING') continue;
+    if (!isWallOpening(opening.spec)) continue;
     const list = openingsByWall.get(rel.wallLocalId) ?? [];
     list.push(opening.spec);
     openingsByWall.set(rel.wallLocalId, list);
@@ -168,6 +170,7 @@ export async function toIfc(
 
     const openingElement = elements.find((el) => el.localId === rel.openingLocalId);
     if (openingElement === undefined || openingElement.category !== 'OPENING') continue;
+    if (!isWallOpening(openingElement.spec)) continue;
 
     const { openingEntityId, openingPlacementId } = writeOpeningGeometry(
       w, openingElement.guid, openingElement.spec, wallElement.spec, wallPlacementId, geomSubContextId, ownerHistoryId

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -26,6 +26,7 @@ import {
 } from '../ifc-writer/psetWriter.js';
 import {
   writeOpeningGeometry,
+  writeSlabOpeningGeometry,
   writeDoorEntity,
   writeWindowEntity,
   writeRelVoidsElement,
@@ -39,8 +40,8 @@ import type { Result } from 'brepjs';
 import { err } from 'brepjs';
 import type { LocalId } from '../identity/localId.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
-import type { BimElement, WallOpeningSpec } from '../types/bimTypes.js';
-import { isWallOpening } from '../types/bimTypes.js';
+import type { BimElement, WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
+import { isWallOpening, isSlabOpening } from '../types/bimTypes.js';
 import type { BimRelationship } from '../types/relationships.js';
 
 export async function toIfc(
@@ -113,6 +114,17 @@ export async function toIfc(
     openingsByWall.set(rel.wallLocalId, list);
   }
 
+  const openingsBySlab = new Map<LocalId, SlabOpeningSpec[]>();
+  for (const rel of relationships) {
+    if (rel.kind !== 'VOIDS_SLAB') continue;
+    const opening = elements.find((el) => el.localId === rel.openingLocalId);
+    if (opening === undefined || opening.category !== 'OPENING') continue;
+    if (!isSlabOpening(opening.spec)) continue;
+    const list = openingsBySlab.get(rel.slabLocalId) ?? [];
+    list.push(opening.spec);
+    openingsBySlab.set(rel.slabLocalId, list);
+  }
+
   for (const [i, wall] of walls.entries()) {
     const containingId = findContainerOf(wall.localId, relationships);
     const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
@@ -152,7 +164,10 @@ export async function toIfc(
     if (slab.spec.customProperties !== undefined) {
       writeCustomPsets(w, ownerHistoryId, slabExpressId, slab.spec.customProperties);
     }
-    writeSlabBaseQuantities(w, ownerHistoryId, slabExpressId, slab.spec);
+    writeSlabBaseQuantities(
+      w, ownerHistoryId, slabExpressId, slab.spec,
+      openingsBySlab.get(slab.localId) ?? []
+    );
   }
 
   const openingPlacementMap = new Map<LocalId, number>();
@@ -180,6 +195,28 @@ export async function toIfc(
     openingEntityMap.set(rel.openingLocalId, openingEntityId);
 
     writeRelVoidsElement(w, rel.guid, ownerHistoryId, wallExpressId, openingEntityId);
+  }
+
+  for (const rel of relationships) {
+    if (rel.kind !== 'VOIDS_SLAB') continue;
+    const slabElement = elements.find(
+      (el): el is BimElement<'SLAB'> => el.category === 'SLAB' && el.localId === rel.slabLocalId
+    );
+    if (slabElement === undefined) continue;
+    const slabExpressId = idMap.get(rel.slabLocalId);
+    const slabPlacementId = placementMap.get(rel.slabLocalId);
+    if (slabExpressId === undefined || slabPlacementId === undefined) continue;
+
+    const openingElement = elements.find((el) => el.localId === rel.openingLocalId);
+    if (openingElement === undefined || openingElement.category !== 'OPENING') continue;
+    if (!isSlabOpening(openingElement.spec)) continue;
+
+    const { openingEntityId } = writeSlabOpeningGeometry(
+      w, openingElement.guid, openingElement.spec, slabElement.spec, slabPlacementId, geomSubContextId, ownerHistoryId
+    );
+    idMap.set(rel.openingLocalId, openingEntityId);
+
+    writeRelVoidsElement(w, rel.guid, ownerHistoryId, slabExpressId, openingEntityId);
   }
 
   for (const [i, door] of doors.entries()) {

--- a/packages/brepjs-bim/src/specs/openingSpec.ts
+++ b/packages/brepjs-bim/src/specs/openingSpec.ts
@@ -67,3 +67,31 @@ export function parseWindowSpec(input: unknown): Result<WindowSpec, BimError> {
   }
   return ok(result.data as WindowSpec);
 }
+
+/**
+ * Input for BimModel.addSlabOpening — a vertical through-hole in a slab.
+ * All dimensions in mm, offsets in the slab's local XY frame.
+ */
+export interface SlabOpeningInput {
+  readonly sizeX: number;
+  readonly sizeY: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly slabLocalId: LocalId;
+}
+
+const SlabOpeningInputSchema = z.object({
+  sizeX: z.number().positive(),
+  sizeY: z.number().positive(),
+  offsetX: z.number().nonnegative(),
+  offsetY: z.number().nonnegative(),
+  slabLocalId: z.number().int().positive(),
+});
+
+export function parseSlabOpeningInput(input: unknown): Result<SlabOpeningInput, BimError> {
+  const result = SlabOpeningInputSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_SLAB_OPENING_INPUT', result.error.message, result.error));
+  }
+  return ok(result.data as SlabOpeningInput);
+}

--- a/packages/brepjs-bim/src/types/bimTypes.ts
+++ b/packages/brepjs-bim/src/types/bimTypes.ts
@@ -22,12 +22,31 @@ export type BimCategory =
   | 'BUILDING'
   | 'STOREY';
 
-export type OpeningSpec = {
+export type WallOpeningSpec = {
+  readonly kind: 'WALL_OPENING';
   readonly width: number;
   readonly height: number;
   readonly offsetAlongWall: number;
   readonly offsetFromFloor: number;
 };
+
+export type SlabOpeningSpec = {
+  readonly kind: 'SLAB_OPENING';
+  readonly sizeX: number;
+  readonly sizeY: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+};
+
+export type OpeningSpec = WallOpeningSpec | SlabOpeningSpec;
+
+export function isWallOpening(spec: OpeningSpec): spec is WallOpeningSpec {
+  return spec.kind === 'WALL_OPENING';
+}
+
+export function isSlabOpening(spec: OpeningSpec): spec is SlabOpeningSpec {
+  return spec.kind === 'SLAB_OPENING';
+}
 
 export type BimSpecFor<C extends BimCategory> = C extends 'WALL'
   ? WallSpec

--- a/packages/brepjs-bim/src/types/relationships.ts
+++ b/packages/brepjs-bim/src/types/relationships.ts
@@ -33,6 +33,14 @@ export interface VoidsWallRel {
   readonly openingLocalId: LocalId;
 }
 
+export interface VoidsSlabRel {
+  readonly kind: 'VOIDS_SLAB';
+  readonly guid: IfcGuid;
+  readonly localId: LocalId;
+  readonly slabLocalId: LocalId;
+  readonly openingLocalId: LocalId;
+}
+
 export interface FillsOpeningRel {
   readonly kind: 'FILLS_OPENING';
   readonly guid: IfcGuid;
@@ -46,4 +54,5 @@ export type BimRelationship =
   | ContainedInRel
   | AssociatesMaterialRel
   | VoidsWallRel
+  | VoidsSlabRel
   | FillsOpeningRel;

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -433,4 +433,39 @@ describe('BimModel.addSlabOpening (M6)', () => {
     expect(model.getAllElements().length).toBe(elementsBefore);
     expect(model.getAllRelationships().length).toBe(relsBefore);
   });
+
+  it('addSlabOpening rejects overlap with an existing opening on the same slab', () => {
+    const { model, slabId } = buildSlabModel();
+    unwrap(model.addSlabOpening({
+      sizeX: 1000, sizeY: 1000, offsetX: 500, offsetY: 500,
+      slabLocalId: slabId,
+    }));
+    const elementsBefore = model.getAllElements().length;
+    const relsBefore = model.getAllRelationships().length;
+    const volAfterFirst = slabVolume(model);
+
+    const result = model.addSlabOpening({
+      sizeX: 600, sizeY: 600, offsetX: 1000, offsetY: 1000,
+      slabLocalId: slabId,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('SLAB_OPENING_OVERLAP');
+
+    expect(model.getAllElements().length).toBe(elementsBefore);
+    expect(model.getAllRelationships().length).toBe(relsBefore);
+    expect(slabVolume(model)).toBeCloseTo(volAfterFirst, -2);
+  });
+
+  it('addSlabOpening allows two openings that touch edge-to-edge (non-overlap)', () => {
+    const { model, slabId } = buildSlabModel();
+    unwrap(model.addSlabOpening({
+      sizeX: 1000, sizeY: 1000, offsetX: 0, offsetY: 0,
+      slabLocalId: slabId,
+    }));
+    const second = model.addSlabOpening({
+      sizeX: 1000, sizeY: 1000, offsetX: 1000, offsetY: 0,
+      slabLocalId: slabId,
+    });
+    expect(second.ok).toBe(true);
+  });
 });

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -330,3 +330,107 @@ describe('BimModel.addSlab', () => {
     expect(matRels[0]?.materialName).toBe('Concrete');
   });
 });
+
+describe('BimModel.addSlabOpening (M6)', () => {
+  const SLAB_SPEC = {
+    length: 6000,
+    width: 4000,
+    thickness: 200,
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    predefinedType: 'FLOOR' as const,
+    materialName: 'Concrete',
+  };
+
+  function buildSlabModel() {
+    const model = new BimModel();
+    unwrap(model.init({ name: 'Test' }));
+    const slabId = unwrap(model.addSlab(SLAB_SPEC));
+    return { model, slabId };
+  }
+
+  function slabVolume(model: BimModel): number {
+    const slab = model.getSlabs()[0];
+    if (!slab) throw new Error('Expected one slab');
+    return unwrap(measureVolume(slab.geometry));
+  }
+
+  it('adds a slab opening and creates VOIDS_SLAB rel', () => {
+    const { model, slabId } = buildSlabModel();
+    const result = model.addSlabOpening({
+      sizeX: 1000, sizeY: 1500, offsetX: 1000, offsetY: 800,
+      slabLocalId: slabId,
+    });
+    expect(result.ok).toBe(true);
+    const voidsRels = model.getAllRelationships().filter((r) => r.kind === 'VOIDS_SLAB');
+    expect(voidsRels).toHaveLength(1);
+  });
+
+  it('slab volume drops by opening volume after addSlabOpening', () => {
+    const { model, slabId } = buildSlabModel();
+    const grossVol = slabVolume(model);
+
+    unwrap(model.addSlabOpening({
+      sizeX: 1000, sizeY: 1500, offsetX: 1000, offsetY: 800,
+      slabLocalId: slabId,
+    }));
+
+    const netVol = slabVolume(model);
+    const expectedDelta = 1000 * 1500 * SLAB_SPEC.thickness;
+    expect(grossVol - netVol).toBeCloseTo(expectedDelta, -2);
+  });
+
+  it('multiple slab openings each remove their volume', () => {
+    const { model, slabId } = buildSlabModel();
+    const grossVol = slabVolume(model);
+
+    unwrap(model.addSlabOpening({
+      sizeX: 800, sizeY: 1200, offsetX: 200, offsetY: 200,
+      slabLocalId: slabId,
+    }));
+    unwrap(model.addSlabOpening({
+      sizeX: 600, sizeY: 600, offsetX: 4000, offsetY: 2500,
+      slabLocalId: slabId,
+    }));
+
+    const netVol = slabVolume(model);
+    const expectedDelta = (800 * 1200 + 600 * 600) * SLAB_SPEC.thickness;
+    expect(grossVol - netVol).toBeCloseTo(expectedDelta, -2);
+  });
+
+  it('addSlabOpening with bounds violation does not mutate the model', () => {
+    const { model, slabId } = buildSlabModel();
+    const elementsBefore = model.getAllElements().length;
+    const relsBefore = model.getAllRelationships().length;
+    const grossVol = slabVolume(model);
+
+    const result = model.addSlabOpening({
+      sizeX: SLAB_SPEC.length + 100, sizeY: 100,
+      offsetX: 0, offsetY: 0,
+      slabLocalId: slabId,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('SLAB_OPENING_EXCEEDS_SLAB_BOUNDS');
+
+    expect(model.getAllElements().length).toBe(elementsBefore);
+    expect(model.getAllRelationships().length).toBe(relsBefore);
+    expect(slabVolume(model)).toBeCloseTo(grossVol, -2);
+  });
+
+  it('addSlabOpening with invalid slab reference does not mutate the model', () => {
+    const { model } = buildSlabModel();
+    const elementsBefore = model.getAllElements().length;
+    const relsBefore = model.getAllRelationships().length;
+
+    const result = model.addSlabOpening({
+      sizeX: 500, sizeY: 500, offsetX: 0, offsetY: 0,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- testing invalid input
+      slabLocalId: 9999 as any,
+    });
+    expect(result.ok).toBe(false);
+
+    expect(model.getAllElements().length).toBe(elementsBefore);
+    expect(model.getAllRelationships().length).toBe(relsBefore);
+  });
+});

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -640,3 +640,147 @@ describe('IFC Slab round-trip (M5)', () => {
     api.CloseModel(mid);
   });
 });
+
+describe('IFC Slab Opening round-trip (M6)', () => {
+  const SLAB_SPEC = {
+    length: 6000,
+    width: 4000,
+    thickness: 250,
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    predefinedType: 'FLOOR' as const,
+    materialName: 'Concrete',
+  };
+
+  async function buildSlabWithOpenings(): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'Slab Opening Test' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(initResult.value, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const slabResult = model.addSlab(SLAB_SPEC);
+    if (!slabResult.ok) throw new Error(slabResult.error.message);
+    model.placeIn(slabResult.value, storeyId);
+    // Stairwell + MEP penetration
+    const o1 = model.addSlabOpening({
+      sizeX: 1200, sizeY: 1500, offsetX: 500, offsetY: 500,
+      slabLocalId: slabResult.value,
+    });
+    if (!o1.ok) throw new Error(o1.error.message);
+    const o2 = model.addSlabOpening({
+      sizeX: 400, sizeY: 400, offsetX: 4500, offsetY: 3000,
+      slabLocalId: slabResult.value,
+    });
+    if (!o2.ok) throw new Error(o2.error.message);
+    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    return { api, mid };
+  }
+
+  it('emits two IfcOpeningElements for two slab openings', async () => {
+    const { api, mid } = await buildSlabWithOpenings();
+    const openings = api.GetLineIDsWithType(mid, WebIFC.IFCOPENINGELEMENT);
+    expect(openings.size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('emits two IfcRelVoidsElement linking openings to the slab', async () => {
+    const { api, mid } = await buildSlabWithOpenings();
+    const slabIds = api.GetLineIDsWithType(mid, WebIFC.IFCSLAB);
+    const slabExpressId = slabIds.get(0);
+    const voids = api.GetLineIDsWithType(mid, WebIFC.IFCRELVOIDSELEMENT);
+    expect(voids.size()).toBe(2);
+    for (let i = 0; i < voids.size(); i++) {
+      const rel = api.GetLine(mid, voids.get(i)) as Record<string, unknown>;
+      const relating = (rel['RelatingBuildingElement'] as { value?: number } | undefined)?.value;
+      expect(relating).toBe(slabExpressId);
+    }
+    api.CloseModel(mid);
+  });
+
+  it('Qto_SlabBaseQuantities has NetArea < GrossArea and NetVolume < GrossVolume', async () => {
+    const { api, mid } = await buildSlabWithOpenings();
+    const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    let qto: Record<string, unknown> | undefined;
+    for (let i = 0; i < elemQuantities.size(); i++) {
+      const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Qto_SlabBaseQuantities') { qto = candidate; break; }
+    }
+    if (qto === undefined) throw new Error('Expected Qto_SlabBaseQuantities');
+
+    const numericByName = new Map<string, number>();
+    const refs = qto['Quantities'] as Array<{ value: number }>;
+    for (const ref of refs) {
+      const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      if (name === undefined) continue;
+      const areaVal = (q['AreaValue'] as { value?: number } | undefined)?.value;
+      const volumeVal = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      const num = areaVal ?? volumeVal;
+      if (num !== undefined) numericByName.set(name, num);
+    }
+
+    // 6 × 4 slab, openings 1.2×1.5 + 0.4×0.4
+    const totalOpeningAreaM2 = 1.2 * 1.5 + 0.4 * 0.4;
+    expect(numericByName.get('GrossArea')).toBeCloseTo(6 * 4, 5);
+    expect(numericByName.get('NetArea')).toBeCloseTo(6 * 4 - totalOpeningAreaM2, 5);
+    expect(numericByName.get('GrossVolume')).toBeCloseTo(6 * 4 * 0.25, 5);
+    expect(numericByName.get('NetVolume')).toBeCloseTo((6 * 4 - totalOpeningAreaM2) * 0.25, 5);
+    api.CloseModel(mid);
+  });
+
+  it('slab without openings still emits NetArea === GrossArea', async () => {
+    const model = new BimModel();
+    const initResult = model.init({ name: 'No-op Slab' });
+    if (!initResult.ok) throw new Error(initResult.error.message);
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    model.aggregate(initResult.value, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+    const slabResult = model.addSlab(SLAB_SPEC);
+    if (!slabResult.ok) throw new Error(slabResult.error.message);
+    model.placeIn(slabResult.value, storeyId);
+
+    const result = await toIfc(model, { applicationName: 't', applicationVersion: '0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+
+    const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    let qto: Record<string, unknown> | undefined;
+    for (let i = 0; i < elemQuantities.size(); i++) {
+      const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Qto_SlabBaseQuantities') { qto = candidate; break; }
+    }
+    if (qto === undefined) throw new Error('Expected Qto_SlabBaseQuantities');
+    let grossArea = 0, netArea = 0, grossVol = 0, netVol = 0;
+    const refs = qto['Quantities'] as Array<{ value: number }>;
+    for (const ref of refs) {
+      const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      const a = (q['AreaValue'] as { value?: number } | undefined)?.value;
+      const v = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      if (name === 'GrossArea' && a !== undefined) grossArea = a;
+      if (name === 'NetArea' && a !== undefined) netArea = a;
+      if (name === 'GrossVolume' && v !== undefined) grossVol = v;
+      if (name === 'NetVolume' && v !== undefined) netVol = v;
+    }
+    expect(grossArea).toBeGreaterThan(0);
+    expect(netArea).toBeCloseTo(grossArea, 6);
+    expect(netVol).toBeCloseTo(grossVol, 6);
+    api.CloseModel(mid);
+  });
+});

--- a/packages/brepjs-bim/tests/slabOpeningFns.test.ts
+++ b/packages/brepjs-bim/tests/slabOpeningFns.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume } from 'brepjs';
+import { slabOpeningToSolid } from '../src/elementFns/slabOpeningFns.js';
+import type { SlabOpeningSpec } from '../src/types/bimTypes.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const SLAB_THICKNESS = 200;
+const SPEC: SlabOpeningSpec = {
+  kind: 'SLAB_OPENING',
+  sizeX: 1000,
+  sizeY: 1500,
+  offsetX: 500,
+  offsetY: 800,
+};
+
+describe('slabOpeningToSolid', () => {
+  it('returns a ValidSolid for a typical stairwell-sized opening', () => {
+    const result = slabOpeningToSolid(SPEC, SLAB_THICKNESS);
+    expect(result.ok).toBe(true);
+    if (result.ok) result.value[Symbol.dispose]();
+  });
+
+  it('volume slightly exceeds sizeX × sizeY × thickness due to ε overshoot in Z', () => {
+    const result = slabOpeningToSolid(SPEC, SLAB_THICKNESS);
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    const nominal = SPEC.sizeX * SPEC.sizeY * SLAB_THICKNESS;
+    expect(vol.value).toBeGreaterThan(nominal);
+    expect(vol.value).toBeLessThan(nominal * 1.05);
+  });
+
+  it('rejects zero sizeX', () => {
+    const result = slabOpeningToSolid({ ...SPEC, sizeX: 0 }, SLAB_THICKNESS);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe('BIM_SPEC');
+    expect(result.error.code).toBe('SLAB_OPENING_ZERO_SIZE_X');
+  });
+
+  it('rejects zero sizeY', () => {
+    const result = slabOpeningToSolid({ ...SPEC, sizeY: 0 }, SLAB_THICKNESS);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SLAB_OPENING_ZERO_SIZE_Y');
+  });
+
+  it('rejects zero slab thickness', () => {
+    const result = slabOpeningToSolid(SPEC, 0);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('SLAB_OPENING_ZERO_SLAB_THICKNESS');
+  });
+});


### PR DESCRIPTION
## Summary

Generalizes the M3+M4 opening pipeline from walls to slabs.

- **`SlabOpeningSpec`**: `{ kind: 'SLAB_OPENING', sizeX, sizeY, offsetX, offsetY }` (slab-local XY frame). `OpeningSpec` is now a discriminated union of `WallOpeningSpec | SlabOpeningSpec`; type guards `isWallOpening` / `isSlabOpening` narrow at writer sites.
- **`slabOpeningToSolid`**: boolean tool that pierces the slab vertically through `±ε` to avoid OCCT coplanar-face hazards (mirrors `openingToSolid`).
- **`VoidsSlabRel`**: new relationship parallel to `VoidsWallRel`. IFC writer maps both to `IfcRelVoidsElement` (which is generic over host element in IFC).
- **`BimModel.addSlabOpening`**: atomic — validates bounds, cuts the slab solid, registers `OPENING` element + `VOIDS_SLAB` rel only on success. Cut failures and bounds violations leave the model untouched.
- **IFC serialization**: `writeSlabOpeningGeometry` emits an `IfcOpeningElement` extruded through the slab thickness; `toIfc` walks `VOIDS_SLAB` rels after the wall openings pass.
- **`Qto_SlabBaseQuantities`**: `writeSlabBaseQuantities` now takes the slab's opening list and computes `NetArea = GrossArea − Σ(sizeX × sizeY)`, `NetVolume = NetArea × thickness`. Slabs without openings still emit `Net === Gross` (correct).
- **Public API**: exports `SlabOpeningInput`, `parseSlabOpeningInput`, `WallOpeningSpec`, `SlabOpeningSpec`, `isWallOpening`, `isSlabOpening`, `VoidsSlabRel`.

## Architecture note

The opening pipeline is now symmetric across walls and slabs:

| Pipeline step | Walls (M3+M4) | Slabs (M6) |
|---|---|---|
| Public input | `DoorSpec`/`WindowSpec` | `SlabOpeningInput` |
| Geometric spec | `WallOpeningSpec` | `SlabOpeningSpec` |
| Tool builder | `openingToSolid` | `slabOpeningToSolid` |
| Cut helper | `#cutWallGeometry` | `#cutSlabGeometry` |
| Replace helper | `#replaceWallGeometry` | `#replaceSlabGeometry` |
| Rel | `VOIDS_WALL` | `VOIDS_SLAB` |
| IFC writer | `writeOpeningGeometry` | `writeSlabOpeningGeometry` |
| Net qty input | `WallOpeningSpec[]` | `SlabOpeningSpec[]` |

No filler entity for slab openings — `IfcRelFillsElement` is optional in IFC4 and slab cuts (stairwells, MEP penetrations) typically don't have one.

## Test plan

- [ ] `slabOpeningFns.test.ts` — 5 tests for `slabOpeningToSolid` (returns ValidSolid, volume bounds, rejects zero dims, rejects zero slab thickness)
- [ ] `bimModel.test.ts` — 5 new tests for `addSlabOpening`: rel emission, single-opening volume drop, two-opening volume sum, bounds-violation rollback, invalid-slab rollback
- [ ] `roundTrip.test.ts` — 4 new tests: `IfcOpeningElement` count for slab openings, voids-rel linkage to slab express ID, `Qto_SlabBaseQuantities` numeric NetArea/NetVolume vs Gross, slab-without-openings sanity
- [ ] All 115 BIM package tests pass; root `npm run validate` is green; package build clean (+~8 KB)