### PR TITLE
fix(manifold): dispose replay intermediates to stop WASM-heap leak

### DIFF
--- a/src/kernel/manifold/replay.ts
+++ b/src/kernel/manifold/replay.ts
@@ -476,17 +476,11 @@ function isShellResult(
   );
 }
 
-/**
- * Replay an op-graph onto `targetKernel`, returning the exact B-rep shape.
- *
- * Memoized post-order: each node's inputs are replayed first (deduplicated via
- * the shared cache so a DAG with reused sub-graphs replays each node once), then
- * the node's own handler runs. Throws on any non-replayable node or unmapped op.
- */
-export function replay(
+function replayNode(
   node: OpNode,
   targetKernel: KernelAdapter,
-  cache: Map<OpNode, KernelShape> = new Map()
+  cache: Map<OpNode, KernelShape>,
+  allocated: Set<KernelShape>
 ): KernelShape {
   const cached = cache.get(node);
   if (cached !== undefined) return cached;
@@ -502,8 +496,36 @@ export function replay(
     throw new Error(`manifold replay: no replay handler for op '${node.op}'`);
   }
 
-  const inputs = node.inputs.map((child) => replay(child, targetKernel, cache));
+  const inputs = node.inputs.map((child) => replayNode(child, targetKernel, cache, allocated));
   const result = handler(targetKernel, node.params, inputs);
   cache.set(node, result);
+  allocated.add(result);
   return result;
+}
+
+/**
+ * Replay an op-graph onto `targetKernel`, returning the exact B-rep shape.
+ *
+ * Memoized post-order: each node's inputs are replayed first (deduplicated via
+ * the shared cache so a DAG with reused sub-graphs replays each node once), then
+ * the node's own handler runs. Throws on any non-replayable node or unmapped op.
+ *
+ * Every node produces an intermediate OCCT WASM-heap shape, but only the root is
+ * returned (and retained by the caller's `brepCache`). To avoid leaking the rest
+ * for the lifetime of the session, the intermediates this call allocated are
+ * disposed once the full recursion completes — they are only inputs to copying
+ * ops (booleans/modifiers), so the root holds its own geometry. Shapes the caller
+ * pre-seeded into `cache` are not in `allocated` and so are never disposed here.
+ */
+export function replay(
+  node: OpNode,
+  targetKernel: KernelAdapter,
+  cache: Map<OpNode, KernelShape> = new Map()
+): KernelShape {
+  const allocated = new Set<KernelShape>();
+  const root = replayNode(node, targetKernel, cache, allocated);
+  for (const shape of allocated) {
+    if (shape !== root) targetKernel.dispose(shape);
+  }
+  return root;
 }

--- a/tests/parity/manifold.test.ts
+++ b/tests/parity/manifold.test.ts
@@ -30,6 +30,9 @@ import {
   hausdorff,
   tessellate,
 } from '../helpers/meshParity.js';
+import { replay } from '@/kernel/manifold/replay.js';
+import { nodeOf, type ManifoldShape } from '@/kernel/manifold/meshHandle.js';
+import type { OpNode } from '@/kernel/manifold/opGraph.js';
 
 interface Pair {
   readonly m: KernelAdapter;
@@ -391,5 +394,70 @@ describe('TIER D (degradation): raw-mesh origin exports faceted + warns', () => 
     expect(message).not.toContain('faceted');
     expect(typeof step).toBe('string');
     expect(step.length).toBeGreaterThan(0);
+  });
+});
+
+/** Count distinct nodes in an op-graph (DAG-safe). */
+function countNodes(root: OpNode): number {
+  const seen = new Set<OpNode>();
+  const walk = (n: OpNode): void => {
+    if (seen.has(n)) return;
+    seen.add(n);
+    n.inputs.forEach(walk);
+  };
+  walk(root);
+  return seen.size;
+}
+
+describe('replay disposal (#1118): no intermediate WASM-heap leak', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('frees every intermediate except the root, and the root stays valid', () => {
+    const k = kernels();
+    if (!k) return;
+
+    // A deep graph of copying ops only (no extrude/sweep/loft, whose helpers also
+    // call dispose), so the dispose spy counts exactly the node intermediates.
+    const base = k.m.makeBox(10, 10, 10);
+    const filleted = k.m.fillet(base, k.m.iterShapes(base, 'edge').slice(0, 1), 1);
+    const tool = k.m.translate(k.m.makeBox(4, 4, 4), 5, 0, 0);
+    const fused = k.m.fuse(filleted, tool);
+    const shape = k.m.cut(fused, k.m.makeBox(3, 3, 20));
+
+    const node = nodeOf(shape as ManifoldShape);
+    const nodeCount = countNodes(node);
+    expect(nodeCount).toBe(7);
+
+    const disposeSpy = vi.spyOn(k.o, 'dispose');
+    const root = replay(node, k.o);
+
+    // Root survives disposal of the intermediates and is a real, non-empty solid.
+    expect(k.o.volume(root)).toBeGreaterThan(0);
+    const bb = k.o.boundingBox(root);
+    expect(bb.max[0] - bb.min[0]).toBeGreaterThan(0);
+    // Exactly the non-root intermediates were freed (one dispose per node but the root).
+    expect(disposeSpy).toHaveBeenCalledTimes(nodeCount - 1);
+
+    k.o.dispose(root);
+  });
+
+  it('repeated replay of the same graph stays valid (no use-after-free)', () => {
+    const k = kernels();
+    if (!k) return;
+
+    const shape = k.m.cut(k.m.makeBox(8, 8, 8), k.m.translate(k.m.makeBox(4, 4, 4), 2, 2, 2));
+    const node = nodeOf(shape as ManifoldShape);
+
+    let prevVol = -1;
+    for (let i = 0; i < 3; i++) {
+      const root = replay(node, k.o);
+      const vol = k.o.volume(root);
+      expect(vol).toBeGreaterThan(0);
+      if (prevVol >= 0) expect(vol).toBeCloseTo(prevVol, 6);
+      prevVol = vol;
+      k.o.dispose(root);
+    }
   });
 });


