### PR TITLE
fix(apps): auto-recover from stale chunk preload errors after redeploy

### DIFF
--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -4,6 +4,48 @@ import { h } from 'vue';
 import Layout from './Layout.vue';
 import './custom.css';
 
+/**
+ * Recover from stale lazy-loaded chunks after a redeploy.
+ *
+ * Vite emits content-hashed chunks (e.g. `VPLocalSearchBox.<hash>.js`) and
+ * serves them `immutable`, so each deploy renames them and drops the old ones.
+ * A long-lived tab (or HTTP-cached `app.js`) still references the previous
+ * hashes; when a lazy `import()` — the local search box, mermaid diagrams —
+ * fires, the chunk 404s and Vite raises `vite:preloadError`.
+ *
+ * Reloading re-fetches `index.html` (served `must-revalidate`, always fresh),
+ * which points at the current hashes. The sessionStorage guard reloads at most
+ * once per ~10s window so a genuinely-broken deploy surfaces the error instead
+ * of looping forever.
+ */
+function registerPreloadErrorRecovery(): void {
+  const RELOAD_KEY = 'brepjs:preload-error-reloaded-at';
+  const RELOAD_DEBOUNCE_MS = 10_000;
+
+  window.addEventListener('vite:preloadError', (event) => {
+    let lastReload = 0;
+    try {
+      lastReload = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0);
+    } catch {
+      // sessionStorage may be unavailable (privacy mode); fall through to reload.
+    }
+
+    // Already reloaded recently → likely a real broken deploy, not a stale
+    // tab. Let the error propagate so it's visible instead of looping.
+    if (Date.now() - lastReload < RELOAD_DEBOUNCE_MS) return;
+
+    try {
+      sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+    } catch {
+      // Ignore — a missing guard only risks a single extra reload.
+    }
+
+    // Suppress Vite's default rethrow, then reload to pick up fresh hashes.
+    event.preventDefault();
+    window.location.reload();
+  });
+}
+
 const theme: Theme = {
   extends: DefaultTheme,
   Layout: () => h(Layout),
@@ -13,6 +55,7 @@ const theme: Theme = {
     // emit pageviews automatically once mounted.
     if (typeof window !== 'undefined') {
       void import('@vercel/analytics').then(({ inject }) => inject());
+      registerPreloadErrorRecovery();
     }
   },
 };

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -19,7 +19,9 @@ import './custom.css';
  * of looping forever.
  */
 function registerPreloadErrorRecovery(): void {
-  const RELOAD_KEY = 'brepjs:preload-error-reloaded-at';
+  if (typeof window === 'undefined') return;
+
+  const RELOAD_KEY = 'brepjs:docs:preload-error-reloaded-at';
   const RELOAD_DEBOUNCE_MS = 10_000;
 
   window.addEventListener('vite:preloadError', (event) => {

--- a/apps/playground/src/lib/preloadErrorRecovery.ts
+++ b/apps/playground/src/lib/preloadErrorRecovery.ts
@@ -1,0 +1,44 @@
+/**
+ * Recover from stale lazy-loaded chunks after a redeploy.
+ *
+ * Vite emits content-hashed chunks and serves them `immutable`, so each deploy
+ * renames them and drops the old ones. A long-lived tab (or HTTP-cached entry
+ * script) still references the previous hashes; when a lazy `import()` — the
+ * viewer panel, route chunks — fires, the chunk 404s and Vite raises
+ * `vite:preloadError`.
+ *
+ * Reloading re-fetches `index.html` (served `must-revalidate`, always fresh),
+ * which points at the current hashes. The sessionStorage guard reloads at most
+ * once per ~10s window so a genuinely-broken deploy surfaces the error (and the
+ * viewer's ErrorBoundary fallback) instead of looping forever.
+ */
+export function registerPreloadErrorRecovery(): void {
+  if (typeof window === 'undefined') return;
+
+  const RELOAD_KEY = 'brepjs:preload-error-reloaded-at';
+  const RELOAD_DEBOUNCE_MS = 10_000;
+
+  window.addEventListener('vite:preloadError', (event) => {
+    let lastReload = 0;
+    try {
+      lastReload = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0);
+    } catch {
+      // sessionStorage may be unavailable (privacy mode); fall through to reload.
+    }
+
+    // Already reloaded recently → likely a real broken deploy, not a stale
+    // tab. Let the error propagate so the ErrorBoundary fallback shows instead
+    // of looping.
+    if (Date.now() - lastReload < RELOAD_DEBOUNCE_MS) return;
+
+    try {
+      sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+    } catch {
+      // Ignore — a missing guard only risks a single extra reload.
+    }
+
+    // Suppress Vite's default rethrow, then reload to pick up fresh hashes.
+    event.preventDefault();
+    window.location.reload();
+  });
+}

--- a/apps/playground/src/lib/preloadErrorRecovery.ts
+++ b/apps/playground/src/lib/preloadErrorRecovery.ts
@@ -15,7 +15,7 @@
 export function registerPreloadErrorRecovery(): void {
   if (typeof window === 'undefined') return;
 
-  const RELOAD_KEY = 'brepjs:preload-error-reloaded-at';
+  const RELOAD_KEY = 'brepjs:playground:preload-error-reloaded-at';
   const RELOAD_DEBOUNCE_MS = 10_000;
 
   window.addEventListener('vite:preloadError', (event) => {

--- a/apps/playground/src/main.tsx
+++ b/apps/playground/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { registerPreloadErrorRecovery } from './lib/preloadErrorRecovery';
 import './styles/globals.css';
+
+registerPreloadErrorRecovery();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Problem

Reported via a console error on `www.brepjs.dev`:

```
/assets/chunks/VPLocalSearchBox.DFTP76I7.js  Failed to load resource: 404
TypeError: Failed to fetch dynamically imported module: .../VPLocalSearchBox.DFTP76I7.js
```

**Root cause — stale chunk references after a redeploy.** Vite emits content-hashed chunks and serves them `immutable`. Each deploy renames every chunk and drops the previous build's files. A long-lived tab (or an HTTP-cached entry script) still points at the old hashes; the failure only surfaces when a **lazy** `import()` fires — the docs local-search box, mermaid diagrams, or the playground's viewer panel — because eagerly-loaded chunks were already in memory.

Diagnosis confirmed the live deploy is healthy: the current `theme.*.js` references `VPLocalSearchBox.d_sowymi.js` (HTTP 200), while the browser requested the stale `…DFTP76I7.js` (HTTP 404). VitePress 1.6.4 ships **no** `vite:preloadError` handling, so there was no recovery path.

## Fix

Add a `vite:preloadError` listener to both frontend apps. When a lazy chunk 404s, suppress Vite's default rethrow and reload the page — `index.html` is served `must-revalidate`, so the reload fetches the current hashes. A `sessionStorage` debounce reloads **at most once per ~10s window**, so a genuinely broken deploy surfaces the error instead of refresh-looping.

- **`apps/docs`** — handler in the VitePress theme's `enhanceApp` (SSR-guarded, alongside the existing analytics inject).
- **`apps/playground`** — handler in `main.tsx` via a new `lib/preloadErrorRecovery.ts`. Complements the existing `ViewerPanel` `ErrorBoundary`: the global handler auto-recovers stale-deploy cases at the module-loader level; the boundary remains the visible fallback when auto-recovery is exhausted.

## Notes

- This is a **forward** fix: it protects clients that load the patched shell from the next deploy onward. Clients currently sitting on a broken shell still need one manual hard-refresh — already-cached JS can't be patched retroactively without a service worker (out of scope / heavier than warranted).

## Verification

- New code type-checks under `--strict`; `vite:preloadError` is typed via `vite/client`'s `WindowEventMap`.
- Prettier clean.
- ⚠️ Full `tsc -b` / build could not be run in the authoring environment (local Node 20 < the project's required Node 24 blocks installing `@vercel/analytics`/`sucrase`). The only typecheck errors observed were those pre-existing missing modules — **none** reference the changed files. Please confirm CI green before merge.