### PR TITLE
feat(bim): phase 2 data conformance + geometry-representation breadth

### DIFF
--- a/packages/brepjs-bim/src/ifc-writer/classificationWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/classificationWriter.ts
@@ -1,0 +1,82 @@
+import * as WebIFC from 'web-ifc';
+import type { IfcWriter } from './ifcWriter.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
+import { deriveIfcGuidSync } from '../identity/guidDerivation.js';
+
+export type { ClassificationRef } from '../types/classificationTypes.js';
+
+/** Stable derivation key for an IfcRelAssociatesClassification, keyed on the ref. */
+function makeClassificationRelKey(ref: ClassificationRef): string {
+  return `rel-class:${ref.system}:${ref.code}`;
+}
+
+/**
+ * Writes the IFC classification entities for a set of references and associates
+ * each to its elements.
+ *
+ * For every distinct classification system a single `IfcClassification` is
+ * emitted (deduplicated by system name within this call). Each reference yields
+ * one `IfcClassificationReference` pointing at that system, plus one
+ * `IfcRelAssociatesClassification` linking the reference to its related objects.
+ * The rel's GlobalId is derived deterministically from the reference's
+ * system/code so re-exports stay byte-stable.
+ *
+ * @param refs maps each classification reference to the express IDs of the IFC
+ *   elements it classifies.
+ */
+export function writeClassificationRefs(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  refs: ReadonlyMap<ClassificationRef, readonly number[]>
+): void {
+  // system name → IfcClassification expressId, scoped to this call only.
+  const systemIds = new Map<string, number>();
+
+  for (const [ref, relatedObjectIds] of refs) {
+    if (relatedObjectIds.length === 0) continue;
+
+    let classificationId = systemIds.get(ref.system);
+    if (classificationId === undefined) {
+      classificationId = w.nextId();
+      w.writeLine({
+        expressID: classificationId,
+        type: WebIFC.IFCCLASSIFICATION,
+        Source: null,
+        Edition: ref.edition !== undefined ? w.mkType(WebIFC.IFCLABEL, ref.edition) : null,
+        EditionDate: null,
+        Name: w.mkType(WebIFC.IFCLABEL, ref.system),
+        Description: null,
+        Location:
+          ref.location !== undefined ? w.mkType(WebIFC.IFCURIREFERENCE, ref.location) : null,
+        ReferenceTokens: null,
+      });
+      systemIds.set(ref.system, classificationId);
+    }
+
+    const referenceId = w.nextId();
+    w.writeLine({
+      expressID: referenceId,
+      type: WebIFC.IFCCLASSIFICATIONREFERENCE,
+      Location: null,
+      Identification: w.mkType(WebIFC.IFCIDENTIFIER, ref.code),
+      Name: ref.description !== undefined ? w.mkType(WebIFC.IFCLABEL, ref.description) : null,
+      ReferencedSource: w.ref(classificationId),
+      Description: null,
+      Sort: null,
+    });
+
+    w.writeLine({
+      expressID: w.nextId(),
+      type: WebIFC.IFCRELASSOCIATESCLASSIFICATION,
+      GlobalId: w.mkType(
+        WebIFC.IFCGLOBALLYUNIQUEID,
+        deriveIfcGuidSync(makeClassificationRelKey(ref))
+      ),
+      OwnerHistory: w.ref(ownerHistoryId),
+      Name: null,
+      Description: null,
+      RelatedObjects: relatedObjectIds.map((id) => w.ref(id)),
+      RelatingClassification: w.ref(referenceId),
+    });
+  }
+}

--- a/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
@@ -1,6 +1,7 @@
 import * as WebIFC from 'web-ifc';
 import type { IfcWriter } from './ifcWriter.js';
 import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
+import { writeWallAxisRepresentation } from './tessellationWriter.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
 import type { BeamSpec } from '../specs/beamSpec.js';
@@ -83,13 +84,17 @@ export function writeWallGeometry(
     Items: [w.ref(extrusionId)],
   });
 
+  // Axis representation: a 2D centreline from (0,0) to (length,0) in the wall's
+  // local XY plane, the standard companion to the SweptSolid body for walls.
+  const axisRepId = writeWallAxisRepresentation(w, spec.length, geomSubContextId);
+
   const productDefinitionShapeId = w.nextId();
   w.writeLine({
     expressID: productDefinitionShapeId,
     type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
     Name: null,
     Description: null,
-    Representations: [w.ref(shapeRepId)],
+    Representations: [w.ref(axisRepId), w.ref(shapeRepId)],
   });
 
   return { localPlacementId, productDefinitionShapeId };

--- a/packages/brepjs-bim/src/ifc-writer/materialWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/materialWriter.ts
@@ -1,0 +1,174 @@
+import * as WebIFC from 'web-ifc';
+import type { IfcWriter } from './ifcWriter.js';
+import type { IfcGuid } from '../identity/ifcGuid.js';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import { toIfcLengthM } from '../units/units.js';
+
+export type { MaterialLayer } from '../types/materialTypes.js';
+
+export interface MaterialLayerSetSpec {
+  readonly kind: 'LAYER_SET';
+  readonly layerSetName: string;
+  readonly layers: readonly MaterialLayer[];
+  /** Offset of the layer set from the element reference line, in mm (default 0). */
+  readonly offsetFromReferenceLine?: number | undefined;
+}
+
+export interface MaterialProfileSpec {
+  readonly kind: 'PROFILE_SET';
+  readonly profileSetName: string;
+  /** Name of the profile; the profile geometry is referenced by name only. */
+  readonly profileName: string;
+  readonly materialName: string;
+}
+
+export type MaterialSpec = MaterialLayerSetSpec | MaterialProfileSpec;
+
+// IFCLOGICAL unknown sentinel; layers carry a tri-state ventilation flag.
+const LOGICAL_TRUE = 'T';
+const LOGICAL_FALSE = 'F';
+const LOGICAL_UNKNOWN = 'U';
+
+function writeMaterial(w: IfcWriter, name: string): number {
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCMATERIAL,
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    Category: null,
+  });
+}
+
+function writeMaterialLayer(w: IfcWriter, layer: MaterialLayer): number {
+  const materialId = writeMaterial(w, layer.name);
+  const isVentilated =
+    layer.isVentilated === undefined
+      ? LOGICAL_UNKNOWN
+      : layer.isVentilated
+        ? LOGICAL_TRUE
+        : LOGICAL_FALSE;
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCMATERIALLAYER,
+    Material: w.ref(materialId),
+    LayerThickness: w.mkType(WebIFC.IFCNONNEGATIVELENGTHMEASURE, toIfcLengthM(layer.thicknessMm)),
+    IsVentilated: w.mkType(WebIFC.IFCLOGICAL, isVentilated),
+    Name: w.mkType(WebIFC.IFCLABEL, layer.name),
+    Description: null,
+    Category: null,
+    Priority: layer.priority !== undefined ? w.mkType(WebIFC.IFCINTEGER, layer.priority) : null,
+  });
+}
+
+function writeRelAssociatesMaterial(
+  w: IfcWriter,
+  guid: IfcGuid,
+  ownerHistoryId: number,
+  relatingMaterialId: number,
+  relatedObjectIds: readonly number[]
+): number {
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCRELASSOCIATESMATERIAL,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: null,
+    Description: null,
+    RelatedObjects: relatedObjectIds.map((id) => w.ref(id)),
+    RelatingMaterial: w.ref(relatingMaterialId),
+  });
+}
+
+/**
+ * Writes IfcMaterialLayer × N + IfcMaterialLayerSet + IfcMaterialLayerSetUsage,
+ * then associates the usage with the related objects via IfcRelAssociatesMaterial.
+ * The rel GlobalId comes from `guid` (a deterministic, caller-supplied GUID).
+ * Returns the IfcRelAssociatesMaterial express ID, or 0 if the layer list is
+ * empty (nothing is written).
+ */
+export function writeMaterialLayerSet(
+  w: IfcWriter,
+  guid: IfcGuid,
+  ownerHistoryId: number,
+  spec: MaterialLayerSetSpec,
+  relatedObjectIds: readonly number[],
+  direction: 'AXIS2' | 'AXIS3' = 'AXIS2'
+): number {
+  if (spec.layers.length === 0) {
+    console.warn(`materialWriter: layer set "${spec.layerSetName}" has no layers; skipping write`);
+    return 0;
+  }
+
+  const layerIds = spec.layers.map((layer) => writeMaterialLayer(w, layer));
+  const layerSetId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCMATERIALLAYERSET,
+    MaterialLayers: layerIds.map((id) => w.ref(id)),
+    LayerSetName: w.mkType(WebIFC.IFCLABEL, spec.layerSetName),
+    Description: null,
+  });
+
+  const offsetM = toIfcLengthM(spec.offsetFromReferenceLine ?? 0);
+  const usageId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCMATERIALLAYERSETUSAGE,
+    ForLayerSet: w.ref(layerSetId),
+    LayerSetDirection: { type: 3, value: direction },
+    DirectionSense: { type: 3, value: 'POSITIVE' },
+    OffsetFromReferenceLine: w.mkType(WebIFC.IFCLENGTHMEASURE, offsetM),
+    ReferenceExtent: null,
+  });
+
+  return writeRelAssociatesMaterial(w, guid, ownerHistoryId, usageId, relatedObjectIds);
+}
+
+/**
+ * Writes a IfcMaterialProfileSet referencing a single named profile + material,
+ * then associates it with the related objects via IfcRelAssociatesMaterial.
+ * Profile geometry is referenced by name only (no IfcProfileDef geometry).
+ * Returns the IfcRelAssociatesMaterial express ID.
+ */
+export function writeMaterialProfileSet(
+  w: IfcWriter,
+  guid: IfcGuid,
+  ownerHistoryId: number,
+  spec: MaterialProfileSpec,
+  relatedObjectIds: readonly number[]
+): number {
+  const materialId = writeMaterial(w, spec.materialName);
+  const profileId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCMATERIALPROFILE,
+    Name: w.mkType(WebIFC.IFCLABEL, spec.profileName),
+    Description: null,
+    Material: w.ref(materialId),
+    Profile: null,
+    Priority: null,
+    Category: null,
+  });
+  const profileSetId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCMATERIALPROFILESET,
+    Name: w.mkType(WebIFC.IFCLABEL, spec.profileSetName),
+    Description: null,
+    MaterialProfiles: [w.ref(profileId)],
+    CompositeProfile: null,
+  });
+
+  return writeRelAssociatesMaterial(w, guid, ownerHistoryId, profileSetId, relatedObjectIds);
+}
+
+/**
+ * Writes a bare IfcMaterial + IfcRelAssociatesMaterial. This is the
+ * single-material path used when no layer/profile spec is present.
+ */
+export function writeMaterialSimple(
+  w: IfcWriter,
+  guid: IfcGuid,
+  ownerHistoryId: number,
+  materialName: string,
+  relatedObjectIds: readonly number[]
+): void {
+  const materialId = writeMaterial(w, materialName);
+  writeRelAssociatesMaterial(w, guid, ownerHistoryId, materialId, relatedObjectIds);
+}

