### PR TITLE
feat(bim): beams & columns with profile family — M7

### DIFF
--- a/packages/brepjs-bim/src/elementFns/beamFns.ts
+++ b/packages/brepjs-bim/src/elementFns/beamFns.ts
@@ -1,0 +1,43 @@
+import { polygon, extrude, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { BeamSpec } from '../specs/beamSpec.js';
+import type { BimError } from '../errors/bimError.js';
+import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
+import { profileToPolygon } from './profileFns.js';
+
+// Returned solid is unplaced template geometry: profile in the global YZ plane
+// (cross-section centered on the local Y/Z axes), extruded along +X by length.
+// origin/axisX/axisZ are applied by the IFC layer via IfcLocalPlacement.
+//
+// The profile is rotated from its native XY definition into YZ here so that
+// the brepjs solid grows in +X to match the standard wall/extrusion pattern.
+export function beamToSolid(spec: BeamSpec): Result<ValidSolid, BimError> {
+  if (spec.length <= 0) {
+    return err(specError('BEAM_ZERO_LENGTH', 'Beam length must be positive'));
+  }
+
+  // profileToPolygon returns points in XY (z=0). Map (x,y,0) → (0,x,y) so the
+  // profile lies in the YZ plane at x=0 ready to extrude along +X.
+  const profilePts = profileToPolygon(spec.profile).map<[number, number, number]>(
+    ([px, py]) => [0, px, py]
+  );
+
+  const profileResult = polygon(profilePts);
+  if (!profileResult.ok) {
+    return err(fromBrepError(profileResult.error, 'BEAM_PROFILE_FAILED', 'Failed to create beam profile'));
+  }
+
+  using profile = profileResult.value;
+  const solidResult = extrude(profile, [spec.length, 0, 0]);
+  if (!solidResult.ok) {
+    return err(fromBrepError(solidResult.error, 'BEAM_EXTRUDE_FAILED', 'Failed to extrude beam profile'));
+  }
+
+  const solid = solidResult.value;
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(geometryError('BEAM_INVALID_SOLID', 'Extruded beam solid failed validity check'));
+  }
+  return ok(solid);
+}

--- a/packages/brepjs-bim/src/elementFns/columnFns.ts
+++ b/packages/brepjs-bim/src/elementFns/columnFns.ts
@@ -1,0 +1,36 @@
+import { polygon, extrude, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { ColumnSpec } from '../specs/columnSpec.js';
+import type { BimError } from '../errors/bimError.js';
+import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
+import { profileToPolygon } from './profileFns.js';
+
+// Returned solid is unplaced template geometry: profile in the global XY plane
+// (cross-section centered on the local origin), extruded along +Z by height.
+// origin/axisX/axisZ are applied by the IFC layer via IfcLocalPlacement.
+export function columnToSolid(spec: ColumnSpec): Result<ValidSolid, BimError> {
+  if (spec.height <= 0) {
+    return err(specError('COLUMN_ZERO_HEIGHT', 'Column height must be positive'));
+  }
+
+  const profilePts = profileToPolygon(spec.profile);
+
+  const profileResult = polygon(profilePts);
+  if (!profileResult.ok) {
+    return err(fromBrepError(profileResult.error, 'COLUMN_PROFILE_FAILED', 'Failed to create column profile'));
+  }
+
+  using profile = profileResult.value;
+  const solidResult = extrude(profile, [0, 0, spec.height]);
+  if (!solidResult.ok) {
+    return err(fromBrepError(solidResult.error, 'COLUMN_EXTRUDE_FAILED', 'Failed to extrude column profile'));
+  }
+
+  const solid = solidResult.value;
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(geometryError('COLUMN_INVALID_SOLID', 'Extruded column solid failed validity check'));
+  }
+  return ok(solid);
+}

--- a/packages/brepjs-bim/src/elementFns/profileFns.ts
+++ b/packages/brepjs-bim/src/elementFns/profileFns.ts
@@ -38,6 +38,9 @@ export function profileToPolygon(
       ];
     }
     case 'CIRCULAR': {
+      if (circleSegments < 3) {
+        throw new Error(`profileToPolygon: circleSegments must be >= 3, got ${circleSegments}`);
+      }
       const pts: Array<[number, number, number]> = [];
       for (let i = 0; i < circleSegments; i++) {
         const theta = (2 * Math.PI * i) / circleSegments;

--- a/packages/brepjs-bim/src/elementFns/profileFns.ts
+++ b/packages/brepjs-bim/src/elementFns/profileFns.ts
@@ -1,0 +1,70 @@
+import type { Profile } from '../specs/profile.js';
+
+// Analytical cross-section area of a profile (mm²).
+export function profileCrossSectionArea(profile: Profile): number {
+  switch (profile.kind) {
+    case 'RECTANGULAR':
+      return profile.width * profile.height;
+    case 'CIRCULAR':
+      return Math.PI * profile.radius * profile.radius;
+    case 'I_BEAM': {
+      const flangeArea = 2 * profile.overallWidth * profile.flangeThickness;
+      const webHeight = profile.overallDepth - 2 * profile.flangeThickness;
+      const webArea = webHeight * profile.webThickness;
+      return flangeArea + webArea;
+    }
+  }
+}
+
+// Returns 3D polygon vertices (z = 0) approximating the profile outline.
+// Used as the source polygon for brepjs polygon() + extrude().
+// Polygon is centered on the local origin.
+//
+// Circular profiles are tessellated to N segments (N = 32 default — visually
+// circular while staying lightweight for boolean tools).
+export function profileToPolygon(
+  profile: Profile,
+  circleSegments = 32
+): Array<[number, number, number]> {
+  switch (profile.kind) {
+    case 'RECTANGULAR': {
+      const halfW = profile.width / 2;
+      const halfH = profile.height / 2;
+      return [
+        [-halfW, -halfH, 0],
+        [halfW, -halfH, 0],
+        [halfW, halfH, 0],
+        [-halfW, halfH, 0],
+      ];
+    }
+    case 'CIRCULAR': {
+      const pts: Array<[number, number, number]> = [];
+      for (let i = 0; i < circleSegments; i++) {
+        const theta = (2 * Math.PI * i) / circleSegments;
+        pts.push([profile.radius * Math.cos(theta), profile.radius * Math.sin(theta), 0]);
+      }
+      return pts;
+    }
+    case 'I_BEAM': {
+      const halfW = profile.overallWidth / 2;
+      const halfD = profile.overallDepth / 2;
+      const halfWeb = profile.webThickness / 2;
+      const flangeInnerY = halfD - profile.flangeThickness;
+      // Trace the I outline clockwise starting from bottom-left flange corner.
+      return [
+        [-halfW, -halfD, 0],
+        [halfW, -halfD, 0],
+        [halfW, -flangeInnerY, 0],
+        [halfWeb, -flangeInnerY, 0],
+        [halfWeb, flangeInnerY, 0],
+        [halfW, flangeInnerY, 0],
+        [halfW, halfD, 0],
+        [-halfW, halfD, 0],
+        [-halfW, flangeInnerY, 0],
+        [-halfWeb, flangeInnerY, 0],
+        [-halfWeb, -flangeInnerY, 0],
+        [-halfW, -flangeInnerY, 0],
+      ];
+    }
+  }
+}

--- a/packages/brepjs-bim/src/ifc-writer/entityWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/entityWriter.ts
@@ -185,3 +185,68 @@ export function writeSlabEntity(
   });
   return id;
 }
+
+export type BeamPredefinedTypeIfc =
+  | 'BEAM'
+  | 'JOIST'
+  | 'LINTEL'
+  | 'HOLLOWCORE'
+  | 'PURLIN'
+  | 'RAFTER'
+  | 'SPANDREL'
+  | 'T_BEAM'
+  | 'NOTDEFINED';
+
+export function writeBeamEntity(
+  w: IfcWriter,
+  guid: IfcGuid,
+  name: string,
+  predefinedType: BeamPredefinedTypeIfc,
+  ownerHistoryId: number,
+  localPlacementId: number,
+  productDefinitionShapeId: number
+): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCBEAM,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(localPlacementId),
+    Representation: w.ref(productDefinitionShapeId),
+    Tag: null,
+    PredefinedType: { type: 3, value: predefinedType },
+  });
+  return id;
+}
+
+export type ColumnPredefinedTypeIfc = 'COLUMN' | 'PILASTER' | 'NOTDEFINED';
+
+export function writeColumnEntity(
+  w: IfcWriter,
+  guid: IfcGuid,
+  name: string,
+  predefinedType: ColumnPredefinedTypeIfc,
+  ownerHistoryId: number,
+  localPlacementId: number,
+  productDefinitionShapeId: number
+): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCCOLUMN,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(localPlacementId),
+    Representation: w.ref(productDefinitionShapeId),
+    Tag: null,
+    PredefinedType: { type: 3, value: predefinedType },
+  });
+  return id;
+}

--- a/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
@@ -252,15 +252,33 @@ export function writeProfile(w: IfcWriter, profile: Profile): number {
   }
 }
 
