### PR TITLE
test(parity): tighten boolean tolerance floors 0.06 → 0.051

### DIFF
--- a/tests/parity/booleans.test.ts
+++ b/tests/parity/booleans.test.ts
@@ -240,10 +240,11 @@ describe('INVARIANT: fuseAll equals chained pairwise fuse by volume', () => {
         if (!isOk(abc)) return;
         const lhs = volOf(unwrap(all));
         const rhs = volOf(unwrap(abc));
-        // 1% relative, with a 0.06 absolute floor — strictly subsumes the prior
+        // 1% relative, with a 0.051 absolute floor — strictly subsumes the prior
         // `toBeCloseTo(_, 1)` (0.05) so any case the old test accepted is still
-        // accepted, plus headroom for the 1-ULP shrinker cases on dx ≈ 4e-7.
-        const tol = Math.max(0.06, 1e-2 * Math.max(Math.abs(lhs), Math.abs(rhs)));
+        // accepted, plus 1e-3 (≈ 5e15 ULP) headroom for the 1-ULP shrinker
+        // cases on dx ≈ 4e-7.
+        const tol = Math.max(0.051, 1e-2 * Math.max(Math.abs(lhs), Math.abs(rhs)));
         expect(Math.abs(lhs - rhs)).toBeLessThanOrEqual(tol);
       }),
       { numRuns: NUM_RUNS }
@@ -278,10 +279,10 @@ describe('INVARIANT: cut-then-fuse-back recovers original volume', () => {
         if (!isOk(recombined)) return;
         const lhs = volOf(unwrap(recombined));
         const rhs = volOf(a);
-        // 1% relative, with a 0.06 absolute floor — strictly subsumes the prior
+        // 1% relative, with a 0.051 absolute floor — strictly subsumes the prior
         // `toBeCloseTo(_, 1)` (0.05). The 0.05 cap was real ULP headroom on the
         // dx ≈ 4e-7 near-concentric case the kernel resolves to within 0.05.
-        const tol = Math.max(0.06, 1e-2 * Math.max(Math.abs(lhs), Math.abs(rhs)));
+        const tol = Math.max(0.051, 1e-2 * Math.max(Math.abs(lhs), Math.abs(rhs)));
         expect(Math.abs(lhs - rhs)).toBeLessThanOrEqual(tol);
       }),
       { numRuns: NUM_RUNS }


### PR DESCRIPTION
## Summary
Follow-up to #1078 addressing Greptile's P2 feedback.

The `0.06` absolute floor I picked for the two `precision=1` invariants (`fuseAll == chained fuse`, `cut-then-fuse-back`) was 20% wider than strictly needed. The reported CI overshoot was only `~2e-17` over the old `toBeCloseTo(_, 1)` (= 0.05) threshold, so `0.051` is more than enough:
- Strictly subsumes the old 0.05 absolute behavior (any case the old test accepted is still accepted)
- `1e-3` headroom is ≈ 5e15 ULP at the 0.05 scale — orders of magnitude more than the ULP overshoot
- Preserves more sensitivity in the small-volume range where the absolute floor dominates (cube volumes < 6 with `fcDim() ∈ [0.5, 50]`)

For a 0.125-volume cube, the new floor permits up to ~41% relative error vs ~48% with `0.06` — a real sensitivity gain in the regime where fast-check most often shrinks.

The `inclusion-exclusion` invariant's `2e-3` floor (already only 2× the original `1e-3`) is unchanged — it's already as tight as it can be while absorbing the observed ULP.

## Test plan
- [x] `npm run typecheck`
- [x] 3x consecutive OCCT parity runs: 20/20 each
- [x] Pre-push `test:full` + `knip`: green