--- a/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/openingWriter.ts
@@ -6,11 +6,14 @@ import type { WallSpec } from '../specs/wallSpec.js';
 import type { WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
 import { toIfcLengthM } from '../units/units.js';
+import { writeCommonPset } from './psetWriter.js';
 
 export interface OpeningIds {
   openingEntityId: number;
   openingPlacementId: number;
 }
+
+type PsetValue = string | number | boolean;
 
 type OpeningPsetSpec = {
   readonly isExternal?: boolean | undefined;
@@ -18,72 +21,6 @@ type OpeningPsetSpec = {
   readonly acousticRating?: string | undefined;
   readonly thermalTransmittance?: number | undefined;
 };
-
-type PsetValue = string | number | boolean;
-
-function writePsetValue(w: IfcWriter, value: PsetValue): Record<string, unknown> {
-  if (typeof value === 'boolean') {
-    return w.mkType(WebIFC.IFCBOOLEAN, value);
-  }
-  if (typeof value === 'number') {
-    return w.mkType(WebIFC.IFCREAL, value);
-  }
-  return w.mkType(WebIFC.IFCLABEL, value);
-}
-
-function writePropertySingleValue(w: IfcWriter, name: string, value: PsetValue): number {
-  const id = w.nextId();
-  w.writeLine({
-    expressID: id,
-    type: WebIFC.IFCPROPERTYSINGLEVALUE,
-    Name: w.mkType(WebIFC.IFCIDENTIFIER, name),
-    Description: null,
-    NominalValue: writePsetValue(w, value),
-    Unit: null,
-  });
-  return id;
-}
-
-function writePropertySet(
-  w: IfcWriter,
-  ownerHistoryId: number,
-  name: string,
-  properties: Record<string, PsetValue>
-): number {
-  const propIds = Object.entries(properties).map(([k, v]) =>
-    writePropertySingleValue(w, k, v)
-  );
-  const id = w.nextId();
-  w.writeLine({
-    expressID: id,
-    type: WebIFC.IFCPROPERTYSET,
-    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, w.guidFor(id)),
-    OwnerHistory: w.ref(ownerHistoryId),
-    Name: w.mkType(WebIFC.IFCLABEL, name),
-    Description: null,
-    HasProperties: propIds.map((pid) => w.ref(pid)),
-  });
-  return id;
-}
-
-function writeRelDefinesByProperties(
-  w: IfcWriter,
-  ownerHistoryId: number,
-  entityId: number,
-  psetId: number
-): void {
-  const relId = w.nextId();
-  w.writeLine({
-    expressID: relId,
-    type: WebIFC.IFCRELDEFINESBYPROPERTIES,
-    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, w.guidFor(relId)),
-    OwnerHistory: w.ref(ownerHistoryId),
-    Name: null,
-    Description: null,
-    RelatedObjects: [w.ref(entityId)],
-    RelatingPropertyDefinition: w.ref(psetId),
-  });
-}
 
 function writeAxis2Placement2D(w: IfcWriter): number {
   const originId = w.nextId();
@@ -119,11 +56,14 @@ export function writeOpeningGeometry(
   const offsetAlongWallM = toIfcLengthM(openingSpec.offsetAlongWall);
   const offsetFromFloorM = toIfcLengthM(openingSpec.offsetFromFloor);
   const thicknessM = toIfcLengthM(wallSpec.thickness);
+  const wallHeightM = toIfcLengthM(wallSpec.height);
 
   // Placement: centered on opening, starting at outer face (+thicknessM/2) so extrusion covers full wall depth
   const placement3DId = writeAxis2Placement3D(
     w,
-    [offsetAlongWallM + widthM / 2, thicknessM / 2, offsetFromFloorM + heightM / 2],
+    // Wall SweptSolid is centered in local Z ([-h/2, +h/2]); shift the void down
+    // by wallHeight/2 so offsetFromFloor is measured from the wall base.
+    [offsetAlongWallM + widthM / 2, thicknessM / 2, -wallHeightM / 2 + offsetFromFloorM + heightM / 2],
     [0, -1, 0],
     [1, 0, 0]
   );
@@ -292,12 +232,74 @@ export function writeSlabOpeningGeometry(
   return { openingEntityId, openingPlacementId };
 }
 
+// Default panel depth (mm) for a door/window filler when no depth is supplied.
+const DEFAULT_PANEL_DEPTH_MM = 100;
+
+// Emits a flat panel body for a door/window filler: a width×height rectangle
+// (centered on the opening's local origin) extruded along local +Z by depthM.
+// The opening's local frame places local X along the wall and local Z into the
+// wall, so the panel fills the opening face. Returns the IfcProductDefinitionShape.
+function writePanelBody(
+  w: IfcWriter,
+  widthM: number,
+  heightM: number,
+  depthM: number,
+  geomSubContextId: number
+): number {
+  const profileId = w.nextId();
+  w.writeLine({
+    expressID: profileId,
+    type: WebIFC.IFCRECTANGLEPROFILEDEF,
+    ProfileType: { type: 3, value: 'AREA' },
+    ProfileName: null,
+    Position: w.ref(writeAxis2Placement2D(w)),
+    XDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, widthM),
+    YDim: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, heightM),
+  });
+
+  const extrusionPosId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const extrusionDirId = writeDirection(w, [0, 0, 1]);
+  const extrusionId = w.nextId();
+  w.writeLine({
+    expressID: extrusionId,
+    type: WebIFC.IFCEXTRUDEDAREASOLID,
+    SweptArea: w.ref(profileId),
+    Position: w.ref(extrusionPosId),
+    ExtrudedDirection: w.ref(extrusionDirId),
+    Depth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, depthM),
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'SweptSolid'),
+    Items: [w.ref(extrusionId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+  return productDefinitionShapeId;
+}
+
 export function writeDoorEntity(
   w: IfcWriter,
   guid: IfcGuid,
   name: string,
   ownerHistoryId: number,
-  openingPlacementId: number
+  openingPlacementId: number,
+  geomSubContextId: number,
+  overallWidthM: number,
+  overallHeightM: number,
+  nominalDepthMm?: number
 ): number {
   const placement3DId = writeAxis2Placement3D(w, [0, 0, 0]);
   const localPlacementId = w.nextId();
@@ -307,6 +309,11 @@ export function writeDoorEntity(
     PlacementRelTo: w.ref(openingPlacementId),
     RelativePlacement: w.ref(placement3DId),
   });
+
+  const depthM = toIfcLengthM(nominalDepthMm ?? DEFAULT_PANEL_DEPTH_MM);
+  const productDefinitionShapeId = writePanelBody(
+    w, overallWidthM, overallHeightM, depthM, geomSubContextId
+  );
 
   const id = w.nextId();
   w.writeLine({
@@ -318,10 +325,10 @@ export function writeDoorEntity(
     Description: null,
     ObjectType: null,
     ObjectPlacement: w.ref(localPlacementId),
-    Representation: null,
+    Representation: w.ref(productDefinitionShapeId),
     Tag: null,
-    OverallHeight: null,
-    OverallWidth: null,
+    OverallHeight: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, overallHeightM),
+    OverallWidth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, overallWidthM),
     PredefinedType: null,
     OperationType: null,
     UserDefinedOperationType: null,
@@ -334,7 +341,11 @@ export function writeWindowEntity(
   guid: IfcGuid,
   name: string,
   ownerHistoryId: number,
-  openingPlacementId: number
+  openingPlacementId: number,
+  geomSubContextId: number,
+  overallWidthM: number,
+  overallHeightM: number,
+  nominalDepthMm?: number
 ): number {
   const placement3DId = writeAxis2Placement3D(w, [0, 0, 0]);
   const localPlacementId = w.nextId();
@@ -344,6 +355,11 @@ export function writeWindowEntity(
     PlacementRelTo: w.ref(openingPlacementId),
     RelativePlacement: w.ref(placement3DId),
   });
+
+  const depthM = toIfcLengthM(nominalDepthMm ?? DEFAULT_PANEL_DEPTH_MM);
+  const productDefinitionShapeId = writePanelBody(
+    w, overallWidthM, overallHeightM, depthM, geomSubContextId
+  );
 
   const id = w.nextId();
   w.writeLine({
@@ -355,10 +371,10 @@ export function writeWindowEntity(
     Description: null,
     ObjectType: null,
     ObjectPlacement: w.ref(localPlacementId),
-    Representation: null,
+    Representation: w.ref(productDefinitionShapeId),
     Tag: null,
-    OverallHeight: null,
-    OverallWidth: null,
+    OverallHeight: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, overallHeightM),
+    OverallWidth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, overallWidthM),
     PredefinedType: null,
     PartitioningType: null,
     UserDefinedPartitioningType: null,
@@ -404,19 +420,22 @@ export function writeRelFillsElement(
   });
 }
 
+function buildOpeningPsetValues(spec: OpeningPsetSpec): Record<string, PsetValue> {
+  const values: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) values['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) values['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) values['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) values['ThermalTransmittance'] = spec.thermalTransmittance;
+  return values;
+}
+
 export function writeDoorCommonPset(
   w: IfcWriter,
   ownerHistoryId: number,
   doorEntityId: number,
   spec: OpeningPsetSpec
 ): void {
-  const props: Record<string, PsetValue> = {};
-  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
-  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
-  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_DoorCommon', props);
-  writeRelDefinesByProperties(w, ownerHistoryId, doorEntityId, psetId);
+  writeCommonPset(w, ownerHistoryId, doorEntityId, 'DOOR', buildOpeningPsetValues(spec));
 }
 
 export function writeWindowCommonPset(
@@ -425,32 +444,5 @@ export function writeWindowCommonPset(
   windowEntityId: number,
   spec: OpeningPsetSpec
 ): void {
-  const propIds: number[] = [];
-  if (spec.isExternal !== undefined) propIds.push(writePropertySingleValue(w, 'IsExternal', spec.isExternal));
-  if (spec.fireRating !== undefined) propIds.push(writePropertySingleValue(w, 'FireRating', spec.fireRating));
-  if (spec.acousticRating !== undefined) propIds.push(writePropertySingleValue(w, 'AcousticRating', spec.acousticRating));
-  if (spec.thermalTransmittance !== undefined) {
-    const id = w.nextId();
-    w.writeLine({
-      expressID: id,
-      type: WebIFC.IFCPROPERTYSINGLEVALUE,
-      Name: w.mkType(WebIFC.IFCIDENTIFIER, 'ThermalTransmittance'),
-      Description: null,
-      NominalValue: w.mkType(WebIFC.IFCTHERMALTRANSMITTANCEMEASURE, spec.thermalTransmittance),
-      Unit: null,
-    });
-    propIds.push(id);
-  }
-  if (propIds.length === 0) return;
-  const psetId = w.nextId();
-  w.writeLine({
-    expressID: psetId,
-    type: WebIFC.IFCPROPERTYSET,
-    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, w.guidFor(psetId)),
-    OwnerHistory: w.ref(ownerHistoryId),
-    Name: w.mkType(WebIFC.IFCLABEL, 'Pset_WindowCommon'),
-    Description: null,
-    HasProperties: propIds.map((pid) => w.ref(pid)),
-  });
-  writeRelDefinesByProperties(w, ownerHistoryId, windowEntityId, psetId);
+  writeCommonPset(w, ownerHistoryId, windowEntityId, 'WINDOW', buildOpeningPsetValues(spec));
 }

--- a/packages/brepjs-bim/src/ifc-writer/proxyWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/proxyWriter.ts
@@ -1,0 +1,69 @@
+import * as WebIFC from 'web-ifc';
+import type { IfcWriter } from './ifcWriter.js';
+import { writeAxis2Placement3D } from './headerWriter.js';
+import { writeTessellation } from './tessellationWriter.js';
+import type { TessellationOutput } from './tessellationWriter.js';
+import type { IfcGuid } from '../identity/ifcGuid.js';
+import type { ProxySpec } from '../specs/proxySpec.js';
+
+export interface ProxyRepresentationIds {
+  readonly localPlacementId: number;
+  readonly productDefinitionShapeId: number;
+  readonly tessellation: TessellationOutput;
+}
+
+/**
+ * Writes the IfcLocalPlacement (at origin, relative to parentPlacementId) and a
+ * tessellated body (IfcTriangulatedFaceSet) for a proxy's solid. The solid is
+ * exported in its authored coordinate frame; placement is identity because proxy
+ * solids carry their own world positions in the brepjs geometry.
+ */
+export function writeProxyGeometry(
+  w: IfcWriter,
+  spec: ProxySpec,
+  geomSubContextId: number,
+  parentPlacementId: number | null
+): ProxyRepresentationIds {
+  const placement3DId = writeAxis2Placement3D(w, [0, 0, 0]);
+  const localPlacementId = w.nextId();
+  w.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: parentPlacementId !== null ? w.ref(parentPlacementId) : null,
+    RelativePlacement: w.ref(placement3DId),
+  });
+
+  const tessellation = writeTessellation(w, spec.solid, geomSubContextId, localPlacementId);
+
+  return {
+    localPlacementId,
+    productDefinitionShapeId: tessellation.productDefinitionShapeId,
+    tessellation,
+  };
+}
+
+export function writeProxyEntity(
+  w: IfcWriter,
+  guid: IfcGuid,
+  name: string,
+  predefinedType: string,
+  ownerHistoryId: number,
+  localPlacementId: number,
+  productDefinitionShapeId: number
+): number {
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCBUILDINGELEMENTPROXY,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: w.ref(localPlacementId),
+    Representation: w.ref(productDefinitionShapeId),
+    Tag: null,
+    PredefinedType: { type: 3, value: predefinedType },
+  });
+  return id;
+}

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -7,10 +7,27 @@ import type { ColumnSpec } from '../specs/columnSpec.js';
 import type { WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
 import { profileCrossSectionArea } from '../elementFns/profileFns.js';
 import { toIfcLengthM } from '../units/units.js';
+import type { PsetCategory, PsetTemplate } from '../psets/psetTemplates.js';
+import { measureTypeFor, webIfcConstantFor, templateFor } from '../psets/psetTemplates.js';
 
 type PsetValue = string | number | boolean;
 
-function writePsetValue(w: IfcWriter, value: PsetValue): Record<string, unknown> {
+/**
+ * Resolves the IFC measure value for a Pset property by name. Properties listed
+ * in the Pset measure-type table emit their canonical IFC measure type (e.g.
+ * `ThermalTransmittance` → IFCTHERMALTRANSMITTANCEMEASURE); unlisted properties
+ * fall back to the JS-type heuristic (boolean→IFCBOOLEAN, number→IFCREAL,
+ * string→IFCLABEL).
+ */
+function writePsetValueTyped(
+  w: IfcWriter,
+  name: string,
+  value: PsetValue
+): Record<string, unknown> {
+  const measureType = measureTypeFor(name);
+  if (measureType !== undefined) {
+    return w.mkType(webIfcConstantFor(measureType), value);
+  }
   if (typeof value === 'boolean') {
     return w.mkType(WebIFC.IFCBOOLEAN, value);
   }
@@ -20,28 +37,60 @@ function writePsetValue(w: IfcWriter, value: PsetValue): Record<string, unknown>
   return w.mkType(WebIFC.IFCLABEL, value);
 }
 
-function writePropertySingleValue(w: IfcWriter, name: string, value: PsetValue): number {
+export function writePropertySingleValueTyped(
+  w: IfcWriter,
+  name: string,
+  value: PsetValue
+): number {
   const id = w.nextId();
   w.writeLine({
     expressID: id,
     type: WebIFC.IFCPROPERTYSINGLEVALUE,
     Name: w.mkType(WebIFC.IFCIDENTIFIER, name),
     Description: null,
-    NominalValue: writePsetValue(w, value),
+    NominalValue: writePsetValueTyped(w, name, value),
     Unit: null,
   });
   return id;
 }
 
-function writePropertySet(
+/**
+ * Emits an IfcPropertyEnumeratedValue: the value plus the backing
+ * IfcPropertyEnumeration listing every legal value. Used for enumerated Pset
+ * properties such as `Status`.
+ */
+export function writePropertyEnumeratedValue(
+  w: IfcWriter,
+  name: string,
+  value: string,
+  enumValues: readonly string[]
+): number {
+  const enumerationId = w.nextId();
+  w.writeLine({
+    expressID: enumerationId,
+    type: WebIFC.IFCPROPERTYENUMERATION,
+    Name: w.mkType(WebIFC.IFCLABEL, name),
+    EnumerationValues: enumValues.map((v) => w.mkType(WebIFC.IFCLABEL, v)),
+    Unit: null,
+  });
+  const id = w.nextId();
+  w.writeLine({
+    expressID: id,
+    type: WebIFC.IFCPROPERTYENUMERATEDVALUE,
+    Name: w.mkType(WebIFC.IFCIDENTIFIER, name),
+    Description: null,
+    EnumerationValues: [w.mkType(WebIFC.IFCLABEL, value)],
+    EnumerationReference: w.ref(enumerationId),
+  });
+  return id;
+}
+
+export function writePropertySet(
   w: IfcWriter,
   ownerHistoryId: number,
   name: string,
-  properties: Record<string, PsetValue>
+  propertyIds: readonly number[]
 ): number {
-  const propIds = Object.entries(properties).map(([k, v]) =>
-    writePropertySingleValue(w, k, v)
-  );
   const id = w.nextId();
   w.writeLine({
     expressID: id,
@@ -50,12 +99,12 @@ function writePropertySet(
     OwnerHistory: w.ref(ownerHistoryId),
     Name: w.mkType(WebIFC.IFCLABEL, name),
     Description: null,
-    HasProperties: propIds.map((pid) => w.ref(pid)),
+    HasProperties: propertyIds.map((pid) => w.ref(pid)),
   });
   return id;
 }
 
-function writeRelDefinesByProperties(
+export function writeRelDefinesByProperties(
   w: IfcWriter,
   ownerHistoryId: number,
   entityExpressId: number,
@@ -74,21 +123,65 @@ function writeRelDefinesByProperties(
   });
 }
 
+/**
+ * Writes the Pset_*Common set for an element from its category template: each
+ * value present in `values` is emitted with the measure type declared in the
+ * template (single value, or enumerated value where the template marks it so).
+ * Properties absent from `values` are skipped; an empty set writes nothing.
+ */
+function writeCommonPsetFromTemplate(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  entityExpressId: number,
+  template: PsetTemplate,
+  values: Readonly<Record<string, PsetValue>>
+): void {
+  const propIds: number[] = [];
+  for (const prop of template.properties) {
+    const value = values[prop.name];
+    if (value === undefined) continue;
+    if (prop.kind === 'enumerated') {
+      propIds.push(
+        writePropertyEnumeratedValue(w, prop.name, String(value), prop.enumValues)
+      );
+    } else {
+      propIds.push(writePropertySingleValueTyped(w, prop.name, value));
+    }
+  }
+  if (propIds.length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, template.psetName, propIds);
+  writeRelDefinesByProperties(w, ownerHistoryId, entityExpressId, psetId);
+}
+
+/**
+ * Writes the standard Pset_*Common set for an element from its category template
+ * and a set of property values. Shared by the door/window pset writers in
+ * openingWriter.ts so every element type emits the correct measure types.
+ */
+export function writeCommonPset(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  entityExpressId: number,
+  category: PsetCategory,
+  values: Readonly<Record<string, PsetValue>>
+): void {
+  writeCommonPsetFromTemplate(w, ownerHistoryId, entityExpressId, templateFor(category), values);
+}
+
 export function writeWallCommonPset(
   w: IfcWriter,
   ownerHistoryId: number,
   wallExpressId: number,
   spec: WallSpec
 ): void {
-  const props: Record<string, PsetValue> = {};
-  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
-  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
-  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
-  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
-  if (spec.loadBearing !== undefined) props['LoadBearing'] = spec.loadBearing;
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_WallCommon', props);
-  writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, psetId);
+  const values: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) values['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) values['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) values['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) values['ThermalTransmittance'] = spec.thermalTransmittance;
+  if (spec.loadBearing !== undefined) values['LoadBearing'] = spec.loadBearing;
+  if (spec.status !== undefined) values['Status'] = spec.status;
+  writeCommonPset(w, ownerHistoryId, wallExpressId, 'WALL', values);
 }
 
 interface ManufacturerFields {
@@ -106,9 +199,13 @@ export function writeManufacturerPset(
   const props: Record<string, PsetValue> = {};
   if (spec.manufacturerName !== undefined) props['Manufacturer'] = spec.manufacturerName;
   if (spec.manufacturerModel !== undefined) props['ModelLabel'] = spec.manufacturerModel;
-  if (spec.manufacturerProductionYear !== undefined) props['ProductionYear'] = spec.manufacturerProductionYear;
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_ManufacturerTypeInformation', props);
+  if (spec.manufacturerProductionYear !== undefined)
+    // Pset_ManufacturerTypeInformation.ProductionYear is an IfcLabel (string) in
+    // IFC4; stringify the numeric year so the SPF token is well-formed.
+    props['ProductionYear'] = String(spec.manufacturerProductionYear);
+  const propIds = Object.entries(props).map(([k, v]) => writePropertySingleValueTyped(w, k, v));
+  if (propIds.length === 0) return;
+  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_ManufacturerTypeInformation', propIds);
   writeRelDefinesByProperties(w, ownerHistoryId, entityExpressId, psetId);
 }
 
@@ -119,8 +216,9 @@ export function writeCustomPsets(
   customProperties: Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
 ): void {
   for (const [psetName, props] of Object.entries(customProperties)) {
-    if (Object.keys(props).length === 0) continue;
-    const psetId = writePropertySet(w, ownerHistoryId, psetName, { ...props });
+    const propIds = Object.entries(props).map(([k, v]) => writePropertySingleValueTyped(w, k, v));
+    if (propIds.length === 0) continue;
+    const psetId = writePropertySet(w, ownerHistoryId, psetName, propIds);
     writeRelDefinesByProperties(w, ownerHistoryId, entityExpressId, psetId);
   }
 }
@@ -241,17 +339,16 @@ export function writeSlabCommonPset(
   slabExpressId: number,
   spec: SlabSpec
 ): void {
-  const props: Record<string, PsetValue> = {};
-  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
-  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
-  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
-  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
-  if (spec.loadBearing !== undefined) props['LoadBearing'] = spec.loadBearing;
-  if (spec.combustible !== undefined) props['Combustible'] = spec.combustible;
-  if (spec.compartmentation !== undefined) props['Compartmentation'] = spec.compartmentation;
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_SlabCommon', props);
-  writeRelDefinesByProperties(w, ownerHistoryId, slabExpressId, psetId);
+  const values: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) values['IsExternal'] = spec.isExternal;
+  if (spec.fireRating !== undefined) values['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) values['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) values['ThermalTransmittance'] = spec.thermalTransmittance;
+  if (spec.loadBearing !== undefined) values['LoadBearing'] = spec.loadBearing;
+  if (spec.combustible !== undefined) values['Combustible'] = spec.combustible;
+  if (spec.compartmentation !== undefined) values['Compartmentation'] = spec.compartmentation;
+  if (spec.status !== undefined) values['Status'] = spec.status;
+  writeCommonPset(w, ownerHistoryId, slabExpressId, 'SLAB', values);
 }
 
 export function writeSlabBaseQuantities(
@@ -298,16 +395,18 @@ interface CommonStructuralFields {
   readonly fireRating?: string | undefined;
   readonly acousticRating?: string | undefined;
   readonly thermalTransmittance?: number | undefined;
+  readonly status?: string | undefined;
 }
 
-function buildCommonProps(spec: CommonStructuralFields): Record<string, PsetValue> {
-  const props: Record<string, PsetValue> = {};
-  if (spec.isExternal !== undefined) props['IsExternal'] = spec.isExternal;
-  if (spec.loadBearing !== undefined) props['LoadBearing'] = spec.loadBearing;
-  if (spec.fireRating !== undefined) props['FireRating'] = spec.fireRating;
-  if (spec.acousticRating !== undefined) props['AcousticRating'] = spec.acousticRating;
-  if (spec.thermalTransmittance !== undefined) props['ThermalTransmittance'] = spec.thermalTransmittance;
-  return props;
+function buildCommonValues(spec: CommonStructuralFields): Record<string, PsetValue> {
+  const values: Record<string, PsetValue> = {};
+  if (spec.isExternal !== undefined) values['IsExternal'] = spec.isExternal;
+  if (spec.loadBearing !== undefined) values['LoadBearing'] = spec.loadBearing;
+  if (spec.fireRating !== undefined) values['FireRating'] = spec.fireRating;
+  if (spec.acousticRating !== undefined) values['AcousticRating'] = spec.acousticRating;
+  if (spec.thermalTransmittance !== undefined) values['ThermalTransmittance'] = spec.thermalTransmittance;
+  if (spec.status !== undefined) values['Status'] = spec.status;
+  return values;
 }
 
 export function writeBeamCommonPset(
@@ -316,10 +415,7 @@ export function writeBeamCommonPset(
   beamExpressId: number,
   spec: BeamSpec
 ): void {
-  const props = buildCommonProps(spec);
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_BeamCommon', props);
-  writeRelDefinesByProperties(w, ownerHistoryId, beamExpressId, psetId);
+  writeCommonPset(w, ownerHistoryId, beamExpressId, 'BEAM', buildCommonValues(spec));
 }
 
 export function writeColumnCommonPset(
@@ -328,10 +424,7 @@ export function writeColumnCommonPset(
   columnExpressId: number,
   spec: ColumnSpec
 ): void {
-  const props = buildCommonProps(spec);
-  if (Object.keys(props).length === 0) return;
-  const psetId = writePropertySet(w, ownerHistoryId, 'Pset_ColumnCommon', props);
-  writeRelDefinesByProperties(w, ownerHistoryId, columnExpressId, psetId);
+  writeCommonPset(w, ownerHistoryId, columnExpressId, 'COLUMN', buildCommonValues(spec));
 }
 
 export function writeBeamBaseQuantities(

--- a/packages/brepjs-bim/src/ifc-writer/relWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/relWriter.ts
@@ -39,30 +39,3 @@ export function writeRelContainedInSpatialStructure(
     RelatingStructure: w.ref(relatingStructureId),
   });
 }
-
-export function writeRelAssociatesMaterial(
-  w: IfcWriter,
-  guid: IfcGuid,
-  ownerHistoryId: number,
-  materialName: string,
-  relatedObjectIds: number[]
-): void {
-  const materialId = w.nextId();
-  w.writeLine({
-    expressID: materialId,
-    type: WebIFC.IFCMATERIAL,
-    Name: w.mkType(WebIFC.IFCLABEL, materialName),
-    Description: null,
-    Category: null,
-  });
-  w.writeLine({
-    expressID: w.nextId(),
-    type: WebIFC.IFCRELASSOCIATESMATERIAL,
-    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, guid),
-    OwnerHistory: w.ref(ownerHistoryId),
-    Name: null,
-    Description: null,
-    RelatedObjects: relatedObjectIds.map((id) => w.ref(id)),
-    RelatingMaterial: w.ref(materialId),
-  });
-}

--- a/packages/brepjs-bim/src/ifc-writer/tessellationWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/tessellationWriter.ts
@@ -1,0 +1,277 @@
+import * as WebIFC from 'web-ifc';
+import { mesh } from 'brepjs';
+import type { ValidSolid } from 'brepjs';
+import type { IfcWriter } from './ifcWriter.js';
+import { toIfcLengthM } from '../units/units.js';
+
+export interface TessellationResult {
+  readonly productDefinitionShapeId: number;
+  /** True when the IfcFacetedBrep fallback was used because mesh() failed. */
+  readonly usedFallback: false;
+}
+
+export interface TessellationFallbackResult {
+  readonly productDefinitionShapeId: number;
+  readonly usedFallback: true;
+  readonly fallbackReason: string;
+}
+
+export type TessellationOutput = TessellationResult | TessellationFallbackResult;
+
+// Coarse mesh defaults appropriate for IFC export (not render quality). IFC
+// validators do not require fine meshes; finer values bloat the SPF file.
+const IFC_MESH_TOLERANCE_MM = 5;
+const IFC_MESH_ANGULAR_TOLERANCE_RAD = 0.3;
+
+/**
+ * Writes an IfcTriangulatedFaceSet (preferred IFC4 tessellation) from a brepjs
+ * ValidSolid, wrapped in an IfcShapeRepresentation (Body/Tessellation) and an
+ * IfcProductDefinitionShape. Returns the IfcProductDefinitionShape express ID.
+ *
+ * Vertices from mesh() are in mm (brepjs native units) and are converted to
+ * metres for IFC. CoordIndex is emitted 1-based as IFC requires.
+ *
+ * On mesh() failure the function falls back to a degenerate single-vertex
+ * IfcFacetedBrep, logs a console.warn, and returns usedFallback: true. The
+ * caller should surface the fallback through its ValidationReport.
+ *
+ * geomSubContextId must be the geometric representation sub-context ('Body').
+ * localPlacement is accepted for call-site symmetry with the other geometry
+ * writers; tessellation placement is carried by the owning product, not by the
+ * shape representation, so it is not referenced here.
+ */
+export function writeTessellation(
+  w: IfcWriter,
+  solid: ValidSolid,
+  geomSubContextId: number,
+  _localPlacementId: number | null,
+  toleranceMm: number = IFC_MESH_TOLERANCE_MM
+): TessellationOutput {
+  let meshData;
+  try {
+    meshData = mesh(solid, {
+      tolerance: toleranceMm,
+      angularTolerance: IFC_MESH_ANGULAR_TOLERANCE_RAD,
+    });
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    console.warn(`writeTessellation: mesh() failed, using IfcFacetedBrep fallback: ${reason}`);
+    return writeFacetedBrepFallback(w, geomSubContextId, reason);
+  }
+
+  const { vertices, triangles } = meshData;
+  if (vertices.length === 0 || triangles.length === 0) {
+    const reason = 'mesh() returned an empty triangle set';
+    console.warn(`writeTessellation: ${reason}, using IfcFacetedBrep fallback`);
+    return writeFacetedBrepFallback(w, geomSubContextId, reason);
+  }
+
+  // Build the coordinate list (metres) as [x, y, z] triples. vertices is a
+  // flat Float32Array of interleaved positions in mm.
+  const coordList: number[][] = [];
+  for (let i = 0; i + 2 < vertices.length; i += 3) {
+    coordList.push([
+      toIfcLengthM(vertices[i] ?? 0),
+      toIfcLengthM(vertices[i + 1] ?? 0),
+      toIfcLengthM(vertices[i + 2] ?? 0),
+    ]);
+  }
+
+  const pointListId = w.nextId();
+  w.writeLine({
+    expressID: pointListId,
+    type: WebIFC.IFCCARTESIANPOINTLIST3D,
+    CoordList: coordList.map((pt) => pt.map((v) => w.mkType(WebIFC.IFCLENGTHMEASURE, v))),
+    TagList: null,
+  });
+
+  // Build 1-based 3-tuple coordinate indices directly from the Uint32Array to
+  // avoid an intermediate flat allocation. triangles holds 0-based vertex ids.
+  const coordIndex: number[][] = [];
+  for (let i = 0; i + 2 < triangles.length; i += 3) {
+    coordIndex.push([
+      (triangles[i] ?? 0) + 1,
+      (triangles[i + 1] ?? 0) + 1,
+      (triangles[i + 2] ?? 0) + 1,
+    ]);
+  }
+
+  const faceSetId = w.nextId();
+  w.writeLine({
+    expressID: faceSetId,
+    type: WebIFC.IFCTRIANGULATEDFACESET,
+    Coordinates: w.ref(pointListId),
+    Normals: null,
+    Closed: true,
+    CoordIndex: coordIndex.map((tri) =>
+      tri.map((idx) => w.mkType(WebIFC.IFCPOSITIVEINTEGER, idx))
+    ),
+    PnIndex: null,
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'Tessellation'),
+    Items: [w.ref(faceSetId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+
+  return { productDefinitionShapeId, usedFallback: false };
+}
+
+/**
+ * Builds a wall 'Axis' IfcShapeRepresentation: an IfcPolyline from (0,0) to
+ * (lengthM, 0) in the wall's local XY plane, wrapped in an IfcShapeRepresentation
+ * with RepresentationIdentifier='Axis', RepresentationType='Curve2D'. Returns
+ * the IfcShapeRepresentation express ID so callers can add it alongside the Body
+ * representation in an IfcProductDefinitionShape.
+ *
+ * wallLengthMm is the wall length in mm (brepjs native units); it is converted
+ * to metres for IFC.
+ */
+export function writeWallAxisRepresentation(
+  w: IfcWriter,
+  wallLengthMm: number,
+  geomSubContextId: number
+): number {
+  const lengthM = toIfcLengthM(wallLengthMm);
+
+  const startId = w.nextId();
+  w.writeLine({
+    expressID: startId,
+    type: WebIFC.IFCCARTESIANPOINT,
+    Coordinates: [w.mkType(WebIFC.IFCLENGTHMEASURE, 0), w.mkType(WebIFC.IFCLENGTHMEASURE, 0)],
+  });
+
+  const endId = w.nextId();
+  w.writeLine({
+    expressID: endId,
+    type: WebIFC.IFCCARTESIANPOINT,
+    Coordinates: [w.mkType(WebIFC.IFCLENGTHMEASURE, lengthM), w.mkType(WebIFC.IFCLENGTHMEASURE, 0)],
+  });
+
+  const polylineId = w.nextId();
+  w.writeLine({
+    expressID: polylineId,
+    type: WebIFC.IFCPOLYLINE,
+    Points: [w.ref(startId), w.ref(endId)],
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Axis'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'Curve2D'),
+    Items: [w.ref(polylineId)],
+  });
+
+  return shapeRepId;
+}
+
+// Degenerate IfcFacetedBrep used only when mesh() fails. A real face-polygon
+// extraction is not available without a working mesh, so this emits a minimal
+// valid-shaped (but geometrically empty) brep so the product still references a
+// representation. The fallback is flagged to the caller via usedFallback: true.
+function writeFacetedBrepFallback(
+  w: IfcWriter,
+  geomSubContextId: number,
+  reason: string
+): TessellationFallbackResult {
+  const originId = w.nextId();
+  w.writeLine({
+    expressID: originId,
+    type: WebIFC.IFCCARTESIANPOINT,
+    Coordinates: [
+      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+    ],
+  });
+
+  // IfcPolyLoop requires >= 3 points. Emit a degenerate triangle of three
+  // coincident origin points so the fallback shell satisfies the IFC4 schema
+  // (checkSchema) instead of tripping a polyloop cardinality violation.
+  const p2Id = w.nextId();
+  const p3Id = w.nextId();
+  for (const id of [p2Id, p3Id]) {
+    w.writeLine({
+      expressID: id,
+      type: WebIFC.IFCCARTESIANPOINT,
+      Coordinates: [
+        w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+        w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+        w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+      ],
+    });
+  }
+  const loopId = w.nextId();
+  w.writeLine({
+    expressID: loopId,
+    type: WebIFC.IFCPOLYLOOP,
+    Polygon: [w.ref(originId), w.ref(p2Id), w.ref(p3Id)],
+  });
+
+  const faceOuterBoundId = w.nextId();
+  w.writeLine({
+    expressID: faceOuterBoundId,
+    type: WebIFC.IFCFACEOUTERBOUND,
+    Bound: w.ref(loopId),
+    Orientation: true,
+  });
+
+  const faceId = w.nextId();
+  w.writeLine({
+    expressID: faceId,
+    type: WebIFC.IFCFACE,
+    Bounds: [w.ref(faceOuterBoundId)],
+  });
+
+  const shellId = w.nextId();
+  w.writeLine({
+    expressID: shellId,
+    type: WebIFC.IFCCLOSEDSHELL,
+    CfsFaces: [w.ref(faceId)],
+  });
+
+  const brepId = w.nextId();
+  w.writeLine({
+    expressID: brepId,
+    type: WebIFC.IFCFACETEDBREP,
+    Outer: w.ref(shellId),
+  });
+
+  const shapeRepId = w.nextId();
+  w.writeLine({
+    expressID: shapeRepId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: w.ref(geomSubContextId),
+    RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: w.mkType(WebIFC.IFCLABEL, 'Brep'),
+    Items: [w.ref(brepId)],
+  });
+
+  const productDefinitionShapeId = w.nextId();
+  w.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [w.ref(shapeRepId)],
+  });
+
+  return { productDefinitionShapeId, usedFallback: true, fallbackReason: reason };
+}

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -13,6 +13,7 @@ export { makeLocalIdCounter } from './identity/localId.js';
 export { checkReferentialIntegrity } from './validation/referentialIntegrity.js';
 export { checkSchema } from './validation/schemaCheck.js';
 export { checkRoundTrip } from './validation/roundTrip.js';
+export { checkGeometryValidity } from './validation/geometryValidity.js';
 export {
   issue,
   emptyReport,
@@ -20,6 +21,18 @@ export {
   countBySeverity,
 } from './validation/severity.js';
 export { writeIfcType } from './ifc-writer/typeWriter.js';
+export {
+  writeMaterialLayerSet,
+  writeMaterialProfileSet,
+  writeMaterialSimple,
+} from './ifc-writer/materialWriter.js';
+export { writeClassificationRefs } from './ifc-writer/classificationWriter.js';
+export {
+  PSET_TEMPLATES,
+  PSET_PROPERTY_TYPE_TABLE,
+  measureTypeFor,
+  templateFor,
+} from './psets/psetTemplates.js';
 export { DEFAULT_UNITS, toLengthMm, toIfcLengthM } from './units/units.js';
 export { specError, ifcError, geometryError, fromBrepError } from './errors/bimError.js';
 
@@ -34,10 +47,31 @@ export type {
   IShapeProfile,
 } from './specs/profile.js';
 export type { DoorSpec, WindowSpec, SlabOpeningInput } from './specs/openingSpec.js';
+export type { ProxySpec } from './specs/proxySpec.js';
 export type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from './specs/spatialSpec.js';
 export type { BimCategory, BimElement, AnyBimElement, OpeningSpec, WallOpeningSpec, SlabOpeningSpec } from './types/bimTypes.js';
 export { isWallOpening, isSlabOpening } from './types/bimTypes.js';
-export type { BimRelationship, VoidsWallRel, VoidsSlabRel, FillsOpeningRel } from './types/relationships.js';
+export type {
+  BimRelationship,
+  AssociatesMaterialRel,
+  AssociatesClassificationRel,
+  VoidsWallRel,
+  VoidsSlabRel,
+  FillsOpeningRel,
+} from './types/relationships.js';
+export type { MaterialLayer } from './types/materialTypes.js';
+export type {
+  MaterialLayerSetSpec,
+  MaterialProfileSpec,
+  MaterialSpec,
+} from './ifc-writer/materialWriter.js';
+export type { ClassificationRef } from './types/classificationTypes.js';
+export type {
+  PsetCategory,
+  PsetMeasureType,
+  PsetTemplate,
+  PsetPropertyTemplate,
+} from './psets/psetTemplates.js';
 export type { BimError, BimErrorKind } from './errors/bimError.js';
 export type { IfcGuid } from './identity/ifcGuid.js';
 export type { LocalId, LocalIdCounter } from './identity/localId.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -12,15 +12,19 @@ import type {
   AggregatesRel,
   ContainedInRel,
   AssociatesMaterialRel,
+  AssociatesClassificationRel,
   VoidsWallRel,
   VoidsSlabRel,
   FillsOpeningRel,
 } from '../types/relationships.js';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
 import type { BeamSpec } from '../specs/beamSpec.js';
 import type { ColumnSpec } from '../specs/columnSpec.js';
 import type { DoorSpec, WindowSpec, SlabOpeningInput } from '../specs/openingSpec.js';
+import type { ProxySpec } from '../specs/proxySpec.js';
 import type { ProjectSpec, SiteSpec, BuildingSpec, StoreySpec } from '../specs/spatialSpec.js';
 import { wallToSolid } from '../elementFns/wallFns.js';
 import { slabToSolid } from '../elementFns/slabFns.js';
@@ -57,7 +61,8 @@ export class BimModel {
         el.category === 'WALL' ||
         el.category === 'SLAB' ||
         el.category === 'BEAM' ||
-        el.category === 'COLUMN'
+        el.category === 'COLUMN' ||
+        el.category === 'PROXY'
       ) {
         el.geometry[Symbol.dispose]();
       }
@@ -80,11 +85,8 @@ export class BimModel {
     const geomResult = wallToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('WALL', spec, geomResult.value);
-    this.#makeRel<AssociatesMaterialRel>({
-      kind: 'ASSOCIATES_MATERIAL',
-      materialName: spec.materialName,
-      relatedObjects: [id],
-    });
+    this.#associateMaterial(id, spec);
+    this.#associateClassification(id, spec);
     return ok(id);
   }
 
@@ -92,11 +94,8 @@ export class BimModel {
     const geomResult = slabToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('SLAB', spec, geomResult.value);
-    this.#makeRel<AssociatesMaterialRel>({
-      kind: 'ASSOCIATES_MATERIAL',
-      materialName: spec.materialName,
-      relatedObjects: [id],
-    });
+    this.#associateMaterial(id, spec);
+    this.#associateClassification(id, spec);
     return ok(id);
   }
 
@@ -104,11 +103,8 @@ export class BimModel {
     const geomResult = beamToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('BEAM', spec, geomResult.value);
-    this.#makeRel<AssociatesMaterialRel>({
-      kind: 'ASSOCIATES_MATERIAL',
-      materialName: spec.materialName,
-      relatedObjects: [id],
-    });
+    this.#associateMaterial(id, spec);
+    this.#associateClassification(id, spec);
     return ok(id);
   }
 
@@ -116,11 +112,74 @@ export class BimModel {
     const geomResult = columnToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('COLUMN', spec, geomResult.value);
+    this.#associateMaterial(id, spec);
+    this.#associateClassification(id, spec);
+    return ok(id);
+  }
+
+  /**
+   * Associates a classification reference with one or more elements, creating an
+   * IfcRelAssociatesClassification on export. Returns the relationship's localId.
+   */
+  addClassification(ref: ClassificationRef, elementLocalIds: readonly LocalId[]): LocalId {
+    return this.#makeRel<AssociatesClassificationRel>({
+      kind: 'ASSOCIATES_CLASSIFICATION',
+      ref,
+      relatedObjects: [...elementLocalIds],
+    });
+  }
+
+  #associateMaterial(
+    id: LocalId,
+    spec: {
+      readonly materialName: string;
+      readonly materialLayers?: readonly MaterialLayer[] | undefined;
+      readonly layerSetName?: string | undefined;
+    }
+  ): void {
+    const hasLayers = spec.materialLayers !== undefined && spec.materialLayers.length > 0;
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
       materialName: spec.materialName,
       relatedObjects: [id],
+      ...(hasLayers
+        ? {
+            materialLayers: spec.materialLayers,
+            layerSetName: spec.layerSetName ?? spec.materialName,
+          }
+        : {}),
     });
