### PR TITLE
test(brepkit): un-skip cannedSketches face-offset divergence

### DIFF
--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -96,14 +96,6 @@ export const divergences: DivergenceMap = {
     },
 
     // -----------------------------------------------------------------------
-    // cannedSketches.test.ts
-    // -----------------------------------------------------------------------
-    'cannedSketches.faceOffset': {
-      kind: 'skip',
-      reason: 'brepkit: face offset area=576 vs expected<400 (offset not applied correctly)',
-    },
-
-    // -----------------------------------------------------------------------
     // kernel-ops.test.ts
     // -----------------------------------------------------------------------
     'kernelOps.variableFilletRadius': {


### PR DESCRIPTION
The brepkit `sketchFaceOffset` inward path now produces the expected shrunk area (~252.6 for a 20×20 box face offset by -2, well under the 400 threshold) instead of expanding to area 576.

This removes the stale `cannedSketches.faceOffset` skip entry so the test runs under the brepkit kernel.

Validated with a locally-built brepkit-wasm carrying the offset sign fix: the cross-kernel test `sketchFaceOffset shrinks a face inward` passes for brepkit, occt, and occt-wasm.