### PR TITLE
feat(sheetmetal): corner & bend reliefs for manufacturable multi-bend parts

### DIFF
--- a/packages/brepjs-sheetmetal/.claude/agent-memory-local/engineer/MEMORY.md
+++ b/packages/brepjs-sheetmetal/.claude/agent-memory-local/engineer/MEMORY.md
@@ -1,0 +1,5 @@
+# Engineer Memory — brepjs-sheetmetal
+
+## Reliefs
+
+- [PR3 reliefs](project_sheetmetal_reliefs_pr3.md) — bend/corner relief invariants: bendLines carry id+inward, severed-solid guard, obround = recorded intent only, corner side = width??depth

--- a/packages/brepjs-sheetmetal/.claude/agent-memory-local/engineer/project_sheetmetal_reliefs_pr3.md
+++ b/packages/brepjs-sheetmetal/.claude/agent-memory-local/engineer/project_sheetmetal_reliefs_pr3.md
@@ -1,0 +1,20 @@
+---
+name: sheetmetal-reliefs-pr3
+description: brepjs-sheetmetal PR3 (feat/sheetmetal-reliefs) review-fix conventions and relief geometry gotchas
+metadata:
+  type: project
+---
+
+PR3 = bend + corner reliefs for brepjs-sheetmetal (branch feat/sheetmetal-reliefs).
+
+**Why:** Multi-bend parts tear/collide; reliefs are recorded features (like CornerMiter) cut from the 3D solid and replayed by unfold as 2D notches.
+
+**How to apply (relief geometry invariants):**
+
+- `FlatPattern.bendLines` now carries `id` AND `inward: [number,number]`. The id lets `developedBendLine` match a flange's 2D bend line by id, not by span/angle signature — required because same-span flanges (autoBendReliefs) would otherwise misplace notches. The `inward` unit dir = negation of the placed child frame's `v` (develop-out) axis; this is the into-parent direction the 2D notch cuts toward, correct for chained flanges (a base-center heuristic was wrong for them).
+- `devOf` in reliefFns reuses canonical `developedLength` (allowanceFns), not a hand-rolled arc-length copy. Note: `developedLength`/`bendAllowance` honor `rule.allowance` but ignore `rule.deduction` by design.
+- Both `addBendRelief` and `cornerRelief` guard after the cut: `!isValid(solid) || getSolids(solid).length > 1` → err `RELIEF_SEVERED_SOLID` (a too-large notch can sever a small flange).
+- `cornerRelief` square side = `spec.width ?? depth` (corner notches are conventionally square; width overrides the side and is recorded truthfully as ReliefFeature.width).
+- `obround` is recorded intent only — geometry is rectangular for both shapes. README + ReliefSpec docstring both say so; don't re-promise semicircular ends without building cylinder end-caps.
+
+**Gates:** typecheck|lint|build|test|snapshot all via `--workspace=brepjs-sheetmetal`; snapshot must exit 0. 115 tests after fixes (added: same-span id matching, corner width-honoring, chained-flange inward).

--- a/packages/brepjs-sheetmetal/.claude/agent-memory-local/reviewer/MEMORY.md
+++ b/packages/brepjs-sheetmetal/.claude/agent-memory-local/reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Reviewer Memory — brepjs-sheetmetal
+
+- [Sheetmetal relief review hotspots](project_sheetmetal_relief_review.md) — 2D-vs-3D notch placement, bend-line matched by geometry not id, obround no-op, gate commands

--- a/packages/brepjs-sheetmetal/.claude/agent-memory-local/reviewer/project_sheetmetal_relief_review.md
+++ b/packages/brepjs-sheetmetal/.claude/agent-memory-local/reviewer/project_sheetmetal_relief_review.md
@@ -1,0 +1,19 @@
+---
+name: sheetmetal-relief-review
+description: Recurring review hotspots in packages/brepjs-sheetmetal reliefs/unfold (2D-vs-3D notch placement, bend-line matching)
+metadata:
+  type: project
+---
+
+PR3 (feat/sheetmetal-reliefs) added bend + corner reliefs as recorded features replayed by unfold (mirroring CornerMiter on part.miters).
+
+**Recurring fragility to check in this package:**
+
+- 2D notch placement (`developedBendLine` in reliefFns.ts) re-runs `unfold` and matches a bend line by geometric signature (span + angleDeg + direction) — NOT by flange id, because `FlatPattern.bendLines` carries no id. Two flanges with the same span/angle/direction (symmetric parts, `autoBendReliefs` over a box) both match the first bend line → 2D notch misplaced while 3D cut is correct. Always test multi-partial-flange / symmetric parts when reliefs change.
+- 3D cut and 2D notch are computed from independent sources (3D from `bend.axisOrigin`; 2D from re-run unfold). They coincide only for root flanges by the base-mapping identity. Chained (non-root) partial flanges are untested: `developedInward` assumes the base center `(baseLength/2, width/2)`.
+- `obround` shape is recorded but geometrically a no-op (always boxes/rect notches). README documents this; types.ts docstring does not. Don't trust a "shape" test that only checks the recorded string + isValid.
+- `cornerRelief` ignores `spec.width` (notch is always `depth×depth` square) yet records `width`; and it does no internal isValid/single-solid guard after cut.
+
+**Gate commands (from repo root):** `npm run typecheck|lint|build|snapshot --workspace=brepjs-sheetmetal`; tests via `npx vitest run --root packages/brepjs-sheetmetal`. Snapshot prints per-demo round-trip Δvol; relief'd/mitered demos intentionally skip the partToFlatInput→fold oracle (notched outline isn't a plain rectangle).
+
+**Test idiom to watch:** new tests use `if (isErr(x)) return;` which silently passes on unexpected failure; only safe when preceded by `expect(x.ok).toBe(true)`.

--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -23,13 +23,14 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 
 ## Status
 