+// Cross product. Assumes both inputs are unit vectors and orthogonal so the
+// result is also unit-length — the placement consumers require unit axes.
+function crossUnit(
+  a: [number, number, number],
+  b: [number, number, number]
+): [number, number, number] {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
 // Emits IfcLocalPlacement + IfcExtrudedAreaSolid + IfcProductDefinitionShape
 // for a linear element (beam or column). Profile is in local XY, extrusion
-// along +Z by extrusionLengthM.
+// along local +Z by extrusionLengthM.
+//
+// placementAxis is the IFC Axis (local Z, the extrusion direction in world).
+// placementRefDirection is the IFC RefDirection (local X). IFC derives the
+// local Y as Axis × RefDirection, so callers must supply RefDirection such
+// that the derived local Y matches the desired profile-up direction.
 function writeLinearExtrusion(
   w: IfcWriter,
   profile: Profile,
   origin: [number, number, number],
-  axisX: [number, number, number],
-  axisZ: [number, number, number],
+  placementAxis: [number, number, number],
+  placementRefDirection: [number, number, number],
   extrusionLengthM: number,
   geomSubContextId: number,
   parentPlacementId: number | null
@@ -268,8 +286,8 @@ function writeLinearExtrusion(
   const placement3DId = writeAxis2Placement3D(
     w,
     origin.map(toIfcLengthM) as [number, number, number],
-    axisZ,
-    axisX
+    placementAxis,
+    placementRefDirection
   );
 
   const localPlacementId = w.nextId();
@@ -315,29 +333,32 @@ function writeLinearExtrusion(
   return { localPlacementId, productDefinitionShapeId };
 }
 
-// Beam geometry: profile rotated from local XY → local YZ at placement time
-// by setting the placement's axisX (along beam) and axisZ (profile up).
-// IFC convention extrudes along the placement's local +Z, so we set
-// placement axisZ = world axisX (beam length direction).
+// Beam geometry: IFC extrudes the profile along the placement's local +Z, so
+// we set placementAxis = spec.axisX (the beam's length direction in world).
+// We want the derived local Y (= IFC's Axis × RefDirection) to equal
+// spec.axisZ (the profile's "up"), so RefDirection = spec.axisZ × spec.axisX.
 export function writeBeamGeometry(
   w: IfcWriter,
   spec: BeamSpec,
   geomSubContextId: number,
   parentPlacementId: number | null
 ): LinearElementRepresentationIds {
+  const refDirection = crossUnit(spec.axisZ, spec.axisX);
   return writeLinearExtrusion(
     w,
     spec.profile,
     spec.origin,
-    spec.axisZ,
     spec.axisX,
+    refDirection,
     toIfcLengthM(spec.length),
     geomSubContextId,
     parentPlacementId
   );
 }
 
-// Column geometry: profile in local XY extruded along local +Z (= world axisZ).
+// Column geometry: profile in local XY extruded along local +Z (= spec.axisZ).
+// spec.axisX directly defines the profile's X orientation, which is exactly
+// IFC's RefDirection.
 export function writeColumnGeometry(
   w: IfcWriter,
   spec: ColumnSpec,
@@ -348,8 +369,8 @@ export function writeColumnGeometry(
     w,
     spec.profile,
     spec.origin,
-    spec.axisX,
     spec.axisZ,
+    spec.axisX,
     toIfcLengthM(spec.height),
     geomSubContextId,
     parentPlacementId

--- a/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
@@ -3,6 +3,9 @@ import type { IfcWriter } from './ifcWriter.js';
 import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
+import type { BeamSpec } from '../specs/beamSpec.js';
+import type { ColumnSpec } from '../specs/columnSpec.js';
+import type { Profile } from '../specs/profile.js';
 import { toIfcLengthM } from '../units/units.js';
 
 export interface WallRepresentationIds {
@@ -11,6 +14,11 @@ export interface WallRepresentationIds {
 }
 
 export interface SlabRepresentationIds {
+  localPlacementId: number;
+  productDefinitionShapeId: number;
+}
+
+export interface LinearElementRepresentationIds {
   localPlacementId: number;
   productDefinitionShapeId: number;
 }
@@ -195,4 +203,155 @@ function writeAxis2Placement2D(w: IfcWriter): number {
     RefDirection: null,
   });
   return id;
+}
+
+// Emits the IFC profile definition for the given Profile. Returns the express
+// ID of the profile entity (IfcRectangleProfileDef / IfcCircleProfileDef /
+// IfcIShapeProfileDef). All dimensions are converted to metres for IFC export.
+export function writeProfile(w: IfcWriter, profile: Profile): number {
+  const positionId = writeAxis2Placement2D(w);
+  const id = w.nextId();
+  switch (profile.kind) {
+    case 'RECTANGULAR':
+      w.writeLine({
+        expressID: id,
+        type: WebIFC.IFCRECTANGLEPROFILEDEF,
+        ProfileType: { type: 3, value: 'AREA' },
+        ProfileName: null,
+        Position: w.ref(positionId),
+        XDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.width)),
+        YDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.height)),
+      });
+      return id;
+    case 'CIRCULAR':
+      w.writeLine({
+        expressID: id,
+        type: WebIFC.IFCCIRCLEPROFILEDEF,
+        ProfileType: { type: 3, value: 'AREA' },
+        ProfileName: null,
+        Position: w.ref(positionId),
+        Radius: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.radius)),
+      });
+      return id;
+    case 'I_BEAM':
+      w.writeLine({
+        expressID: id,
+        type: WebIFC.IFCISHAPEPROFILEDEF,
+        ProfileType: { type: 3, value: 'AREA' },
+        ProfileName: null,
+        Position: w.ref(positionId),
+        OverallWidth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.overallWidth)),
+        OverallDepth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.overallDepth)),
+        WebThickness: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.webThickness)),
+        FlangeThickness: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.flangeThickness)),
+        FilletRadius: null,
+        FlangeEdgeRadius: null,
+        FlangeSlope: null,
+      });
+      return id;
+  }
+}
+
+// Emits IfcLocalPlacement + IfcExtrudedAreaSolid + IfcProductDefinitionShape
+// for a linear element (beam or column). Profile is in local XY, extrusion
+// along +Z by extrusionLengthM.
+function writeLinearExtrusion(
+  w: IfcWriter,
+  profile: Profile,
+  origin: [number, number, number],
+  axisX: [number, number, number],
+  axisZ: [number, number, number],
+  extrusionLengthM: number,
+  geomSubContextId: number,
+  parentPlacementId: number | null
+): LinearElementRepresentationIds {
+  const placement3DId = writeAxis2Placement3D(
+    w,
+    origin.map(toIfcLengthM) as [number, number, number],
+    axisZ,
+    axisX
+  );
+
+  const localPlacementId = w.nextId();
+  w.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: parentPlacementId !== null ? w.ref(parentPlacementId) : null,
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const profileId = writeProfile(w, profile);
+  const extrusionPosId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const extrusionDirId = writeDirection(w, [0, 0, 1]);
+  const extrusionId = w.nextId();
+  w.writeLine({
+    expressID: extrusionId,
+    type: WebIFC.IFCEXTRUDEDAREASOLID,
+    SweptArea: w.ref(profileId),
+    Position: w.ref(extrusionPosId),
+    ExtrudedDirection: w.ref(extrusionDirId),
+    Depth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, extrusionLengthM),
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'SweptSolid'),
+    Items: [w.ref(extrusionId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+
+  return { localPlacementId, productDefinitionShapeId };
+}
+
+// Beam geometry: profile rotated from local XY → local YZ at placement time
+// by setting the placement's axisX (along beam) and axisZ (profile up).
+// IFC convention extrudes along the placement's local +Z, so we set
+// placement axisZ = world axisX (beam length direction).
+export function writeBeamGeometry(
+  w: IfcWriter,
+  spec: BeamSpec,
+  geomSubContextId: number,
+  parentPlacementId: number | null
+): LinearElementRepresentationIds {
+  return writeLinearExtrusion(
+    w,
+    spec.profile,
+    spec.origin,
+    spec.axisZ,
+    spec.axisX,
+    toIfcLengthM(spec.length),
+    geomSubContextId,
+    parentPlacementId
+  );
+}
+
+// Column geometry: profile in local XY extruded along local +Z (= world axisZ).
+export function writeColumnGeometry(
+  w: IfcWriter,
+  spec: ColumnSpec,
+  geomSubContextId: number,
+  parentPlacementId: number | null
+): LinearElementRepresentationIds {
+  return writeLinearExtrusion(
+    w,
+    spec.profile,
+    spec.origin,
+    spec.axisX,
+    spec.axisZ,
+    toIfcLengthM(spec.height),
+    geomSubContextId,
+    parentPlacementId
+  );
 }

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -3,7 +3,10 @@ import type { IfcWriter } from './ifcWriter.js';
 import { newIfcGuid } from '../identity/ifcGuid.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
+import type { BeamSpec } from '../specs/beamSpec.js';
+import type { ColumnSpec } from '../specs/columnSpec.js';
 import type { WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
+import { profileCrossSectionArea } from '../elementFns/profileFns.js';
 import { toIfcLengthM } from '../units/units.js';
 
 type PsetValue = string | number | boolean;
@@ -287,4 +290,89 @@ export function writeSlabBaseQuantities(
 
   const qtoId = writeElementQuantity(w, ownerHistoryId, 'Qto_SlabBaseQuantities', qtyIds);
   writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, qtoId);
+}
+
+interface CommonStructuralFields {
+  readonly isExternal?: boolean | undefined;
+  readonly loadBearing?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+}
+
+function buildCommonProps(spec: CommonStructuralFields): Record<string, PsetValue> {
+  const props: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
+  if (spec.loadBearing !== undefined) props['LoadBearing'] = spec.loadBearing;
+  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
+  return props;
+}
+
+export function writeBeamCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  beamExpressId: number,
+  spec: BeamSpec
+): void {
+  const props = buildCommonProps(spec);
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_BeamCommon', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, beamExpressId, psetId);
+}
+
+export function writeColumnCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  columnExpressId: number,
+  spec: ColumnSpec
+): void {
+  const props = buildCommonProps(spec);
+  if (Object.keys(props).length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_ColumnCommon', props);
+  writeRelDefinesByProperties(w, ownerHistoryId, columnExpressId, psetId);
+}
+
+export function writeBeamBaseQuantities(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  beamExpressId: number,
+  spec: BeamSpec
+): void {
+  const lengthM = toIfcLengthM(spec.length);
+  // Profile area is in mm²; convert to m² (divide by 1e6).
+  const crossSectionAreaM2 = profileCrossSectionArea(spec.profile) / 1_000_000;
+  const grossVolumeM3 = crossSectionAreaM2 * lengthM;
+
+  const qtyIds = [
+    writeQtyLength(w, 'Length', lengthM),
+    writeQtyArea(w, 'CrossSectionArea', crossSectionAreaM2),
+    writeQtyVolume(w, 'GrossVolume', grossVolumeM3),
+    writeQtyVolume(w, 'NetVolume', grossVolumeM3),
+  ];
+
+  const qtoId = writeElementQuantity(w, ownerHistoryId, 'Qto_BeamBaseQuantities', qtyIds);
+  writeRelDefinesByProperties(w, ownerHistoryId, beamExpressId, qtoId);
+}
+
+export function writeColumnBaseQuantities(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  columnExpressId: number,
+  spec: ColumnSpec
+): void {
+  const heightM = toIfcLengthM(spec.height);
+  const crossSectionAreaM2 = profileCrossSectionArea(spec.profile) / 1_000_000;
+  const grossVolumeM3 = crossSectionAreaM2 * heightM;
+
+  const qtyIds = [
+    writeQtyLength(w, 'Length', heightM),
+    writeQtyArea(w, 'CrossSectionArea', crossSectionAreaM2),
+    writeQtyVolume(w, 'GrossVolume', grossVolumeM3),
+    writeQtyVolume(w, 'NetVolume', grossVolumeM3),
+  ];
+
+  const qtoId = writeElementQuantity(w, ownerHistoryId, 'Qto_ColumnBaseQuantities', qtyIds);
+  writeRelDefinesByProperties(w, ownerHistoryId, columnExpressId, qtoId);
 }

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -2,6 +2,9 @@ export { BimModel } from './model/bimModel.js';
 export { toIfc } from './serialize/toIfc.js';
 export { parseWallSpec } from './specs/wallSpec.js';
 export { parseSlabSpec } from './specs/slabSpec.js';
+export { parseBeamSpec } from './specs/beamSpec.js';
+export { parseColumnSpec } from './specs/columnSpec.js';
+export { parseProfile } from './specs/profile.js';
 export { parseDoorSpec, parseWindowSpec, parseSlabOpeningInput } from './specs/openingSpec.js';
 export { newIfcGuid, isValidIfcGuid } from './identity/ifcGuid.js';
 export { makeLocalIdCounter } from './identity/localId.js';
@@ -10,6 +13,14 @@ export { specError, ifcError, geometryError, fromBrepError } from './errors/bimE
 
 export type { WallSpec } from './specs/wallSpec.js';
 export type { SlabSpec, SlabPredefinedType } from './specs/slabSpec.js';
+export type { BeamSpec, BeamPredefinedType } from './specs/beamSpec.js';
+export type { ColumnSpec, ColumnPredefinedType } from './specs/columnSpec.js';
+export type {
+  Profile,
+  RectangularProfile,
+  CircularProfile,
+  IShapeProfile,
+} from './specs/profile.js';
 export type { DoorSpec, WindowSpec, SlabOpeningInput } from './specs/openingSpec.js';
 export type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from './specs/spatialSpec.js';
 export type { BimCategory, BimElement, AnyBimElement, OpeningSpec, WallOpeningSpec, SlabOpeningSpec } from './types/bimTypes.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -18,10 +18,14 @@ import type {
 } from '../types/relationships.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
