### PR TITLE
fix(occt-wasm): retain OcctKernel wrapper to prevent GC use-after-free

### DIFF
--- a/docs/kernel-swap.md
+++ b/docs/kernel-swap.md
@@ -68,7 +68,21 @@ Adapter for the external `brepkit-wasm` WASM package. Create with `new BrepkitAd
 
 ### `OcctWasmAdapter`
 
-Adapter for the external `occt-wasm` WASM package. This is an arena-based OCCT V8 kernel compiled to WASM — all geometry is identified by `u32` handles into the arena. Create with `new OcctWasmAdapter(Module, kernel)` and register via `registerKernel('occt-wasm', adapter)`.
+Adapter for the external `occt-wasm` WASM package. This is an arena-based OCCT V8 kernel compiled to WASM — all geometry is identified by `u32` handles into the arena.
+
+When you use occt-wasm's high-level `OcctKernel` wrapper, build the adapter with `OcctWasmAdapter.fromKernel(kernel)`:
+
+```typescript
+import { OcctKernel } from 'occt-wasm';
+import { OcctWasmAdapter } from 'brepjs/kernel/occtWasm/occtWasmAdapter';
+
+const kernel = await OcctKernel.init();
+registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
+```
+
+> **Lifetime coupling.** `OcctKernel` registers itself with a `FinalizationRegistry` that deletes its raw kernel on garbage collection. An adapter that only borrows the raw kernel (`new OcctWasmAdapter(kernel.getRawModule(), kernel.getRawKernel())`) can be left pointing at freed memory once the wrapper is collected, surfacing as `BindingError: Cannot pass deleted object as a pointer of type OcctKernel*`. `fromKernel` pins the wrapper for the adapter's lifetime, so prefer it over the raw constructor whenever a wrapper exists.
+
+The raw `new OcctWasmAdapter(Module, kernel)` constructor remains for callers that own a raw Embind kernel directly (`new Module.OcctKernel()`), which the adapter already retains.
 
 Unlike `brepjs-opencascade`, `occt-wasm` is not auto-detected by `init()` because the WASM binary location cannot be inferred without build-tool configuration. You must register it manually.
 

--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -85,11 +85,12 @@ await bkInit();
 registerKernel('brepkit', new BrepkitAdapter(new BrepKernel()));
 
 // occt-wasm (external occt-wasm package)
-import createOcctWasm from 'occt-wasm';
+import { OcctKernel } from 'occt-wasm';
 import { OcctWasmAdapter } from 'brepjs/kernel/occtWasm/occtWasmAdapter';
-const Module = await createOcctWasm();
-const kernel = new Module.OcctKernel();
-registerKernel('occt-wasm', new OcctWasmAdapter(Module, kernel));
+// fromKernel pins the OcctKernel wrapper so its FinalizationRegistry can't free
+// the raw kernel out from under the adapter. See docs/kernel-swap.md.
+const kernel = await OcctKernel.init();
+registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
 
 // Custom kernel
 registerKernel('rust', new RustAdapter(wasm));

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -9,10 +9,24 @@
  *
  * ## Lifecycle
  *
+ * occt-wasm's high-level `OcctKernel` wrapper is the recommended owner. Build
+ * the adapter from it with {@link OcctWasmAdapter.fromKernel} so the adapter
+ * pins the wrapper for its own lifetime:
+ *
  * ```ts
- * import createOcctWasm from 'occt-wasm';
+ * import { OcctKernel } from 'occt-wasm';
  * import { OcctWasmAdapter } from './occtWasmAdapter.js';
  * import { registerKernel } from '../index.js';
+ *
+ * const kernel = await OcctKernel.init();
+ * registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
+ * ```
+ *
+ * The raw `(module, kernel)` constructor remains for callers that own the raw
+ * Embind kernel directly (e.g. `new Module.OcctKernel()`):
+ *
+ * ```ts
+ * import createOcctWasm from 'occt-wasm';
  *
  * const Module = await createOcctWasm();
  * const kernel = new Module.OcctKernel();
