### PR TITLE
feat(sheetmetal): multi-bend authoring, down-bends, closed-box seams

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -10,21 +10,27 @@ Pipeline: **author part → auto-miter corners → fold to 3D → unfold to flat
 
 ## Scope
 
-First build is a single end-to-end vertical slice for straight (cylindrical) bends, authoring our own
-parts (not unfolding foreign solids). The bend model is K-factor based with an extensible schema, so it
-can grow toward bend-tables without a rewrite.
+Straight (cylindrical) bends, authoring our own parts (not unfolding foreign solids). The bend model is
+K-factor based with an extensible schema, so it can grow toward bend-tables without a rewrite.
 
 - Bend allowance: `BA = (π/180)·|angle|·(R + K·T)`
 - Defaults: units are mm; K-factor `0.44`; inner radius `= thickness`.
 
+Authoring supports arbitrary bend trees: flanges off any of the four base edges, **chained
+flange-off-flange** bends (U-channels, Z-profiles, box walls), **up/down** fold direction, and
+**partial/offset** flanges (more than one flange per edge). Closed profiles (tubes/boxes) author a seam
+edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid connected pattern.
+
 ## Status
 
-| Phase        | Contents                                                                                                             |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
-| 1 (scaffold) | package skeleton, data model (`types.ts`), starter gauge library (`materials.ts`)                                    |
-| 2+           | allowance/feature-tree/unfold math, flange authoring + auto-miter, DXF/report/validation, public API + fluent facade |
+| Area            | State                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------- |
+| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams       |
+| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area |
+| Miter / outputs | auto corner-miter, multi-layer DXF, JSON bend report, manufacturability warnings       |
+| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                |
 
-`FlatInput` (flat-pattern → fold, the inverse direction) is deferred to Phase 2.
+`FlatInput` (flat-pattern → fold, the inverse direction) is not yet implemented.
 
 ## Design
 

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -18,7 +18,8 @@ import { fileURLToPath } from 'node:url';
 import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, isErr, initFromOC } from 'brepjs';
 import type { Solid, Vec3 } from 'brepjs';
 import { author, miterCorner, unfold } from '../src/api.js';