+import type { BeamSpec } from '../specs/beamSpec.js';
+import type { ColumnSpec } from '../specs/columnSpec.js';
 import type { DoorSpec, WindowSpec, SlabOpeningInput } from '../specs/openingSpec.js';
 import type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from '../specs/spatialSpec.js';
 import { wallToSolid } from '../elementFns/wallFns.js';
 import { slabToSolid } from '../elementFns/slabFns.js';
+import { beamToSolid } from '../elementFns/beamFns.js';
+import { columnToSolid } from '../elementFns/columnFns.js';
 import { openingToSolid } from '../elementFns/openingFns.js';
 import { slabOpeningToSolid } from '../elementFns/slabOpeningFns.js';
 
@@ -42,7 +46,12 @@ export class BimModel {
 
   [Symbol.dispose](): void {
     for (const el of this.#elements.values()) {
-      if (el.category === 'WALL' || el.category === 'SLAB') {
+      if (
+        el.category === 'WALL' ||
+        el.category === 'SLAB' ||
+        el.category === 'BEAM' ||
+        el.category === 'COLUMN'
+      ) {
         el.geometry[Symbol.dispose]();
       }
     }
@@ -76,6 +85,30 @@ export class BimModel {
     const geomResult = slabToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('SLAB', spec, geomResult.value);
+    this.#makeRel<AssociatesMaterialRel>({
+      kind: 'ASSOCIATES_MATERIAL',
+      materialName: spec.materialName,
+      relatedObjects: [id],
+    });
+    return ok(id);
+  }
+
+  addBeam(spec: BeamSpec): Result<LocalId, BimError> {
+    const geomResult = beamToSolid(spec);
+    if (!geomResult.ok) return err(geomResult.error);
+    const id = this.#makeElement('BEAM', spec, geomResult.value);
+    this.#makeRel<AssociatesMaterialRel>({
+      kind: 'ASSOCIATES_MATERIAL',
+      materialName: spec.materialName,
+      relatedObjects: [id],
+    });
+    return ok(id);
+  }
+
+  addColumn(spec: ColumnSpec): Result<LocalId, BimError> {
+    const geomResult = columnToSolid(spec);
+    if (!geomResult.ok) return err(geomResult.error);
+    const id = this.#makeElement('COLUMN', spec, geomResult.value);
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
       materialName: spec.materialName,
@@ -334,6 +367,22 @@ export class BimModel {
       if (el.category === 'SLAB') slabs.push(el);
     }
     return slabs;
+  }
+
+  getBeams(): BimElement<'BEAM'>[] {
+    const beams: BimElement<'BEAM'>[] = [];
+    for (const el of this.#elements.values()) {
+      if (el.category === 'BEAM') beams.push(el);
+    }
+    return beams;
+  }
+
+  getColumns(): BimElement<'COLUMN'>[] {
+    const columns: BimElement<'COLUMN'>[] = [];
+    for (const el of this.#elements.values()) {
+      if (el.category === 'COLUMN') columns.push(el);
+    }
+    return columns;
   }
 
   getAllElements(): AnyBimElement[] {

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -9,8 +9,15 @@ import {
   writeStorey,
   writeWallEntity,
   writeSlabEntity,
+  writeBeamEntity,
+  writeColumnEntity,
 } from '../ifc-writer/entityWriter.js';
-import { writeWallGeometry, writeSlabGeometry } from '../ifc-writer/geometryWriter.js';
+import {
+  writeWallGeometry,
+  writeSlabGeometry,
+  writeBeamGeometry,
+  writeColumnGeometry,
+} from '../ifc-writer/geometryWriter.js';
 import {
   writeRelAggregates,
   writeRelContainedInSpatialStructure,
@@ -23,6 +30,10 @@ import {
   writeWallBaseQuantities,
   writeSlabCommonPset,
   writeSlabBaseQuantities,
+  writeBeamCommonPset,
+  writeBeamBaseQuantities,
+  writeColumnCommonPset,
+  writeColumnBaseQuantities,
 } from '../ifc-writer/psetWriter.js';
 import {
   writeOpeningGeometry,
@@ -61,6 +72,8 @@ export async function toIfc(
   const relationships = model.getAllRelationships();
   const walls = model.getWalls();
   const slabs = model.getSlabs();
+  const beams = model.getBeams();
+  const columns = model.getColumns();
   const doors = model.getDoors();
   const windows = model.getWindows();
 
@@ -168,6 +181,46 @@ export async function toIfc(
       w, ownerHistoryId, slabExpressId, slab.spec,
       openingsBySlab.get(slab.localId) ?? []
     );
+  }
+
+  for (const [i, beam] of beams.entries()) {
+    const containingId = findContainerOf(beam.localId, relationships);
+    const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
+    const { localPlacementId, productDefinitionShapeId } = writeBeamGeometry(
+      w, beam.spec, geomSubContextId, storeyPlacementId
+    );
+    const beamExpressId = writeBeamEntity(
+      w, beam.guid, `Beam ${i + 1}`, beam.spec.predefinedType ?? 'NOTDEFINED',
+      ownerHistoryId, localPlacementId, productDefinitionShapeId
+    );
+    idMap.set(beam.localId, beamExpressId);
+    placementMap.set(beam.localId, localPlacementId);
+    writeBeamCommonPset(w, ownerHistoryId, beamExpressId, beam.spec);
+    writeManufacturerPset(w, ownerHistoryId, beamExpressId, beam.spec);
+    if (beam.spec.customProperties !== undefined) {
+      writeCustomPsets(w, ownerHistoryId, beamExpressId, beam.spec.customProperties);
+    }
+    writeBeamBaseQuantities(w, ownerHistoryId, beamExpressId, beam.spec);
+  }
+
+  for (const [i, column] of columns.entries()) {
+    const containingId = findContainerOf(column.localId, relationships);
+    const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
+    const { localPlacementId, productDefinitionShapeId } = writeColumnGeometry(
+      w, column.spec, geomSubContextId, storeyPlacementId
+    );
+    const columnExpressId = writeColumnEntity(
+      w, column.guid, `Column ${i + 1}`, column.spec.predefinedType ?? 'NOTDEFINED',
+      ownerHistoryId, localPlacementId, productDefinitionShapeId
+    );
+    idMap.set(column.localId, columnExpressId);
+    placementMap.set(column.localId, localPlacementId);
+    writeColumnCommonPset(w, ownerHistoryId, columnExpressId, column.spec);
+    writeManufacturerPset(w, ownerHistoryId, columnExpressId, column.spec);
+    if (column.spec.customProperties !== undefined) {
+      writeCustomPsets(w, ownerHistoryId, columnExpressId, column.spec.customProperties);
+    }
+    writeColumnBaseQuantities(w, ownerHistoryId, columnExpressId, column.spec);
   }
 
   const openingPlacementMap = new Map<LocalId, number>();

--- a/packages/brepjs-bim/src/specs/beamSpec.ts
+++ b/packages/brepjs-bim/src/specs/beamSpec.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+import type { BimError } from '../errors/bimError.js';
+import { specError } from '../errors/bimError.js';
+import type { Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { Profile } from './profile.js';
+import { ProfileSchema, parseProfile } from './profile.js';
+
+export type BeamPredefinedType =
+  | 'BEAM'
+  | 'JOIST'
+  | 'LINTEL'
+  | 'HOLLOWCORE'
+  | 'PURLIN'
+  | 'RAFTER'
+  | 'SPANDREL'
+  | 'T_BEAM'
+  | 'NOTDEFINED';
+
+// A linear beam: profile extruded along axisX by length.
+// All dimensions in mm. axisX defines the extrusion direction (along the beam),
+// axisZ defines the profile's "up" direction in world space (typically vertical
+// for horizontal beams).
+export interface BeamSpec {
+  readonly length: number;
+  readonly profile: Profile;
+  readonly origin: [number, number, number];
+  readonly axisX: [number, number, number];
+  readonly axisZ: [number, number, number];
+  readonly predefinedType?: BeamPredefinedType | undefined;
+  readonly materialName: string;
+
+  readonly isExternal?: boolean | undefined;
+  readonly loadBearing?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+
+  readonly manufacturerName?: string | undefined;
+  readonly manufacturerModel?: string | undefined;
+  readonly manufacturerProductionYear?: number | undefined;
+
+  readonly customProperties?:
+    | Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+    | undefined;
+}
+
+const unitVec = z.tuple([z.number(), z.number(), z.number()]).refine(
+  (v) => Math.abs(v[0] ** 2 + v[1] ** 2 + v[2] ** 2 - 1) < 1e-6,
+  { message: 'must be a unit vector' }
+);
+
+const BeamSpecSchema = z.object({
+  length: z.number().positive(),
+  profile: ProfileSchema,
+  origin: z.tuple([z.number(), z.number(), z.number()]),
+  axisX: unitVec,
+  axisZ: unitVec,
+  predefinedType: z.enum([
+    'BEAM', 'JOIST', 'LINTEL', 'HOLLOWCORE',
+    'PURLIN', 'RAFTER', 'SPANDREL', 'T_BEAM', 'NOTDEFINED',
+  ]).optional(),
+  materialName: z.string().min(1),
+
+  isExternal: z.boolean().optional(),
+  loadBearing: z.boolean().optional(),
+  fireRating: z.string().optional(),
+  acousticRating: z.string().optional(),
+  thermalTransmittance: z.number().positive().optional(),
+
+  manufacturerName: z.string().optional(),
+  manufacturerModel: z.string().optional(),
+  manufacturerProductionYear: z.number().int().positive().optional(),
+
+  customProperties: z.record(
+    z.string(),
+    z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+  ).optional(),
+}).superRefine((data, ctx) => {
+  const dot =
+    data.axisX[0] * data.axisZ[0] +
+    data.axisX[1] * data.axisZ[1] +
+    data.axisX[2] * data.axisZ[2];
+  if (Math.abs(dot) > 1e-6) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'axisX and axisZ must be orthogonal',
+      path: ['axisZ'],
+    });
+  }
+});
+
+export function parseBeamSpec(input: unknown): Result<BeamSpec, BimError> {
+  const result = BeamSpecSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_BEAM_SPEC', result.error.message, result.error));
+  }
+  // Re-validate the profile to enforce I-beam dimension constraints
+  const profileCheck = parseProfile(result.data.profile);
+  if (!profileCheck.ok) return err(profileCheck.error);
+  return ok(result.data as BeamSpec);
+}

