### PR TITLE
fix(occtwasm): line-mirror transform, STL export adapter, compound boolean tool

### DIFF
--- a/src/kernel/geometry2d.ts
+++ b/src/kernel/geometry2d.ts
@@ -300,8 +300,25 @@ export function scaleCurve2d(c: Curve2dObj, factor: number, cx: number, cy: numb
 
   switch (c.__bk2d) {
     case 'line': {
+      // Scale BOTH endpoints and recompute direction/length. Scaling only the
+      // origin (keeping dx/dy/len) left the endpoint wrong for factor != 1 —
+      // most damagingly for mirror (factor = -1, via mirrorAtPoint), which
+      // reflected the origin but kept the original direction, so the line
+      // pointed the wrong way. Consecutive glyph lines then no longer shared a
+      // vertex, leaving font wires disconnected/invalid (engraved-text bug).
       const [ox, oy] = scalePoint(c.ox, c.oy);
-      return { ...c, ox, oy };
+      const [ex, ey] = scalePoint(c.ox + c.dx * c.len, c.oy + c.dy * c.len);
+      const ndx = ex - ox;
+      const ndy = ey - oy;
+      const nlen = Math.sqrt(ndx * ndx + ndy * ndy);
+      return {
+        ...c,
+        ox,
+        oy,
+        dx: nlen > 0 ? ndx / nlen : c.dx,
+        dy: nlen > 0 ? ndy / nlen : c.dy,
+        len: nlen,
+      };
     }
     case 'circle': {
       const [ncx, ncy] = scalePoint(c.cx, c.cy);

--- a/src/kernel/interfaces/ioOps.ts
+++ b/src/kernel/interfaces/ioOps.ts
@@ -11,7 +11,12 @@ import type { KernelShape, KernelType, StepAssemblyPart } from '@/kernel/types.j
 export interface KernelIOOps {
   // --- Standard formats ---
   exportSTEP(shapes: KernelShape[]): string;
-  exportSTL(shape: KernelShape, binary?: boolean): string | ArrayBuffer;
+  exportSTL(
+    shape: KernelShape,
+    binary?: boolean,
+    tolerance?: number,
+    angularTolerance?: number
+  ): string | ArrayBuffer;
   importSTEP(data: string | ArrayBuffer): KernelShape[];
   importSTL(data: string | ArrayBuffer): KernelShape;
   exportIGES(shapes: KernelShape[]): string;

--- a/src/kernel/occtWasm/booleanOps.ts
+++ b/src/kernel/occtWasm/booleanOps.ts
@@ -59,7 +59,7 @@ export function intersect(
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  return wrapResult(k, k.intersect(unwrap(shape), unwrap(tool)));
+  return wrapResult(k, k.intersect(unwrap(shape), resolveBooleanTool(k, tool)));
 }
 
 export function section(

--- a/src/kernel/occtWasm/booleanOps.ts
+++ b/src/kernel/occtWasm/booleanOps.ts
@@ -18,6 +18,23 @@ import type {
 import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
 import { makeVecU32, unwrap, wrapResult } from './helpers.js';
 
+/**
+ * Normalize a boolean tool to a single fused solid when it is a compound of
+ * multiple solids (e.g. engraved text — one solid per glyph). occt-wasm's
+ * boolean returns an empty result for such compound tools where opencascade
+ * tolerated them; fusing the solids first yields a usable single tool.
+ * Single-solid (or non-solid) tools pass through untouched.
+ */
+export function resolveBooleanTool(k: OcctKernelWasm, tool: KernelShape): number {
+  const toolId = unwrap(tool);
+  const solids = k.getSubShapes(toolId, 'solid');
+  try {
+    return solids.size() > 1 ? k.fuseAll(solids) : toolId;
+  } finally {
+    solids.delete();
+  }
+}
+
 export function fuse(
   k: OcctKernelWasm,
   shape: KernelShape,
@@ -33,7 +50,7 @@ export function cut(
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  return wrapResult(k, k.cut(unwrap(shape), unwrap(tool)));
+  return wrapResult(k, k.cut(unwrap(shape), resolveBooleanTool(k, tool)));
 }
 
 export function intersect(

--- a/src/kernel/occtWasm/evolutionOps.ts
+++ b/src/kernel/occtWasm/evolutionOps.ts
@@ -26,6 +26,7 @@ import {
   unwrap,
   wrapResult,
 } from './helpers.js';
+import { resolveBooleanTool } from './booleanOps.js';
 
 /**
  * Parse an EvolutionData result from the WASM kernel into a ShapeEvolution.
@@ -236,7 +237,12 @@ export function cutWithHistory(
 ): DiagnosticOperationResult {
   const hashVec = makeVecInt(Module, inputFaceHashes);
   try {
-    const evo = k.cutWithHistory(unwrap(shape), unwrap(tool), hashVec, hashUpperBound);
+    const evo = k.cutWithHistory(
+      unwrap(shape),
+      resolveBooleanTool(k, tool),
+      hashVec,
+      hashUpperBound
+    );
     const { id, evolution } = parseEvolution(evo);
     return {
       shape: wrapResult(k, id),

--- a/src/kernel/occtWasm/evolutionOps.ts
+++ b/src/kernel/occtWasm/evolutionOps.ts
@@ -265,7 +265,12 @@ export function intersectWithHistory(
 ): DiagnosticOperationResult {
   const hashVec = makeVecInt(Module, inputFaceHashes);
   try {
-    const evo = k.intersectWithHistory(unwrap(shape), unwrap(tool), hashVec, hashUpperBound);
+    const evo = k.intersectWithHistory(
+      unwrap(shape),
+      resolveBooleanTool(k, tool),
+      hashVec,
+      hashUpperBound
+    );
     const { id, evolution } = parseEvolution(evo);
     return {
       shape: wrapResult(k, id),

--- a/src/kernel/occtWasm/ioOps.ts
+++ b/src/kernel/occtWasm/ioOps.ts
@@ -127,7 +127,7 @@ export function exportSTL(
     const { vertices, triangles } = mesh(shape, { tolerance, angularTolerance, skipNormals: true });
     return buildBinarySTL(vertices, triangles);
   }
-  return k.exportStl(unwrap(shape), 0.1, true);
+  return k.exportStl(unwrap(shape), tolerance, true);
 }
 
 /** Serialize a triangle soup as a binary STL (80-byte header + uint32 count + 50B/tri). */

--- a/src/kernel/occtWasm/ioOps.ts
+++ b/src/kernel/occtWasm/ioOps.ts
@@ -111,18 +111,75 @@ export function exportSTEP(
 
 export function exportSTL(
   k: OcctKernelWasm,
+  mesh: MeshFn,
   shape: KernelShape,
-  binary?: boolean
+  binary?: boolean,
+  tolerance = 1e-3,
+  angularTolerance = 0.1
 ): string | ArrayBuffer {
-  const ascii = !binary;
-  const result = k.exportStl(unwrap(shape), 0.1, ascii);
   if (binary) {
-    const buf = new ArrayBuffer(result.length);
-    const view = new Uint8Array(buf);
-    for (let i = 0; i < result.length; i++) view[i] = result.charCodeAt(i);
-    return buf;
+    // Build the binary STL in JS from the triangulation. occt-wasm's native
+    // exportStl returns the binary payload as a JS string, and reconstructing
+    // bytes from it via charCodeAt is lossy — binary bytes outside the ASCII
+    // range get mangled by the WASM string marshalling, producing a truncated,
+    // unparseable buffer for some meshes (e.g. compartment partitions). Building
+    // from the mesh sidesteps the string entirely, mirroring exportGLB/OBJ/PLY.
+    const { vertices, triangles } = mesh(shape, { tolerance, angularTolerance, skipNormals: true });
+    return buildBinarySTL(vertices, triangles);
   }
-  return result;
+  return k.exportStl(unwrap(shape), 0.1, true);
+}
+
+/** Serialize a triangle soup as a binary STL (80-byte header + uint32 count + 50B/tri). */
+function buildBinarySTL(vertices: Float32Array, triangles: Uint32Array): ArrayBuffer {
+  const triCount = Math.floor(triangles.length / 3);
+  const buffer = new ArrayBuffer(84 + triCount * 50);
+  const view = new DataView(buffer);
+  view.setUint32(80, triCount, true);
+  let offset = 84;
+  for (let i = 0; i < triCount; i++) {
+    const ia = (triangles[i * 3] ?? 0) * 3;
+    const ib = (triangles[i * 3 + 1] ?? 0) * 3;
+    const ic = (triangles[i * 3 + 2] ?? 0) * 3;
+    const ax = vertices[ia] ?? 0,
+      ay = vertices[ia + 1] ?? 0,
+      az = vertices[ia + 2] ?? 0;
+    const bx = vertices[ib] ?? 0,
+      by = vertices[ib + 1] ?? 0,
+      bz = vertices[ib + 2] ?? 0;
+    const cx = vertices[ic] ?? 0,
+      cy = vertices[ic + 1] ?? 0,
+      cz = vertices[ic + 2] ?? 0;
+    // Facet normal from the triangle winding (right-hand rule).
+    const ux = bx - ax,
+      uy = by - ay,
+      uz = bz - az;
+    const vx = cx - ax,
+      vy = cy - ay,
+      vz = cz - az;
+    let nx = uy * vz - uz * vy;
+    let ny = uz * vx - ux * vz;
+    let nz = ux * vy - uy * vx;
+    const len = Math.hypot(nx, ny, nz) || 1;
+    nx /= len;
+    ny /= len;
+    nz /= len;
+    view.setFloat32(offset, nx, true);
+    view.setFloat32(offset + 4, ny, true);
+    view.setFloat32(offset + 8, nz, true);
+    view.setFloat32(offset + 12, ax, true);
+    view.setFloat32(offset + 16, ay, true);
+    view.setFloat32(offset + 20, az, true);
+    view.setFloat32(offset + 24, bx, true);
+    view.setFloat32(offset + 28, by, true);
+    view.setFloat32(offset + 32, bz, true);
+    view.setFloat32(offset + 36, cx, true);
+    view.setFloat32(offset + 40, cy, true);
+    view.setFloat32(offset + 44, cz, true);
+    view.setUint16(offset + 48, 0, true);
+    offset += 50;
+  }
+  return buffer;
 }
 
 export function importSTEP(k: OcctKernelWasm, data: string | ArrayBuffer): KernelShape[] {

--- a/src/kernel/occtWasm/kernel2dOps.ts
+++ b/src/kernel/occtWasm/kernel2dOps.ts
@@ -319,14 +319,9 @@ export function scaleCurve2d(
   cx: number,
   cy: number
 ): Curve2dHandle {
-  const result = ow2d.scaleCurve2d(c2d(curve), factor, cx, cy);
-  // Fix: geometry2d scaleCurve2d doesn't scale line length. Patch it.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- patch line length
-  const r = result as any;
-  if (r.__bk2d === 'line' && typeof r.len === 'number') {
-    r.len = r.len * Math.abs(factor);
-  }
-  return c2dWrap(result);
+  // geometry2d.scaleCurve2d now scales line endpoints + recomputes length, so
+  // the previous len-only patch here is removed (it would double-apply).
+  return c2dWrap(ow2d.scaleCurve2d(c2d(curve), factor, cx, cy));
 }
 
 export function mirrorCurve2dAtPoint(curve: Curve2dHandle, cx: number, cy: number): Curve2dHandle {

--- a/src/kernel/occtWasm/kernel2dOps.ts
+++ b/src/kernel/occtWasm/kernel2dOps.ts
@@ -319,8 +319,8 @@ export function scaleCurve2d(
   cx: number,
   cy: number
 ): Curve2dHandle {
-  // geometry2d.scaleCurve2d now scales line endpoints + recomputes length, so
-  // the previous len-only patch here is removed (it would double-apply).
+  // geometry2d.scaleCurve2d already scales line endpoints and recomputes length;
+  // do not re-patch len here (it would double-apply).
   return c2dWrap(ow2d.scaleCurve2d(c2d(curve), factor, cx, cy));
 }
 

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1110,8 +1110,20 @@ export class OcctWasmAdapter implements KernelAdapter {
     return ioOps.exportSTEP(this.k, this.makeCompound.bind(this), shapes);
   }
 
-  exportSTL(shape: KernelShape, binary?: boolean): string | ArrayBuffer {
-    return ioOps.exportSTL(this.k, shape, binary);
+  exportSTL(
+    shape: KernelShape,
+    binary?: boolean,
+    tolerance?: number,
+    angularTolerance?: number
+  ): string | ArrayBuffer {
+    return ioOps.exportSTL(
+      this.k,
+      this.mesh.bind(this),
+      shape,
+      binary,
+      tolerance,
+      angularTolerance
+    );
   }
 
   importSTEP(data: string | ArrayBuffer): KernelShape[] {

--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -284,7 +284,7 @@ export function exportSTL(
     if (!getKernel().hasTriangulation(shape.wrapped)) {
       getKernel().meshShape(shape.wrapped, tolerance, angularTolerance);
     }
-    const stlData = getKernel().exportSTL(shape.wrapped, binary);
+    const stlData = getKernel().exportSTL(shape.wrapped, binary, tolerance, angularTolerance);
     return ok(new Blob([stlData], { type: 'application/sla' }));
   } catch (e) {
     return err(exportError(e, 'STL'));


### PR DESCRIPTION
Three occt-wasm-path fixes surfaced while making occt-wasm a downstream default kernel:

- **`scaleCurve2d` (2D line transform).** Scaled only a line's origin, leaving `dx/dy/len` unchanged. Since `mirrorAtPoint = scaleCurve2d(c, -1)`, mirroring a line reflected its origin but kept its direction → wrong endpoint. Consecutive mirrored segments (font glyph outlines) no longer shared a vertex, so `MakeWire` produced disconnected, BRepCheck-invalid wires → invalid solids the strict occt-wasm boolean engine drops (lost engraved/embossed text). Now scales both endpoints and recomputes direction/length.
- **`exportSTL` adapter signature.** The occt-wasm adapter called `ioOps.exportSTL(this.k, shape, binary)` but the signature is `(k, mesh, shape, binary, tol, angTol)`, so `mesh` received the shape and every binary STL export threw `STL_FILE_READ_ERROR`. Adapter now passes `this.mesh.bind(this)` + tolerances (like `exportGLB`/`OBJ`), and the binary STL is built from the triangulation in JS (occt-wasm's native `exportStl` returns a lossy JS string).
- **Compound boolean tools.** `resolveBooleanTool` fuses a multi-solid compound tool into one watertight solid before cut/cutWithHistory; single-solid tools pass through.