### PR TITLE
test(brepkit): un-skip fillet-all-edges modifierFns test

### DIFF
--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -60,10 +60,6 @@ export const divergences: DivergenceMap = {
     // -----------------------------------------------------------------------
     // modifierFns.test.ts
     // -----------------------------------------------------------------------
-    'modifierFns.filletAllEdges': {
-      kind: 'skip',
-      reason: 'brepkit over-fillets when all 12 edges are filleted (vol ~530 vs >800 expected)',
-    },
     'modifierFns.variableFilletRadius': {
       kind: 'not-implemented',
       reason:

--- a/tests/modifierFns.test.ts
+++ b/tests/modifierFns.test.ts
@@ -68,8 +68,7 @@ describe('thicken', () => {
 });
 
 describe('fillet', () => {
-  it('fillets all edges of a box with constant radius', (ctx) => {
-    skipIfDiverges(ctx, 'modifierFns.filletAllEdges');
+  it('fillets all edges of a box with constant radius', () => {
     const b = box(10, 10, 10);
     const result = fillet(b, 1);
     expect(isOk(result)).toBe(true);
@@ -342,7 +341,7 @@ describe('variableFillet validation', () => {
 describe('null-shape pre-validation', () => {
   function makeNullShape(): Shape3D {
     const oc = getKernel().oc;
-    return createSolid(new oc.TopoDS_Solid()) as Shape3D;
+    return createSolid(new oc.TopoDS_Solid());
   }
 
   it('fillet rejects null shape', (ctx) => {


### PR DESCRIPTION
## What

Un-skips the brepkit-only `modifierFns` test "fillets all edges of a box with constant radius" and removes its `modifierFns.filletAllEdges` kernel-divergence entry.

## Why

brepkit-wasm 2.101.0 ships the fillet fix (brepkit #734). Filleting all 12 edges of a 10×10×10 box with radius 1 now yields a volume of **~974.96** — comfortably inside the test's expected `800 < vol < 1000` band — instead of over-removing material as the old divergence reason described.

## Verification

- Un-skipped test passes under `TEST_KERNEL=brepkit` (vol 974.96).
- Full modifierFns suite under brepkit: 29 passed, 6 skipped.
- Repo gate green: typecheck, eslint, knip, full test suite + coverage thresholds.

## Notes

- Scoped to the brepkit-only `modifierFns` test. The cross-kernel agreement fillet test is intentionally left untouched (its reference kernel throws on this input in-environment).