### PR TITLE
ci: raise validate-pack file limit to 500

### DIFF
--- a/scripts/validate-pack.sh
+++ b/scripts/validate-pack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-MAX_FILES=420
+MAX_FILES=500
 
 PACK_OUTPUT=$(npm pack --dry-run --ignore-scripts 2>&1)
 TOTAL_FILES=$(echo "$PACK_OUTPUT" | grep "total files" | awk '{print $NF}')


### PR DESCRIPTION
## Problem

The `publish-brepjs` job in Release Please **failed for the 18.34.0 release**, so the version was tagged and GitHub-released but **never published to npm** (`npm view brepjs version` still shows 18.33.2).

Root cause: PR #1117 (Manifold mesh/CSG kernel) added new `.d.ts` declaration files, pushing the published package to **432 files**. `scripts/validate-pack.sh` (run via `prepublishOnly`) caps at `MAX_FILES=420`:

```
ERROR: Too many files in package (432 > 420)
npm error command failed: bash scripts/validate-pack.sh
```

## Fix

Raise `MAX_FILES` 420 → 500. The growth is legitimate:
- No `.d.ts.map` sidecars (the script's other guard still passes at 0)
- 843 kB packed / 3.6 MB unpacked
- ~68 files of headroom

## Recovery

After merge, republish 18.34.0 via `Release Please` → `Run workflow` with **republish = true** (the workflow's built-in recovery path for a failed auto-publish).

## Verification

```
$ bash scripts/validate-pack.sh
Package files: 432 (max: 500)
Package validation passed
```