--- a/packages/brepjs-bim/src/specs/columnSpec.ts
+++ b/packages/brepjs-bim/src/specs/columnSpec.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import type { BimError } from '../errors/bimError.js';
+import { specError } from '../errors/bimError.js';
+import type { Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+import type { Profile } from './profile.js';
+import { ProfileSchema, parseProfile } from './profile.js';
+
+export type ColumnPredefinedType = 'COLUMN' | 'PILASTER' | 'NOTDEFINED';
+
+// A vertical column: profile extruded along axisZ by height.
+// All dimensions in mm. axisZ defines the extrusion direction (typically up),
+// axisX defines the profile's "X" orientation in world space.
+export interface ColumnSpec {
+  readonly height: number;
+  readonly profile: Profile;
+  readonly origin: [number, number, number];
+  readonly axisX: [number, number, number];
+  readonly axisZ: [number, number, number];
+  readonly predefinedType?: ColumnPredefinedType | undefined;
+  readonly materialName: string;
+
+  readonly isExternal?: boolean | undefined;
+  readonly loadBearing?: boolean | undefined;
+  readonly fireRating?: string | undefined;
+  readonly acousticRating?: string | undefined;
+  readonly thermalTransmittance?: number | undefined;
+
+  readonly manufacturerName?: string | undefined;
+  readonly manufacturerModel?: string | undefined;
+  readonly manufacturerProductionYear?: number | undefined;
+
+  readonly customProperties?:
+    | Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+    | undefined;
+}
+
+const unitVec = z.tuple([z.number(), z.number(), z.number()]).refine(
+  (v) => Math.abs(v[0] ** 2 + v[1] ** 2 + v[2] ** 2 - 1) < 1e-6,
+  { message: 'must be a unit vector' }
+);
+
+const ColumnSpecSchema = z.object({
+  height: z.number().positive(),
+  profile: ProfileSchema,
+  origin: z.tuple([z.number(), z.number(), z.number()]),
+  axisX: unitVec,
+  axisZ: unitVec,
+  predefinedType: z.enum(['COLUMN', 'PILASTER', 'NOTDEFINED']).optional(),
+  materialName: z.string().min(1),
+
+  isExternal: z.boolean().optional(),
+  loadBearing: z.boolean().optional(),
+  fireRating: z.string().optional(),
+  acousticRating: z.string().optional(),
+  thermalTransmittance: z.number().positive().optional(),
+
+  manufacturerName: z.string().optional(),
+  manufacturerModel: z.string().optional(),
+  manufacturerProductionYear: z.number().int().positive().optional(),
+
+  customProperties: z.record(
+    z.string(),
+    z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+  ).optional(),
+}).superRefine((data, ctx) => {
+  const dot =
+    data.axisX[0] * data.axisZ[0] +
+    data.axisX[1] * data.axisZ[1] +
+    data.axisX[2] * data.axisZ[2];
+  if (Math.abs(dot) > 1e-6) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'axisX and axisZ must be orthogonal',
+      path: ['axisZ'],
+    });
+  }
+});
+
+export function parseColumnSpec(input: unknown): Result<ColumnSpec, BimError> {
+  const result = ColumnSpecSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_COLUMN_SPEC', result.error.message, result.error));
+  }
+  const profileCheck = parseProfile(result.data.profile);
+  if (!profileCheck.ok) return err(profileCheck.error);
+  return ok(result.data as ColumnSpec);
+}