+  }
+
+  #associateClassification(
+    id: LocalId,
+    spec: { readonly classification?: ClassificationRef | undefined }
+  ): void {
+    if (spec.classification === undefined) return;
+    this.#makeRel<AssociatesClassificationRel>({
+      kind: 'ASSOCIATES_CLASSIFICATION',
+      ref: spec.classification,
+      relatedObjects: [id],
+    });
+  }
+
+  /**
+   * Adds an IfcBuildingElementProxy. The model TAKES OWNERSHIP of `spec.solid`
+   * and disposes it on model disposal; the caller must not dispose it (see
+   * {@link ProxySpec.solid}).
+   */
+  addProxy(spec: ProxySpec): Result<LocalId, BimError> {
+    if (spec.solid === null || spec.solid === undefined) {
+      return err(specError('PROXY_NO_GEOMETRY', 'ProxySpec.solid is required'));
+    }
+    const id = this.#makeElement('PROXY', spec, spec.solid);
+    if (spec.materialName !== undefined) {
+      this.#makeRel<AssociatesMaterialRel>({
+        kind: 'ASSOCIATES_MATERIAL',
+        materialName: spec.materialName,
+        relatedObjects: [id],
+      });
+    }
     return ok(id);
   }
 
@@ -390,6 +449,14 @@ export class BimModel {
       if (el.category === 'COLUMN') columns.push(el);
     }
     return columns;
