### PR TITLE
test: un-skip face-offset inward-shrink cross-kernel test

### DIFF
--- a/tests/cannedSketches.test.ts
+++ b/tests/cannedSketches.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
-import { skipIfDiverges } from './helpers/kernelDivergences.js';
 import {
   sketchCircle,
   sketchEllipse,
@@ -108,8 +107,7 @@ describe('Canned sketches', () => {
     expect(sketchPolysides(10, 5, 0, { plane })).toBeDefined();
   });
 
-  it('sketchFaceOffset shrinks a face inward', (ctx) => {
-    skipIfDiverges(ctx, 'cannedSketches.faceOffset');
+  it('sketchFaceOffset shrinks a face inward', () => {
     const b = box(20, 20, 20);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test indexing
     const face = getFaces(b)[0]!;

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -96,14 +96,6 @@ export const divergences: DivergenceMap = {
     },
 
     // -----------------------------------------------------------------------
-    // cannedSketches.test.ts
-    // -----------------------------------------------------------------------
-    'cannedSketches.faceOffset': {
-      kind: 'skip',
-      reason: 'brepkit: face offset area=576 vs expected<400 (offset not applied correctly)',
-    },
-
-    // -----------------------------------------------------------------------
     // kernelCall.test.ts
     // -----------------------------------------------------------------------
     'kernelCall.doubleFillet': {


### PR DESCRIPTION
## Summary

Un-skips the `cannedSketches.faceOffset` cross-kernel divergence. The reference-kernel face offset previously grew a face when asked to shrink it inward (inward offset of -2 on a 20x20 box face produced area 576 instead of 256) because the offset direction was tied to the loop's stored traversal winding / face-normal sign.

This is fixed in the reference kernel by the winding-robust planar offset sign change (brepkit PR https://github.com/andymai/brepkit/pull/741, merged), which normalizes the offset sign against the loop's signed area so negative always shrinks and positive always grows, independent of winding.

## Changes

- Remove the `cannedSketches.faceOffset` skip entry from `tests/helpers/kernelDivergences.ts`.
- Drop the `skipIfDiverges` guard (and now-unused import) from `tests/cannedSketches.test.ts` so the inward-shrink assertion (`area < 400`) runs on both kernels.

## Blocked

DRAFT — blocked on the brepkit-wasm release that bundles brepkit PR #741. Merge only after that release is pulled into brepjs; until then the brepkit kernel will still report area 576 and fail this assertion.