@@ -107,17 +121,45 @@ function notImplemented(method: string): never {
 // - collectDistanceSamples, computePrincipalDirections, surfaceDerivatives,
 //   eigenvector2x2, liftAndNormalize, degenerateOrthoFrame, pointAt → ./measureOps.ts
 
+/**
+ * Minimal view of occt-wasm's `OcctKernel` wrapper — anything exposing the raw
+ * Embind module and kernel. Accepted by {@link OcctWasmAdapter.fromKernel}.
+ */
+export interface OcctKernelOwner {
+  getRawModule(): OcctWasmModule;
+  getRawKernel(): OcctKernelWasm;
+}
+
 export class OcctWasmAdapter implements KernelAdapter {
   readonly oc: KernelInstance;
   readonly kernelId = 'occt-wasm';
 
   private readonly Module: OcctWasmModule;
   private readonly k: OcctKernelWasm;
+  // Pins the owning OcctKernel wrapper so its FinalizationRegistry can't reclaim
+  // the borrowed raw kernel while this adapter is still live.
+  private readonly owner: unknown;
 
-  constructor(module: OcctWasmModule, kernel: OcctKernelWasm) {
+  constructor(module: OcctWasmModule, kernel: OcctKernelWasm, owner?: unknown) {
     this.Module = module;
     this.k = wrapKernelExceptions(kernel, module);
     this.oc = buildOcShim(module, this.k);
+    this.owner = owner;
+  }
+
+  /**
+   * Build an adapter from occt-wasm's `OcctKernel` wrapper, retaining it for the
+   * adapter's lifetime. Prefer this over the raw `(module, kernel)` constructor:
+   * the wrapper deletes its raw kernel when garbage-collected, so an adapter that
+   * only borrows the raw kernel can be left pointing at freed memory.
+   */
+  static fromKernel(kernel: OcctKernelOwner): OcctWasmAdapter {
+    return new OcctWasmAdapter(kernel.getRawModule(), kernel.getRawKernel(), kernel);
+  }
+
+  /** The owner retained to keep the borrowed raw kernel alive, or `undefined` when built from a raw kernel. */
+  get retainedKernelOwner(): unknown {
+    return this.owner;
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -138,9 +138,9 @@ export class OcctWasmAdapter implements KernelAdapter {
   private readonly k: OcctKernelWasm;
   // Pins the owning OcctKernel wrapper so its FinalizationRegistry can't reclaim
   // the borrowed raw kernel while this adapter is still live.
-  private readonly owner: unknown;
+  private readonly owner: OcctKernelOwner | undefined;
 
-  constructor(module: OcctWasmModule, kernel: OcctKernelWasm, owner?: unknown) {
+  constructor(module: OcctWasmModule, kernel: OcctKernelWasm, owner?: OcctKernelOwner) {
     this.Module = module;
     this.k = wrapKernelExceptions(kernel, module);
     this.oc = buildOcShim(module, this.k);
@@ -158,7 +158,7 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   /** The owner retained to keep the borrowed raw kernel alive, or `undefined` when built from a raw kernel. */
-  get retainedKernelOwner(): unknown {
+  get retainedKernelOwner(): OcctKernelOwner | undefined {
     return this.owner;
   }
 

--- a/tests/occtWasmAdapter.test.ts
+++ b/tests/occtWasmAdapter.test.ts
@@ -1,0 +1,48 @@
+/**
+ * OcctWasmAdapter unit tests — `fromKernel` wrapper retention.
+ *
+ * Plain stub objects suffice: the adapter constructor never calls into the
+ * kernel, so no WASM init is required here.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { OcctWasmAdapter } from '@/kernel/occtWasm/occtWasmAdapter.js';
+import type { OcctWasmModule, OcctKernelWasm } from '@/kernel/occtWasm/occtWasmTypes.js';
+
+const stubModule = (): OcctWasmModule => ({}) as unknown as OcctWasmModule;
+const stubKernel = (): OcctKernelWasm => ({}) as unknown as OcctKernelWasm;
+
+describe('OcctWasmAdapter.fromKernel', () => {
+  it('derives module and raw kernel from an occt-wasm OcctKernel wrapper', () => {
+    const module = stubModule();
+    const kernel = stubKernel();
+    const owner = {
+      getRawModule: vi.fn(() => module),
+      getRawKernel: vi.fn(() => kernel),
+    };
+
+    const adapter = OcctWasmAdapter.fromKernel(owner);
+
+    expect(adapter).toBeInstanceOf(OcctWasmAdapter);
+    expect(adapter.kernelId).toBe('occt-wasm');
+    expect(owner.getRawModule).toHaveBeenCalledTimes(1);
+    expect(owner.getRawKernel).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains a strong reference to the wrapper for the adapter lifetime', () => {
+    const owner = {
+      getRawModule: () => stubModule(),
+      getRawKernel: () => stubKernel(),
+    };
+
+    const adapter = OcctWasmAdapter.fromKernel(owner);
+
+    expect(adapter.retainedKernelOwner).toBe(owner);
+  });
+
+  it('retains nothing when built from a raw module and kernel', () => {
+    const adapter = new OcctWasmAdapter(stubModule(), stubKernel());
+
+    expect(adapter.retainedKernelOwner).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a timing-dependent use-after-free when brepjs is driven by occt-wasm's high-level `OcctKernel` wrapper.

occt-wasm's `OcctKernel` registers **itself** with a `FinalizationRegistry` whose callback runs `raw.releaseAll()` + `raw.delete()`. `OcctWasmAdapter` was constructed from only the borrowed raw `(module, kernel)`, never the wrapper — so once the wrapper went unreachable, a GC freed the kernel out from under the still-registered adapter, and the next operation threw:

```
BindingError: Cannot pass deleted object as a pointer of type OcctKernel*
```

This reproduces in real apps: the first generation succeeds, then after enough idle time for a GC the next operation blows up.

## Changes

- **`OcctWasmAdapter.fromKernel(kernel)`** — factory that derives the raw module/kernel from occt-wasm's `OcctKernel` wrapper and pins the wrapper in a `private readonly owner` field for the adapter's lifetime. This makes the lifetime coupling structural (issue's preferred option #1).
- **`OcctKernelOwner` interface** — minimal structural view (`getRawModule()` / `getRawKernel()`) so brepjs stays decoupled from the upstream class.
- **`retainedKernelOwner` getter** — exposes the pinned owner, turning retention into a deterministic, tested contract (and aiding diagnosis of this exact failure).
- The raw `new OcctWasmAdapter(module, kernel)` constructor is unchanged and still valid for callers that own a raw Embind kernel directly (`new Module.OcctKernel()`), which the adapter already retains via its proxy.
- Docs updated with the lifetime warning at the call site: adapter JSDoc, `docs/kernel-swap.md`, `src/kernel/README.md` (issue's option #3).

## Tests

New `tests/occtWasmAdapter.test.ts` (no WASM init required — the constructor never calls into the kernel):
- `fromKernel` derives module + raw kernel from the wrapper
- the adapter retains a strong reference to the wrapper
- the raw constructor retains nothing

## Verification

`typecheck`, `lint`, `check:boundaries`, `check:patterns`, `knip`, and the full changed-file test suite all pass. Independent code review found no material issues.

Closes #1091