+  }
+
+  getProxies(): BimElement<'PROXY'>[] {
+    const proxies: BimElement<'PROXY'>[] = [];
+    for (const el of this.#elements.values()) {
+      if (el.category === 'PROXY') proxies.push(el);
+    }
+    return proxies;
   }
 
   getAllElements(): AnyBimElement[] {

--- a/packages/brepjs-bim/src/psets/psetTemplates.ts
+++ b/packages/brepjs-bim/src/psets/psetTemplates.ts
@@ -1,0 +1,239 @@
+import * as WebIFC from 'web-ifc';
+
+/**
+ * IFC measure types used by the standard Pset_*Common property sets.
+ * Each maps to a web-ifc defined-type constant via {@link webIfcConstantFor}.
+ */
+export type PsetMeasureType =
+  | 'IFCBOOLEAN'
+  | 'IFCIDENTIFIER'
+  | 'IFCLABEL'
+  | 'IFCTEXT'
+  | 'IFCREAL'
+  | 'IFCINTEGER'
+  | 'IFCLENGTHMEASURE'
+  | 'IFCPOSITIVELENGTHMEASURE'
+  | 'IFCAREAMEASURE'
+  | 'IFCVOLUMEMEASURE'
+  | 'IFCRATIOMEASURE'
+  | 'IFCPOSITIVERATIOMEASURE'
+  | 'IFCPLANEANGLEMEASURE'
+  | 'IFCTHERMALTRANSMITTANCEMEASURE';
+
+/** The six element categories that carry a standard Pset_*Common set. */
+export type PsetCategory = 'WALL' | 'SLAB' | 'BEAM' | 'COLUMN' | 'DOOR' | 'WINDOW';
+
+interface SingleValueTemplate {
+  readonly name: string;
+  readonly measureType: PsetMeasureType;
+  readonly kind: 'single';
+}
+
+interface EnumeratedValueTemplate {
+  readonly name: string;
+  readonly measureType: PsetMeasureType;
+  readonly kind: 'enumerated';
+  /** Legal values for the enumeration, in canonical IFC order. */
+  readonly enumValues: readonly string[];
+}
+
+export type PsetPropertyTemplate = SingleValueTemplate | EnumeratedValueTemplate;
+
+export interface PsetTemplate {
+  readonly psetName: string;
+  readonly properties: readonly PsetPropertyTemplate[];
+}
+
+// The bSI-standard Status enumeration shared by every Pset_*Common set.
+const STATUS_ENUM_VALUES = [
+  'NEW',
+  'EXISTING',
+  'DEMOLISH',
+  'TEMPORARY',
+  'OTHER',
+  'NOTKNOWN',
+  'UNSET',
+] as const;
+
+const STATUS_PROPERTY: EnumeratedValueTemplate = {
+  name: 'Status',
+  measureType: 'IFCLABEL',
+  kind: 'enumerated',
+  enumValues: STATUS_ENUM_VALUES,
+};
+
+function single(name: string, measureType: PsetMeasureType): SingleValueTemplate {
+  return { name, measureType, kind: 'single' };
+}
+
+/**
+ * Per-property IFC measure type for every property appearing in the standard
+ * Pset_*Common sets. The psetWriter consults this to emit the correct measure
+ * type instead of the legacy everything-is-IFCREAL heuristic. Properties absent
+ * from this table have no standard measure type and the writer falls back to its
+ * JS-type heuristic.
+ */
+export const PSET_PROPERTY_TYPE_TABLE: Readonly<Record<string, PsetMeasureType>> = {
+  // Shared common properties
+  Reference: 'IFCIDENTIFIER',
+  Status: 'IFCLABEL',
+  IsExternal: 'IFCBOOLEAN',
+  LoadBearing: 'IFCBOOLEAN',
+  FireRating: 'IFCLABEL',
+  AcousticRating: 'IFCLABEL',
+  ThermalTransmittance: 'IFCTHERMALTRANSMITTANCEMEASURE',
+  Combustible: 'IFCBOOLEAN',
+  Compartmentation: 'IFCBOOLEAN',
+  SurfaceSpreadOfFlame: 'IFCLABEL',
+  // Manufacturer information (used by type objects)
+  Manufacturer: 'IFCLABEL',
+  ModelLabel: 'IFCLABEL',
+  ProductionYear: 'IFCLABEL',
+  // Door / window common properties
+  FireExit: 'IFCBOOLEAN',
+  SelfClosing: 'IFCBOOLEAN',
+  SmokeStop: 'IFCBOOLEAN',
+  HandicapAccessible: 'IFCBOOLEAN',
+  HasDrive: 'IFCBOOLEAN',
+  // bSI types Infiltration as IfcVolumetricFlowRateMeasure, which is outside the
+  // Pset_*Common measure-type set this module covers; emit it as IFCREAL.
+  Infiltration: 'IFCREAL',
+  GlazingAreaFraction: 'IFCPOSITIVERATIOMEASURE',
+  SecurityRating: 'IFCLABEL',
+};
+
+const WALL_COMMON_TEMPLATE: PsetTemplate = {
+  psetName: 'Pset_WallCommon',
+  properties: [
+    single('Reference', 'IFCIDENTIFIER'),
+    STATUS_PROPERTY,
+    single('IsExternal', 'IFCBOOLEAN'),
+    single('LoadBearing', 'IFCBOOLEAN'),
+    single('FireRating', 'IFCLABEL'),
+    single('AcousticRating', 'IFCLABEL'),
+    single('ThermalTransmittance', 'IFCTHERMALTRANSMITTANCEMEASURE'),
+    single('Combustible', 'IFCBOOLEAN'),
+    single('Compartmentation', 'IFCBOOLEAN'),
+    single('SurfaceSpreadOfFlame', 'IFCLABEL'),
+  ],
+};
+
+const SLAB_COMMON_TEMPLATE: PsetTemplate = {
+  psetName: 'Pset_SlabCommon',
+  properties: [
+    single('Reference', 'IFCIDENTIFIER'),
+    STATUS_PROPERTY,
+    single('IsExternal', 'IFCBOOLEAN'),
+    single('LoadBearing', 'IFCBOOLEAN'),
+    single('FireRating', 'IFCLABEL'),
+    single('AcousticRating', 'IFCLABEL'),
+    single('ThermalTransmittance', 'IFCTHERMALTRANSMITTANCEMEASURE'),
+    single('Combustible', 'IFCBOOLEAN'),
+    single('Compartmentation', 'IFCBOOLEAN'),
+    single('SurfaceSpreadOfFlame', 'IFCLABEL'),
+  ],
+};
+
+const BEAM_COMMON_TEMPLATE: PsetTemplate = {
+  psetName: 'Pset_BeamCommon',
+  properties: [
+    single('Reference', 'IFCIDENTIFIER'),
+    STATUS_PROPERTY,
+    single('IsExternal', 'IFCBOOLEAN'),
+    single('LoadBearing', 'IFCBOOLEAN'),
+    single('FireRating', 'IFCLABEL'),
+    single('AcousticRating', 'IFCLABEL'),
+    single('ThermalTransmittance', 'IFCTHERMALTRANSMITTANCEMEASURE'),
+  ],
+};
+
+const COLUMN_COMMON_TEMPLATE: PsetTemplate = {
+  psetName: 'Pset_ColumnCommon',
+  properties: [
+    single('Reference', 'IFCIDENTIFIER'),
+    STATUS_PROPERTY,
+    single('IsExternal', 'IFCBOOLEAN'),
+    single('LoadBearing', 'IFCBOOLEAN'),
+    single('FireRating', 'IFCLABEL'),
+    single('AcousticRating', 'IFCLABEL'),
+    single('ThermalTransmittance', 'IFCTHERMALTRANSMITTANCEMEASURE'),
+  ],
+};
+
+const DOOR_COMMON_TEMPLATE: PsetTemplate = {
+  psetName: 'Pset_DoorCommon',
+  properties: [
+    single('Reference', 'IFCIDENTIFIER'),
+    STATUS_PROPERTY,
+    single('IsExternal', 'IFCBOOLEAN'),
+    single('FireRating', 'IFCLABEL'),
+    single('AcousticRating', 'IFCLABEL'),
+    single('SecurityRating', 'IFCLABEL'),
+    single('ThermalTransmittance', 'IFCTHERMALTRANSMITTANCEMEASURE'),
+    single('FireExit', 'IFCBOOLEAN'),
+    single('SelfClosing', 'IFCBOOLEAN'),
+    single('SmokeStop', 'IFCBOOLEAN'),
+    single('HandicapAccessible', 'IFCBOOLEAN'),
+    single('HasDrive', 'IFCBOOLEAN'),
+    single('Infiltration', 'IFCREAL'),
+  ],
+};
+
+const WINDOW_COMMON_TEMPLATE: PsetTemplate = {
+  psetName: 'Pset_WindowCommon',
+  properties: [
+    single('Reference', 'IFCIDENTIFIER'),
+    STATUS_PROPERTY,
+    single('IsExternal', 'IFCBOOLEAN'),
+    single('FireRating', 'IFCLABEL'),
+    single('AcousticRating', 'IFCLABEL'),
+    single('SecurityRating', 'IFCLABEL'),
+    single('ThermalTransmittance', 'IFCTHERMALTRANSMITTANCEMEASURE'),
+    single('FireExit', 'IFCBOOLEAN'),
+    single('SmokeStop', 'IFCBOOLEAN'),
+    single('GlazingAreaFraction', 'IFCPOSITIVERATIOMEASURE'),
+    single('Infiltration', 'IFCREAL'),
+  ],
+};
+
+/** Standard Pset_*Common template keyed by element category. */
+export const PSET_TEMPLATES: Readonly<Record<PsetCategory, PsetTemplate>> = {
+  WALL: WALL_COMMON_TEMPLATE,
+  SLAB: SLAB_COMMON_TEMPLATE,
+  BEAM: BEAM_COMMON_TEMPLATE,
+  COLUMN: COLUMN_COMMON_TEMPLATE,
+  DOOR: DOOR_COMMON_TEMPLATE,
+  WINDOW: WINDOW_COMMON_TEMPLATE,
+};
+
+const WEBIFC_CONSTANT_BY_MEASURE: Readonly<Record<PsetMeasureType, number>> = {
+  IFCBOOLEAN: WebIFC.IFCBOOLEAN,
+  IFCIDENTIFIER: WebIFC.IFCIDENTIFIER,
+  IFCLABEL: WebIFC.IFCLABEL,
+  IFCTEXT: WebIFC.IFCTEXT,
+  IFCREAL: WebIFC.IFCREAL,
+  IFCINTEGER: WebIFC.IFCINTEGER,
+  IFCLENGTHMEASURE: WebIFC.IFCLENGTHMEASURE,
+  IFCPOSITIVELENGTHMEASURE: WebIFC.IFCPOSITIVELENGTHMEASURE,
+  IFCAREAMEASURE: WebIFC.IFCAREAMEASURE,
+  IFCVOLUMEMEASURE: WebIFC.IFCVOLUMEMEASURE,
+  IFCRATIOMEASURE: WebIFC.IFCRATIOMEASURE,
+  IFCPOSITIVERATIOMEASURE: WebIFC.IFCPOSITIVERATIOMEASURE,
+  IFCPLANEANGLEMEASURE: WebIFC.IFCPLANEANGLEMEASURE,
+  IFCTHERMALTRANSMITTANCEMEASURE: WebIFC.IFCTHERMALTRANSMITTANCEMEASURE,
+};
+
+/** Looks up the standard IFC measure type for a Pset property name. */
+export function measureTypeFor(propertyName: string): PsetMeasureType | undefined {
+  return PSET_PROPERTY_TYPE_TABLE[propertyName];
+}
+
+/** Resolves a measure type to its web-ifc defined-type constant. */
+export function webIfcConstantFor(measureType: PsetMeasureType): number {
+  return WEBIFC_CONSTANT_BY_MEASURE[measureType];
+}
+
+/** Returns the standard Pset_*Common template for an element category. */
+export function templateFor(category: PsetCategory): PsetTemplate {
+  return PSET_TEMPLATES[category];
+}

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -21,8 +21,11 @@ import {
 import {
   writeRelAggregates,
   writeRelContainedInSpatialStructure,
-  writeRelAssociatesMaterial,
 } from '../ifc-writer/relWriter.js';
+import { writeMaterialLayerSet, writeMaterialSimple } from '../ifc-writer/materialWriter.js';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import { writeClassificationRefs } from '../ifc-writer/classificationWriter.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
 import {
   writeWallCommonPset,
   writeManufacturerPset,
@@ -45,11 +48,14 @@ import {
   writeDoorCommonPset,
   writeWindowCommonPset,
 } from '../ifc-writer/openingWriter.js';
+import { writeProxyGeometry, writeProxyEntity } from '../ifc-writer/proxyWriter.js';
 import { writeIfcType } from '../ifc-writer/typeWriter.js';
 import type { IfcTypeName } from '../ifc-writer/typeWriter.js';
+import { toIfcLengthM } from '../units/units.js';
+import { checkGeometryValidity } from '../validation/geometryValidity.js';
 import type { BimError } from '../errors/bimError.js';
 import { ifcError } from '../errors/bimError.js';
-import type { Result } from 'brepjs';
+import type { Result, ValidSolid } from 'brepjs';
 import { err, ok } from 'brepjs';
 import type { LocalId } from '../identity/localId.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
@@ -60,7 +66,7 @@ import type { BimRelationship } from '../types/relationships.js';
 import { checkReferentialIntegrity } from '../validation/referentialIntegrity.js';
 import { checkSchema } from '../validation/schemaCheck.js';
 import { checkRoundTrip } from '../validation/roundTrip.js';
-import { hasErrors, type ValidationReport } from '../validation/severity.js';
+import { hasErrors, type ValidationReport, type ValidationIssue } from '../validation/severity.js';
 
 export async function toIfc(
   model: BimModel,
@@ -85,6 +91,7 @@ export async function toIfc(
   const columns = model.getColumns();
   const doors = model.getDoors();
   const windows = model.getWindows();
+  const proxies = model.getProxies();
 
   const { ownerHistoryId, geomContextId, geomSubContextId, unitAssignmentId } = writeHeader(w, meta);
 
@@ -232,6 +239,24 @@ export async function toIfc(
     writeColumnBaseQuantities(w, ownerHistoryId, columnExpressId, column.spec);
   }
 
+  for (const [i, proxy] of proxies.entries()) {
+    const containingId = findContainerOf(proxy.localId, relationships);
+    const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
+    const { localPlacementId, productDefinitionShapeId } = writeProxyGeometry(
+      w, proxy.spec, geomSubContextId, storeyPlacementId
+    );
+    const proxyExpressId = writeProxyEntity(
+      w, proxy.guid, proxy.spec.name || `Proxy ${i + 1}`,
+      proxy.spec.predefinedType ?? 'NOTDEFINED',
+      ownerHistoryId, localPlacementId, productDefinitionShapeId
+    );
+    idMap.set(proxy.localId, proxyExpressId);
+    placementMap.set(proxy.localId, localPlacementId);
+    if (proxy.spec.customProperties !== undefined) {
+      writeCustomPsets(w, ownerHistoryId, proxyExpressId, proxy.spec.customProperties);
+    }
+  }
+
   const openingPlacementMap = new Map<LocalId, number>();
   const openingEntityMap = new Map<LocalId, number>();
 
@@ -289,7 +314,10 @@ export async function toIfc(
     const openingPlacementId = openingPlacementMap.get(fillsRel.openingLocalId);
     const openingEntityId = openingEntityMap.get(fillsRel.openingLocalId);
     if (openingPlacementId === undefined || openingEntityId === undefined) continue;
-    const doorExpressId = writeDoorEntity(w, door.guid, `Door ${i + 1}`, ownerHistoryId, openingPlacementId);
+    const doorExpressId = writeDoorEntity(
+      w, door.guid, `Door ${i + 1}`, ownerHistoryId, openingPlacementId, geomSubContextId,
+      toIfcLengthM(door.spec.width), toIfcLengthM(door.spec.height)
+    );
     idMap.set(door.localId, doorExpressId);
     writeRelFillsElement(w, fillsRel.guid, ownerHistoryId, openingEntityId, doorExpressId);
     writeDoorCommonPset(w, ownerHistoryId, doorExpressId, door.spec);
@@ -303,7 +331,10 @@ export async function toIfc(
     const openingPlacementId = openingPlacementMap.get(fillsRel.openingLocalId);
     const openingEntityId = openingEntityMap.get(fillsRel.openingLocalId);
     if (openingPlacementId === undefined || openingEntityId === undefined) continue;
-    const windowExpressId = writeWindowEntity(w, win.guid, `Window ${i + 1}`, ownerHistoryId, openingPlacementId);
+    const windowExpressId = writeWindowEntity(
+      w, win.guid, `Window ${i + 1}`, ownerHistoryId, openingPlacementId, geomSubContextId,
+      toIfcLengthM(win.spec.width), toIfcLengthM(win.spec.height)
+    );
     idMap.set(win.localId, windowExpressId);
     writeRelFillsElement(w, fillsRel.guid, ownerHistoryId, openingEntityId, windowExpressId);
     writeWindowCommonPset(w, ownerHistoryId, windowExpressId, win.spec);
@@ -331,22 +362,93 @@ export async function toIfc(
     );
   }
 
-  const byMaterial = new Map<string, { guid: IfcGuid; ids: number[] }>();
+  // Bare (single-name) material associations are deduplicated by material name so
+  // every element sharing a material points at one IfcMaterial. Layered material
+  // associations cannot be deduplicated by name (each carries its own layer
+  // build-up) so each is written individually as an IfcMaterialLayerSet.
+  const bySimpleMaterial = new Map<string, { guid: IfcGuid; ids: number[] }>();
+  interface LayeredAssociation {
+    readonly guid: IfcGuid;
+    readonly layerSetName: string;
+    readonly layers: readonly MaterialLayer[];
+    readonly ids: number[];
+    readonly direction: 'AXIS2' | 'AXIS3';
+  }
+  const layeredAssociations: LayeredAssociation[] = [];
+  const categoryById = new Map<LocalId, string>(elements.map((e) => [e.localId, e.category]));
+
   for (const rel of relationships) {
     if (rel.kind !== 'ASSOCIATES_MATERIAL') continue;
     const objectExpressIds = rel.relatedObjects
       .map((id) => idMap.get(id))
       .filter((id): id is number => id !== undefined);
-    const existing = byMaterial.get(rel.materialName);
+    if (objectExpressIds.length === 0) continue;
+
+    if (rel.materialLayers !== undefined && rel.materialLayers.length > 0) {
+      const firstObj = rel.relatedObjects[0];
+      const hostCat = firstObj !== undefined ? categoryById.get(firstObj) : undefined;
+      // Walls layer across their thickness (AXIS2); slabs/roofs/coverings layer
+      // vertically (AXIS3). The wrong sense misrenders the build-up in viewers.
+      const direction: 'AXIS2' | 'AXIS3' =
+        hostCat === 'SLAB' || hostCat === 'ROOF' || hostCat === 'COVERING' ? 'AXIS3' : 'AXIS2';
+      layeredAssociations.push({
+        guid: rel.guid,
+        layerSetName: rel.layerSetName ?? rel.materialName,
+        layers: rel.materialLayers,
+        ids: objectExpressIds,
+        direction,
+      });
+      continue;
+    }
+
+    const existing = bySimpleMaterial.get(rel.materialName);
     if (existing !== undefined) {
-      byMaterial.set(rel.materialName, { guid: existing.guid, ids: [...existing.ids, ...objectExpressIds] });
+      bySimpleMaterial.set(rel.materialName, {
+        guid: existing.guid,
+        ids: [...existing.ids, ...objectExpressIds],
+      });
     } else {
-      byMaterial.set(rel.materialName, { guid: rel.guid, ids: objectExpressIds });
+      bySimpleMaterial.set(rel.materialName, { guid: rel.guid, ids: objectExpressIds });
     }
   }
-  for (const [materialName, { guid, ids }] of byMaterial) {
+
+  for (const [materialName, { guid, ids }] of bySimpleMaterial) {
     if (ids.length === 0) continue;
-    writeRelAssociatesMaterial(w, guid, ownerHistoryId, materialName, ids);
+    writeMaterialSimple(w, guid, ownerHistoryId, materialName, ids);
+  }
+  for (const assoc of layeredAssociations) {
+    writeMaterialLayerSet(
+      w,
+      assoc.guid,
+      ownerHistoryId,
+      { kind: 'LAYER_SET', layerSetName: assoc.layerSetName, layers: assoc.layers },
+      assoc.ids,
+      assoc.direction
+    );
+  }
+
+  // Dedupe by system:code (not object identity) so two elements citing the same
+  // classification share one IfcClassificationReference instead of producing two
+  // entities with identical derived GlobalIds. Accumulate all referencing objects.
+  const classByKey = new Map<string, { ref: ClassificationRef; ids: number[] }>();
+  for (const rel of relationships) {
+    if (rel.kind !== 'ASSOCIATES_CLASSIFICATION') continue;
+    const objectExpressIds = rel.relatedObjects
+      .map((id) => idMap.get(id))
+      .filter((id): id is number => id !== undefined);
+    if (objectExpressIds.length === 0) continue;
+    const key = `${rel.ref.system}:${rel.ref.code}`;
+    const entry = classByKey.get(key);
+    if (entry === undefined) {
+      classByKey.set(key, { ref: rel.ref, ids: [...objectExpressIds] });
+    } else {
+      entry.ids.push(...objectExpressIds);
+    }
+  }
+  const byClassification = new Map<ClassificationRef, number[]>();
+  for (const { ref, ids } of classByKey.values()) byClassification.set(ref, ids);
+  if (byClassification.size > 0) {
+    writeClassificationRefs(w, ownerHistoryId, byClassification);
   }
 
   writeTypeLayer(w, ownerHistoryId, model, idMap);
@@ -448,15 +550,45 @@ export async function toIfcValidated(
   if (!bytesResult.ok) return bytesResult;
   const bytes = bytesResult.value;
 
+  const geometry = collectGeometryIssues(model);
   const schema = await checkSchema(bytes);
   const roundTrip = await checkRoundTrip(bytes);
 
   // Integrity warnings (e.g. orphaned openings) are carried through alongside the
-  // post-save diagnostics; integrity errors already short-circuited above.
+  // geometry-validity and post-save diagnostics; integrity errors already
+  // short-circuited above.
   const report: ValidationReport = {
-    issues: [...integrity.issues, ...schema.issues, ...roundTrip.issues],
+    issues: [
+      ...integrity.issues,
+      ...geometry.issues,
+      ...schema.issues,
+      ...roundTrip.issues,
+    ],
   };
   return ok({ bytes, report });
+}
+
+/**
+ * Runs the GEOMETRY-VALIDITY gate over every solid-bearing element (walls,
+ * slabs, beams, columns, proxies) and merges the per-element reports. Used by
+ * {@link toIfcValidated}; plain {@link toIfc} stays permissive and never runs it.
+ */
+function collectGeometryIssues(model: BimModel): ValidationReport {
+  const issues: ValidationIssue[] = [];
+  const groups: ReadonlyArray<readonly [string, ReadonlyArray<{ geometry: ValidSolid }>]> = [
+    ['Wall', model.getWalls()],
+    ['Slab', model.getSlabs()],
+    ['Beam', model.getBeams()],
+    ['Column', model.getColumns()],
+    ['Proxy', model.getProxies()],
+  ];
+  for (const [label, elements] of groups) {
+    elements.forEach((el, index) => {
+      const report = checkGeometryValidity(el.geometry, `${label} ${index + 1}`);
+      issues.push(...report.issues);
+    });
+  }
+  return { issues };
 }
 
 function findParentOf(childId: LocalId, relationships: readonly BimRelationship[]): LocalId | null {

--- a/packages/brepjs-bim/src/specs/beamSpec.ts
+++ b/packages/brepjs-bim/src/specs/beamSpec.ts
@@ -5,6 +5,9 @@ import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 import type { Profile } from './profile.js';
 import { ProfileSchema, parseProfile } from './profile.js';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
+import { MaterialLayerSchema, ClassificationRefSchema } from './materialSpec.js';
 
 export type BeamPredefinedType =
   | 'BEAM'
@@ -35,6 +38,17 @@ export interface BeamSpec {
   readonly fireRating?: string | undefined;
   readonly acousticRating?: string | undefined;
   readonly thermalTransmittance?: number | undefined;
+  readonly status?: string | undefined;
+
+  /**
+   * When present, the beam is associated via a layered IfcMaterialLayerSet built
+   * from these layers instead of the bare `materialName` IfcMaterial.
+   */
+  readonly materialLayers?: readonly MaterialLayer[] | undefined;
+  readonly layerSetName?: string | undefined;
+
+  /** When present, associates the beam with an external classification code. */
+  readonly classification?: ClassificationRef | undefined;
 
   readonly manufacturerName?: string | undefined;
   readonly manufacturerModel?: string | undefined;
@@ -67,6 +81,11 @@ const BeamSpecSchema = z.object({
   fireRating: z.string().optional(),
   acousticRating: z.string().optional(),
   thermalTransmittance: z.number().positive().optional(),
+  status: z.string().optional(),
+
+  materialLayers: z.array(MaterialLayerSchema).optional(),
+  layerSetName: z.string().optional(),
+  classification: ClassificationRefSchema.optional(),
 
   manufacturerName: z.string().optional(),
   manufacturerModel: z.string().optional(),

--- a/packages/brepjs-bim/src/specs/columnSpec.ts
+++ b/packages/brepjs-bim/src/specs/columnSpec.ts
@@ -5,6 +5,9 @@ import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 import type { Profile } from './profile.js';
 import { ProfileSchema, parseProfile } from './profile.js';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
+import { MaterialLayerSchema, ClassificationRefSchema } from './materialSpec.js';
 
 export type ColumnPredefinedType = 'COLUMN' | 'PILASTER' | 'NOTDEFINED';
 
@@ -25,6 +28,17 @@ export interface ColumnSpec {
   readonly fireRating?: string | undefined;
   readonly acousticRating?: string | undefined;
   readonly thermalTransmittance?: number | undefined;
+  readonly status?: string | undefined;
+
+  /**
+   * When present, the column is associated via a layered IfcMaterialLayerSet
+   * built from these layers instead of the bare `materialName` IfcMaterial.
+   */
+  readonly materialLayers?: readonly MaterialLayer[] | undefined;
+  readonly layerSetName?: string | undefined;
+
+  /** When present, associates the column with an external classification code. */
+  readonly classification?: ClassificationRef | undefined;
 
   readonly manufacturerName?: string | undefined;
   readonly manufacturerModel?: string | undefined;
@@ -54,6 +68,11 @@ const ColumnSpecSchema = z.object({
   fireRating: z.string().optional(),
   acousticRating: z.string().optional(),
   thermalTransmittance: z.number().positive().optional(),
+  status: z.string().optional(),
+
+  materialLayers: z.array(MaterialLayerSchema).optional(),
+  layerSetName: z.string().optional(),
+  classification: ClassificationRefSchema.optional(),
 
   manufacturerName: z.string().optional(),
   manufacturerModel: z.string().optional(),

--- a/packages/brepjs-bim/src/specs/materialSpec.ts
+++ b/packages/brepjs-bim/src/specs/materialSpec.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Shared Zod schemas for the optional material-layer and classification fields
+ * that element specs (wall/slab/beam/column) accept. Centralised here so every
+ * spec validates these fields identically.
+ */
+
+export const MaterialLayerSchema = z.object({
+  name: z.string().min(1),
+  thicknessMm: z.number().positive(),
+  isVentilated: z.boolean().optional(),
+  priority: z.number().int().optional(),
+});
+
+export const ClassificationRefSchema = z.object({
+  system: z.string().min(1),
+  edition: z.string().optional(),
+  location: z.string().optional(),
+  code: z.string().min(1),
+  description: z.string().optional(),
+});

--- a/packages/brepjs-bim/src/specs/proxySpec.ts
+++ b/packages/brepjs-bim/src/specs/proxySpec.ts
@@ -1,0 +1,23 @@
+import type { ValidSolid } from 'brepjs';
+
+/**
+ * Specification for an IfcBuildingElementProxy — arbitrary geometry that does
+ * not map to a typed element (wall/slab/beam/column). The solid is exported via
+ * the tessellation path (IfcTriangulatedFaceSet). All custom-property values are
+ * grouped by pset name. The solid is a brepjs ValidSolid handle, so this spec is
+ * not a plain serializable object and is validated structurally, not via Zod.
+ */
+export interface ProxySpec {
+  readonly name: string;
+  /**
+   * The proxy body. OWNERSHIP TRANSFERS to the BimModel on addProxy(): the model
+   * disposes this handle when it is disposed, so the caller MUST NOT dispose it
+   * itself (no `using`) — doing so double-frees the underlying WASM shape.
+   */
+  readonly solid: ValidSolid;
+  readonly materialName?: string | undefined;
+  readonly predefinedType?: 'COMPLEX' | 'ELEMENT' | 'NOTDEFINED' | 'PARTIAL' | undefined;
+  readonly customProperties?:
+    | Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>
+    | undefined;
+}

--- a/packages/brepjs-bim/src/specs/slabSpec.ts
+++ b/packages/brepjs-bim/src/specs/slabSpec.ts
@@ -3,6 +3,9 @@ import type { BimError } from '../errors/bimError.js';
 import { specError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
+import { MaterialLayerSchema, ClassificationRefSchema } from './materialSpec.js';
 
 export type SlabPredefinedType = 'FLOOR' | 'ROOF' | 'LANDING' | 'BASESLAB';
 
@@ -27,6 +30,17 @@ export interface SlabSpec {
   readonly loadBearing?: boolean | undefined;
   readonly combustible?: boolean | undefined;
   readonly compartmentation?: boolean | undefined;
+  readonly status?: string | undefined;
+
+  /**
+   * When present, the slab is associated via a layered IfcMaterialLayerSet built
+   * from these layers instead of the bare `materialName` IfcMaterial.
+   */
+  readonly materialLayers?: readonly MaterialLayer[] | undefined;
+  readonly layerSetName?: string | undefined;
+
+  /** When present, associates the slab with an external classification code. */
+  readonly classification?: ClassificationRef | undefined;
 
   readonly manufacturerName?: string | undefined;
   readonly manufacturerModel?: string | undefined;
@@ -59,6 +73,11 @@ const SlabSpecSchema = z.object({
   loadBearing: z.boolean().optional(),
   combustible: z.boolean().optional(),
   compartmentation: z.boolean().optional(),
+  status: z.string().optional(),
+
+  materialLayers: z.array(MaterialLayerSchema).optional(),
+  layerSetName: z.string().optional(),
+  classification: ClassificationRefSchema.optional(),
 
   manufacturerName: z.string().optional(),
   manufacturerModel: z.string().optional(),

--- a/packages/brepjs-bim/src/specs/wallSpec.ts
+++ b/packages/brepjs-bim/src/specs/wallSpec.ts
@@ -3,6 +3,9 @@ import type { BimError } from '../errors/bimError.js';
 import { specError } from '../errors/bimError.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
+import type { MaterialLayer } from '../types/materialTypes.js';
+import type { ClassificationRef } from '../types/classificationTypes.js';
+import { MaterialLayerSchema, ClassificationRefSchema } from './materialSpec.js';
 
 /** A straight wall aligned along an arbitrary axis in 3D. All dimensions in mm. */
 export interface WallSpec {
@@ -19,6 +22,17 @@ export interface WallSpec {
   readonly acousticRating?: string | undefined;
   readonly thermalTransmittance?: number | undefined;
   readonly loadBearing?: boolean | undefined;
+  readonly status?: string | undefined;
+
+  /**
+   * When present, the wall is associated via a layered IfcMaterialLayerSet built
+   * from these layers instead of the bare `materialName` IfcMaterial.
+   */
+  readonly materialLayers?: readonly MaterialLayer[] | undefined;
+  readonly layerSetName?: string | undefined;
+
+  /** When present, associates the wall with an external classification code. */
+  readonly classification?: ClassificationRef | undefined;
 
   readonly manufacturerName?: string | undefined;
   readonly manufacturerModel?: string | undefined;
@@ -48,6 +62,11 @@ const WallSpecSchema = z.object({
   acousticRating: z.string().optional(),
   thermalTransmittance: z.number().positive().optional(),
   loadBearing: z.boolean().optional(),
+  status: z.string().optional(),
+
+  materialLayers: z.array(MaterialLayerSchema).optional(),
+  layerSetName: z.string().optional(),
+  classification: ClassificationRefSchema.optional(),
 
   manufacturerName: z.string().optional(),
   manufacturerModel: z.string().optional(),

--- a/packages/brepjs-bim/src/types/bimTypes.ts
+++ b/packages/brepjs-bim/src/types/bimTypes.ts
@@ -6,6 +6,7 @@ import type { SlabSpec } from '../specs/slabSpec.js';
 import type { BeamSpec } from '../specs/beamSpec.js';
 import type { ColumnSpec } from '../specs/columnSpec.js';
 import type { DoorSpec, WindowSpec } from '../specs/openingSpec.js';
+import type { ProxySpec } from '../specs/proxySpec.js';
 import type {
   ProjectSpec,
   SiteSpec,
@@ -21,6 +22,7 @@ export type BimCategory =
   | 'OPENING'
   | 'DOOR'
   | 'WINDOW'
+  | 'PROXY'
   | 'PROJECT'
   | 'SITE'
   | 'BUILDING'
@@ -66,21 +68,24 @@ export type BimSpecFor<C extends BimCategory> = C extends 'WALL'
             ? DoorSpec
             : C extends 'WINDOW'
               ? WindowSpec
-              : C extends 'PROJECT'
-                ? ProjectSpec
-                : C extends 'SITE'
-                  ? SiteSpec
-                  : C extends 'BUILDING'
-                    ? BuildingSpec
-                    : C extends 'STOREY'
-                      ? StoreySpec
-                      : never;
+              : C extends 'PROXY'
+                ? ProxySpec
+                : C extends 'PROJECT'
+                  ? ProjectSpec
+                  : C extends 'SITE'
+                    ? SiteSpec
+                    : C extends 'BUILDING'
+                      ? BuildingSpec
+                      : C extends 'STOREY'
+                        ? StoreySpec
+                        : never;
 
 export type BimGeometryFor<C extends BimCategory> = C extends
   | 'WALL'
   | 'SLAB'
   | 'BEAM'
   | 'COLUMN'
+  | 'PROXY'
   ? ValidSolid
   : null;
 
@@ -100,6 +105,7 @@ export type AnyBimElement =
   | BimElement<'OPENING'>
   | BimElement<'DOOR'>
   | BimElement<'WINDOW'>
+  | BimElement<'PROXY'>
   | BimElement<'PROJECT'>
   | BimElement<'SITE'>
   | BimElement<'BUILDING'>

--- a/packages/brepjs-bim/src/types/classificationTypes.ts
+++ b/packages/brepjs-bim/src/types/classificationTypes.ts
@@ -1,0 +1,16 @@
+/**
+ * A reference into an external classification system (e.g. Uniclass 2015 or
+ * OmniClass). Pure data, no imports, so it is safe to import from any layer.
+ */
+export interface ClassificationRef {
+  /** Classification system name, e.g. 'Uniclass2015'. */
+  readonly system: string;
+  /** Edition of the system, e.g. '2015'. */
+  readonly edition?: string | undefined;
+  /** URL locating the system or table. */
+  readonly location?: string | undefined;
+  /** The classification code, e.g. 'Ss_15_10_30_14'. */
+  readonly code: string;
+  /** Human-readable label for the referenced code. */
+  readonly description?: string | undefined;
+}

--- a/packages/brepjs-bim/src/types/materialTypes.ts
+++ b/packages/brepjs-bim/src/types/materialTypes.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared material-association value types. Pure data, no imports, so they are
+ * safe to reference from both the type layer (relationships, specs) and the
+ * ifc-writer layer without risking a circular import.
+ */
+
+/** One physical layer in a layered material set (e.g. a wall build-up). */
+export interface MaterialLayer {
+  readonly name: string;
+  readonly thicknessMm: number;
+  readonly isVentilated?: boolean | undefined;
+  readonly priority?: number | undefined;
+}

--- a/packages/brepjs-bim/src/types/relationships.ts
+++ b/packages/brepjs-bim/src/types/relationships.ts
@@ -1,5 +1,7 @@
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { LocalId } from '../identity/localId.js';
+import type { MaterialLayer } from './materialTypes.js';
+import type { ClassificationRef } from './classificationTypes.js';
 
 export interface AggregatesRel {
   readonly kind: 'AGGREGATES';
@@ -22,6 +24,20 @@ export interface AssociatesMaterialRel {
   readonly guid: IfcGuid;
   readonly localId: LocalId;
   readonly materialName: string;
+  readonly relatedObjects: readonly LocalId[];
+  /**
+   * When present, the element is associated via an IfcMaterialLayerSet built from
+   * these layers instead of the bare `materialName` IfcMaterial.
+   */
+  readonly materialLayers?: readonly MaterialLayer[] | undefined;
+  readonly layerSetName?: string | undefined;
+}
+
+export interface AssociatesClassificationRel {
+  readonly kind: 'ASSOCIATES_CLASSIFICATION';
+  readonly guid: IfcGuid;
+  readonly localId: LocalId;
+  readonly ref: ClassificationRef;
   readonly relatedObjects: readonly LocalId[];
 }
 
@@ -53,6 +69,7 @@ export type BimRelationship =
   | AggregatesRel
   | ContainedInRel
   | AssociatesMaterialRel
+  | AssociatesClassificationRel
   | VoidsWallRel
   | VoidsSlabRel
   | FillsOpeningRel;

--- a/packages/brepjs-bim/src/validation/geometryValidity.ts
+++ b/packages/brepjs-bim/src/validation/geometryValidity.ts
@@ -1,0 +1,112 @@
+import { autoHeal, isValid, measureVolume, type ValidSolid } from 'brepjs';
+import {
+  appendIssues,
+  emptyReport,
+  issue,
+  type ValidationIssue,
+  type ValidationReport,
+} from './severity.js';
+
+/**
+ * Minimum solid volume (mm³) treated as physically meaningful. Real building
+ * elements are many orders of magnitude larger; degenerate solids produced by
+ * near-zero transforms or collapsed sweeps fall well below this and are
+ * reported as zero-volume errors.
+ */
+const MIN_VOLUME_MM3 = 1e-6;
+
+/**
+ * GEOMETRY-VALIDITY gate.
+ *
+ * Validates one or more brepjs ValidSolids for IFC export readiness:
+ *  - BRepCheck validity (isValid). Invalid topology that autoHeal cannot
+ *    repair is an error; geometry that only became valid after healing is a
+ *    warning (the exported solid differs from the authored one).
+ *  - Non-zero volume (measureVolume > MIN_VOLUME_MM3). Zero/negative volume
+ *    is an error — such a solid carries no usable geometry.
+ *
+ * The brand `ValidSolid` only asserts validity at construction time; transforms
+ * (scaling, boolean ops, sweeps) can still yield degenerate or invalid results,
+ * so the runtime checks here are not redundant with the type.
+ *
+ * `entity` is the human-readable identifier surfaced on each ValidationIssue.
+ * When validating a list it is appended with the element index.
+ */
+export function checkGeometryValidity(
+  solids: ValidSolid | readonly ValidSolid[],
+  entity?: string,
+): ValidationReport {
+  const list = Array.isArray(solids) ? (solids as readonly ValidSolid[]) : [solids as ValidSolid];
+
+  let report = emptyReport();
+  for (const [index, solid] of list.entries()) {
+    const label = labelFor(entity, index, list.length);
+    report = appendIssues(report, checkOne(solid, label));
+  }
+  return report;
+}
+
+function labelFor(entity: string | undefined, index: number, count: number): string | undefined {
+  if (entity === undefined) return undefined;
+  return count > 1 ? `${entity} [${index}]` : entity;
+}
+
+function checkOne(solid: ValidSolid, entity: string | undefined): readonly ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (!isValid(solid)) {
+    const heal = autoHeal(solid);
+    if (heal.ok && heal.value.report.isValid) {
+      issues.push(
+        issue(
+          'warning',
+          'HEALED_GEOMETRY',
+          'Solid was invalid but autoHeal repaired it; the exported geometry differs from the authored solid',
+          entity,
+          { steps: heal.value.report.steps },
+        ),
+      );
+      // Volume of the original invalid solid is meaningless; the healed solid is
+      // what would be exported. Skip the volume check rather than measure garbage.
+      return issues;
+    } else {
+      issues.push(
+        issue(
+          'error',
+          'INVALID_GEOMETRY',
+          'Solid fails BRepCheck validity and could not be auto-healed',
+          entity,
+        ),
+      );
+      // A solid that fails validity has no trustworthy volume; stop here.
+      return issues;
+    }
+  }
+
+  const volume = measureVolume(solid);
+  if (!volume.ok) {
+    issues.push(
+      issue(
+        'error',
+        'VOLUME_FAILED',
+        `Volume could not be measured: ${volume.error.message}`,
+        entity,
+      ),
+    );
+    return issues;
+  }
+
+  if (volume.value <= MIN_VOLUME_MM3) {
+    issues.push(
+      issue(
+        'error',
+        'ZERO_VOLUME',
+        `Solid has zero or negligible volume (${volume.value} mm³); it carries no usable geometry`,
+        entity,
+        { volumeMm3: volume.value },
+      ),
+    );
+  }
+
+  return issues;
+}

--- a/packages/brepjs-bim/tests/classificationWriter.test.ts
+++ b/packages/brepjs-bim/tests/classificationWriter.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import * as WebIFC from 'web-ifc';
+import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
+import { writeClassificationRefs } from '../src/ifc-writer/classificationWriter.js';
+import type { ClassificationRef } from '../src/types/classificationTypes.js';
+import { newIfcGuid } from '../src/identity/ifcGuid.js';
+
+async function makeWriter(): Promise<IfcWriter> {
+  const result = await IfcWriter.create();
+  if (!result.ok) throw new Error(result.error.message);
+  return result.value;
+}
+
+function writeOwnerHistory(w: IfcWriter): number {
+  const personId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCPERSON,
+    Identification: null,
+    FamilyName: null,
+    GivenName: null,
+    MiddleNames: null,
+    PrefixTitles: null,
+    SuffixTitles: null,
+    Roles: null,
+    Addresses: null,
+  });
+  const orgId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCORGANIZATION,
+    Identification: null,
+    Name: w.mkType(WebIFC.IFCLABEL, 'brepjs-bim'),
+    Description: null,
+    Roles: null,
+    Addresses: null,
+  });
+  const personAndOrgId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCPERSONANDORGANIZATION,
+    ThePerson: w.ref(personId),
+    TheOrganization: w.ref(orgId),
+    Roles: null,
+  });
+  const appId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCAPPLICATION,
+    ApplicationDeveloper: w.ref(orgId),
+    Version: w.mkType(WebIFC.IFCLABEL, '0'),
+    ApplicationFullName: w.mkType(WebIFC.IFCLABEL, 'brepjs-bim-test'),
+    ApplicationIdentifier: w.mkType(WebIFC.IFCIDENTIFIER, 'brepjs-bim-test'),
+  });
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCOWNERHISTORY,
+    OwningUser: w.ref(personAndOrgId),
+    OwningApplication: w.ref(appId),
+    State: null,
+    ChangeAction: { type: 3, value: 'NOCHANGE' },
+    LastModifiedDate: null,
+    LastModifyingUser: null,
+    LastModifyingApplication: null,
+    CreationDate: w.mkType(WebIFC.IFCTIMESTAMP, 0),
+  });
+}
+
+function writeWall(w: IfcWriter, ownerHistoryId: number): number {
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCWALL,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, 'Wall'),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: null,
+    Representation: null,
+    Tag: null,
+    PredefinedType: null,
+  });
+}
+
+async function openSaved(w: IfcWriter): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+  const saved = w.save();
+  if (!saved.ok) throw new Error(saved.error.message);
+  const api = new WebIFC.IfcAPI();
+  await api.Init();
+  const mid = api.OpenModel(saved.value);
+  return { api, mid };
+}
+
+describe('classificationWriter', () => {
+  it('serializes an IfcClassificationReference with code and links the element via IfcRelAssociatesClassification', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wall = writeWall(w, oh);
+
+    const ref: ClassificationRef = {
+      system: 'Uniclass2015',
+      edition: '2015',
+      location: 'https://uniclass.thenbs.com/',
+      code: 'Ss_15_10_30_14',
+      description: 'Concrete wall systems',
+    };
+    const refs = new Map<ClassificationRef, readonly number[]>([[ref, [wall]]]);
+
+    writeClassificationRefs(w, oh, refs);
+
+    const { api, mid } = await openSaved(w);
+
+    // One classification system entity.
+    const classifications = api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATION);
+    expect(classifications.size()).toBe(1);
+    const classification = api.GetLine(mid, classifications.get(0)) as Record<string, unknown>;
+    expect((classification['Name'] as { value?: string } | undefined)?.value).toBe('Uniclass2015');
+
+    // One classification reference, carrying the code in Identification.
+    const refIds = api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATIONREFERENCE);
+    expect(refIds.size()).toBe(1);
+    const classRef = api.GetLine(mid, refIds.get(0)) as Record<string, unknown>;
+    expect((classRef['Identification'] as { value?: string } | undefined)?.value).toBe(
+      'Ss_15_10_30_14'
+    );
+    const referencedSource = (classRef['ReferencedSource'] as { value?: number } | undefined)
+      ?.value;
+    expect(referencedSource).toBe(classifications.get(0));
+
+    // The association rel points at the wall and at the reference.
+    const relIds = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESCLASSIFICATION);
+    expect(relIds.size()).toBe(1);
+    const rel = api.GetLine(mid, relIds.get(0)) as Record<string, unknown>;
+    const related = (rel['RelatedObjects'] ?? []) as Array<{ value: number }>;
+    expect(related.map((r) => r.value)).toContain(wall);
+    const relatingClassification = (
+      rel['RelatingClassification'] as { value?: number } | undefined
+    )?.value;
+    expect(relatingClassification).toBe(refIds.get(0));
+
+    // The rel carries a valid 22-char deterministic GlobalId.
+    const relGuid = (rel['GlobalId'] as { value?: string } | undefined)?.value;
+    expect(typeof relGuid).toBe('string');
+    expect((relGuid as string).length).toBe(22);
+
+    api.CloseModel(mid);
+  });
+
+  it('deduplicates IfcClassification by system across multiple references', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wallA = writeWall(w, oh);
+    const wallB = writeWall(w, oh);
+
+    const refA: ClassificationRef = { system: 'Uniclass2015', code: 'Ss_15_10_30_14' };
+    const refB: ClassificationRef = { system: 'Uniclass2015', code: 'Ss_20_05_15' };
+    const refs = new Map<ClassificationRef, readonly number[]>([
+      [refA, [wallA]],
+      [refB, [wallB]],
+    ]);
+
+    writeClassificationRefs(w, oh, refs);
+
+    const { api, mid } = await openSaved(w);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATION).size()).toBe(1);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATIONREFERENCE).size()).toBe(2);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESCLASSIFICATION).size()).toBe(2);
+    api.CloseModel(mid);
+  });
+
+  it('produces deterministic rel GlobalIds across two writes of the same refs', async () => {
+    const ref: ClassificationRef = { system: 'OmniClass', code: '23-13 11 11' };
+
+    const guidsFor = async (): Promise<string[]> => {
+      const w = await makeWriter();
+      const oh = writeOwnerHistory(w);
+      const wall = writeWall(w, oh);
+      writeClassificationRefs(
+        w,
+        oh,
+        new Map<ClassificationRef, readonly number[]>([[ref, [wall]]])
+      );
+      const { api, mid } = await openSaved(w);
+      const relIds = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESCLASSIFICATION);
+      const rel = api.GetLine(mid, relIds.get(0)) as Record<string, unknown>;
+      const guid = (rel['GlobalId'] as { value?: string } | undefined)?.value ?? '';
+      api.CloseModel(mid);
+      return [guid];
+    };
+
+    expect(await guidsFor()).toEqual(await guidsFor());
+  });
+});

