### PR TITLE
feat(sheetmetal): tabs, tab-and-slot joints, louvers, dimples/embosses

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -30,7 +30,9 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 | Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`         |
 | Reliefs         | bend reliefs (slots at partial-flange bend-line ends), corner reliefs (notch at a corner) |
 | Cutouts         | holes / slots (rect + obround) / polygons punched on the base or a folded flange          |
-| Miter / outputs | auto corner-miter, multi-layer DXF, JSON bend report, manufacturability warnings          |
+| Tabs / joints   | additive edge tabs, self-fixturing tab-and-slot joints (tab + matching mating slot)       |
+| Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)    |
+| Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings         |
 | API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                   |
 
 `fold(input: FlatInput)` folds a flat pattern back up into a 3D part — the inverse of `unfold`. A
@@ -90,6 +92,61 @@ Cutouts round-trip through `fold` via `FoldRegion.cutouts` (and `FlatInput.baseC
 cutout'd part's volume. Unlike notched reliefs, cutouts don't change the outer outline, so a cutout'd part
 still round-trips through the strict outline oracle.
 
+## Tabs and tab-and-slot joints
+
+A **tab** is the additive counterpart of a cutout: a rectangular protrusion of material extending
+**outward** from a flat region's edge. `addTab(part, { region, side, offset, width, length })` builds the
+tab as a region-local rectangle just past the chosen `side`, places it on the correct folded face via the
+region's world frame, extrudes it through the sheet thickness and **fuses** it on — so the volume rises by
+`width · length · thickness`. The same rectangle is mapped through the region's developed frame and recorded
+as a `TabFeature`, so `unfold` **extends the outer outline** by the protrusion and grows `developedArea` by
+the tab area. Guards a valid, single-bodied result (`TAB_INVALID_SOLID`) and rejects a tab overhanging its
+edge (`TAB_OUT_OF_BOUNDS`).
+
+`tabAndSlot(part, tab, { region, x, y, clearance? })` is the headline self-locating joint: it fuses a tab on
+one region **and** punches a matching **slot cutout** on the mating region, sized so the tab's cross-section
+(`width × thickness`) inserts into the slot. The slot is `tab.width + clearance` long by `thickness +
+clearance` wide — always strictly larger than the tab cross-section, so the joint mates (clearance defaults
+to `0.1` mm). Use it to make boxes/enclosures that self-fixture before welding.
+
+Tabs ride through `fold` via `FoldRegion.tabs` / `FlatInput.baseTabs`, so `fold` re-fuses them and a tab'd
+part folds back into the same volume. Like cutouts and forms, a tab carries its region-local spec, so
+`partToFlatInput` re-attaches it onto the recovered region and `fold(partToFlatInput(part))` round-trips a
+tab'd part's volume through the strict oracle. Although a tab protrudes the outer outline, the parser
+recovers the base/flange rectangles from the bend lines and the unprotruded edges, so the protrusion does
+not corrupt region recovery (a tab on an unmappable region fails loudly with `TAB_REGION_UNMAPPED` rather
+than being silently dropped).
+
+## Form features (louvers, embosses, dimples)
+
+Form features are **locally formed** — they neither remove nor add net material, so the developed **outline
+and area are unchanged**; the flat pattern instead carries the fabrication markers on a `FORM` DXF layer.
+
+- `louver(part, { region, x, y, length, width, height, direction? })` — a vent cut on three sides with the
+  flap formed up along the hinge. In the **flat pattern** it emits the three cut sides as an **open** cut
+  path in `FlatPattern.formCuts` (the fabricator cuts three of the footprint's four sides — all but the
+  hinge) plus the hinge fold line in `FlatPattern.formHinges`, so a fabricator cuts the U and folds the flap
+  about the uncut hinge. The cut path is emitted as an open LWPOLYLINE on the DXF `FORM` layer (not a closed
+  rectangle, which would drop the flap out).
+- `emboss(part, { region, x, y, diameter, height, kind: 'emboss' | 'dimple' })` — a round local form, raised
+  (`emboss`) or recessed (`dimple`). The footprint circle is emitted as a marker (`FlatPattern.formMarkers`).
+
+**3D fidelity (simplified, documented).** The public CSG-only API makes true sheet forming (bending the flap
+continuous with the parent, or stretch-forming a spherical cap) impractical, so the 3D representations are
+deliberately simplified while keeping a **valid single solid** — the flat pattern is the fabrication-critical
+output:
+
+- _Louver_: the vent opening (`length × width`) is cut fully through the sheet, and the formed flap is
+  represented as a thin plate hinged on one side and tilted up to `height`, fused at the hinge so the result
+  stays one body. (True forming keeps the flap material continuous with the parent.)
+- _Emboss_: a short cylinder fused onto the formed face (raised by `height`). _Dimple_: a shallow cylinder
+  recess cut into the formed face (recessed by `height`, never through — rejected if `height ≥ thickness`).
+  The flat-topped round approximates a true spherical/conical form so the solid stays valid.
+
+Forms ride through `fold` via `FoldRegion.forms` / `FlatInput.baseForms`. Because they are material-neutral
+they don't change the outline, so a **formed part still round-trips** through the strict outline oracle
+(`partToFlatInput` carries the region-local form specs across, exactly as it does for cutouts).
+
 ## Design
 
 All geometry is computed analytically from the authored feature tree — bend axis, radius, and angle are
@@ -109,10 +166,11 @@ All public operations return `Result<T>` (from `brepjs`); non-fatal warnings tra
 ## Snapshot harness
 
 A standalone visual harness lives in `harness/snapshot.ts`. It imports
