### PR TITLE
fix(io): name the offending sub-solid when STEP/STL export aborts on degenerate geometry

### DIFF
--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -207,12 +207,14 @@ function describeOffendingSolids(shape: AnyShape<Dimension>): string {
   solids.forEach((solid, i) => {
     try {
       getBounds(solid);
-    } catch {
+    } catch (e) {
+      // Mirror probeSerializable: a TypeError is a programming bug, not degenerate geometry.
+      if (e instanceof TypeError) throw e;
       bad.push(i);
     }
   });
   if (bad.length === 0) {
-    return `; could not localize the offending sub-shape among ${solids.length} solids`;
+    return `; could not localize the offending sub-solid among ${solids.length} solids`;
   }
   return `; offending sub-solid${bad.length > 1 ? 's' : ''} (of ${solids.length}): index ${bad.join(', ')}`;
 }

--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -16,7 +16,7 @@ import {
   setEdgeMeshForShape,
 } from './meshCache.js';
 import { getFaceOrigins } from './shapeFns.js';
-import { getBounds } from './topologyQueryFns.js';
+import { getBounds, getSolids } from './topologyQueryFns.js';
 
 // ---------------------------------------------------------------------------
 // Mesh types
@@ -190,6 +190,34 @@ function exportError(e: unknown, fmt: 'STEP' | 'STL'): BrepError {
 }
 
 /**
+ * When a compound's bounds probe fails, localize the offending sub-solid(s) so the
+ * caller can heal or drop them. Returns a suffix for the error message; empty when
+ * the shape is a single solid or localization itself fails. Only reached on the
+ * error path, so the extra per-solid probes cost nothing in the happy case.
+ */
+function describeOffendingSolids(shape: AnyShape<Dimension>): string {
+  let solids;
+  try {
+    solids = getSolids(shape);
+  } catch {
+    return '';
+  }
+  if (solids.length <= 1) return '';
+  const bad: number[] = [];
+  solids.forEach((solid, i) => {
+    try {
+      getBounds(solid);
+    } catch {
+      bad.push(i);
+    }
+  });
+  if (bad.length === 0) {
+    return `; could not localize the offending sub-shape among ${solids.length} solids`;
+  }
+  return `; offending sub-solid${bad.length > 1 ? 's' : ''} (of ${solids.length}): index ${bad.join(', ')}`;
+}
+
+/**
  * Probe a shape's bounding box before handing it to the STEP/STL writer.
  *
  * Some sub-shapes pass `isValid`/`validSolid` yet are degenerate enough that the
@@ -210,7 +238,7 @@ function probeSerializable(shape: AnyShape<Dimension>, fmt: 'STEP' | 'STL'): Bre
     if (e instanceof TypeError) throw e;
     return ioError(
       `${fmt}_EXPORT_UNSERIALIZABLE`,
-      `${fmt} export aborted: the shape contains degenerate geometry the ${fmt} writer cannot serialize (bounding-box evaluation failed); export was skipped to avoid crashing the kernel`,
+      `${fmt} export aborted: the shape contains degenerate geometry the ${fmt} writer cannot serialize (bounding-box evaluation failed); export was skipped to avoid crashing the kernel${describeOffendingSolids(shape)}`,
       e
     );
   }

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -9,6 +9,7 @@ import {
   exportSTEP,
   exportSTL,
   exportIGES,
+  compound,
   isOk,
   isErr,
   unwrap,
@@ -162,6 +163,25 @@ describe('meshFns', () => {
       } finally {
         boundsSpy.mockRestore();
         writerSpy.mockRestore();
+      }
+    });
+
+    it('localizes the offending sub-solid index in the UNSERIALIZABLE message for a compound', () => {
+      // When bounds fail on a multi-solid compound, the error should name which
+      // sub-solid(s) failed so callers can locate and heal them (#1126).
+      const comp = compound([box(4, 4, 4), box(4, 4, 4)]);
+      const boundsSpy = vi.spyOn(getKernel(), 'boundingBox').mockImplementation(() => {
+        throw new Error('Bnd_Box is void');
+      });
+      try {
+        const result = exportSTEP(comp);
+        expect(isErr(result)).toBe(true);
+        const msg = unwrapErr(result).message;
+        expect(msg).toContain('offending sub-solid');
+        expect(msg).toContain('of 2');
+        expect(msg).toMatch(/index 0, 1/);
+      } finally {
+        boundsSpy.mockRestore();
       }
     });
   });


### PR DESCRIPTION
Refs #1126 (ask 3). Builds on #1131.

## What
When the pre-export bounds probe (#1131) fails on a **multi-solid compound**, iterate the sub-solids and report which index/indices fail their *own* bounds probe. The `STEP/STL_EXPORT_UNSERIALIZABLE` message goes from:

> STEP export aborted: the shape contains degenerate geometry … export was skipped to avoid crashing the kernel

to:

> … export was skipped to avoid crashing the kernel**; offending sub-solid (of 65): index 0**

This directly answers the issue's ask 3 — *"surface which sub-shape index/type failed, so callers can locate and heal it"* — so a caller hitting the guard can drop/heal the degenerate piece instead of guessing.

## Notes
- The per-solid probes run **only on the error path**, so the happy path is unaffected.
- Single-solid shapes get no suffix (nothing to localize). If localization itself can't pin it down, the message says so rather than implying precision it doesn't have.

## Tests
`tests/meshFns.test.ts`: new test builds a 2-solid compound, mocks `boundingBox` to throw, and asserts the error names `index 0, 1` of `2`. All meshFns tests pass under both the `occt` and `occt-wasm` projects.

## Scope
Reporting/diagnostics only — the underlying OCCT writer OOB-trap on BRepCheck-valid degenerate geometry remains a `brepjs-opencascade`/upstream-OCCT issue, still tracked in #1126.