--- a/packages/brepjs-bim/tests/geometryValidity.test.ts
+++ b/packages/brepjs-bim/tests/geometryValidity.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { box, scale } from 'brepjs';
+import { initOCCT } from '../../../tests/setup.js';
+import { checkGeometryValidity } from '../src/validation/geometryValidity.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+describe('checkGeometryValidity', () => {
+  it('passes a valid box with no error issues', () => {
+    const solid = box(1000, 500, 300);
+    const report = checkGeometryValidity(solid, 'Box 1');
+    const errors = report.issues.filter((i) => i.severity === 'error');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a list of valid solids', () => {
+    const a = box(1000, 500, 300);
+    const b = box(200, 200, 200);
+    const report = checkGeometryValidity([a, b]);
+    const errors = report.issues.filter((i) => i.severity === 'error');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('reports a ZERO_VOLUME error for a degenerate near-zero-volume solid', () => {
+    // Uniformly scaling a valid box by a tiny factor keeps the topology valid
+    // (isValid passes) while collapsing the volume to ~1e-13 mm³ — a degenerate
+    // solid that carries no usable geometry for IFC export.
+    const degenerate = scale(box(1000, 500, 300), 1e-7);
+    const report = checkGeometryValidity(degenerate, 'Flat 1');
+    const errors = report.issues.filter((i) => i.severity === 'error');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((i) => i.code === 'ZERO_VOLUME')).toBe(true);
+  });
+
+  it('attaches the supplied entity label to issues', () => {
+    const degenerate = scale(box(1000, 500, 300), 1e-7);
+    const report = checkGeometryValidity(degenerate, 'My Element');
+    const errors = report.issues.filter((i) => i.severity === 'error');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.every((i) => i.entity === 'My Element')).toBe(true);
+  });
+
+  it('indexes labels when validating a list of more than one solid', () => {
+    const good = box(1000, 500, 300);
+    const degenerate = scale(box(1000, 500, 300), 1e-7);
+    const report = checkGeometryValidity([good, degenerate], 'Wall');
+    const errors = report.issues.filter((i) => i.severity === 'error');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.every((i) => i.entity === 'Wall [1]')).toBe(true);
+  });
+});