-`brepjs-sheetmetal` directly (no playground dependency), builds the headline
-L-bracket with a mitered corner, then renders the folded 3D part next to its
-developed flat pattern as a single side-by-side SVG and also writes the folded
-solid as STEP.
+`brepjs-sheetmetal` directly (no playground dependency), builds a set of demos —
+the headline L-bracket with a mitered corner, a tray, reliefs, a cutout panel, a
+**tab-and-slot box** (self-locating corner joint), and a **louvered panel** (vent
+flaps + emboss/dimple) — then renders each folded 3D part next to its developed
+flat pattern as a single side-by-side SVG and also writes the folded solid as STEP.
 
 ```bash
 npm run snapshot --workspace=brepjs-sheetmetal

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -20,9 +20,11 @@ import type { Solid, Vec3 } from 'brepjs';
 import { author, miterCorner, unfold, fold } from '../src/api.js';
 import { addBendRelief, cornerRelief } from '../src/reliefFns.js';
 import { addCutout } from '../src/cutoutFns.js';
+import { addTab, tabAndSlot, type SlotPlacement } from '../src/tabFns.js';
+import { addForm } from '../src/formFns.js';
 import { partToFlatInput } from '../src/foldFns.js';
 import type { AuthorSpec } from '../src/authorFns.js';
-import type { BendRule, CutoutSpec, FlatPattern, SheetMetalPart } from '../src/types.js';
+import type { BendRule, CutoutSpec, FlatPattern, FormSpec, SheetMetalPart, TabSpec } from '../src/types.js';
 
 /**
  * Boot the OCCT-WASM kernel directly from `brepjs-opencascade` (the same recipe
@@ -66,6 +68,12 @@ interface Demo {
   cornerRelief?: { a: string; b: string };
   /** Optional cutouts (holes / slots / polygons) punched after authoring. */
   cutouts?: CutoutSpec[];
+  /** Optional tabs (additive protrusions) fused after authoring. */
+  tabs?: TabSpec[];
+  /** Optional tab-and-slot joints (a tab + a matching mating slot). */
+  tabSlots?: { tab: TabSpec; slot: SlotPlacement }[];
+  /** Optional form features (louvers / embosses) formed after authoring. */
+  forms?: FormSpec[];
 }
 
 const DEMOS: Demo[] = [
@@ -147,6 +155,38 @@ const DEMOS: Demo[] = [
       { kind: 'hole', region: 'lip', x: 30, y: 9, diameter: 8 },
     ],
   },
+  {
+    name: 'tab-and-slot-box',
+    spec: {
+      thickness: T,
+      base: { length: 60, width: 60 },
+      flanges: [
+        { id: 'wx', length: 20, angleDeg: 90, rule, side: 'xmax' },
+        { id: 'wy', length: 20, angleDeg: 90, rule, side: 'ymax' },
+      ],
+    },
+    // Self-locating box corners: a tab on one wall inserts into a slot on the next.
+    tabSlots: [
+      {
+        tab: { region: 'wx', side: 'xmax', offset: 6, width: 10, length: 4 },
+        slot: { region: 'wy', x: 10, y: 10, clearance: 0.2 },
+      },
+    ],
+  },
+  {
+    name: 'louvered-panel',
+    spec: {
+      thickness: T,
+      base: { length: 80, width: 50 },
+      flanges: [{ id: 'lip', length: 14, angleDeg: 90, rule, side: 'ymax' }],
+    },
+    forms: [
+      { kind: 'louver', region: 'base', x: 25, y: 20, length: 30, width: 8, height: 4 },
+      { kind: 'louver', region: 'base', x: 25, y: 35, length: 30, width: 8, height: 4 },
+      { kind: 'emboss', region: 'base', x: 60, y: 20, diameter: 10, height: 2, form: 'emboss' },
+      { kind: 'emboss', region: 'base', x: 60, y: 35, diameter: 10, height: 0.5, form: 'dimple' },
+    ],
+  },
 ];
 
 async function main(): Promise<void> {
@@ -186,6 +226,21 @@ async function renderDemo(demo: Demo): Promise<string[]> {
     if (isErr(cutResult)) throw new Error(`cutout '${demo.name}' failed: ${cutResult.error.message}`);
     part = cutResult.value;
   }
+  for (const spec of demo.tabs ?? []) {
+    const tabResult = addTab(part, spec);
+    if (isErr(tabResult)) throw new Error(`tab '${demo.name}' failed: ${tabResult.error.message}`);
+    part = tabResult.value;
+  }
+  for (const ts of demo.tabSlots ?? []) {
+    const tsResult = tabAndSlot(part, ts.tab, ts.slot);
+    if (isErr(tsResult)) throw new Error(`tabAndSlot '${demo.name}' failed: ${tsResult.error.message}`);
+    part = tsResult.value;
+  }
+  for (const spec of demo.forms ?? []) {
+    const formResult = addForm(part, spec);
+    if (isErr(formResult)) throw new Error(`form '${demo.name}' failed: ${formResult.error.message}`);
+    part = formResult.value;
+  }
   if (part.solid === undefined) throw new Error(`'${demo.name}' has no solid`);
 
   const unfolded = unfold(part);
@@ -208,6 +263,10 @@ async function renderDemo(demo: Demo): Promise<string[]> {
   // Mitered AND relief'd parts are intentionally skipped (a notched/chamfered outline
   // is not a plain rectangle, so patternToFlatInput cannot re-parse it); a failure on
   // a plain demo is a real round-trip regression, so it must surface as such.
+  // Tabs, cutouts and forms ride the recorded-feature path (partToFlatInput carries
+  // their region-local specs), so a tab'd/formed part still round-trips even though a
+  // tab protrudes the outline — the parser recovers the base/flange rectangles from
+  // the bend lines and unprotruded edges.
   const skipRoundTrip = demo.miter !== undefined || part.reliefs !== undefined;
   let roundTrip = '(fold round-trip skipped: mitered/relief’d part)';
   if (!skipRoundTrip) {
@@ -281,8 +340,16 @@ function renderFlatSvg(pattern: FlatPattern): string {
   const holeSegs: Seg2[] = pattern.holes.flatMap((w) =>
     getEdges(w).map((e) => ({ a: to2(curveStartPoint(e)), b: to2(curveEndPoint(e)) }))
   );
+  const formSegs: Seg2[] = [
+    ...pattern.formCuts,
+    ...pattern.formMarkers,
+  ].flatMap((w) => getEdges(w).map((e) => ({ a: to2(curveStartPoint(e)), b: to2(curveEndPoint(e)) })));
+  const hingeSegs: Seg2[] = pattern.formHinges.map((e) => ({
+    a: to2(curveStartPoint(e)),
+    b: to2(curveEndPoint(e)),
+  }));
 
-  const allPts = [...outlineSegs, ...bendSegs, ...holeSegs].flatMap((s) => [s.a, s.b]);
+  const allPts = [...outlineSegs, ...bendSegs, ...holeSegs, ...formSegs, ...hingeSegs].flatMap((s) => [s.a, s.b]);
   const body =
     outlineSegs
       .map((s) => `<line class="outline" x1="${fmt(s.a[0])}" y1="${fmt(s.a[1])}" x2="${fmt(s.b[0])}" y2="${fmt(s.b[1])}" />`)
@@ -294,6 +361,14 @@ function renderFlatSvg(pattern: FlatPattern): string {
     '\n' +
     holeSegs
       .map((s) => `<line class="hole" x1="${fmt(s.a[0])}" y1="${fmt(s.a[1])}" x2="${fmt(s.b[0])}" y2="${fmt(s.b[1])}" />`)
+      .join('\n') +
+    '\n' +
+    formSegs
+      .map((s) => `<line class="form" x1="${fmt(s.a[0])}" y1="${fmt(s.a[1])}" x2="${fmt(s.b[0])}" y2="${fmt(s.b[1])}" />`)
+      .join('\n') +
+    '\n' +
+    hingeSegs
+      .map((s) => `<line class="hinge" x1="${fmt(s.a[0])}" y1="${fmt(s.a[1])}" x2="${fmt(s.b[0])}" y2="${fmt(s.b[1])}" />`)
       .join('\n');
 
   return fitPanel(body, bounds(allPts), 'Flat pattern', '#b8431d', true);
@@ -359,7 +434,7 @@ function fitPanel(body: string, box: Box, title: string, stroke: string, flipY =
 function composeSideBySide(left: string, right: string): string {
   return [
     `<svg xmlns="http://www.w3.org/2000/svg" width="${PANEL_W * 2}" height="${PANEL_H}" viewBox="0 0 ${PANEL_W * 2} ${PANEL_H}">`,
-    `<style>.bend{stroke-dasharray:4 3}.hole{stroke:#2a9d4a}</style>`,
+    `<style>.bend{stroke-dasharray:4 3}.hole{stroke:#2a9d4a}.form{stroke:#9d4aa0}.hinge{stroke:#9d4aa0;stroke-dasharray:2 2}</style>`,
     `<g>${left}</g>`,
     `<g transform="translate(${PANEL_W} 0)">${right}</g>`,
     `</svg>`,

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -31,6 +31,12 @@ import {
   addSlot as addSlotFn,
   addPolygonCutout as addPolygonCutoutFn,
 } from './cutoutFns.js';
+import {
+  addTab as addTabFn,
+  tabAndSlot as tabAndSlotFn,
+  type SlotPlacement,
+} from './tabFns.js';
+import { louver as louverFn, emboss as embossFn } from './formFns.js';
 import { flatPatternToDXF as flatPatternToDXFFn, type DxfOptions } from './dxfFns.js';
 import {
   buildReport as buildReportFn,
@@ -47,6 +53,7 @@ import type {
   BendRule,
   ReliefSpec,
   CutoutSpec,
+  TabSpec,
   UnfoldResult,
   SheetMetalWarning,
 } from './types.js';
@@ -139,6 +146,44 @@ export function addPolygonCutout(
   return addPolygonCutoutFn(part, region, points);
 }
 
+/** Fuse a rectangular tab (additive protrusion) onto a region's edge. */
+export function addTab(part: SheetMetalPart, spec: TabSpec): Result<SheetMetalPart> {
+  return addTabFn(part, spec);
+}
+
+/** Self-fixturing tab-and-slot joint: a tab on one region + a matching slot on another. */
+export function tabAndSlot(
+  part: SheetMetalPart,
+  tab: TabSpec,
+  slot: SlotPlacement
+): Result<SheetMetalPart> {
+  return tabAndSlotFn(part, tab, slot);
+}
+
+/** Form a louver (vent flap cut on 3 sides, formed up along the hinge) on a region. */
+export function louver(
+  part: SheetMetalPart,
+  opts: {
+    region: string;
+    x: number;
+    y: number;
+    length: number;
+    width: number;
+    height: number;
+    direction?: 'up' | 'down';
+  }
+): Result<SheetMetalPart> {
+  return louverFn(part, opts);
+}
+
+/** Form a round emboss (raised) or dimple (recessed) on a region. */
+export function emboss(
+  part: SheetMetalPart,
+  opts: { region: string; x: number; y: number; diameter: number; height: number; kind: 'dimple' | 'emboss' }
+): Result<SheetMetalPart> {
+  return embossFn(part, opts);
+}
+
 /** Emit an annotated multi-layer DXF string for a flat pattern. */
 export function toDXF(pattern: FlatPattern, options?: DxfOptions): Result<string> {
   return flatPatternToDXFFn(pattern, options);
@@ -174,4 +219,4 @@ export function developed(angleDeg: number, thickness: number, rule: BendRule): 
   return developedLengthFn(angleDeg, thickness, rule);
 }
 
-export type { AuthorSpec, FlangeSpec, MiterPlane, DxfOptions };
+export type { AuthorSpec, FlangeSpec, MiterPlane, DxfOptions, SlotPlacement };

--- a/packages/brepjs-sheetmetal/src/cutoutFns.ts
+++ b/packages/brepjs-sheetmetal/src/cutoutFns.ts
@@ -127,8 +127,38 @@ export function addPolygonCutout(
 }
 
 /** `'base'` is an alias for the base region; everything else passes through. */
-function resolveRegionId(region: string): string {
+export function resolveRegionId(region: string): string {
   return region === 'base' || region === 'face-0' ? ROOT_FLAT_ID : region;
+}
+
+/**
+ * Resolve a region's world {@link FlatFrame} and developed {@link Frame2} in one
+ * shared feature-tree walk — the lookup tabs/forms need to place geometry on the
+ * correct folded face and emit the matching developed-plane loops. Mirrors the
+ * frame resolution {@link addCutout} performs inline.
+ */
+export function regionFrames(
+  part: SheetMetalPart,
+  region: string
+): Result<{ regionId: string; world: FlatFrame; dev: Frame2 }> {
+  const regionId = resolveRegionId(region);
+  const treeResult = featureTree(part);
+  if (!treeResult.ok) return treeResult;
+  const tree = treeResult.value;
+  const framesResult = worldFrames(part, tree);
+  if (!framesResult.ok) return framesResult;
+  const world = framesResult.value.get(regionId);
+  if (world === undefined) {
+    return err(validationError('UNKNOWN_REGION', `region '${region}' not found`));
+  }
+  const dev = developedFrame(part, regionId, tree);
+  if (!dev.ok) return dev;
+  return ok({ regionId, world, dev: dev.value });
+}
+
+/** Developed-plane (u, v) extent of a region: base dims, or a flange frame's lengths. */
+export function regionDevExtent(part: SheetMetalPart, regionId: string, world: FlatFrame): Extent {
+  return regionExtent(part, regionId, world);
 }
 
 /** Closed local-plane loop (CCW, no closing-point duplicate) for a cutout spec. */
@@ -200,7 +230,7 @@ function slotPts(cx: number, cy: number, length: number, width: number, angleDeg
 }
 
 /** Local-frame extent the cutout must fit within. */
-interface Extent {
+export interface Extent {
   uMax: number;
   vMax: number;
 }
@@ -266,7 +296,7 @@ function developedFrame(part: SheetMetalPart, regionId: string, tree?: FeatureTr
 }
 
 /** Map a region-local `(x, y)` into developed-plane coordinates via its {@link Frame2}. */
-function mapToFrame2(p: Pt2, f: Frame2): Pt2 {
+export function mapToFrame2(p: Pt2, f: Frame2): Pt2 {
   return [
     f.origin[0] + f.u[0] * p[0] + f.v[0] * p[1],
     f.origin[1] + f.u[1] * p[0] + f.v[1] * p[1],

--- a/packages/brepjs-sheetmetal/src/dxfFns.ts
+++ b/packages/brepjs-sheetmetal/src/dxfFns.ts
@@ -10,11 +10,13 @@ const LAYER_OUTLINE = 'OUTLINE';
 const LAYER_BEND_UP = 'BEND_UP';
 const LAYER_BEND_DOWN = 'BEND_DOWN';
 const LAYER_CUTOUT = 'CUTOUT';
+const LAYER_FORM = 'FORM';
 
 const COLOR_OUTLINE = 7;
 const COLOR_BEND_UP = 1;
 const COLOR_BEND_DOWN = 5;
 const COLOR_CUTOUT = 3;
+const COLOR_FORM = 4;
 
 type Pt2 = [number, number];
 
@@ -95,11 +97,12 @@ function writeTables(w: DxfWriter): void {
   w.pair(2, 'LAYER');
   w.handle();
   w.pair(100, 'AcDbSymbolTable');
-  w.pair(70, 4);
+  w.pair(70, 5);
   writeLayer(w, LAYER_OUTLINE, COLOR_OUTLINE);
   writeLayer(w, LAYER_BEND_UP, COLOR_BEND_UP);
   writeLayer(w, LAYER_BEND_DOWN, COLOR_BEND_DOWN);
   writeLayer(w, LAYER_CUTOUT, COLOR_CUTOUT);
+  writeLayer(w, LAYER_FORM, COLOR_FORM);
   w.pair(0, 'ENDTAB');
   w.pair(0, 'ENDSEC');
 }
@@ -135,17 +138,39 @@ function writeEntities(w: DxfWriter, outline: Pt2[], pattern: FlatPattern, textH
     writePolyline(w, loopPoints(hole), LAYER_CUTOUT);
   }
 
+  // Form features: louver U-cuts are OPEN three-side cut paths (the hinge side is
+  // left uncut and drawn separately below), emboss footprints are closed marker
+  // polylines, louver hinge lines are LINEs — all on the FORM layer.
+  for (const cut of pattern.formCuts) {
+    writeOpenPolyline(w, pathPoints(cut), LAYER_FORM);
+  }
+  for (const marker of pattern.formMarkers) {
+    writePolyline(w, loopPoints(marker), LAYER_FORM);
+  }
+  for (const hinge of pattern.formHinges) {
+    writeLine(w, toPt2(curveStartPoint(hinge)), toPt2(curveEndPoint(hinge)), LAYER_FORM);
+  }
+
   w.pair(0, 'ENDSEC');
 }
 
 function writePolyline(w: DxfWriter, points: Pt2[], layer: string): void {
+  writeLwPolyline(w, points, layer, true);
+}
+
+/** An OPEN LWPOLYLINE (no closing segment back to the first vertex). */
+function writeOpenPolyline(w: DxfWriter, points: Pt2[], layer: string): void {
+  writeLwPolyline(w, points, layer, false);
+}
+
+function writeLwPolyline(w: DxfWriter, points: Pt2[], layer: string, closed: boolean): void {
   w.pair(0, 'LWPOLYLINE');
   w.handle();
   w.pair(100, 'AcDbEntity');
   w.pair(8, layer);
   w.pair(100, 'AcDbPolyline');
   w.pair(90, points.length);
-  w.pair(70, 1);
+  w.pair(70, closed ? 1 : 0);
   for (const [x, y] of points) {
     w.pair(10, x);
     w.pair(20, y);
@@ -201,6 +226,15 @@ function outlinePoints(pattern: FlatPattern): Result<Pt2[]> {
 /** Ordered vertices of a closed cutout wire (one per edge start point). */
 function loopPoints(wire: Wire): Pt2[] {
   return getEdges(wire).map((e) => toPt2(curveStartPoint(e)));
+}
+
+/** Ordered vertices of an OPEN wire: every edge start plus the final endpoint. */
+function pathPoints(wire: Wire): Pt2[] {
+  const edges = getEdges(wire);
+  const pts = edges.map((e) => toPt2(curveStartPoint(e)));
+  const last = edges[edges.length - 1];
+  if (last !== undefined) pts.push(toPt2(curveEndPoint(last)));
+  return pts;
 }
 
 function toPt2(v: Vec3): Pt2 {

--- a/packages/brepjs-sheetmetal/src/facade.ts
+++ b/packages/brepjs-sheetmetal/src/facade.ts
@@ -13,7 +13,7 @@
 import type { BrepError, Result } from 'brepjs';
 import { isErr } from 'brepjs';
 import type { AuthorSpec, BaseFlatSpec, FlangeSpec, SeamSpec } from './authorFns.js';
-import type { MiterPlane, DxfOptions } from './api.js';
+import type { MiterPlane, DxfOptions, SlotPlacement } from './api.js';
 import {
   author,
   unfold,
@@ -27,6 +27,10 @@ import {
   addHole,
   addSlot,
   addPolygonCutout,
+  addTab,
+  tabAndSlot,
+  louver,
+  emboss,
   toDXF,
   report,
   validate,
@@ -39,6 +43,7 @@ import type {
   MaterialSpec,
   ReliefSpec,
   CutoutSpec,
+  TabSpec,
   SheetMetalWarning,
   UnfoldResult,
 } from './types.js';
@@ -117,6 +122,41 @@ class SheetMetalPartHandle {
   /** Punch an arbitrary polygon cutout from its region-local `points`. */
   polygonCutout(region: string, points: [number, number][]): SheetMetalPartHandle {
     return new SheetMetalPartHandle(unwrapOrThrow(addPolygonCutout(this.part, region, points)));
+  }
+
+  /** Fuse a rectangular tab (additive protrusion) onto a region's edge. */
+  tab(spec: TabSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(addTab(this.part, spec)));
+  }
+
+  /** Self-fixturing tab-and-slot joint: a tab on one region + a matching slot on another. */
+  tabAndSlot(tab: TabSpec, slot: SlotPlacement): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(tabAndSlot(this.part, tab, slot)));
+  }
+
+  /** Form a louver (vent flap) on a region. */
+  louver(opts: {
+    region: string;
+    x: number;
+    y: number;
+    length: number;
+    width: number;
+    height: number;
+    direction?: 'up' | 'down';
+  }): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(louver(this.part, opts)));
+  }
+
+  /** Form a round emboss (raised) or dimple (recessed) on a region. */
+  emboss(opts: {
+    region: string;
+    x: number;
+    y: number;
+    diameter: number;
+    height: number;
+    kind: 'dimple' | 'emboss';
+  }): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(emboss(this.part, opts)));
   }
 
   /** Flatten into a developed flat pattern + bend report + warnings. */
@@ -220,6 +260,37 @@ class SheetMetalBuilder {
 
   polygonCutout(region: string, points: [number, number][]): SheetMetalPartHandle {
     return this.build().polygonCutout(region, points);
+  }
+
+  tab(spec: TabSpec): SheetMetalPartHandle {
+    return this.build().tab(spec);
+  }
+
+  tabAndSlot(tab: TabSpec, slot: SlotPlacement): SheetMetalPartHandle {
+    return this.build().tabAndSlot(tab, slot);
+  }
+
+  louver(opts: {
+    region: string;
+    x: number;
+    y: number;
+    length: number;
+    width: number;
+    height: number;
+    direction?: 'up' | 'down';
+  }): SheetMetalPartHandle {
+    return this.build().louver(opts);
+  }
+
+  emboss(opts: {
+    region: string;
+    x: number;
+    y: number;
+    diameter: number;
+    height: number;
+    kind: 'dimple' | 'emboss';
+  }): SheetMetalPartHandle {
+    return this.build().emboss(opts);
   }
 
   unfold(): UnfoldResult {

--- a/packages/brepjs-sheetmetal/src/foldFns.ts
+++ b/packages/brepjs-sheetmetal/src/foldFns.ts
@@ -15,13 +15,17 @@ import type {
   FlatPattern,
   FlatSide,
   FoldRegion,
+  FormSpec,
   MaterialSpec,
   SheetMetalPart,
   SheetMetalWarning,
+  TabSpec,
 } from './types.js';
 import { authorPart, type AuthorSpec, type FlangeSpec } from './authorFns.js';
 import { addBendRelief } from './reliefFns.js';
 import { addCutout } from './cutoutFns.js';
+import { addTab } from './tabFns.js';
+import { addForm } from './formFns.js';
 import { featureTree, ROOT_FLAT_ID } from './featureTreeFns.js';
 import { developedLength } from './allowanceFns.js';
 import { unfold, edgeBasis2, type Frame2 } from './unfoldFns.js';
@@ -85,6 +89,33 @@ export function foldWithWarnings(input: FlatInput): Result<FoldResult> {
       const cutResult = addCutout(part, { ...spec, region: region.id });
       if (!cutResult.ok) return cutResult;
       part = cutResult.value;
+    }
+  }
+
+  // Re-apply recorded tabs (additive protrusions) and form features so a tab'd /
+  // formed part folds back into the same solid + recorded features.
+  for (const spec of input.baseTabs ?? []) {
+    const tabbed = addTab(part, { ...spec, region: ROOT_FLAT_ID });
+    if (!tabbed.ok) return tabbed;
+    part = tabbed.value;
+  }
+  for (const region of input.regions) {
+    for (const spec of region.tabs ?? []) {
+      const tabbed = addTab(part, { ...spec, region: region.id });
+      if (!tabbed.ok) return tabbed;
+      part = tabbed.value;
+    }
+  }
+  for (const spec of input.baseForms ?? []) {
+    const formed = addForm(part, { ...spec, region: ROOT_FLAT_ID });
+    if (!formed.ok) return formed;
+    part = formed.value;
+  }
+  for (const region of input.regions) {
+    for (const spec of region.forms ?? []) {
+      const formed = addForm(part, { ...spec, region: region.id });
+      if (!formed.ok) return formed;
+      part = formed.value;
     }
   }
 
@@ -212,7 +243,11 @@ export function partToFlatInput(part: SheetMetalPart): Result<FlatInput> {
   });
   if (!recovered.ok) return recovered;
 
-  return attachCutouts(part, recovered.value);
+  const withCutouts = attachCutouts(part, recovered.value);
+  if (!withCutouts.ok) return withCutouts;
+  const withTabs = attachTabs(part, withCutouts.value);
+  if (!withTabs.ok) return withTabs;
+  return attachForms(part, withTabs.value);
 }
 
 /**
@@ -264,6 +299,107 @@ function attachCutouts(part: SheetMetalPart, input: FlatInput): Result<FlatInput
     ...input,
     regions,
     ...(baseCutouts.length > 0 ? { baseCutouts } : {}),
+  });
+}
+
+/**
+ * Re-attach a part's recorded tabs onto a recovered {@link FlatInput}, mirroring
+ * {@link attachCutouts}. A tab carries its region-local {@link TabSpec}, so it
+ * replays through the recorded-feature path exactly as cutouts/forms do — the spec,
+ * not the outline, drives the re-fuse. (The tab does extend the outer outline, but
+ * the outline parser only needs to recover the base/flange rectangles, which it does
+ * from the bend lines and the unprotruded edges; see {@link partToFlatInput}.) An
+ * unmappable region fails loudly rather than silently dropping the tab — silently
+ * shedding it would change the refolded volume with no diagnostic.
+ */
+function attachTabs(part: SheetMetalPart, input: FlatInput): Result<FlatInput> {
+  if (part.tabs === undefined || part.tabs.length === 0) return ok(input);
+
+  const recoveredIdByFlange = new Map<string, string>();
+  const tree = featureTree(part);
+  if (tree.ok) {
+    tree.value.bends.forEach((tb, i) => recoveredIdByFlange.set(tb.child, `b${i}`));
+  }
+
+  const baseTabs: TabSpec[] = [];
+  const byRegion = new Map<string, TabSpec[]>();
+  for (const t of part.tabs) {
+    if (t.region === ROOT_FLAT_ID) {
+      baseTabs.push(t.spec);
+      continue;
+    }
+    const recoveredId = recoveredIdByFlange.get(t.region);
+    if (recoveredId === undefined) {
+      return err(
+        validationError(
+          'TAB_REGION_UNMAPPED',
+          `partToFlatInput: tab on region '${t.region}' has no recovered flat region; round-trip would drop it`
+        )
+      );
+    }
+    const list = byRegion.get(recoveredId) ?? [];
+    list.push(t.spec);
+    byRegion.set(recoveredId, list);
+  }
+
+  const regions = input.regions.map((r) => {
+    const specs = byRegion.get(r.id);
+    return specs === undefined ? r : { ...r, tabs: specs };
+  });
+
+  return ok({
+    ...input,
+    regions,
+    ...(baseTabs.length > 0 ? { baseTabs } : {}),
+  });
+}
+
+/**
+ * Re-attach a part's recorded form features (louvers / embosses) onto a recovered
+ * {@link FlatInput}, mirroring {@link attachCutouts}. Forms are net-material-neutral
+ * (they don't change the outer outline), so they round-trip cleanly through the
+ * outline oracle; only their region-local specs need carrying across. An unmappable
+ * region fails loudly rather than silently dropping the form.
+ */
+function attachForms(part: SheetMetalPart, input: FlatInput): Result<FlatInput> {
+  if (part.forms === undefined || part.forms.length === 0) return ok(input);
+
+  const recoveredIdByFlange = new Map<string, string>();
+  const tree = featureTree(part);
+  if (tree.ok) {
+    tree.value.bends.forEach((tb, i) => recoveredIdByFlange.set(tb.child, `b${i}`));
+  }
+
+  const baseForms: FormSpec[] = [];
+  const byRegion = new Map<string, FormSpec[]>();
+  for (const f of part.forms) {
+    if (f.region === ROOT_FLAT_ID) {
+      baseForms.push(f.spec);
+      continue;
+    }
+    const recoveredId = recoveredIdByFlange.get(f.region);
+    if (recoveredId === undefined) {
+      return err(
+        validationError(
+          'FORM_REGION_UNMAPPED',
+          `partToFlatInput: form on region '${f.region}' has no recovered flat region; round-trip would drop it`
+        )
+      );
+    }
+    const list = byRegion.get(recoveredId) ?? [];
+    list.push(f.spec);
+    byRegion.set(recoveredId, list);
+  }
+
+  const regions = input.regions.map((r) => {
+    const specs = byRegion.get(r.id);
+    return specs === undefined ? r : { ...r, forms: specs };
+  });
+
+  return ok({
+    ...input,
+    regions,
+    ...(baseForms.length > 0 ? { baseForms } : {}),
   });
 }
 

--- a/packages/brepjs-sheetmetal/src/formFns.ts
+++ b/packages/brepjs-sheetmetal/src/formFns.ts
@@ -1,0 +1,381 @@
+import {
+  type Result,
+  type Vec3,
+  type Solid,
+  ok,
+  err,
+  validationError,
+  box,
+  cylinder,
+  line,
+  wireLoop,
+  face,
+  extrude,
+  cut,
+  fuse,
+  rotate,
+  translate,
+  getSolids,
+  isValid,
+  isPlanarWire,
+  vecAdd,
+  vecScale,
+  vecCross,
+  vecNormalize,
+} from 'brepjs';
+import type { FormSpec, FormFeature, SheetMetalPart } from './types.js';
+import { normalizeSolid } from './internal.js';
+import type { FlatFrame } from './authorFns.js';
+import type { Frame2 } from './unfoldFns.js';
+import { regionFrames, regionDevExtent, mapToFrame2 } from './cutoutFns.js';
+
+const EPS = 1e-6;
+const HAIR = 0.05;
+const CIRCLE_SEGMENTS = 48;
+
+type Pt2 = [number, number];
+
+/**
+ * Add a form feature (louver or emboss/dimple) to a named flat region.
+ *
+ * 3D FIDELITY (simplified, by design — the public CSG-only API makes true forming
+ * impractical):
+ * - LOUVER: the vent opening (`length × width`) is cut fully through the sheet, and
+ *   the formed flap is represented as a thin box hinged on one side and tilted up to
+ *   `height`, fused so it stays connected to the body at the hinge. True forming
+ *   keeps the flap continuous with the parent and bends it; the cut+tilted-flap
+ *   representation captures the vent geometry while keeping a single valid solid.
+ * - EMBOSS: a short cylinder fused onto the formed face (raised by `height`).
+ *   DIMPLE: a shallow cylindrical recess cut into the formed face (recessed by
+ *   `height`, never through). A true spherical/conical form is approximated by the
+ *   flat-topped round so the result stays a valid single body.
+ *
+ * FLAT PATTERN (the fabrication-critical representation): the louver emits its
+ * footprint as an OPEN three-side cut path (the fabricator cuts three of its four
+ * sides — all but the hinge) plus the hinge fold line; the emboss emits its footprint
+ * circle as a marker. Forming removes no net material, so the developed outline and
+ * area are unchanged. Guards a valid, single-bodied solid.
+ */
+export function addForm(part: SheetMetalPart, spec: FormSpec): Result<SheetMetalPart> {
+  const solid = part.solid;
+  if (solid === undefined) {
+    return err(validationError('NO_SOLID', 'addForm: part has no folded solid to form'));
+  }
+
+  const framesResult = regionFrames(part, spec.region);
+  if (!framesResult.ok) return framesResult;
+  const { regionId, world, dev } = framesResult.value;
+  const ext = regionDevExtent(part, regionId, world);
+
+  if (spec.kind === 'louver') return louverForm(part, solid, spec, regionId, world, dev, ext);
+  return embossForm(part, solid, spec, regionId, world, dev, ext);
+}
+
+/** Louver vent: cut the opening, fuse the tilted flap, emit the U-cut + hinge in 2D. */
+function louverForm(
+  part: SheetMetalPart,
+  partSolid: Solid,
+  spec: Extract<FormSpec, { kind: 'louver' }>,
+  regionId: string,
+  world: FlatFrame,
+  dev: Frame2,
+  ext: { uMax: number; vMax: number }
+): Result<SheetMetalPart> {
+  if (!Number.isFinite(spec.length) || spec.length <= 0 || !Number.isFinite(spec.width) || spec.width <= 0) {
+    return err(validationError('INVALID_FORM', 'louver length/width must be positive'));
+  }
+  if (!Number.isFinite(spec.height) || spec.height <= 0) {
+    return err(validationError('INVALID_FORM', `louver height must be positive, got ${spec.height}`));
+  }
+  // Louver footprint in region-local coords, centred at (x, y): `length` along u,
+  // `width` along v. The hinge is the −v edge of the footprint.
+  const hl = spec.length / 2;
+  const hw = spec.width / 2;
+  const x0 = spec.x - hl;
+  const x1 = spec.x + hl;
+  const y0 = spec.y - hw;
+  const y1 = spec.y + hw;
+  if (x0 < -EPS || x1 > ext.uMax + EPS || y0 < -EPS || y1 > ext.vMax + EPS) {
+    return err(
+      validationError('FORM_OUT_OF_BOUNDS', `louver at (${spec.x}, ${spec.y}) lies outside region [0,${ext.uMax}]×[0,${ext.vMax}]`)
+    );
+  }
+
+  const dir = spec.direction ?? 'up';
+  const sign = dir === 'up' ? 1 : -1;
+
+  // Cut the vent opening fully through the sheet.
+  const openingLocal: Pt2[] = [
+    [x0, y0],
+    [x1, y0],
+    [x1, y1],
+    [x0, y1],
+  ];
+  const opening = buildThroughTool(openingLocal, world, part.thickness);
+  if (!opening.ok) return opening;
+  const cutResult = cut(partSolid, opening.value);
+  if (!cutResult.ok) return cutResult;
+  let solid = normalizeSolid(cutResult.value);
+
+  // Fuse the tilted flap, hinged on the −v edge (y0), rising over the opening to
+  // `height` on the formed face. Built in region-local space then placed via the
+  // world frame; overlaps the hinge edge so it fuses into one body.
+  const flap = buildLouverFlap(world, x0, x1, y0, spec.width, spec.height, part.thickness, sign);
+  if (!flap.ok) return flap;
+  const fused = fuse(solid, flap.value);
+  if (!fused.ok) return fused;
+  solid = normalizeSolid(fused.value);
+
+  if (!isValid(solid) || getSolids(solid).length > 1) {
+    return err(
+      validationError('FORM_INVALID_SOLID', `addForm: louver on region '${spec.region}' did not form a single valid body`)
+    );
+  }
+
+  // 2D: the louver footprint as the OPEN three-side U-cut the fabricator actually
+  // cuts (all but the hinge at y0), plus the hinge segment as a separate fold line.
+  // The cut path walks the three non-hinge sides — [x1,y0]→[x1,y1]→[x0,y1]→[x0,y0] —
+  // leaving the y0 edge uncut so the flap stays hinged; emitting a closed loop would
+  // tell the fabricator to cut all four sides and drop the flap out entirely.
+  // Developed outline/area unchanged (forming is net-material-neutral).
+  const cutPath: Pt2[] = [
+    mapToFrame2([x1, y0], dev),
+    mapToFrame2([x1, y1], dev),
+    mapToFrame2([x0, y1], dev),
+    mapToFrame2([x0, y0], dev),
+  ];
+  const hingeA = mapToFrame2([x0, y0], dev);
+  const hingeB = mapToFrame2([x1, y0], dev);
+  const feature: FormFeature = {
+    spec,
+    region: regionId,
+    cuts: [cutPath],
+    markers: [],
+    hinge: [hingeA, hingeB],
+  };
+  return ok({ ...part, solid, forms: [...(part.forms ?? []), feature] });
+}
+
+/** Emboss/dimple: fuse a raised cylinder or cut a shallow recess; emit a 2D footprint. */
+function embossForm(
+  part: SheetMetalPart,
+  partSolid: Solid,
+  spec: Extract<FormSpec, { kind: 'emboss' }>,
+  regionId: string,
+  world: FlatFrame,
+  dev: Frame2,
+  ext: { uMax: number; vMax: number }
+): Result<SheetMetalPart> {
+  if (!Number.isFinite(spec.diameter) || spec.diameter <= 0) {
+    return err(validationError('INVALID_FORM', `emboss diameter must be positive, got ${spec.diameter}`));
+  }
+  if (!Number.isFinite(spec.height) || spec.height <= 0) {
+    return err(validationError('INVALID_FORM', `emboss height must be positive, got ${spec.height}`));
+  }
+  const r = spec.diameter / 2;
+  if (spec.x - r < -EPS || spec.x + r > ext.uMax + EPS || spec.y - r < -EPS || spec.y + r > ext.vMax + EPS) {
+    return err(
+      validationError('FORM_OUT_OF_BOUNDS', `emboss at (${spec.x}, ${spec.y}) lies outside region [0,${ext.uMax}]×[0,${ext.vMax}]`)
+    );
+  }
+  if (spec.form === 'dimple' && spec.height >= part.thickness - EPS) {
+    return err(
+      validationError('INVALID_FORM', `dimple depth ${spec.height} must be less than thickness ${part.thickness}`)
+    );
+  }
+
+  // Centre of the form on the formed (+n) face, in world space.
+  const faceCentre = vecAdd(
+    vecAdd(vecAdd(world.origin, vecScale(world.u, spec.x)), vecScale(world.v, spec.y)),
+    vecScale(world.n, part.thickness)
+  );
+
+  let solid: Solid;
+  if (spec.form === 'emboss') {
+    // Raised cylinder: base sunk a hair into the sheet for a robust fuse, extending
+    // +n by `height`.
+    const base = vecAdd(faceCentre, vecScale(world.n, -HAIR));
+    const bump = cylinder(r, spec.height + HAIR, { at: base, axis: world.n });
+    const fused = fuse(partSolid, bump);
+    if (!fused.ok) return fused;
+    solid = normalizeSolid(fused.value);
+  } else {
+    // Recess: cut a shallow cylinder down from the formed face by `height` (+HAIR so
+    // the tool pokes cleanly through the top surface).
+    const top = vecAdd(faceCentre, vecScale(world.n, HAIR));
+    const tool = cylinder(r, spec.height + HAIR, { at: top, axis: vecScale(world.n, -1) });
+    const cutResult = cut(partSolid, tool);
+    if (!cutResult.ok) return cutResult;
+    solid = normalizeSolid(cutResult.value);
+  }
+
+  if (!isValid(solid) || getSolids(solid).length > 1) {
+    return err(
+      validationError('FORM_INVALID_SOLID', `addForm: ${spec.form} on region '${spec.region}' did not form a single valid body`)
+    );
+  }
+
+  const marker = circleLocal([spec.x, spec.y], r).map((p) => mapToFrame2(p, dev));
+  const feature: FormFeature = {
+    spec,
+    region: regionId,
+    cuts: [],
+    markers: [marker],
+  };
+  return ok({ ...part, solid, forms: [...(part.forms ?? []), feature] });
+}
+
+/** A louver vent on a region; see {@link addForm}. */
+export function louver(
+  part: SheetMetalPart,
+  opts: {
+    region: string;
+    x: number;
+    y: number;
+    length: number;
+    width: number;
+    height: number;
+    direction?: 'up' | 'down';
+  }
+): Result<SheetMetalPart> {
+  return addForm(part, { kind: 'louver', ...opts });
+}
+
+/** An emboss (raised) or dimple (recessed) round form on a region; see {@link addForm}. */
+export function emboss(
+  part: SheetMetalPart,
+  opts: { region: string; x: number; y: number; diameter: number; height: number; kind: 'dimple' | 'emboss' }
+): Result<SheetMetalPart> {
+  return addForm(part, {
+    kind: 'emboss',
+    region: opts.region,
+    x: opts.x,
+    y: opts.y,
+    diameter: opts.diameter,
+    height: opts.height,
+    form: opts.kind,
+  });
+}
+
+/** Extrude a region-local loop fully through the sheet (a through-cut tool). */
+function buildThroughTool(local: Pt2[], f: FlatFrame, thickness: number): Result<Solid> {
+  const base = vecAdd(f.origin, vecScale(f.n, -HAIR));
+  const worldPts: Vec3[] = local.map(([x, y]) =>
+    vecAdd(vecAdd(base, vecScale(f.u, x)), vecScale(f.v, y))
+  );
+  const edges = [];
+  for (let i = 0; i < worldPts.length; i += 1) {
+    const a = worldPts[i];
+    const b = worldPts[(i + 1) % worldPts.length];
+    if (a === undefined || b === undefined) {
+      return err(validationError('FORM_TOOL_FAILED', 'failed to index form loop points'));
+    }
+    edges.push(line(a, b));
+  }
+  const wire = wireLoop(edges);
+  if (!wire.ok) return wire;
+  if (!isPlanarWire(wire.value)) {
+    return err(validationError('FORM_TOOL_FAILED', 'form profile wire is not planar'));
+  }
+  const profile = face(wire.value);
+  if (!profile.ok) return profile;
+  const depth = thickness + 2 * HAIR;
+  return extrude(profile.value, [f.n[0] * depth, f.n[1] * depth, f.n[2] * depth]);
+}
+
+/**
+ * Tilted louver flap, hinged on the `y0` (−v) edge of the opening: a thin plate
+ * spanning `[x0,x1]` along u and `width` along v, tilted up about the hinge so its
+ * far edge rises by `height` on the formed face (`sign` = +1 up / −1 down). Built in
+ * a canonical local frame (hinge along +X at the origin, depth +Y, thickness +Z),
+ * tilted about +X, then mapped onto the world frame's u/v/n.
+ */
+function buildLouverFlap(
+  f: FlatFrame,
+  x0: number,
+  x1: number,
+  y0: number,
+  width: number,
+  height: number,
+  thickness: number,
+  sign: number
+): Result<Solid> {
+  const plateThk = Math.max(thickness, EPS);
+  const len = x1 - x0;
+  // Tilt angle so the far edge (depth `width`) rises by `height`.
+  const tiltDeg = (Math.atan2(height, width) * 180) / Math.PI;
+
+  // Canonical flap: hinge along +X over [0,len], depth +Y over [0,width], thickness
+  // sunk a hair below 0 so it overlaps the sheet at the hinge for a robust fuse.
+  let flap: Solid = box(len, width, plateThk);
+  flap = translate(flap, [0, 0, -plateThk + HAIR]);
+  flap = rotate(flap, -sign * tiltDeg, { at: [0, 0, 0], axis: [1, 0, 0] });
+
+  // Place: canonical +X→world u, +Y→world v, +Z→world n, origin at the hinge corner
+  // on the formed face.
+  const u = vecNormalize(f.u);
+  const n = vecNormalize(f.n);
+  const v = vecNormalize(vecCross(n, u));
+  const hingeCorner = vecAdd(
+    vecAdd(vecAdd(f.origin, vecScale(f.u, x0)), vecScale(f.v, y0)),
+    vecScale(f.n, thickness)
+  );
+  const placed = mapLocalToWorld(flap, u, v, n, hingeCorner);
+  return ok(placed);
+}
+
+/** Map a solid built in a canonical XYZ frame onto world axes (uT, vT, nT) at origin. */
+function mapLocalToWorld(s: Solid, uT: Vec3, vT: Vec3, nT: Vec3, origin: Vec3): Solid {
+  const m: number[] = [uT[0], vT[0], nT[0], uT[1], vT[1], nT[1], uT[2], vT[2], nT[2]];
+  const aa = matrixToAxisAngle(m);
+  const rotated = aa.angleDeg === 0 ? s : rotate(s, aa.angleDeg, { at: [0, 0, 0], axis: aa.axis });
+  return translate(rotated, origin);
+}
+
+/** Axis-angle of a 3×3 row-major rotation matrix (columns = target basis). */
+function matrixToAxisAngle(m: number[]): { axis: Vec3; angleDeg: number } {
+  const m00 = m[0] ?? 0;
+  const m01 = m[1] ?? 0;
+  const m02 = m[2] ?? 0;
+  const m10 = m[3] ?? 0;
+  const m11 = m[4] ?? 0;
+  const m12 = m[5] ?? 0;
+  const m20 = m[6] ?? 0;
+  const m21 = m[7] ?? 0;
+  const m22 = m[8] ?? 0;
+  const trace = m00 + m11 + m22;
+  const cos = Math.max(-1, Math.min(1, (trace - 1) / 2));
+  const angle = Math.acos(cos);
+  const angleDeg = (angle * 180) / Math.PI;
+  if (angle < 1e-9) return { axis: [0, 0, 1], angleDeg: 0 };
+  if (Math.PI - angle < 1e-6) {
+    const xx = (m00 + 1) / 2;
+    const yy = (m11 + 1) / 2;
+    const zz = (m22 + 1) / 2;
+    let axis: Vec3;
+    if (xx >= yy && xx >= zz) {
+      const x = Math.sqrt(Math.max(xx, 0));
+      axis = [x, (m01 + m10) / (4 * x), (m02 + m20) / (4 * x)];
+    } else if (yy >= zz) {
+      const y = Math.sqrt(Math.max(yy, 0));
+      axis = [(m01 + m10) / (4 * y), y, (m12 + m21) / (4 * y)];
+    } else {
+      const z = Math.sqrt(Math.max(zz, 0));
+      axis = [(m02 + m20) / (4 * z), (m12 + m21) / (4 * z), z];
+    }
+    return { axis: vecNormalize(axis), angleDeg: 180 };
+  }
+  const denom = 2 * Math.sin(angle);
+  const axis: Vec3 = [(m21 - m12) / denom, (m02 - m20) / denom, (m10 - m01) / denom];
+  return { axis: vecNormalize(axis), angleDeg };
+}
+
+/** Region-local circle loop (CCW) centred at `c` of radius `r`. */
+function circleLocal(c: Pt2, r: number): Pt2[] {
+  const pts: Pt2[] = [];
+  for (let i = 0; i < CIRCLE_SEGMENTS; i += 1) {
+    const a = (2 * Math.PI * i) / CIRCLE_SEGMENTS;
+    pts.push([c[0] + r * Math.cos(a), c[1] + r * Math.sin(a)]);
+  }
+  return pts;
+}

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -44,6 +44,11 @@ export { addBendRelief, autoBendReliefs, cornerRelief } from './reliefFns.js';
 
 export { addCutout, addHole, addSlot, addPolygonCutout } from './cutoutFns.js';
 
+export { addTab, tabAndSlot } from './tabFns.js';
+export type { SlotPlacement } from './tabFns.js';
+
+export { addForm, louver, emboss } from './formFns.js';
+
 export { flatPatternToDXF } from './dxfFns.js';
 export type { DxfOptions } from './dxfFns.js';
 
@@ -84,6 +89,10 @@ export type {
   ReliefFeature,
   CutoutSpec,
   CutoutFeature,
+  TabSpec,
+  TabFeature,
+  FormSpec,
+  FormFeature,
   SheetMetalPart,
   FlatPattern,
   FlatInput,

--- a/packages/brepjs-sheetmetal/src/tabFns.ts
+++ b/packages/brepjs-sheetmetal/src/tabFns.ts
@@ -101,6 +101,10 @@ export interface SlotPlacement {
   x: number;
   y: number;
   clearance?: number | undefined;
+  /** In-plane rotation of the slot (deg, CCW) in the mating region's local frame.
+   * Default 0 = slot length along the region's +x (bend-axis) direction; set this
+   * when the tab meets the slot region at a non-default orientation. */
+  angleDeg?: number | undefined;
 }
 
 /**
@@ -134,6 +138,7 @@ export function tabAndSlot(
     y: slot.y,
     length: slotLength,
     width: slotWidth,
+    ...(slot.angleDeg !== undefined ? { angleDeg: slot.angleDeg } : {}),
   });
 }
 

--- a/packages/brepjs-sheetmetal/src/tabFns.ts
+++ b/packages/brepjs-sheetmetal/src/tabFns.ts
@@ -1,0 +1,220 @@
+import {
+  type Result,
+  type Vec3,
+  type Solid,
+  ok,
+  err,
+  validationError,
+  line,
+  wireLoop,
+  face,
+  extrude,
+  fuse,
+  getSolids,
+  isValid,
+  isPlanarWire,
+  vecAdd,
+  vecScale,
+} from 'brepjs';
+import type { TabSpec, TabFeature, SheetMetalPart } from './types.js';
+import { normalizeSolid } from './internal.js';
+import type { FlatFrame } from './authorFns.js';
+import type { Frame2 } from './unfoldFns.js';
+import { regionFrames, regionDevExtent, mapToFrame2, addSlot } from './cutoutFns.js';
+
+const EPS = 1e-6;
+
+type Pt2 = [number, number];
+
+/**
+ * Fuse a rectangular tab onto a named flat region's edge — additive material (the
+ * counterpart of a cutout). The tab is built as a region-local rectangle just past
+ * the chosen `side`, placed onto the correct folded face via the region's world
+ * {@link FlatFrame}, extruded through the sheet thickness and fused to the solid. The
+ * same local rectangle, mapped through the region's developed {@link Frame2}, is
+ * recorded as a {@link TabFeature} so {@link unfold} extends the OUTER outline by the
+ * protrusion (tabs add material, so the developed area grows). Guards a valid,
+ * single-bodied solid.
+ */
+export function addTab(part: SheetMetalPart, spec: TabSpec): Result<SheetMetalPart> {
+  if (part.solid === undefined) {
+    return err(validationError('NO_SOLID', 'addTab: part has no folded solid to fuse onto'));
+  }
+  if (!Number.isFinite(spec.width) || spec.width <= 0) {
+    return err(validationError('INVALID_TAB', `tab width must be positive, got ${spec.width}`));
+  }
+  if (!Number.isFinite(spec.length) || spec.length <= 0) {
+    return err(validationError('INVALID_TAB', `tab length must be positive, got ${spec.length}`));
+  }
+  if (!Number.isFinite(spec.offset) || spec.offset < -EPS) {
+    return err(validationError('INVALID_TAB', `tab offset must be non-negative, got ${spec.offset}`));
+  }
+
+  const framesResult = regionFrames(part, spec.region);
+  if (!framesResult.ok) return framesResult;
+  const { regionId, world, dev } = framesResult.value;
+
+  const ext = regionDevExtent(part, regionId, world);
+  // The tab attaches to a region edge and runs `width` ALONG it; that span must lie
+  // within the edge's length, or the protrusion overhangs the region.
+  const edgeLen = spec.side === 'xmax' || spec.side === 'xmin' ? ext.vMax : ext.uMax;
+  if (spec.offset + spec.width > edgeLen + EPS) {
+    return err(
+      validationError(
+        'TAB_OUT_OF_BOUNDS',
+        `tab [${spec.offset}, ${spec.offset + spec.width}] on side '${spec.side}' exceeds edge length ${edgeLen}`
+      )
+    );
+  }
+
+  const local = tabLocalRect(spec, ext);
+
+  const tool = buildTabSolid(local, world, part.thickness);
+  if (!tool.ok) return tool;
+
+  const fused = fuse(part.solid, tool.value);
+  if (!fused.ok) return fused;
+  const solid = normalizeSolid(fused.value);
+  if (!isValid(solid) || getSolids(solid).length > 1) {
+    return err(
+      validationError(
+        'TAB_INVALID_SOLID',
+        `addTab: tab on region '${spec.region}' did not fuse into a single valid body`
+      )
+    );
+  }
+
+  const rect = devRect(local, dev);
+  const feature: TabFeature = {
+    spec,
+    region: regionId,
+    rect,
+    area: spec.width * spec.length,
+  };
+
+  return ok({ ...part, solid, tabs: [...(part.tabs ?? []), feature] });
+}
+
+/** The mating-slot placement for a {@link tabAndSlot} joint. */
+export interface SlotPlacement {
+  region: string;
+  x: number;
+  y: number;
+  clearance?: number | undefined;
+}
+
+/**
+ * Self-fixturing tab-and-slot joint: fuse a tab on one region and punch a matching
+ * SLOT CUTOUT on the mating region, sized so the tab's cross-section
+ * (`width × thickness`) inserts into the slot. The slot is `tab.width + clearance`
+ * long by `thickness + clearance` wide, centred at the mating region's local
+ * `(x, y)`. The slot is always strictly larger than the tab cross-section, so the
+ * joint mates (verified numerically by callers). Clearance defaults to `0.1` mm.
+ */
+export function tabAndSlot(
+  part: SheetMetalPart,
+  tab: TabSpec,
+  slot: SlotPlacement
+): Result<SheetMetalPart> {
+  const clearance = slot.clearance ?? 0.1;
+  if (!Number.isFinite(clearance) || clearance < 0) {
+    return err(validationError('INVALID_CLEARANCE', `clearance must be non-negative, got ${clearance}`));
+  }
+
+  const withTab = addTab(part, tab);
+  if (!withTab.ok) return withTab;
+
+  // The tab's inserted cross-section is `width` (along the edge) by `thickness`
+  // (through the sheet); the slot must clear both, so it's sized + clearance.
+  const slotLength = tab.width + clearance;
+  const slotWidth = part.thickness + clearance;
+
+  return addSlot(withTab.value, slot.region, {
+    x: slot.x,
+    y: slot.y,
+    length: slotLength,
+    width: slotWidth,
+  });
+}
+
+/**
+ * Region-local rectangle of the tab as four corners (CCW), extending OUTWARD past
+ * the chosen edge by `length`, spanning `[offset, offset+width]` along the edge.
+ */
+function tabLocalRect(spec: TabSpec, ext: { uMax: number; vMax: number }): Pt2[] {
+  const o = spec.offset;
+  const w = o + spec.width;
+  const l = spec.length;
+  switch (spec.side) {
+    case 'xmax':
+      return [
+        [ext.uMax, o],
+        [ext.uMax + l, o],
+        [ext.uMax + l, w],
+        [ext.uMax, w],
+      ];
+    case 'xmin':
+      return [
+        [-l, o],
+        [0, o],
+        [0, w],
+        [-l, w],
+      ];
+    case 'ymax':
+      return [
+        [o, ext.vMax],
+        [w, ext.vMax],
+        [w, ext.vMax + l],
+        [o, ext.vMax + l],
+      ];
+    case 'ymin':
+      return [
+        [o, -l],
+        [w, -l],
+        [w, 0],
+        [o, 0],
+      ];
+    default:
+      return spec.side satisfies never;
+  }
+}
+
+/** Extrude the region-local tab rectangle through the sheet via the region world frame. */
+function buildTabSolid(local: Pt2[], f: FlatFrame, thickness: number): Result<Solid> {
+  const worldPts: Vec3[] = local.map(([x, y]) =>
+    vecAdd(vecAdd(f.origin, vecScale(f.u, x)), vecScale(f.v, y))
+  );
+  const edges = [];
+  for (let i = 0; i < worldPts.length; i += 1) {
+    const a = worldPts[i];
+    const b = worldPts[(i + 1) % worldPts.length];
+    if (a === undefined || b === undefined) {
+      return err(validationError('TAB_TOOL_FAILED', 'failed to index tab rectangle points'));
+    }
+    edges.push(line(a, b));
+  }
+  const wire = wireLoop(edges);
+  if (!wire.ok) return wire;
+  if (!isPlanarWire(wire.value)) {
+    return err(validationError('TAB_TOOL_FAILED', 'tab profile wire is not planar'));
+  }
+  const profile = face(wire.value);
+  if (!profile.ok) return profile;
+  return extrude(profile.value, [f.n[0] * thickness, f.n[1] * thickness, f.n[2] * thickness]);
+}
+
+/** Developed-plane axis-aligned rectangle `[x0,y0,x1,y1]` of the local tab rect. */
+function devRect(local: Pt2[], dev: Frame2): [number, number, number, number] {
+  let x0 = Infinity;
+  let y0 = Infinity;
+  let x1 = -Infinity;
+  let y1 = -Infinity;
+  for (const p of local) {
+    const [x, y] = mapToFrame2(p, dev);
+    if (x < x0) x0 = x;
+    if (x > x1) x1 = x;
+    if (y < y0) y0 = y;
+    if (y > y1) y1 = y;
+  }
+  return [x0, y0, x1, y1];
+}

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -304,7 +304,7 @@ export interface BendReport {
 }
 
 export type SheetMetalWarning = {
-  code: 'COLLISION' | 'SEAM_CUT' | 'MIN_RADIUS' | 'INVALID_SOLID';
+  code: 'COLLISION' | 'SEAM_CUT' | 'MIN_RADIUS' | 'INVALID_SOLID' | 'MITER_NOT_DEVELOPED';
   message: string;
   featureId?: string | undefined;
 };

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -161,6 +161,96 @@ export interface CutoutFeature {
   area: number;
 }
 
+/**
+ * A rectangular tab: additive material extending OUTWARD from a flat region's edge
+ * (the additive counterpart of a cutout). `region` names the flat (a flange id, or
+ * `'base'`/`'root'` for the base); `side` is the region-local edge it protrudes
+ * from; `offset` is its start position along that edge and `width` its extent along
+ * it; `length` is how far it sticks out past the edge. The tab is full thickness.
+ */
+export interface TabSpec {
+  region: string;
+  side: FlatSide;
+  offset: number;
+  width: number;
+  length: number;
+}
+
+/**
+ * A recorded tab, mirroring {@link CutoutFeature}: enough to replay the developed
+ * protrusion and re-fuse the 3D material on a re-fold. `rect` is the developed-plane
+ * rectangle `[x0, y0, x1, y1]` added to the outer outline; `area` is its area, added
+ * to the developed area.
+ */
+export interface TabFeature {
+  spec: TabSpec;
+  /** The region (flange id, or `'root'`) the tab protrudes from. */
+  region: string;
+  /** Developed-plane protrusion rectangle `[x0, y0, x1, y1]`. */
+  rect: [number, number, number, number];
+  /** Area of the protrusion rectangle (`width · length`). */
+  area: number;
+}
+
+/**
+ * A form feature: a louver (vent flap) or an emboss/dimple (round bump), formed
+ * locally on a flat region's face. Forms do not remove or add net material, so the
+ * developed outline is unchanged; the flat pattern carries the fabrication markers
+ * (the louver U-cut + hinge line, the emboss footprint circle) on a FORM layer.
+ *
+ * - `louver` — a vent cut on three sides with the flap formed up along the hinge.
+ *   `length` runs along the hinge, `width` is the flap depth (perpendicular), and
+ *   `height` is how far the flap rises. `direction` picks the formed face (`up` =
+ *   +n, the default).
+ * - `emboss` / `dimple` — a round local form of `diameter` rising (`emboss`) or
+ *   recessed (`dimple`) by `height`.
+ *
+ * Coordinates are region-local: `(x, y)` is the form centre, `+x` along the region
+ * `u` axis, `+y` along `v`.
+ */
+export type FormSpec =
+  | {
+      kind: 'louver';
+      region: string;
+      x: number;
+      y: number;
+      length: number;
+      width: number;
+      height: number;
+      direction?: 'up' | 'down' | undefined;
+    }
+  | {
+      kind: 'emboss';
+      region: string;
+      x: number;
+      y: number;
+      diameter: number;
+      height: number;
+      form: 'dimple' | 'emboss';
+    };
+
+/**
+ * A recorded form feature, mirroring {@link CutoutFeature}. `spec` is the original
+ * region-local feature (so {@link FoldRegion} can re-apply it on a re-fold). `cuts`
+ * are OPEN developed-plane cut paths: the louver's three cut sides — all but the
+ * {@link FormFeature.hinge} side — as an open polyline the fabricator cuts to free
+ * the flap; empty for an emboss/dimple, which removes no material. `markers` are
+ * closed developed-plane marker loops (the emboss/dimple footprint circle; empty for
+ * a louver). `hinge` is the developed-plane fold segment of a louver — the one
+ * footprint side NOT cut — and is `undefined` for an emboss/dimple.
+ */
+export interface FormFeature {
+  spec: FormSpec;
+  /** The region (flange id, or `'root'`) the form sits on. */
+  region: string;
+  /** Developed-plane cut paths (open) a fabricator cuts; empty for embosses. */
+  cuts: [number, number][][];
+  /** Developed-plane marker loops (closed) for the FORM layer. */
+  markers: [number, number][][];
+  /** Developed-plane hinge segment `[a, b]` for a louver; undefined otherwise. */
+  hinge?: [[number, number], [number, number]] | undefined;
+}
+
 export interface SheetMetalPart {
   thickness: number;
   /** Base flat extent along +X (x∈[0, baseLength]); the east-run length. */
@@ -174,6 +264,8 @@ export interface SheetMetalPart {
   miters?: CornerMiter[] | undefined;
   reliefs?: ReliefFeature[] | undefined;
   cutouts?: CutoutFeature[] | undefined;
+  tabs?: TabFeature[] | undefined;
+  forms?: FormFeature[] | undefined;
 }
 
 export interface FlatPattern {
@@ -189,6 +281,13 @@ export interface FlatPattern {
   }[];
   /** Interior cutout loops (holes/slots/polygons) as closed wires in the developed plane. */
   holes: Wire[];
+  /** Form cut paths (louver U-cuts) a fabricator cuts before forming, as open wires
+   * (the three non-hinge sides; the hinge rides in {@link FlatPattern.formHinges}). */
+  formCuts: Wire[];
+  /** Form marker loops (emboss/dimple footprints) for annotation, as closed wires. */
+  formMarkers: Wire[];
+  /** Form hinge lines (louver fold lines) for annotation, as edges. */
+  formHinges: Edge[];
   developedArea: number;
 }
 
@@ -245,6 +344,10 @@ export interface FoldRegion {
   bendRelief?: ReliefSpec | undefined;
   /** Cutouts to punch into this region (in region-local coords) after folding. */
   cutouts?: CutoutSpec[] | undefined;
+  /** Tabs to fuse onto this region's edges (in region-local coords) after folding. */
+  tabs?: TabSpec[] | undefined;
+  /** Form features (louvers / embosses) on this region (region-local) after folding. */
+  forms?: FormSpec[] | undefined;
 }
 
 /**
@@ -264,4 +367,8 @@ export interface FlatInput {
   regions: FoldRegion[];
   /** Cutouts to punch into the base region (in base-local coords) after folding. */
   baseCutouts?: CutoutSpec[] | undefined;
+  /** Tabs to fuse onto the base region's edges (in base-local coords) after folding. */
+  baseTabs?: TabSpec[] | undefined;
+  /** Form features on the base region (base-local coords) after folding. */
+  baseForms?: FormSpec[] | undefined;
 }

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -6,6 +6,7 @@ import {
   err,
   validationError,
   line,
+  wire,
   wireLoop,
 } from 'brepjs';
 import type {
@@ -71,16 +72,28 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   for (const placed of layout.flats) rects.push(placed.rect);
   for (const strip of layout.strips) rects.push(strip);
 
+  // Tabs are additive protrusions: their developed rectangles join the outer-outline
+  // union and add to the developed area.
+  const tabRects: Rect[] = (part.tabs ?? []).map((t) => ({ x0: t.rect[0], y0: t.rect[1], x1: t.rect[2], y1: t.rect[3] }));
+  for (const r of tabRects) rects.push(r);
+
   const notches: Rect[] = (part.reliefs ?? []).flatMap((relief) =>
     relief.notches.map(([x0, y0, x1, y1]) => ({ x0, y0, x1, y1 }))
   );
-  const outlineResult = buildOutline(rects, layout, part.miters ?? [], notches);
+  // The L-miter chamfer special-case can't express tabs either; once any tab is
+  // recorded, fall through to the rectilinear-union path (which absorbs tab rects).
+  const miters = tabRects.length > 0 ? [] : part.miters ?? [];
+  const outlineResult = buildOutline(rects, layout, miters, notches);
   if (!outlineResult.ok) return outlineResult;
   layout.developedArea -= removedNotchArea(rects, notches);
+  for (const t of part.tabs ?? []) layout.developedArea += t.area;
 
   const holesResult = buildHoles(part);
   if (!holesResult.ok) return holesResult;
   for (const c of part.cutouts ?? []) layout.developedArea -= c.area;
+
+  const formsResult = buildForms(part);
+  if (!formsResult.ok) return formsResult;
 
   const bendLines = layout.flats
     .filter((p): p is PlacedFlange => p.kind === 'flange')
@@ -98,6 +111,9 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
     outline: outlineResult.value,
     bendLines,
     holes: holesResult.value,
+    formCuts: formsResult.value.cuts,
+    formMarkers: formsResult.value.markers,
+    formHinges: formsResult.value.hinges,
     developedArea: layout.developedArea,
   };
 
@@ -342,6 +358,76 @@ function buildHoles(part: SheetMetalPart): Result<Wire[]> {
     wires.push(wire.value);
   }
   return ok(wires);
+}
+
+interface FormWires {
+  cuts: Wire[];
+  markers: Wire[];
+  hinges: Edge[];
+}
+
+/**
+ * Developed-plane wires for recorded form features: each louver U-cut and emboss
+ * footprint as a closed {@link Wire}, plus each louver hinge as an {@link Edge}. The
+ * loops were already mapped into developed coordinates when the form was recorded
+ * (via the region's developed frame), so this just traces them. Forms are net-
+ * material-neutral, so the outer outline and developed area are untouched.
+ */
+function buildForms(part: SheetMetalPart): Result<FormWires> {
+  const cuts: Wire[] = [];
+  const markers: Wire[] = [];
+  const hinges: Edge[] = [];
+  for (const form of part.forms ?? []) {
+    for (const path of form.cuts) {
+      const cutWire = openPathWire(path);
+      if (!cutWire.ok) return cutWire;
+      cuts.push(cutWire.value);
+    }
+    for (const loop of form.markers) {
+      const wire = closedLoopWire(loop);
+      if (!wire.ok) return wire;
+      markers.push(wire.value);
+    }
+    if (form.hinge !== undefined) {
+      const [a, b] = form.hinge;
+      hinges.push(line([a[0], a[1], 0], [b[0], b[1], 0]));
+    }
+  }
+  return ok({ cuts, markers, hinges });
+}
+
+/** Trace a closed developed-plane loop (≥ 3 points) into a brepjs {@link Wire}. */
+function closedLoopWire(loop: Pt2[]): Result<Wire> {
+  if (loop.length < 3) {
+    return err(validationError('FORM_LOOP_TOO_SMALL', `form loop has ${loop.length} points, need ≥ 3`));
+  }
+  const edges: Edge[] = [];
+  for (let i = 0; i < loop.length; i += 1) {
+    const a = loop[i];
+    const b = loop[(i + 1) % loop.length];
+    if (a === undefined || b === undefined) {
+      return err(validationError('FORM_LOOP_FAILED', 'failed to index form loop'));
+    }
+    edges.push(line([a[0], a[1], 0], [b[0], b[1], 0]));
+  }
+  return wireLoop(edges);
+}
+
+/** Trace an OPEN developed-plane path (≥ 2 points) into a brepjs {@link Wire}. */
+function openPathWire(path: Pt2[]): Result<Wire> {
+  if (path.length < 2) {
+    return err(validationError('FORM_LOOP_TOO_SMALL', `form cut path has ${path.length} points, need ≥ 2`));
+  }
+  const edges: Edge[] = [];
+  for (let i = 0; i + 1 < path.length; i += 1) {
+    const a = path[i];
+    const b = path[i + 1];
+    if (a === undefined || b === undefined) {
+      return err(validationError('FORM_LOOP_FAILED', 'failed to index form cut path'));
+    }
+    edges.push(line([a[0], a[1], 0], [b[0], b[1], 0]));
+  }
+  return wire(edges);
 }
 
 function rectOf(f: Frame2): Rect {

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -82,7 +82,14 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   );
   // The L-miter chamfer special-case can't express tabs either; once any tab is
   // recorded, fall through to the rectilinear-union path (which absorbs tab rects).
+  // The 3D corner-miter cut still stands; only the developed chamfer is omitted.
   const miters = tabRects.length > 0 ? [] : part.miters ?? [];
+  if (tabRects.length > 0 && (part.miters ?? []).length > 0) {
+    warnings.push({
+      code: 'MITER_NOT_DEVELOPED',
+      message: 'developed outline omits the corner-miter chamfer because a tab is present; the 3D miter cut is unaffected',
+    });
+  }
   const outlineResult = buildOutline(rects, layout, miters, notches);
   if (!outlineResult.ok) return outlineResult;
   layout.developedArea -= removedNotchArea(rects, notches);
@@ -384,9 +391,9 @@ function buildForms(part: SheetMetalPart): Result<FormWires> {
       cuts.push(cutWire.value);
     }
     for (const loop of form.markers) {
-      const wire = closedLoopWire(loop);
-      if (!wire.ok) return wire;
-      markers.push(wire.value);
+      const markerWire = closedLoopWire(loop);
+      if (!markerWire.ok) return markerWire;
+      markers.push(markerWire.value);
     }
     if (form.hinge !== undefined) {
       const [a, b] = form.hinge;
@@ -416,7 +423,7 @@ function closedLoopWire(loop: Pt2[]): Result<Wire> {
 /** Trace an OPEN developed-plane path (≥ 2 points) into a brepjs {@link Wire}. */
 function openPathWire(path: Pt2[]): Result<Wire> {
   if (path.length < 2) {
-    return err(validationError('FORM_LOOP_TOO_SMALL', `form cut path has ${path.length} points, need ≥ 2`));
+    return err(validationError('FORM_PATH_TOO_SHORT', `form cut path has ${path.length} points, need ≥ 2`));
   }
   const edges: Edge[] = [];
   for (let i = 0; i + 1 < path.length; i += 1) {

--- a/packages/brepjs-sheetmetal/tests/dxf.test.ts
+++ b/packages/brepjs-sheetmetal/tests/dxf.test.ts
@@ -80,14 +80,14 @@ describe('flatPatternToDXF — structure', () => {
     expect(r.value).toContain('BEND_DOWN');
   });
 
-  it('LAYER table entry count matches the 4 layers written', () => {
+  it('LAYER table entry count matches the 5 layers written', () => {
     const r = flatPatternToDXF(unfoldPattern('up'));
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     const lines = r.value.split('\n');
     const symIdx = lines.indexOf('AcDbSymbolTable');
     expect(lines[symIdx + 1]).toBe('70');
-    expect(lines[symIdx + 2]).toBe('4');
+    expect(lines[symIdx + 2]).toBe('5');
   });
 
   it('is R2000-conformant: $HANDSEED + AcDb subclass markers on every entity', () => {

--- a/packages/brepjs-sheetmetal/tests/formfeatures.test.ts
+++ b/packages/brepjs-sheetmetal/tests/formfeatures.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { isOk, isErr, unwrap, measureVolume, isValid, getSolids, getEdges, curveStartPoint } from 'brepjs';
+import type { Wire } from 'brepjs';
+import { author } from '../src/api.js';
+import { addTab, tabAndSlot } from '../src/tabFns.js';
+import { louver, emboss } from '../src/formFns.js';
+import { unfold } from '../src/unfoldFns.js';
+import { fold, partToFlatInput } from '../src/foldFns.js';
+import { flatPatternToDXF } from '../src/dxfFns.js';
+import type { BendRule, FlatInput, SheetMetalPart } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const rule: BendRule = { innerRadius: 2, kFactor: 0.44 };
+const T = 1;
+
+function basePart(length = 40, width = 40): SheetMetalPart {
+  return unwrap(author({ thickness: T, base: { length, width }, flanges: [] }));
+}
+
+function flangePart(): SheetMetalPart {
+  return unwrap(
+    author({
+      thickness: T,
+      base: { length: 40, width: 40 },
+      flanges: [{ id: 'fy', length: 20, angleDeg: 90, rule, side: 'ymax' }],
+    })
+  );
+}
+
+function vol(part: SheetMetalPart): number {
+  const solid = part.solid;
+  if (solid === undefined) throw new Error('no solid');
+  return unwrap(measureVolume(solid));
+}
+
+function outlineBBox(wire: Wire): { x0: number; y0: number; x1: number; y1: number } {
+  const pts = getEdges(wire).map((e) => curveStartPoint(e));
+  let x0 = Infinity;
+  let y0 = Infinity;
+  let x1 = -Infinity;
+  let y1 = -Infinity;
+  for (const p of pts) {
+    if (p[0] < x0) x0 = p[0];
+    if (p[0] > x1) x1 = p[0];
+    if (p[1] < y0) y0 = p[1];
+    if (p[1] > y1) y1 = p[1];
+  }
+  return { x0, y0, x1, y1 };
+}
+
+/**
+ * Closed-flag (group code 70) of the first LWPOLYLINE on the FORM layer in a DXF.
+ * Walks the group-code/value pairs so it matches the polyline's own 70 — not the
+ * FORM layer-table record's 70.
+ */
+function formCutPolylineClosedFlag(dxf: string): string | undefined {
+  const lines = dxf.split('\n');
+  let inFormPolyline = false;
+  let onFormLayer = false;
+  for (let i = 0; i + 1 < lines.length; i += 2) {
+    const code = lines[i];
+    const value = lines[i + 1];
+    if (code === '0') {
+      inFormPolyline = value === 'LWPOLYLINE';
+      onFormLayer = false;
+    } else if (inFormPolyline && code === '8') {
+      onFormLayer = value === 'FORM';
+    } else if (inFormPolyline && onFormLayer && code === '70') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+describe('addTab — additive protrusion', () => {
+  it('raises the volume by ~width·length·thickness and stays a single valid body', () => {
+    const base = basePart();
+    const v0 = vol(base);
+    const tabbed = addTab(base, { region: 'base', side: 'xmax', offset: 10, width: 12, length: 8 });
+    expect(isOk(tabbed)).toBe(true);
+    if (!isOk(tabbed)) return;
+
+    const rise = vol(tabbed.value) - v0;
+    expect(rise).toBeCloseTo(12 * 8 * T, 4);
+
+    const solid = tabbed.value.solid;
+    expect(solid).toBeDefined();
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+  });
+
+  it('extends the developed outer outline past the base edge by the tab length', () => {
+    const base = basePart(40, 40);
+    const tabbed = unwrap(addTab(base, { region: 'base', side: 'xmax', offset: 10, width: 12, length: 8 }));
+    const pattern = unwrap(unfold(tabbed)).pattern;
+
+    const bb = outlineBBox(pattern.outline);
+    // The xmax tab pushes the outline's +X reach from 40 to 48.
+    expect(bb.x1).toBeCloseTo(48, 3);
+  });
+
+  it('adds the tab area to the developed area', () => {
+    const base = basePart(40, 40);
+    const area0 = unwrap(unfold(base)).pattern.developedArea;
+    const tabbed = unwrap(addTab(base, { region: 'base', side: 'ymax', offset: 8, width: 10, length: 6 }));
+    const area1 = unwrap(unfold(tabbed)).pattern.developedArea;
+    expect(area1 - area0).toBeCloseTo(10 * 6, 4);
+  });
+
+  it('an xmin tab extends the outline into negative X by the tab length', () => {
+    const base = basePart(40, 40);
+    const tabbed = unwrap(addTab(base, { region: 'base', side: 'xmin', offset: 10, width: 12, length: 8 }));
+    const pattern = unwrap(unfold(tabbed)).pattern;
+    const bb = outlineBBox(pattern.outline);
+    expect(bb.x0).toBeCloseTo(-8, 3);
+  });
+
+  it('fuses a tab onto a folded flange edge (volume rises, solid valid)', () => {
+    const part = flangePart();
+    const v0 = vol(part);
+    const tabbed = addTab(part, { region: 'fy', side: 'xmax', offset: 5, width: 10, length: 6 });
+    expect(isOk(tabbed)).toBe(true);
+    if (!isOk(tabbed)) return;
+    expect(vol(tabbed.value) - v0).toBeCloseTo(10 * 6 * T, 4);
+    const solid = tabbed.value.solid;
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+  });
+
+  it('rejects a tab running past the edge length', () => {
+    const base = basePart(40, 40);
+    const oob = addTab(base, { region: 'base', side: 'xmax', offset: 35, width: 10, length: 6 });
+    expect(isErr(oob)).toBe(true);
+    if (isErr(oob)) expect(oob.error.code).toBe('TAB_OUT_OF_BOUNDS');
+  });
+
+  it('rejects an unknown region', () => {
+    const base = basePart();
+    const bad = addTab(base, { region: 'nope', side: 'xmax', offset: 0, width: 5, length: 5 });
+    expect(isErr(bad)).toBe(true);
+    if (isErr(bad)) expect(bad.error.code).toBe('UNKNOWN_REGION');
+  });
+
+  it('rejects a non-positive tab length', () => {
+    const base = basePart();
+    const bad = addTab(base, { region: 'base', side: 'xmax', offset: 0, width: 5, length: 0 });
+    expect(isErr(bad)).toBe(true);
+    if (isErr(bad)) expect(bad.error.code).toBe('INVALID_TAB');
+  });
+});
+
+describe('tabAndSlot — self-fixturing joint', () => {
+  it('places a tab on one region and a slot on the mating region; slot clears the tab', () => {
+    const tabWidth = 10;
+    const clearance = 0.2;
+    const part = basePart(60, 40);
+    const joined = tabAndSlot(
+      part,
+      { region: 'base', side: 'xmax', offset: 15, width: tabWidth, length: 8 },
+      { region: 'base', x: 30, y: 20, clearance }
+    );
+    expect(isOk(joined)).toBe(true);
+    if (!isOk(joined)) return;
+
+    // The tab is recorded, and exactly one slot cutout was punched.
+    expect(joined.value.tabs?.length).toBe(1);
+    expect(joined.value.cutouts?.length).toBe(1);
+
+    // The slot opening must clear the tab cross-section + clearance on both axes.
+    const slotSpec = joined.value.cutouts?.[0]?.spec;
+    expect(slotSpec?.kind).toBe('slot');
+    if (slotSpec?.kind !== 'slot') return;
+    expect(slotSpec.length).toBeGreaterThan(tabWidth);
+    expect(slotSpec.length).toBeCloseTo(tabWidth + clearance, 6);
+    expect(slotSpec.width).toBeGreaterThan(T);
+    expect(slotSpec.width).toBeCloseTo(T + clearance, 6);
+
+    const solid = joined.value.solid;
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+  });
+
+  it('defaults clearance so the slot is still strictly larger than the tab', () => {
+    const part = basePart(60, 40);
+    const joined = unwrap(
+      tabAndSlot(
+        part,
+        { region: 'base', side: 'xmax', offset: 15, width: 10, length: 8 },
+        { region: 'base', x: 30, y: 20 }
+      )
+    );
+    const slotSpec = joined.cutouts?.[0]?.spec;
+    if (slotSpec?.kind !== 'slot') throw new Error('expected slot');
+    expect(slotSpec.length).toBeGreaterThan(10);
+    expect(slotSpec.width).toBeGreaterThan(T);
+  });
+});
+
+describe('louver — formed vent', () => {
+  it('keeps a single valid solid and emits the U-cut + hinge in the flat pattern', () => {
+    const base = basePart(60, 40);
+    const formed = louver(base, { region: 'base', x: 30, y: 20, length: 16, width: 8, height: 4 });
+    expect(isOk(formed)).toBe(true);
+    if (!isOk(formed)) return;
+
+    const solid = formed.value.solid;
+    expect(solid).toBeDefined();
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+
+    const pattern = unwrap(unfold(formed.value)).pattern;
+    expect(pattern.formCuts.length).toBe(1);
+    expect(pattern.formHinges.length).toBe(1);
+
+    // The cut is the OPEN three-side U (the hinge side is left uncut), so it has 3
+    // segments, not the 4 a closed rectangle would have — a closed loop would tell
+    // the fabricator to cut all four sides and drop the flap out.
+    const cut = pattern.formCuts[0];
+    if (cut === undefined) throw new Error('expected a form cut');
+    expect(getEdges(cut).length).toBe(3);
+  });
+
+  it('emits the louver cut as an OPEN polyline (group 70=0) in the DXF', () => {
+    const base = basePart(60, 40);
+    const formed = unwrap(louver(base, { region: 'base', x: 30, y: 20, length: 16, width: 8, height: 4 }));
+    const pattern = unwrap(unfold(formed)).pattern;
+    const dxf = unwrap(flatPatternToDXF(pattern));
+    // The FORM-layer cut LWPOLYLINE must carry the open flag (70 / 0), so a CAM
+    // reader does not auto-close the U and cut the hinge.
+    expect(formCutPolylineClosedFlag(dxf)).toBe('0');
+  });
+
+  it('leaves the developed outline and area unchanged (forming is material-neutral)', () => {
+    const base = basePart(60, 40);
+    const before = unwrap(unfold(base)).pattern;
+    const beforeBB = outlineBBox(before.outline);
+    const formed = unwrap(louver(base, { region: 'base', x: 30, y: 20, length: 16, width: 8, height: 4 }));
+    const after = unwrap(unfold(formed)).pattern;
+    const afterBB = outlineBBox(after.outline);
+
+    expect(after.developedArea).toBeCloseTo(before.developedArea, 4);
+    expect(afterBB.x0).toBeCloseTo(beforeBB.x0, 4);
+    expect(afterBB.x1).toBeCloseTo(beforeBB.x1, 4);
+    expect(afterBB.y0).toBeCloseTo(beforeBB.y0, 4);
+    expect(afterBB.y1).toBeCloseTo(beforeBB.y1, 4);
+  });
+
+  it('writes the louver cut + hinge on the FORM layer of the DXF', () => {
+    const base = basePart(60, 40);
+    const formed = unwrap(louver(base, { region: 'base', x: 30, y: 20, length: 16, width: 8, height: 4 }));
+    const pattern = unwrap(unfold(formed)).pattern;
+    const dxf = unwrap(flatPatternToDXF(pattern));
+    expect(dxf).toContain('FORM');
+  });
+
+  it('forms a down-direction louver into a valid single solid', () => {
+    const base = basePart(60, 40);
+    const formed = louver(base, { region: 'base', x: 30, y: 20, length: 16, width: 8, height: 4, direction: 'down' });
+    expect(isOk(formed)).toBe(true);
+    if (!isOk(formed)) return;
+    const solid = formed.value.solid;
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+  });
+
+  it('rejects a louver out of region bounds', () => {
+    const base = basePart(60, 40);
+    const oob = louver(base, { region: 'base', x: 58, y: 20, length: 16, width: 8, height: 4 });
+    expect(isErr(oob)).toBe(true);
+    if (isErr(oob)) expect(oob.error.code).toBe('FORM_OUT_OF_BOUNDS');
+  });
+});
+
+describe('emboss / dimple — round formed bump', () => {
+  it('emboss fuses a raised bump: volume rises, solid valid, footprint marker present', () => {
+    const base = basePart();
+    const v0 = vol(base);
+    const formed = emboss(base, { region: 'base', x: 20, y: 20, diameter: 8, height: 2, kind: 'emboss' });
+    expect(isOk(formed)).toBe(true);
+    if (!isOk(formed)) return;
+
+    expect(vol(formed.value)).toBeGreaterThan(v0);
+    const solid = formed.value.solid;
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+
+    const pattern = unwrap(unfold(formed.value)).pattern;
+    expect(pattern.formMarkers.length).toBe(1);
+    // Developed outline unchanged.
+    const v1area = pattern.developedArea;
+    expect(v1area).toBeCloseTo(unwrap(unfold(base)).pattern.developedArea, 4);
+  });
+
+  it('dimple cuts a shallow recess: volume drops, solid valid', () => {
+    const base = basePart();
+    const v0 = vol(base);
+    const formed = emboss(base, { region: 'base', x: 20, y: 20, diameter: 8, height: 0.4, kind: 'dimple' });
+    expect(isOk(formed)).toBe(true);
+    if (!isOk(formed)) return;
+    expect(vol(formed.value)).toBeLessThan(v0);
+    const solid = formed.value.solid;
+    if (solid === undefined) return;
+    expect(isValid(solid)).toBe(true);
+    expect(getSolids(solid).length).toBe(1);
+  });
+
+  it('rejects a dimple deeper than the sheet thickness', () => {
+    const base = basePart();
+    const bad = emboss(base, { region: 'base', x: 20, y: 20, diameter: 8, height: T + 1, kind: 'dimple' });
+    expect(isErr(bad)).toBe(true);
+    if (isErr(bad)) expect(bad.error.code).toBe('INVALID_FORM');
+  });
+});
+
+describe('tab round-trip through fold', () => {
+  it('folds a FlatInput with a base tab into the same volume as addTab', () => {
+    const base = basePart(40, 40);
+    const tabSpec = { region: 'base' as const, side: 'xmax' as const, offset: 10, width: 12, length: 8 };
+    const direct = unwrap(addTab(base, tabSpec));
+
+    const input: FlatInput = {
+      thickness: T,
+      baseLength: 40,
+      width: 40,
+      regions: [],
+      baseTabs: [tabSpec],
+    };
+    const refolded = unwrap(fold(input));
+    expect(refolded.tabs?.length).toBe(1);
+    expect(vol(refolded)).toBeCloseTo(vol(direct), 5);
+  });
+
+  it('carries a base tab through partToFlatInput so fold round-trips its volume', () => {
+    const base = basePart(40, 40);
+    const direct = unwrap(addTab(base, { region: 'base', side: 'xmax', offset: 10, width: 12, length: 8 }));
+
+    // partToFlatInput must recover the tab spec (not silently drop it); the base
+    // length recovers as 40 even though the tab protrudes the outline to x=48.
+    const recovered = unwrap(partToFlatInput(direct));
+    expect(recovered.baseLength).toBeCloseTo(40, 3);
+    expect(recovered.baseTabs?.length).toBe(1);
+
+    const refolded = unwrap(fold(recovered));
+    expect(refolded.tabs?.length).toBe(1);
+    expect(vol(refolded)).toBeCloseTo(vol(direct), 4);
+  });
+
+  it('carries a flange tab through partToFlatInput onto the recovered region', () => {
+    const part = flangePart();
+    const direct = unwrap(addTab(part, { region: 'fy', side: 'xmax', offset: 5, width: 10, length: 6 }));
+
+    const recovered = unwrap(partToFlatInput(direct));
+    const regionWithTab = recovered.regions.find((r) => r.tabs !== undefined);
+    expect(regionWithTab?.tabs?.length).toBe(1);
+
+    const refolded = unwrap(fold(recovered));
+    expect(refolded.tabs?.length).toBe(1);
+    expect(vol(refolded)).toBeCloseTo(vol(direct), 4);
+  });
+});
+
+describe('form round-trip through fold', () => {
+  it('folds a FlatInput with a base emboss into the same volume as emboss()', () => {
+    const base = basePart();
+    const embossSpec = { region: 'base' as const, x: 20, y: 20, diameter: 8, height: 2, kind: 'emboss' as const };
+    const direct = unwrap(emboss(base, embossSpec));
+
+    const input: FlatInput = {
+      thickness: T,
+      baseLength: 40,
+      width: 40,
+      regions: [],
+      baseForms: [{ kind: 'emboss', region: 'base', x: 20, y: 20, diameter: 8, height: 2, form: 'emboss' }],
+    };
+    const refolded = unwrap(fold(input));
+    expect(refolded.forms?.length).toBe(1);
+    expect(vol(refolded)).toBeCloseTo(vol(direct), 5);
+  });
+});

--- a/packages/brepjs-sheetmetal/tests/formfeatures.test.ts
+++ b/packages/brepjs-sheetmetal/tests/formfeatures.test.ts
@@ -201,6 +201,20 @@ describe('tabAndSlot — self-fixturing joint', () => {
     expect(slotSpec.length).toBeGreaterThan(10);
     expect(slotSpec.width).toBeGreaterThan(T);
   });
+
+  it('threads the slot angleDeg through so the slot can be oriented to match the tab', () => {
+    const part = basePart(60, 40);
+    const joined = unwrap(
+      tabAndSlot(
+        part,
+        { region: 'base', side: 'xmax', offset: 15, width: 10, length: 8 },
+        { region: 'base', x: 30, y: 20, angleDeg: 90 }
+      )
+    );
+    const slotSpec = joined.cutouts?.[0]?.spec;
+    if (slotSpec?.kind !== 'slot') throw new Error('expected slot');
+    expect(slotSpec.angleDeg).toBe(90);
+  });
 });
 
 describe('louver — formed vent', () => {


### PR DESCRIPTION
## Phase 2 · PR5 of a stacked sequence

Adds form features across the additive / assembly / formed axis, on top of the cutout machinery from PR4.

### What's new
- **Tabs** (`addTab`): a rectangular protrusion fused onto a region's edge via its world frame — adds material (volume rises) and *extends* the developed outer outline (the inverse of a cutout).
- **Tab-and-slot joints** (`tabAndSlot`): a tab plus a mating slot cutout sized `tab + clearance`, positioned so the joint self-locates when folded. The slot opening is **numerically guaranteed** larger than the tab cross-section (the test that matters for a part that actually assembles).
- **Louvers** (`louver`): an open three-side flap cut + hinge fold line — the fabricable flat representation a brake/laser operator needs — with a valid raised-flap solid.
- **Dimples / embosses** (`emboss`): raised/recessed round forms (material-neutral footprint markers in the flat).

### Design
- `TabSpec`/`TabFeature`, `FormSpec`/`FormFeature`; `FlatPattern` gains `formCuts`/`formMarkers`/`formHinges`; `FoldRegion`/`FlatInput` carry `tabs`/`forms`; `dxfFns` gains a `FORM` layer (open polylines for louver cuts).
- Forms are recorded, valid single solids. True forming is impractical with a CSG-only kernel, so the 3D form is simplified (documented) — the **flat pattern is the fabrication-critical output**, and it's correct.
- Guards: out-of-bounds, sever (`height ≥ thickness` rejected for dimples), unknown-region; `attachTabs`/`attachForms` fail loud (`TAB_REGION_UNMAPPED`/`FORM_REGION_UNMAPPED`) rather than silently dropping a feature.

### Round-trip
- Tabs round-trip through the **real outline oracle** (`partToFlatInput → fold`, Δvol ~1e-12) — review disproved an initial assumption that protrusions can't be recovered (the parser reads base/flange rects from bend lines, off the tab span). Forms are material-neutral and ride as recorded features.

### Verification
- typecheck / lint / build clean; **153 tests** (130 prior + 23 new) green against occt-wasm; snapshot adds `tab-and-slot-box` + `louvered-panel` demos (both round-trip).
- Built via a multi-agent Workflow (implement → adversarial review → fix); review caught a silent tab-round-trip gap (no `attachTabs`) and a louver flat-pattern that emitted a *closed* cut loop (would drop the flap out at fabrication) — both fixed.

### Stack
PR1–PR4 merged (#1177, #1180, #1182, #1184). Remaining: contour/lofted flanges · foreign-solid unfold. OCCT-WASM-first.