### PR TITLE
test(io): cover STEP export of BOPAlgo-corrupted geometry (#1126)

### DIFF
--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -229,6 +229,13 @@ function describeOffendingSolids(shape: AnyShape<Dimension>): string {
  * cheap pre-export probe lets us return a clean `Err` instead of crashing.
  * Heuristic, not universal: it only catches shapes whose bounding-box evaluation
  * also throws.
+ *
+ * Note: the canonical #1126 shape (an annular-sector tread fused with a frenet
+ * helical rail) is NOT caught here — `getBounds` *succeeds* on it, as do
+ * `isValid`/`validSolid`/`mesh`/`measureArea`, and `autoHeal` cannot repair it.
+ * No known non-trapping check detects that BOPAlgo corruption; the only safety net
+ * for it is `exportError` classifying the writer's `WebAssembly.RuntimeError` as
+ * `*_EXPORT_CRASHED`. A real fix must come from the kernel (OCCT BOPAlgo).
  */
 function probeSerializable(shape: AnyShape<Dimension>, fmt: 'STEP' | 'STL'): BrepError | null {
   try {

--- a/tests/stepExportDegenerate.test.ts
+++ b/tests/stepExportDegenerate.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from './setup.js';
+import {
+  draw,
+  translate,
+  fuseAll,
+  helix,
+  sweep,
+  sketchCircle,
+  createPlane,
+  box,
+  exportSTEP,
+  isOk,
+  isErr,
+  unwrap,
+  unwrapErr,
+  type AnyShape,
+} from '@/index.js';
+
+const deg = (d: number) => (d * Math.PI) / 180;
+
+/**
+ * Reconstructs the smallest known reproduction of #1126: fusing an annular-sector
+ * tread (arc-cylinder + planar faces, from `threePointsArcTo` + `extrude`) with a
+ * frenet-swept helical rail tube. The two solids are *geometrically disjoint*, yet
+ * OCCT's BOPAlgo corrupts both outputs' exact topology — they pass
+ * `isValid`/`validSolid`/`mesh`/`getBounds`/`measureArea` but OOB-trap the STEP/BREP
+ * writer. Each input serializes fine on its own; only this specific pairing triggers it.
+ *
+ * Note: the list-builder `fuseAll` path reproduces this deterministically; the
+ * pairwise `fuse` path (a different OCCT algorithm) does not, so this must use `fuseAll`.
+ */
+function buildCorruptingFuse(): AnyShape {
+  const TREAD_T = 4,
+    TREAD_INNER_R = 10,
+    TREAD_OUTER_R = 62,
+    TREAD_SWEEP = 24,
+    TREAD_Z0 = 4;
+  const RAIL_DIA = 5,
+    RAIL_R = 66,
+    RAIL_Z_START = 14,
+    RAIL_Z_END = 130;
+
+  const half = TREAD_SWEEP / 2;
+  const pt = (r: number, a: number): [number, number] => [r * Math.cos(a), r * Math.sin(a)];
+  const tread = draw(pt(TREAD_INNER_R, deg(-half)))
+    .lineTo(pt(TREAD_OUTER_R, deg(-half)))
+    .threePointsArcTo(pt(TREAD_OUTER_R, deg(half)), [TREAD_OUTER_R, 0])
+    .lineTo(pt(TREAD_INNER_R, deg(half)))
+    .threePointsArcTo(pt(TREAD_INNER_R, deg(-half)), [TREAD_INNER_R, 0])
+    .close()
+    .sketchOnPlane('XY')
+    .extrude(TREAD_T);
+  const tread0 = translate(tread, [0, 0, TREAD_Z0]);
+
+  const railHeight = RAIL_Z_END - RAIL_Z_START;
+  const railPath = helix(railHeight, railHeight, RAIL_R, { at: [0, 0, RAIL_Z_START] });
+  const railPlane = createPlane([RAIL_R, 0, RAIL_Z_START], null, [
+    0,
+    RAIL_R,
+    railHeight / (2 * Math.PI),
+  ]);
+  const railProfile = sketchCircle(RAIL_DIA / 2, { plane: railPlane }).wire;
+  const rail = unwrap(sweep(railProfile, railPath, { frenet: true }));
+
+  return unwrap(fuseAll([tread0, rail]));
+}
+
+// Isolated in its own file: a successful trap poisons the kernel's writer for the
+// rest of the worker, so this must not share a process with other export tests.
+// Gated to occt — the BOPAlgo corruption is specific to the occt-wasm build (the
+// manifold mesh kernel doesn't export STEP at all).
+describe.skipIf(currentKernel !== 'occt')(
+  'STEP export of BOPAlgo-corrupted geometry (#1126)',
+  () => {
+    beforeAll(async () => {
+      await initKernel();
+    }, 30000);
+
+    it('exports a healthy box before the poisoning call', () => {
+      // Proves the kernel is alive, so a later failure is attributable to the shape.
+      expect(isOk(exportSTEP(box(5, 5, 5)))).toBe(true);
+    });
+
+    it('returns a clean Err (never throws, never a phantom file-read error)', () => {
+      const shape = buildCorruptingFuse();
+
+      // Core #1126/#1128 guarantee: the writer trap is caught and returned as a Result,
+      // so we reach here at all instead of an uncaught WASM trap escaping to the caller.
+      const result = exportSTEP(shape);
+      expect(result).toBeDefined();
+
+      // A future OCCT fix flips this to Ok — allowed. What must never regress: the trap
+      // being mislabelled as the phantom "Failed to read exported STEP file" error.
+      if (isErr(result)) {
+        const { code } = unwrapErr(result);
+        expect(['STEP_EXPORT_CRASHED', 'STEP_EXPORT_UNSERIALIZABLE']).toContain(code);
+        expect(code).not.toBe('STEP_FILE_READ_ERROR');
+      }
+    });
+  }
+);

--- a/tests/stepExportDegenerate.test.ts
+++ b/tests/stepExportDegenerate.test.ts
@@ -15,6 +15,7 @@ import {
   unwrap,
   unwrapErr,
   type AnyShape,
+  type Result,
 } from '@/index.js';
 
 const deg = (d: number) => (d * Math.PI) / 180;
@@ -86,13 +87,16 @@ describe.skipIf(currentKernel !== 'occt')(
       const shape = buildCorruptingFuse();
 
       // Core #1126/#1128 guarantee: the writer trap is caught and returned as a Result,
-      // so we reach here at all instead of an uncaught WASM trap escaping to the caller.
-      const result = exportSTEP(shape);
-      expect(result).toBeDefined();
+      // never an uncaught WASM trap escaping to the caller. Assert the no-throw contract
+      // directly (one call only — a second would hit the now-poisoned writer).
+      let result: Result<Blob> | undefined;
+      expect(() => {
+        result = exportSTEP(shape);
+      }).not.toThrow();
 
       // A future OCCT fix flips this to Ok — allowed. What must never regress: the trap
       // being mislabelled as the phantom "Failed to read exported STEP file" error.
-      if (isErr(result)) {
+      if (result && isErr(result)) {
         const { code } = unwrapErr(result);
         expect(['STEP_EXPORT_CRASHED', 'STEP_EXPORT_UNSERIALIZABLE']).toContain(code);
         expect(code).not.toBe('STEP_FILE_READ_ERROR');


### PR DESCRIPTION
## What

Adds a real-geometry regression test for #1126 and documents the kernel-level root cause in `meshFns`.

## Root cause (bisected)

The #1126 spiral-staircase part fails STEP export on a sub-solid that passes `isValid`/`validSolid`/`mesh`/`getBounds`/`measureArea` yet OOB-traps the writer. Minimal cause:

```js
exportSTEP(unwrap(fuseAll([tread0, rail]))) // -> Err(STEP_EXPORT_CRASHED)
```

The N-way general fuse (`fuseAll` → `BRepAlgoAPI_BuilderAlgo`) of two **geometrically disjoint** solids — an annular-sector tread and a frenet-swept helical rail — silently corrupts their exact topology. Pairwise `fuse` is clean; either input alone is clean; the corrupt faces are all `PLANE`/`CYLINDRE` (corrupt pcurve/topology, not bad surface geometry). It reproduces from BREP-loaded inputs too.

This is an OCCT BOPAlgo defect — not fixable on the TS side: no non-trapping check detects it (`isValid`/`checkBoolean`/`mesh`/`getBounds` all pass), and `autoHeal`/`healSolid` can't repair it.

## Changes

- **`tests/stepExportDegenerate.test.ts`** — real-geometry regression locking the #1128 guarantee: the writer trap is caught & classified (`STEP_EXPORT_CRASHED`), never escapes as an uncaught throw, never mislabelled as the phantom "Failed to read exported STEP file". Tolerant of a future OCCT fix (Ok allowed). Isolated in its own file because a caught writer trap still poisons the worker's writer; gated to occt.
- **`src/topology/meshFns.ts`** — comment documenting that the canonical #1126 shape isn't caught by the `getBounds` probe and that the `RuntimeError` classification is the only safety net until the kernel bug is fixed.

## Follow-up

Kernel-level fix tracked upstream; a self-contained OCCT repro (input BREPs + JS + C++) is prepared separately. #1126 stays open for the kernel fix.