### PR TITLE
test(parity): quantize boolean offset generator to kill degenerate flake

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -49,6 +49,15 @@ cleanroom rewrite and represent the parity gap. They do not block PRs.
   expected sum. Property tests run with `numRuns: 50`.
 - **Round-trip serialization**: `toBeCloseTo(original, 6)` — six decimals.
 
+## Input generators
+
+`fcDim` excludes near-zero/huge dimensions; `fcOffset` is **quantized to a
+0.05 mm grid**. Sub-micron, non-zero offsets put solids in near-coincident
+configurations OCCT booleans resolve unstably (volumes up to ~98% wrong), and
+fast-check shrinks straight toward them — a nondeterministic CI red. Use
+`fcOffset` for positional offsets rather than a raw `fc.double`, or the
+degeneracy returns.
+
 ## Adding a test
 
 Use the helpers in `tests/parity/helpers.ts`:

--- a/tests/parity/helpers.ts
+++ b/tests/parity/helpers.ts
@@ -22,8 +22,18 @@ export const REL_TOL = 1e-6;
  */
 export const fcDim = (): fc.Arbitrary<number> => fc.double({ min: 0.5, max: 50, noNaN: true });
 
-/** A coordinate offset (can be negative). */
-export const fcOffset = (): fc.Arbitrary<number> => fc.double({ min: -25, max: 25, noNaN: true });
+/**
+ * A coordinate offset (can be negative), quantized to a 0.05 mm grid.
+ *
+ * OCCT booleans return grossly wrong volumes (observed up to ~98% off) when a
+ * cube is shifted by a sub-micron, non-zero offset — a near-coincident config
+ * the kernel resolves unstably. fast-check shrinks toward exactly those values
+ * (offsets ≈ 4e-7), reddening CI nondeterministically. Quantizing keeps the
+ * smallest non-zero offset (0.05) clear of that band while leaving 0 exact;
+ * 1001 grid points is ample coverage for overlap/containment geometry.
+ */
+export const fcOffset = (): fc.Arbitrary<number> =>
+  fc.double({ min: -25, max: 25, noNaN: true }).map((x) => Math.round(x / 0.05) * 0.05);
 
 /** Build a box of given dimensions at the origin. */
 export function unitCube(w: number, d: number, h: number): Shape3D {


### PR DESCRIPTION
## Problem

`tests/parity/booleans.test.ts > INVARIANT: inclusion–exclusion on cubes` (and the other `fcOffset`-driven parity invariants) flake in CI. It hit the re-run of #1100 (`0.0020000000000000018 ≤ 0.002`) and is tracked as a recurring "rerun-on-hit" tax.

## Root cause (measured, not guessed)

The counterexample always *looks* like "1 ULP over tol" because fast-check's shrinker drives any failing input down to drift ≈ tol + ε — so the reported value reflects the threshold, not the kernel's real error. That's why bumping the absolute floor (1e-3 → 2e-3) only relocated the cliff.

Probing the actual kernel drift over `fcOffset`'s distribution (20k draws):

| Offset generator | Max inclusion–exclusion drift |
|---|---|
| `fc.double({min:-25,max:25})` (current) | **112,671** (~98% volume error) |
| Quantized to 0.05 grid (this PR) | **8.4e-10** |

The catastrophic tail comes from fast-check generating **sub-micron, non-zero offsets** (e.g. `dy ≈ 4.9e-7`, plus subnormals like `1e-288`). OCCT booleans resolve those near-coincident configs unstably and return grossly wrong volumes. The observed CI reds (~0.002) are the mild edge of the same tail. **No tolerance can cover a 10⁵ drift** — the fix has to be the input space, not the threshold.

## Fix

Quantize `fcOffset` to a 0.05 mm grid (`tests/parity/helpers.ts`) so the smallest non-zero offset clears the degeneracy band; `0` stays exact. This matches the parity policy that already excludes degenerate dimensions in `fcDim`. 1001 grid points is ample coverage for overlap/containment geometry. Tolerances are left as-is — they now carry ~10⁷× headroom.

Also documents the gotcha in `tests/parity/README.md` so future tests use `fcOffset` rather than a raw `fc.double`.

## Verification

- Same 20k-draw probe: max drift **112,671 → 8.4e-10**.
- `booleans.test.ts`: 20/20 across **3 fresh fast-check seeds**.
- `transforms.test.ts` (also uses `fcOffset`): 38/38.
- Full `test:full` (pre-push): passes with coverage 87.4% stmts / 94.3% funcs — no regressions.

Supersedes the rerun-on-hit workaround for this flake.