-import type { BendRule, FlatPattern } from '../src/types.js';
+import type { AuthorSpec } from '../src/authorFns.js';
+import type { BendRule, FlatPattern, SheetMetalPart } from '../src/types.js';
 
 /**
  * Boot the OCCT-WASM kernel directly from `brepjs-opencascade` (the same recipe
@@ -51,54 +52,99 @@ const PANEL_W = 480;
 const PANEL_H = 480;
 const PAD = 28;
 
+interface Demo {
+  name: string;
+  spec: AuthorSpec;
+  /** Optional auto-miter applied to the authored part before unfolding. */
+  miter?: { a: string; b: string; gap: number };
+}
+
+const DEMOS: Demo[] = [
+  {
+    name: 'bracket',
+    spec: {
+      thickness: T,
+      base: { length: 40, width: 40 },
+      flanges: [
+        { id: 'fx', length: 18, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'fy', length: 18, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    },
+    miter: { a: 'fx', b: 'fy', gap: 1 },
+  },
+  {
+    name: 'u-channel',
+    spec: {
+      thickness: T,
+      base: { length: 60, width: 30 },
+      flanges: [
+        { id: 'left', length: 18, angleDeg: 90, rule, side: 'xmin' },
+        { id: 'right', length: 18, angleDeg: 90, rule, side: 'xmax' },
+      ],
+    },
+  },
+  {
+    name: 'tray',
+    spec: {
+      thickness: T,
+      base: { length: 50, width: 40 },
+      flanges: [
+        { id: 'xn', length: 14, angleDeg: 90, rule, side: 'xmin' },
+        { id: 'xp', length: 14, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'yn', length: 14, angleDeg: 90, rule, side: 'ymin' },
+        { id: 'yp', length: 14, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    },
+  },
+];
+
 async function main(): Promise<void> {
   await initOCCT();
   await mkdir(OUT_DIR, { recursive: true });
 
-  const authored = author({
-    thickness: T,
-    base: { length: 40, width: 40 },
-    flanges: [
-      { id: 'fx', length: 18, angleDeg: 90, rule, side: 'xmax' },
-      { id: 'fy', length: 18, angleDeg: 90, rule, side: 'ymax' },
-    ],
-  });
-  if (isErr(authored)) throw new Error(`author failed: ${authored.error.message}`);
+  const lines = ['brepjs-sheetmetal snapshot harness'];
+  for (const demo of DEMOS) {
+    lines.push(...(await renderDemo(demo)));
+  }
+  lines.push('');
+  process.stdout.write(lines.join('\n'));
+}
 
-  const mitered = miterCorner(authored.value, 'fx', 'fy', 1);
-  if (isErr(mitered)) throw new Error(`miterCorner failed: ${mitered.error.message}`);
-  const part = mitered.value;
-  if (part.solid === undefined) throw new Error('mitered part has no solid');
+async function renderDemo(demo: Demo): Promise<string[]> {
+  const authored = author(demo.spec);
+  if (isErr(authored)) throw new Error(`author '${demo.name}' failed: ${authored.error.message}`);
+
+  let part: SheetMetalPart = authored.value;
+  if (demo.miter !== undefined) {
+    const mitered = miterCorner(part, demo.miter.a, demo.miter.b, demo.miter.gap);
+    if (isErr(mitered)) throw new Error(`miterCorner '${demo.name}' failed: ${mitered.error.message}`);
+    part = mitered.value;
+  }
+  if (part.solid === undefined) throw new Error(`'${demo.name}' has no solid`);
 
   const unfolded = unfold(part);
-  if (isErr(unfolded)) throw new Error(`unfold failed: ${unfolded.error.message}`);
+  if (isErr(unfolded)) throw new Error(`unfold '${demo.name}' failed: ${unfolded.error.message}`);
   const pattern = unfolded.value.pattern;
 
-  const foldedPanel = renderFoldedSvg(part.solid);
-  const flatPanel = renderFlatSvg(pattern);
-  const svg = composeSideBySide(foldedPanel, flatPanel);
-
-  const svgPath = resolve(OUT_DIR, 'bracket.svg');
+  const svg = composeSideBySide(renderFoldedSvg(part.solid), renderFlatSvg(pattern));
+  const svgPath = resolve(OUT_DIR, `${demo.name}.svg`);
   await writeFile(svgPath, svg, 'utf8');
 
   const step = exportSTEP(part.solid);
   let stepPath = '(STEP export skipped)';
   if (!isErr(step)) {
-    stepPath = resolve(OUT_DIR, 'bracket.step');
+    stepPath = resolve(OUT_DIR, `${demo.name}.step`);
     await writeFile(stepPath, Buffer.from(await step.value.arrayBuffer()));
   }
 
-  process.stdout.write(
-    [
-      'brepjs-sheetmetal snapshot harness',
-      `  folded + flat SVG : ${svgPath}`,
-      `  folded STEP       : ${stepPath}`,
-      `  bend lines        : ${pattern.bendLines.length}`,
-      `  developed area    : ${pattern.developedArea.toFixed(2)} mm²`,
-      `  warnings          : ${unfolded.value.warnings.length}`,
-      '',
-    ].join('\n')
-  );
+  return [
+    `  [${demo.name}]`,
+    `    folded + flat SVG : ${svgPath}`,
+    `    folded STEP       : ${stepPath}`,
+    `    bend lines        : ${pattern.bendLines.length}`,
+    `    developed area    : ${pattern.developedArea.toFixed(2)} mm²`,
+    `    warnings          : ${unfolded.value.warnings.length}`,
+  ];
 }
 
 interface Seg2 {

--- a/packages/brepjs-sheetmetal/src/authorFns.ts
+++ b/packages/brepjs-sheetmetal/src/authorFns.ts
@@ -1,6 +1,7 @@
 import {
   type Result,
   type Vec3,
+  type Bounds3D,
   type Solid,
   type ValidSolid,
   ok,
@@ -13,40 +14,71 @@ import {
   intersect,
   rotate,
   translate,
+  vecAdd,
+  vecSub,
+  vecScale,
+  vecDot,
+  vecCross,
+  vecNormalize,
 } from 'brepjs';
 import type {
   BendFeature,
   BendRule,
   FlangeFeature,
   EdgeRef,
+  FlatSide,
   MaterialSpec,
   MiterSpec,
   SheetMetalPart,
 } from './types.js';
 import { normalizeSolid } from './internal.js';
+import { ROOT_FLAT_ID } from './featureTreeFns.js';
 
 /** Authoring options for the base flat the flanges attach to. */
 export interface BaseFlatSpec {
   /** Extent along the run (+X) axis. */
   length: number;
-  /** Extent along the width (+Y) axis; shared by every flange. */
+  /** Extent along the width (+Y) axis. */
   width: number;
 }
 
-/** Which base edge a flange folds off. */
-export type FlangeSide = 'xmax' | 'ymax';
+/** Which edge a flange folds off (of the base, or of its parent flange). */
+export type FlangeSide = FlatSide;
 
-/** A single flange to author off an edge of the base flat. */
+/** A single flange to author off an edge of its parent flat. */
 export interface FlangeSpec {
   id: string;
   /** Flat length measured from the end of the bend along the flange plane. */
   length: number;
-  /** Signed fold angle in degrees (Phase 1: fold direction is `up`). */
+  /** Signed fold angle in degrees. */
   angleDeg: number;
   rule: BendRule;
-  /** Base edge to attach to. Default `'xmax'` (the leading +X edge). */
+  /** Parent edge to attach to. Default `'xmax'` (the leading +X edge). */
   side?: FlangeSide | undefined;
+  /** Fold direction relative to the parent face normal. Default `'up'`. */
+  direction?: 'up' | 'down' | undefined;
+  /** Id of another flange this flange folds off (its distal edge). Default = base flat. */
+  parent?: string | undefined;
+  /** Start position along the parent edge. Default `0`. */
+  offset?: number | undefined;
+  /** Extent along the parent edge. Default = full parent-edge length. */
+  width?: number | undefined;
   miter?: MiterSpec | undefined;
+}
+
+/**
+ * A seam: a bend connecting two already-authored flats that is intentionally left
+ * unfolded (a free edge). Closing the last wall of a box/tube back onto an earlier
+ * flat produces a cyclic feature graph; the feature tree turns this edge into a
+ * SEAM_CUT, and the unfold leaves the flats connected through the spanning tree.
+ */
+export interface SeamSpec {
+  /** Flat id the seam folds from (an authored flange, or `'root'`/`'face-0'` for the base). */
+  parent: string;
+  /** Flat id the seam meets (must already be authored; `'root'`/`'face-0'` = base). */
+  child: string;
+  angleDeg: number;
+  rule: BendRule;
 }
 
 /** Inputs for {@link authorPart}. */
@@ -55,29 +87,47 @@ export interface AuthorSpec {
   base: BaseFlatSpec;
   flanges: FlangeSpec[];
   material?: MaterialSpec | undefined;
+  /** Optional seams that close a profile into a tube/box (left unfolded). */
+  seams?: SeamSpec[] | undefined;
 }
 
 /**
  * Stable edge reference for flange attachment. The base flat is `face-0`; every
- * flange face is `face-<n+1>` in authoring order. The leading (+X) edge of a flat
- * is `edgeIndex 0` — the only edge Phase 1 attaches flanges to. This scheme is
- * deterministic from construction order and is what the unfold/feature tree
- * consume (it never reads topology back out of the B-rep).
+ * flange face is `face-<n+1>` in authoring order. The leading edge of a flat is
+ * `edgeIndex 0`. The reference also carries `parentId`/`side`/`offset`/`extent`
+ * so the feature tree and recursive unfold can resolve the exact parent edge a
+ * flange folds from without reading topology back out of the B-rep.
  */
 export function baseEdgeRef(faceIndex: number): EdgeRef {
   return { kind: 'index', faceIndex, edgeIndex: 0 };
 }
 
 /**
- * Author a straight-bend sheet-metal part: a base flat plus one or more flanges
- * folded up off its leading edge. Returns a {@link SheetMetalPart} carrying the
- * folded 3D solid and the recorded bend feature tree (axis/angle/direction/rule
- * per bend) that the unfold consumes.
- *
- * Solid construction (plan §4): the base is a thickened rectangle; each flange is
- * a rectangular flat positioned by rotating about its recorded bend axis at the
- * inner-radius offset, joined to the base by a real cylindrical bend patch, then
- * fused. All construction stays on the public, OCCT-WASM-safe API.
+ * A flat in the part: the base, or a placed flange face. Each carries the world
+ * frame (origin + orthonormal axes) of its top surface so a child flange can be
+ * built directly off any of its four edges, at any fold direction.
+ */
+interface FlatFrame {
+  id: string;
+  /** Lower-left corner of the flat's top surface (the +normal side). */
+  origin: Vec3;
+  /** In-plane direction; the flat spans `[0, uLen]` along it. */
+  u: Vec3;
+  /** In-plane direction; the flat spans `[0, vLen]` along it. */
+  v: Vec3;
+  /** Outward face normal of the top surface (n = u × v). */
+  n: Vec3;
+  uLen: number;
+  vLen: number;
+}
+
+/**
+ * Author a sheet-metal part: a base flat plus an arbitrary tree of flanges. Each
+ * flange folds off one of the four edges of its parent flat (the base by default,
+ * or another flange via `parent`), in the requested direction (up/down), over an
+ * optional sub-span of that edge (`offset`/`width`). Returns a {@link SheetMetalPart}
+ * carrying the folded 3D solid and the recorded bend feature tree the unfold
+ * consumes. All construction stays on the public, OCCT-WASM-safe API.
  */
 export function authorPart(spec: AuthorSpec): Result<SheetMetalPart> {
   const { thickness } = spec;
@@ -93,34 +143,71 @@ export function authorPart(spec: AuthorSpec): Result<SheetMetalPart> {
   }
 
   const seen = new Set<string>();
-  const seenSides = new Set<FlangeSide>();
   for (const flange of spec.flanges) {
     if (seen.has(flange.id)) {
       return err(validationError('DUPLICATE_FLANGE', `duplicate flange id '${flange.id}'`));
     }
     seen.add(flange.id);
-    // Phase 1 places one flange per base edge; two on the same side would overlap
-    // and the unfold would silently keep only the last, so reject it up front.
-    const side: FlangeSide = flange.side ?? 'xmax';
-    if (seenSides.has(side)) {
-      return err(
-        validationError('DUPLICATE_SIDE', `flange '${flange.id}' reuses side '${side}'; one flange per side in Phase 1`)
-      );
-    }
-    seenSides.add(side);
   }
 
-  let solid: Solid = box(baseLen, width, thickness);
+  // Two flanges on the same parent edge must not overlap along that edge.
+  const overlap = checkEdgeOverlaps(spec.flanges, baseLen, width);
+  if (!overlap.ok) return overlap;
 
+  const ROOT = ROOT_FLAT_ID;
+  const frames = new Map<string, FlatFrame>();
+  // Frame origin sits on the sheet's −normal (bottom) surface; the flat spans
+  // `thickness` along +n. This matches the canonical assembly, whose z=0 plane is
+  // the sheet bottom and whose bend cylinder sits at z = T+r (up) / −r (down).
+  frames.set(ROOT, {
+    id: ROOT,
+    origin: [0, 0, 0],
+    u: [1, 0, 0],
+    v: [0, 1, 0],
+    n: [0, 0, 1],
+    uLen: baseLen,
+    vLen: width,
+  });
+
+  let solid: Solid = box(baseLen, width, thickness);
   const flanges: FlangeFeature[] = [];
   const bends: BendFeature[] = [];
 
+  // Author in spec order; a chained flange must follow its parent. Resolve the
+  // parent frame by flange id (or the base for a root flange).
   for (const flange of spec.flanges) {
-    const built = buildFlange(solid, baseLen, width, thickness, flange);
+    const parentId = flange.parent ?? ROOT;
+    const parentFrame = frames.get(parentId);
+    if (parentFrame === undefined) {
+      return err(
+        validationError('UNKNOWN_PARENT', `flange '${flange.id}' parent '${flange.parent}' not authored yet`)
+      );
+    }
+    const built = buildFlange(solid, parentFrame, thickness, flange);
     if (!built.ok) return built;
     solid = built.value.solid;
     flanges.push(built.value.flange);
     bends.push(built.value.bend);
+    frames.set(flange.id, built.value.childFrame);
+  }
+
+  for (const seam of spec.seams ?? []) {
+    const seamParent = seam.parent === 'face-0' ? ROOT : seam.parent;
+    const seamChild = seam.child === 'face-0' ? ROOT : seam.child;
+    if (!frames.has(seamParent) || !frames.has(seamChild)) {
+      return err(
+        validationError('UNKNOWN_SEAM_FLAT', `seam ${seam.parent}↔${seam.child} references an unauthored flat`)
+      );
+    }
+    const parentFrame = frames.get(seamParent) as FlatFrame;
+    bends.push({
+      id: `seam::${seamParent}::${seamChild}`,
+      axisOrigin: [parentFrame.origin[0], parentFrame.origin[1], parentFrame.origin[2]],
+      axisDir: [parentFrame.u[0], parentFrame.u[1], parentFrame.u[2]],
+      angleDeg: seam.angleDeg,
+      direction: 'up',
+      rule: seam.rule,
+    });
   }
 
   return ok({
@@ -134,16 +221,75 @@ export function authorPart(spec: AuthorSpec): Result<SheetMetalPart> {
   });
 }
 
+/**
+ * Reject two flanges on the same parent edge whose [offset, offset+width] ranges
+ * overlap. The edge length a flange's default span fills must be the *resolved*
+ * parent-edge length, not the base's: a chained flange folds off another flange
+ * whose edges have that flange's own span/length, so keying the default off the
+ * base dimensions would compute a bogus span and spuriously reject valid pairs.
+ */
+function checkEdgeOverlaps(specs: FlangeSpec[], baseLen: number, width: number): Result<void> {
+  interface Range {
+    id: string;
+    lo: number;
+    hi: number;
+  }
+  // Resolved child-frame dims per flange: spanLen along the bend axis, flatLen out.
+  // Walked in spec order (a chained flange always follows its parent), mirroring
+  // the authoring loop so parent frames are known before their children.
+  const dims = new Map<string, { spanLen: number; flatLen: number }>();
+  const edgeLenFor = (parentId: string, side: FlatSide): number => {
+    const onWidthEdge = side === 'xmax' || side === 'xmin';
+    if (parentId === ROOT_FLAT_ID) return onWidthEdge ? width : baseLen;
+    const p = dims.get(parentId);
+    if (p === undefined) return onWidthEdge ? width : baseLen;
+    // Parent flange frame: uLen = its span (xmax/xmin edges), vLen = its length.
+    return onWidthEdge ? p.flatLen : p.spanLen;
+  };
+
+  const byEdge = new Map<string, Range[]>();
+  for (const f of specs) {
+    const side: FlatSide = f.side ?? 'xmax';
+    const parentId = f.parent ?? ROOT_FLAT_ID;
+    const key = `${parentId}::${side}`;
+    const edgeLen = edgeLenFor(parentId, side);
+    const lo = f.offset ?? 0;
+    const span = f.width ?? edgeLen;
+    const hi = lo + span;
+    const list = byEdge.get(key) ?? [];
+    for (const r of list) {
+      if (lo < r.hi - 1e-9 && r.lo < hi - 1e-9) {
+        return err(
+          validationError(
+            'OVERLAPPING_FLANGES',
+            `flange '${f.id}' overlaps '${r.id}' on edge '${key}' ([${lo}, ${hi}] ∩ [${r.lo}, ${r.hi}])`
+          )
+        );
+      }
+    }
+    list.push({ id: f.id, lo, hi });
+    byEdge.set(key, list);
+    dims.set(f.id, { spanLen: span, flatLen: f.length });
+  }
+  return ok(undefined);
+}
+
 interface BuiltFlange {
   solid: Solid;
   flange: FlangeFeature;
   bend: BendFeature;
+  childFrame: FlatFrame;
 }
 
+/**
+ * Build one flange off `parent`'s chosen edge and fuse it to `base`. The flange
+ * assembly (cylindrical bend patch + flat) is constructed in a canonical frame
+ * (bend axis +Y at the origin, outward run +X, top surface +Z) honouring the
+ * up/down fold, then rigidly mapped onto the parent edge's world frame.
+ */
 function buildFlange(
   base: Solid,
-  baseLen: number,
-  width: number,
+  parent: FlatFrame,
   thickness: number,
   flange: FlangeSpec
 ): Result<BuiltFlange> {
@@ -160,81 +306,345 @@ function buildFlange(
     return err(validationError('INVALID_RADIUS', `flange '${flange.id}' innerRadius must be non-negative`));
   }
 
-  const side: FlangeSide = flange.side ?? 'xmax';
-  // The bend axis runs along the chosen edge, raised R above the base top surface
-  // so the inner bend radius is R (inner cylinder tangent to the top at z=T). The
-  // flange spans the full edge; its bend sweeps up about that axis.
-  const span = side === 'xmax' ? width : baseLen;
+  const side: FlatSide = flange.side ?? 'xmax';
+  const direction: 'up' | 'down' = flange.direction ?? 'up';
+  const edge = parentEdge(parent, side);
+  const offset = flange.offset ?? 0;
+  const span = flange.width ?? edge.length;
+  if (!Number.isFinite(offset) || offset < -1e-9) {
+    return err(validationError('INVALID_OFFSET', `flange '${flange.id}' offset must be non-negative`));
+  }
+  if (!Number.isFinite(span) || span <= 0) {
+    return err(validationError('INVALID_FLANGE_WIDTH', `flange '${flange.id}' width must be positive`));
+  }
+  if (offset + span > edge.length + 1e-6) {
+    return err(
+      validationError('FLANGE_OUT_OF_BOUNDS', `flange '${flange.id}' [${offset}, ${offset + span}] exceeds parent edge length ${edge.length}`)
+    );
+  }
 
-  // Build the patch + flat in a canonical frame: axis along +Y at the origin, the
-  // base contact straight below, run direction +X. Then place onto the real edge.
-  const canonOrigin: Vec3 = [0, 0, thickness + r];
-  const patch = buildBendPatch(canonOrigin, flange.angleDeg, r, span, thickness);
+  // Canonical assembly: bend axis +Y, outward run +X, top surface +Z, spanning
+  // +Y over [0, span]. Up folds toward +Z, down folds below the base plane.
+  const canonAxisZ = direction === 'up' ? thickness + r : -r;
+  const canonOrigin: Vec3 = [0, 0, canonAxisZ];
+  const patch = buildBendPatch(canonOrigin, flange.angleDeg, r, span, thickness, direction);
   if (!patch.ok) return patch;
-  const flat = buildFlangeFlat(canonOrigin, flange.angleDeg, span, thickness, flange.length);
+  const flat = buildFlangeFlat(canonOrigin, flange.angleDeg, span, thickness, flange.length, direction);
 
-  const place = placement(side, baseLen, width);
-  const patchPlaced = place(patch.value);
-  const flatPlaced = place(flat);
+  // World frame the canonical assembly maps onto: bend axis = edge.dir, outward
+  // run = edge.out, top normal = parent.n. The bend axis sits at offset along the
+  // edge; the canonical contact (axis straight above the base seam) maps onto the
+  // parent edge line.
+  const place = frameTransform(edge.dir, edge.out, parent.n, edge.start, offset);
+  const patchPlaced = place.solid(patch.value);
+  const flatPlaced = place.solid(flat);
 
   const fusedPatch = fuse(base, patchPlaced);
   if (!fusedPatch.ok) return fusedPatch;
   const fused = fuse(fusedPatch.value, flatPlaced);
   if (!fused.ok) return fused;
 
-  const axisOrigin: Vec3 =
-    side === 'xmax' ? [baseLen, 0, thickness + r] : [0, width, thickness + r];
-  const axisDir: Vec3 = side === 'xmax' ? [0, 1, 0] : [1, 0, 0];
-
+  const sign = direction === 'up' ? 1 : -1;
+  // Recorded bend axis = the cylinder centre line: parent edge + n·(T+r up | r down).
+  const axisOrigin = vecAdd(
+    vecAdd(edge.start, vecScale(edge.dir, offset)),
+    vecScale(parent.n, canonAxisZ)
+  );
   const bend: BendFeature = {
     id: flange.id,
     axisOrigin: [axisOrigin[0], axisOrigin[1], axisOrigin[2]],
-    axisDir: [axisDir[0], axisDir[1], axisDir[2]],
+    axisDir: [edge.dir[0], edge.dir[1], edge.dir[2]],
     angleDeg: flange.angleDeg,
-    direction: 'up',
+    direction,
     rule: flange.rule,
   };
+
+  const childFrame = computeChildFrame(flange.id, place, span, flange.angleDeg, thickness, r, sign, flange.length);
+
+  // True folded AABB of the whole flange (bend patch + flat) in world space.
+  // Computed from the real placed geometry so chained flanges — whose bend axis
+  // sits off the z=0 base plane — get a correct box, not the z=0-flattened one a
+  // purely analytic re-fold would produce. The collision check reuses this.
+  const foldedBounds = flangeFoldedBounds(childFrame, edge, offset, span, parent.n, canonAxisZ, thickness);
 
   const flangeFeature: FlangeFeature = {
     id: flange.id,
-    baseEdge: baseEdgeRef(0),
+    baseEdge: {
+      kind: 'index',
+      faceIndex: parent.id === ROOT_FLAT_ID ? 0 : -1,
+      edgeIndex: 0,
+      parentId: parent.id,
+      side,
+      offset,
+      extent: span,
+    },
     length: flange.length,
     span,
+    offset,
     angleDeg: flange.angleDeg,
+    direction,
     rule: flange.rule,
+    foldedBounds,
     ...(flange.miter !== undefined ? { miter: flange.miter } : {}),
   };
 
-  return ok({ solid: fused.value, flange: flangeFeature, bend });
+  return ok({ solid: fused.value, flange: flangeFeature, bend, childFrame });
+}
+
+interface ParentEdge {
+  /** Direction along the edge (the bend axis). */
+  dir: Vec3;
+  /** Outward in-plane direction the flange runs (perpendicular to dir). */
+  out: Vec3;
+  /** Start corner of the edge (offset 0). */
+  start: Vec3;
+  /** Edge length. */
+  length: number;
 }
 
 /**
- * Map the canonical-frame flange assembly (axis +Y at origin, run +X, spanning
- * +Y over [0, span]) onto the requested base edge. `xmax` is a pure +X shift; for
- * `ymax` a +90° rotation about Z turns the run from +X to +Y and the axis from +Y
- * to −X, after which a shift lands it on the +Y edge spanning X in [0, baseLen].
+ * Resolve one of the four edges of a flat frame. The bend axis `dir` is chosen so
+ * the canonical assembly maps onto it by a proper rotation: `out × dir = n`, i.e.
+ * `dir = n × out`. `start` is the edge endpoint from which `dir` runs along the
+ * edge, so the flange spans `start + offset·dir` to `start + (offset+span)·dir`.
  */
-function placement(side: FlangeSide, baseLen: number, width: number): (s: Solid) => Solid {
-  if (side === 'xmax') {
-    return (s) => translate(s, [baseLen, 0, 0]);
+function parentEdge(f: FlatFrame, side: FlatSide): ParentEdge {
+  const o = f.origin;
+  const uTop = vecAdd(o, vecScale(f.u, f.uLen));
+  const vTop = vecAdd(o, vecScale(f.v, f.vLen));
+  const uvTop = vecAdd(uTop, vecScale(f.v, f.vLen));
+
+  let out: Vec3;
+  let length: number;
+  let a: Vec3;
+  let b: Vec3;
+  switch (side) {
+    case 'xmax':
+      out = f.u;
+      length = f.vLen;
+      a = uTop;
+      b = uvTop;
+      break;
+    case 'xmin':
+      out = vecScale(f.u, -1);
+      length = f.vLen;
+      a = o;
+      b = vTop;
+      break;
+    case 'ymax':
+      out = f.v;
+      length = f.uLen;
+      a = vTop;
+      b = uvTop;
+      break;
+    case 'ymin':
+      out = vecScale(f.v, -1);
+      length = f.uLen;
+      a = o;
+      b = uTop;
+      break;
   }
-  return (s) => {
-    const rotated = rotate(s, 90, { at: [0, 0, 0], axis: [0, 0, 1] });
-    return translate(rotated, [baseLen, width, 0]);
+  const dir = vecNormalize(vecCross(f.n, out));
+  // Pick the endpoint from which `dir` points toward the other endpoint.
+  const toB = vecSub(b, a);
+  const start = vecDot(toB, dir) >= 0 ? a : b;
+  return { dir, out, start, length };
+}
+
+/**
+ * Frame of the child flange's flat (bottom/−normal surface, near corner), for
+ * chaining grandchildren. Derived by folding the canonical flat by ∓θ about the
+ * bend axis, then mapping through the same rigid transform that placed the flange.
+ */
+function computeChildFrame(
+  id: string,
+  place: PlacedTransform,
+  span: number,
+  angleDeg: number,
+  thickness: number,
+  r: number,
+  sign: number,
+  length: number
+): FlatFrame {
+  const theta = (angleDeg * Math.PI) / 180;
+  const axisZ = sign > 0 ? thickness + r : -r;
+
+  // Canonical fold = rotate by −sign·θ about +Y at pivot [0,0,axisZ]. Run +X and
+  // normal +Z fold accordingly; the flat's near-bottom corner ([0,0,0]) rotates
+  // about the pivot. (rotate by a about +Y: [x,z]→[x cos a + z sin a, −x sin a + z cos a].)
+  const a = -sign * theta;
+  const ca = Math.cos(a);
+  const sa = Math.sin(a);
+  const runC: Vec3 = [ca, 0, -sa];
+  const nC: Vec3 = [sa, 0, ca];
+  const dz = -axisZ;
+  const cornerC: Vec3 = [dz * sa, 0, axisZ + dz * ca];
+
+  return {
+    id,
+    origin: place.point(cornerC),
+    u: place.vector([0, 1, 0]),
+    v: place.vector(runC),
+    n: place.vector(nC),
+    uLen: span,
+    vLen: length,
   };
 }
 
 /**
- * Cylindrical bend patch: the annular wedge swept by the bend. Built as a hollow
- * tube (outer radius R+T, inner R) along +Y, intersected with the angular wedge
- * spanning the fold, then translated so the inner surface meets the base edge.
+ * World-space AABB of a folded flange: the union of the flat box (from its child
+ * frame) and the bend region between the parent edge and the bend-axis cylinder.
+ * Built from the real placed corners, so a chained flange folded off a vertical
+ * wall is bounded correctly rather than collapsed into the z=0 base plane.
+ */
+function flangeFoldedBounds(
+  child: FlatFrame,
+  edge: ParentEdge,
+  offset: number,
+  span: number,
+  parentN: Vec3,
+  canonAxisZ: number,
+  thickness: number
+): Bounds3D {
+  const corners: Vec3[] = [];
+  // Flat box: child.origin + [0,uLen]·u + [0,vLen]·v + [0,thickness]·n.
+  for (const s of [0, child.uLen]) {
+    for (const l of [0, child.vLen]) {
+      for (const t of [0, thickness]) {
+        corners.push(
+          vecAdd(
+            vecAdd(vecAdd(child.origin, vecScale(child.u, s)), vecScale(child.v, l)),
+            vecScale(child.n, t)
+          )
+        );
+      }
+    }
+  }
+  // Bend region: from the parent edge contact (sheet at the seam) out to the bend
+  // axis line, over the flange span. Captures the cylindrical patch's footprint.
+  const edgeBase = vecAdd(edge.start, vecScale(edge.dir, offset));
+  const axisLine = vecAdd(edgeBase, vecScale(parentN, canonAxisZ));
+  for (const s of [0, span]) {
+    const along = vecScale(edge.dir, s);
+    corners.push(vecAdd(edgeBase, along));
+    corners.push(vecAdd(vecAdd(edgeBase, along), vecScale(parentN, thickness)));
+    corners.push(vecAdd(axisLine, along));
+  }
+  return aabbOf(corners);
+}
+
+function aabbOf(corners: Vec3[]): Bounds3D {
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  let zMin = Infinity;
+  let zMax = -Infinity;
+  for (const c of corners) {
+    if (c[0] < xMin) xMin = c[0];
+    if (c[0] > xMax) xMax = c[0];
+    if (c[1] < yMin) yMin = c[1];
+    if (c[1] > yMax) yMax = c[1];
+    if (c[2] < zMin) zMin = c[2];
+    if (c[2] > zMax) zMax = c[2];
+  }
+  return { xMin, xMax, yMin, yMax, zMin, zMax };
+}
+
+interface PlacedTransform {
+  solid: (s: Solid) => Solid;
+  point: (p: Vec3) => Vec3;
+  vector: (v: Vec3) => Vec3;
+}
+
+/**
+ * Rigid transform mapping the canonical flange assembly (bend axis +Y, run +X,
+ * normal +Z, contact at the origin) onto a world edge frame: align +X→`runT`,
+ * +Y→`axisT`, +Z→`nT`, then slide the axis to `edgeStart + offset·axisT`.
+ */
+function frameTransform(
+  axisT: Vec3,
+  runT: Vec3,
+  nT: Vec3,
+  edgeStart: Vec3,
+  offset: number
+): PlacedTransform {
+  // Rotation matrix R with columns [runT | axisT | nT] sends canonical X,Y,Z to
+  // the target basis. Convert to axis-angle and rotate about the origin.
+  const m: number[] = [
+    runT[0], axisT[0], nT[0],
+    runT[1], axisT[1], nT[1],
+    runT[2], axisT[2], nT[2],
+  ];
+  const aa = matrixToAxisAngle(m);
+  const target = vecAdd(edgeStart, vecScale(axisT, offset));
+  const applyR = (v: Vec3): Vec3 =>
+    vecAdd(vecAdd(vecScale(runT, v[0]), vecScale(axisT, v[1])), vecScale(nT, v[2]));
+  return {
+    solid: (s: Solid) => {
+      const rotated = aa.angleDeg === 0 ? s : rotate(s, aa.angleDeg, { at: [0, 0, 0], axis: aa.axis });
+      return translate(rotated, target);
+    },
+    point: (p: Vec3) => vecAdd(applyR(p), target),
+    vector: applyR,
+  };
+}
+
+/** Axis-angle of a 3×3 rotation matrix (row-major). */
+function matrixToAxisAngle(m: number[]): { axis: Vec3; angleDeg: number } {
+  const m00 = m[0] ?? 0;
+  const m01 = m[1] ?? 0;
+  const m02 = m[2] ?? 0;
+  const m10 = m[3] ?? 0;
+  const m11 = m[4] ?? 0;
+  const m12 = m[5] ?? 0;
+  const m20 = m[6] ?? 0;
+  const m21 = m[7] ?? 0;
+  const m22 = m[8] ?? 0;
+
+  const trace = m00 + m11 + m22;
+  const cos = Math.max(-1, Math.min(1, (trace - 1) / 2));
+  const angle = Math.acos(cos);
+  const angleDeg = (angle * 180) / Math.PI;
+  if (angle < 1e-9) return { axis: [0, 0, 1], angleDeg: 0 };
+
+  if (Math.PI - angle < 1e-6) {
+    // 180°: axis is the column of (R + I) with the largest diagonal.
+    const xx = (m00 + 1) / 2;
+    const yy = (m11 + 1) / 2;
+    const zz = (m22 + 1) / 2;
+    let axis: Vec3;
+    if (xx >= yy && xx >= zz) {
+      const x = Math.sqrt(Math.max(xx, 0));
+      axis = [x, (m01 + m10) / (4 * x), (m02 + m20) / (4 * x)];
+    } else if (yy >= zz) {
+      const y = Math.sqrt(Math.max(yy, 0));
+      axis = [(m01 + m10) / (4 * y), y, (m12 + m21) / (4 * y)];
+    } else {
+      const z = Math.sqrt(Math.max(zz, 0));
+      axis = [(m02 + m20) / (4 * z), (m12 + m21) / (4 * z), z];
+    }
+    return { axis: vecNormalize(axis), angleDeg: 180 };
+  }
+
+  const denom = 2 * Math.sin(angle);
+  const axis: Vec3 = [(m21 - m12) / denom, (m02 - m20) / denom, (m10 - m01) / denom];
+  return { axis: vecNormalize(axis), angleDeg };
+}
+
+/**
+ * Cylindrical bend patch swept by the fold. Built as a hollow tube (outer R+T,
+ * inner R) along +Y, intersected with the angular wedge for the fold. For an up
+ * bend the axis sits above the base (sweep from −Z toward the flange); for a down
+ * bend it sits below (sweep from +Z toward the flange).
  */
 function buildBendPatch(
   axisOrigin: Vec3,
   thetaDeg: number,
   r: number,
   width: number,
-  thickness: number
+  thickness: number,
+  direction: 'up' | 'down'
 ): Result<ValidSolid> {
   const outerR = r + thickness;
 
@@ -247,30 +657,28 @@ function buildBendPatch(
     tube = carved.value;
   }
 
-  const wedge = buildWedge(axisOrigin, thetaDeg, outerR, width);
+  const wedge = buildWedge(axisOrigin, thetaDeg, outerR, width, direction);
   if (!wedge.ok) return wedge;
   return intersect(tube, wedge.value) as Result<ValidSolid>;
 }
 
 /**
- * Convex angular wedge (≤180°) isolating the fold sweep. The inner arc starts
- * pointing straight down (−Z) at the base contact and sweeps to the flange. With
- * OCCT's `rotate(+90°, +Y)` mapping +X→−Z, the wedge is the intersection of two
- * half-spaces through the bend axis: the +X side of the vertical start plane, and
- * the keep-side of the end plane (the start plane rotated by the fold). Both are
- * generous boxes; the tube intersection trims them to the true annular sector.
+ * Convex angular wedge (≤180°) isolating the fold sweep. The inner arc starts at
+ * the base contact (straight down −Z for an up bend, straight up +Z for a down
+ * bend) and sweeps to the flange. Built as the intersection of the +X half-space
+ * through the bend axis with that half-space rotated by the fold; the tube
+ * intersection trims it to the true annular sector.
  */
 function buildWedge(
   axisOrigin: Vec3,
   thetaDeg: number,
   outerR: number,
-  width: number
+  width: number,
+  direction: 'up' | 'down'
 ): Result<Solid> {
   const span = outerR * 2 + 2;
   const margin = 1;
 
-  // Half-space A: keep X >= axis.x. A block sitting on the +X side of the axis,
-  // covering the full Z extent of the tube and the full width.
   const blockA = box(span, width + 2 * margin, 2 * span);
   const halfA: Solid = translate(blockA, [
     axisOrigin[0],
@@ -278,26 +686,32 @@ function buildWedge(
     axisOrigin[2] - span,
   ]);
 
-  // Half-space B: half-A rotated about the bend axis by (180 - theta) degrees, so
-  // its keep-face normal aligns with the end edge of the sweep. Their intersection
-  // is the convex wedge between the start (-Z) and flange directions.
-  const halfB = rotate(halfA, 180 - thetaDeg, { at: axisOrigin, axis: [0, 1, 0] });
+  // Up bends sweep from −Z (rotate +X start plane by +(180−θ)); down bends mirror
+  // about the axis, sweeping from +Z (rotate by −(180−θ)).
+  const sign = direction === 'up' ? 1 : -1;
+  const halfB = rotate(halfA, sign * (180 - thetaDeg), { at: axisOrigin, axis: [0, 1, 0] });
 
   return intersect(halfA, halfB);
 }
 
-/** The flange flat, built lying along +X past the bend, then folded up to angle. */
+/** The flange flat, built lying along +X past the bend, then folded to angle θ. */
 function buildFlangeFlat(
   axisOrigin: Vec3,
   thetaDeg: number,
   width: number,
   thickness: number,
-  length: number
+  length: number,
+  direction: 'up' | 'down'
 ): Solid {
-  // Unfolded (theta=0) the flange is coplanar with the base sheet (Z in [0, T]),
-  // running in +X from the bend's tangent point at x = axisOrigin.x. Folding up by
-  // theta is rotate(-theta) about +Y (which sends +X toward +Z).
+  // Unfolded the flat is coplanar with the base sheet; for an up bend it lies in
+  // Z∈[0,T] folding up (rotate −θ about +Y sends +X toward +Z); for a down bend it
+  // lies in Z∈[−T,0] folding down (rotate +θ sends +X toward −Z).
+  if (direction === 'up') {
+    const flat = box(length, width, thickness);
+    const positioned: Solid = translate(flat, [axisOrigin[0], axisOrigin[1], 0]);
+    return rotate(positioned, -thetaDeg, { at: axisOrigin, axis: [0, 1, 0] });
+  }
   const flat = box(length, width, thickness);
-  const positioned: Solid = translate(flat, [axisOrigin[0], axisOrigin[1], 0]);
-  return rotate(positioned, -thetaDeg, { at: axisOrigin, axis: [0, 1, 0] });
+  const positioned: Solid = translate(flat, [axisOrigin[0], axisOrigin[1], -thickness]);
+  return rotate(positioned, thetaDeg, { at: axisOrigin, axis: [0, 1, 0] });
 }

--- a/packages/brepjs-sheetmetal/src/authorFns.ts
+++ b/packages/brepjs-sheetmetal/src/authorFns.ts
@@ -146,8 +146,12 @@ export function authorPart(spec: AuthorSpec): Result<SheetMetalPart> {
   for (const flange of spec.flanges) {
     // `::` is reserved as the seam-bend id delimiter (`seam::<parent>::<child>`);
     // allowing it in a flange id would make the seam parent/child ambiguous to parse.
-    if (flange.id === '' || flange.id.includes('::')) {
-      return err(validationError('INVALID_FLANGE_ID', `flange id must be non-empty and must not contain '::', got '${flange.id}'`));
+    // `root`/`face-0` are reserved sentinels for the base flat — a flange reusing
+    // either would silently overwrite the base frame and fold off wrong geometry.
+    if (flange.id === '' || flange.id.includes('::') || flange.id === ROOT_FLAT_ID || flange.id === 'face-0') {
+      return err(
+        validationError('INVALID_FLANGE_ID', `flange id must be non-empty, must not contain '::', and must not reuse the reserved ids 'root'/'face-0', got '${flange.id}'`)
+      );
     }
     if (seen.has(flange.id)) {
       return err(validationError('DUPLICATE_FLANGE', `duplicate flange id '${flange.id}'`));

--- a/packages/brepjs-sheetmetal/src/authorFns.ts
+++ b/packages/brepjs-sheetmetal/src/authorFns.ts
@@ -144,6 +144,11 @@ export function authorPart(spec: AuthorSpec): Result<SheetMetalPart> {
 
   const seen = new Set<string>();
   for (const flange of spec.flanges) {
+    // `::` is reserved as the seam-bend id delimiter (`seam::<parent>::<child>`);
+    // allowing it in a flange id would make the seam parent/child ambiguous to parse.
+    if (flange.id === '' || flange.id.includes('::')) {
+      return err(validationError('INVALID_FLANGE_ID', `flange id must be non-empty and must not contain '::', got '${flange.id}'`));
+    }
     if (seen.has(flange.id)) {
       return err(validationError('DUPLICATE_FLANGE', `duplicate flange id '${flange.id}'`));
     }
@@ -197,6 +202,16 @@ export function authorPart(spec: AuthorSpec): Result<SheetMetalPart> {
     if (!frames.has(seamParent) || !frames.has(seamChild)) {
       return err(
         validationError('UNKNOWN_SEAM_FLAT', `seam ${seam.parent}↔${seam.child} references an unauthored flat`)
+      );
+    }
+    if (!Number.isFinite(seam.angleDeg) || seam.angleDeg <= 0 || seam.angleDeg > 180) {
+      return err(
+        validationError('INVALID_SEAM_ANGLE', `seam ${seam.parent}↔${seam.child} angleDeg must be in (0, 180], got ${seam.angleDeg}`)
+      );
+    }
+    if (!Number.isFinite(seam.rule.innerRadius) || seam.rule.innerRadius < 0) {
+      return err(
+        validationError('INVALID_SEAM_RADIUS', `seam ${seam.parent}↔${seam.child} innerRadius must be non-negative`)
       );
     }
     const parentFrame = frames.get(seamParent) as FlatFrame;

--- a/packages/brepjs-sheetmetal/src/facade.ts
+++ b/packages/brepjs-sheetmetal/src/facade.ts
@@ -12,7 +12,7 @@
 
 import type { BrepError, Result } from 'brepjs';
 import { isErr } from 'brepjs';
-import type { AuthorSpec, BaseFlatSpec, FlangeSpec } from './authorFns.js';
+import type { AuthorSpec, BaseFlatSpec, FlangeSpec, SeamSpec } from './authorFns.js';
 import type { MiterPlane, DxfOptions } from './api.js';
 import {
   author,
@@ -107,9 +107,14 @@ class SheetMetalBuilder {
 
   constructor(private readonly spec: AuthorSpec) {}
 
-  /** Add a flange folded up off a base edge. */
+  /** Add a flange folded off its parent edge (the base by default). */
   flange(flange: FlangeSpec): SheetMetalBuilder {
     return new SheetMetalBuilder({ ...this.spec, flanges: [...this.spec.flanges, flange] });
+  }
+
+  /** Add a seam closing a profile into a tube/box (left unfolded). */
+  seam(seam: SeamSpec): SheetMetalBuilder {
+    return new SheetMetalBuilder({ ...this.spec, seams: [...(this.spec.seams ?? []), seam] });
   }
 
   /** Set the part material (its thickness/default rule). */

--- a/packages/brepjs-sheetmetal/src/featureTreeFns.ts
+++ b/packages/brepjs-sheetmetal/src/featureTreeFns.ts
@@ -80,9 +80,12 @@ export function buildFeatureGraph(part: SheetMetalPart): Result<FeatureGraph> {
     // A seam bend (`seam::<parent>::<child>`) is an explicit edge between two
     // already-authored flats — the cycle-closing edge of a tube/box profile.
     if (bend.id.startsWith('seam::')) {
-      const parts = bend.id.split('::');
-      const parent = parts[1];
-      const child = parts[2];
+      // Format is `seam::<parent>::<child>`; flange ids are validated to exclude
+      // `::`, so the last delimiter splits parent from child unambiguously.
+      const withoutPrefix = bend.id.slice('seam::'.length);
+      const sep = withoutPrefix.lastIndexOf('::');
+      const parent = sep >= 0 ? withoutPrefix.slice(0, sep) : undefined;
+      const child = sep >= 0 ? withoutPrefix.slice(sep + 2) : undefined;
       if (parent === undefined || child === undefined || !nodes.has(parent) || !nodes.has(child)) {
         return err(
           validationError('UNRESOLVED_SEAM', `seam bend '${bend.id}' references an unknown flat`)

--- a/packages/brepjs-sheetmetal/src/featureTreeFns.ts
+++ b/packages/brepjs-sheetmetal/src/featureTreeFns.ts
@@ -77,6 +77,21 @@ export function buildFeatureGraph(part: SheetMetalPart): Result<FeatureGraph> {
     }
     seenBendIds.add(bend.id);
 
+    // A seam bend (`seam::<parent>::<child>`) is an explicit edge between two
+    // already-authored flats — the cycle-closing edge of a tube/box profile.
+    if (bend.id.startsWith('seam::')) {
+      const parts = bend.id.split('::');
+      const parent = parts[1];
+      const child = parts[2];
+      if (parent === undefined || child === undefined || !nodes.has(parent) || !nodes.has(child)) {
+        return err(
+          validationError('UNRESOLVED_SEAM', `seam bend '${bend.id}' references an unknown flat`)
+        );
+      }
+      edges.push({ bend, parent, child });
+      continue;
+    }
+
     const child = resolveChildFlat(bend.id, nodes);
     if (child === undefined) {
       return err(
@@ -104,6 +119,10 @@ function resolveChildFlat(bendId: string, nodes: Map<string, FlatNode>): string 
 function resolveParentFlat(flange: FlangeFeature | undefined, nodes: Map<string, FlatNode>): string {
   if (flange === undefined) return ROOT_FLAT_ID;
   const ref = flange.baseEdge;
+  // Chained flanges name their parent flat directly; `face-0` is the base flat.
+  if (ref.parentId !== undefined && ref.parentId !== 'face-0' && nodes.has(ref.parentId)) {
+    return ref.parentId;
+  }
   return nodes.has(`face-${ref.faceIndex}`) ? `face-${ref.faceIndex}` : ROOT_FLAT_ID;
 }
 
@@ -117,9 +136,21 @@ export function buildFeatureTree(graph: FeatureGraph, rootId: string = ROOT_FLAT
     return err(validationError('UNKNOWN_ROOT', `root flat '${rootId}' not present in graph`));
   }
 
+  // Authored seam bends (`seam::…`) are explicitly the cycle-closing edges of a
+  // closed profile. They must never enter the spanning tree, or the BFS can grab a
+  // seam as a tree edge and demote a real authored bend to the seam cut — placing
+  // its child flat off the wrong frame. Exclude them from BFS and record them as
+  // seam cuts directly, so authored seams are always the non-tree edges.
+  const seamEdges: BendEdge[] = [];
+  const treeCandidates: BendEdge[] = [];
+  for (const edge of graph.edges) {
+    if (edge.bend.id.startsWith('seam::')) seamEdges.push(edge);
+    else treeCandidates.push(edge);
+  }
+
   const adjacency = new Map<string, BendEdge[]>();
   for (const id of graph.nodes.keys()) adjacency.set(id, []);
-  for (const edge of graph.edges) {
+  for (const edge of treeCandidates) {
     adjacency.get(edge.parent)?.push(edge);
     adjacency.get(edge.child)?.push(edge);
   }
@@ -145,14 +176,19 @@ export function buildFeatureTree(graph: FeatureGraph, rootId: string = ROOT_FLAT
 
   const warnings: SheetMetalWarning[] = [];
   const seams: SeamCut[] = [];
-  for (const edge of graph.edges) {
-    if (treeEdges.has(edge)) continue;
+  const recordSeam = (edge: BendEdge): void => {
     seams.push({ bend: edge.bend, between: [edge.parent, edge.child] });
     warnings.push({
       code: 'SEAM_CUT',
       message: `closed profile: bend '${edge.bend.id}' (${edge.parent}↔${edge.child}) becomes a seam cut`,
       featureId: edge.bend.id,
     });
+  };
+  for (const edge of seamEdges) recordSeam(edge);
+  // A non-seam edge left out of the tree closes a cycle authored without a seam.
+  for (const edge of treeCandidates) {
+    if (treeEdges.has(edge)) continue;
+    recordSeam(edge);
   }
 
   for (const node of graph.nodes.values()) {

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -31,6 +31,7 @@ export type {
   BaseFlatSpec,
   FlangeSpec,
   FlangeSide,
+  SeamSpec,
 } from './authorFns.js';
 
 export { miterCut, autoMiterCorner } from './miterFns.js';
@@ -61,6 +62,7 @@ export { sheetMetal, fromPart, SheetMetalError, SheetMetalBuilder, SheetMetalPar
 
 export type {
   EdgeRef,
+  FlatSide,
   BendRule,
   MaterialSpec,
   MiterSpec,

--- a/packages/brepjs-sheetmetal/src/internal.ts
+++ b/packages/brepjs-sheetmetal/src/internal.ts
@@ -1,4 +1,5 @@
 import { type Solid, type Vec3, isSolid, getSolids } from 'brepjs';
+import type { FlatSide } from './types.js';
 
 /**
  * OCCT boolean fuse returns a compound wrapping the unioned solid. Extract the
@@ -12,17 +13,16 @@ export function normalizeSolid(shape: Solid): Solid {
   return only ?? shape;
 }
 
-/** Which way a flange develops in the flat pattern, from its recorded bend axis. */
-export type RunDir = 'east' | 'north';
-
 /**
- * Classify a bend's run direction from its recorded axis: an axis along +Y
- * (|axisDir.y|>0.5) belongs to an east flange (develops in +X); an axis along
- * +X belongs to a north flange (develops in +Y). Shared by the unfold and the
- * bend report so their layouts agree.
+ * Fallback develop side for a hand-built flange whose `baseEdge.side` is omitted:
+ * derive it from the recorded bend axis. An axis along +Y (|axisDir.y|>0.5) is an
+ * east flange that develops in +X (`xmax`); an axis along +X is a north flange
+ * developing in +Y (`ymax`). This preserves the original axis-only unfold
+ * heuristic for external fixtures predating the explicit `side` field; parts from
+ * {@link authorPart} always set `side`, so this only kicks in for the legacy path.
  */
-export function classifyRunDir(axisDir: Vec3): RunDir | undefined {
-  if (Math.abs(axisDir[1]) > 0.5) return 'east';
-  if (Math.abs(axisDir[0]) > 0.5) return 'north';
+export function sideFromAxisDir(axisDir: Vec3): FlatSide | undefined {
+  if (Math.abs(axisDir[1]) > 0.5) return 'xmax';
+  if (Math.abs(axisDir[0]) > 0.5) return 'ymax';
   return undefined;
 }

--- a/packages/brepjs-sheetmetal/src/reportFns.ts
+++ b/packages/brepjs-sheetmetal/src/reportFns.ts
@@ -1,24 +1,14 @@
 import { type Result, ok, err, validationError } from 'brepjs';
 import type { BendReport, SheetMetalPart, UnfoldResult } from './types.js';
 import { featureTree } from './featureTreeFns.js';
-import { developedLength } from './allowanceFns.js';
-import { classifyRunDir } from './internal.js';
-
-interface ReportEntry {
-  id: string;
-  angleDeg: number;
-  radius: number;
-  allowance: number;
-  flatLength: number;
-  direction: 'up' | 'down';
-}
+import { layoutTree, reportFromLayout } from './unfoldFns.js';
 
 /**
  * Build the bend-table JSON report directly from an authored part. Walks the
- * same feature tree the unfold consumes so the per-bend values and the total
- * flat size agree with the flat pattern. `allowance` is the consumed neutral-axis
- * arc length (the bend allowance); `flatLength` is the straight flange leg past
- * the bend — distinct values a downstream nesting/cut-list tool needs separately.
+ * same tree layout the unfold consumes so the per-bend values and the total flat
+ * size agree with the flat pattern. `allowance` is the consumed neutral-axis arc
+ * length (the bend allowance); `flatLength` is the straight flange leg past the
+ * bend — distinct values a downstream nesting/cut-list tool needs separately.
  */
 export function buildReport(part: SheetMetalPart): Result<BendReport> {
   const treeResult = featureTree(part);
@@ -34,44 +24,9 @@ export function buildReport(part: SheetMetalPart): Result<BendReport> {
     return err(validationError('INVALID_WIDTH', `part width must be positive, got ${width}`));
   }
 
-  let maxX = baseLength;
-  let maxY = width;
-  const bends: ReportEntry[] = [];
-
-  for (const treeBend of tree.bends) {
-    const dir = classifyRunDir(treeBend.bend.axisDir);
-    if (dir === undefined) {
-      return err(
-        validationError('UNRESOLVED_RUN_DIR', `bend '${treeBend.bend.id}' axisDir is not axis-aligned`)
-      );
-    }
-
-    const devResult = developedLength(treeBend.bend.angleDeg, part.thickness, treeBend.bend.rule);
-    if (!devResult.ok) return devResult;
-    const devLength = devResult.value;
-
-    const childNode = tree.nodes.get(treeBend.child);
-    if (childNode === undefined) {
-      return err(
-        validationError('UNKNOWN_FLAT', `child flat '${treeBend.child}' missing from tree nodes`)
-      );
-    }
-    const length = childNode.flange?.length ?? 0;
-
-    bends.push({
-      id: treeBend.bend.id,
-      angleDeg: treeBend.bend.angleDeg,
-      radius: treeBend.bend.rule.innerRadius,
-      allowance: devLength,
-      flatLength: length,
-      direction: treeBend.bend.direction,
-    });
-
-    if (dir === 'east') maxX = baseLength + devLength + length;
-    else maxY = width + devLength + length;
-  }
-
-  return ok({ bends, totalFlatSize: [maxX, maxY] });
+  const layout = layoutTree(part, tree, baseLength, width);
+  if (!layout.ok) return layout;
+  return ok(reportFromLayout(layout.value));
 }
 
 /**

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -1,6 +1,24 @@
-import type { Solid, Wire, Edge } from 'brepjs';
+import type { Solid, Wire, Edge, Bounds3D } from 'brepjs';
 
-export type EdgeRef = { kind: 'index'; faceIndex: number; edgeIndex: number };
+/** Which edge of a flat a child flange folds off. */
+export type FlatSide = 'xmin' | 'xmax' | 'ymin' | 'ymax';
+
+/**
+ * Reference to the parent edge a flange folds from. `faceIndex` keeps the legacy
+ * construction-order scheme (`face-0` = base flat). `parentId` names the parent
+ * flat directly (a flange id for chained flanges, or undefined for the base) and
+ * `side`/`offset`/`extent` locate the flange along that parent edge — the data
+ * the recursive unfold walk and the feature tree consume.
+ */
+export type EdgeRef = {
+  kind: 'index';
+  faceIndex: number;
+  edgeIndex: number;
+  parentId?: string | undefined;
+  side?: FlatSide | undefined;
+  offset?: number | undefined;
+  extent?: number | undefined;
+};
 
 export interface BendRule {
   innerRadius: number;
@@ -36,8 +54,15 @@ export interface FlangeFeature {
   length: number;
   /** Extent along the bend axis — the flange's cross-width in the developed strip. */
   span: number;
+  /** Start position of the flange measured along the parent edge (0 = edge start). */
+  offset?: number | undefined;
   angleDeg: number;
+  direction?: 'up' | 'down' | undefined;
   rule: BendRule;
+  /** World-space AABB of the folded flange, recorded by {@link authorPart} from the
+   * real placed geometry. The collision check prefers this over an analytic re-fold,
+   * which is only correct for root flanges (chained flanges fold off an off-plane edge). */
+  foldedBounds?: Bounds3D | undefined;
   miter?: MiterSpec | undefined;
 }
 

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -284,7 +284,6 @@ function placeChild(
 function edgeBasis2(f: Frame2, side: FlatSide): { along: Pt2; out: Pt2; edgeOrigin: Pt2 } {
   const uTop = add2(f.origin, scale2(f.u, f.uLen));
   const vTop = add2(f.origin, scale2(f.v, f.vLen));
-  const uvTop = add2(uTop, scale2(f.v, f.vLen));
   switch (side) {
     case 'xmax':
       return { along: f.v, out: f.u, edgeOrigin: uTop };
@@ -295,7 +294,7 @@ function edgeBasis2(f: Frame2, side: FlatSide): { along: Pt2; out: Pt2; edgeOrig
     case 'ymin':
       return { along: f.u, out: neg2(f.v), edgeOrigin: f.origin };
     default:
-      return { along: f.u, out: f.v, edgeOrigin: uvTop };
+      return side satisfies never;
   }
 }
 

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -15,27 +15,26 @@ import type {
   BendReport,
   SheetMetalWarning,
   CornerMiter,
+  FlatSide,
 } from './types.js';
-import { featureTree, type FeatureTree, type FlatNode } from './featureTreeFns.js';
+import { featureTree, type FeatureTree, ROOT_FLAT_ID } from './featureTreeFns.js';
 import { developedLength } from './allowanceFns.js';
-import { classifyRunDir, type RunDir } from './internal.js';
+import { sideFromAxisDir } from './internal.js';
 
 type Pt2 = [number, number];
 
 /**
- * Tree-driven analytic unfold of a straight-bend part into its flat pattern.
- *
- * Each flange develops perpendicularly off its own bend line, in the direction
- * fixed by the recorded bend axis: an 'east' flange (|axisDir.y|>0.5) unfolds in
- * +X off the x=baseLength edge; a 'north' flange (|axisDir.x|>0.5) unfolds in +Y
- * off the y=width edge. The base occupies x∈[0,baseLength], y∈[0,width]; each
- * flange adds a strip of its developed bend length (neutral-axis arc) plus its
- * flat length past the bend. The developed outline is the rectilinear union of
- * the base and the present flange regions — a rectangle for ≤1 flange, an
- * L-hexagon when both an east and a north flange are present. A recorded corner
- * miter replaces the shared reflex corner with a 45° chamfer so the two upright
- * flanges clear each other by the miter gap once folded. Bend lines and the
- * outline are emitted as native brepjs wires; warnings ride inside the Ok payload.
+ * Tree-driven analytic unfold of an arbitrary straight-bend part into its flat
+ * pattern. Walks the feature tree in BFS order placing every flat in the flat
+ * plane: the base occupies `[0,baseLength]×[0,width]`; each child flange lays a
+ * developed-bend strip (width = neutral-axis arc length) along the parent edge it
+ * folds from — respecting its offset/span along that edge — then its own flat past
+ * the strip, perpendicular to the edge and pointing outward. The developed outline
+ * is the rectilinear union of the base and every placed flat/strip rectangle,
+ * emitted as a single closed brepjs wire. A recorded corner miter replaces the
+ * shared reflex corner of two perpendicular base flanges with a 45° chamfer.
+ * Closed profiles produce a SEAM_CUT warning (the cycle-closing bend is left
+ * unfolded). Warnings ride inside the Ok payload.
  */
 export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   const treeResult = featureTree(part);
@@ -53,28 +52,35 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
 
   const warnings: SheetMetalWarning[] = [...tree.warnings];
 
-  const layoutResult = layoutRun(part, tree, baseLength, width);
+  const layoutResult = layoutTree(part, tree, baseLength, width);
   if (!layoutResult.ok) return layoutResult;
   const layout = layoutResult.value;
 
-  for (const flange of layout.flanges) {
-    if (part.thickness > 0 && flange.rule.innerRadius < part.thickness) {
+  for (const placed of layout.flats) {
+    if (placed.kind !== 'flange') continue;
+    if (part.thickness > 0 && placed.rule.innerRadius < part.thickness) {
       warnings.push({
         code: 'MIN_RADIUS',
-        message: `bend '${flange.id}' inner radius ${flange.rule.innerRadius} < thickness ${part.thickness}`,
-        featureId: flange.id,
+        message: `bend '${placed.id}' inner radius ${placed.rule.innerRadius} < thickness ${part.thickness}`,
+        featureId: placed.id,
       });
     }
   }
 
-  const outlineResult = buildOutline(layout, part.miters ?? []);
+  const rects: Rect[] = [];
+  for (const placed of layout.flats) rects.push(placed.rect);
+  for (const strip of layout.strips) rects.push(strip);
+
+  const outlineResult = buildOutline(rects, layout, part.miters ?? []);
   if (!outlineResult.ok) return outlineResult;
 
-  const bendLines = layout.flanges.map((flange) => ({
-    line: bendLineEdge(flange, layout.baseLength, layout.width),
-    angleDeg: flange.angleDeg,
-    direction: flange.direction,
-  }));
+  const bendLines = layout.flats
+    .filter((p): p is PlacedFlange => p.kind === 'flange')
+    .map((p) => ({
+      line: bendLineEdge(p),
+      angleDeg: p.angleDeg,
+      direction: p.direction,
+    }));
 
   const pattern: FlatPattern = {
     outline: outlineResult.value,
@@ -82,65 +88,104 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
     developedArea: layout.developedArea,
   };
 
-  const report = buildReport(layout);
+  const report = reportFromLayout(layout);
 
   return ok({ pattern, report, warnings });
 }
 
-interface FlangeLayout {
+/** A placed flat rectangle in the developed (flat-pattern) plane. */
+export interface Rect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/** 2D frame of a placed flat: occupies [0,uLen]×[0,vLen] in (u,v) from `origin`. */
+export interface Frame2 {
+  origin: Pt2;
+  u: Pt2;
+  v: Pt2;
+  uLen: number;
+  vLen: number;
+}
+
+export interface PlacedBase {
+  kind: 'base';
   id: string;
-  dir: RunDir;
-  /** Developed (neutral-axis) bend length laid down as a flat strip. */
+  rect: Rect;
+  frame: Frame2;
+}
+
+export interface PlacedFlange {
+  kind: 'flange';
+  id: string;
+  rect: Rect;
+  frame: Frame2;
+  /** Strip rectangle laid along the parent edge (developed bend). */
+  strip: Rect;
+  /** Bend line endpoints (along the parent edge, over the flange span). */
+  bendA: Pt2;
+  bendB: Pt2;
   dev: number;
-  /** Flat length past the bend. */
   length: number;
-  /** Extent along the bend axis. */
   span: number;
   angleDeg: number;
   direction: 'up' | 'down';
   rule: { innerRadius: number; kFactor: number; allowance?: number | undefined };
+  /** True when this flange folds directly off the base and spans its full edge. */
+  baseFull: boolean;
+  side: FlatSide;
 }
 
-interface RunLayout {
+export type Placed = PlacedBase | PlacedFlange;
+
+export interface TreeLayout {
   baseLength: number;
   width: number;
-  /** Total developed extent along +X (base plus the east flange, if present). */
-  maxX: number;
-  /** Total developed extent along +Y (base plus the north flange, if present). */
-  maxY: number;
   developedArea: number;
-  flanges: FlangeLayout[];
-  east?: FlangeLayout | undefined;
-  north?: FlangeLayout | undefined;
+  flats: Placed[];
+  strips: Rect[];
 }
 
-function flangeSpanOf(node: FlatNode, fallback: number): number {
-  if (node.flange === undefined) return fallback;
-  return node.flange.span;
-}
-
-function flangeLengthOf(node: FlatNode): number {
-  if (node.flange === undefined) return 0;
-  return node.flange.length;
-}
-
-function layoutRun(
+export function layoutTree(
   part: SheetMetalPart,
   tree: FeatureTree,
   baseLength: number,
   width: number
-): Result<RunLayout> {
-  const flanges: FlangeLayout[] = [];
-  let east: FlangeLayout | undefined;
-  let north: FlangeLayout | undefined;
+): Result<TreeLayout> {
+  const frames = new Map<string, Frame2>();
+  frames.set(ROOT_FLAT_ID, {
+    origin: [0, 0],
+    u: [1, 0],
+    v: [0, 1],
+    uLen: baseLength,
+    vLen: width,
+  });
 
+  const flats: Placed[] = [
+    {
+      kind: 'base',
+      id: ROOT_FLAT_ID,
+      frame: frames.get(ROOT_FLAT_ID) as Frame2,
+      rect: rectOf(frames.get(ROOT_FLAT_ID) as Frame2),
+    },
+  ];
+  const strips: Rect[] = [];
   let developedArea = baseLength * width;
 
   for (const treeBend of tree.bends) {
-    const dir = classifyRunDir(treeBend.bend.axisDir);
-    if (dir === undefined) {
+    const childNode = tree.nodes.get(treeBend.child);
+    if (childNode === undefined || childNode.flange === undefined) {
       return err(
-        validationError('UNRESOLVED_RUN_DIR', `bend '${treeBend.bend.id}' axisDir is not axis-aligned`)
+        validationError('UNKNOWN_FLAT', `child flat '${treeBend.child}' has no flange feature`)
+      );
+    }
+    const flange = childNode.flange;
+    const parentFrame = frames.get(treeBend.parent);
+    if (parentFrame === undefined) {
+      return err(
+        validationError('UNKNOWN_FLAT', `parent flat '${treeBend.parent}' missing from layout`)
       );
     }
 
@@ -148,58 +193,154 @@ function layoutRun(
     if (!devResult.ok) return devResult;
     const dev = devResult.value;
 
-    const childNode = tree.nodes.get(treeBend.child);
-    if (childNode === undefined) {
-      return err(
-        validationError('UNKNOWN_FLAT', `child flat '${treeBend.child}' missing from tree nodes`)
-      );
-    }
-    const span = flangeSpanOf(childNode, dir === 'east' ? width : baseLength);
-    const length = flangeLengthOf(childNode);
+    // Authored parts always record `baseEdge.side`; hand-built fixtures may encode
+    // the develop direction only via the bend axis, so fall back to that.
+    const side: FlatSide = flange.baseEdge.side ?? sideFromAxisDir(treeBend.bend.axisDir) ?? 'xmax';
+    const offset = flange.offset ?? flange.baseEdge.offset ?? 0;
+    const span = flange.span;
+    const length = flange.length;
 
-    const flange: FlangeLayout = {
-      id: treeBend.bend.id,
-      dir,
-      dev,
-      length,
-      span,
+    const placed = placeChild(flange.id, parentFrame, side, offset, span, dev, length, {
       angleDeg: treeBend.bend.angleDeg,
       direction: treeBend.bend.direction,
       rule: treeBend.bend.rule,
-    };
-    flanges.push(flange);
+      baseFull: treeBend.parent === ROOT_FLAT_ID && offset <= 1e-6 && span >= edgeLength(parentFrame, side) - 1e-6,
+      side,
+    });
+    frames.set(flange.id, placed.frame);
+    flats.push(placed);
+    strips.push(placed.strip);
     developedArea += (dev + length) * span;
-
-    if (dir === 'east') east = flange;
-    else north = flange;
   }
 
-  const maxX = baseLength + (east !== undefined ? east.dev + east.length : 0);
-  const maxY = width + (north !== undefined ? north.dev + north.length : 0);
-
-  return ok({
-    baseLength,
-    width,
-    maxX,
-    maxY,
-    developedArea,
-    flanges,
-    east,
-    north,
-  });
+  return ok({ baseLength, width, developedArea, flats, strips });
 }
 
-function bendLineEdge(flange: FlangeLayout, baseLength: number, width: number): Edge {
-  if (flange.dir === 'east') {
-    // bend line runs along Y at x=baseLength, spanning the base width.
-    return line([baseLength, 0, 0], [baseLength, width, 0]);
+function edgeLength(f: Frame2, side: FlatSide): number {
+  return side === 'xmax' || side === 'xmin' ? f.vLen : f.uLen;
+}
+
+/**
+ * Place a child flange off `parent`'s edge `side`. The strip (developed bend) is
+ * laid from the edge outward by `dev`; the child flat follows for `length`. The
+ * child's own 2D frame starts past the strip so grandchildren chain correctly.
+ */
+function placeChild(
+  id: string,
+  parent: Frame2,
+  side: FlatSide,
+  offset: number,
+  span: number,
+  dev: number,
+  length: number,
+  meta: {
+    angleDeg: number;
+    direction: 'up' | 'down';
+    rule: { innerRadius: number; kFactor: number; allowance?: number | undefined };
+    baseFull: boolean;
+    side: FlatSide;
   }
-  // bend line runs along X at y=width, spanning the base length.
-  return line([0, width, 0], [baseLength, width, 0]);
+): PlacedFlange {
+  // Edge basis in 2D: `along` runs the edge (bend axis), `out` points outward.
+  const { along, out, edgeOrigin } = edgeBasis2(parent, side);
+
+  const base = add2(edgeOrigin, scale2(along, offset));
+  const bendA = base;
+  const bendB = add2(base, scale2(along, span));
+
+  const stripFar = add2(base, scale2(out, dev));
+
+  const strip = rectFromCorners(base, add2(bendB, scale2(out, dev)));
+  const flatRect = rectFromCorners(stripFar, add2(add2(stripFar, scale2(along, span)), scale2(out, length)));
+
+  const childFrame: Frame2 = {
+    origin: stripFar,
+    u: along,
+    v: out,
+    uLen: span,
+    vLen: length,
+  };
+
+  return {
+    kind: 'flange',
+    id,
+    frame: childFrame,
+    rect: flatRect,
+    strip,
+    bendA,
+    bendB,
+    dev,
+    length,
+    span,
+    angleDeg: meta.angleDeg,
+    direction: meta.direction,
+    rule: meta.rule,
+    baseFull: meta.baseFull,
+    side: meta.side,
+  };
 }
 
-function buildOutline(layout: RunLayout, miters: CornerMiter[]): Result<Wire> {
-  const corners = outlineCorners(layout, miters);
+/** Edge origin + along/out unit directions for one side of a 2D frame. */
+function edgeBasis2(f: Frame2, side: FlatSide): { along: Pt2; out: Pt2; edgeOrigin: Pt2 } {
+  const uTop = add2(f.origin, scale2(f.u, f.uLen));
+  const vTop = add2(f.origin, scale2(f.v, f.vLen));
+  const uvTop = add2(uTop, scale2(f.v, f.vLen));
+  switch (side) {
+    case 'xmax':
+      return { along: f.v, out: f.u, edgeOrigin: uTop };
+    case 'xmin':
+      return { along: f.v, out: neg2(f.u), edgeOrigin: f.origin };
+    case 'ymax':
+      return { along: f.u, out: f.v, edgeOrigin: vTop };
+    case 'ymin':
+      return { along: f.u, out: neg2(f.v), edgeOrigin: f.origin };
+    default:
+      return { along: f.u, out: f.v, edgeOrigin: uvTop };
+  }
+}
+
+function bendLineEdge(p: PlacedFlange): Edge {
+  return line([p.bendA[0], p.bendA[1], 0], [p.bendB[0], p.bendB[1], 0]);
+}
+
+function rectOf(f: Frame2): Rect {
+  const c0 = f.origin;
+  const c1 = add2(add2(f.origin, scale2(f.u, f.uLen)), scale2(f.v, f.vLen));
+  return rectFromCorners(c0, c1);
+}
+
+function rectFromCorners(a: Pt2, b: Pt2): Rect {
+  return {
+    x0: Math.min(a[0], b[0]),
+    y0: Math.min(a[1], b[1]),
+    x1: Math.max(a[0], b[0]),
+    y1: Math.max(a[1], b[1]),
+  };
+}
+
+function add2(a: Pt2, b: Pt2): Pt2 {
+  return [a[0] + b[0], a[1] + b[1]];
+}
+function scale2(a: Pt2, s: number): Pt2 {
+  return [a[0] * s, a[1] * s];
+}
+function neg2(a: Pt2): Pt2 {
+  return [-a[0], -a[1]];
+}
+
+/**
+ * Outline of the developed pattern. For the simple two-perpendicular-flange L
+ * (base + an east + a north flange) a recorded corner miter chamfers the reflex
+ * vertex; otherwise the outline is the rectilinear union of all placed rectangles
+ * emitted as one closed loop. Holes are not possible for the supported shapes
+ * (every arm attaches to the simply-connected base or a chain thereof).
+ */
+function buildOutline(rects: Rect[], layout: TreeLayout, miters: CornerMiter[]): Result<Wire> {
+  const miterCorners = lShapedMiter(layout, miters);
+  const corners = miterCorners ?? rectilinearUnion(rects);
+  if (corners.length < 3) {
+    return err(validationError('OUTLINE_BUILD_FAILED', 'developed outline has fewer than 3 vertices'));
+  }
   const edges: Edge[] = [];
   for (let i = 0; i < corners.length; i += 1) {
     const from = corners[i];
@@ -213,75 +354,175 @@ function buildOutline(layout: RunLayout, miters: CornerMiter[]): Result<Wire> {
 }
 
 /**
- * CCW rectilinear polygon of the developed outline. With only an east or only a
- * north flange (or neither) the union is the [maxX]×[maxY] rectangle. With both,
- * it is the L-hexagon whose reentrant corner sits at (baseLength, width); a
- * recorded east↔north miter replaces that reflex vertex with a 45° chamfer
- * offset outward by the gap so the diagonal clearance equals the miter gap.
+ * Special-case the classic L: a base with exactly one east (+X) and one north
+ * (+Y) full-span flange and a recorded miter between them. Returns the chamfered
+ * hexagon; `undefined` if this isn't that shape (fall back to the union outline).
  */
-function outlineCorners(layout: RunLayout, miters: CornerMiter[]): Pt2[] {
-  const { baseLength, width, maxX, maxY, east, north } = layout;
+function lShapedMiter(layout: TreeLayout, miters: CornerMiter[]): Pt2[] | undefined {
+  const flanges = layout.flats.filter((p): p is PlacedFlange => p.kind === 'flange');
+  if (flanges.length !== 2) return undefined;
+  const east = flanges.find((f) => f.baseFull && f.side === 'xmax');
+  const north = flanges.find((f) => f.baseFull && f.side === 'ymax');
+  if (east === undefined || north === undefined) return undefined;
 
-  if (east === undefined || north === undefined) {
-    return [
-      [0, 0],
-      [maxX, 0],
-      [maxX, maxY],
-      [0, maxY],
-    ];
-  }
-
-  // L-hexagon: the reflex corner is at (baseLength, width).
-  const reflex: Pt2 = [baseLength, width];
+  const baseLength = layout.baseLength;
+  const width = layout.width;
+  const maxX = baseLength + east.dev + east.length;
+  const maxY = width + north.dev + north.length;
   const gap = miterGapFor(miters, east.id, north.id);
 
-  // A zero (or negative) gap removes no clearance, so the chamfer would collapse
-  // both vertices onto the reflex corner — a degenerate zero-length edge that
-  // wireLoop rejects. Treat it as the plain L-hexagon (no notch).
   if (gap === undefined || gap <= 0) {
     return [
       [0, 0],
       [maxX, 0],
       [maxX, width],
-      reflex,
+      [baseLength, width],
       [baseLength, maxY],
       [0, maxY],
     ];
   }
-
-  // Replace the reflex vertex with a 45° chamfer pulled outward by `gap`: the two
-  // flanges fold up about x=baseLength and y=width, so offsetting the chamfer by
-  // gap along +X and +Y leaves a gap-wide clearance between their upright edges.
-  const c1: Pt2 = [baseLength + gap, width];
-  const c2: Pt2 = [baseLength, width + gap];
   return [
     [0, 0],
     [maxX, 0],
     [maxX, width],
-    c1,
-    c2,
+    [baseLength + gap, width],
+    [baseLength, width + gap],
     [baseLength, maxY],
     [0, maxY],
   ];
 }
 
-function miterGapFor(miters: CornerMiter[], eastId: string, northId: string): number | undefined {
+function miterGapFor(miters: CornerMiter[], aId: string, bId: string): number | undefined {
   for (const m of miters) {
-    if ((m.flangeA === eastId && m.flangeB === northId) || (m.flangeA === northId && m.flangeB === eastId)) {
+    if ((m.flangeA === aId && m.flangeB === bId) || (m.flangeA === bId && m.flangeB === aId)) {
       return m.gap;
     }
   }
   return undefined;
 }
 
-function buildReport(layout: RunLayout): BendReport {
-  const bends = layout.flanges.map((flange) => ({
-    id: flange.id,
-    angleDeg: flange.angleDeg,
-    radius: flange.rule.innerRadius,
-    allowance: flange.dev,
-    flatLength: flange.length,
-    direction: flange.direction,
+/**
+ * Outline loop of the union of axis-aligned rectangles, assuming the union is a
+ * single simply-connected rectilinear region (true for every shape this package
+ * authors: arms attached to a connected base). Built by a vertical-line sweep
+ * tracking the covered y-spans, then tracing the boundary contour. The sweep emits
+ * a CCW loop of corner points with no collinear duplicates.
+ */
+function rectilinearUnion(rects: Rect[]): Pt2[] {
+  const xs = uniqueSorted(rects.flatMap((r) => [r.x0, r.x1]));
+  const ys = uniqueSorted(rects.flatMap((r) => [r.y0, r.y1]));
+  if (xs.length < 2 || ys.length < 2) return [];
+
+  // Cell-occupancy grid over the arrangement of all rectangle edges.
+  const nx = xs.length - 1;
+  const ny = ys.length - 1;
+  const filled = new Set<number>();
+  for (let i = 0; i < nx; i += 1) {
+    const cx = ((xs[i] as number) + (xs[i + 1] as number)) / 2;
+    for (let j = 0; j < ny; j += 1) {
+      const cy = ((ys[j] as number) + (ys[j + 1] as number)) / 2;
+      if (rects.some((r) => cx > r.x0 && cx < r.x1 && cy > r.y0 && cy < r.y1)) {
+        filled.add(i * ny + j);
+      }
+    }
+  }
+
+  // Collect boundary unit-edges (segments between adjacent grid nodes that border
+  // a filled and an unfilled cell), oriented CCW (filled cell on the left).
+  const segs: { a: Pt2; b: Pt2 }[] = [];
+  const isFilled = (i: number, j: number): boolean =>
+    i >= 0 && i < nx && j >= 0 && j < ny && filled.has(i * ny + j);
+
+  for (let i = 0; i < nx; i += 1) {
+    for (let j = 0; j < ny; j += 1) {
+      if (!isFilled(i, j)) continue;
+      const x0 = xs[i] as number;
+      const x1 = xs[i + 1] as number;
+      const y0 = ys[j] as number;
+      const y1 = ys[j + 1] as number;
+      // Bottom edge: boundary if cell below is empty. CCW → left-to-right.
+      if (!isFilled(i, j - 1)) segs.push({ a: [x0, y0], b: [x1, y0] });
+      // Top edge: boundary if cell above empty. CCW → right-to-left.
+      if (!isFilled(i, j + 1)) segs.push({ a: [x1, y1], b: [x0, y1] });
+      // Left edge: boundary if cell left empty. CCW → top-to-bottom.
+      if (!isFilled(i - 1, j)) segs.push({ a: [x0, y1], b: [x0, y0] });
+      // Right edge: boundary if cell right empty. CCW → bottom-to-top.
+      if (!isFilled(i + 1, j)) segs.push({ a: [x1, y0], b: [x1, y1] });
+    }
+  }
+
+  return traceLoop(segs);
+}
+
+/** Chain oriented boundary segments into a single loop, dropping collinear points. */
+function traceLoop(segs: { a: Pt2; b: Pt2 }[]): Pt2[] {
+  if (segs.length === 0) return [];
+  const key = (p: Pt2): string => `${p[0]}|${p[1]}`;
+  const from = new Map<string, Pt2>();
+  for (const s of segs) from.set(key(s.a), s.b);
+
+  const startSeg = segs[0] as { a: Pt2; b: Pt2 };
+  const start = startSeg.a;
+  const raw: Pt2[] = [start];
+  let cur = startSeg.b;
+  let guard = 0;
+  const limit = segs.length + 4;
+  while (key(cur) !== key(start) && guard < limit) {
+    raw.push(cur);
+    const next = from.get(key(cur));
+    if (next === undefined) break;
+    cur = next;
+    guard += 1;
+  }
+
+  // Drop collinear interior points so consecutive edges aren't degenerate.
+  const out: Pt2[] = [];
+  for (let i = 0; i < raw.length; i += 1) {
+    const prev = raw[(i - 1 + raw.length) % raw.length] as Pt2;
+    const here = raw[i] as Pt2;
+    const next = raw[(i + 1) % raw.length] as Pt2;
+    const d1x = here[0] - prev[0];
+    const d1y = here[1] - prev[1];
+    const d2x = next[0] - here[0];
+    const d2y = next[1] - here[1];
+    if (Math.abs(d1x * d2y - d1y * d2x) > 1e-9) out.push(here);
+  }
+  return out;
+}
+
+function uniqueSorted(values: number[]): number[] {
+  const sorted = [...values].sort((a, b) => a - b);
+  const out: number[] = [];
+  for (const v of sorted) {
+    const last = out[out.length - 1];
+    if (last === undefined || Math.abs(v - last) > 1e-9) out.push(v);
+  }
+  return out;
+}
+
+export function reportFromLayout(layout: TreeLayout): BendReport {
+  const flanges = layout.flats.filter((p): p is PlacedFlange => p.kind === 'flange');
+  const bends = flanges.map((f) => ({
+    id: f.id,
+    angleDeg: f.angleDeg,
+    radius: f.rule.innerRadius,
+    allowance: f.dev,
+    flatLength: f.length,
+    direction: f.direction,
   }));
-  return { bends, totalFlatSize: [layout.maxX, layout.maxY] };
+
+  // totalFlatSize is the overall bounding-box span of the developed pattern, which
+  // for parts whose flanges extend into negative coordinates (xmin/ymin sides) is
+  // the max−min extent, not just the max.
+  let minX = 0;
+  let minY = 0;
+  let maxX = layout.baseLength;
+  let maxY = layout.width;
+  for (const r of layout.flats.map((p) => p.rect).concat(layout.strips)) {
+    if (r.x0 < minX) minX = r.x0;
+    if (r.y0 < minY) minY = r.y0;
+    if (r.x1 > maxX) maxX = r.x1;
+    if (r.y1 > maxY) maxY = r.y1;
+  }
+  return { bends, totalFlatSize: [maxX - minX, maxY - minY] };
 }

--- a/packages/brepjs-sheetmetal/src/validateFns.ts
+++ b/packages/brepjs-sheetmetal/src/validateFns.ts
@@ -10,6 +10,7 @@ import {
   vecCross,
 } from 'brepjs';
 import type { BendFeature, SheetMetalPart, SheetMetalWarning } from './types.js';
+import { ROOT_FLAT_ID } from './featureTreeFns.js';
 
 const OVERLAP_TOL = 1e-6;
 
@@ -60,6 +61,7 @@ function checkMinRadius(part: SheetMetalPart): SheetMetalWarning[] {
   const warnings: SheetMetalWarning[] = [];
   if (!(part.thickness > 0)) return warnings;
   for (const bend of part.bends) {
+    if (bend.id.startsWith('seam::')) continue;
     if (bend.rule.innerRadius < part.thickness) {
       warnings.push({
         code: 'MIN_RADIUS',
@@ -82,10 +84,18 @@ function checkCollisions(part: SheetMetalPart): SheetMetalWarning[] {
   for (const bend of part.bends) {
     const flange = part.flanges.find((f) => f.id === bend.id);
     if (flange === undefined) continue;
-    boxes.push({
-      id: bend.id,
-      bounds: flangeBounds(bend, flange.length, flange.span, part.thickness, center),
-    });
+    // The analytic flangeBounds re-fold assumes the flange folds off the z=0 base
+    // plane: correct for root flanges, but wrong for chained flanges whose parent
+    // edge sits off that plane (it would report false-positive corner collisions).
+    // For chained flanges, use the AABB authorPart recorded from real geometry.
+    const parentId = flange.baseEdge.parentId;
+    const isChained =
+      parentId !== undefined && parentId !== ROOT_FLAT_ID && parentId !== 'face-0';
+    const bounds =
+      isChained && flange.foldedBounds !== undefined
+        ? flange.foldedBounds
+        : flangeBounds(bend, flange.length, flange.span, part.thickness, center);
+    boxes.push({ id: bend.id, bounds });
   }
 
   for (let i = 0; i < boxes.length; i += 1) {
@@ -123,7 +133,8 @@ function flangeBounds(
 ): Bounds3D {
   const axis = vecNormalize(bend.axisDir);
   const run = outwardRun(bend.axisOrigin, axis, center);
-  const up: Vec3 = [0, 0, 1];
+  // A down-bend folds the run toward −Z instead of +Z.
+  const up: Vec3 = bend.direction === 'down' ? [0, 0, -1] : [0, 0, 1];
 
   const theta = (bend.angleDeg * Math.PI) / 180;
   const cos = Math.cos(theta);

--- a/packages/brepjs-sheetmetal/tests/author.test.ts
+++ b/packages/brepjs-sheetmetal/tests/author.test.ts
@@ -121,8 +121,10 @@ describe('miter — two-flange corner', () => {
     expect(result.value.bends).toHaveLength(2);
 
     const [bx, by] = result.value.bends;
+    // Bend axes are right-handed with the outward run (out × dir = n), so the
+    // ymax axis runs along −X (its sign is geometry-significant, not decorative).
     expect(bx?.axisDir).toEqual([0, 1, 0]);
-    expect(by?.axisDir).toEqual([1, 0, 0]);
+    expect(by?.axisDir).toEqual([-1, 0, 0]);
   });
 
   it('auto-miters the corner into a valid solid', () => {
@@ -179,7 +181,7 @@ describe('miter — two-flange corner', () => {
 describe('authorPart — input validation', () => {
   const rule = { innerRadius: R, kFactor: 0.44 };
 
-  it('rejects two flanges on the same side (would overlap and corrupt the flat pattern)', () => {
+  it('rejects two full-span flanges on the same side (they would overlap)', () => {
     const result = authorPart({
       thickness: T,
       base: { length: 30, width: 10 },
@@ -190,10 +192,10 @@ describe('authorPart — input validation', () => {
     });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('DUPLICATE_SIDE');
+    expect(result.error.code).toBe('OVERLAPPING_FLANGES');
   });
 
-  it('treats an omitted side as xmax for the duplicate-side check', () => {
+  it('treats an omitted side as xmax for the overlap check', () => {
     const result = authorPart({
       thickness: T,
       base: { length: 30, width: 10 },
@@ -212,6 +214,23 @@ describe('authorPart — input validation', () => {
       flanges: [
         { id: 'a', length: 12, angleDeg: 90, rule, side: 'xmax' },
         { id: 'b', length: 12, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('keys the overlap check on the resolved chained-parent edge, not the base', () => {
+    // The wall folds off the base xmax edge (length = base width = 10), spans 8 of
+    // it, and is 20 long. Its ymax edge therefore has length = the wall span = 8.
+    // Two partial flanges chained off wall.ymax sit at [0,3] and [5,8] — valid only
+    // when the overlap check resolves the parent edge to 8, not the base width/length.
+    const result = authorPart({
+      thickness: T,
+      base: { length: 60, width: 10 },
+      flanges: [
+        { id: 'wall', length: 20, angleDeg: 90, rule, side: 'xmax', width: 8 },
+        { id: 'c1', length: 6, angleDeg: 90, rule, side: 'ymax', parent: 'wall', offset: 0, width: 3 },
+        { id: 'c2', length: 6, angleDeg: 90, rule, side: 'ymax', parent: 'wall', offset: 5, width: 3 },
       ],
     });
     expect(result.ok).toBe(true);

--- a/packages/brepjs-sheetmetal/tests/multibend.test.ts
+++ b/packages/brepjs-sheetmetal/tests/multibend.test.ts
@@ -257,3 +257,40 @@ describe('multi-bend report', () => {
     expect(rep.value.bends.map((b) => b.id).sort()).toEqual(['a', 'b', 'c']);
   });
 });
+
+describe('input validation', () => {
+  it("rejects a flange id containing '::' (reserved seam delimiter)", () => {
+    const bad = author({
+      thickness: T,
+      base: { length: 30, width: 30 },
+      flanges: [{ id: 'left::wall', length: 10, angleDeg: 90, rule, side: 'xmax' }],
+    });
+    expect(bad.ok).toBe(false);
+    if (!isErr(bad)) return;
+    expect(bad.error.code).toBe('INVALID_FLANGE_ID');
+  });
+
+  it('rejects a seam with an out-of-range angle', () => {
+    const bad = author({
+      thickness: T,
+      base: { length: 30, width: 30 },
+      flanges: [{ id: 'w1', length: 20, angleDeg: 90, rule, side: 'xmax' }],
+      seams: [{ parent: 'w1', child: 'root', angleDeg: -90, rule }],
+    });
+    expect(bad.ok).toBe(false);
+    if (!isErr(bad)) return;
+    expect(bad.error.code).toBe('INVALID_SEAM_ANGLE');
+  });
+
+  it('rejects a seam with a negative inner radius', () => {
+    const bad = author({
+      thickness: T,
+      base: { length: 30, width: 30 },
+      flanges: [{ id: 'w1', length: 20, angleDeg: 90, rule, side: 'xmax' }],
+      seams: [{ parent: 'w1', child: 'root', angleDeg: 90, rule: { innerRadius: -1, kFactor: K } }],
+    });
+    expect(bad.ok).toBe(false);
+    if (!isErr(bad)) return;
+    expect(bad.error.code).toBe('INVALID_SEAM_RADIUS');
+  });
+});

--- a/packages/brepjs-sheetmetal/tests/multibend.test.ts
+++ b/packages/brepjs-sheetmetal/tests/multibend.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { isValid, measureVolume, getEdges, getBounds, isErr } from 'brepjs';
+import { author, unfold, report } from '../src/api.js';
+import type { BendRule } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const T = 1;
+const R = 2;
+const K = 0.44;
+const rule: BendRule = { innerRadius: R, kFactor: K };
+const DEV = (Math.PI / 180) * 90 * (R + K * T);
+
+describe('chained U-channel (base → wall → return)', () => {
+  it('builds a valid solid and unfolds with the area invariant', () => {
+    const baseLen = 40;
+    const width = 30;
+    const authored = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [
+        { id: 'wall', length: 20, angleDeg: 90, rule, side: 'xmax' },
+        // The return folds off the wall's distal edge (parallel to the base) — the
+        // wall's `ymax` edge, which runs the full base-width span.
+        { id: 'return', length: 10, angleDeg: 90, rule, side: 'ymax', parent: 'wall' },
+      ],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    expect(authored.value.solid).toBeDefined();
+    if (authored.value.solid === undefined) return;
+    expect(isValid(authored.value.solid)).toBe(true);
+
+    const unfolded = unfold(authored.value);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+
+    // Developed area = base + each (strip + flat) over its span (both span the full
+    // 30-wide edge: the wall off the base, the return off the wall's distal edge).
+    const expected = baseLen * width + (DEV + 20) * width + (DEV + 10) * width;
+    expect(unfolded.value.pattern.developedArea).toBeCloseTo(expected, 6);
+    expect(unfolded.value.pattern.bendLines).toHaveLength(2);
+    expect(getEdges(unfolded.value.pattern.outline).length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('U-channel from two opposite base edges', () => {
+  it('develops into a single rectangle widened on both sides', () => {
+    const baseLen = 40;
+    const width = 30;
+    const authored = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [
+        { id: 'left', length: 15, angleDeg: 90, rule, side: 'xmin' },
+        { id: 'right', length: 15, angleDeg: 90, rule, side: 'xmax' },
+      ],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    expect(isValid(authored.value.solid ?? (() => { throw new Error('no solid'); })())).toBe(true);
+
+    const unfolded = unfold(authored.value);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+
+    const expected = baseLen * width + 2 * (DEV + 15) * width;
+    expect(unfolded.value.pattern.developedArea).toBeCloseTo(expected, 6);
+    const [maxX, maxY] = unfolded.value.report.totalFlatSize;
+    expect(maxX).toBeCloseTo(baseLen + 2 * (DEV + 15), 6);
+    expect(maxY).toBeCloseTo(width, 6);
+  });
+});
+
+describe('4-sided tray (a flange off every base edge)', () => {
+  it('builds a valid solid and unfolds into a plus/cross outline', () => {
+    const baseLen = 40;
+    const width = 30;
+    const fl = 12;
+    const authored = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [
+        { id: 'xn', length: fl, angleDeg: 90, rule, side: 'xmin' },
+        { id: 'xp', length: fl, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'yn', length: fl, angleDeg: 90, rule, side: 'ymin' },
+        { id: 'yp', length: fl, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    expect(isValid(authored.value.solid ?? (() => { throw new Error('no solid'); })())).toBe(true);
+
+    const unfolded = unfold(authored.value);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+
+    const expected =
+      baseLen * width + 2 * (DEV + fl) * width + 2 * (DEV + fl) * baseLen;
+    expect(unfolded.value.pattern.developedArea).toBeCloseTo(expected, 6);
+    expect(unfolded.value.pattern.bendLines).toHaveLength(4);
+    // A plus/cross outline has 12 corners.
+    expect(getEdges(unfolded.value.pattern.outline)).toHaveLength(12);
+  });
+});
+
+describe('down-bend', () => {
+  it('records direction "down", stays valid, and matches an up-bend in volume', () => {
+    const baseLen = 40;
+    const width = 20;
+    const flangeLen = 15;
+    const down = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [{ id: 'd', length: flangeLen, angleDeg: 90, rule, side: 'xmax', direction: 'down' }],
+    });
+    expect(down.ok).toBe(true);
+    if (isErr(down)) return;
+    expect(down.value.bends[0]?.direction).toBe('down');
+    expect(down.value.solid).toBeDefined();
+    if (down.value.solid === undefined) return;
+    expect(isValid(down.value.solid)).toBe(true);
+
+    const downVol = measureVolume(down.value.solid);
+    expect(downVol.ok).toBe(true);
+    if (isErr(downVol)) return;
+
+    // A down-bend folds the same material the other way: volume is unchanged but
+    // the flange now sits below the base plane (zMin < 0).
+    const up = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [{ id: 'd', length: flangeLen, angleDeg: 90, rule, side: 'xmax', direction: 'up' }],
+    });
+    expect(up.ok).toBe(true);
+    if (isErr(up)) return;
+    const upVol = measureVolume(up.value.solid ?? (() => { throw new Error('no solid'); })());
+    expect(upVol.ok).toBe(true);
+    if (isErr(upVol)) return;
+    expect(downVol.value).toBeCloseTo(upVol.value, 3);
+
+    // The defining property of a down-bend: the flange physically sits below the
+    // base plane. Equal volume + valid solid alone can't distinguish a wrong-sign
+    // rotation that produces an up-bend shape with 'down' metadata.
+    const bounds = getBounds(down.value.solid);
+    expect(bounds.zMin).toBeLessThan(-0.5);
+    expect(bounds.zMax).toBeCloseTo(T, 3);
+
+    const unfolded = unfold(down.value);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+    expect(unfolded.value.pattern.bendLines[0]?.direction).toBe('down');
+  });
+});
+
+describe('partial / offset flanges (two on one edge)', () => {
+  it('places both without overlap and sums their developed strips', () => {
+    const baseLen = 40;
+    const width = 30;
+    const authored = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [
+        { id: 'a', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 0, width: 15 },
+        { id: 'b', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 20, width: 15 },
+      ],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    expect(isValid(authored.value.solid ?? (() => { throw new Error('no solid'); })())).toBe(true);
+
+    const unfolded = unfold(authored.value);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+    expect(unfolded.value.pattern.bendLines).toHaveLength(2);
+
+    const expected = baseLen * width + 2 * (DEV + 10) * 15;
+    expect(unfolded.value.pattern.developedArea).toBeCloseTo(expected, 6);
+  });
+
+  it('rejects two flanges that overlap on the same edge', () => {
+    const overlapping = author({
+      thickness: T,
+      base: { length: 40, width: 30 },
+      flanges: [
+        { id: 'a', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 0, width: 25 },
+        { id: 'b', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 20, width: 15 },
+      ],
+    });
+    expect(overlapping.ok).toBe(false);
+    if (overlapping.ok) return;
+    expect(overlapping.error.code).toBe('OVERLAPPING_FLANGES');
+  });
+});
+
+describe('closed-box seam', () => {
+  it('produces a SEAM_CUT warning and a valid connected flat pattern', () => {
+    const baseLen = 40;
+    const width = 30;
+    const closed = author({
+      thickness: T,
+      base: { length: baseLen, width },
+      flanges: [
+        { id: 'w1', length: 20, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'w2', length: 30, angleDeg: 90, rule, side: 'xmax', parent: 'w1' },
+        { id: 'w3', length: 20, angleDeg: 90, rule, side: 'xmax', parent: 'w2' },
+      ],
+      seams: [{ parent: 'w3', child: 'root', angleDeg: 90, rule }],
+    });
+    expect(closed.ok).toBe(true);
+    if (isErr(closed)) return;
+
+    const unfolded = unfold(closed.value);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+
+    // The SEAM_CUT must land on the authored seam bend, not a real wall bend: the
+    // BFS must never promote the seam edge into the spanning tree.
+    const seamWarning = unfolded.value.warnings.find((w) => w.code === 'SEAM_CUT');
+    expect(seamWarning?.featureId).toMatch(/^seam::/);
+    // The seam edge is left unfolded, so only the three spanning-tree bends fold.
+    expect(unfolded.value.pattern.bendLines).toHaveLength(3);
+    // Developed area = base + each wall's (strip + flat) over its span, in
+    // spanning-tree order root→w1→w2→w3. Each wall folds off its parent's distal
+    // (xmax) edge, so its span is the parent's flat length: w1 spans the base width
+    // (30, length 20); w2 spans w1's length (20, length 30); w3 spans w2's length
+    // (30, length 20). A corrupted tree that demoted a wall to the seam — or placed
+    // w3 off the base instead of w2 — would not match this analytic sum.
+    const expectedArea =
+      baseLen * width + (DEV + 20) * 30 + (DEV + 30) * 20 + (DEV + 20) * 30;
+    expect(unfolded.value.pattern.developedArea).toBeCloseTo(expectedArea, 6);
+    expect(getEdges(unfolded.value.pattern.outline).length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('multi-bend report', () => {
+  it('has one entry per folded bend (N flanges → N entries)', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 50, width: 40 },
+      flanges: [
+        { id: 'a', length: 10, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'b', length: 10, angleDeg: 90, rule, side: 'xmin' },
+        { id: 'c', length: 10, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+
+    const rep = report(authored.value);
+    expect(rep.ok).toBe(true);
+    if (isErr(rep)) return;
+    expect(rep.value.bends).toHaveLength(3);
+    expect(rep.value.bends.map((b) => b.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/packages/brepjs-sheetmetal/tests/multibend.test.ts
+++ b/packages/brepjs-sheetmetal/tests/multibend.test.ts
@@ -270,6 +270,17 @@ describe('input validation', () => {
     expect(bad.error.code).toBe('INVALID_FLANGE_ID');
   });
 
+  it.each(['root', 'face-0'])("rejects a flange reusing the reserved id '%s'", (reserved) => {
+    const bad = author({
+      thickness: T,
+      base: { length: 30, width: 30 },
+      flanges: [{ id: reserved, length: 10, angleDeg: 90, rule, side: 'xmax' }],
+    });
+    expect(bad.ok).toBe(false);
+    if (!isErr(bad)) return;
+    expect(bad.error.code).toBe('INVALID_FLANGE_ID');
+  });
+
   it('rejects a seam with an out-of-range angle', () => {
     const bad = author({
       thickness: T,

--- a/packages/brepjs-sheetmetal/tests/validate.test.ts
+++ b/packages/brepjs-sheetmetal/tests/validate.test.ts
@@ -99,6 +99,23 @@ describe('validatePart — flange collision', () => {
     expect(collision?.message).toMatch(/overlap once folded/);
   });
 
+  it('does not flag a chained U-channel (return folds clear of the base)', () => {
+    const result = authorPart({
+      thickness: 1,
+      base: { length: 40, width: 30 },
+      flanges: [
+        { id: 'wall', length: 20, angleDeg: 90, rule: { innerRadius: 2, kFactor: 0.44 }, side: 'xmax' },
+        { id: 'return', length: 10, angleDeg: 90, rule: { innerRadius: 2, kFactor: 0.44 }, side: 'ymax', parent: 'wall' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The wall is vertical and the return folds off its distal edge, parallel to
+    // the base but lifted 20 above it — their AABBs must not be reported colliding.
+    expect(codes(validatePart(result.value))).not.toContain('COLLISION');
+  });
+
   it('does not flag a single-flange part', () => {
     const result = authorPart({
       thickness: 1,


### PR DESCRIPTION
## Phase 2 · PR1 of a stacked sequence

First PR of the maximal sheet-metal expansion. Generalizes the domain past the Phase-1 two-flange envelope and lays the load-bearing foundation (recursive tree-walk unfold) that the rest of the stack builds on.

### What's new
- **Authoring**: flanges off all four base edges; **chained flange-off-flange** bends (U-channels, Z-profiles, box walls); **up/down** fold direction; **partial/offset** flanges (multiple flanges per edge), with overlap rejection.
- **Unfold**: replaces the hardcoded `east`/`north` two-slot `RunLayout` with a **recursive BFS tree-walk** 2D placement, emitting a rectilinear-union outline for arbitrary arm trees (combs, trays, chains) plus bend lines and developed area.
- **Closed-box seams end-to-end**: authored `seam::` edges are excluded from the spanning tree and recorded as `SEAM_CUT`, so the cycle-closing edge stays unfolded and the part flattens into a valid connected pattern.
- **Propagation**: report (N bends), validate (real folded AABBs for chained flanges), miter, facade (`.seam()`), index exports (`FlatSide`, `SeamSpec`).
- **Harness**: parameterized into bracket + U-channel + tray demos.

### Verification
- typecheck / lint / build clean; **84 tests** (74 prior + 10 new) green against OCCT-WASM.
- New tests cover: chained U-channel + area invariant, opposite-edge U, 4-side tray, down-bend (below-plane bounds + volume), partial/offset flanges + overlap rejection, closed-box `SEAM_CUT`, multi-bend report.
- Built via a multi-agent Workflow (implement → adversarial review → fix). Review caught a masked **seam-BFS** correctness bug (a seam edge could be promoted into the spanning tree, demoting a real bend to the cut); fixed by partitioning seam edges before BFS.

### Scope notes
- The unfold outline is exact for the supported families (single flange/side, U-channels, trays, chains, combs); the 45° corner-miter chamfer applies to the classic base-L pair, other recorded miters cut the 3D solid but fall back to the un-chamfered union outline.
- `validateFns` collision is analytic/advisory (kernel-free AABB).

### Stack
Next PRs (sequential, merged into `main`): flat→fold inverse · corner/bend reliefs · cutouts/holes · tabs/slots/form features · contour/lofted flanges · foreign-solid unfold.

OCCT-WASM-first; brepkit parity deferred to a later sweep.