### PR DESCRIPTION
Closes #1118.

## Problem
`replay()` reconstructs an OCCT B-rep from a manifold op-graph by building **one OCCT shape per op-node** into a local cache, then returns only the **root** (which the caller retains in `brepCache`). When `replay()` returned, the JS `Map` was GC'd — but GC only reclaims the JS handles, **not** the WASM-heap `TopoDS_Shape` objects. So every non-root node's shape leaked, and repeatedly exercising B-rep export / exact-query in a long-running session slowly accumulated OCCT objects.

## Fix
Wrap the recursion in a disposal scope: track the shapes **this call** allocated and `dispose()` every one except the returned root, once the full recursion completes. They are only inputs to copying ops (booleans/modifiers), so the root holds its own geometry. Shapes a caller pre-seeds into `cache` are not in the allocated set, so they're never disposed here (robust against a future `brepCache`-seeded cache).

## Why it's safe (the issue flagged UAF risk)
A prior ad-hoc disposal attempt corrupted a face by freeing a wire too early. This fix only frees **node-result** shapes after the entire recursion, never sub-shapes a live shape still references, and never the root. Verified by test, not just metrics.

## Tests (`tests/parity/manifold.test.ts`)
- **Exact disposal accounting**: a 7-node graph (box → fillet → fuse(translate(box)) → cut(box)) of copying-only ops (so no helper `dispose` calls pollute the count) asserts `occt.dispose` is called exactly `nodeCount - 1` times, and the root remains a valid non-empty solid (`volume > 0`, non-degenerate bbox) — proving intermediates are freed and the root survives.
- **No use-after-free**: replaying the same graph 3× yields a valid solid with stable volume each time.
- Full manifold parity suite stays green (29 passed); OCCT gate green.

## Scope
Fixes the node-result intermediates (the bulk leak). A smaller, separate follow-up remains for intra-handler sub-shapes (`resolveSelection`'s `iterShapes` results, `sectionWire`'s discarded face) — deferred because they're sub-shapes of live inputs and need per-handler UAF review.