--- a/packages/brepjs-bim/tests/materialWriter.test.ts
+++ b/packages/brepjs-bim/tests/materialWriter.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import * as WebIFC from 'web-ifc';
+import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
+import {
+  writeMaterialLayerSet,
+  writeMaterialSimple,
+  type MaterialLayerSetSpec,
+} from '../src/ifc-writer/materialWriter.js';
+import { deriveIfcGuid } from '../src/identity/guidDerivation.js';
+import { newIfcGuid } from '../src/identity/ifcGuid.js';
+
+async function makeWriter(): Promise<IfcWriter> {
+  const result = await IfcWriter.create();
+  if (!result.ok) throw new Error(result.error.message);
+  return result.value;
+}
+
+// Minimal owner history + element occurrences so the association rel has valid refs.
+function writeOwnerHistory(w: IfcWriter): number {
+  const personId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCPERSON,
+    Identification: null,
+    FamilyName: null,
+    GivenName: null,
+    MiddleNames: null,
+    PrefixTitles: null,
+    SuffixTitles: null,
+    Roles: null,
+    Addresses: null,
+  });
+  const orgId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCORGANIZATION,
+    Identification: null,
+    Name: w.mkType(WebIFC.IFCLABEL, 'brepjs-bim'),
+    Description: null,
+    Roles: null,
+    Addresses: null,
+  });
+  const personAndOrgId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCPERSONANDORGANIZATION,
+    ThePerson: w.ref(personId),
+    TheOrganization: w.ref(orgId),
+    Roles: null,
+  });
+  const appId = w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCAPPLICATION,
+    ApplicationDeveloper: w.ref(orgId),
+    Version: w.mkType(WebIFC.IFCLABEL, '0'),
+    ApplicationFullName: w.mkType(WebIFC.IFCLABEL, 'brepjs-bim-test'),
+    ApplicationIdentifier: w.mkType(WebIFC.IFCIDENTIFIER, 'brepjs-bim-test'),
+  });
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCOWNERHISTORY,
+    OwningUser: w.ref(personAndOrgId),
+    OwningApplication: w.ref(appId),
+    State: null,
+    ChangeAction: { type: 3, value: 'NOCHANGE' },
+    LastModifiedDate: null,
+    LastModifyingUser: null,
+    LastModifyingApplication: null,
+    CreationDate: w.mkType(WebIFC.IFCTIMESTAMP, 0),
+  });
+}
+
+function writeWall(w: IfcWriter, ownerHistoryId: number): number {
+  return w.writeLine({
+    expressID: w.nextId(),
+    type: WebIFC.IFCWALL,
+    GlobalId: w.mkType(WebIFC.IFCGLOBALLYUNIQUEID, newIfcGuid()),
+    OwnerHistory: w.ref(ownerHistoryId),
+    Name: w.mkType(WebIFC.IFCLABEL, 'Wall'),
+    Description: null,
+    ObjectType: null,
+    ObjectPlacement: null,
+    Representation: null,
+    Tag: null,
+    PredefinedType: null,
+  });
+}
+
+async function openSaved(w: IfcWriter): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+  const saved = w.save();
+  if (!saved.ok) throw new Error(saved.error.message);
+  const api = new WebIFC.IfcAPI();
+  await api.Init();
+  const mid = api.OpenModel(saved.value);
+  return { api, mid };
+}
+
+const LAYERED_WALL: MaterialLayerSetSpec = {
+  kind: 'LAYER_SET',
+  layerSetName: 'Exterior Wall - 250mm',
+  layers: [
+    { name: 'Brick', thicknessMm: 100 },
+    { name: 'Air Gap', thicknessMm: 25, isVentilated: true },
+    { name: 'Insulation', thicknessMm: 50, priority: 1 },
+    { name: 'Concrete Block', thicknessMm: 75 },
+  ],
+  offsetFromReferenceLine: 0,
+};
+
+describe('materialWriter', () => {
+  it('serializes a layered wall material set without throwing', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wall = writeWall(w, oh);
+    const guid = await deriveIfcGuid('rel-material:layered-wall');
+
+    const relId = writeMaterialLayerSet(w, guid, oh, LAYERED_WALL, [wall]);
+    expect(relId).toBeGreaterThan(0);
+
+    const { api, mid } = await openSaved(w);
+
+    const layerSetIds = api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYERSET);
+    expect(layerSetIds.size()).toBe(1);
+
+    const layerIds = api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYER);
+    expect(layerIds.size()).toBe(LAYERED_WALL.layers.length);
+
+    const usageIds = api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYERSETUSAGE);
+    expect(usageIds.size()).toBe(1);
+
+    api.CloseModel(mid);
+  });
+
+  it('layer set carries the layer names and thicknesses', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wall = writeWall(w, oh);
+    const guid = await deriveIfcGuid('rel-material:layered-wall-2');
+
+    writeMaterialLayerSet(w, guid, oh, LAYERED_WALL, [wall]);
+
+    const { api, mid } = await openSaved(w);
+    const layerIds = api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYER);
+    const thicknesses: number[] = [];
+    for (let i = 0; i < layerIds.size(); i++) {
+      const layer = api.GetLine(mid, layerIds.get(i)) as Record<string, unknown>;
+      const t = (layer['LayerThickness'] as { value?: number } | undefined)?.value;
+      if (typeof t === 'number') thicknesses.push(t);
+    }
+    // Thicknesses are emitted in metres (mm / 1000).
+    expect(thicknesses).toContain(0.1);
+    expect(thicknesses).toContain(0.05);
+    api.CloseModel(mid);
+  });
+
+  it('association rel references the related element(s)', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wallA = writeWall(w, oh);
+    const wallB = writeWall(w, oh);
+    const guid = await deriveIfcGuid('rel-material:layered-wall-multi');
+
+    writeMaterialLayerSet(w, guid, oh, LAYERED_WALL, [wallA, wallB]);
+
+    const { api, mid } = await openSaved(w);
+    const relIds = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESMATERIAL);
+    expect(relIds.size()).toBe(1);
+
+    const rel = api.GetLine(mid, relIds.get(0)) as Record<string, unknown>;
+    const related = (rel['RelatedObjects'] ?? []) as Array<{ value: number }>;
+    const relatedIds = related.map((r) => r.value);
+    expect(relatedIds).toContain(wallA);
+    expect(relatedIds).toContain(wallB);
+
+    // The rel must point its RelatingMaterial at the IfcMaterialLayerSetUsage.
+    const usageIds = api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYERSETUSAGE);
+    const relatingMaterial = (rel['RelatingMaterial'] as { value?: number } | undefined)?.value;
+    expect(relatingMaterial).toBe(usageIds.get(0));
+
+    // GUID is the deterministic one we passed in.
+    const relGuid = (rel['GlobalId'] as { value?: string } | undefined)?.value;
+    expect(relGuid).toBe(guid);
+    api.CloseModel(mid);
+  });
+
+  it('empty layer list writes nothing and returns 0', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wall = writeWall(w, oh);
+    const guid = await deriveIfcGuid('rel-material:empty');
+
+    const relId = writeMaterialLayerSet(
+      w,
+      guid,
+      oh,
+      { kind: 'LAYER_SET', layerSetName: 'Empty', layers: [] },
+      [wall]
+    );
+    expect(relId).toBe(0);
+
+    const { api, mid } = await openSaved(w);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYERSET).size()).toBe(0);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESMATERIAL).size()).toBe(0);
+    api.CloseModel(mid);
+  });
+
+  it('writeMaterialSimple emits a bare IfcMaterial and association rel', async () => {
+    const w = await makeWriter();
+    const oh = writeOwnerHistory(w);
+    const wall = writeWall(w, oh);
+    const guid = await deriveIfcGuid('rel-material:simple');
+
+    writeMaterialSimple(w, guid, oh, 'Concrete', [wall]);
+
+    const { api, mid } = await openSaved(w);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCMATERIAL).size()).toBe(1);
+    const relIds = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESMATERIAL);
+    expect(relIds.size()).toBe(1);
+
+    const rel = api.GetLine(mid, relIds.get(0)) as Record<string, unknown>;
+    const related = (rel['RelatedObjects'] ?? []) as Array<{ value: number }>;
+    expect(related.map((r) => r.value)).toContain(wall);
+    api.CloseModel(mid);
+  });
+});

