### PR TITLE
ci: shard test job across runners to fix flaky per-test timeout (#1102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,35 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # Sharded across runners so each fork processes ~1/4 of the suite. OCCT WASM
+    # linear memory grows monotonically across tests; a long single-runner run
+    # (173 files / 4 forks × 6 GB heap) over-commits the 16 GB runner into swap,
+    # stalling a fork until the 90s per-test timeout trips (#1102). Short shards
+    # exit before accumulation reaches that threshold. Coverage runs separately
+    # (the `coverage` job) — vitest --merge-reports can't recombine coverage
+    # across shards in this workspace+v8 setup.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
-      - run: npm run test:full -- --reporter=default --reporter=github-actions
+      - run: npm run test:ci -- --shard=${{ matrix.shard }}/4 --reporter=default --reporter=github-actions
+
+  coverage:
+    # Coverage thresholds run on main only — informational, not a PR gate (kept
+    # out of ci-pass). The full instrumented suite can't shard (see `test`), so
+    # it runs on one runner with maxWorkers=2 and a raised per-test timeout to
+    # ride out any residual swap stall rather than red on the 90s default.
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup
+      - run: npm run test:full -- --reporter=default --maxWorkers=2 --testTimeout=180000
 
   size:
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 isolate-*.log
 docs-api/
 coverage/
+.vitest-reports/
 *.tsbuildinfo
 .env
 .vercel

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "vitest run --project occt --changed",
     "test:full": "vitest run --project occt --coverage",
+    "test:ci": "vitest run --project occt",
     "test:watch": "vitest --project occt",
     "test:brepkit": "vitest run --project brepkit",
     "test:stress": "vitest run --config vitest.stress.config.ts",


### PR DESCRIPTION
## Problem

`tests/2d.test.ts > CompoundBlueprint > 'basic properties and SVG'` intermittently times out at the **90s per-test limit**, reddening CI on unrelated PRs (#1080, #1096, #1100) and forcing manual re-runs. The test is trivial (two rects + an SVG string) and passes in **~36s in isolation** — it was never the test.

## Root cause

The `test` job ran all **173 files in 4 forks**, each allowed `--max-old-space-size=6144` → a **24 GB heap ceiling on a 16 GB `ubuntu-24.04` runner**. OCCT WASM linear memory grows monotonically across tests, so a long single-runner run over-commits into swap and **freezes a fork** until whatever test is mid-flight trips the 90s timeout.

Smoking gun from the #1100 re-run: `2d.test.ts`'s fork was frozen for **224s of a 235s suite** — the file itself is intrinsically fast.

## Fix

- **Shard the `test` job into a 4-way matrix.** Each fork now processes ~1/4 of the suite and exits before WASM accumulation reaches the swap threshold. This is the PR correctness gate (`ci-pass` aggregates all four shards).
- **New `test:ci` script** (`vitest run --project occt`, no `--coverage`) for the shards. Coverage can't ride along: vitest `--merge-reports` cannot recombine v8 coverage across shards in this workspace setup (verified — reads the blobs but reconstructs 0%).
- **Coverage thresholds move to a main-only `coverage` job** — informational, *not* a PR gate (kept out of `ci-pass`). Runs the full instrumented suite at `--maxWorkers=2` with a raised `--testTimeout` to ride out any residual stall.

## Verification

- `npm run test:ci -- --shard=1/40` → passes, no coverage-threshold error (coverage correctly absent on shards).
- Pre-commit (typecheck + boundaries + changed tests): 3301 pass.
- This PR self-tests the new sharded matrix (the `coverage` job is skipped on PRs).

Closes #1102