### PR TITLE
feat(sheetmetal): flat-pattern→fold inverse with non-circular round-trip oracle

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -27,10 +27,20 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 | --------------- | -------------------------------------------------------------------------------------- |
 | Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams       |
 | Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area |
+| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`      |
 | Miter / outputs | auto corner-miter, multi-layer DXF, JSON bend report, manufacturability warnings       |
 | API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                |
 
-`FlatInput` (flat-pattern → fold, the inverse direction) is not yet implemented.
+`fold(input: FlatInput)` folds a flat pattern back up into a 3D part — the inverse of `unfold`. A
+`FlatInput` is a region-tree (a base rectangle plus child fold regions, each with a fold line, angle,
+direction, and bend rule), the inverse of the unfold layout. `patternToFlatInput(pattern, { thickness,
+ruleFor })` recovers that region-tree from the **2D flat-pattern geometry alone** — the developed outline
+wire and bend-line edges — reading real coordinates back out with the public `getEdges` / `curveStartPoint`
+/ `curveEndPoint` readers; only the bend rule (which a flat pattern cannot encode) is a supplied input.
+`partToFlatInput(part)` chains `unfold` → `patternToFlatInput`, so `fold(partToFlatInput(part))` round-trips
+volume, validity, and bend/flange counts through the 2D geometry — making the round-trip a genuine,
+non-circular oracle. Fold reuses the forward authoring bend geometry wholesale (no duplicated bend math),
+and rides SEAM_CUT / MIN_RADIUS warnings inside the Ok payload.
 
 ## Design
 

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -15,9 +15,10 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, isErr, initFromOC } from 'brepjs';
+import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, measureVolume, isErr, initFromOC } from 'brepjs';
 import type { Solid, Vec3 } from 'brepjs';
-import { author, miterCorner, unfold } from '../src/api.js';
+import { author, miterCorner, unfold, fold } from '../src/api.js';
+import { partToFlatInput } from '../src/foldFns.js';
 import type { AuthorSpec } from '../src/authorFns.js';
 import type { BendRule, FlatPattern, SheetMetalPart } from '../src/types.js';
 
@@ -137,14 +138,42 @@ async function renderDemo(demo: Demo): Promise<string[]> {
     await writeFile(stepPath, Buffer.from(await step.value.arrayBuffer()));
   }
 
+  // Fold round-trip: re-derive a FlatInput from the part and fold it back up,
+  // demonstrating unfold→fold reproduces the part's volume (the PR2 oracle).
+  // Mitered parts are intentionally skipped; a failure on a non-mitered demo is a
+  // real round-trip regression, so it must surface rather than read as "skipped".
+  let roundTrip = '(fold round-trip skipped: mitered part)';
+  if (demo.miter === undefined) {
+    roundTrip = foldRoundTrip(part);
+  }
+
   return [
     `  [${demo.name}]`,
     `    folded + flat SVG : ${svgPath}`,
     `    folded STEP       : ${stepPath}`,
     `    bend lines        : ${pattern.bendLines.length}`,
     `    developed area    : ${pattern.developedArea.toFixed(2)} mm²`,
+    `    fold round-trip   : ${roundTrip}`,
     `    warnings          : ${unfolded.value.warnings.length}`,
   ];
+}
+
+/**
+ * Round-trip a non-mitered part through `partToFlatInput → fold` and report the
+ * volume delta. Any Err or missing solid is a genuine round-trip regression, so it
+ * is reported as FAILED with the reason — never silently as "skipped".
+ */
+function foldRoundTrip(part: SheetMetalPart): string {
+  if (part.solid === undefined) return '(fold round-trip FAILED: part has no solid)';
+  const flatInput = partToFlatInput(part);
+  if (isErr(flatInput)) return `(fold round-trip FAILED: ${flatInput.error.message})`;
+  const refolded = fold(flatInput.value);
+  if (isErr(refolded)) return `(fold round-trip FAILED: ${refolded.error.message})`;
+  if (refolded.value.solid === undefined) return '(fold round-trip FAILED: refolded part has no solid)';
+  const vA = measureVolume(part.solid);
+  const vB = measureVolume(refolded.value.solid);
+  if (isErr(vA) || isErr(vB)) return '(fold round-trip FAILED: volume not measurable)';
+  return `Δvol ${Math.abs(vA.value - vB.value).toExponential(2)} mm³`;
 }
 
 interface Seg2 {

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -14,6 +14,7 @@ import {
   type FlangeSpec,
 } from './authorFns.js';
 import { unfold as unfoldFn } from './unfoldFns.js';
+import { fold as foldFn } from './foldFns.js';
 import {
   miterCut as miterCutFn,
   autoMiterCorner as autoMiterCornerFn,
@@ -30,6 +31,7 @@ import { bendAllowance as bendAllowanceFn, developedLength as developedLengthFn 
 import type {
   SheetMetalPart,
   FlatPattern,
+  FlatInput,
   BendReport,
   BendRule,
   UnfoldResult,
@@ -44,6 +46,11 @@ export function author(spec: AuthorSpec): Result<SheetMetalPart> {
 /** Flatten an authored part into a developed flat pattern + bend report + warnings. */
 export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   return unfoldFn(part);
+}
+
+/** Fold a flat pattern (region-tree) up into a 3D part — the inverse of {@link unfold}. */
+export function fold(input: FlatInput): Result<SheetMetalPart> {
+  return foldFn(input);
 }
 
 /** Cut a part by an oriented plane, removing material on the `+normal` side. */

--- a/packages/brepjs-sheetmetal/src/facade.ts
+++ b/packages/brepjs-sheetmetal/src/facade.ts
@@ -17,6 +17,7 @@ import type { MiterPlane, DxfOptions } from './api.js';
 import {
   author,
   unfold,
+  fold,
   miter,
   miterCorner,
   toDXF,
@@ -26,6 +27,7 @@ import {
 import type {
   SheetMetalPart,
   FlatPattern,
+  FlatInput,
   BendReport,
   MaterialSpec,
   SheetMetalWarning,
@@ -171,6 +173,11 @@ export function sheetMetal(base: BaseFlatSpec, thickness: number): SheetMetalBui
 /** Re-enter the fluent chain from an already-authored part. */
 export function fromPart(part: SheetMetalPart): SheetMetalPartHandle {
   return new SheetMetalPartHandle(part);
+}
+
+/** Fold a flat pattern up into a part and re-enter the fluent chain. */
+export function foldFlat(input: FlatInput): SheetMetalPartHandle {
+  return new SheetMetalPartHandle(unwrapOrThrow(fold(input)));
 }
 
 export { SheetMetalBuilder, SheetMetalPartHandle };

--- a/packages/brepjs-sheetmetal/src/foldFns.ts
+++ b/packages/brepjs-sheetmetal/src/foldFns.ts
@@ -316,7 +316,14 @@ function orderedLoop(segs: { a: Pt2; b: Pt2 }[]): Pt2[] | undefined {
   if (segs.length === 0) return undefined;
   const key = (p: Pt2): string => `${round(p[0])}|${round(p[1])}`;
   const from = new Map<string, Pt2>();
-  for (const s of segs) from.set(key(s.a), s.b);
+  // Two segments sharing a start-vertex key means the loop isn't a simple chain
+  // (floating-point drift can also collapse two near vertices into one bucket);
+  // bail rather than silently overwrite and trace a wrong polygon.
+  for (const s of segs) {
+    const k = key(s.a);
+    if (from.has(k)) return undefined;
+    from.set(k, s.b);
+  }
   const start = segs[0]?.a;
   if (start === undefined) return undefined;
   const loop: Pt2[] = [start];
@@ -374,7 +381,16 @@ function baseRect(
   if (xs.length < 2 || ys.length < 2) {
     return err(validationError('BASE_NOT_FOUND', 'cannot locate base region at origin'));
   }
-  const yProbe = firstFilledCellMid(ys.filter((v) => v > -EPS), (mid) => contains(1e-3, mid));
+  // Probe halfway between the origin and the first positive x grid line — a
+  // scale-invariant point inside the base's undivided +X span (the base is one
+  // rectangle in X, so the first gridline > 0 is its right edge). Avoids assuming
+  // any absolute unit and stays correct when xmin/ymin flanges add negative coords.
+  const xFirstPositive = xs.find((v) => v > EPS);
+  if (xFirstPositive === undefined) {
+    return err(validationError('BASE_NOT_FOUND', 'no positive x extent to locate the base region'));
+  }
+  const xProbeBase = xFirstPositive / 2;
+  const yProbe = firstFilledCellMid(ys.filter((v) => v > -EPS), (mid) => contains(xProbeBase, mid));
   if (yProbe === undefined) {
     return err(validationError('BASE_NOT_FOUND', 'origin cell is not inside the developed region'));
   }

--- a/packages/brepjs-sheetmetal/src/foldFns.ts
+++ b/packages/brepjs-sheetmetal/src/foldFns.ts
@@ -1,0 +1,644 @@
+import {
+  type Result,
+  type Vec3,
+  ok,
+  err,
+  validationError,
+  getEdges,
+  curveStartPoint,
+  curveEndPoint,
+} from 'brepjs';
+import type {
+  BendRule,
+  FlatInput,
+  FlatPattern,
+  FlatSide,
+  FoldRegion,
+  MaterialSpec,
+  SheetMetalPart,
+  SheetMetalWarning,
+} from './types.js';
+import { authorPart, type AuthorSpec, type FlangeSpec } from './authorFns.js';
+import { featureTree } from './featureTreeFns.js';
+import { developedLength } from './allowanceFns.js';
+import { unfold, edgeBasis2, type Frame2 } from './unfoldFns.js';
+import { validatePart } from './validateFns.js';
+
+/** A folded part plus the warnings raised while folding (e.g. SEAM_CUT, MIN_RADIUS). */
+export interface FoldResult {
+  part: SheetMetalPart;
+  warnings: SheetMetalWarning[];
+}
+
+/**
+ * Fold a flat pattern up into a 3D part. Each {@link FoldRegion} folds about its
+ * fold line off its parent region, exactly inverting {@link unfold}: folding by an
+ * angle is the same rigid construction the forward authoring path performs, so this
+ * reuses {@link authorPart}'s bend geometry wholesale rather than re-deriving it.
+ *
+ * The result carries a fully-populated {@link SheetMetalPart} (valid solid + the
+ * BendFeature/FlangeFeature tree consistent with `authorPart`), so
+ * `unfold(fold(input))` round-trips. SEAM_CUT-style and min-radius warnings ride
+ * inside the Ok payload.
+ */
+export function fold(input: FlatInput): Result<SheetMetalPart> {
+  const result = foldWithWarnings(input);
+  if (!result.ok) return result;
+  return ok(result.value.part);
+}
+
+/** {@link fold} that also surfaces the fold warnings alongside the part. */
+export function foldWithWarnings(input: FlatInput): Result<FoldResult> {
+  const spec: AuthorSpec = {
+    thickness: input.thickness,
+    base: { length: input.baseLength, width: input.width },
+    flanges: input.regions.map(regionToFlange),
+    ...(input.material !== undefined ? { material: input.material } : {}),
+  };
+
+  const authored = authorPart(spec);
+  if (!authored.ok) return authored;
+  const part = authored.value;
+
+  // SEAM_CUT comes from the feature-tree walk; INVALID_SOLID / COLLISION / MIN_RADIUS
+  // come from the canonical validator, so fold inherits the same checks (and message
+  // text) as the rest of the package instead of re-deriving min-radius here.
+  const warnings: SheetMetalWarning[] = [];
+  const tree = featureTree(part);
+  if (tree.ok) warnings.push(...tree.value.warnings);
+  warnings.push(...validatePart(part));
+
+  return ok({ part, warnings });
+}
+
+function regionToFlange(region: FoldRegion): FlangeSpec {
+  return {
+    id: region.id,
+    length: region.length,
+    angleDeg: region.angleDeg,
+    rule: region.rule,
+    direction: region.direction,
+    ...(region.side !== undefined ? { side: region.side } : {}),
+    ...(region.parent !== undefined ? { parent: region.parent } : {}),
+    ...(region.offset !== undefined ? { offset: region.offset } : {}),
+    ...(region.width !== undefined ? { width: region.width } : {}),
+    ...(region.miter !== undefined ? { miter: region.miter } : {}),
+  };
+}
+
+/** How to resolve the bend rule for a bend line read out of a 2D flat pattern. */
+export interface PatternToFlatInputOptions {
+  thickness: number;
+  /**
+   * Rule for bend line `i` (0-based, in {@link FlatPattern.bendLines} order). A flat
+   * pattern is pure geometry and cannot encode K-factor/inner-radius, so the rule is
+   * a required *input*; only the regions/sides/offsets/spans/lengths/angles are
+   * recovered from the 2D geometry.
+   */
+  ruleFor: (bendIndex: number) => BendRule;
+  material?: MaterialSpec | undefined;
+}
+
+/**
+ * Reconstruct a {@link FlatInput} region-tree from the *2D flat-pattern geometry*
+ * alone — `pattern.outline` (a closed 2D wire) and `pattern.bendLines` (each a 2D
+ * segment + fold angle/direction). Nothing is read from a feature tree or a 3D
+ * solid: the regions, sides, offsets, spans and flat lengths are all recovered by
+ * reading real 2D coordinates back out of the wire/edges via the public brepjs
+ * geometry readers (`getEdges`, `curveStartPoint`, `curveEndPoint`).
+ *
+ * This is the non-circular round-trip bridge: feeding `unfold(part).pattern` through
+ * here and into {@link fold} exercises unfold's 2D placement, this parser, and the
+ * forward fold geometry — a bug in any of them breaks the round-trip.
+ *
+ * Algorithm (rectilinear families — PR1 develops only axis-aligned rectangles):
+ * every bend line is an axis-aligned segment lying on the shared edge between a
+ * parent region and a child's developed strip. The developed strip width is
+ * `developedLength(angle, thickness, ruleFor(i))` (the supplied rule). BFS outward
+ * from the base region (the one anchored at the origin): a bend line on a known
+ * region's edge spawns a child region whose far edge is the next outward bend line
+ * (a grandchild) or the outline boundary; `length = far-extent − dev`, `span` =
+ * bend-line length, `offset`/`side` are the bend line's position on the parent edge.
+ */
+export function patternToFlatInput(
+  pattern: FlatPattern,
+  opts: PatternToFlatInputOptions
+): Result<FlatInput> {
+  const { thickness, ruleFor, material } = opts;
+  if (!Number.isFinite(thickness) || thickness <= 0) {
+    return err(validationError('INVALID_THICKNESS', `thickness must be positive, got ${thickness}`));
+  }
+
+  const segsResult = parseBendLines(pattern, thickness, ruleFor);
+  if (!segsResult.ok) return segsResult;
+  const bends = segsResult.value;
+
+  const outline = parseOutlineExtents(pattern);
+  if (!outline.ok) return outline;
+  const { xs, ys, contains } = outline.value;
+
+  const base = baseRect(xs, ys, contains, bends);
+  if (!base.ok) return base;
+  const baseRectVal = base.value;
+
+  const buildResult = buildRegions(baseRectVal, bends, contains);
+  if (!buildResult.ok) return buildResult;
+
+  return ok({
+    thickness,
+    baseLength: baseRectVal.x1 - baseRectVal.x0,
+    width: baseRectVal.y1 - baseRectVal.y0,
+    ...(material !== undefined ? { material } : {}),
+    regions: buildResult.value,
+  });
+}
+
+/**
+ * Convert an authored {@link SheetMetalPart} into the {@link FlatInput} that folds
+ * back into it, going strictly through the 2D flat pattern: `unfold(part)` produces
+ * the developed wire + bend lines, and {@link patternToFlatInput} recovers the
+ * region tree from that 2D geometry. Only the bend *rule* is read off the part (by
+ * matching bend id), which a flat pattern legitimately cannot encode; every
+ * geometric attribute is parsed from the wire/edges. This makes the round-trip
+ * oracle non-circular — a bug in unfold's 2D placement or in the parser breaks it.
+ *
+ * Seam bends (closed profiles) are left unfolded by `unfold`, so the recovered part
+ * is the open spanning-tree shape, not the re-closed box.
+ */
+export function partToFlatInput(part: SheetMetalPart): Result<FlatInput> {
+  const unfolded = unfold(part);
+  if (!unfolded.ok) return unfolded;
+  const pattern = unfolded.value.pattern;
+
+  // The rule is allowed as an input (a flat pattern cannot encode K-factor). Match
+  // each bend line back to its authored bend by id, in unfold's bend-line order
+  // (which is the spanning-tree order featureTree/layoutTree emit), falling back to
+  // a default rule if a bend can't be matched.
+  const ruleByIndex = bendRulesInOrder(part);
+  const fallback: BendRule = part.material?.defaultRule ?? { innerRadius: part.thickness, kFactor: 0.44 };
+
+  return patternToFlatInput(pattern, {
+    thickness: part.thickness,
+    ruleFor: (i) => ruleByIndex[i] ?? fallback,
+    ...(part.material !== undefined ? { material: part.material } : {}),
+  });
+}
+
+/**
+ * Bend rules in {@link FlatPattern.bendLines} order. `unfold` emits bend lines in
+ * the layout walk's order, which is the feature tree's BFS (spanning-tree) order;
+ * the same walk drives the rules here so index `i` lines up with bend line `i`.
+ */
+function bendRulesInOrder(part: SheetMetalPart): BendRule[] {
+  const tree = featureTree(part);
+  if (!tree.ok) return part.flanges.map((f) => f.rule);
+  const ruleById = new Map<string, BendRule>();
+  for (const f of part.flanges) ruleById.set(f.id, f.rule);
+  for (const b of part.bends) if (!ruleById.has(b.id)) ruleById.set(b.id, b.rule);
+  const rules: BendRule[] = [];
+  for (const tb of tree.value.bends) {
+    rules.push(ruleById.get(tb.child) ?? tb.bend.rule);
+  }
+  return rules;
+}
+
+const EPS = 1e-6;
+
+type Pt2 = [number, number];
+
+/** A bend line parsed from the 2D pattern: an axis-aligned segment + fold metadata. */
+interface BendSeg {
+  index: number;
+  /** Orientation of the segment line. */
+  axis: 'h' | 'v';
+  /** Fixed coordinate of the line (x for vertical, y for horizontal). */
+  fixed: number;
+  /** Segment span on the free axis: `[lo, hi]`. */
+  lo: number;
+  hi: number;
+  span: number;
+  angleDeg: number;
+  direction: 'up' | 'down';
+  /** The supplied rule (a flat pattern cannot encode K-factor, so it's an input). */
+  rule: BendRule;
+  /** Developed strip width for this bend (from the supplied rule). */
+  dev: number;
+}
+
+function parseBendLines(
+  pattern: FlatPattern,
+  thickness: number,
+  ruleFor: (i: number) => BendRule
+): Result<BendSeg[]> {
+  const out: BendSeg[] = [];
+  for (let i = 0; i < pattern.bendLines.length; i += 1) {
+    const bl = pattern.bendLines[i];
+    if (bl === undefined) continue;
+    const a = curveStartPoint(bl.line);
+    const b = curveEndPoint(bl.line);
+    const seg = axisAlignedSeg(a, b);
+    if (seg === undefined) {
+      return err(
+        validationError('NON_AXIS_BEND', `bend line ${i} is not axis-aligned: (${a[0]},${a[1]})→(${b[0]},${b[1]})`)
+      );
+    }
+    const rule = ruleFor(i);
+    const devResult = developedLength(bl.angleDeg, thickness, rule);
+    if (!devResult.ok) return devResult;
+    out.push({
+      index: i,
+      axis: seg.axis,
+      fixed: seg.fixed,
+      lo: seg.lo,
+      hi: seg.hi,
+      span: seg.hi - seg.lo,
+      angleDeg: bl.angleDeg,
+      direction: bl.direction,
+      rule,
+      dev: devResult.value,
+    });
+  }
+  return ok(out);
+}
+
+function axisAlignedSeg(a: Vec3, b: Vec3): { axis: 'h' | 'v'; fixed: number; lo: number; hi: number } | undefined {
+  if (Math.abs(a[0] - b[0]) < EPS) {
+    return { axis: 'v', fixed: (a[0] + b[0]) / 2, lo: Math.min(a[1], b[1]), hi: Math.max(a[1], b[1]) };
+  }
+  if (Math.abs(a[1] - b[1]) < EPS) {
+    return { axis: 'h', fixed: (a[1] + b[1]) / 2, lo: Math.min(a[0], b[0]), hi: Math.max(a[0], b[0]) };
+  }
+  return undefined;
+}
+
+interface OutlineExtents {
+  /** Sorted unique x-coordinates of every outline vertex. */
+  xs: number[];
+  /** Sorted unique y-coordinates of every outline vertex. */
+  ys: number[];
+  /** True if the point lies strictly inside the filled (developed) region. */
+  contains: (x: number, y: number) => boolean;
+}
+
+/**
+ * Read the outline wire's vertices back out via `getEdges` + curve endpoint readers
+ * and build a point-in-region test over the axis-aligned arrangement they induce.
+ * The developed pattern is a simply-connected rectilinear polygon, so a winding-free
+ * cell test (is this cell's centre inside the polygon) suffices.
+ */
+function parseOutlineExtents(pattern: FlatPattern): Result<OutlineExtents> {
+  const edges = getEdges(pattern.outline);
+  if (edges.length < 3) {
+    return err(validationError('OUTLINE_TOO_SMALL', `outline has ${edges.length} edges, need ≥ 3`));
+  }
+  const segs: { a: Pt2; b: Pt2 }[] = [];
+  const xsRaw: number[] = [];
+  const ysRaw: number[] = [];
+  for (const e of edges) {
+    const s = curveStartPoint(e);
+    const t = curveEndPoint(e);
+    segs.push({ a: [s[0], s[1]], b: [t[0], t[1]] });
+    xsRaw.push(s[0], t[0]);
+    ysRaw.push(s[1], t[1]);
+  }
+  const poly = orderedLoop(segs);
+  if (poly === undefined) {
+    return err(validationError('OUTLINE_NOT_CLOSED', 'outline edges do not form a single closed loop'));
+  }
+  const xs = uniqueSorted(xsRaw);
+  const ys = uniqueSorted(ysRaw);
+  const contains = (x: number, y: number): boolean => pointInPolygon(poly, x, y);
+  return ok({ xs, ys, contains });
+}
+
+/** Chain segments into one ordered vertex loop, or undefined if they don't close. */
+function orderedLoop(segs: { a: Pt2; b: Pt2 }[]): Pt2[] | undefined {
+  if (segs.length === 0) return undefined;
+  const key = (p: Pt2): string => `${round(p[0])}|${round(p[1])}`;
+  const from = new Map<string, Pt2>();
+  for (const s of segs) from.set(key(s.a), s.b);
+  const start = segs[0]?.a;
+  if (start === undefined) return undefined;
+  const loop: Pt2[] = [start];
+  let cur = from.get(key(start));
+  let guard = 0;
+  while (cur !== undefined && key(cur) !== key(start) && guard < segs.length + 2) {
+    loop.push(cur);
+    cur = from.get(key(cur));
+    guard += 1;
+  }
+  if (cur === undefined || key(cur) !== key(start)) return undefined;
+  return loop;
+}
+
+function round(n: number): number {
+  return Math.round(n / EPS) * EPS;
+}
+
+/** Standard ray-cast point-in-polygon for the (axis-aligned) outline loop. */
+function pointInPolygon(poly: Pt2[], x: number, y: number): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i, i += 1) {
+    const pi = poly[i];
+    const pj = poly[j];
+    if (pi === undefined || pj === undefined) continue;
+    const intersect =
+      pi[1] > y !== pj[1] > y &&
+      x < ((pj[0] - pi[0]) * (y - pi[1])) / (pj[1] - pi[1]) + pi[0];
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+interface Rect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/**
+ * Base region: the rectangle anchored at the origin, `[0, baseLength] × [0, width]`
+ * (the unfold layout fixes the base frame there). Each base edge is bounded by the
+ * bend line lying on it (a tray folds off all four edges) or, when no flange folds
+ * off that edge, by the outline boundary. The extents are therefore the nearest
+ * base-bounding bend line — a bend line perpendicular to the run that crosses the
+ * origin row/column — clamped to the outline reach.
+ */
+function baseRect(
+  xs: number[],
+  ys: number[],
+  contains: (x: number, y: number) => boolean,
+  bends: BendSeg[]
+): Result<Rect> {
+  if (xs.length < 2 || ys.length < 2) {
+    return err(validationError('BASE_NOT_FOUND', 'cannot locate base region at origin'));
+  }
+  const yProbe = firstFilledCellMid(ys.filter((v) => v > -EPS), (mid) => contains(1e-3, mid));
+  if (yProbe === undefined) {
+    return err(validationError('BASE_NOT_FOUND', 'origin cell is not inside the developed region'));
+  }
+  const x0 = 0;
+  const y0 = 0;
+  // +X base edge: nearest vertical bend line right of origin crossing the base row,
+  // else the outline reach.
+  const xBendBound = nearestBend(bends, 'v', yProbe, x0, 1);
+  const x1 = xBendBound ?? marchOutline(x0, 1, (c) => contains(c, yProbe));
+  const xProbe = (x0 + x1) / 2;
+  const yBendBound = nearestBend(bends, 'h', xProbe, y0, 1);
+  const y1 = yBendBound ?? marchOutline(y0, 1, (c) => contains(xProbe, c));
+  if (x1 <= x0 + EPS || y1 <= y0 + EPS) {
+    return err(validationError('BASE_NOT_FOUND', 'base region has zero extent'));
+  }
+  return ok({ x0, y0, x1, y1 });
+}
+
+/**
+ * Nearest bend line of the given orientation, on the `dir` side of `from` along its
+ * perpendicular axis, whose span covers the base `cross` coordinate — i.e. a bend
+ * line lying on the base's far edge in that direction. Returns its fixed coordinate.
+ */
+function nearestBend(
+  bends: BendSeg[],
+  axis: 'h' | 'v',
+  cross: number,
+  from: number,
+  dir: 1 | -1
+): number | undefined {
+  let best: number | undefined;
+  for (const b of bends) {
+    if (b.axis !== axis) continue;
+    if (cross < b.lo - EPS || cross > b.hi + EPS) continue;
+    const beyond = dir > 0 ? b.fixed > from + EPS : b.fixed < from - EPS;
+    if (!beyond) continue;
+    if (best === undefined || Math.abs(b.fixed - from) < Math.abs(best - from)) best = b.fixed;
+  }
+  return best;
+}
+
+/** First arrangement cell whose midpoint passes `probe`; locates an interior coord. */
+function firstFilledCellMid(coords: number[], probe: (mid: number) => boolean): number | undefined {
+  for (let j = 0; j + 1 < coords.length; j += 1) {
+    const lo = coords[j];
+    const hi = coords[j + 1];
+    if (lo === undefined || hi === undefined) continue;
+    const mid = (lo + hi) / 2;
+    if (probe(mid)) return mid;
+  }
+  return undefined;
+}
+
+/** March from `c0` in `dir` until the probe leaves the region; bisect to the boundary. */
+function marchOutline(c0: number, dir: 1 | -1, probe: (c: number) => boolean): number {
+  let inside = c0 + dir * EPS * 4;
+  let step = 1;
+  let guard = 0;
+  while (probe(inside + dir * step) && guard < 100000) {
+    inside += dir * step;
+    step *= 2;
+    guard += 1;
+  }
+  let lo = inside;
+  let hi = inside + dir * step;
+  for (let i = 0; i < 60; i += 1) {
+    const m = (lo + hi) / 2;
+    if (probe(m)) lo = m;
+    else hi = m;
+  }
+  return lo;
+}
+
+/**
+ * BFS outward from the base, attributing each bend line to the region whose local
+ * edge it lies on (the parent) and spawning the child region beyond it. Each region
+ * carries its 2D frame; a bend line collinear with one of the parent's four local
+ * edges, within that edge's span, folds a child whose far edge is the nearest
+ * outward grandchild bend line or the outline boundary. `side`/`offset` are reported
+ * in the parent's local frame so the re-fold reproduces the authored attachment.
+ */
+function buildRegions(
+  base: Rect,
+  bends: BendSeg[],
+  contains: (x: number, y: number) => boolean
+): Result<FoldRegion[]> {
+  const regions: FoldRegion[] = [];
+  const used = new Set<number>();
+  const baseFrame: Frame2 = {
+    origin: [base.x0, base.y0],
+    u: [1, 0],
+    v: [0, 1],
+    uLen: base.x1 - base.x0,
+    vLen: base.y1 - base.y0,
+  };
+  const queue: { frame: Frame2; id: string | undefined }[] = [{ frame: baseFrame, id: undefined }];
+  const idForBend = (b: BendSeg): string => `b${b.index}`;
+
+  let guard = 0;
+  while (queue.length > 0 && guard < bends.length + 4) {
+    guard += 1;
+    const node = queue.shift();
+    if (node === undefined) break;
+    for (const b of bends) {
+      if (used.has(b.index)) continue;
+      const attached = bendOnFrameEdge(b, node.frame);
+      if (attached === undefined) continue;
+      used.add(b.index);
+
+      const far = farExtent(b, attached.outSign, bends, contains);
+      const length = far - b.dev;
+      if (length <= EPS) {
+        return err(
+          validationError('BAD_FLANGE_LENGTH', `recovered flange length for bend ${b.index} is non-positive (${length})`)
+        );
+      }
+
+      const id = idForBend(b);
+      const region: FoldRegion = {
+        id,
+        length,
+        angleDeg: b.angleDeg,
+        direction: b.direction,
+        rule: b.rule,
+        side: attached.side,
+        offset: attached.offset,
+        width: b.span,
+        ...(node.id !== undefined ? { parent: node.id } : {}),
+      };
+      regions.push(region);
+      queue.push({ frame: childFrame(attached, b, length), id });
+    }
+  }
+
+  if (used.size !== bends.length) {
+    return err(
+      validationError('UNATTACHED_BEND', `${bends.length - used.size} bend line(s) could not be attached to a region`)
+    );
+  }
+
+  return ok(regions);
+}
+
+interface BendAttachment {
+  side: FlatSide;
+  offset: number;
+  /** Edge basis of the parent's local edge `side` (mirrors unfold `edgeBasis2`). */
+  along: Pt2;
+  out: Pt2;
+  edgeOrigin: Pt2;
+  /** Sign of `out` on the bend's perpendicular axis, so `farExtent` marches outward. */
+  outSign: 1 | -1;
+}
+
+/**
+ * If bend `b` lies on one of `frame`'s four local edges (within that edge's span),
+ * return the parent-local `side`, the `offset` along that edge, and the edge basis.
+ * The bend line is collinear with the edge `edgeOrigin + along·t`, `t ∈ [0, edgeLen]`;
+ * the offset is the projection of the bend's near endpoint onto `along`.
+ */
+function bendOnFrameEdge(b: BendSeg, frame: Frame2): BendAttachment | undefined {
+  const segMid = bendMidpoint(b);
+  const segDir: Pt2 = b.axis === 'v' ? [0, 1] : [1, 0];
+  for (const side of ['xmax', 'xmin', 'ymax', 'ymin'] as const) {
+    const basis = edgeBasis2(frame, side);
+    // Edge must be parallel to the bend (along ∥ segDir) and the bend must sit on it.
+    if (Math.abs(cross2(basis.along, segDir)) > EPS) continue;
+    const rel: Pt2 = [segMid[0] - basis.edgeOrigin[0], segMid[1] - basis.edgeOrigin[1]];
+    const perp = Math.abs(dot2(rel, basis.out));
+    if (perp > EPS) continue;
+    const t = dot2(rel, basis.along);
+    const edgeLen = edgeLengthOf(frame, side);
+    const half = b.span / 2;
+    if (t < half - EPS || t > edgeLen - half + EPS) continue;
+    const offset = t - half;
+    // Outward sign on the bend's perpendicular axis (X for a vertical bend line,
+    // Y for a horizontal one), so `farExtent` marches the right way.
+    const outComp = b.axis === 'v' ? basis.out[0] : basis.out[1];
+    const outSign: 1 | -1 = outComp >= 0 ? 1 : -1;
+    return { side, offset: Math.max(0, offset), along: basis.along, out: basis.out, edgeOrigin: basis.edgeOrigin, outSign };
+  }
+  return undefined;
+}
+
+/**
+ * Child region frame, mirroring unfold's `placeChild`: origin past the developed
+ * strip (`edgeOrigin + along·offset + out·dev`), u along the bend axis (span), v
+ * outward (length). This keeps recovered frames identical to the layout's so a
+ * grandchild attaches to the right local edge.
+ */
+function childFrame(attached: BendAttachment, b: BendSeg, length: number): Frame2 {
+  const stripFar: Pt2 = [
+    attached.edgeOrigin[0] + attached.along[0] * attached.offset + attached.out[0] * b.dev,
+    attached.edgeOrigin[1] + attached.along[1] * attached.offset + attached.out[1] * b.dev,
+  ];
+  return { origin: stripFar, u: attached.along, v: attached.out, uLen: b.span, vLen: length };
+}
+
+function edgeLengthOf(f: Frame2, side: FlatSide): number {
+  return side === 'xmax' || side === 'xmin' ? f.vLen : f.uLen;
+}
+
+function bendMidpoint(b: BendSeg): Pt2 {
+  const mid = (b.lo + b.hi) / 2;
+  return b.axis === 'v' ? [b.fixed, mid] : [mid, b.fixed];
+}
+
+function cross2(a: Pt2, b: Pt2): number {
+  return a[0] * b[1] - a[1] * b[0];
+}
+function dot2(a: Pt2, b: Pt2): number {
+  return a[0] * b[0] + a[1] * b[1];
+}
+
+/**
+ * Far perpendicular extent (strip + flat) of a child region from its bend line: the
+ * nearest grandchild bend line beyond `b` (parallel, overlapping the span, same
+ * outward side) or, failing that, the outline boundary, measured as a distance from
+ * the bend line outward. Because bend lines are axis-aligned, the outward direction
+ * is along the bend's perpendicular axis with `outSign` (from the edge basis).
+ */
+function farExtent(
+  b: BendSeg,
+  outSign: 1 | -1,
+  bends: BendSeg[],
+  contains: (x: number, y: number) => boolean
+): number {
+  let nearest: number | undefined;
+  for (const g of bends) {
+    if (g.index === b.index) continue;
+    if (g.axis !== b.axis) continue;
+    const overlaps = g.lo < b.hi - EPS && b.lo < g.hi - EPS;
+    if (!overlaps) continue;
+    const beyond = outSign > 0 ? g.fixed > b.fixed + EPS : g.fixed < b.fixed - EPS;
+    if (!beyond) continue;
+    if (nearest === undefined || Math.abs(g.fixed - b.fixed) < Math.abs(nearest - b.fixed)) {
+      nearest = g.fixed;
+    }
+  }
+  const boundary = nearest ?? outlineFar(b, outSign, contains);
+  return Math.abs(boundary - b.fixed);
+}
+
+/**
+ * March perpendicular outward from the bend line until the region stops being filled
+ * (the outline boundary), probing at the span midpoint, then bisect to the boundary.
+ */
+function outlineFar(
+  b: BendSeg,
+  outSign: 1 | -1,
+  contains: (x: number, y: number) => boolean
+): number {
+  const mid = (b.lo + b.hi) / 2;
+  const probe = (perp: number): boolean =>
+    b.axis === 'v' ? contains(perp, mid) : contains(mid, perp);
+  return marchOutline(b.fixed, outSign, probe);
+}
+
+function uniqueSorted(values: number[]): number[] {
+  const sorted = [...values].sort((a, b) => a - b);
+  const out: number[] = [];
+  for (const v of sorted) {
+    const last = out[out.length - 1];
+    if (last === undefined || Math.abs(v - last) > EPS) out.push(v);
+  }
+  return out;
+}

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -25,6 +25,9 @@ export type {
 
 export { unfold } from './unfoldFns.js';
 
+export { fold, foldWithWarnings, patternToFlatInput, partToFlatInput } from './foldFns.js';
+export type { FoldResult, PatternToFlatInputOptions } from './foldFns.js';
+
 export { authorPart, baseEdgeRef } from './authorFns.js';
 export type {
   AuthorSpec,
@@ -47,6 +50,7 @@ export { validatePart } from './validateFns.js';
 export {
   author,
   unfold as unfoldPart,
+  fold as foldPart,
   miter,
   miterCorner,
   toDXF,
@@ -58,7 +62,7 @@ export {
   developed,
 } from './api.js';
 
-export { sheetMetal, fromPart, SheetMetalError, SheetMetalBuilder, SheetMetalPartHandle } from './facade.js';
+export { sheetMetal, fromPart, foldFlat, SheetMetalError, SheetMetalBuilder, SheetMetalPartHandle } from './facade.js';
 
 export type {
   EdgeRef,
@@ -71,6 +75,8 @@ export type {
   CornerMiter,
   SheetMetalPart,
   FlatPattern,
+  FlatInput,
+  FoldRegion,
   BendReport,
   SheetMetalWarning,
   UnfoldResult,

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -115,3 +115,47 @@ export interface UnfoldResult {
   report: BendReport;
   warnings: SheetMetalWarning[];
 }
+
+/**
+ * One fold-up region in a {@link FlatInput}: a rectangle in the flat pattern that
+ * folds about a fold line off its parent region (the base by default, or another
+ * region via `parent`). The region-tree is the inverse of the unfold layout, and is
+ * recovered purely from the 2D flat-pattern geometry by `patternToFlatInput` — so
+ * folding it up just re-runs the forward author geometry. `side`/`offset`/`width`
+ * locate the fold line along the parent edge exactly as the authoring `FlangeSpec`
+ * does (`side` is expressed in the parent region's local frame).
+ */
+export interface FoldRegion {
+  id: string;
+  /** Flat extent of the region away from the fold line (becomes the flange length). */
+  length: number;
+  angleDeg: number;
+  direction: 'up' | 'down';
+  rule: BendRule;
+  /** Which edge of the parent region this region folds off. Default `'xmax'`. */
+  side?: FlatSide | undefined;
+  /** Id of another fold region this one chains off. Default = base region. */
+  parent?: string | undefined;
+  /** Start position along the parent edge. Default `0`. */
+  offset?: number | undefined;
+  /** Extent along the parent edge. Default = full parent-edge length. */
+  width?: number | undefined;
+  miter?: MiterSpec | undefined;
+}
+
+/**
+ * A flat pattern to fold up into a 3D part: the base region (a rectangle) plus a
+ * tree of {@link FoldRegion}s, each folding off its parent about a fold line. This
+ * is the inverse of {@link unfold}: a region-tree rather than a 2D outline, which
+ * avoids fragile auto-partitioning of an arbitrary developed polygon and maps
+ * one-to-one onto the authored feature tree.
+ */
+export interface FlatInput {
+  thickness: number;
+  /** Base region extent along +X (the run). */
+  baseLength: number;
+  /** Base region extent along +Y (the developed-strip width). */
+  width: number;
+  material?: MaterialSpec | undefined;
+  regions: FoldRegion[];
+}

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -281,7 +281,7 @@ function placeChild(
 }
 
 /** Edge origin + along/out unit directions for one side of a 2D frame. */
-function edgeBasis2(f: Frame2, side: FlatSide): { along: Pt2; out: Pt2; edgeOrigin: Pt2 } {
+export function edgeBasis2(f: Frame2, side: FlatSide): { along: Pt2; out: Pt2; edgeOrigin: Pt2 } {
   const uTop = add2(f.origin, scale2(f.u, f.uLen));
   const vTop = add2(f.origin, scale2(f.v, f.vLen));
   switch (side) {

--- a/packages/brepjs-sheetmetal/tests/fold.test.ts
+++ b/packages/brepjs-sheetmetal/tests/fold.test.ts
@@ -362,3 +362,35 @@ describe('fold matches author for an equivalent spec', () => {
     expect(volFold).toBeCloseTo(volAuthor, 6);
   });
 });
+
+describe('scale invariance — sub-millimeter parts round-trip (base probe is unit-free)', () => {
+  it('recovers the base of a 0.5mm part (would fail a hardcoded 1e-3 mm x probe)', () => {
+    const smallRule: BendRule = { innerRadius: 0.1, kFactor: K };
+    const authored = author({
+      thickness: 0.1,
+      base: { length: 0.6, width: 0.5 },
+      flanges: [{ id: 'f', length: 0.3, angleDeg: 90, rule: smallRule, side: 'xmax' }],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    const partA = authored.value;
+    if (partA.solid === undefined) return;
+    const volA = unwrap(measureVolume(partA.solid));
+
+    const unfolded = unfold(partA);
+    if (isErr(unfolded)) return;
+    const flatInput = patternToFlatInput(unfolded.value.pattern, {
+      thickness: 0.1,
+      ruleFor: () => smallRule,
+    });
+    expect(flatInput.ok).toBe(true);
+    if (isErr(flatInput)) return;
+
+    const folded = fold(flatInput.value);
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    if (folded.value.solid === undefined) return;
+    expect(isValid(folded.value.solid)).toBe(true);
+    expect(unwrap(measureVolume(folded.value.solid))).toBeCloseTo(volA, 6);
+  });
+});

--- a/packages/brepjs-sheetmetal/tests/fold.test.ts
+++ b/packages/brepjs-sheetmetal/tests/fold.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { isValid, measureVolume, isErr, unwrap } from 'brepjs';
+import { author, unfold } from '../src/api.js';
+import { fold, foldWithWarnings, partToFlatInput, patternToFlatInput } from '../src/foldFns.js';
+import type { AuthorSpec } from '../src/authorFns.js';
+import type { BendRule, FlatInput } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const T = 1;
+const R = 2;
+const K = 0.44;
+const rule: BendRule = { innerRadius: R, kFactor: K };
+const DEV = (Math.PI / 180) * 90 * (R + K * T);
+
+/**
+ * The headline non-circular oracle: author(spec) → partA; unfold → the 2D flat
+ * pattern; patternToFlatInput recovers the region tree FROM THE 2D GEOMETRY ALONE
+ * (the outline wire + bend-line edges, plus the supplied rule); fold(recovered) →
+ * partB. partB must reproduce partA's volume, validity, and bend/flange counts.
+ *
+ * This is non-circular because the FlatInput fed to fold is parsed back out of the
+ * developed wire/edges — never read off partA's feature tree — so a bug in unfold's
+ * 2D placement, in the parser, OR in fold breaks the assertion (see the perturbation
+ * test below for proof the assertion has teeth).
+ */
+function roundTrip(name: string, spec: AuthorSpec): void {
+  it(`${name}: fold(patternToFlatInput(unfold(author))) reproduces the part`, () => {
+    const authored = author(spec);
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    const partA = authored.value;
+    expect(partA.solid).toBeDefined();
+    if (partA.solid === undefined) return;
+    expect(isValid(partA.solid)).toBe(true);
+    const volA = unwrap(measureVolume(partA.solid));
+
+    const unfolded = unfold(partA);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+
+    // Recover the region tree from the 2D pattern. The rule is a legitimate input (a
+    // flat pattern can't encode K-factor); everything geometric is parsed from the
+    // wire/edges. Bend lines come out in spanning-tree order, all sharing `rule`.
+    const flatInput = patternToFlatInput(unfolded.value.pattern, {
+      thickness: T,
+      ruleFor: () => rule,
+    });
+    expect(flatInput.ok).toBe(true);
+    if (isErr(flatInput)) return;
+    expect(flatInput.value.regions.length).toBe(partA.flanges.length);
+
+    const folded = fold(flatInput.value);
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    const partB = folded.value;
+    expect(partB.solid).toBeDefined();
+    if (partB.solid === undefined) return;
+    expect(isValid(partB.solid)).toBe(true);
+    const volB = unwrap(measureVolume(partB.solid));
+
+    expect(volB).toBeCloseTo(volA, 4);
+    expect(partB.bends.length).toBe(partA.bends.length);
+    expect(partB.flanges.length).toBe(partA.flanges.length);
+  });
+}
+
+describe('round-trip oracle (a): author → unfold → patternToFlatInput → fold', () => {
+  roundTrip('single 90° bracket', {
+    thickness: T,
+    base: { length: 40, width: 30 },
+    flanges: [{ id: 'f', length: 18, angleDeg: 90, rule, side: 'xmax' }],
+  });
+
+  roundTrip('U-channel (chain: base → wall → return)', {
+    thickness: T,
+    base: { length: 40, width: 30 },
+    flanges: [
+      { id: 'wall', length: 20, angleDeg: 90, rule, side: 'xmax' },
+      { id: 'return', length: 10, angleDeg: 90, rule, side: 'ymax', parent: 'wall' },
+    ],
+  });
+
+  roundTrip('4-sided tray (branching)', {
+    thickness: T,
+    base: { length: 50, width: 40 },
+    flanges: [
+      { id: 'xn', length: 12, angleDeg: 90, rule, side: 'xmin' },
+      { id: 'xp', length: 12, angleDeg: 90, rule, side: 'xmax' },
+      { id: 'yn', length: 12, angleDeg: 90, rule, side: 'ymin' },
+      { id: 'yp', length: 12, angleDeg: 90, rule, side: 'ymax' },
+    ],
+  });
+
+  roundTrip('down-bend', {
+    thickness: T,
+    base: { length: 40, width: 20 },
+    flanges: [{ id: 'd', length: 15, angleDeg: 90, rule, side: 'xmax', direction: 'down' }],
+  });
+
+  roundTrip('partial / offset flanges (two on one edge)', {
+    thickness: T,
+    base: { length: 40, width: 30 },
+    flanges: [
+      { id: 'a', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 0, width: 15 },
+      { id: 'b', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 20, width: 15 },
+    ],
+  });
+});
+
+describe('round-trip oracle: the geometry recovered from the 2D pattern is correct', () => {
+  // Asserts the parser reads the *right* numbers back out of the wire/edges (not the
+  // feature tree): each recovered region's side/offset/span/length/direction must
+  // equal the authored flange's. If unfold's 2D placement or the parser were wrong,
+  // these would drift even when the volume happened to match.
+  it('recovers side/offset/span/length for the chained U-channel', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 40, width: 30 },
+      flanges: [
+        { id: 'wall', length: 20, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'return', length: 10, angleDeg: 90, rule, side: 'ymax', parent: 'wall' },
+      ],
+    });
+    if (isErr(authored)) throw new Error('author failed');
+    const unfolded = unfold(authored.value);
+    if (isErr(unfolded)) throw new Error('unfold failed');
+
+    const recovered = patternToFlatInput(unfolded.value.pattern, { thickness: T, ruleFor: () => rule });
+    if (isErr(recovered)) throw new Error('patternToFlatInput failed');
+    const [wall, ret] = recovered.value.regions;
+
+    expect(recovered.value.baseLength).toBeCloseTo(40, 4);
+    expect(recovered.value.width).toBeCloseTo(30, 4);
+
+    expect(wall?.side).toBe('xmax');
+    expect(wall?.offset).toBeCloseTo(0, 4);
+    expect(wall?.width).toBeCloseTo(30, 4);
+    expect(wall?.length).toBeCloseTo(20, 4);
+    expect(wall?.parent).toBeUndefined();
+
+    // The return folds off the wall's distal edge — recovered in the WALL's local
+    // frame as `ymax`, exactly the authored attachment (a global-frame parser would
+    // mislabel this `xmax`).
+    expect(ret?.side).toBe('ymax');
+    expect(ret?.parent).toBe(wall?.id);
+    expect(ret?.length).toBeCloseTo(10, 4);
+    expect(ret?.width).toBeCloseTo(30, 4);
+  });
+
+  // Demonstrates the oracle has teeth: a deliberately WRONG recovered FlatInput (the
+  // flange length halved) folds to a measurably different volume, so the round-trip
+  // assertion above would FAIL if the geometry were recovered incorrectly.
+  it('a perturbed (wrong) flat input folds to a different volume', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 40, width: 30 },
+      flanges: [{ id: 'f', length: 18, angleDeg: 90, rule, side: 'xmax' }],
+    });
+    if (isErr(authored)) throw new Error('author failed');
+    if (authored.value.solid === undefined) throw new Error('no solid');
+    const volA = unwrap(measureVolume(authored.value.solid));
+
+    const unfolded = unfold(authored.value);
+    if (isErr(unfolded)) throw new Error('unfold failed');
+    const recovered = patternToFlatInput(unfolded.value.pattern, { thickness: T, ruleFor: () => rule });
+    if (isErr(recovered)) throw new Error('patternToFlatInput failed');
+
+    const correct = fold(recovered.value);
+    if (isErr(correct) || correct.value.solid === undefined) throw new Error('fold failed');
+    expect(unwrap(measureVolume(correct.value.solid))).toBeCloseTo(volA, 4);
+
+    const perturbed: FlatInput = {
+      ...recovered.value,
+      regions: recovered.value.regions.map((r) => ({ ...r, length: r.length / 2 })),
+    };
+    const wrong = fold(perturbed);
+    if (isErr(wrong) || wrong.value.solid === undefined) throw new Error('fold failed');
+    const volWrong = unwrap(measureVolume(wrong.value.solid));
+
+    expect(Math.abs(volWrong - volA)).toBeGreaterThan(1);
+  });
+
+  // Teeth on a *branching* attribute, not just length: halving each tray flange's
+  // recovered width shrinks every wall, so a mis-recovered width (or side) on the
+  // four-sided tray diverges the folded volume — the round-trip oracle would catch it.
+  it('a perturbed (wrong) tray width folds to a different volume', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 50, width: 40 },
+      flanges: [
+        { id: 'xn', length: 12, angleDeg: 90, rule, side: 'xmin' },
+        { id: 'xp', length: 12, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'yn', length: 12, angleDeg: 90, rule, side: 'ymin' },
+        { id: 'yp', length: 12, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    });
+    if (isErr(authored)) throw new Error('author failed');
+    if (authored.value.solid === undefined) throw new Error('no solid');
+    const volA = unwrap(measureVolume(authored.value.solid));
+
+    const unfolded = unfold(authored.value);
+    if (isErr(unfolded)) throw new Error('unfold failed');
+    const recovered = patternToFlatInput(unfolded.value.pattern, { thickness: T, ruleFor: () => rule });
+    if (isErr(recovered)) throw new Error('patternToFlatInput failed');
+
+    const correct = fold(recovered.value);
+    if (isErr(correct) || correct.value.solid === undefined) throw new Error('fold failed');
+    expect(unwrap(measureVolume(correct.value.solid))).toBeCloseTo(volA, 4);
+
+    const perturbed: FlatInput = {
+      ...recovered.value,
+      regions: recovered.value.regions.map((r) =>
+        r.width !== undefined ? { ...r, width: r.width / 2 } : r
+      ),
+    };
+    const wrong = fold(perturbed);
+    if (isErr(wrong) || wrong.value.solid === undefined) throw new Error('fold failed');
+    expect(Math.abs(unwrap(measureVolume(wrong.value.solid)) - volA)).toBeGreaterThan(1);
+  });
+});
+
+describe('round-trip oracle (b): stability under repeated fold/unfold', () => {
+  it('fold → unfold → patternToFlatInput → fold keeps the volume stable', () => {
+    const input: FlatInput = {
+      thickness: T,
+      baseLength: 40,
+      width: 30,
+      regions: [
+        { id: 'wall', length: 20, angleDeg: 90, direction: 'up', rule, side: 'xmax' },
+        { id: 'return', length: 10, angleDeg: 90, direction: 'up', rule, side: 'ymax', parent: 'wall' },
+      ],
+    };
+
+    const first = fold(input);
+    expect(first.ok).toBe(true);
+    if (isErr(first)) return;
+    if (first.value.solid === undefined) return;
+    const vol1 = unwrap(measureVolume(first.value.solid));
+
+    const reInput = partToFlatInput(first.value);
+    expect(reInput.ok).toBe(true);
+    if (isErr(reInput)) return;
+
+    const second = fold(reInput.value);
+    expect(second.ok).toBe(true);
+    if (isErr(second)) return;
+    if (second.value.solid === undefined) return;
+    const vol2 = unwrap(measureVolume(second.value.solid));
+
+    expect(vol2).toBeCloseTo(vol1, 4);
+  });
+});
+
+describe('round-trip oracle (c): direct FlatInput volume invariant', () => {
+  // Analytic check for an up-bend AND a down-bend: the folded solid is the union of
+  // three prismatic pieces, so its volume is an exact analytic quantity (not merely
+  // developedArea×thickness, which only holds at K=0.5). The base box is
+  // baseLength×width×T; the flange flat is flangeLen×span×T; the bend patch is the
+  // cylindrical annular sector swept by the fold, cross-section (θ/2)(outerR²−innerR²)
+  // = θ·(R+T/2)·T. A down-bend folds the same material the other way, so the volume
+  // is identical.
+  it.each([
+    { name: 'up-bend', direction: 'up' as const },
+    { name: 'down-bend', direction: 'down' as const },
+  ])('$name: folded volume = base + flange flat + bend patch', ({ direction }) => {
+    const baseLength = 40;
+    const width = 30;
+    const flangeLen = 18;
+    const span = width;
+    const input: FlatInput = {
+      thickness: T,
+      baseLength,
+      width,
+      regions: [{ id: 'f', length: flangeLen, angleDeg: 90, direction, rule, side: 'xmax' }],
+    };
+
+    const folded = fold(input);
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    if (folded.value.solid === undefined) return;
+    expect(isValid(folded.value.solid)).toBe(true);
+    const vol = unwrap(measureVolume(folded.value.solid));
+
+    const theta = (Math.PI / 180) * 90;
+    const baseVol = baseLength * width * T;
+    const flatVol = flangeLen * span * T;
+    const bendVol = theta * (R + T / 2) * T * span;
+    expect(vol).toBeCloseTo(baseVol + flatVol + bendVol, 2);
+
+    // The neutral-axis development (K=0.44) underestimates this by the
+    // (0.5−K)·T·θ·span sliver, confirming dev is measured at the neutral axis.
+    const developedArea = baseLength * width + (DEV + flangeLen) * span;
+    const expectedSliver = (0.5 - K) * T * theta * span;
+    expect(vol - developedArea * T).toBeCloseTo(expectedSliver, 2);
+  });
+});
+
+describe('fold warnings ride inside the Ok payload', () => {
+  it('emits MIN_RADIUS when inner radius < thickness', () => {
+    const input: FlatInput = {
+      thickness: 3,
+      baseLength: 40,
+      width: 30,
+      regions: [
+        { id: 'f', length: 18, angleDeg: 90, direction: 'up', rule: { innerRadius: 1, kFactor: K }, side: 'xmax' },
+      ],
+    };
+    const folded = foldWithWarnings(input);
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    expect(folded.value.warnings.some((w) => w.code === 'MIN_RADIUS')).toBe(true);
+  });
+
+  // Fold runs the canonical validator, so it surfaces COLLISION (two un-mitered
+  // adjacent flanges overlapping at the corner) — not just MIN_RADIUS.
+  it('emits COLLISION for un-mitered adjacent flanges', () => {
+    const input: FlatInput = {
+      thickness: T,
+      baseLength: 40,
+      width: 40,
+      regions: [
+        { id: 'fx', length: 18, angleDeg: 90, direction: 'up', rule, side: 'xmax' },
+        { id: 'fy', length: 18, angleDeg: 90, direction: 'up', rule, side: 'ymax' },
+      ],
+    };
+    const folded = foldWithWarnings(input);
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    expect(folded.value.warnings.some((w) => w.code === 'COLLISION')).toBe(true);
+  });
+});
+
+describe('fold matches author for an equivalent spec', () => {
+  it('a hand FlatInput folds to the same volume as the equivalent author spec', () => {
+    const baseLength = 40;
+    const width = 30;
+    const authored = author({
+      thickness: T,
+      base: { length: baseLength, width },
+      flanges: [{ id: 'f', length: 18, angleDeg: 90, rule, side: 'xmax', direction: 'up' }],
+    });
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    if (authored.value.solid === undefined) return;
+    const volAuthor = unwrap(measureVolume(authored.value.solid));
+
+    const folded = fold({
+      thickness: T,
+      baseLength,
+      width,
+      regions: [{ id: 'f', length: 18, angleDeg: 90, direction: 'up', rule, side: 'xmax' }],
+    });
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    if (folded.value.solid === undefined) return;
+    const volFold = unwrap(measureVolume(folded.value.solid));
+
+    expect(volFold).toBeCloseTo(volAuthor, 6);
+  });
+});


### PR DESCRIPTION
## Phase 2 · PR2 of a stacked sequence

Adds `fold` — the inverse of `unfold` — turning a flat pattern back into a 3D sheet-metal part, and establishes a **genuine round-trip oracle** that becomes the regression net for the rest of the stack.

### What's new
- **`fold(input: FlatInput)`** folds a `FoldRegion` tree up into a `SheetMetalPart`, reusing `authorPart`'s forward bend geometry (no duplicated bend math).
- **`patternToFlatInput(pattern, { thickness, ruleFor })`** recovers the region tree from the **2D flat-pattern geometry alone** — reading coordinates back out of the outline `Wire` and bend-line `Edge`s via `getEdges` / `curveStartPoint` / `curveEndPoint`. Regions, sides, offsets, spans, lengths, angles and directions are all derived from geometry, recovered in each parent's *local* frame (so a chained `return` folds off the correct edge). Only the bend **rule** (K-factor) is a supplied input — a flat pattern physically can't encode it.
- `partToFlatInput` routes through `unfold → patternToFlatInput`. Surfaced via `api.ts` / `facade.ts` (`foldFlat`) / `index.ts`.

### Why the oracle matters (and is non-circular)
The first cut of this PR was a circular no-op: `fold` called `authorPart` and the "oracle" read the region values back out of the feature tree, so the round-trip passed *by construction*. That was caught in adversarial review and reworked. Now `author → unfold → patternToFlatInput → fold` forces the data through **real 2D geometry**, so a bug in either direction breaks the volume assertion:
- Round-trip Δvol ~1e-13 mm³ across single bracket, U-channel (chain), 4-sided tray, down-bend, and partial/offset families; valid solids; matching bend/flange counts.
- **Perturbation tests** confirm the assertion has teeth (halving a recovered length/width diverges volume by >1 mm³).
- A dedicated test asserts the recovered `side`/`offset`/`span`/`length` equal the authored values (not just that volume matches).

### Quality
- `fold` validation reuses the canonical `validatePart` (COLLISION/INVALID_SOLID/MIN_RADIUS) instead of a hand-rolled copy; `edgeBasis2` is exported from `unfoldFns` and shared so `fold`/`unfold` stay in lockstep.
- typecheck / lint / build clean; **103 tests** (89 prior + 14 new) green against occt-wasm; snapshot harness reports the fold round-trip Δvol per demo.
- Built via a multi-agent Workflow (implement → adversarial review → fix); the circular-oracle defect was found and corrected before this PR was opened.

### Stack
PR1 (multi-bend authoring) merged as #1177. Remaining: corner/bend reliefs · cutouts/holes · tabs/slots/form features · contour/lofted flanges · foreign-solid unfold. OCCT-WASM-first.