--- a/packages/brepjs-bim/src/specs/profile.ts
+++ b/packages/brepjs-bim/src/specs/profile.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import type { BimError } from '../errors/bimError.js';
+import { specError } from '../errors/bimError.js';
+import type { Result } from 'brepjs';
+import { ok, err } from 'brepjs';
+
+// Cross-section profile for an extruded structural element. All dimensions in mm.
+// Profile lives in the local XY plane; extrusion happens along the element's
+// extrusion axis (see BeamSpec / ColumnSpec).
+
+export type RectangularProfile = {
+  readonly kind: 'RECTANGULAR';
+  readonly width: number;   // X extent
+  readonly height: number;  // Y extent
+};
+
+export type CircularProfile = {
+  readonly kind: 'CIRCULAR';
+  readonly radius: number;
+};
+
+// IfcIShapeProfileDef parameters: outer bounding box + flange/web thicknesses.
+//   overallWidth: outer X extent (flange width)
+//   overallDepth: outer Y extent (total height)
+//   flangeThickness: top and bottom flange thickness
+//   webThickness: vertical web thickness (centered)
+export type IShapeProfile = {
+  readonly kind: 'I_BEAM';
+  readonly overallWidth: number;
+  readonly overallDepth: number;
+  readonly flangeThickness: number;
+  readonly webThickness: number;
+};
+
+export type Profile = RectangularProfile | CircularProfile | IShapeProfile;
+
+const RectangularProfileSchema = z.object({
+  kind: z.literal('RECTANGULAR'),
+  width: z.number().positive(),
+  height: z.number().positive(),
+});
+
+const CircularProfileSchema = z.object({
+  kind: z.literal('CIRCULAR'),
+  radius: z.number().positive(),
+});
+
+const IShapeProfileSchema = z.object({
+  kind: z.literal('I_BEAM'),
+  overallWidth: z.number().positive(),
+  overallDepth: z.number().positive(),
+  flangeThickness: z.number().positive(),
+  webThickness: z.number().positive(),
+});
+
+export const ProfileSchema = z.discriminatedUnion('kind', [
+  RectangularProfileSchema,
+  CircularProfileSchema,
+  IShapeProfileSchema,
+]);
+
+export function parseProfile(input: unknown): Result<Profile, BimError> {
+  const result = ProfileSchema.safeParse(input);
+  if (!result.success) {
+    return err(specError('INVALID_PROFILE', result.error.message, result.error));
+  }
+  const profile = result.data as Profile;
+  if (profile.kind === 'I_BEAM') {
+    if (2 * profile.flangeThickness >= profile.overallDepth) {
+      return err(specError(
+        'INVALID_PROFILE',
+        'I-beam flangeThickness × 2 must be less than overallDepth'
+      ));
+    }
+    if (profile.webThickness >= profile.overallWidth) {
+      return err(specError(
+        'INVALID_PROFILE',
+        'I-beam webThickness must be less than overallWidth'
+      ));
+    }
+  }
+  return ok(profile);
+}