--- a/packages/brepjs-bim/tests/phase2Data.test.ts
+++ b/packages/brepjs-bim/tests/phase2Data.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import * as WebIFC from 'web-ifc';
+import { BimModel } from '../src/model/bimModel.js';
+import { toIfc } from '../src/serialize/toIfc.js';
+
+beforeAll(async () => { await initOCCT(); }, 30000);
+
+const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
+
+function spatialModel(): { model: BimModel; storeyId: number } {
+  const model = new BimModel();
+  const initResult = model.init({ name: 'Phase2 Data' });
+  if (!initResult.ok) throw new Error(initResult.error.message);
+  const projectId = initResult.value;
+  const siteId = model.addSite({ name: 'Site' });
+  const buildingId = model.addBuilding({ name: 'Building' });
+  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  model.aggregate(projectId, siteId);
+  model.aggregate(siteId, buildingId);
+  model.aggregate(buildingId, storeyId);
+  return { model, storeyId };
+}
+
+async function openModel(bytes: Uint8Array): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+  const api = new WebIFC.IfcAPI();
+  await api.Init();
+  const mid = api.OpenModel(bytes);
+  return { api, mid };
+}
+
+// A round-tripped NominalValue wrapper carries the schema type name (e.g.
+// 'IFCBOOLEAN', 'IFCTHERMALTRANSMITTANCEMEASURE') that the measure type was
+// minted with. The numeric `type` field is only a coarse kind code (string/
+// real/enum) that cannot distinguish IFCREAL from IFCTHERMALTRANSMITTANCEMEASURE.
+function measureName(value: Record<string, unknown> | undefined): string | undefined {
+  return (value as { name?: string } | undefined)?.name;
+}
+
+describe('Phase 2 data integration', () => {
+  it('emits Pset_WallCommon properties with correct (non-IFCREAL) measure types', async () => {
+    const { model, storeyId } = spatialModel();
+    const wall = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+      isExternal: true,
+      fireRating: 'REI120',
+      thermalTransmittance: 0.35,
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+    model.placeIn(wall.value, storeyId);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const { api, mid } = await openModel(result.value);
+
+    const propIds = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYSINGLEVALUE);
+    const byName = new Map<string, string | undefined>();
+    for (let i = 0; i < propIds.size(); i++) {
+      const prop = api.GetLine(mid, propIds.get(i)) as Record<string, unknown>;
+      const name = (prop['Name'] as { value?: string } | undefined)?.value;
+      if (name === undefined) continue;
+      byName.set(name, measureName(prop['NominalValue'] as Record<string, unknown> | undefined));
+    }
+
+    expect(byName.get('IsExternal')).toBe('IFCBOOLEAN');
+    expect(byName.get('FireRating')).toBe('IFCLABEL');
+    expect(byName.get('ThermalTransmittance')).toBe('IFCTHERMALTRANSMITTANCEMEASURE');
+    // The legacy heuristic would have typed ThermalTransmittance as IFCREAL.
+    expect(byName.get('ThermalTransmittance')).not.toBe('IFCREAL');
+    api.CloseModel(mid);
+  });
+
+  it('emits the Status property as an IfcPropertyEnumeratedValue', async () => {
+    const { model, storeyId } = spatialModel();
+    const wall = model.addWall({
+      length: 4000, height: 2700, thickness: 200,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+      status: 'EXISTING',
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+    model.placeIn(wall.value, storeyId);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const { api, mid } = await openModel(result.value);
+
+    const enumIds = api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYENUMERATEDVALUE);
+    expect(enumIds.size()).toBe(1);
+    const enumProp = api.GetLine(mid, enumIds.get(0)) as Record<string, unknown>;
+    expect((enumProp['Name'] as { value?: string } | undefined)?.value).toBe('Status');
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCPROPERTYENUMERATION).size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('associates a layered material via IfcRelAssociatesMaterial + IfcMaterialLayerSet', async () => {
+    const { model, storeyId } = spatialModel();
+    const wall = model.addWall({
+      length: 5000, height: 3000, thickness: 300,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Wall Buildup',
+      layerSetName: 'Cavity Wall',
+      materialLayers: [
+        { name: 'Brick', thicknessMm: 100 },
+        { name: 'Insulation', thicknessMm: 100, isVentilated: false },
+        { name: 'Blockwork', thicknessMm: 100 },
+      ],
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+    model.placeIn(wall.value, storeyId);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const { api, mid } = await openModel(result.value);
+
+    const layerSets = api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYERSET);
+    expect(layerSets.size()).toBe(1);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYER).size()).toBe(3);
+
+    const rels = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESMATERIAL);
+    expect(rels.size()).toBe(1);
+    const wallId = api.GetLineIDsWithType(mid, WebIFC.IFCWALL).get(0);
+    const rel = api.GetLine(mid, rels.get(0)) as Record<string, unknown>;
+    const related = (rel['RelatedObjects'] as Array<{ value?: number }> | undefined) ?? [];
+    expect(related.map((r) => r.value)).toContain(wallId);
+    api.CloseModel(mid);
+  });
+
+  it('associates a classification reference via IfcRelAssociatesClassification', async () => {
+    const { model, storeyId } = spatialModel();
+    const wall = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+      classification: {
+        system: 'Uniclass2015',
+        edition: '2015',
+        code: 'Ss_25_10_30',
+        description: 'Framed walls',
+      },
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+    model.placeIn(wall.value, storeyId);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const { api, mid } = await openModel(result.value);
+
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATION).size()).toBe(1);
+    const refIds = api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATIONREFERENCE);
+    expect(refIds.size()).toBe(1);
+    const refLine = api.GetLine(mid, refIds.get(0)) as Record<string, unknown>;
+    expect((refLine['Identification'] as { value?: string } | undefined)?.value).toBe('Ss_25_10_30');
+
+    const rels = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESCLASSIFICATION);
+    expect(rels.size()).toBe(1);
+    const wallId = api.GetLineIDsWithType(mid, WebIFC.IFCWALL).get(0);
+    const rel = api.GetLine(mid, rels.get(0)) as Record<string, unknown>;
+    const related = (rel['RelatedObjects'] as Array<{ value?: number }> | undefined) ?? [];
+    expect(related.map((r) => r.value)).toContain(wallId);
+    api.CloseModel(mid);
+  });
+
+  it('addClassification associates an existing element after the fact', async () => {
+    const { model, storeyId } = spatialModel();
+    const wall = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+    model.placeIn(wall.value, storeyId);
+    model.addClassification({ system: 'OmniClass', code: '21-02 10 10' }, [wall.value]);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const { api, mid } = await openModel(result.value);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESCLASSIFICATION).size()).toBe(1);
+    api.CloseModel(mid);
+  });
+
+  it('keeps the bare-material path for walls without layers (backward compat)', async () => {
+    const { model, storeyId } = spatialModel();
+    const wall = model.addWall({
+      length: 5000, height: 3000, thickness: 250,
+      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+    model.placeIn(wall.value, storeyId);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const { api, mid } = await openModel(result.value);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCMATERIALLAYERSET).size()).toBe(0);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCMATERIAL).size()).toBe(1);
+    expect(api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESMATERIAL).size()).toBe(1);
+    api.CloseModel(mid);
+  });
+});

