### PR TITLE
chore: stop tracking .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"2e9444c7-757f-4210-9b84-4379ddb9ee72","pid":34654,"procStart":"24602","acquiredAt":1778167093868}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code agent memory (user-specific, not shared)
 .claude/agent-memory-local/
+.claude/scheduled_tasks.lock
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
Per-session state (sessionId/pid/procStart) that churns on every run — never belonged in version control. Untracks it and adds a `.gitignore` entry alongside the existing `.claude/agent-memory-local/`. File is preserved on disk.