### PR TITLE
ci(hooks): align pre-push with the CI test gate (drop coverage)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,8 +3,12 @@ set -e
 
 echo "Running comprehensive checks before push..."
 
-# Full test suite with coverage
-npm run test:full
+# Full suite without coverage — mirrors the CI gate (the sharded `test` job runs
+# test:ci). Coverage is main-only and non-blocking in CI (the `coverage` job is
+# excluded from ci-pass), so gating pushes on it is stricter than CI and pays the
+# v8 instrumentation + report cost on every push. Set VITEST_MAX_WORKERS to trade
+# RAM for wall-time if you have the headroom (default 4; each fork caps at 6 GB).
+npm run test:ci
 
 # Detect unused code
 npm run knip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Monorepo with two publishable packages:
 ## Git hooks
 
 - **Pre-commit**: lint-staged (ESLint + Prettier + pattern checker) + typecheck + boundary check (parallel), then changed-file tests (no coverage thresholds). Set `FULL_TESTS=1` for full coverage run
-- **Pre-push**: Full `test:full` + `knip` (~30s)
+- **Pre-push**: Full `test:ci` (no coverage, mirrors the CI gate) + `knip`. Coverage is main-only/non-blocking in CI, so it's not run here. Set `VITEST_MAX_WORKERS` to use more cores locally (default 4)
 - Bypass: `--no-verify` (not recommended)
 
 ## Key patterns

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,14 @@ const alwaysExclude = [
   '.worktrees/**',
 ];
 
+// Default 4 — CI's sharded `test` job runs on 16 GB runners where OCCT WASM
+// linear memory grows monotonically across a fork's files; more forks over-commit
+// into swap and trip the per-test timeout (#1102). Overridable so a many-core,
+// high-RAM machine can raise it locally without changing the CI default.
+const parsedMaxWorkers = Number(process.env['VITEST_MAX_WORKERS']);
+const maxWorkers =
+  Number.isInteger(parsedMaxWorkers) && parsedMaxWorkers > 0 ? parsedMaxWorkers : 4;
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -39,7 +47,7 @@ export default defineConfig({
     testTimeout: 90000,
     pool: 'forks',
     execArgv: ['--max-old-space-size=6144'],
-    maxWorkers: 4,
+    maxWorkers,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

Aligns the `pre-push` hook with what CI actually gates on, and gives a local lever to use more cores.

Pre-push ran `test:full` — the full suite **with v8 coverage**. But CI gates PRs on the sharded `test` job, which runs `test:ci` (full suite, **no coverage**); the `coverage` job runs `test:full` **main-only** and is deliberately excluded from `ci-pass` (informational, non-blocking). So the hook was *stricter than CI* and paid coverage instrumentation + lcov/text report generation on every push, for a gate CI doesn't enforce.

## Changes

- **`.husky/pre-push`** now runs `npm run test:ci` (full suite, no coverage) instead of `npm run test:full`. `knip` still runs.
- **`vitest.config.ts`** `maxWorkers` is now overridable via `VITEST_MAX_WORKERS`, **default unchanged at 4**. Invalid/empty values fall back to 4.
- Docs (`CLAUDE.md` hooks section) updated to match.

## Why keep the default at 4

CI's sharded `test` job runs `test:ci` with the config default on 16 GB runners. OCCT WASM linear memory grows monotonically across a fork's files, so more forks over-commit into swap and trip the per-test timeout — exactly the failure #1102 fixed by sharding. Raising the default would reintroduce that. The env override lets a high-RAM, many-core dev machine opt into more forks locally (e.g. `VITEST_MAX_WORKERS=8`) without touching CI. The `coverage` job is unaffected — it passes `--maxWorkers=2` on the CLI, which overrides the config regardless of the env var.

## Verification

- `maxWorkers` resolution: unset → 4, `VITEST_MAX_WORKERS=8` → 8, garbage → 4.
- `typecheck`, `prettier --check`, and `vitest list` all clean.
- This PR's own push dogfoods the new hook (runs `test:ci`).

No library code changes — `ci`-typed so it doesn't trigger a release.