-| Area            | State                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------- |
-| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams       |
-| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area |
-| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`      |
-| Miter / outputs | auto corner-miter, multi-layer DXF, JSON bend report, manufacturability warnings       |
-| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                |
+| Area            | State                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams          |
+| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area    |
+| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`         |
+| Reliefs         | bend reliefs (slots at partial-flange bend-line ends), corner reliefs (notch at a corner) |
+| Miter / outputs | auto corner-miter, multi-layer DXF, JSON bend report, manufacturability warnings          |
+| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                   |
 
 `fold(input: FlatInput)` folds a flat pattern back up into a 3D part — the inverse of `unfold`. A
 `FlatInput` is a region-tree (a base rectangle plus child fold regions, each with a fold line, angle,
@@ -41,6 +42,27 @@ wire and bend-line edges — reading real coordinates back out with the public `
 volume, validity, and bend/flange counts through the 2D geometry — making the round-trip a genuine,
 non-circular oracle. Fold reuses the forward authoring bend geometry wholesale (no duplicated bend math),
 and rides SEAM_CUT / MIN_RADIUS warnings inside the Ok payload.
+
+## Reliefs
+
+Multi-bend parts tear or collide at corners unless material is relieved. Reliefs are recorded features
+(like corner miters): cut from the folded 3D solid and replayed by `unfold` as 2D notches subtracted from
+the developed outline (so they ride in the DXF `OUTLINE` layer and shrink `developedArea`).
+
+- `addBendRelief(part, flangeId, spec?)` cuts a slot at each **mid-edge end** of a partial/offset flange's
+  bend line — the ends that don't reach the parent-edge endpoint, where the parent material would tear.
+  `autoBendReliefs(part, spec?)` adds one to every partial-span flange (full-span flanges are skipped).
+- `cornerRelief(part, flangeIdA, flangeIdB, spec?)` cuts a square notch centred on the shared corner of two
+  adjacent flanges — the notch alternative to a 45° miter. The square side is `spec.width` when given, else
+  the depth clearance. It records the corner as resolved, so the `COLLISION` warning the un-relieved corner
+  raised goes away.
+
+A `ReliefSpec` is `{ shape: 'rectangular' | 'obround'; width?; depth? }`. Defaults: `width ≈ thickness`,
+`depth ≈ developedLength(bend) + thickness`. `obround` records the rounded-slot intent; the developed notch
+and 3D cut are rectangular for both shapes in this version. Reliefs round-trip through `fold` via a
+`FoldRegion.bendRelief` field; the strict geometric round-trip oracle (`partToFlatInput → fold`) skips
+relief'd parts because a notched outline is not a plain rectangle the parser can re-derive (same as mitered
+parts).
 
 ## Design
 

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, measureVolume, isErr, initFromOC } from 'brepjs';
 import type { Solid, Vec3 } from 'brepjs';
 import { author, miterCorner, unfold, fold } from '../src/api.js';
+import { addBendRelief, cornerRelief } from '../src/reliefFns.js';
 import { partToFlatInput } from '../src/foldFns.js';
 import type { AuthorSpec } from '../src/authorFns.js';
 import type { BendRule, FlatPattern, SheetMetalPart } from '../src/types.js';
@@ -58,6 +59,10 @@ interface Demo {
   spec: AuthorSpec;
   /** Optional auto-miter applied to the authored part before unfolding. */
   miter?: { a: string; b: string; gap: number };
+  /** Optional bend relief on a partial flange (slot at each mid-edge bend-line end). */
+  bendRelief?: { flange: string };
+  /** Optional corner relief notch between two adjacent flanges. */
+  cornerRelief?: { a: string; b: string };
 }
 
 const DEMOS: Demo[] = [
@@ -97,6 +102,29 @@ const DEMOS: Demo[] = [
       ],
     },
   },
+  {
+    name: 'bend-relief',
+    spec: {
+      thickness: T,
+      base: { length: 60, width: 40 },
+      // A partial flange centred on the ymax edge: both bend-line ends sit mid-edge
+      // and would tear the parent without a relief slot.
+      flanges: [{ id: 'tab', length: 16, angleDeg: 90, rule, side: 'ymax', offset: 18, width: 24 }],
+    },
+    bendRelief: { flange: 'tab' },
+  },
+  {
+    name: 'corner-relief',
+    spec: {
+      thickness: T,
+      base: { length: 44, width: 44 },
+      flanges: [
+        { id: 'fx', length: 16, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'fy', length: 16, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    },
+    cornerRelief: { a: 'fx', b: 'fy' },
+  },
 ];
 
 async function main(): Promise<void> {
@@ -121,6 +149,16 @@ async function renderDemo(demo: Demo): Promise<string[]> {
     if (isErr(mitered)) throw new Error(`miterCorner '${demo.name}' failed: ${mitered.error.message}`);
     part = mitered.value;
   }
+  if (demo.bendRelief !== undefined) {
+    const relieved = addBendRelief(part, demo.bendRelief.flange);
+    if (isErr(relieved)) throw new Error(`bendRelief '${demo.name}' failed: ${relieved.error.message}`);
+    part = relieved.value;
+  }
+  if (demo.cornerRelief !== undefined) {
+    const relieved = cornerRelief(part, demo.cornerRelief.a, demo.cornerRelief.b);
+    if (isErr(relieved)) throw new Error(`cornerRelief '${demo.name}' failed: ${relieved.error.message}`);
+    part = relieved.value;
+  }
   if (part.solid === undefined) throw new Error(`'${demo.name}' has no solid`);
 
   const unfolded = unfold(part);
@@ -140,10 +178,12 @@ async function renderDemo(demo: Demo): Promise<string[]> {
 
   // Fold round-trip: re-derive a FlatInput from the part and fold it back up,
   // demonstrating unfold→fold reproduces the part's volume (the PR2 oracle).
-  // Mitered parts are intentionally skipped; a failure on a non-mitered demo is a
-  // real round-trip regression, so it must surface rather than read as "skipped".
-  let roundTrip = '(fold round-trip skipped: mitered part)';
-  if (demo.miter === undefined) {
+  // Mitered AND relief'd parts are intentionally skipped (a notched/chamfered outline
+  // is not a plain rectangle, so patternToFlatInput cannot re-parse it); a failure on
+  // a plain demo is a real round-trip regression, so it must surface as such.
+  const skipRoundTrip = demo.miter !== undefined || part.reliefs !== undefined;
+  let roundTrip = '(fold round-trip skipped: mitered/relief’d part)';
+  if (!skipRoundTrip) {
     roundTrip = foldRoundTrip(part);
   }
 

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -20,6 +20,11 @@ import {
   autoMiterCorner as autoMiterCornerFn,
   type MiterPlane,
 } from './miterFns.js';
+import {
+  addBendRelief as addBendReliefFn,
+  autoBendReliefs as autoBendReliefsFn,
+  cornerRelief as cornerReliefFn,
+} from './reliefFns.js';
 import { flatPatternToDXF as flatPatternToDXFFn, type DxfOptions } from './dxfFns.js';
 import {
   buildReport as buildReportFn,
@@ -34,6 +39,7 @@ import type {
   FlatInput,
   BendReport,
   BendRule,
+  ReliefSpec,
   UnfoldResult,
   SheetMetalWarning,
 } from './types.js';
@@ -66,6 +72,30 @@ export function miterCorner(
   gap = 0
 ): Result<SheetMetalPart> {
   return autoMiterCornerFn(part, flangeIdA, flangeIdB, gap);
+}
+
+/** Add a bend relief slot at each mid-edge end of a partial flange's bend line. */
+export function bendRelief(
+  part: SheetMetalPart,
+  flangeId: string,
+  spec?: ReliefSpec
+): Result<SheetMetalPart> {
+  return addBendReliefFn(part, flangeId, spec);
+}
+
+/** Add a bend relief to every partial-span bend in the part. */
+export function autoReliefs(part: SheetMetalPart, spec?: ReliefSpec): Result<SheetMetalPart> {
+  return autoBendReliefsFn(part, spec);
+}
+
+/** Cut a corner relief notch at the shared corner of two adjacent flanges. */
+export function relieveCorner(
+  part: SheetMetalPart,
+  flangeIdA: string,
+  flangeIdB: string,
+  spec?: ReliefSpec
+): Result<SheetMetalPart> {
+  return cornerReliefFn(part, flangeIdA, flangeIdB, spec);
 }
 
 /** Emit an annotated multi-layer DXF string for a flat pattern. */

--- a/packages/brepjs-sheetmetal/src/facade.ts
+++ b/packages/brepjs-sheetmetal/src/facade.ts
@@ -20,6 +20,9 @@ import {
   fold,
   miter,
   miterCorner,
+  bendRelief,
+  autoReliefs,
+  relieveCorner,
   toDXF,
   report,
   validate,
@@ -30,6 +33,7 @@ import type {
   FlatInput,
   BendReport,
   MaterialSpec,
+  ReliefSpec,
   SheetMetalWarning,
   UnfoldResult,
 } from './types.js';
@@ -70,6 +74,21 @@ class SheetMetalPartHandle {
   /** Auto-miter the shared corner of two flanges with an optional gap. */
   miterCorner(flangeIdA: string, flangeIdB: string, gap = 0): SheetMetalPartHandle {
     return new SheetMetalPartHandle(unwrapOrThrow(miterCorner(this.part, flangeIdA, flangeIdB, gap)));
+  }
+
+  /** Add a bend relief at each mid-edge end of a partial flange's bend line. */
+  bendRelief(flangeId: string, spec?: ReliefSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(bendRelief(this.part, flangeId, spec)));
+  }
+
+  /** Add a bend relief to every partial-span bend in the part. */
+  autoReliefs(spec?: ReliefSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(autoReliefs(this.part, spec)));
+  }
+
+  /** Cut a corner relief notch at the shared corner of two adjacent flanges. */
+  cornerRelief(flangeIdA: string, flangeIdB: string, spec?: ReliefSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(relieveCorner(this.part, flangeIdA, flangeIdB, spec)));
   }
 
   /** Flatten into a developed flat pattern + bend report + warnings. */
@@ -142,6 +161,18 @@ class SheetMetalBuilder {
 
   miterCorner(flangeIdA: string, flangeIdB: string, gap = 0): SheetMetalPartHandle {
     return this.build().miterCorner(flangeIdA, flangeIdB, gap);
+  }
+
+  bendRelief(flangeId: string, spec?: ReliefSpec): SheetMetalPartHandle {
+    return this.build().bendRelief(flangeId, spec);
+  }
+
+  autoReliefs(spec?: ReliefSpec): SheetMetalPartHandle {
+    return this.build().autoReliefs(spec);
+  }
+
+  cornerRelief(flangeIdA: string, flangeIdB: string, spec?: ReliefSpec): SheetMetalPartHandle {
+    return this.build().cornerRelief(flangeIdA, flangeIdB, spec);
   }
 
   unfold(): UnfoldResult {

--- a/packages/brepjs-sheetmetal/src/foldFns.ts
+++ b/packages/brepjs-sheetmetal/src/foldFns.ts
@@ -19,6 +19,7 @@ import type {
   SheetMetalWarning,
 } from './types.js';
 import { authorPart, type AuthorSpec, type FlangeSpec } from './authorFns.js';
+import { addBendRelief } from './reliefFns.js';
 import { featureTree } from './featureTreeFns.js';
 import { developedLength } from './allowanceFns.js';
 import { unfold, edgeBasis2, type Frame2 } from './unfoldFns.js';
@@ -58,7 +59,17 @@ export function foldWithWarnings(input: FlatInput): Result<FoldResult> {
 
   const authored = authorPart(spec);
   if (!authored.ok) return authored;
-  const part = authored.value;
+  let part = authored.value;
+
+  // Re-apply any bend reliefs recorded on the regions, so fold reproduces a
+  // relief'd part's solid + recorded feature (reliefs are cut after the solid is
+  // built, exactly as the explicit `addBendRelief` API does).
+  for (const region of input.regions) {
+    if (region.bendRelief === undefined) continue;
+    const relieved = addBendRelief(part, region.id, region.bendRelief);
+    if (!relieved.ok) return relieved;
+    part = relieved.value;
+  }
 
   // SEAM_CUT comes from the feature-tree walk; INVALID_SOLID / COLLISION / MIN_RADIUS
   // come from the canonical validator, so fold inherits the same checks (and message

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -40,6 +40,8 @@ export type {
 export { miterCut, autoMiterCorner } from './miterFns.js';
 export type { MiterPlane } from './miterFns.js';
 
+export { addBendRelief, autoBendReliefs, cornerRelief } from './reliefFns.js';
+
 export { flatPatternToDXF } from './dxfFns.js';
 export type { DxfOptions } from './dxfFns.js';
 
@@ -53,6 +55,9 @@ export {
   fold as foldPart,
   miter,
   miterCorner,
+  bendRelief,
+  autoReliefs,
+  relieveCorner,
   toDXF,
   report,
   reportFrom,
@@ -73,6 +78,8 @@ export type {
   BendFeature,
   FlangeFeature,
   CornerMiter,
+  ReliefSpec,
+  ReliefFeature,
   SheetMetalPart,
   FlatPattern,
   FlatInput,

--- a/packages/brepjs-sheetmetal/src/reliefFns.ts
+++ b/packages/brepjs-sheetmetal/src/reliefFns.ts
@@ -1,0 +1,481 @@
+import {
+  type Result,
+  type Vec3,
+  type Solid,
+  ok,
+  err,
+  validationError,
+  box,
+  cut,
+  rotate,
+  translate,
+  getBounds,
+  getSolids,
+  isValid,
+  curveStartPoint,
+  curveEndPoint,
+  vecAdd,
+  vecSub,
+  vecScale,
+  vecCross,
+  vecDot,
+  vecNormalize,
+} from 'brepjs';
+import type {
+  BendFeature,
+  FlangeFeature,
+  ReliefFeature,
+  ReliefSpec,
+  SheetMetalPart,
+} from './types.js';
+import { normalizeSolid } from './internal.js';
+import { unfold } from './unfoldFns.js';
+import { developedLength } from './allowanceFns.js';
+
+const EPS = 1e-6;
+const Z_AXIS: Vec3 = [0, 0, 1];
+
+type Pt2 = [number, number];
+type NotchRect = [number, number, number, number];
+
+/**
+ * Add a bend relief to a flange: a small slot cut into the PARENT flat at each end
+ * of the bend line that does not reach the parent edge endpoint (a partial/offset
+ * flange). Without it the parent material tears at the corner where the bend
+ * terminates mid-edge. Each slot is `width` (≈ thickness) along the parent edge by
+ * `depth` (≈ developed length + clearance) into the parent flat, cut from the 3D
+ * solid and recorded so {@link unfold} replays the 2D notch.
+ *
+ * A relief is a recorded feature replayed by unfold — exactly the pattern
+ * {@link autoMiterCorner} establishes for corner miters.
+ */
+export function addBendRelief(
+  part: SheetMetalPart,
+  flangeId: string,
+  spec: ReliefSpec = { shape: 'rectangular' }
+): Result<SheetMetalPart> {
+  if (part.solid === undefined) {
+    return err(validationError('NO_SOLID', 'addBendRelief: part has no folded solid to cut'));
+  }
+  const flange = part.flanges.find((f) => f.id === flangeId);
+  const bend = part.bends.find((b) => b.id === flangeId);
+  if (flange === undefined || bend === undefined) {
+    return err(validationError('UNKNOWN_FLANGE', `addBendRelief: flange '${flangeId}' not found`));
+  }
+
+  const dims = reliefDims(spec, part.thickness, devOf(bend, part.thickness));
+  if (!dims.ok) return dims;
+  const { width, depth } = dims.value;
+
+  const geo = bendReliefGeometry(part, flange, bend, width, depth);
+  if (geo === undefined) {
+    return err(
+      validationError(
+        'BEND_RELIEF_NOT_NEEDED',
+        `addBendRelief: bend '${flangeId}' spans its full parent edge; no relief end to cut`
+      )
+    );
+  }
+
+  let solid = part.solid;
+  for (const tool of geo.tools3d) {
+    const result = cut(solid, tool);
+    if (!result.ok) return result;
+    solid = normalizeSolid(result.value);
+  }
+  if (!isValid(solid) || getSolids(solid).length > 1) {
+    return err(
+      validationError(
+        'RELIEF_SEVERED_SOLID',
+        `addBendRelief: slot (width ${width}, depth ${depth}) severs flange '${flangeId}' into multiple bodies; reduce width/depth`
+      )
+    );
+  }
+
+  const feature: ReliefFeature = {
+    kind: 'bend',
+    shape: spec.shape,
+    flangeA: flangeId,
+    width,
+    depth,
+    notches: geo.notches2d,
+  };
+
+  return ok({ ...part, solid, reliefs: [...(part.reliefs ?? []), feature] });
+}
+
+/**
+ * Add a bend relief to every partial-span bend (a flange that does not span its
+ * full parent edge). Full-span flanges are skipped — they have no mid-edge bend
+ * terminus to relieve. Convenience over calling {@link addBendRelief} per flange.
+ */
+export function autoBendReliefs(
+  part: SheetMetalPart,
+  spec: ReliefSpec = { shape: 'rectangular' }
+): Result<SheetMetalPart> {
+  let current = part;
+  for (const flange of part.flanges) {
+    const bend = current.bends.find((b) => b.id === flange.id);
+    if (bend === undefined) continue;
+    const dims = reliefDims(spec, current.thickness, devOf(bend, current.thickness));
+    if (!dims.ok) return dims;
+    const geo = bendReliefGeometry(current, flange, bend, dims.value.width, dims.value.depth);
+    if (geo === undefined) continue;
+    const next = addBendRelief(current, flange.id, spec);
+    if (!next.ok) return next;
+    current = next.value;
+  }
+  return ok(current);
+}
+
+/**
+ * Corner relief between two adjacent flanges: a notch cut at their shared corner so
+ * the two upright flanges clear each other once folded — the alternative to a 45°
+ * miter for the same corner {@link autoMiterCorner} handles. The notch is cut from
+ * the solid and recorded as a {@link ReliefFeature}; the corner is also recorded in
+ * `miters` (gap 0) so the collision check treats the interference as resolved.
+ */
+export function cornerRelief(
+  part: SheetMetalPart,
+  flangeIdA: string,
+  flangeIdB: string,
+  spec: ReliefSpec = { shape: 'rectangular' }
+): Result<SheetMetalPart> {
+  if (part.solid === undefined) {
+    return err(validationError('NO_SOLID', 'cornerRelief: part has no folded solid'));
+  }
+  const bendA = part.bends.find((b) => b.id === flangeIdA);
+  const bendB = part.bends.find((b) => b.id === flangeIdB);
+  if (bendA === undefined || bendB === undefined) {
+    return err(
+      validationError('UNKNOWN_FLANGE', `cornerRelief: flange '${flangeIdA}' or '${flangeIdB}' not found`)
+    );
+  }
+  const axisA = vecNormalize(bendA.axisDir);
+  const axisB = vecNormalize(bendB.axisDir);
+  if (Math.hypot(...vecCross(axisA, axisB)) < EPS) {
+    return err(
+      validationError('PARALLEL_FLANGES', 'cornerRelief: flange bend axes are parallel; no corner to relieve')
+    );
+  }
+
+  const devClearance = Math.max(devOf(bendA, part.thickness), devOf(bendB, part.thickness));
+  const dims = reliefDims(spec, part.thickness, devClearance);
+  if (!dims.ok) return dims;
+  const { depth } = dims.value;
+
+  // The corner notch is a square; its side is the user's `width` when given, else
+  // the depth clearance. Recording the side as `width` keeps the feature truthful.
+  const side = spec.width ?? depth;
+
+  const flangeA = part.flanges.find((f) => f.id === flangeIdA);
+  const flangeB = part.flanges.find((f) => f.id === flangeIdB);
+  const geo = cornerReliefGeometry(part, axisA, axisB, bendA, bendB, side, flangeA, flangeB);
+  const tool = squareTool(part.solid, geo.cornerXY, side);
+  const result = cut(part.solid, tool);
+  if (!result.ok) return result;
+
+  const solid = normalizeSolid(result.value);
+  if (!isValid(solid) || getSolids(solid).length > 1) {
+    return err(
+      validationError(
+        'RELIEF_SEVERED_SOLID',
+        `cornerRelief: notch (side ${side}) severs the part into multiple bodies; reduce width/depth`
+      )
+    );
+  }
+
+  const feature: ReliefFeature = {
+    kind: 'corner',
+    shape: spec.shape,
+    flangeA: flangeIdA,
+    flangeB: flangeIdB,
+    width: side,
+    depth,
+    notches: [geo.notch2d],
+  };
+
+  return ok({
+    ...part,
+    solid,
+    reliefs: [...(part.reliefs ?? []), feature],
+    miters: [...(part.miters ?? []), { flangeA: flangeIdA, flangeB: flangeIdB, gap: 0 }],
+  });
+}
+
+/**
+ * Developed strip width of a bend, via the canonical {@link developedLength} so the
+ * default relief depth tracks the same neutral-axis arc length the unfold uses.
+ * Falls back to the inner radius if the rule is degenerate (the depth is only a
+ * heuristic clearance, so a positive fallback keeps a valid default tool).
+ */
+function devOf(bend: BendFeature, thickness: number): number {
+  const dev = developedLength(bend.angleDeg, thickness, bend.rule);
+  return dev.ok ? dev.value : bend.rule.innerRadius;
+}
+
+/** Resolve relief width/depth from the spec, defaulting to thickness / (dev + T). */
+function reliefDims(
+  spec: ReliefSpec,
+  thickness: number,
+  dev: number
+): Result<{ width: number; depth: number }> {
+  const width = spec.width ?? thickness;
+  const depth = spec.depth ?? dev + thickness;
+  if (!Number.isFinite(width) || width <= 0) {
+    return err(validationError('INVALID_RELIEF_WIDTH', `relief width must be positive, got ${width}`));
+  }
+  if (!Number.isFinite(depth) || depth <= 0) {
+    return err(validationError('INVALID_RELIEF_DEPTH', `relief depth must be positive, got ${depth}`));
+  }
+  return ok({ width, depth });
+}
+
+interface BendReliefGeometry {
+  tools3d: Solid[];
+  notches2d: NotchRect[];
+}
+
+/**
+ * Build the 3D cut tools and 2D developed-plane notch rectangles for a bend relief.
+ * In 3D each slot straddles a bend-line end on the parent edge and cuts inward
+ * (toward the parent interior) by `depth`, full thickness. In 2D the slot sits at
+ * the corresponding bend-line endpoint and cuts into the parent rectangle the same
+ * way. Returns `undefined` when the flange spans its full parent edge (no mid-edge
+ * end to relieve).
+ */
+function bendReliefGeometry(
+  part: SheetMetalPart,
+  flange: FlangeFeature,
+  bend: BendFeature,
+  width: number,
+  depth: number
+): BendReliefGeometry | undefined {
+  if (part.solid === undefined) return undefined;
+
+  const axis = vecNormalize(bend.axisDir);
+  const span = flange.span;
+  const offset = flange.offset ?? flange.baseEdge.offset ?? 0;
+  const edgeLen = parentEdgeLength(part, flange);
+
+  const atStart = offset > EPS;
+  const atEnd = offset + span < edgeLen - EPS;
+  if (!atStart && !atEnd) return undefined;
+
+  const b = getBounds(part.solid);
+  const center: Vec3 = [(b.xMin + b.xMax) / 2, (b.yMin + b.yMax) / 2, 0];
+  const inward = inwardRun(bend.axisOrigin, axis, center);
+  const edgeBase: Vec3 = [bend.axisOrigin[0], bend.axisOrigin[1], 0];
+
+  const tools3d: Solid[] = [];
+  const ends: number[] = [];
+  if (atStart) ends.push(0);
+  if (atEnd) ends.push(span);
+  for (const s of ends) {
+    const at = vecAdd(edgeBase, vecScale(axis, s));
+    tools3d.push(slotTool3d(at, axis, inward, width, depth, part.thickness));
+  }
+
+  const notches2d = bendNotches2d(part, flange, width, depth, atStart, atEnd);
+  return { tools3d, notches2d };
+}
+
+/**
+ * Developed-plane notch rectangles for a bend relief, located at the bend-line ends
+ * and cutting into the PARENT rectangle (opposite the develop-out direction). The
+ * unfold is the source of truth for 2D placement, so we read the developed bend
+ * line straight from it and offset inward.
+ */
+function bendNotches2d(
+  part: SheetMetalPart,
+  flange: FlangeFeature,
+  width: number,
+  depth: number,
+  atStart: boolean,
+  atEnd: boolean
+): NotchRect[] {
+  const placed = developedBendLine(part, flange);
+  if (placed === undefined) return [];
+  const { bendA, bendB, inward } = placed;
+  const len = Math.max(dist2(bendA, bendB), EPS);
+  const along: Pt2 = [(bendB[0] - bendA[0]) / len, (bendB[1] - bendA[1]) / len];
+  const half = width / 2;
+  const make = (p: Pt2): NotchRect => {
+    const c0: Pt2 = [p[0] - along[0] * half, p[1] - along[1] * half];
+    const c1: Pt2 = [
+      p[0] + along[0] * half + inward[0] * depth,
+      p[1] + along[1] * half + inward[1] * depth,
+    ];
+    return [Math.min(c0[0], c1[0]), Math.min(c0[1], c1[1]), Math.max(c0[0], c1[0]), Math.max(c0[1], c1[1])];
+  };
+  const notches: NotchRect[] = [];
+  if (atStart) notches.push(make(bendA));
+  if (atEnd) notches.push(make(bendB));
+  return notches;
+}
+
+interface DevelopedBendLine {
+  bendA: Pt2;
+  bendB: Pt2;
+  inward: Pt2;
+}
+
+/**
+ * Locate a flange's bend line in the developed plane by re-running the unfold and
+ * matching by flange id — the unfold owns 2D placement, so the notch always
+ * coincides with the real developed geometry. Matching by id (not by geometric
+ * signature) keeps placement correct when several flanges share the same
+ * span/angle/direction, as in {@link autoBendReliefs}.
+ */
+function developedBendLine(part: SheetMetalPart, flange: FlangeFeature): DevelopedBendLine | undefined {
+  const unfolded = unfold({ ...part, reliefs: undefined });
+  if (!unfolded.ok) return undefined;
+  const bl = unfolded.value.pattern.bendLines.find((b) => b.id === flange.id);
+  if (bl === undefined) return undefined;
+  const a = toPt2(curveStartPoint(bl.line));
+  const b = toPt2(curveEndPoint(bl.line));
+  return { bendA: a, bendB: b, inward: bl.inward };
+}
+
+interface CornerReliefGeometry {
+  cornerXY: Pt2;
+  notch2d: NotchRect;
+}
+
+/**
+ * Corner relief geometry: the shared-corner point of the two flanges' bend lines in
+ * world XY, plus a square developed-plane notch CENTRED on the reflex corner of the
+ * two flanges (`(baseLength, width)` for the classic +X/+Y L). Centring the square
+ * on the corner bites the base and both flange roots equally, so the developed
+ * outline stays a single closed loop (a notch landing its far corner exactly on the
+ * reflex vertex would pinch the boundary).
+ */
+function cornerReliefGeometry(
+  part: SheetMetalPart,
+  axisA: Vec3,
+  axisB: Vec3,
+  bendA: BendFeature,
+  bendB: BendFeature,
+  side: number,
+  flangeA: FlangeFeature | undefined,
+  flangeB: FlangeFeature | undefined
+): CornerReliefGeometry {
+  const corner = cornerPoint(bendA.axisOrigin, axisA, bendB.axisOrigin, axisB);
+  const [cx, cy] = developedCorner(part, flangeA, flangeB);
+  const h = side / 2;
+  const notch2d: NotchRect = [cx - h, cy - h, cx + h, cy + h];
+  return { cornerXY: [corner[0], corner[1]], notch2d };
+}
+
+/**
+ * Developed-plane base corner shared by two perpendicular base flanges, picked from
+ * their sides: an `xmax` flange's corner x is `baseLength`, an `xmin`'s is `0`; a
+ * `ymax`'s corner y is `width`, a `ymin`'s is `0`. Defaults to the +X/+Y corner.
+ */
+function developedCorner(
+  part: SheetMetalPart,
+  flangeA: FlangeFeature | undefined,
+  flangeB: FlangeFeature | undefined
+): Pt2 {
+  let cx = part.baseLength;
+  let cy = part.width;
+  for (const f of [flangeA, flangeB]) {
+    const side = f?.baseEdge.side;
+    if (side === 'xmin') cx = 0;
+    else if (side === 'xmax') cx = part.baseLength;
+    else if (side === 'ymin') cy = 0;
+    else if (side === 'ymax') cy = part.width;
+  }
+  return [cx, cy];
+}
+
+/** Point on bend A's line closest to bend B's line (their shared corner). */
+function cornerPoint(originA: Vec3, dirA: Vec3, originB: Vec3, dirB: Vec3): Vec3 {
+  const w0 = vecSub(originA, originB);
+  const a = vecDot(dirA, dirA);
+  const b = vecDot(dirA, dirB);
+  const c = vecDot(dirB, dirB);
+  const d = vecDot(dirA, w0);
+  const e = vecDot(dirB, w0);
+  const denom = a * c - b * b;
+  if (Math.abs(denom) < 1e-9) return originA;
+  const sc = (b * e - c * d) / denom;
+  return vecAdd(originA, vecScale(dirA, sc));
+}
+
+/** In-plane perpendicular to `axis` pointing toward the part center (into the parent). */
+function inwardRun(axisOrigin: Vec3, axis: Vec3, center: Vec3): Vec3 {
+  const perp = vecNormalize(vecCross(axis, Z_AXIS));
+  const toCenter: Vec3 = [center[0] - axisOrigin[0], center[1] - axisOrigin[1], 0];
+  const dot = perp[0] * toCenter[0] + perp[1] * toCenter[1];
+  return dot >= 0 ? perp : [-perp[0], -perp[1], -perp[2]];
+}
+
+/** Parent-edge length the flange folds off (base edge for root flanges). */
+function parentEdgeLength(part: SheetMetalPart, flange: FlangeFeature): number {
+  const side = flange.baseEdge.side ?? 'xmax';
+  const onWidthEdge = side === 'xmax' || side === 'xmin';
+  const parentId = flange.baseEdge.parentId;
+  if (parentId === undefined || parentId === 'root' || parentId === 'face-0') {
+    return onWidthEdge ? part.width : part.baseLength;
+  }
+  const parent = part.flanges.find((f) => f.id === parentId);
+  if (parent === undefined) return onWidthEdge ? part.width : part.baseLength;
+  return onWidthEdge ? parent.length : parent.span;
+}
+
+/**
+ * A box tool for a bend-relief slot: a `width × depth × (thickness + margins)` block
+ * whose `width` axis runs along the parent edge and `depth` axis points inward,
+ * placed so it straddles the edge point `at` and cuts through the parent surface.
+ */
+function slotTool3d(
+  at: Vec3,
+  along: Vec3,
+  inward: Vec3,
+  width: number,
+  depth: number,
+  thickness: number
+): Solid {
+  const margin = thickness + 2;
+  // Canonical: width along +X, depth along +Y, height along +Z (cuts through Z).
+  // Rotating by `deg` sends +X→along and +Y→(along rotated +90° = [-along.y, along.x]).
+  // If that rotated +Y opposes `inward`, build the block extending in −Y so it cuts
+  // into the parent rather than out into the flange.
+  const rotPerp: Vec3 = [-along[1], along[0], 0];
+  const y0 = vecDot(rotPerp, inward) >= 0 ? 0 : -depth;
+  let tool: Solid = box(width, depth, thickness + 2 * margin);
+  tool = translate(tool, [-width / 2, y0, -margin]);
+  tool = orientXY(tool, along);
+  return translate(tool, [at[0], at[1], 0]);
+}
+
+/**
+ * Square corner-relief tool: a `side × side × (height + margins)` block CENTRED on
+ * the corner point in XY and spanning the full part height, so it removes material
+ * from the base corner and both flange roots. Corner reliefs sit at axis-aligned
+ * base corners for the supported perpendicular flange shapes, so the tool stays
+ * axis-aligned.
+ */
+function squareTool(solid: Solid, cornerXY: Pt2, side: number): Solid {
+  const b = getBounds(solid);
+  const margin = 2;
+  const h = side / 2;
+  const tool = box(side, side, b.zMax - b.zMin + 2 * margin);
+  return translate(tool, [cornerXY[0] - h, cornerXY[1] - h, b.zMin - margin]);
+}
+
+/** Rotate a shape about +Z so its local +X axis points along `xT` (in the XY plane). */
+function orientXY(shape: Solid, xT: Vec3): Solid {
+  const deg = (Math.atan2(xT[1], xT[0]) * 180) / Math.PI;
+  if (Math.abs(deg) < 1e-9) return shape;
+  return rotate(shape, deg, { at: [0, 0, 0], axis: Z_AXIS });
+}
+
+function toPt2(v: Vec3): Pt2 {
+  return [v[0], v[1]];
+}
+
+function dist2(a: Pt2, b: Pt2): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1]);
+}

--- a/packages/brepjs-sheetmetal/src/reliefFns.ts
+++ b/packages/brepjs-sheetmetal/src/reliefFns.ts
@@ -115,14 +115,13 @@ export function autoBendReliefs(
 ): Result<SheetMetalPart> {
   let current = part;
   for (const flange of part.flanges) {
-    const bend = current.bends.find((b) => b.id === flange.id);
-    if (bend === undefined) continue;
-    const dims = reliefDims(spec, current.thickness, devOf(bend, current.thickness));
-    if (!dims.ok) return dims;
-    const geo = bendReliefGeometry(current, flange, bend, dims.value.width, dims.value.depth);
-    if (geo === undefined) continue;
+    // Let addBendRelief own the needed/not-needed decision rather than recomputing
+    // the relief geometry here just to peek (which also allocated throwaway tools).
     const next = addBendRelief(current, flange.id, spec);
-    if (!next.ok) return next;
+    if (!next.ok) {
+      if (next.error.code === 'BEND_RELIEF_NOT_NEEDED') continue;
+      return next;
+    }
     current = next.value;
   }
   return ok(current);
@@ -165,7 +164,8 @@ export function cornerRelief(
   const { depth } = dims.value;
 
   // The corner notch is a square; its side is the user's `width` when given, else
-  // the depth clearance. Recording the side as `width` keeps the feature truthful.
+  // the depth clearance. Both recorded dims are the actual side so a consumer
+  // reading width/depth reconstructs the real cut (not a stale clearance value).
   const side = spec.width ?? depth;
 
   const flangeA = part.flanges.find((f) => f.id === flangeIdA);
@@ -191,7 +191,7 @@ export function cornerRelief(
     flangeA: flangeIdA,
     flangeB: flangeIdB,
     width: side,
-    depth,
+    depth: side,
     notches: [geo.notch2d],
   };
 

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -73,6 +73,45 @@ export interface CornerMiter {
   gap: number;
 }
 
+/**
+ * A relief cut to make a multi-bend part manufacturable. `shape` records the intent:
+ * `rectangular` is a plain slot, `obround` the rounded-slot (semicircular-ended,
+ * lower-stress) standard relief. In this version both produce rectangular geometry —
+ * `obround` only carries the rounded-end intent onto the recorded feature; the
+ * developed notch and 3D cut are rectangular for both. `width` runs along the parent
+ * edge (the slot's narrow extent, default ≈ material thickness); `depth` cuts
+ * perpendicular into the parent flat (default ≈ the bend's developed length plus a
+ * small clearance). For a corner relief, `width` sets the square notch side (default
+ * ≈ depth).
+ */
+export interface ReliefSpec {
+  shape: 'rectangular' | 'obround';
+  width?: number | undefined;
+  depth?: number | undefined;
+}
+
+/**
+ * A recorded relief, mirroring {@link CornerMiter}: enough information for the
+ * unfold to replay the 2D notch without reparsing geometry. `kind` distinguishes a
+ * bend relief (a slot at each end of a partial bend line, into the parent flat)
+ * from a corner relief (a notch at the shared corner of two flanges). `notches`
+ * are the developed-plane (flat-pattern) rectangles to subtract from the outline;
+ * each is also cut from the 3D solid. `shape` carries the rounded-end option onto
+ * the developed outline.
+ */
+export interface ReliefFeature {
+  kind: 'bend' | 'corner';
+  shape: 'rectangular' | 'obround';
+  /** The flange the relief was applied to (bend relief) or the first flange (corner relief). */
+  flangeA: string;
+  /** The second flange of a corner relief; undefined for a bend relief. */
+  flangeB?: string | undefined;
+  width: number;
+  depth: number;
+  /** Developed-plane notch rectangles `[x0, y0, x1, y1]` subtracted from the outline. */
+  notches: [number, number, number, number][];
+}
+
 export interface SheetMetalPart {
   thickness: number;
   /** Base flat extent along +X (x∈[0, baseLength]); the east-run length. */
@@ -84,11 +123,20 @@ export interface SheetMetalPart {
   bends: BendFeature[];
   solid?: Solid | undefined;
   miters?: CornerMiter[] | undefined;
+  reliefs?: ReliefFeature[] | undefined;
 }
 
 export interface FlatPattern {
   outline: Wire;
-  bendLines: { line: Edge; angleDeg: number; direction: 'up' | 'down' }[];
+  bendLines: {
+    id: string;
+    line: Edge;
+    angleDeg: number;
+    direction: 'up' | 'down';
+    /** Unit direction in the developed plane pointing into the parent flat (the
+     * side a bend relief notches), opposite the develop-out direction. */
+    inward: [number, number];
+  }[];
   developedArea: number;
 }
 
@@ -141,6 +189,8 @@ export interface FoldRegion {
   /** Extent along the parent edge. Default = full parent-edge length. */
   width?: number | undefined;
   miter?: MiterSpec | undefined;
+  /** Bend relief to add at this region's partial-span fold-line ends after folding. */
+  bendRelief?: ReliefSpec | undefined;
 }
 
 /**

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -71,15 +71,23 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   for (const placed of layout.flats) rects.push(placed.rect);
   for (const strip of layout.strips) rects.push(strip);
 
-  const outlineResult = buildOutline(rects, layout, part.miters ?? []);
+  const notches: Rect[] = (part.reliefs ?? []).flatMap((relief) =>
+    relief.notches.map(([x0, y0, x1, y1]) => ({ x0, y0, x1, y1 }))
+  );
+  const outlineResult = buildOutline(rects, layout, part.miters ?? [], notches);
   if (!outlineResult.ok) return outlineResult;
+  layout.developedArea -= removedNotchArea(rects, notches);
 
   const bendLines = layout.flats
     .filter((p): p is PlacedFlange => p.kind === 'flange')
     .map((p) => ({
+      id: p.id,
       line: bendLineEdge(p),
       angleDeg: p.angleDeg,
       direction: p.direction,
+      // The child frame's v axis is the develop-out direction; into-parent is its
+      // negation. Correct for chained flanges too (it is local to the placement).
+      inward: [-p.frame.v[0], -p.frame.v[1]] as [number, number],
     }));
 
   const pattern: FlatPattern = {
@@ -334,9 +342,16 @@ function neg2(a: Pt2): Pt2 {
  * emitted as one closed loop. Holes are not possible for the supported shapes
  * (every arm attaches to the simply-connected base or a chain thereof).
  */
-function buildOutline(rects: Rect[], layout: TreeLayout, miters: CornerMiter[]): Result<Wire> {
-  const miterCorners = lShapedMiter(layout, miters);
-  const corners = miterCorners ?? rectilinearUnion(rects);
+function buildOutline(
+  rects: Rect[],
+  layout: TreeLayout,
+  miters: CornerMiter[],
+  notches: Rect[]
+): Result<Wire> {
+  // The lShapedMiter chamfer special-case can't express a notch, so once any relief
+  // is recorded fall through to the rectilinear-union path (which subtracts notches).
+  const miterCorners = notches.length > 0 ? undefined : lShapedMiter(layout, miters);
+  const corners = miterCorners ?? rectilinearUnion(rects, notches);
   if (corners.length < 3) {
     return err(validationError('OUTLINE_BUILD_FAILED', 'developed outline has fewer than 3 vertices'));
   }
@@ -407,12 +422,16 @@ function miterGapFor(miters: CornerMiter[], aId: string, bId: string): number | 
  * tracking the covered y-spans, then tracing the boundary contour. The sweep emits
  * a CCW loop of corner points with no collinear duplicates.
  */
-function rectilinearUnion(rects: Rect[]): Pt2[] {
-  const xs = uniqueSorted(rects.flatMap((r) => [r.x0, r.x1]));
-  const ys = uniqueSorted(rects.flatMap((r) => [r.y0, r.y1]));
+function rectilinearUnion(rects: Rect[], notches: Rect[] = []): Pt2[] {
+  const cuts = [...rects.flatMap((r) => [r.x0, r.x1]), ...notches.flatMap((r) => [r.x0, r.x1])];
+  const cutsY = [...rects.flatMap((r) => [r.y0, r.y1]), ...notches.flatMap((r) => [r.y0, r.y1])];
+  const xs = uniqueSorted(cuts);
+  const ys = uniqueSorted(cutsY);
   if (xs.length < 2 || ys.length < 2) return [];
 
-  // Cell-occupancy grid over the arrangement of all rectangle edges.
+  // Cell-occupancy grid: a cell is filled if its centre lies in the rectangle union
+  // and in no notch (notches subtract material; they sit on the boundary so the
+  // result stays simply-connected).
   const nx = xs.length - 1;
   const ny = ys.length - 1;
   const filled = new Set<number>();
@@ -420,9 +439,9 @@ function rectilinearUnion(rects: Rect[]): Pt2[] {
     const cx = ((xs[i] as number) + (xs[i + 1] as number)) / 2;
     for (let j = 0; j < ny; j += 1) {
       const cy = ((ys[j] as number) + (ys[j + 1] as number)) / 2;
-      if (rects.some((r) => cx > r.x0 && cx < r.x1 && cy > r.y0 && cy < r.y1)) {
-        filled.add(i * ny + j);
-      }
+      const inRect = rects.some((r) => cx > r.x0 && cx < r.x1 && cy > r.y0 && cy < r.y1);
+      const inNotch = notches.some((r) => cx > r.x0 && cx < r.x1 && cy > r.y0 && cy < r.y1);
+      if (inRect && !inNotch) filled.add(i * ny + j);
     }
   }
 
@@ -451,6 +470,38 @@ function rectilinearUnion(rects: Rect[]): Pt2[] {
   }
 
   return traceLoop(segs);
+}
+
+/**
+ * Area of material removed by the relief notches: the portion of each notch that
+ * overlaps the rectangle union, summed over a shared cell grid so overlapping
+ * notches (e.g. two corner reliefs meeting) are not double-counted.
+ */
+function removedNotchArea(rects: Rect[], notches: Rect[]): number {
+  if (notches.length === 0) return 0;
+  const xs = uniqueSorted([
+    ...rects.flatMap((r) => [r.x0, r.x1]),
+    ...notches.flatMap((r) => [r.x0, r.x1]),
+  ]);
+  const ys = uniqueSorted([
+    ...rects.flatMap((r) => [r.y0, r.y1]),
+    ...notches.flatMap((r) => [r.y0, r.y1]),
+  ]);
+  let area = 0;
+  for (let i = 0; i + 1 < xs.length; i += 1) {
+    const x0 = xs[i] as number;
+    const x1 = xs[i + 1] as number;
+    const cx = (x0 + x1) / 2;
+    for (let j = 0; j + 1 < ys.length; j += 1) {
+      const y0 = ys[j] as number;
+      const y1 = ys[j + 1] as number;
+      const cy = (y0 + y1) / 2;
+      const inRect = rects.some((r) => cx > r.x0 && cx < r.x1 && cy > r.y0 && cy < r.y1);
+      const inNotch = notches.some((r) => cx > r.x0 && cx < r.x1 && cy > r.y0 && cy < r.y1);
+      if (inRect && inNotch) area += (x1 - x0) * (y1 - y0);
+    }
+  }
+  return area;
 }
 
 /** Chain oriented boundary segments into a single loop, dropping collinear points. */

--- a/packages/brepjs-sheetmetal/src/validateFns.ts
+++ b/packages/brepjs-sheetmetal/src/validateFns.ts
@@ -98,11 +98,19 @@ function checkCollisions(part: SheetMetalPart): SheetMetalWarning[] {
     boxes.push({ id: bend.id, bounds });
   }
 
+  // A corner resolved by a miter or a corner relief is no longer an interference:
+  // both record a `CornerMiter` for the pair, so skip those pairs.
+  const resolved = new Set<string>();
+  for (const m of part.miters ?? []) {
+    resolved.add(pairKey(m.flangeA, m.flangeB));
+  }
+
   for (let i = 0; i < boxes.length; i += 1) {
     for (let j = i + 1; j < boxes.length; j += 1) {
       const a = boxes[i];
       const b = boxes[j];
       if (a === undefined || b === undefined) continue;
+      if (resolved.has(pairKey(a.id, b.id))) continue;
       if (boundsOverlap(a.bounds, b.bounds)) {
         warnings.push({
           code: 'COLLISION',
@@ -194,6 +202,11 @@ function outwardRun(axisOrigin: Vec3, axis: Vec3, center: Vec3): Vec3 {
   ];
   const dot = perp[0] * toEdge[0] + perp[1] * toEdge[1];
   return dot >= 0 ? perp : [-perp[0], -perp[1], -perp[2]];
+}
+
+/** Order-independent key for a flange pair (corner identity). */
+function pairKey(a: string, b: string): string {
+  return a < b ? `${a}::${b}` : `${b}::${a}`;
 }
 
 function boundsOverlap(a: Bounds3D, b: Bounds3D): boolean {

--- a/packages/brepjs-sheetmetal/tests/relief.test.ts
+++ b/packages/brepjs-sheetmetal/tests/relief.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { isValid, measureVolume, getEdges, isErr, unwrap } from 'brepjs';
+import { author, unfold, validate } from '../src/api.js';
+import { addBendRelief, autoBendReliefs, cornerRelief } from '../src/reliefFns.js';
+import { fold, partToFlatInput } from '../src/foldFns.js';
+import type { BendRule, FlatInput } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const T = 1;
+const R = 2;
+const K = 0.44;
+const rule: BendRule = { innerRadius: R, kFactor: K };
+const DEV = (Math.PI / 180) * 90 * (R + K * T);
+
+/** A base part with a single partial flange centred on the ymax edge (both ends mid-edge). */
+function partialPart() {
+  return author({
+    thickness: T,
+    base: { length: 40, width: 30 },
+    flanges: [{ id: 'a', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 10, width: 15 }],
+  });
+}
+
+describe('bend relief — partial flange', () => {
+  it('cuts a slot at each mid-edge bend-line end: volume and developed area both drop', () => {
+    const authored = partialPart();
+    expect(authored.ok).toBe(true);
+    if (isErr(authored)) return;
+    const base = authored.value;
+    if (base.solid === undefined) return;
+    const volBefore = unwrap(measureVolume(base.solid));
+    const areaBefore = unwrap(unfold(base)).pattern.developedArea;
+
+    const width = T;
+    const depth = DEV + T;
+    const relieved = addBendRelief(base, 'a', { shape: 'rectangular', width, depth });
+    expect(relieved.ok).toBe(true);
+    if (isErr(relieved)) return;
+    const part = relieved.value;
+
+    // Two mid-edge ends → two recorded notches.
+    expect(part.reliefs).toBeDefined();
+    expect(part.reliefs?.[0]?.notches).toHaveLength(2);
+    if (part.solid === undefined) return;
+    expect(isValid(part.solid)).toBe(true);
+
+    // Each slot removes width×depth×thickness from the parent; both slots sit fully
+    // inside the base, so volume drops by 2·(width·depth·T).
+    const removed = 2 * width * depth * T;
+    const volAfter = unwrap(measureVolume(part.solid));
+    expect(volBefore - volAfter).toBeCloseTo(removed, 3);
+
+    // The developed outline drops by the same 2D notch area (×1, it is a 2D area).
+    const unfolded = unfold(part);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+    expect(areaBefore - unfolded.value.pattern.developedArea).toBeCloseTo(2 * width * depth, 3);
+    // The notch turns two clean corners into eight extra vertices (a slot is 6 new
+    // edges vs. the straight edge it replaces), so the outline gains corners.
+    expect(getEdges(unfolded.value.pattern.outline).length).toBeGreaterThan(6);
+  });
+
+  it('places the notch at the developed bend-line ends (inside the base, on the bend edge)', () => {
+    const authored = partialPart();
+    if (isErr(authored)) return;
+    const relieved = addBendRelief(authored.value, 'a', { shape: 'rectangular' });
+    if (isErr(relieved)) return;
+    const notches = relieved.value.reliefs?.[0]?.notches ?? [];
+    expect(notches).toHaveLength(2);
+    // The ymax bend line sits at y=30 (base width); slots cut inward (−y), so each
+    // notch's top edge is y=30 and it extends below by `depth`.
+    for (const [x0, y0, x1, y1] of notches) {
+      expect(y1).toBeCloseTo(30, 3);
+      expect(y0).toBeLessThan(30);
+      // x straddles a bend-line end (offset 10 and 25 along the 40-long edge).
+      const cx = (x0 + x1) / 2;
+      expect([10, 25].some((e) => Math.abs(cx - e) < 0.6)).toBe(true);
+    }
+  });
+
+  it('rejects a relief on a full-span flange (no mid-edge end to relieve)', () => {
+    const full = author({
+      thickness: T,
+      base: { length: 40, width: 30 },
+      flanges: [{ id: 'a', length: 10, angleDeg: 90, rule, side: 'xmax' }],
+    });
+    if (isErr(full)) return;
+    const r = addBendRelief(full.value, 'a');
+    expect(r.ok).toBe(false);
+    if (!isErr(r)) return;
+    expect(r.error.code).toBe('BEND_RELIEF_NOT_NEEDED');
+  });
+});
+
+describe('bend relief — obround vs rectangular', () => {
+  it('records the requested shape and stays valid for both', () => {
+    const authored = partialPart();
+    if (isErr(authored)) return;
+    for (const shape of ['rectangular', 'obround'] as const) {
+      const r = addBendRelief(authored.value, 'a', { shape });
+      expect(r.ok).toBe(true);
+      if (isErr(r)) continue;
+      expect(r.value.reliefs?.[0]?.shape).toBe(shape);
+      if (r.value.solid === undefined) continue;
+      expect(isValid(r.value.solid)).toBe(true);
+      expect(unfold(r.value).ok).toBe(true);
+    }
+  });
+});
+
+describe('bend relief — same-span flanges on different edges', () => {
+  it('places each flange’s notch on its own developed bend line (matched by id, not signature)', () => {
+    // Two partial flanges sharing span/angle/direction but on perpendicular edges:
+    // a signature match would put both notches on the first matching bend line.
+    const authored = author({
+      thickness: T,
+      base: { length: 40, width: 40 },
+      flanges: [
+        { id: 'north', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 10, width: 15 },
+        { id: 'east', length: 10, angleDeg: 90, rule, side: 'xmax', offset: 10, width: 15 },
+      ],
+    });
+    if (isErr(authored)) return;
+
+    const withNorth = addBendRelief(authored.value, 'north', { shape: 'rectangular' });
+    expect(withNorth.ok).toBe(true);
+    if (isErr(withNorth)) return;
+    const withBoth = addBendRelief(withNorth.value, 'east', { shape: 'rectangular' });
+    expect(withBoth.ok).toBe(true);
+    if (isErr(withBoth)) return;
+
+    const reliefs = withBoth.value.reliefs ?? [];
+    const north = reliefs.find((r) => r.flangeA === 'north');
+    const east = reliefs.find((r) => r.flangeA === 'east');
+    expect(north?.notches).toHaveLength(2);
+    expect(east?.notches).toHaveLength(2);
+
+    // The north (ymax) bend line is horizontal at y=40, so its notches' top edge is
+    // y≈40. The east (xmax) bend line is vertical at x=40, so its notches' right edge
+    // is x≈40. If both had matched the same bend line these would coincide.
+    for (const [, , , y1] of north?.notches ?? []) expect(y1).toBeCloseTo(40, 3);
+    for (const [, , x1] of east?.notches ?? []) expect(x1).toBeCloseTo(40, 3);
+  });
+});
+
+describe('bend relief — chained partial flange', () => {
+  it('notches into the parent flange strip (inward read from placement, not base center)', () => {
+    // A partial flange off a wall flange: its developed bend line sits past the wall
+    // strip, far from the base center, so a center-based inward guess would point the
+    // notch the wrong way. The notch must cut back toward the wall (decreasing y).
+    const authored = author({
+      thickness: T,
+      base: { length: 60, width: 20 },
+      flanges: [
+        { id: 'wall', length: 20, angleDeg: 90, rule, side: 'xmax', width: 16 },
+        { id: 'lip', length: 6, angleDeg: 90, rule, side: 'xmax', parent: 'wall', offset: 4, width: 8 },
+      ],
+    });
+    if (isErr(authored)) return;
+    const relieved = addBendRelief(authored.value, 'lip', { shape: 'rectangular' });
+    expect(relieved.ok).toBe(true);
+    if (isErr(relieved)) return;
+    const lip = relieved.value.reliefs?.find((r) => r.flangeA === 'lip');
+    expect(lip?.notches).toHaveLength(2);
+    if (relieved.value.solid === undefined) return;
+    expect(isValid(relieved.value.solid)).toBe(true);
+
+    // The lip's developed bend line lies past the wall strip (high y), and inward
+    // runs back toward the wall (−y). So both notches share their top edge (the bend
+    // line) and cut downward — proving inward came from the lip's own placement, not a
+    // guess toward the base center (which would have pushed them the wrong way).
+    const notches = lip?.notches ?? [];
+    const yTops = notches.map(([, , , y1]) => y1);
+    expect(Math.abs((yTops[0] ?? 0) - (yTops[1] ?? 0))).toBeLessThan(1e-3);
+    for (const [, y0, , y1] of notches) {
+      expect(y0).toBeLessThan(y1);
+    }
+  });
+});
+
+describe('auto bend reliefs', () => {
+  it('adds a relief to every partial flange and skips full-span ones', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 60, width: 40 },
+      flanges: [
+        { id: 'partial', length: 10, angleDeg: 90, rule, side: 'ymax', offset: 10, width: 20 },
+        { id: 'full', length: 10, angleDeg: 90, rule, side: 'xmax' },
+      ],
+    });
+    if (isErr(authored)) return;
+    const r = autoBendReliefs(authored.value);
+    expect(r.ok).toBe(true);
+    if (isErr(r)) return;
+    // Only the partial flange gets a relief feature.
+    expect(r.value.reliefs).toHaveLength(1);
+    expect(r.value.reliefs?.[0]?.flangeA).toBe('partial');
+    if (r.value.solid === undefined) return;
+    expect(isValid(r.value.solid)).toBe(true);
+  });
+});
+
+describe('corner relief — two adjacent flanges', () => {
+  it('notches the shared corner, stays valid, and resolves the collision warning', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 40, width: 40 },
+      flanges: [
+        { id: 'fx', length: 18, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'fy', length: 18, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    });
+    if (isErr(authored)) return;
+    // Un-relieved: the two upright flanges collide at the corner.
+    expect(validate(authored.value).some((w) => w.code === 'COLLISION')).toBe(true);
+
+    const relieved = cornerRelief(authored.value, 'fx', 'fy', { shape: 'rectangular' });
+    expect(relieved.ok).toBe(true);
+    if (isErr(relieved)) return;
+    const part = relieved.value;
+    expect(part.reliefs?.[0]?.kind).toBe('corner');
+    if (part.solid === undefined) return;
+    expect(isValid(part.solid)).toBe(true);
+
+    // Collision is resolved (recorded like a miter).
+    expect(validate(part).some((w) => w.code === 'COLLISION')).toBe(false);
+
+    // The corner notch appears in the developed outline at (baseLength, width).
+    const unfolded = unfold(part);
+    expect(unfolded.ok).toBe(true);
+    if (isErr(unfolded)) return;
+    expect(getEdges(unfolded.value.pattern.outline).length).toBeGreaterThan(6);
+    // The square notch is centred on the reflex corner (baseLength, width); only the
+    // base quadrant and the two flange-strip quadrants are filled there (the 4th,
+    // x>baseLength & y>width, is empty), so it removes 3·(depth/2)² of developed area.
+    const depth = DEV + T;
+    const areaBefore = unwrap(unfold(authored.value)).pattern.developedArea;
+    expect(areaBefore - unfolded.value.pattern.developedArea).toBeCloseTo(3 * (depth / 2) ** 2, 2);
+  });
+
+  it('honours spec.width as the square notch side and records it', () => {
+    const authored = author({
+      thickness: T,
+      base: { length: 40, width: 40 },
+      flanges: [
+        { id: 'fx', length: 18, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'fy', length: 18, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    });
+    if (isErr(authored)) return;
+    const w = 6;
+    const relieved = cornerRelief(authored.value, 'fx', 'fy', { shape: 'rectangular', width: w });
+    expect(relieved.ok).toBe(true);
+    if (isErr(relieved)) return;
+    // The recorded width is the actual square side, and the removed developed area
+    // is the 3 filled quadrants of a w×w square at the reflex corner.
+    expect(relieved.value.reliefs?.[0]?.width).toBeCloseTo(w, 3);
+    const before = unwrap(unfold(authored.value)).pattern.developedArea;
+    const after = unwrap(unfold(relieved.value)).pattern.developedArea;
+    expect(before - after).toBeCloseTo(3 * (w / 2) ** 2, 2);
+  });
+});
+
+describe('round-trip — fold preserves the relief feature and reproduces volume', () => {
+  it('fold(FlatInput with bendRelief) reproduces a relief’d part’s volume', () => {
+    // Author + relief the part one way…
+    const authored = partialPart();
+    if (isErr(authored)) return;
+    const relieved = addBendRelief(authored.value, 'a', { shape: 'rectangular' });
+    if (isErr(relieved)) return;
+    if (relieved.value.solid === undefined) return;
+    const volA = unwrap(measureVolume(relieved.value.solid));
+
+    // …and fold an equivalent FlatInput carrying the same relief on its region.
+    const input: FlatInput = {
+      thickness: T,
+      baseLength: 40,
+      width: 30,
+      regions: [
+        {
+          id: 'a',
+          length: 10,
+          angleDeg: 90,
+          direction: 'up',
+          rule,
+          side: 'ymax',
+          offset: 10,
+          width: 15,
+          bendRelief: { shape: 'rectangular' },
+        },
+      ],
+    };
+    const folded = fold(input);
+    expect(folded.ok).toBe(true);
+    if (isErr(folded)) return;
+    expect(folded.value.reliefs).toHaveLength(1);
+    if (folded.value.solid === undefined) return;
+    expect(isValid(folded.value.solid)).toBe(true);
+    const volB = unwrap(measureVolume(folded.value.solid));
+
+    // Both cut the same relief, so the volumes match.
+    expect(volB).toBeCloseTo(volA, 3);
+  });
+
+  // The strict geometric round-trip oracle (partToFlatInput → fold) SKIPS relief'd
+  // parts: a notched developed outline is not a plain rectangle, so patternToFlatInput
+  // cannot re-parse it (same reasoning as mitered parts). Instead we round-trip the
+  // recorded feature: a relief'd part's recovered FlatInput drops the notch (the
+  // parser reads only the rectangle families), so re-folding it yields the un-relief'd
+  // volume — proving the notch is genuinely a recorded feature, not re-parsed geometry.
+  it('partToFlatInput drops the notch (relief is a recorded feature, not re-parsed)', () => {
+    const authored = partialPart();
+    if (isErr(authored)) return;
+    const relieved = addBendRelief(authored.value, 'a', { shape: 'rectangular' });
+    if (isErr(relieved)) return;
+    // patternToFlatInput parses the notched outline; the notch turns the base into a
+    // non-rectangle, so recovery either fails or omits the notch — either way it must
+    // not throw, and a successful recovery carries no bendRelief.
+    const recovered = partToFlatInput(relieved.value);
+    if (recovered.ok) {
+      for (const region of recovered.value.regions) {
+        expect(region.bendRelief).toBeUndefined();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Phase 2 · PR3 of a stacked sequence

Adds **relief notches** so multi-bend parts can actually be fabricated — without the material tearing or colliding at corners and partial-bend ends. This is the first PR that encodes *fabrication* knowledge on top of the geometry.

### What's new
- **Bend reliefs**: `addBendRelief(part, flangeId, spec)` + `autoBendReliefs(part)` cut a relief slot at each mid-edge end of a partial/offset bend (the ends where the bend line meets un-bent metal and would otherwise crack).
- **Corner reliefs**: `cornerRelief(part, idA, idB, spec)` notches the shared corner of two flanges so they clear when folded — the notch alternative to a 45° miter. It records a zero-gap miter so the `validate` `COLLISION` warning clears.
- Recorded features (`SheetMetalPart.reliefs`) cut into the 3D solid **and** replayed as 2D notches in `unfold`, mirroring the existing miter machinery. `developedArea` drops by the removed notch area.

### Design
- `ReliefSpec { shape: 'rectangular' | 'obround'; width?; depth? }` (obround records intent; geometry is rectangular in this version — documented). Defaults: `width ≈ thickness`, `depth ≈ developedLength + thickness`.
- `FlatPattern.bendLines` now carry the bend `id`, so reliefs locate the correct line even when multiple flanges share span/angle/direction (fixed a notch-misplacement bug found in review).
- Inward notch direction is derived from the placed child frame (correct for chained flanges, not just root). Both relief ops guard against severing the solid (`RELIEF_SEVERED_SOLID`).
- `fold` re-applies `FoldRegion.bendRelief`; the strict geometric round-trip oracle skips relief'd parts (a notched outline isn't a plain rectangle — same handling as mitered parts), with a feature-level volume check instead.

### Verification
- typecheck / lint / build clean; **115 tests** (104 prior + 11 new) green against occt-wasm; snapshot adds bend-relief + corner-relief demos.
- Geometric assertions: 3D volume drop ≈ notch volume, 2D `developedArea` drop ≈ notch area, notch placement on the correct bend line inside the parent, `COLLISION` resolved after corner relief, valid solids + valid closed outline wires.
- Built via a multi-agent Workflow (implement → adversarial review → fix); review caught the same-span notch-misplacement bug and a missing severed-solid guard, both fixed before opening.

### Stack
PR1 (multi-bend) #1177, PR2 (flat→fold + round-trip oracle) #1180 merged. Remaining: cutouts/holes · tabs/slots/form features · contour/lofted flanges · foreign-solid unfold. OCCT-WASM-first.