--- a/packages/brepjs-bim/src/types/bimTypes.ts
+++ b/packages/brepjs-bim/src/types/bimTypes.ts
@@ -3,6 +3,8 @@ import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { LocalId } from '../identity/localId.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
+import type { BeamSpec } from '../specs/beamSpec.js';
+import type { ColumnSpec } from '../specs/columnSpec.js';
 import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
 import type {
   ProjectSpec,
@@ -14,6 +16,8 @@ import type {
 export type BimCategory =
   | 'WALL'
   | 'SLAB'
+  | 'BEAM'
+  | 'COLUMN'
   | 'OPENING'
   | 'DOOR'
   | 'WINDOW'
@@ -52,23 +56,31 @@ export type BimSpecFor<C extends BimCategory> = C extends 'WALL'
   ? WallSpec
   : C extends 'SLAB'
     ? SlabSpec
-    : C extends 'OPENING'
-      ? OpeningSpec
-      : C extends 'DOOR'
-        ? DoorSpec
-        : C extends 'WINDOW'
-          ? WindowSpec
-          : C extends 'PROJECT'
-            ? ProjectSpec
-            : C extends 'SITE'
-              ? SiteSpec
-              : C extends 'BUILDING'
-                ? BuildingSpec
-                : C extends 'STOREY'
-                  ? StoreySpec
-                  : never;
+    : C extends 'BEAM'
+      ? BeamSpec
+      : C extends 'COLUMN'
+        ? ColumnSpec
+        : C extends 'OPENING'
+          ? OpeningSpec
+          : C extends 'DOOR'
+            ? DoorSpec
+            : C extends 'WINDOW'
+              ? WindowSpec
+              : C extends 'PROJECT'
+                ? ProjectSpec
+                : C extends 'SITE'
+                  ? SiteSpec
+                  : C extends 'BUILDING'
+                    ? BuildingSpec
+                    : C extends 'STOREY'
+                      ? StoreySpec
+                      : never;
 
-export type BimGeometryFor<C extends BimCategory> = C extends 'WALL' | 'SLAB'
+export type BimGeometryFor<C extends BimCategory> = C extends
+  | 'WALL'
+  | 'SLAB'
+  | 'BEAM'
+  | 'COLUMN'
   ? ValidSolid
   : null;
 
@@ -83,6 +95,8 @@ export interface BimElement<C extends BimCategory> {
 export type AnyBimElement =
   | BimElement<'WALL'>
   | BimElement<'SLAB'>
+  | BimElement<'BEAM'>
+  | BimElement<'COLUMN'>
   | BimElement<'OPENING'>
   | BimElement<'DOOR'>
   | BimElement<'WINDOW'>

--- a/packages/brepjs-bim/tests/beamFns.test.ts
+++ b/packages/brepjs-bim/tests/beamFns.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume } from 'brepjs';
+import { beamToSolid } from '../src/elementFns/beamFns.js';
+import { parseBeamSpec } from '../src/specs/beamSpec.js';
+import type { BeamSpec } from '../src/specs/beamSpec.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const BASE: BeamSpec = {
+  length: 5000,
+  profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+  origin: [0, 0, 0],
+  axisX: [1, 0, 0],
+  axisZ: [0, 0, 1],
+  materialName: 'Steel',
+};
+
+describe('beamToSolid', () => {
+  it('rectangular beam returns ValidSolid with correct volume', () => {
+    const result = beamToSolid(BASE);
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    expect(vol.value).toBeCloseTo(5000 * 200 * 400, -2);
+  });
+
+  it('circular beam returns ValidSolid with correct volume', () => {
+    const result = beamToSolid({
+      ...BASE,
+      profile: { kind: 'CIRCULAR', radius: 100 },
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    // Tessellated circle approximates the true π·r² area; accept within 1%.
+    const nominal = 5000 * Math.PI * 100 * 100;
+    expect(vol.value).toBeGreaterThan(nominal * 0.99);
+    expect(vol.value).toBeLessThan(nominal * 1.01);
+  });
+
+  it('I-beam returns ValidSolid with cross-section-area × length', () => {
+    const result = beamToSolid({
+      ...BASE,
+      profile: {
+        kind: 'I_BEAM',
+        overallWidth: 200,
+        overallDepth: 400,
+        flangeThickness: 15,
+        webThickness: 10,
+      },
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    // 2 × (200 × 15) + (400 - 30) × 10 = 9700; × 5000 length = 48 500 000
+    expect(vol.value).toBeCloseTo(5000 * 9700, -2);
+  });
+
+  it('rejects zero length', () => {
+    const result = beamToSolid({ ...BASE, length: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('BEAM_ZERO_LENGTH');
+  });
+});
+
+describe('parseBeamSpec', () => {
+  it('accepts a minimal valid beam', () => {
+    const result = parseBeamSpec(BASE);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts all predefined types', () => {
+    for (const t of ['BEAM', 'JOIST', 'LINTEL', 'NOTDEFINED'] as const) {
+      const result = parseBeamSpec({ ...BASE, predefinedType: t });
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('rejects an invalid profile', () => {
+    const result = parseBeamSpec({
+      ...BASE,
+      profile: { kind: 'RECTANGULAR', width: -1, height: 100 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an I-beam with degenerate flanges', () => {
+    const result = parseBeamSpec({
+      ...BASE,
+      profile: {
+        kind: 'I_BEAM',
+        overallWidth: 200,
+        overallDepth: 100,
+        flangeThickness: 50,
+        webThickness: 10,
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-orthogonal axes', () => {
+    const result = parseBeamSpec({ ...BASE, axisZ: [1, 0, 0] });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -469,3 +469,107 @@ describe('BimModel.addSlabOpening (M6)', () => {
     expect(second.ok).toBe(true);
   });
 });
+
+describe('BimModel.addBeam (M7)', () => {
+  const BEAM_SPEC = {
+    length: 5000,
+    profile: { kind: 'RECTANGULAR' as const, width: 200, height: 400 },
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    materialName: 'Steel',
+  };
+
+  it('adds a beam and returns a LocalId', () => {
+    const model = new BimModel();
+    const result = model.addBeam(BEAM_SPEC);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(model.getBeams()).toHaveLength(1);
+    expect(model.getElement(result.value)).not.toBeNull();
+  });
+
+  it('addBeam fails with invalid spec', () => {
+    const model = new BimModel();
+    const result = model.addBeam({ ...BEAM_SPEC, length: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('beam volume matches profile area × length', () => {
+    const model = new BimModel();
+    const result = model.addBeam(BEAM_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const beam = model.getBeams()[0];
+    if (!beam) throw new Error('Expected one beam');
+    const vol = unwrap(measureVolume(beam.geometry));
+    expect(vol).toBeCloseTo(200 * 400 * 5000, -2);
+  });
+
+  it('[Symbol.dispose] disposes beam geometry', () => {
+    const model = new BimModel();
+    const result = model.addBeam(BEAM_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const beam = model.getBeams()[0];
+    if (!beam) throw new Error('Expected one beam');
+    model[Symbol.dispose]();
+    expect(beam.geometry.disposed).toBe(true);
+  });
+
+  it('emits an ASSOCIATES_MATERIAL relationship', () => {
+    const model = new BimModel();
+    const result = model.addBeam(BEAM_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const matRels = model
+      .getAllRelationships()
+      .filter((r) => r.kind === 'ASSOCIATES_MATERIAL');
+    expect(matRels).toHaveLength(1);
+    expect(matRels[0]?.materialName).toBe('Steel');
+  });
+});
+
+describe('BimModel.addColumn (M7)', () => {
+  const COLUMN_SPEC = {
+    height: 3000,
+    profile: { kind: 'CIRCULAR' as const, radius: 200 },
+    origin: [0, 0, 0] as [number, number, number],
+    axisX: [1, 0, 0] as [number, number, number],
+    axisZ: [0, 0, 1] as [number, number, number],
+    materialName: 'Concrete',
+  };
+
+  it('adds a column and returns a LocalId', () => {
+    const model = new BimModel();
+    const result = model.addColumn(COLUMN_SPEC);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(model.getColumns()).toHaveLength(1);
+  });
+
+  it('addColumn fails with invalid spec', () => {
+    const model = new BimModel();
+    const result = model.addColumn({ ...COLUMN_SPEC, height: 0 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('column volume matches profile area × height', () => {
+    const model = new BimModel();
+    const result = model.addColumn(COLUMN_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const column = model.getColumns()[0];
+    if (!column) throw new Error('Expected one column');
+    const vol = unwrap(measureVolume(column.geometry));
+    const nominal = Math.PI * 200 * 200 * 3000;
+    expect(vol).toBeGreaterThan(nominal * 0.99);
+    expect(vol).toBeLessThan(nominal * 1.01);
+  });
+
+  it('[Symbol.dispose] disposes column geometry', () => {
+    const model = new BimModel();
+    const result = model.addColumn(COLUMN_SPEC);
+    if (!result.ok) throw new Error(result.error.message);
+    const column = model.getColumns()[0];
+    if (!column) throw new Error('Expected one column');
+    model[Symbol.dispose]();
+    expect(column.geometry.disposed).toBe(true);
+  });
+});

--- a/packages/brepjs-bim/tests/columnFns.test.ts
+++ b/packages/brepjs-bim/tests/columnFns.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume } from 'brepjs';
+import { columnToSolid } from '../src/elementFns/columnFns.js';
+import { parseColumnSpec } from '../src/specs/columnSpec.js';
+import type { ColumnSpec } from '../src/specs/columnSpec.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const BASE: ColumnSpec = {
+  height: 3000,
+  profile: { kind: 'RECTANGULAR', width: 300, height: 300 },
+  origin: [0, 0, 0],
+  axisX: [1, 0, 0],
+  axisZ: [0, 0, 1],
+  materialName: 'Concrete',
+};
+
+describe('columnToSolid', () => {
+  it('rectangular column returns ValidSolid with correct volume', () => {
+    const result = columnToSolid(BASE);
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    expect(vol.value).toBeCloseTo(300 * 300 * 3000, -2);
+  });
+
+  it('circular column returns ValidSolid with correct volume', () => {
+    const result = columnToSolid({
+      ...BASE,
+      profile: { kind: 'CIRCULAR', radius: 200 },
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    const nominal = Math.PI * 200 * 200 * 3000;
+    expect(vol.value).toBeGreaterThan(nominal * 0.99);
+    expect(vol.value).toBeLessThan(nominal * 1.01);
+  });
+
+  it('I-beam column returns ValidSolid with cross-section-area × height', () => {
+    const result = columnToSolid({
+      ...BASE,
+      profile: {
+        kind: 'I_BEAM',
+        overallWidth: 200,
+        overallDepth: 400,
+        flangeThickness: 15,
+        webThickness: 10,
+      },
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    expect(vol.value).toBeCloseTo(3000 * 9700, -2);
+  });
+
+  it('rejects zero height', () => {
+    const result = columnToSolid({ ...BASE, height: 0 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('COLUMN_ZERO_HEIGHT');
+  });
+});
+
+describe('parseColumnSpec', () => {
+  it('accepts a minimal valid column', () => {
+    const result = parseColumnSpec(BASE);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts all predefined types', () => {
+    for (const t of ['COLUMN', 'PILASTER', 'NOTDEFINED'] as const) {
+      const result = parseColumnSpec({ ...BASE, predefinedType: t });
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('rejects an invalid profile', () => {
+    const result = parseColumnSpec({
+      ...BASE,
+      profile: { kind: 'CIRCULAR', radius: 0 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-orthogonal axes', () => {
+    const result = parseColumnSpec({ ...BASE, axisZ: [1, 0, 0] });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/brepjs-bim/tests/profile.test.ts
+++ b/packages/brepjs-bim/tests/profile.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { parseProfile } from '../src/specs/profile.js';
+import {
+  profileCrossSectionArea,
+  profileToPolygon,
+} from '../src/elementFns/profileFns.js';
+import type { Profile } from '../src/specs/profile.js';
+
+describe('parseProfile', () => {
+  it('accepts a rectangular profile', () => {
+    const result = parseProfile({ kind: 'RECTANGULAR', width: 200, height: 400 });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a circular profile', () => {
+    const result = parseProfile({ kind: 'CIRCULAR', radius: 150 });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts an I-beam profile', () => {
+    const result = parseProfile({
+      kind: 'I_BEAM',
+      overallWidth: 200,
+      overallDepth: 400,
+      flangeThickness: 15,
+      webThickness: 10,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects unknown kind', () => {
+    const result = parseProfile({ kind: 'T_SHAPE', width: 100, height: 200 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects negative dimensions', () => {
+    const result = parseProfile({ kind: 'RECTANGULAR', width: -1, height: 100 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects I-beam where flanges meet (zero web)', () => {
+    const result = parseProfile({
+      kind: 'I_BEAM',
+      overallWidth: 200,
+      overallDepth: 100,
+      flangeThickness: 50, // 2 × 50 == overallDepth
+      webThickness: 10,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects I-beam where web is wider than flange', () => {
+    const result = parseProfile({
+      kind: 'I_BEAM',
+      overallWidth: 100,
+      overallDepth: 400,
+      flangeThickness: 15,
+      webThickness: 100,
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('profileCrossSectionArea', () => {
+  it('rectangular = width × height', () => {
+    const profile: Profile = { kind: 'RECTANGULAR', width: 200, height: 400 };
+    expect(profileCrossSectionArea(profile)).toBe(80000);
+  });
+
+  it('circular = π × r²', () => {
+    const profile: Profile = { kind: 'CIRCULAR', radius: 100 };
+    expect(profileCrossSectionArea(profile)).toBeCloseTo(Math.PI * 10000, 5);
+  });
+
+  it('I-beam = flange area + web area', () => {
+    const profile: Profile = {
+      kind: 'I_BEAM',
+      overallWidth: 200,
+      overallDepth: 400,
+      flangeThickness: 15,
+      webThickness: 10,
+    };
+    // 2 × (200 × 15) + (400 - 30) × 10 = 6000 + 3700 = 9700
+    expect(profileCrossSectionArea(profile)).toBe(9700);
+  });
+});
+
+describe('profileToPolygon', () => {
+  it('rectangular returns 4 corners centered on origin', () => {
+    const pts = profileToPolygon({ kind: 'RECTANGULAR', width: 200, height: 400 });
+    expect(pts).toHaveLength(4);
+    expect(pts[0]).toEqual([-100, -200, 0]);
+    expect(pts[2]).toEqual([100, 200, 0]);
+  });
+
+  it('circular returns N segments centered on origin', () => {
+    const pts = profileToPolygon({ kind: 'CIRCULAR', radius: 100 }, 16);
+    expect(pts).toHaveLength(16);
+    expect(pts[0]).toEqual([100, 0, 0]);
+    // All points equidistant from origin
+    for (const [x, y] of pts) {
+      expect(Math.sqrt(x * x + y * y)).toBeCloseTo(100, 6);
+    }
+  });
+
+  it('I-beam returns 12 points forming the I outline', () => {
+    const pts = profileToPolygon({
+      kind: 'I_BEAM',
+      overallWidth: 200,
+      overallDepth: 400,
+      flangeThickness: 15,
+      webThickness: 10,
+    });
+    expect(pts).toHaveLength(12);
+    // Bottom-left flange corner
+    expect(pts[0]).toEqual([-100, -200, 0]);
+    // Top-right flange corner
+    expect(pts[6]).toEqual([100, 200, 0]);
+  });
+});

--- a/packages/brepjs-bim/tests/profile.test.ts
+++ b/packages/brepjs-bim/tests/profile.test.ts
@@ -103,6 +103,12 @@ describe('profileToPolygon', () => {
     }
   });
 
+  it('throws if circleSegments < 3', () => {
+    expect(() =>
+      profileToPolygon({ kind: 'CIRCULAR', radius: 100 }, 2)
+    ).toThrow(/circleSegments/);
+  });
+
   it('I-beam returns 12 points forming the I outline', () => {
     const pts = profileToPolygon({
       kind: 'I_BEAM',

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -867,6 +867,52 @@ describe('IFC Beam round-trip (M7)', () => {
     api.CloseModel(mid);
   });
 
+  it('IFC beam placement orients local Y to spec.axisZ (P1 regression guard)', async () => {
+    // Beam along +X with axisZ = [0,0,1]; profile should sit with width along +Y
+    // and height along +Z in world space.
+    const model = new BimModel();
+    unwrap(model.init({ name: 'Orient Test' }));
+    unwrap(model.addBeam({
+      length: 5000,
+      profile: { kind: 'I_BEAM', overallWidth: 200, overallDepth: 400, flangeThickness: 15, webThickness: 10 },
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Steel',
+    }));
+    const result = await toIfc(model, { applicationName: 't', applicationVersion: '0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    const beamIds = api.GetLineIDsWithType(mid, WebIFC.IFCBEAM);
+    const beam = api.GetLine(mid, beamIds.get(0)) as Record<string, unknown>;
+    const placementRef = beam['ObjectPlacement'] as { value: number };
+    const placement = api.GetLine(mid, placementRef.value) as Record<string, unknown>;
+    const relPlacementRef = placement['RelativePlacement'] as { value: number };
+    const relPlacement = api.GetLine(mid, relPlacementRef.value) as Record<string, unknown>;
+
+    const axisRef = relPlacement['Axis'] as { value: number };
+    const refDirRef = relPlacement['RefDirection'] as { value: number };
+    const axisLine = api.GetLine(mid, axisRef.value) as Record<string, unknown>;
+    const refDirLine = api.GetLine(mid, refDirRef.value) as Record<string, unknown>;
+    const axis = (axisLine['DirectionRatios'] as Array<{ value: number }>).map((r) => r.value);
+    const refDir = (refDirLine['DirectionRatios'] as Array<{ value: number }>).map((r) => r.value);
+
+    // Axis = beam length direction
+    expect(axis).toEqual([1, 0, 0]);
+    // Derived local Y = Axis × RefDirection should equal spec.axisZ = [0, 0, 1]
+    const [ax = 0, ay = 0, az = 0] = axis;
+    const [rx = 0, ry = 0, rz = 0] = refDir;
+    const localY: [number, number, number] = [
+      ay * rz - az * ry,
+      az * rx - ax * rz,
+      ax * ry - ay * rx,
+    ];
+    expect(localY[0]).toBeCloseTo(0, 6);
+    expect(localY[1]).toBeCloseTo(0, 6);
+    expect(localY[2]).toBeCloseTo(1, 6);
+    api.CloseModel(mid);
+  });
+
   it('Qto_BeamBaseQuantities has expected numeric values', async () => {
     const { api, mid } = await buildBeamModel();
     const qtoIds = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
+import { unwrap } from 'brepjs';
 import * as WebIFC from 'web-ifc';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
@@ -781,6 +782,239 @@ describe('IFC Slab Opening round-trip (M6)', () => {
     expect(grossArea).toBeGreaterThan(0);
     expect(netArea).toBeCloseTo(grossArea, 6);
     expect(netVol).toBeCloseTo(grossVol, 6);
+    api.CloseModel(mid);
+  });
+});
+
+describe('IFC Beam round-trip (M7)', () => {
+  async function buildBeamModel(): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+    const model = new BimModel();
+    unwrap(model.init({ name: 'Beam Test' }));
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const project = model.getProject();
+    if (!project) throw new Error('expected project');
+    model.aggregate(project.localId, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+
+    const rect = unwrap(model.addBeam({
+      length: 5000,
+      profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+      origin: [0, 0, 3000], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      predefinedType: 'BEAM',
+      materialName: 'Steel',
+      isExternal: false,
+      loadBearing: true,
+      fireRating: 'R60',
+    }));
+    const ibeam = unwrap(model.addBeam({
+      length: 5000,
+      profile: { kind: 'I_BEAM', overallWidth: 200, overallDepth: 400, flangeThickness: 15, webThickness: 10 },
+      origin: [0, 2000, 3000], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      predefinedType: 'JOIST',
+      materialName: 'Steel',
+    }));
+    model.placeIn(rect, storeyId);
+    model.placeIn(ibeam, storeyId);
+
+    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    return { api, mid };
+  }
+
+  it('emits two IfcBeam entities', async () => {
+    const { api, mid } = await buildBeamModel();
+    const beams = api.GetLineIDsWithType(mid, WebIFC.IFCBEAM);
+    expect(beams.size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('IfcBeam PredefinedType matches spec', async () => {
+    const { api, mid } = await buildBeamModel();
+    const beamIds = api.GetLineIDsWithType(mid, WebIFC.IFCBEAM);
+    const types: string[] = [];
+    for (let i = 0; i < beamIds.size(); i++) {
+      const b = api.GetLine(mid, beamIds.get(i)) as Record<string, unknown>;
+      const pred = (b['PredefinedType'] as { value?: string } | undefined)?.value;
+      if (pred !== undefined) types.push(pred);
+    }
+    expect(types.sort()).toEqual(['BEAM', 'JOIST']);
+    api.CloseModel(mid);
+  });
+
+  it('emits an IfcIShapeProfileDef for the I-beam', async () => {
+    const { api, mid } = await buildBeamModel();
+    const profiles = api.GetLineIDsWithType(mid, WebIFC.IFCISHAPEPROFILEDEF);
+    expect(profiles.size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('emits Pset_BeamCommon for the rect beam (has spec fields)', async () => {
+    const { api, mid } = await buildBeamModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSET);
+    let found = false;
+    for (let i = 0; i < ids.size(); i++) {
+      const pset = api.GetLine(mid, ids.get(i)) as Record<string, unknown>;
+      const name = (pset['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Pset_BeamCommon') { found = true; break; }
+    }
+    expect(found).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('Qto_BeamBaseQuantities has expected numeric values', async () => {
+    const { api, mid } = await buildBeamModel();
+    const qtoIds = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    const qtos: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < qtoIds.size(); i++) {
+      const candidate = api.GetLine(mid, qtoIds.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name === 'Qto_BeamBaseQuantities') qtos.push(candidate);
+    }
+    expect(qtos).toHaveLength(2);
+
+    // Pull the rect beam's qto (cross section = 0.2 × 0.4 = 0.08 m²)
+    let rectQto: Record<string, unknown> | undefined;
+    for (const qto of qtos) {
+      const refs = qto['Quantities'] as Array<{ value: number }>;
+      for (const r of refs) {
+        const q = api.GetLine(mid, r.value) as Record<string, unknown>;
+        const name = (q['Name'] as { value?: string } | undefined)?.value;
+        const area = (q['AreaValue'] as { value?: number } | undefined)?.value;
+        if (name === 'CrossSectionArea' && area !== undefined && Math.abs(area - 0.08) < 1e-6) {
+          rectQto = qto;
+        }
+      }
+    }
+    if (rectQto === undefined) throw new Error('Expected rect beam Qto');
+
+    const numericByName = new Map<string, number>();
+    const refs = rectQto['Quantities'] as Array<{ value: number }>;
+    for (const r of refs) {
+      const q = api.GetLine(mid, r.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      if (name === undefined) continue;
+      const lengthVal = (q['LengthValue'] as { value?: number } | undefined)?.value;
+      const areaVal = (q['AreaValue'] as { value?: number } | undefined)?.value;
+      const volumeVal = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      const num = lengthVal ?? areaVal ?? volumeVal;
+      if (num !== undefined) numericByName.set(name, num);
+    }
+    expect(numericByName.get('Length')).toBeCloseTo(5, 5);
+    expect(numericByName.get('CrossSectionArea')).toBeCloseTo(0.08, 5);
+    expect(numericByName.get('GrossVolume')).toBeCloseTo(5 * 0.08, 5);
+    expect(numericByName.get('NetVolume')).toBeCloseTo(5 * 0.08, 5);
+    api.CloseModel(mid);
+  });
+});
+
+describe('IFC Column round-trip (M7)', () => {
+  async function buildColumnModel(): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+    const model = new BimModel();
+    unwrap(model.init({ name: 'Column Test' }));
+    const siteId = model.addSite({ name: 'S' });
+    const buildingId = model.addBuilding({ name: 'B' });
+    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const project = model.getProject();
+    if (!project) throw new Error('expected project');
+    model.aggregate(project.localId, siteId);
+    model.aggregate(siteId, buildingId);
+    model.aggregate(buildingId, storeyId);
+
+    const round = unwrap(model.addColumn({
+      height: 3000,
+      profile: { kind: 'CIRCULAR', radius: 200 },
+      origin: [1000, 1000, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      predefinedType: 'COLUMN',
+      materialName: 'Concrete',
+      loadBearing: true,
+    }));
+    const pilaster = unwrap(model.addColumn({
+      height: 3000,
+      profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+      origin: [2000, 2000, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      predefinedType: 'PILASTER',
+      materialName: 'Concrete',
+    }));
+    model.placeIn(round, storeyId);
+    model.placeIn(pilaster, storeyId);
+
+    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    if (!result.ok) throw new Error(result.error.message);
+    const api = new WebIFC.IfcAPI();
+    await api.Init();
+    const mid = api.OpenModel(result.value);
+    return { api, mid };
+  }
+
+  it('emits two IfcColumn entities', async () => {
+    const { api, mid } = await buildColumnModel();
+    const columns = api.GetLineIDsWithType(mid, WebIFC.IFCCOLUMN);
+    expect(columns.size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('IfcColumn PredefinedType matches spec', async () => {
+    const { api, mid } = await buildColumnModel();
+    const ids = api.GetLineIDsWithType(mid, WebIFC.IFCCOLUMN);
+    const types: string[] = [];
+    for (let i = 0; i < ids.size(); i++) {
+      const c = api.GetLine(mid, ids.get(i)) as Record<string, unknown>;
+      const pred = (c['PredefinedType'] as { value?: string } | undefined)?.value;
+      if (pred !== undefined) types.push(pred);
+    }
+    expect(types.sort()).toEqual(['COLUMN', 'PILASTER']);
+    api.CloseModel(mid);
+  });
+
+  it('emits an IfcCircleProfileDef for the round column', async () => {
+    const { api, mid } = await buildColumnModel();
+    const profiles = api.GetLineIDsWithType(mid, WebIFC.IFCCIRCLEPROFILEDEF);
+    expect(profiles.size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('Qto_ColumnBaseQuantities reflects circular cross-section area', async () => {
+    const { api, mid } = await buildColumnModel();
+    const qtoIds = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
+    let roundQto: Record<string, unknown> | undefined;
+    for (let i = 0; i < qtoIds.size(); i++) {
+      const candidate = api.GetLine(mid, qtoIds.get(i)) as Record<string, unknown>;
+      const name = (candidate['Name'] as { value?: string } | undefined)?.value;
+      if (name !== 'Qto_ColumnBaseQuantities') continue;
+      const refs = candidate['Quantities'] as Array<{ value: number }>;
+      for (const r of refs) {
+        const q = api.GetLine(mid, r.value) as Record<string, unknown>;
+        const qName = (q['Name'] as { value?: string } | undefined)?.value;
+        const area = (q['AreaValue'] as { value?: number } | undefined)?.value;
+        // Round column area in m² = π × 0.2² ≈ 0.12566
+        if (qName === 'CrossSectionArea' && area !== undefined && Math.abs(area - Math.PI * 0.04) < 1e-4) {
+          roundQto = candidate;
+        }
+      }
+    }
+    if (roundQto === undefined) throw new Error('Expected round-column Qto');
+
+    const numericByName = new Map<string, number>();
+    const refs = roundQto['Quantities'] as Array<{ value: number }>;
+    for (const r of refs) {
+      const q = api.GetLine(mid, r.value) as Record<string, unknown>;
+      const name = (q['Name'] as { value?: string } | undefined)?.value;
+      if (name === undefined) continue;
+      const lengthVal = (q['LengthValue'] as { value?: number } | undefined)?.value;
+      const areaVal = (q['AreaValue'] as { value?: number } | undefined)?.value;
+      const volumeVal = (q['VolumeValue'] as { value?: number } | undefined)?.value;
+      const num = lengthVal ?? areaVal ?? volumeVal;
+      if (num !== undefined) numericByName.set(name, num);
+    }
+    expect(numericByName.get('Length')).toBeCloseTo(3, 5);
+    expect(numericByName.get('CrossSectionArea')).toBeCloseTo(Math.PI * 0.04, 5);
+    expect(numericByName.get('GrossVolume')).toBeCloseTo(3 * Math.PI * 0.04, 4);
     api.CloseModel(mid);
   });
 });


### PR DESCRIPTION
## Summary

First structural elements in the BIM package: IfcBeam and IfcColumn with a full parametric profile family.

- **`Profile`**: discriminated union over `RECTANGULAR { width, height }`, `CIRCULAR { radius }`, and `I_BEAM { overallWidth, overallDepth, flangeThickness, webThickness }`. `parseProfile` enforces I-beam geometric constraints (flanges don't meet, web fits inside flange).
- **`profileCrossSectionArea`** + **`profileToPolygon`**: analytical area for Qto and tessellated outline for brepjs `polygon` + `extrude`. Circles default to 32 segments.
- **`BeamSpec`** + **`beamToSolid`**: profile rotated XY→YZ and extruded along +X by `length`. Predefined types: BEAM, JOIST, LINTEL, HOLLOWCORE, PURLIN, RAFTER, SPANDREL, T_BEAM, NOTDEFINED.
- **`ColumnSpec`** + **`columnToSolid`**: profile in XY extruded along +Z by `height`. Predefined types: COLUMN, PILASTER, NOTDEFINED.
- **`BimModel.addBeam` / `addColumn`** + `getBeams` / `getColumns`; new BEAM and COLUMN BimCategory members; `[Symbol.dispose]` releases their geometry.
- **IFC writer**: `writeProfile` (one function for all three profile kinds), `writeLinearExtrusion` shared helper (beams pass `(axisZ, axisX)` to align placement Z with the beam axis; columns pass `(axisX, axisZ)` to keep placement Z vertical), `writeBeamEntity` / `writeColumnEntity` with `PredefinedType`. Full Pset_BeamCommon / Pset_ColumnCommon + Qto_BeamBaseQuantities / Qto_ColumnBaseQuantities (Length, CrossSectionArea, GrossVolume, NetVolume).
- **Public API**: exports `parseProfile`, `parseBeamSpec`, `parseColumnSpec`, `Profile`/`RectangularProfile`/`CircularProfile`/`IShapeProfile`, `BeamSpec`/`BeamPredefinedType`, `ColumnSpec`/`ColumnPredefinedType`.

## Architecture note

The profile family is the first cross-cutting abstraction in `brepjs-bim` — both beams and columns consume it, and future linear structural elements (member, plate) can reuse the same machinery without duplication. `profileToPolygon` returns 3D points so brepjs's `polygon` builds the wire directly; the IFC side gets parametric profile defs from `writeProfile`.

Beam vs column placement asymmetry: in IFC the extrusion always runs along the placement's local Z. The brepjs solid for a beam grows in +X (matching wall convention), so its IFC placement swaps axisX/axisZ to align local Z with world axisX (the beam's length). Columns grow in +Z so their placement passes axes through unchanged.

## Test plan

- [ ] `profile.test.ts` — 13 tests for `parseProfile`, `profileCrossSectionArea`, `profileToPolygon` (rectangular, circular, I-beam)
- [ ] `beamFns.test.ts` — 9 tests: ValidSolid + volume for each profile across beams + spec validation (predefined types, axes, profile rejection)
- [ ] `columnFns.test.ts` — 8 tests: same coverage for columns
- [ ] `bimModel.test.ts` — 9 new tests for `addBeam` / `addColumn`: success, validation failure, volume match, disposal, material rel
- [ ] `roundTrip.test.ts` — 9 new tests: IfcBeam/IfcColumn counts, PredefinedType, IfcIShapeProfileDef / IfcCircleProfileDef presence, Pset_BeamCommon, Qto numeric values for rect beam and round column
- [ ] All 165 BIM tests pass; root `npm run validate` is green; package build clean (~+22 KB for profile + beam + column machinery)