### PR TITLE
fix(kernel): bump occt-wasm to 3.2.0 and read mesh UVs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "knip": "6.14.2",
         "lint-staged": "17.0.5",
         "lz-string": "1.5.0",
-        "occt-wasm": "3.1.0",
+        "occt-wasm": "3.2.0",
         "prettier": "3.8.3",
         "puppeteer": "25.0.4",
         "size-limit": "12.1.0",
@@ -439,7 +439,6 @@
       "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.53.0",
         "@algolia/requester-browser-xhr": "5.53.0",
@@ -1171,7 +1170,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1220,7 +1218,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2955,7 +2952,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -4235,7 +4231,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -4258,7 +4253,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4293,7 +4287,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
       "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -4375,7 +4368,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -5154,7 +5146,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5195,7 +5186,6 @@
       "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.19.0",
         "@algolia/client-abtesting": "5.53.0",
@@ -5923,7 +5913,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6030,7 +6019,6 @@
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6475,7 +6463,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6687,8 +6674,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
       "version": "3.4.5",
@@ -6904,7 +6890,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7330,7 +7315,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -8550,6 +8534,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8561,7 +8546,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "11.5.1",
@@ -8992,7 +8978,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -9122,9 +9107,9 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.1.0.tgz",
-      "integrity": "sha512-IU08VT+mL+PbqoH9LrBT29gVCQHMJLvwxJJobwuvlbcUCRKAMVClOCjhNdPRt10oYLx7Znrl2poo1t59rYeNMA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.2.0.tgz",
+      "integrity": "sha512-qAElY+CWhkMPd0ZE0yjVcTM+nJkUey0lruufe4hPqrX9Ux6jp+Xwi9uPD8gcLgTdeCgd/HHhDNZaUHWaaxhLxg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -9698,7 +9683,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9722,6 +9706,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -9854,7 +9839,6 @@
       "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.132.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -10095,7 +10079,6 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -10500,8 +10483,7 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -10828,9 +10810,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11131,7 +11112,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11870,7 +11850,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12043,7 +12022,6 @@
       "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.34",
         "@vue/compiler-sfc": "3.5.34",
@@ -12287,7 +12265,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "knip": "6.14.2",
     "lint-staged": "17.0.5",
     "lz-string": "1.5.0",
-    "occt-wasm": "3.1.0",
+    "occt-wasm": "3.2.0",
     "prettier": "3.8.3",
     "puppeteer": "25.0.4",
     "size-limit": "12.1.0",

--- a/src/kernel/occtWasm/meshOps.ts
+++ b/src/kernel/occtWasm/meshOps.ts
@@ -42,6 +42,15 @@ export function mesh(
       }
     }
 
+    const uvCount = meshData.uvCount;
+    const uvs = new Float32Array(options.includeUVs ? uvCount : 0);
+    if (options.includeUVs && uvCount > 0) {
+      const uvPtr = meshData.getUvsPtr() >> 2;
+      for (let i = 0; i < uvCount; i++) {
+        uvs[i] = Module.HEAPF32[uvPtr + i] ?? 0;
+      }
+    }
+
     const triangles = new Uint32Array(idxCount);
     for (let i = 0; i < idxCount; i++) {
       triangles[i] = Module.HEAPU32[idxPtr + i] ?? 0;
@@ -64,7 +73,7 @@ export function mesh(
       vertices,
       normals: options.skipNormals ? new Float32Array(0) : normals,
       triangles,
-      uvs: new Float32Array(0),
+      uvs,
       faceGroups,
     };
   } finally {

--- a/src/kernel/occtWasm/occtWasmTypes.ts
+++ b/src/kernel/occtWasm/occtWasmTypes.ts
@@ -40,9 +40,11 @@ export interface OcctWasmHandle {
 export interface EmMeshData {
   positionCount: number;
   normalCount: number;
+  uvCount: number;
   indexCount: number;
   getPositionsPtr(): number;
   getNormalsPtr(): number;
+  getUvsPtr(): number;
   getIndicesPtr(): number;
   getFaceGroupsPtr(): number;
   faceGroupCount: number;


### PR DESCRIPTION
Bumps the `occt-wasm` dev dependency to **3.2.0**, which ships the batched native parity fixes (andymai/occt-wasm#126), and wires the occt-wasm mesh adapter to read the new UV channel.

## What 3.2.0 brings
- **helix** length no longer undershoots (gp_Dir2d normalization fix)
- **getSubShapes/downcast** accept `"compsolid"` (`TopAbs_COMPSOLID`)
- tessellation **MeshData** now carries a UV channel

## brepjs change
`occtWasm/meshOps.mesh` reads `getUvsPtr()`/`uvCount` when `includeUVs` is set, replacing the hardcoded empty UV array (+ `EmMeshData` type).

## Result: occt-wasm parity complete
Against the **published 3.2.0**, the occt-wasm conformance suite is now **3257 passed / 0 failed** — the last 9 gaps (4 helix, 3 uvMesh, 2 compsolid) from the #1136 audit are closed. Full arc this effort: occt-wasm **84 → 0 failures**.

The default `occt` kernel is unaffected (occt-wasm adapter files aren't loaded under `--project occt`).

Closes the op-parity portion of #1136.