### PR TITLE
docs(readme): move demo image into header beside the playground CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ CAD modeling for JavaScript.
 
 **[Getting Started](./docs/getting-started.md)** · **[Cheat Sheet](./docs/cheat-sheet.md)** · **[Docs](https://brepjs.dev/)**
 
+[![brepjs playground: write TypeScript on the left, see the exact solid render on the right](https://raw.githubusercontent.com/andymai/brepjs/main/media/demo.webp)](https://brepjs.dev/playground)
+
 </div>
 
 Shapes are exact mathematical boundaries — not triangle meshes — so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
@@ -31,12 +33,6 @@ const part = unwrap(fillet(drilled, edges, 1.5));
 
 const step = unwrap(exportSTEP(part));
 ```
-
-<div align="center">
-
-[![brepjs playground: write TypeScript on the left, see the exact solid render on the right](https://raw.githubusercontent.com/andymai/brepjs/main/media/demo.webp)](https://brepjs.dev/playground)
-
-</div>
 
 ## Why?
 


### PR DESCRIPTION
## What

Follow-up to #1108. The demo screenshot was stranded below the code example, splitting it from the playground CTA at the top. This pulls it up into the centered header so the two playground entry points (CTA + clickable hero image) sit together as a paired block.

New header order: title → tagline → badges → `▶ Try the live playground` CTA → docs nav → demo image. The standalone image block below the code example is removed.

## Notes

- Docs-only change — non-`!` commit type so release-please does not bump the library major.
- No new assets; reuses `media/demo.webp` already on `main`.