--- a/packages/brepjs-bim/tests/phase2Geometry.test.ts
+++ b/packages/brepjs-bim/tests/phase2Geometry.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as WebIFC from 'web-ifc';
+import { box, scale } from 'brepjs';
+import { initOCCT } from '../../../tests/setup.js';
+import { BimModel } from '../src/model/bimModel.js';
+import { toIfc, toIfcValidated } from '../src/serialize/toIfc.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
+
+// Builds a spatially-complete model (project→site→building→storey) with a wall
+// that hosts a door and a window. Returns the model and the storey id so callers
+// can place additional elements.
+function buildModelWithOpenings(): { model: BimModel; storeyId: number } {
+  const model = new BimModel();
+  const initResult = model.init({ name: 'Phase2 Project' });
+  if (!initResult.ok) throw new Error(initResult.error.message);
+  const projectId = initResult.value;
+  const siteId = model.addSite({ name: 'Site' });
+  const buildingId = model.addBuilding({ name: 'Building' });
+  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  model.aggregate(projectId, siteId);
+  model.aggregate(siteId, buildingId);
+  model.aggregate(buildingId, storeyId);
+
+  const wall = model.addWall({
+    length: 5000,
+    height: 3000,
+    thickness: 250,
+    origin: [0, 0, 0],
+    axisX: [1, 0, 0],
+    axisZ: [0, 0, 1],
+    materialName: 'Concrete',
+  });
+  if (!wall.ok) throw new Error(wall.error.message);
+  model.placeIn(wall.value, storeyId);
+
+  const door = model.addDoor({
+    width: 900,
+    height: 2100,
+    offsetAlongWall: 500,
+    offsetFromFloor: 0,
+    wallLocalId: wall.value,
+    materialName: 'Wood',
+  });
+  if (!door.ok) throw new Error(door.error.message);
+  model.placeIn(door.value, storeyId);
+
+  const win = model.addWindow({
+    width: 1200,
+    height: 1000,
+    offsetAlongWall: 2500,
+    offsetFromFloor: 900,
+    wallLocalId: wall.value,
+    materialName: 'Aluminium',
+  });
+  if (!win.ok) throw new Error(win.error.message);
+  model.placeIn(win.value, storeyId);
+
+  return { model, storeyId };
+}
+
+async function open(bytes: Uint8Array): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+  const api = new WebIFC.IfcAPI();
+  await api.Init();
+  const mid = api.OpenModel(bytes);
+  return { api, mid };
+}
+
+function asValue(v: unknown): number | undefined {
+  if (typeof v === 'number') return v;
+  if (v !== null && typeof v === 'object' && 'value' in v) {
+    return (v as { value?: number }).value;
+  }
+  return undefined;
+}
+
+describe('Phase 2 door/window geometry', () => {
+  it('emits a non-null door Representation with OverallHeight and OverallWidth', async () => {
+    const { model } = buildModelWithOpenings();
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+
+    const { api, mid } = await open(result.value);
+    const doorIds = api.GetLineIDsWithType(mid, WebIFC.IFCDOOR);
+    expect(doorIds.size()).toBe(1);
+    const door = api.GetLine(mid, doorIds.get(0)) as Record<string, unknown>;
+    expect(door['Representation']).not.toBeNull();
+    // 2100mm height / 900mm width → 2.1m / 0.9m.
+    expect(asValue(door['OverallHeight'])).toBeCloseTo(2.1, 5);
+    expect(asValue(door['OverallWidth'])).toBeCloseTo(0.9, 5);
+    api.CloseModel(mid);
+  });
+
+  it('emits a non-null window Representation with OverallHeight and OverallWidth', async () => {
+    const { model } = buildModelWithOpenings();
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+
+    const { api, mid } = await open(result.value);
+    const winIds = api.GetLineIDsWithType(mid, WebIFC.IFCWINDOW);
+    expect(winIds.size()).toBe(1);
+    const win = api.GetLine(mid, winIds.get(0)) as Record<string, unknown>;
+    expect(win['Representation']).not.toBeNull();
+    expect(asValue(win['OverallHeight'])).toBeCloseTo(1.0, 5);
+    expect(asValue(win['OverallWidth'])).toBeCloseTo(1.2, 5);
+    api.CloseModel(mid);
+  });
+
+  it('emits an Axis representation for walls alongside the SweptSolid Body', async () => {
+    const { model } = buildModelWithOpenings();
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+
+    const { api, mid } = await open(result.value);
+    const repIds = api.GetLineIDsWithType(mid, WebIFC.IFCSHAPEREPRESENTATION);
+    let foundAxis = false;
+    for (let i = 0; i < repIds.size(); i++) {
+      const rep = api.GetLine(mid, repIds.get(i)) as Record<string, unknown>;
+      const id = (rep['RepresentationIdentifier'] as { value?: string } | undefined)?.value;
+      if (id === 'Axis') foundAxis = true;
+    }
+    expect(foundAxis).toBe(true);
+    api.CloseModel(mid);
+  });
+});
+
+describe('Phase 2 proxy geometry', () => {
+  it('writes an IfcBuildingElementProxy with a tessellated body that round-trips', async () => {
+    const { model } = buildModelWithOpenings();
+    const proxy = model.addProxy({ name: 'Custom Block', solid: box(800, 600, 400) });
+    if (!proxy.ok) throw new Error(proxy.error.message);
+
+    const result = await toIfc(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+
+    const { api, mid } = await open(result.value);
+    const proxyIds = api.GetLineIDsWithType(mid, WebIFC.IFCBUILDINGELEMENTPROXY);
+    expect(proxyIds.size()).toBe(1);
+    const proxyLine = api.GetLine(mid, proxyIds.get(0)) as Record<string, unknown>;
+    expect(proxyLine['Representation']).not.toBeNull();
+
+    const faceSetIds = api.GetLineIDsWithType(mid, WebIFC.IFCTRIANGULATEDFACESET);
+    expect(faceSetIds.size()).toBe(1);
+    api.CloseModel(mid);
+  });
+});
+
+describe('Phase 2 geometry-validity gate', () => {
+  it('toIfcValidated flags a proxy built from a degenerate solid as ZERO_VOLUME', async () => {
+    const { model } = buildModelWithOpenings();
+    // Uniform near-zero scale keeps topology valid but collapses the volume.
+    const degenerate = scale(box(1000, 500, 300), 1e-7);
+    const proxy = model.addProxy({ name: 'Degenerate', solid: degenerate });
+    if (!proxy.ok) throw new Error(proxy.error.message);
+
+    const result = await toIfcValidated(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const zeroVolume = result.value.report.issues.filter((i) => i.code === 'ZERO_VOLUME');
+    expect(zeroVolume.length).toBeGreaterThan(0);
+    expect(zeroVolume.some((i) => i.severity === 'error')).toBe(true);
+  });
+
+  it('toIfcValidated reports no geometry errors for an all-valid model', async () => {
+    const { model } = buildModelWithOpenings();
+    const proxy = model.addProxy({ name: 'Valid Block', solid: box(800, 600, 400) });
+    if (!proxy.ok) throw new Error(proxy.error.message);
+
+    const result = await toIfcValidated(model, META);
+    if (!result.ok) throw new Error(result.error.message);
+    const geomErrors = result.value.report.issues.filter(
+      (i) =>
+        i.severity === 'error' &&
+        (i.code === 'ZERO_VOLUME' || i.code === 'INVALID_GEOMETRY' || i.code === 'VOLUME_FAILED')
+    );
+    expect(geomErrors).toHaveLength(0);
+  });
+});

--- a/packages/brepjs-bim/tests/psetTemplates.test.ts
+++ b/packages/brepjs-bim/tests/psetTemplates.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import * as WebIFC from 'web-ifc';
+import {
+  PSET_PROPERTY_TYPE_TABLE,
+  PSET_TEMPLATES,
+  measureTypeFor,
+  webIfcConstantFor,
+  templateFor,
+  type PsetMeasureType,
+  type PsetCategory,
+} from '../src/psets/psetTemplates.js';
+
+const ALL_CATEGORIES: readonly PsetCategory[] = [
+  'WALL',
+  'SLAB',
+  'BEAM',
+  'COLUMN',
+  'DOOR',
+  'WINDOW',
+];
+
+describe('psetTemplates — measure type table', () => {
+  it('maps boolean-valued properties to IFCBOOLEAN', () => {
+    expect(PSET_PROPERTY_TYPE_TABLE['IsExternal']).toBe('IFCBOOLEAN');
+    expect(PSET_PROPERTY_TYPE_TABLE['LoadBearing']).toBe('IFCBOOLEAN');
+    expect(PSET_PROPERTY_TYPE_TABLE['Combustible']).toBe('IFCBOOLEAN');
+    expect(PSET_PROPERTY_TYPE_TABLE['Compartmentation']).toBe('IFCBOOLEAN');
+  });
+
+  it('maps ThermalTransmittance to its specific measure type, not IFCREAL', () => {
+    expect(PSET_PROPERTY_TYPE_TABLE['ThermalTransmittance']).toBe(
+      'IFCTHERMALTRANSMITTANCEMEASURE'
+    );
+    expect(PSET_PROPERTY_TYPE_TABLE['ThermalTransmittance']).not.toBe('IFCREAL');
+  });
+
+  it('maps label-valued properties to IFCLABEL', () => {
+    expect(PSET_PROPERTY_TYPE_TABLE['FireRating']).toBe('IFCLABEL');
+    expect(PSET_PROPERTY_TYPE_TABLE['AcousticRating']).toBe('IFCLABEL');
+  });
+
+  it('maps Reference to IFCIDENTIFIER', () => {
+    expect(PSET_PROPERTY_TYPE_TABLE['Reference']).toBe('IFCIDENTIFIER');
+  });
+
+  it('maps ratio/fraction properties to IFCPOSITIVERATIOMEASURE', () => {
+    expect(PSET_PROPERTY_TYPE_TABLE['GlazingAreaFraction']).toBe(
+      'IFCPOSITIVERATIOMEASURE'
+    );
+  });
+});
+
+describe('psetTemplates — measureTypeFor helper', () => {
+  it('returns the measure type for a known property', () => {
+    expect(measureTypeFor('IsExternal')).toBe('IFCBOOLEAN');
+    expect(measureTypeFor('ThermalTransmittance')).toBe(
+      'IFCTHERMALTRANSMITTANCEMEASURE'
+    );
+  });
+
+  it('returns undefined for an unknown property', () => {
+    expect(measureTypeFor('SomeNonStandardProp')).toBeUndefined();
+  });
+});
+
+describe('psetTemplates — webIfcConstantFor helper', () => {
+  it('resolves each measure type to its web-ifc constant', () => {
+    const cases: readonly [PsetMeasureType, number][] = [
+      ['IFCBOOLEAN', WebIFC.IFCBOOLEAN],
+      ['IFCLABEL', WebIFC.IFCLABEL],
+      ['IFCIDENTIFIER', WebIFC.IFCIDENTIFIER],
+      ['IFCTEXT', WebIFC.IFCTEXT],
+      ['IFCREAL', WebIFC.IFCREAL],
+      ['IFCLENGTHMEASURE', WebIFC.IFCLENGTHMEASURE],
+      ['IFCPOSITIVELENGTHMEASURE', WebIFC.IFCPOSITIVELENGTHMEASURE],
+      ['IFCAREAMEASURE', WebIFC.IFCAREAMEASURE],
+      ['IFCVOLUMEMEASURE', WebIFC.IFCVOLUMEMEASURE],
+      ['IFCTHERMALTRANSMITTANCEMEASURE', WebIFC.IFCTHERMALTRANSMITTANCEMEASURE],
+      ['IFCPOSITIVERATIOMEASURE', WebIFC.IFCPOSITIVERATIOMEASURE],
+      ['IFCINTEGER', WebIFC.IFCINTEGER],
+    ];
+    for (const [measure, expected] of cases) {
+      expect(webIfcConstantFor(measure)).toBe(expected);
+    }
+  });
+});
+
+describe('psetTemplates — per-category templates', () => {
+  it('provides a template for all 6 element categories', () => {
+    for (const category of ALL_CATEGORIES) {
+      const template = PSET_TEMPLATES[category];
+      expect(template, `missing template for ${category}`).toBeDefined();
+      expect(template.properties.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('names each template after the bSI Pset_*Common convention', () => {
+    expect(PSET_TEMPLATES.WALL.psetName).toBe('Pset_WallCommon');
+    expect(PSET_TEMPLATES.SLAB.psetName).toBe('Pset_SlabCommon');
+    expect(PSET_TEMPLATES.BEAM.psetName).toBe('Pset_BeamCommon');
+    expect(PSET_TEMPLATES.COLUMN.psetName).toBe('Pset_ColumnCommon');
+    expect(PSET_TEMPLATES.DOOR.psetName).toBe('Pset_DoorCommon');
+    expect(PSET_TEMPLATES.WINDOW.psetName).toBe('Pset_WindowCommon');
+  });
+
+  it('templateFor returns the same template as the map', () => {
+    for (const category of ALL_CATEGORIES) {
+      expect(templateFor(category)).toBe(PSET_TEMPLATES[category]);
+    }
+  });
+
+  it('every property in every template has a resolvable measure type', () => {
+    for (const category of ALL_CATEGORIES) {
+      for (const prop of PSET_TEMPLATES[category].properties) {
+        expect(prop.measureType, `${category}.${prop.name}`).toBeDefined();
+        // The per-property measureType must agree with the global table.
+        expect(PSET_PROPERTY_TYPE_TABLE[prop.name]).toBe(prop.measureType);
+        expect(typeof webIfcConstantFor(prop.measureType)).toBe('number');
+      }
+    }
+  });
+
+  it('marks Status as an enumerated value with the standard status set', () => {
+    for (const category of ALL_CATEGORIES) {
+      const status = PSET_TEMPLATES[category].properties.find(
+        (p) => p.name === 'Status'
+      );
+      expect(status, `${category} missing Status`).toBeDefined();
+      if (status === undefined) continue;
+      expect(status.kind).toBe('enumerated');
+      expect(status.enumValues).toEqual([
+        'NEW',
+        'EXISTING',
+        'DEMOLISH',
+        'TEMPORARY',
+        'OTHER',
+        'NOTKNOWN',
+        'UNSET',
+      ]);
+    }
+  });
+
+  it('marks non-enumerated properties as single values', () => {
+    const isExternal = PSET_TEMPLATES.WALL.properties.find(
+      (p) => p.name === 'IsExternal'
+    );
+    expect(isExternal?.kind).toBe('single');
+    expect(isExternal?.enumValues).toBeUndefined();
+  });
+
+  it('includes the expected core common properties per category', () => {
+    const wallNames = PSET_TEMPLATES.WALL.properties.map((p) => p.name);
+    expect(wallNames).toContain('IsExternal');
+    expect(wallNames).toContain('LoadBearing');
+    expect(wallNames).toContain('ThermalTransmittance');
+    expect(wallNames).toContain('FireRating');
+
+    const slabNames = PSET_TEMPLATES.SLAB.properties.map((p) => p.name);
+    expect(slabNames).toContain('Combustible');
+    expect(slabNames).toContain('Compartmentation');
+
+    const doorNames = PSET_TEMPLATES.DOOR.properties.map((p) => p.name);
+    expect(doorNames).toContain('FireExit');
+    expect(doorNames).toContain('SelfClosing');
+
+    const windowNames = PSET_TEMPLATES.WINDOW.properties.map((p) => p.name);
+    expect(windowNames).toContain('GlazingAreaFraction');
+    expect(windowNames).toContain('Infiltration');
+  });
+});

--- a/packages/brepjs-bim/tests/tessellationWriter.test.ts
+++ b/packages/brepjs-bim/tests/tessellationWriter.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as WebIFC from 'web-ifc';
+import { polygon, extrude, isValidSolid } from 'brepjs';
+import type { ValidSolid } from 'brepjs';
+import { initOCCT } from '../../../tests/setup.js';
+import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
+import { writeHeader } from '../src/ifc-writer/headerWriter.js';
+import {
+  writeTessellation,
+  writeWallAxisRepresentation,
+} from '../src/ifc-writer/tessellationWriter.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
+
+// 1000mm × 1000mm × 1000mm box solid at the origin.
+function makeBoxSolid(): ValidSolid {
+  const profile = polygon([
+    [0, 0, 0],
+    [1000, 0, 0],
+    [1000, 1000, 0],
+    [0, 1000, 0],
+  ]);
+  if (!profile.ok) throw new Error('failed to build box profile');
+  using p = profile.value;
+  const solid = extrude(p, [0, 0, 1000]);
+  if (!solid.ok) throw new Error('failed to extrude box');
+  if (!isValidSolid(solid.value)) throw new Error('box solid is not valid');
+  return solid.value;
+}
+
+async function makeWriter(): Promise<IfcWriter> {
+  const result = await IfcWriter.create();
+  if (!result.ok) throw new Error(result.error.message);
+  return result.value;
+}
+
+async function openSaved(w: IfcWriter): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+  const saved = w.save();
+  if (!saved.ok) throw new Error(saved.error.message);
+  const api = new WebIFC.IfcAPI();
+  await api.Init();
+  const mid = api.OpenModel(saved.value);
+  return { api, mid };
+}
+
+describe('tessellationWriter', () => {
+  it('meshes a box solid into an IfcTriangulatedFaceSet with non-empty coordinates and indices', async () => {
+    const w = await makeWriter();
+    const { geomSubContextId } = writeHeader(w, META);
+    using solid = makeBoxSolid();
+
+    const result = writeTessellation(w, solid, geomSubContextId, null);
+    expect(result.usedFallback).toBe(false);
+    expect(result.productDefinitionShapeId).toBeGreaterThan(0);
+
+    const { api, mid } = await openSaved(w);
+
+    const faceSetIds = api.GetLineIDsWithType(mid, WebIFC.IFCTRIANGULATEDFACESET);
+    expect(faceSetIds.size()).toBe(1);
+
+    const faceSet = api.GetLine(mid, faceSetIds.get(0)) as Record<string, unknown>;
+    const coordIndex = faceSet['CoordIndex'] as unknown[];
+    expect(Array.isArray(coordIndex)).toBe(true);
+    expect(coordIndex.length).toBeGreaterThan(0);
+    // A box has 12 triangles (2 per face × 6 faces).
+    expect(coordIndex.length).toBe(12);
+
+    const pointListIds = api.GetLineIDsWithType(mid, WebIFC.IFCCARTESIANPOINTLIST3D);
+    expect(pointListIds.size()).toBe(1);
+    const pointList = api.GetLine(mid, pointListIds.get(0)) as Record<string, unknown>;
+    const coordList = pointList['CoordList'] as unknown[];
+    expect(Array.isArray(coordList)).toBe(true);
+    expect(coordList.length).toBeGreaterThan(0);
+
+    api.CloseModel(mid);
+  });
+
+  it('emits 1-based coordinate indices and coordinates in metres', async () => {
+    const w = await makeWriter();
+    const { geomSubContextId } = writeHeader(w, META);
+    using solid = makeBoxSolid();
+
+    writeTessellation(w, solid, geomSubContextId, null);
+
+    const { api, mid } = await openSaved(w);
+
+    const faceSet = api.GetLine(
+      mid,
+      api.GetLineIDsWithType(mid, WebIFC.IFCTRIANGULATEDFACESET).get(0)
+    ) as Record<string, unknown>;
+    const coordIndex = faceSet['CoordIndex'] as Array<Array<{ value?: number } | number>>;
+    let minIndex = Number.POSITIVE_INFINITY;
+    for (const tri of coordIndex) {
+      for (const entry of tri) {
+        const v = typeof entry === 'number' ? entry : (entry.value ?? 0);
+        if (v < minIndex) minIndex = v;
+      }
+    }
+    // IFC coordinate indices are 1-based.
+    expect(minIndex).toBeGreaterThanOrEqual(1);
+
+    const pointList = api.GetLine(
+      mid,
+      api.GetLineIDsWithType(mid, WebIFC.IFCCARTESIANPOINTLIST3D).get(0)
+    ) as Record<string, unknown>;
+    const coordList = pointList['CoordList'] as Array<Array<{ value?: number } | number>>;
+    let maxCoord = 0;
+    for (const pt of coordList) {
+      for (const entry of pt) {
+        const v = typeof entry === 'number' ? entry : (entry.value ?? 0);
+        maxCoord = Math.max(maxCoord, Math.abs(v));
+      }
+    }
+    // A 1000mm box converted to metres must have coordinates ≤ ~1, never 1000.
+    expect(maxCoord).toBeLessThan(2);
+    expect(maxCoord).toBeGreaterThan(0);
+
+    api.CloseModel(mid);
+  });
+
+  it('wraps the face set in an IfcShapeRepresentation with RepresentationType Tessellation', async () => {
+    const w = await makeWriter();
+    const { geomSubContextId } = writeHeader(w, META);
+    using solid = makeBoxSolid();
+
+    writeTessellation(w, solid, geomSubContextId, null);
+
+    const { api, mid } = await openSaved(w);
+    const repIds = api.GetLineIDsWithType(mid, WebIFC.IFCSHAPEREPRESENTATION);
+    expect(repIds.size()).toBeGreaterThanOrEqual(1);
+    let foundTessellation = false;
+    for (let i = 0; i < repIds.size(); i++) {
+      const rep = api.GetLine(mid, repIds.get(i)) as Record<string, unknown>;
+      const repType = (rep['RepresentationType'] as { value?: string } | undefined)?.value;
+      if (repType === 'Tessellation') foundTessellation = true;
+    }
+    expect(foundTessellation).toBe(true);
+    api.CloseModel(mid);
+  });
+
+  it('serializes a product definition shape that survives a round-trip', async () => {
+    const w = await makeWriter();
+    const { geomSubContextId } = writeHeader(w, META);
+    using solid = makeBoxSolid();
+
+    const result = writeTessellation(w, solid, geomSubContextId, null);
+
+    const { api, mid } = await openSaved(w);
+    const shape = api.GetLine(mid, result.productDefinitionShapeId) as Record<string, unknown>;
+    expect(shape['type']).toBe(WebIFC.IFCPRODUCTDEFINITIONSHAPE);
+    const reps = (shape['Representations'] ?? []) as unknown[];
+    expect(reps.length).toBeGreaterThanOrEqual(1);
+    api.CloseModel(mid);
+  });
+});
+
+describe('writeWallAxisRepresentation', () => {
+  it('writes a Curve2D Axis representation containing an IfcPolyline', async () => {
+    const w = await makeWriter();
+    const { geomSubContextId } = writeHeader(w, META);
+
+    // 5000mm wall length → 5m polyline from (0,0) to (5,0).
+    const repId = writeWallAxisRepresentation(w, 5000, geomSubContextId);
+    expect(repId).toBeGreaterThan(0);
+
+    const { api, mid } = await openSaved(w);
+
+    const polylineIds = api.GetLineIDsWithType(mid, WebIFC.IFCPOLYLINE);
+    expect(polylineIds.size()).toBe(1);
+
+    const rep = api.GetLine(mid, repId) as Record<string, unknown>;
+    const repId2 = (rep['RepresentationIdentifier'] as { value?: string } | undefined)?.value;
+    const repType = (rep['RepresentationType'] as { value?: string } | undefined)?.value;
+    expect(repId2).toBe('Axis');
+    expect(repType).toBe('Curve2D');
+
+    api.CloseModel(mid);
+  });
+});


### PR DESCRIPTION
**Stacked PR 2 of 5** — Base: \`feat/bim-phase-1-foundations\` (review after PR 1).

### What this adds
**Data:** table-driven Pset measure types (`IfcThermalTransmittanceMeasure`/`IfcBoolean`/`IfcLabel`/`IfcIdentifier`…) replacing the everything→`IFCREAL` heuristic; enums via `IfcPropertyEnumeratedValue`; complete `Pset_*Common` templates. Layered/profiled materials (`IfcMaterialLayerSet`/`Usage`/`MaterialProfileSet` + `IfcRelAssociatesMaterial`). Classification (`IfcClassification`/`Reference` + `IfcRelAssociatesClassification`). New spec fields are optional (backward compatible).

**Geometry:** Tessellation/Brep bodies (`IfcTriangulatedFaceSet`, `IfcFacetedBrep` fallback) + wall Axis. `IfcBuildingElementProxy` catch-all. **Door/Window now emit real geometry + `OverallHeight`/`OverallWidth`** (was `Representation: null`). Geometry-validity gate (closed/manifold/non-zero-volume) surfaced through the phase-1 report.

### Verification
263 tests pass (was 218). typecheck, lint, boundaries clean; zero new pattern violations.

> Stacked series. Do not enable automerge.