### PR TITLE
feat(sheetmetal): contour flanges and lofted/ruled transition flanges

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -23,17 +23,19 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 
 ## Status
 
-| Area            | State                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams          |
-| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area    |
-| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`         |
-| Reliefs         | bend reliefs (slots at partial-flange bend-line ends), corner reliefs (notch at a corner) |
-| Cutouts         | holes / slots (rect + obround) / polygons punched on the base or a folded flange          |
-| Tabs / joints   | additive edge tabs, self-fixturing tab-and-slot joints (tab + matching mating slot)       |
-| Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)    |
-| Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings         |
-| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                   |
+| Area            | State                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams            |
+| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area      |
+| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`           |
+| Reliefs         | bend reliefs (slots at partial-flange bend-line ends), corner reliefs (notch at a corner)   |
+| Cutouts         | holes / slots (rect + obround) / polygons punched on the base or a folded flange            |
+| Tabs / joints   | additive edge tabs, self-fixturing tab-and-slot joints (tab + matching mating slot)         |
+| Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)      |
+| Contour flange  | open line/arc profile swept along a base edge (multi-bend section); EXACT development       |
+| Lofted flange   | ruled transition between two open profiles; triangulated development (exact if developable) |
+| Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings           |
+| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                     |
 
 `fold(input: FlatInput)` folds a flat pattern back up into a 3D part — the inverse of `unfold`. A
 `FlatInput` is a region-tree (a base rectangle plus child fold regions, each with a fold line, angle,
@@ -146,6 +148,33 @@ output:
 Forms ride through `fold` via `FoldRegion.forms` / `FlatInput.baseForms`. Because they are material-neutral
 they don't change the outline, so a **formed part still round-trips** through the strict outline oracle
 (`partToFlatInput` carries the region-local form specs across, exactly as it does for cutouts).
+
+## Contour & lofted/ruled transition flanges
+
+Two profile-driven flanges extend authoring beyond single straight bends:
+
+- `contourFlange(part, { id, side, profile, rule?, offset?, width? })` — an **open 2D profile** (alternating
+  `{ kind: 'line', length }` flats and `{ kind: 'arc', radius, angleDeg, direction }` bends) swept along a
+  straight base edge into a multi-bend cross-section (a return, a hat/top-hat, a J). Each arc becomes a
+  recorded `BendFeature` (id `contour::<flange>::<n>`) and chains frame-to-frame exactly as flange-off-flange
+  bends do. The **development is EXACT**: the developed strip length is the sum of each segment's developed
+  length (lines: `length`; arcs: the canonical `developedLength` = `(π/180)·|angle|·(R + K·T)`). The unfold
+  lays the strip out straight along the base edge with one bend line per arc at its exact cumulative
+  arc-length offset.
+- `loftedFlange(part, { id, profileA, profileB, height, thickness? })` — a **ruled transition** between two
+  parallel open profiles (`profileA` at z=0, `profileB` at z=`height`, equal vertex counts), thickened to a
+  valid solid by triangulating each quad of the ruled surface and extruding each triangle. The
+  **development is by triangulation** — the standard sheet-metal transition development: each quad is split
+  along a diagonal into two triangles laid out flat preserving their true 3D edge lengths. For a genuinely
+  **developable** transition (planar quads / single-curvature) this is **exact to tolerance**; for a
+  non-developable (twisted) transition it is an **approximation**, and the unfold emits a
+  `DEVELOPMENT_APPROXIMATE` warning (inside the `Ok` payload). The triangulated boundary is emitted as a
+  valid closed wire in `FlatPattern.loftedDevelopments`.
+
+Both flanges have **non-rectilinear** developments, so — like miters and tabs — they sit outside the strict
+`patternToFlatInput` outline oracle: verification leans on developed-length/area invariants and solid
+validity rather than a fold round-trip. The contour flange's developed strip still joins the rectilinear
+outline union; the lofted flange's triangulated blank is a separate developed boundary.
 
 ## Design
 

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -22,9 +22,20 @@ import { addBendRelief, cornerRelief } from '../src/reliefFns.js';
 import { addCutout } from '../src/cutoutFns.js';
 import { addTab, tabAndSlot, type SlotPlacement } from '../src/tabFns.js';
 import { addForm } from '../src/formFns.js';
+import { authorContourFlange } from '../src/contourFlangeFns.js';
+import { authorLoftedFlange } from '../src/loftedFlangeFns.js';
 import { partToFlatInput } from '../src/foldFns.js';
 import type { AuthorSpec } from '../src/authorFns.js';
-import type { BendRule, CutoutSpec, FlatPattern, FormSpec, SheetMetalPart, TabSpec } from '../src/types.js';
+import type {
+  BendRule,
+  ContourFlangeSpec,
+  CutoutSpec,
+  FlatPattern,
+  FormSpec,
+  LoftedFlangeSpec,
+  SheetMetalPart,
+  TabSpec,
+} from '../src/types.js';
 
 /**
  * Boot the OCCT-WASM kernel directly from `brepjs-opencascade` (the same recipe
@@ -74,6 +85,10 @@ interface Demo {
   tabSlots?: { tab: TabSpec; slot: SlotPlacement }[];
   /** Optional form features (louvers / embosses) formed after authoring. */
   forms?: FormSpec[];
+  /** Optional contour flanges (open line/arc profile swept along a base edge). */
+  contourFlanges?: ContourFlangeSpec[];
+  /** Optional lofted / ruled transition flanges between two open profiles. */
+  loftedFlanges?: LoftedFlangeSpec[];
 }
 
 const DEMOS: Demo[] = [
@@ -187,6 +202,54 @@ const DEMOS: Demo[] = [
       { kind: 'emboss', region: 'base', x: 60, y: 35, diameter: 10, height: 0.5, form: 'dimple' },
     ],
   },
+  {
+    name: 'contour-flange',
+    spec: {
+      thickness: T,
+      base: { length: 60, width: 30 },
+      flanges: [],
+    },
+    // A return / top-hat cross-section swept along the +X edge.
+    contourFlanges: [
+      {
+        id: 'hat',
+        side: 'xmax',
+        rule,
+        profile: [
+          { kind: 'line', length: 10 },
+          { kind: 'arc', radius: R, angleDeg: 90, direction: 'up' },
+          { kind: 'line', length: 14 },
+          { kind: 'arc', radius: R, angleDeg: 90, direction: 'up' },
+          { kind: 'line', length: 10 },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'lofted-chute',
+    spec: {
+      thickness: T,
+      base: { length: 60, width: 40 },
+      flanges: [],
+    },
+    // A tapered chute: a wide bottom edge transitioning up to a narrower top edge
+    // (a developable truncated-wedge ruled transition).
+    loftedFlanges: [
+      {
+        id: 'chute',
+        profileA: [
+          [10, 40],
+          [50, 40],
+        ],
+        profileB: [
+          [22, 40],
+          [38, 40],
+        ],
+        height: 24,
+        thickness: T,
+      },
+    ],
+  },
 ];
 
 async function main(): Promise<void> {
@@ -241,6 +304,16 @@ async function renderDemo(demo: Demo): Promise<string[]> {
     if (isErr(formResult)) throw new Error(`form '${demo.name}' failed: ${formResult.error.message}`);
     part = formResult.value;
   }
+  for (const spec of demo.contourFlanges ?? []) {
+    const cfResult = authorContourFlange(part, spec);
+    if (isErr(cfResult)) throw new Error(`contourFlange '${demo.name}' failed: ${cfResult.error.message}`);
+    part = cfResult.value;
+  }
+  for (const spec of demo.loftedFlanges ?? []) {
+    const lfResult = authorLoftedFlange(part, spec);
+    if (isErr(lfResult)) throw new Error(`loftedFlange '${demo.name}' failed: ${lfResult.error.message}`);
+    part = lfResult.value;
+  }
   if (part.solid === undefined) throw new Error(`'${demo.name}' has no solid`);
 
   const unfolded = unfold(part);
@@ -267,8 +340,12 @@ async function renderDemo(demo: Demo): Promise<string[]> {
   // their region-local specs), so a tab'd/formed part still round-trips even though a
   // tab protrudes the outline — the parser recovers the base/flange rectangles from
   // the bend lines and unprotruded edges.
-  const skipRoundTrip = demo.miter !== undefined || part.reliefs !== undefined;
-  let roundTrip = '(fold round-trip skipped: mitered/relief’d part)';
+  const skipRoundTrip =
+    demo.miter !== undefined ||
+    part.reliefs !== undefined ||
+    part.contourFlanges !== undefined ||
+    part.loftedFlanges !== undefined;
+  let roundTrip = '(fold round-trip skipped: mitered/relief’d/contour/lofted part)';
   if (!skipRoundTrip) {
     roundTrip = foldRoundTrip(part);
   }
@@ -340,6 +417,9 @@ function renderFlatSvg(pattern: FlatPattern): string {
   const holeSegs: Seg2[] = pattern.holes.flatMap((w) =>
     getEdges(w).map((e) => ({ a: to2(curveStartPoint(e)), b: to2(curveEndPoint(e)) }))
   );
+  const loftedSegs: Seg2[] = pattern.loftedDevelopments.flatMap((w) =>
+    getEdges(w).map((e) => ({ a: to2(curveStartPoint(e)), b: to2(curveEndPoint(e)) }))
+  );
   const formSegs: Seg2[] = [
     ...pattern.formCuts,
     ...pattern.formMarkers,
@@ -349,9 +429,13 @@ function renderFlatSvg(pattern: FlatPattern): string {
     b: to2(curveEndPoint(e)),
   }));
 
-  const allPts = [...outlineSegs, ...bendSegs, ...holeSegs, ...formSegs, ...hingeSegs].flatMap((s) => [s.a, s.b]);
+  const allPts = [...outlineSegs, ...bendSegs, ...holeSegs, ...loftedSegs, ...formSegs, ...hingeSegs].flatMap((s) => [s.a, s.b]);
   const body =
     outlineSegs
+      .map((s) => `<line class="outline" x1="${fmt(s.a[0])}" y1="${fmt(s.a[1])}" x2="${fmt(s.b[0])}" y2="${fmt(s.b[1])}" />`)
+      .join('\n') +
+    '\n' +
+    loftedSegs
       .map((s) => `<line class="outline" x1="${fmt(s.a[0])}" y1="${fmt(s.a[1])}" x2="${fmt(s.b[0])}" y2="${fmt(s.b[1])}" />`)
       .join('\n') +
     '\n' +

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -37,6 +37,8 @@ import {
   type SlotPlacement,
 } from './tabFns.js';
 import { louver as louverFn, emboss as embossFn } from './formFns.js';
+import { authorContourFlange as authorContourFlangeFn } from './contourFlangeFns.js';
+import { authorLoftedFlange as authorLoftedFlangeFn } from './loftedFlangeFns.js';
 import { flatPatternToDXF as flatPatternToDXFFn, type DxfOptions } from './dxfFns.js';
 import {
   buildReport as buildReportFn,
@@ -54,6 +56,8 @@ import type {
   ReliefSpec,
   CutoutSpec,
   TabSpec,
+  ContourFlangeSpec,
+  LoftedFlangeSpec,
   UnfoldResult,
   SheetMetalWarning,
 } from './types.js';
@@ -182,6 +186,23 @@ export function emboss(
   opts: { region: string; x: number; y: number; diameter: number; height: number; kind: 'dimple' | 'emboss' }
 ): Result<SheetMetalPart> {
   return embossFn(part, opts);
+}
+
+/**
+ * Author a contour flange: an open line/arc profile swept along a base edge into a
+ * multi-bend cross-section. The development is exact (Σ segment developed lengths).
+ */
+export function contourFlange(part: SheetMetalPart, spec: ContourFlangeSpec): Result<SheetMetalPart> {
+  return authorContourFlangeFn(part, spec);
+}
+
+/**
+ * Author a lofted / ruled transition flange between two parallel open profiles. The
+ * development is by triangulation — exact for a developable transition, an
+ * approximation (with a `DEVELOPMENT_APPROXIMATE` unfold warning) otherwise.
+ */
+export function loftedFlange(part: SheetMetalPart, spec: LoftedFlangeSpec): Result<SheetMetalPart> {
+  return authorLoftedFlangeFn(part, spec);
 }
 
 /** Emit an annotated multi-layer DXF string for a flat pattern. */

--- a/packages/brepjs-sheetmetal/src/contourFlangeFns.ts
+++ b/packages/brepjs-sheetmetal/src/contourFlangeFns.ts
@@ -1,0 +1,422 @@
+import {
+  type Result,
+  type Vec3,
+  type Solid,
+  type ValidSolid,
+  ok,
+  err,
+  validationError,
+  box,
+  cylinder,
+  fuse,
+  cut,
+  intersect,
+  rotate,
+  translate,
+  vecAdd,
+  vecScale,
+  vecSub,
+  vecDot,
+  vecCross,
+  vecNormalize,
+} from 'brepjs';
+import type {
+  BendFeature,
+  BendRule,
+  ContourFlangeFeature,
+  ContourFlangeSpec,
+  FlatSide,
+  ProfileSegment,
+  SheetMetalPart,
+} from './types.js';
+import { normalizeSolid } from './internal.js';
+import { developedLength } from './allowanceFns.js';
+
+interface SegmentFrame {
+  /** Origin of the −normal (bottom) surface at the start of this segment. */
+  origin: Vec3;
+  /** Outward run direction (the segment's local +X). */
+  run: Vec3;
+  /** Top-surface normal (+Z), n = bendAxis × run. */
+  n: Vec3;
+  /** Bend axis along the base edge (+Y), shared by every segment. */
+  axis: Vec3;
+}
+
+/**
+ * Author a contour flange: an OPEN 2D profile (alternating line/arc segments) swept
+ * along one straight edge of the base flat. Each arc is a cylindrical bend, each
+ * line a flat leg; consecutive segments chain frame-to-frame exactly as
+ * {@link authorPart} chains flanges, building one connected multi-bend cross-section
+ * (a return, a hat, a J). The recorded {@link ContourFlangeFeature} carries each
+ * segment's EXACT developed length (lines: `length`; arcs: the canonical
+ * {@link developedLength}) so the unfold lays the strip out straight with no error.
+ * Construction stays on the public, OCCT-WASM-safe API.
+ */
+export function authorContourFlange(
+  part: SheetMetalPart,
+  spec: ContourFlangeSpec
+): Result<SheetMetalPart> {
+  if (part.solid === undefined) {
+    return err(validationError('NO_SOLID', `part has no solid to attach contour flange '${spec.id}'`));
+  }
+  if (spec.id === '' || spec.id.includes('::')) {
+    return err(
+      validationError('INVALID_CONTOUR_ID', `contour flange id must be non-empty and must not contain '::', got '${spec.id}'`)
+    );
+  }
+  for (const existing of part.contourFlanges ?? []) {
+    if (existing.id === spec.id) {
+      return err(validationError('DUPLICATE_CONTOUR', `duplicate contour flange id '${spec.id}'`));
+    }
+  }
+  if (spec.profile.length === 0) {
+    return err(validationError('EMPTY_PROFILE', `contour flange '${spec.id}' profile is empty`));
+  }
+
+  const thickness = part.thickness;
+  const edge = baseEdge(part, spec.side);
+  const offset = spec.offset ?? 0;
+  const span = spec.width ?? edge.length;
+  if (!Number.isFinite(offset) || offset < -1e-9) {
+    return err(validationError('INVALID_OFFSET', `contour flange '${spec.id}' offset must be non-negative`));
+  }
+  if (!Number.isFinite(span) || span <= 0) {
+    return err(validationError('INVALID_CONTOUR_WIDTH', `contour flange '${spec.id}' width must be positive`));
+  }
+  if (offset + span > edge.length + 1e-6) {
+    return err(
+      validationError('CONTOUR_OUT_OF_BOUNDS', `contour flange '${spec.id}' [${offset}, ${offset + span}] exceeds base edge length ${edge.length}`)
+    );
+  }
+
+  // The profile is swept across `span` along the base edge starting at `offset`.
+  const stripStart = vecAdd(edge.start, vecScale(edge.dir, offset));
+  let frame: SegmentFrame = {
+    origin: stripStart,
+    run: edge.out,
+    n: [0, 0, 1],
+    axis: edge.dir,
+  };
+
+  let solid: Solid = part.solid;
+  const bends: BendFeature[] = [];
+  const segments: ContourFlangeFeature['segments'] = [];
+  let devTotal = 0;
+  let arcIndex = 0;
+
+  for (let i = 0; i < spec.profile.length; i += 1) {
+    const seg = spec.profile[i];
+    if (seg === undefined) continue;
+    if (seg.kind === 'line') {
+      if (!Number.isFinite(seg.length) || seg.length <= 0) {
+        return err(validationError('INVALID_SEGMENT_LENGTH', `contour flange '${spec.id}' line segment ${i} length must be positive`));
+      }
+      const built = buildLineLeg(solid, frame, span, thickness, seg.length);
+      if (!built.ok) return built;
+      solid = built.value.solid;
+      frame = built.value.frame;
+      segments.push({ kind: 'line', dev: seg.length });
+      devTotal += seg.length;
+    } else {
+      const rule: BendRule = spec.rule ?? { innerRadius: seg.radius, kFactor: 0.44 };
+      const built = buildArcBend(solid, frame, span, thickness, seg);
+      if (!built.ok) return built;
+      solid = built.value.solid;
+      frame = built.value.frame;
+
+      const devResult = developedLength(seg.angleDeg, thickness, { ...rule, innerRadius: seg.radius });
+      if (!devResult.ok) return devResult;
+      const dev = devResult.value;
+
+      const bendId = `contour::${spec.id}::${arcIndex}`;
+      arcIndex += 1;
+      bends.push({
+        id: bendId,
+        axisOrigin: [built.value.axisOrigin[0], built.value.axisOrigin[1], built.value.axisOrigin[2]],
+        axisDir: [edge.dir[0], edge.dir[1], edge.dir[2]],
+        angleDeg: seg.angleDeg,
+        direction: seg.direction,
+        rule: { ...rule, innerRadius: seg.radius },
+      });
+      segments.push({ kind: 'arc', dev, angleDeg: seg.angleDeg, direction: seg.direction, bendId });
+      devTotal += dev;
+    }
+  }
+
+  const feature: ContourFlangeFeature = {
+    id: spec.id,
+    side: spec.side,
+    offset,
+    span,
+    developedLength: devTotal,
+    segments,
+  };
+
+  return ok({
+    ...part,
+    solid: normalizeSolid(solid),
+    bends: [...part.bends, ...bends],
+    contourFlanges: [...(part.contourFlanges ?? []), feature],
+  });
+}
+
+interface BuiltSegment {
+  solid: Solid;
+  frame: SegmentFrame;
+}
+
+interface BuiltArc extends BuiltSegment {
+  axisOrigin: Vec3;
+}
+
+/**
+ * Add one straight leg of `legLength` extending from `frame.origin` along
+ * `frame.run`, full thickness along `frame.n`, across `span` along `frame.axis`.
+ * The next segment's frame starts at the leg's far end.
+ */
+function buildLineLeg(
+  base: Solid,
+  frame: SegmentFrame,
+  span: number,
+  thickness: number,
+  legLength: number
+): Result<BuiltSegment> {
+  // Canonical box (legLength × span × thickness) at the origin, mapped onto the
+  // current segment frame: +X→run, +Y→axis, +Z→n.
+  const place = frameTransform(frame.run, frame.axis, frame.n, frame.origin);
+  const canon = box(legLength, span, thickness);
+  const placed = place.solid(canon);
+  const fused = fuse(base, placed);
+  if (!fused.ok) return fused;
+
+  const nextOrigin = vecAdd(frame.origin, vecScale(frame.run, legLength));
+  return ok({ solid: fused.value, frame: { ...frame, origin: nextOrigin } });
+}
+
+/**
+ * Add one cylindrical bend turning the running direction by `angleDeg`. Mirrors
+ * {@link authorPart}'s bend patch: a hollow tube (outer R+T, inner R) intersected
+ * with the fold wedge, in a canonical frame mapped onto the current segment frame.
+ * The returned frame's run/normal are rotated by the fold so the next leg continues
+ * tangentially.
+ */
+function buildArcBend(
+  base: Solid,
+  frame: SegmentFrame,
+  span: number,
+  thickness: number,
+  seg: Extract<ProfileSegment, { kind: 'arc' }>
+): Result<BuiltArc> {
+  const r = seg.radius;
+  if (!Number.isFinite(r) || r < 0) {
+    return err(validationError('INVALID_RADIUS', `contour arc radius must be non-negative, got ${r}`));
+  }
+  if (!Number.isFinite(seg.angleDeg) || seg.angleDeg <= 0 || seg.angleDeg > 180) {
+    return err(validationError('INVALID_ARC_ANGLE', `contour arc angleDeg must be in (0, 180], got ${seg.angleDeg}`));
+  }
+
+  const sign = seg.direction === 'up' ? 1 : -1;
+  // Canonical assembly (authorPart convention): bend axis +Y, run +X, top +Z, with
+  // the bend-axis centre line at z = T+r (up) / −r (down). The current segment frame
+  // maps +X→run, +Y→axis, +Z→n.
+  const canonAxisZ = sign > 0 ? thickness + r : -r;
+  const canonOrigin: Vec3 = [0, 0, canonAxisZ];
+  const place = frameTransform(frame.run, frame.axis, frame.n, frame.origin);
+
+  const patch = buildBendPatch(canonOrigin, seg.angleDeg, r, span, thickness, seg.direction);
+  if (!patch.ok) return patch;
+  const placed = place.solid(patch.value);
+  const fused = fuse(base, placed);
+  if (!fused.ok) return fused;
+
+  // Fold run/normal by ∓θ about the axis (authorPart: rotate −sign·θ about +Y).
+  const theta = (seg.angleDeg * Math.PI) / 180;
+  const a = -sign * theta;
+  const ca = Math.cos(a);
+  const sa = Math.sin(a);
+  // Canonical run +X folds to [ca, 0, −sa]; normal +Z to [sa, 0, ca].
+  const runC: Vec3 = [ca, 0, -sa];
+  const nC: Vec3 = [sa, 0, ca];
+  // The post-bend exit point in canonical coords: the near-bottom corner [0,0,0]
+  // rotated about the pivot [0,0,axisZ].
+  const dz = -canonAxisZ;
+  const cornerC: Vec3 = [dz * sa, 0, canonAxisZ + dz * ca];
+
+  const nextOrigin = place.point(cornerC);
+  const nextRun = place.vector(runC);
+  const nextN = place.vector(nC);
+  const axisOrigin = place.point(canonOrigin);
+
+  return ok({
+    solid: fused.value,
+    frame: { origin: nextOrigin, run: nextRun, n: nextN, axis: frame.axis },
+    axisOrigin,
+  });
+}
+
+interface PlacedTransform {
+  solid: (s: Solid) => Solid;
+  point: (p: Vec3) => Vec3;
+  vector: (v: Vec3) => Vec3;
+}
+
+/**
+ * Rigid map of a canonical assembly (run +X, axis +Y, normal +Z, contact at the
+ * origin) onto a world frame: align +X→`runT`, +Y→`axisT`, +Z→`nT`, then translate
+ * the origin to `origin`.
+ */
+function frameTransform(runT: Vec3, axisT: Vec3, nT: Vec3, origin: Vec3): PlacedTransform {
+  const m: number[] = [
+    runT[0], axisT[0], nT[0],
+    runT[1], axisT[1], nT[1],
+    runT[2], axisT[2], nT[2],
+  ];
+  const aa = matrixToAxisAngle(m);
+  const applyR = (v: Vec3): Vec3 =>
+    vecAdd(vecAdd(vecScale(runT, v[0]), vecScale(axisT, v[1])), vecScale(nT, v[2]));
+  return {
+    solid: (s: Solid) => {
+      const rotated = aa.angleDeg === 0 ? s : rotate(s, aa.angleDeg, { at: [0, 0, 0], axis: aa.axis });
+      return translate(rotated, origin);
+    },
+    point: (p: Vec3) => vecAdd(applyR(p), origin),
+    vector: applyR,
+  };
+}
+
+interface BaseEdge {
+  dir: Vec3;
+  out: Vec3;
+  start: Vec3;
+  length: number;
+}
+
+/** Resolve one of the four edges of the base flat (the contour-flange root). */
+function baseEdge(part: SheetMetalPart, side: FlatSide): BaseEdge {
+  const o: Vec3 = [0, 0, 0];
+  const u: Vec3 = [1, 0, 0];
+  const v: Vec3 = [0, 1, 0];
+  const n: Vec3 = [0, 0, 1];
+  const uLen = part.baseLength;
+  const vLen = part.width;
+
+  const uTop = vecAdd(o, vecScale(u, uLen));
+  const vTop = vecAdd(o, vecScale(v, vLen));
+  const uvTop = vecAdd(uTop, vecScale(v, vLen));
+
+  let out: Vec3;
+  let length: number;
+  let a: Vec3;
+  let b: Vec3;
+  switch (side) {
+    case 'xmax':
+      out = u;
+      length = vLen;
+      a = uTop;
+      b = uvTop;
+      break;
+    case 'xmin':
+      out = vecScale(u, -1);
+      length = vLen;
+      a = o;
+      b = vTop;
+      break;
+    case 'ymax':
+      out = v;
+      length = uLen;
+      a = vTop;
+      b = uvTop;
+      break;
+    case 'ymin':
+      out = vecScale(v, -1);
+      length = uLen;
+      a = o;
+      b = uTop;
+      break;
+  }
+  const dir = vecNormalize(vecCross(n, out));
+  const toB = vecSub(b, a);
+  const start = vecDot(toB, dir) >= 0 ? a : b;
+  return { dir, out, start, length };
+}
+
+/** Cylindrical bend patch (hollow tube ∩ fold wedge), mirroring authorFns. */
+function buildBendPatch(
+  axisOrigin: Vec3,
+  thetaDeg: number,
+  r: number,
+  width: number,
+  thickness: number,
+  direction: 'up' | 'down'
+): Result<ValidSolid> {
+  const outerR = r + thickness;
+  const outer = cylinder(outerR, width, { at: axisOrigin, axis: [0, 1, 0] });
+  let tube: Solid = outer;
+  if (r > 1e-9) {
+    const inner = cylinder(r, width, { at: axisOrigin, axis: [0, 1, 0] });
+    const carved = cut(outer, inner);
+    if (!carved.ok) return carved;
+    tube = carved.value;
+  }
+  const wedge = buildWedge(axisOrigin, thetaDeg, outerR, width, direction);
+  if (!wedge.ok) return wedge;
+  return intersect(tube, wedge.value) as Result<ValidSolid>;
+}
+
+function buildWedge(
+  axisOrigin: Vec3,
+  thetaDeg: number,
+  outerR: number,
+  width: number,
+  direction: 'up' | 'down'
+): Result<Solid> {
+  const span = outerR * 2 + 2;
+  const margin = 1;
+  const blockA = box(span, width + 2 * margin, 2 * span);
+  const halfA: Solid = translate(blockA, [axisOrigin[0], axisOrigin[1] - margin, axisOrigin[2] - span]);
+  const sign = direction === 'up' ? 1 : -1;
+  const halfB = rotate(halfA, sign * (180 - thetaDeg), { at: axisOrigin, axis: [0, 1, 0] });
+  return intersect(halfA, halfB);
+}
+
+/** Axis-angle of a 3×3 rotation matrix (row-major). */
+function matrixToAxisAngle(m: number[]): { axis: Vec3; angleDeg: number } {
+  const m00 = m[0] ?? 0;
+  const m01 = m[1] ?? 0;
+  const m02 = m[2] ?? 0;
+  const m10 = m[3] ?? 0;
+  const m11 = m[4] ?? 0;
+  const m12 = m[5] ?? 0;
+  const m20 = m[6] ?? 0;
+  const m21 = m[7] ?? 0;
+  const m22 = m[8] ?? 0;
+
+  const trace = m00 + m11 + m22;
+  const cos = Math.max(-1, Math.min(1, (trace - 1) / 2));
+  const angle = Math.acos(cos);
+  const angleDeg = (angle * 180) / Math.PI;
+  if (angle < 1e-9) return { axis: [0, 0, 1], angleDeg: 0 };
+
+  if (Math.PI - angle < 1e-6) {
+    const xx = (m00 + 1) / 2;
+    const yy = (m11 + 1) / 2;
+    const zz = (m22 + 1) / 2;
+    let axis: Vec3;
+    if (xx >= yy && xx >= zz) {
+      const x = Math.sqrt(Math.max(xx, 0));
+      axis = [x, (m01 + m10) / (4 * x), (m02 + m20) / (4 * x)];
+    } else if (yy >= zz) {
+      const y = Math.sqrt(Math.max(yy, 0));
+      axis = [(m01 + m10) / (4 * y), y, (m12 + m21) / (4 * y)];
+    } else {
+      const z = Math.sqrt(Math.max(zz, 0));
+      axis = [(m02 + m20) / (4 * z), (m12 + m21) / (4 * z), z];
+    }
+    return { axis: vecNormalize(axis), angleDeg: 180 };
+  }
+
+  const denom = 2 * Math.sin(angle);
+  const axis: Vec3 = [(m21 - m12) / denom, (m02 - m20) / denom, (m10 - m01) / denom];
+  return { axis: vecNormalize(axis), angleDeg };
+}

--- a/packages/brepjs-sheetmetal/src/dxfFns.ts
+++ b/packages/brepjs-sheetmetal/src/dxfFns.ts
@@ -138,6 +138,12 @@ function writeEntities(w: DxfWriter, outline: Pt2[], pattern: FlatPattern, textH
     writePolyline(w, loopPoints(hole), LAYER_CUTOUT);
   }
 
+  // Lofted/ruled transition developed boundaries: closed triangulated outlines on
+  // the OUTLINE layer (each a separate developed blank from the rectilinear outline).
+  for (const dev of pattern.loftedDevelopments) {
+    writePolyline(w, loopPoints(dev), LAYER_OUTLINE);
+  }
+
   // Form features: louver U-cuts are OPEN three-side cut paths (the hinge side is
   // left uncut and drawn separately below), emboss footprints are closed marker
   // polylines, louver hinge lines are LINEs — all on the FORM layer.

--- a/packages/brepjs-sheetmetal/src/facade.ts
+++ b/packages/brepjs-sheetmetal/src/facade.ts
@@ -31,6 +31,8 @@ import {
   tabAndSlot,
   louver,
   emboss,
+  contourFlange,
+  loftedFlange,
   toDXF,
   report,
   validate,
@@ -44,6 +46,8 @@ import type {
   ReliefSpec,
   CutoutSpec,
   TabSpec,
+  ContourFlangeSpec,
+  LoftedFlangeSpec,
   SheetMetalWarning,
   UnfoldResult,
 } from './types.js';
@@ -157,6 +161,16 @@ class SheetMetalPartHandle {
     kind: 'dimple' | 'emboss';
   }): SheetMetalPartHandle {
     return new SheetMetalPartHandle(unwrapOrThrow(emboss(this.part, opts)));
+  }
+
+  /** Author a contour flange (open line/arc profile swept along a base edge). */
+  contourFlange(spec: ContourFlangeSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(contourFlange(this.part, spec)));
+  }
+
+  /** Author a lofted / ruled transition flange between two parallel open profiles. */
+  loftedFlange(spec: LoftedFlangeSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(loftedFlange(this.part, spec)));
   }
 
   /** Flatten into a developed flat pattern + bend report + warnings. */
@@ -291,6 +305,14 @@ class SheetMetalBuilder {
     kind: 'dimple' | 'emboss';
   }): SheetMetalPartHandle {
     return this.build().emboss(opts);
+  }
+
+  contourFlange(spec: ContourFlangeSpec): SheetMetalPartHandle {
+    return this.build().contourFlange(spec);
+  }
+
+  loftedFlange(spec: LoftedFlangeSpec): SheetMetalPartHandle {
+    return this.build().loftedFlange(spec);
   }
 
   unfold(): UnfoldResult {

--- a/packages/brepjs-sheetmetal/src/featureTreeFns.ts
+++ b/packages/brepjs-sheetmetal/src/featureTreeFns.ts
@@ -77,6 +77,13 @@ export function buildFeatureGraph(part: SheetMetalPart): Result<FeatureGraph> {
     }
     seenBendIds.add(bend.id);
 
+    // A contour-flange bend (`contour::<flange>::<n>`) is one arc of a multi-bend
+    // contour flange. The contour flange records its own developed strip in
+    // `part.contourFlanges` and lays out independently of the bend spanning tree
+    // (its development is non-rectilinear, like a miter), so its bends never enter
+    // the graph — they would resolve to no flange flat and break the tree.
+    if (bend.id.startsWith('contour::')) continue;
+
     // A seam bend (`seam::<parent>::<child>`) is an explicit edge between two
     // already-authored flats — the cycle-closing edge of a tube/box profile.
     if (bend.id.startsWith('seam::')) {

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -49,6 +49,9 @@ export type { SlotPlacement } from './tabFns.js';
 
 export { addForm, louver, emboss } from './formFns.js';
 
+export { authorContourFlange } from './contourFlangeFns.js';
+export { authorLoftedFlange } from './loftedFlangeFns.js';
+
 export { flatPatternToDXF } from './dxfFns.js';
 export type { DxfOptions } from './dxfFns.js';
 
@@ -72,6 +75,8 @@ export {
   validate,
   allowance,
   developed,
+  contourFlange,
+  loftedFlange,
 } from './api.js';
 
 export { sheetMetal, fromPart, foldFlat, SheetMetalError, SheetMetalBuilder, SheetMetalPartHandle } from './facade.js';
@@ -93,6 +98,11 @@ export type {
   TabFeature,
   FormSpec,
   FormFeature,
+  ProfileSegment,
+  ContourFlangeSpec,
+  ContourFlangeFeature,
+  LoftedFlangeSpec,
+  LoftedFlangeFeature,
   SheetMetalPart,
   FlatPattern,
   FlatInput,

--- a/packages/brepjs-sheetmetal/src/loftedFlangeFns.ts
+++ b/packages/brepjs-sheetmetal/src/loftedFlangeFns.ts
@@ -1,0 +1,345 @@
+import {
+  type Result,
+  type Vec3,
+  type Wire,
+  type Solid,
+  ok,
+  err,
+  validationError,
+  line,
+  wireLoop,
+  extrude,
+  face,
+  fuse,
+  isPlanarWire,
+  isSolid,
+  getSolids,
+} from 'brepjs';
+import type { LoftedFlangeFeature, LoftedFlangeSpec, SheetMetalPart } from './types.js';
+
+type Pt2 = [number, number];
+
+/**
+ * Relative out-of-plane tolerance for the per-quad developability test: a quad is
+ * twisted (non-developable) when its far corner sits off the diagonal-triangle plane
+ * by more than this fraction of the quad's own size. Relative — not absolute — so a
+ * genuinely flat quad is not false-flagged on a large part (numerical noise scales
+ * with coordinates), nor a real twist missed on a tiny one.
+ */
+const DEVELOPABLE_REL_TOL = 1e-6;
+/** Floor on the size scale so a degenerate (near-zero-size) quad keeps a sane tolerance. */
+const DEVELOPABLE_MIN_SCALE = 1e-9;
+
+/**
+ * Author a lofted / ruled transition flange between two parallel OPEN profiles.
+ * The two profiles are lofted (ruled, straight generators) into a transition surface
+ * and thickened to a valid solid; the result is fused onto the part. The developed
+ * pattern is produced by TRIANGULATION (the standard transition development): each
+ * quad between consecutive vertex pairs is split into two triangles laid flat
+ * edge-length-preserving and accumulated into a developed boundary.
+ *
+ * The triangulated development is EXACT (to tolerance) when the ruled surface is
+ * developable — every quad is planar, so the two triangles share their diagonal in
+ * 3D and the flat layout preserves all lengths and angles. When a quad is non-planar
+ * (twisted ruling) the surface is not developable and the flat layout is an
+ * approximation; {@link approximate} is set and the unfold emits a
+ * `DEVELOPMENT_APPROXIMATE` warning.
+ */
+export function authorLoftedFlange(
+  part: SheetMetalPart,
+  spec: LoftedFlangeSpec
+): Result<SheetMetalPart> {
+  if (spec.id === '' || spec.id.includes('::')) {
+    return err(
+      validationError('INVALID_LOFTED_ID', `lofted flange id must be non-empty and must not contain '::', got '${spec.id}'`)
+    );
+  }
+  for (const existing of part.loftedFlanges ?? []) {
+    if (existing.id === spec.id) {
+      return err(validationError('DUPLICATE_LOFTED', `duplicate lofted flange id '${spec.id}'`));
+    }
+  }
+  if (spec.profileA.length < 2 || spec.profileB.length < 2) {
+    return err(
+      validationError('INVALID_LOFTED_PROFILE', `lofted flange '${spec.id}' profiles need ≥ 2 points each`)
+    );
+  }
+  if (spec.profileA.length !== spec.profileB.length) {
+    return err(
+      validationError('PROFILE_VERTEX_MISMATCH', `lofted flange '${spec.id}' profiles must have equal vertex counts (${spec.profileA.length} vs ${spec.profileB.length}) to pair into ruling triangles`)
+    );
+  }
+  if (!Number.isFinite(spec.height) || spec.height <= 0) {
+    return err(validationError('INVALID_LOFTED_HEIGHT', `lofted flange '${spec.id}' height must be positive, got ${spec.height}`));
+  }
+
+  const thickness = spec.thickness ?? part.thickness;
+  if (!Number.isFinite(thickness) || thickness <= 0) {
+    return err(validationError('INVALID_THICKNESS', `lofted flange '${spec.id}' thickness must be positive`));
+  }
+
+  // 3D profile points: profileA in the z=0 plane, profileB at z=height.
+  const a3: Vec3[] = spec.profileA.map(([x, y]) => [x, y, 0]);
+  const b3: Vec3[] = spec.profileB.map(([x, y]) => [x, y, spec.height]);
+
+  const solidResult = buildLoftedSolid(spec.id, a3, b3, thickness);
+  if (!solidResult.ok) return solidResult;
+
+  const dev = developRuled(a3, b3);
+  const loopResult = closedLoopWire(dev.loop);
+  if (!loopResult.ok) return loopResult;
+
+  const feature: LoftedFlangeFeature = {
+    id: spec.id,
+    developedLoop: dev.loop,
+    developedArea: dev.area,
+    approximate: dev.approximate,
+  };
+
+  // The lofted transition is an independent body fused to the part; like a contour
+  // flange it carries no straight-bend tree entry (its development is the
+  // triangulated loop, not a rectilinear strip).
+  if (part.solid === undefined) {
+    return ok({
+      ...part,
+      solid: solidResult.value,
+      loftedFlanges: [...(part.loftedFlanges ?? []), feature],
+    });
+  }
+  const fused = fuse(part.solid, solidResult.value);
+  if (!fused.ok) return fused;
+
+  return ok({
+    ...part,
+    solid: normalize(fused.value),
+    loftedFlanges: [...(part.loftedFlanges ?? []), feature],
+  });
+}
+
+function normalize(shape: Solid): Solid {
+  if (isSolid(shape)) return shape;
+  const solids = getSolids(shape);
+  return solids.length === 1 ? (solids[0] as Solid) : shape;
+}
+
+/**
+ * Build the thickened ruled transition solid as the union of per-quad plates. Each
+ * quad of the ruled surface is triangulated and each triangle extruded by
+ * `thickness` along its own normal, then all plates are fused. This per-triangle
+ * construction is robust on OCCT-WASM for both planar (developable) and twisted
+ * (non-developable) transitions, where a single lofted-then-shelled surface can fail
+ * to sew.
+ */
+function buildLoftedSolid(id: string, a: Vec3[], b: Vec3[], thickness: number): Result<Solid> {
+  let solid: Solid | undefined;
+  for (let i = 0; i + 1 < a.length; i += 1) {
+    const a0 = a[i];
+    const a1 = a[i + 1];
+    const b0 = b[i];
+    const b1 = b[i + 1];
+    if (a0 === undefined || a1 === undefined || b0 === undefined || b1 === undefined) {
+      return err(validationError('LOFTED_QUAD_FAILED', `lofted flange '${id}' failed to index quad ${i}`));
+    }
+    const plate = buildQuadPlate(id, a0, a1, b1, b0, thickness);
+    if (!plate.ok) return plate;
+    if (solid === undefined) {
+      solid = plate.value;
+    } else {
+      const fused = fuse(solid, plate.value);
+      if (!fused.ok) return fused;
+      solid = normalize(fused.value);
+    }
+  }
+  if (solid === undefined) {
+    return err(validationError('LOFTED_EMPTY', `lofted flange '${id}' produced no quads`));
+  }
+  return ok(solid);
+}
+
+/**
+ * One quad of the ruled surface (corners a0→a1→b1→b0), thickened into a plate. The
+ * quad is split along its a0–b1 diagonal into two triangles lofted to the same
+ * triangles offset by `thickness` along the quad normal — robust on a non-planar
+ * (twisted) quad where a single planar face would fail. We loft each triangle face
+ * pair; for the common planar quad this is exact, for a twisted quad it is the
+ * faceted plate matching the triangulated development.
+ */
+function buildQuadPlate(id: string, a0: Vec3, a1: Vec3, b1: Vec3, b0: Vec3, thickness: number): Result<Solid> {
+  const t1 = buildTrianglePlate(id, a0, a1, b1, thickness);
+  if (!t1.ok) return t1;
+  const t2 = buildTrianglePlate(id, a0, b1, b0, thickness);
+  if (!t2.ok) return t2;
+  const fused = fuse(t1.value, t2.value);
+  if (!fused.ok) return fused;
+  return ok(normalize(fused.value));
+}
+
+/** A flat triangle (p0,p1,p2) extruded by `thickness` along its own normal. */
+function buildTrianglePlate(id: string, p0: Vec3, p1: Vec3, p2: Vec3, thickness: number): Result<Solid> {
+  const e0 = line(p0, p1);
+  const e1 = line(p1, p2);
+  const e2 = line(p2, p0);
+  const loopResult = wireLoop([e0, e1, e2]);
+  if (!loopResult.ok) return loopResult;
+  const loop = loopResult.value;
+  if (!isPlanarWire(loop)) {
+    return err(validationError('LOFTED_TRIANGLE_NONPLANAR', `lofted flange '${id}' triangle is not planar`));
+  }
+  const faceResult = face(loop);
+  if (!faceResult.ok) return faceResult;
+  const n = triangleNormal(p0, p1, p2);
+  const dir: Vec3 = [n[0] * thickness, n[1] * thickness, n[2] * thickness];
+  const extruded = extrude(faceResult.value, dir);
+  if (!extruded.ok) return extruded;
+  return ok(normalize(extruded.value));
+}
+
+function triangleNormal(p0: Vec3, p1: Vec3, p2: Vec3): Vec3 {
+  const u: Vec3 = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+  const v: Vec3 = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+  const c: Vec3 = [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
+  const len = Math.hypot(c[0], c[1], c[2]) || 1;
+  return [c[0] / len, c[1] / len, c[2] / len];
+}
+
+interface Development {
+  loop: Pt2[];
+  area: number;
+  approximate: boolean;
+}
+
+/**
+ * Triangulated development of a ruled transition between two equal-length vertex
+ * lists `a` (z=0) and `b` (z=height). Each quad (a[i],a[i+1],b[i+1],b[i]) is split
+ * along the a[i]–b[i+1] diagonal into two triangles; the triangles are laid out
+ * flat one strip at a time, hinging each new triangle onto the previously-placed
+ * shared edge with its true 3D edge lengths preserved. The developed boundary is the
+ * `a` chain laid along the bottom and the `b` chain returning along the top.
+ *
+ * Developable check: a quad is developable iff its two triangles, sharing the
+ * diagonal, are coplanar — equivalently the far corner b[i] lies in the plane of
+ * (a[i],a[i+1],b[i+1]). Any quad failing this within tolerance flags the whole
+ * development approximate.
+ */
+function developRuled(a: Vec3[], b: Vec3[]): Development {
+  const aFlat: Pt2[] = [];
+  const bFlat: Pt2[] = [];
+  let area = 0;
+  let approximate = false;
+
+  // Place the first ruling (a[0]–b[0]) vertically: a[0] at origin, b[0] straight up
+  // by its true 3D length, so the developed strip grows along +x.
+  const d0 = dist(a[0] as Vec3, b[0] as Vec3);
+  let aPrev: Pt2 = [0, 0];
+  let bPrev: Pt2 = [0, d0];
+  aFlat.push(aPrev);
+  bFlat.push(bPrev);
+
+  for (let i = 0; i + 1 < a.length; i += 1) {
+    const A0 = a[i] as Vec3;
+    const A1 = a[i + 1] as Vec3;
+    const B0 = b[i] as Vec3;
+    const B1 = b[i + 1] as Vec3;
+
+    // True 3D edge lengths of this quad. Diagonal A0–B1 splits it into
+    // T1=(A0,A1,B1) and T2=(A0,B1,B0).
+    const lBottom = dist(A0, A1); // A0→A1
+    const lTop = dist(B0, B1); // B0→B1
+    const lDiag = dist(A0, B1); // shared diagonal A0→B1
+    const lRight = dist(A1, B1); // right ruling A1→B1 (= next quad's left ruling)
+
+    // Developable test: is B0 coplanar with (A0, A1, B1)? If not, the quad is
+    // twisted and the flat layout cannot preserve all edges — mark approximate.
+    // Tolerance is relative to the quad's size so the check is scale-invariant.
+    const scale = Math.max(lBottom, lTop, lDiag, lRight, DEVELOPABLE_MIN_SCALE);
+    if (planeDistance(A0, A1, B1, B0) > DEVELOPABLE_REL_TOL * scale) approximate = true;
+
+    // Place B1 from the known A0(=aPrev, dist=lDiag) and B0(=bPrev, dist=lTop).
+    const b1Flat = placeFrom(aPrev, bPrev, lDiag, lTop);
+    // Place A1 from A0(=aPrev, dist=lBottom) and the just-placed B1(dist=lRight),
+    // preserving the right ruling so it equals the next quad's left ruling exactly.
+    const a1Flat = placeFrom(aPrev, b1Flat, lBottom, lRight);
+
+    aFlat.push(a1Flat);
+    bFlat.push(b1Flat);
+
+    area += triArea3(A0, A1, B1) + triArea3(A0, B1, B0);
+    aPrev = a1Flat;
+    bPrev = b1Flat;
+  }
+
+  // Developed boundary: a-chain forward, b-chain back.
+  const loop: Pt2[] = [...aFlat, ...[...bFlat].reverse()];
+  return { loop, area, approximate };
+}
+
+/**
+ * Place a new point at distance `r1` from `p1` and `r2` from `p2` in 2D, choosing
+ * the solution on the +x side of the directed line p1→p2 (the strip grows toward +x,
+ * so successive rulings advance rightward). Falls back to the midpoint if the circles
+ * do not intersect (degenerate strip).
+ */
+function placeFrom(p1: Pt2, p2: Pt2, r1: number, r2: number): Pt2 {
+  const dx = p2[0] - p1[0];
+  const dy = p2[1] - p1[1];
+  const d = Math.hypot(dx, dy);
+  if (d < 1e-12) return [p1[0] + r1, p1[1]];
+  const a = (r1 * r1 - r2 * r2 + d * d) / (2 * d);
+  const h2 = r1 * r1 - a * a;
+  const h = h2 > 0 ? Math.sqrt(h2) : 0;
+  const mx = p1[0] + (a * dx) / d;
+  const my = p1[1] + (a * dy) / d;
+  // Perpendicular toward +x: pick the offset whose x is larger.
+  const ox = (-dy / d) * h;
+  const oy = (dx / d) * h;
+  const s1: Pt2 = [mx + ox, my + oy];
+  const s2: Pt2 = [mx - ox, my - oy];
+  return s1[0] >= s2[0] ? s1 : s2;
+}
+
+function dist(p: Vec3, q: Vec3): number {
+  return Math.hypot(p[0] - q[0], p[1] - q[1], p[2] - q[2]);
+}
+
+function triArea3(p0: Vec3, p1: Vec3, p2: Vec3): number {
+  const u: Vec3 = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+  const v: Vec3 = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+  const c: Vec3 = [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
+  return Math.hypot(c[0], c[1], c[2]) / 2;
+}
+
+/** Perpendicular distance of `q` from the plane through (p0,p1,p2). */
+function planeDistance(p0: Vec3, p1: Vec3, p2: Vec3, q: Vec3): number {
+  const u: Vec3 = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+  const v: Vec3 = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+  const c: Vec3 = [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
+  const len = Math.hypot(c[0], c[1], c[2]);
+  if (len < 1e-12) return 0;
+  const w: Vec3 = [q[0] - p0[0], q[1] - p0[1], q[2] - p0[2]];
+  return Math.abs((w[0] * c[0] + w[1] * c[1] + w[2] * c[2]) / len);
+}
+
+/** Trace a closed developed-plane loop (≥ 3 points) into a brepjs {@link Wire}. */
+function closedLoopWire(loop: Pt2[]): Result<Wire> {
+  const deduped: Pt2[] = [];
+  for (const p of loop) {
+    const last = deduped[deduped.length - 1];
+    if (last === undefined || Math.hypot(p[0] - last[0], p[1] - last[1]) > 1e-9) deduped.push(p);
+  }
+  // Drop a trailing point coincident with the first (the loop closes implicitly).
+  if (deduped.length > 1) {
+    const first = deduped[0] as Pt2;
+    const last = deduped[deduped.length - 1] as Pt2;
+    if (Math.hypot(first[0] - last[0], first[1] - last[1]) < 1e-9) deduped.pop();
+  }
+  if (deduped.length < 3) {
+    return err(validationError('LOFTED_LOOP_TOO_SMALL', `developed loop has ${deduped.length} points, need ≥ 3`));
+  }
+  const edges = [];
+  for (let i = 0; i < deduped.length; i += 1) {
+    const p = deduped[i] as Pt2;
+    const next = deduped[(i + 1) % deduped.length] as Pt2;
+    edges.push(line([p[0], p[1], 0], [next[0], next[1], 0]));
+  }
+  return wireLoop(edges);
+}

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -251,6 +251,98 @@ export interface FormFeature {
   hinge?: [[number, number], [number, number]] | undefined;
 }
 
+/**
+ * One segment of a contour-flange profile: an open 2D polyline of straight `line`
+ * runs joined by circular-`arc` bends, swept along a straight base edge. A `line`
+ * is a flat leg of `length`; an `arc` is a bend of `radius` turning `angleDeg`
+ * either `up` (toward the parent normal) or `down`. Each arc becomes a recorded
+ * {@link BendFeature}; each line a flat leg of the developed strip.
+ */
+export type ProfileSegment =
+  | { kind: 'line'; length: number }
+  | { kind: 'arc'; radius: number; angleDeg: number; direction: 'up' | 'down' };
+
+/**
+ * A contour flange: an OPEN 2D profile (alternating line/arc {@link ProfileSegment}s)
+ * swept along a straight edge of the base flat (`side`). Unlike a plain flange (one
+ * bend + one flat) this chains an arbitrary multi-bend cross-section — a return, a
+ * hat/top-hat, a J — in one feature. The development is EXACT: the developed strip
+ * length is the sum of each segment's developed length (lines: `length`; arcs: the
+ * canonical {@link bendAllowance}).
+ */
+export interface ContourFlangeSpec {
+  id: string;
+  side: FlatSide;
+  profile: ProfileSegment[];
+  rule?: BendRule | undefined;
+  /** Extent along the base edge (the bend-axis width). Default = full edge length. */
+  width?: number | undefined;
+  /** Start position along the base edge. Default `0`. */
+  offset?: number | undefined;
+}
+
+/**
+ * A recorded contour flange, mirroring {@link FlangeFeature}: enough for the unfold
+ * to lay the developed strip out straight along the base edge without re-deriving
+ * the 3D geometry. `segments` carries each developed segment in order (a flat leg or
+ * a developed bend arc); `developedLength` is their exact sum (the strip length out
+ * from the base edge); `span`/`offset` locate the strip along the base edge.
+ */
+export interface ContourFlangeFeature {
+  id: string;
+  side: FlatSide;
+  /** Start position along the base edge. */
+  offset: number;
+  /** Extent along the base edge (the developed strip width). */
+  span: number;
+  /** Exact developed length out from the base edge (Σ segment developed lengths). */
+  developedLength: number;
+  segments: {
+    kind: 'line' | 'arc';
+    /** Developed length of this segment along the strip. */
+    dev: number;
+    angleDeg?: number | undefined;
+    direction?: 'up' | 'down' | undefined;
+    /** Id of the recorded {@link BendFeature} for an arc segment. */
+    bendId?: string | undefined;
+  }[];
+}
+
+/**
+ * A lofted / ruled transition flange: a ruled surface lofted between two parallel
+ * OPEN profiles (`profileA`, `profileB`) separated by `height` along +Z, thickened
+ * to a valid solid. The development is by TRIANGULATION — the standard sheet-metal
+ * transition development pairing profile vertices into triangles laid flat
+ * preserving edge lengths. Exact to tolerance for a genuinely developable (single-
+ * curvature, straight-generator) transition; an approximation otherwise, in which
+ * case the unfold emits a {@link SheetMetalWarning} `DEVELOPMENT_APPROXIMATE`.
+ */
+export interface LoftedFlangeSpec {
+  id: string;
+  /** Open polyline of the near profile, in the base plane (z = 0). */
+  profileA: [number, number][];
+  /** Open polyline of the far profile (its z is `height`). */
+  profileB: [number, number][];
+  height: number;
+  thickness?: number | undefined;
+}
+
+/**
+ * A recorded lofted flange, mirroring {@link ContourFlangeFeature}. `developedLoop`
+ * is the triangulated flat boundary (a closed developed-plane polygon); `developedArea`
+ * the summed triangle areas; `approximate` flags a non-developable transition the
+ * triangulated development only approximates (the unfold emits the warning).
+ */
+export interface LoftedFlangeFeature {
+  id: string;
+  /** Triangulated developed boundary `[x, y]` (closed) in the developed plane. */
+  developedLoop: [number, number][];
+  /** Summed area of the triangulated development. */
+  developedArea: number;
+  /** True when the transition is not developable; the development is an approximation. */
+  approximate: boolean;
+}
+
 export interface SheetMetalPart {
   thickness: number;
   /** Base flat extent along +X (x∈[0, baseLength]); the east-run length. */
@@ -266,6 +358,8 @@ export interface SheetMetalPart {
   cutouts?: CutoutFeature[] | undefined;
   tabs?: TabFeature[] | undefined;
   forms?: FormFeature[] | undefined;
+  contourFlanges?: ContourFlangeFeature[] | undefined;
+  loftedFlanges?: LoftedFlangeFeature[] | undefined;
 }
 
 export interface FlatPattern {
@@ -288,6 +382,13 @@ export interface FlatPattern {
   formMarkers: Wire[];
   /** Form hinge lines (louver fold lines) for annotation, as edges. */
   formHinges: Edge[];
+  /**
+   * Lofted/ruled transition developed boundaries, as closed wires in the developed
+   * plane (one per recorded {@link LoftedFlangeFeature}). The outline laid out by the
+   * rectilinear union covers the base + straight flanges; a ruled transition's
+   * triangulated development is non-rectilinear and rides here instead.
+   */
+  loftedDevelopments: Wire[];
   developedArea: number;
 }
 
@@ -304,7 +405,13 @@ export interface BendReport {
 }
 
 export type SheetMetalWarning = {
-  code: 'COLLISION' | 'SEAM_CUT' | 'MIN_RADIUS' | 'INVALID_SOLID' | 'MITER_NOT_DEVELOPED';
+  code:
+    | 'COLLISION'
+    | 'SEAM_CUT'
+    | 'MIN_RADIUS'
+    | 'INVALID_SOLID'
+    | 'MITER_NOT_DEVELOPED'
+    | 'DEVELOPMENT_APPROXIMATE';
   message: string;
   featureId?: string | undefined;
 };

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -68,9 +68,15 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
     }
   }
 
+  // Contour-flange developed strips lay out straight along their base edge; compute
+  // them first so their rectangles join the outline union below.
+  const contourResult = buildContourDevelopments(part);
+  if (!contourResult.ok) return contourResult;
+
   const rects: Rect[] = [];
   for (const placed of layout.flats) rects.push(placed.rect);
   for (const strip of layout.strips) rects.push(strip);
+  for (const strip of contourResult.value.strips) rects.push(strip);
 
   // Tabs are additive protrusions: their developed rectangles join the outer-outline
   // union and add to the developed area.
@@ -102,6 +108,23 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   const formsResult = buildForms(part);
   if (!formsResult.ok) return formsResult;
 
+  const loftedResult = buildLoftedDevelopments(part);
+  if (!loftedResult.ok) return loftedResult;
+  for (const lf of part.loftedFlanges ?? []) {
+    layout.developedArea += lf.developedArea;
+    if (lf.approximate) {
+      warnings.push({
+        code: 'DEVELOPMENT_APPROXIMATE',
+        message: `lofted flange '${lf.id}' transition is not developable; its triangulated flat development is an approximation`,
+        featureId: lf.id,
+      });
+    }
+  }
+
+  for (const cf of part.contourFlanges ?? []) {
+    layout.developedArea += cf.developedLength * cf.span;
+  }
+
   const bendLines = layout.flats
     .filter((p): p is PlacedFlange => p.kind === 'flange')
     .map((p) => ({
@@ -112,7 +135,8 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
       // The child frame's v axis is the develop-out direction; into-parent is its
       // negation. Correct for chained flanges too (it is local to the placement).
       inward: [-p.frame.v[0], -p.frame.v[1]] as [number, number],
-    }));
+    }))
+    .concat(contourResult.value.bendLines);
 
   const pattern: FlatPattern = {
     outline: outlineResult.value,
@@ -121,6 +145,7 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
     formCuts: formsResult.value.cuts,
     formMarkers: formsResult.value.markers,
     formHinges: formsResult.value.hinges,
+    loftedDevelopments: loftedResult.value,
     developedArea: layout.developedArea,
   };
 
@@ -401,6 +426,74 @@ function buildForms(part: SheetMetalPart): Result<FormWires> {
     }
   }
   return ok({ cuts, markers, hinges });
+}
+
+/**
+ * Closed developed-plane {@link Wire}s for recorded lofted/ruled transition flanges.
+ * Each feature's triangulated `developedLoop` was already laid out flat when the
+ * flange was authored, so this just traces it into a wire; the boundary is non-
+ * rectilinear so it rides separately from the rectilinear-union outline.
+ */
+function buildLoftedDevelopments(part: SheetMetalPart): Result<Wire[]> {
+  const wires: Wire[] = [];
+  for (const lf of part.loftedFlanges ?? []) {
+    const w = closedLoopWire(lf.developedLoop);
+    if (!w.ok) return w;
+    wires.push(w.value);
+  }
+  return ok(wires);
+}
+
+interface ContourDevelopments {
+  /** Developed strip rectangles (one per contour flange) for the outline union. */
+  strips: Rect[];
+  /** Developed bend lines (one per arc segment) in the flat pattern. */
+  bendLines: FlatPattern['bendLines'];
+}
+
+/**
+ * Lay each recorded contour flange's developed strip out STRAIGHT along its base
+ * edge: a rectangle `span` wide along the edge by `developedLength` out from it,
+ * returned for the outer-outline union. One bend line per arc segment is placed at
+ * that segment's cumulative developed offset out from the base edge — the EXACT
+ * arc-length sum, so the strip length equals Σ segment developed lengths with no
+ * error.
+ */
+function buildContourDevelopments(part: SheetMetalPart): Result<ContourDevelopments> {
+  const strips: Rect[] = [];
+  const bendLines: FlatPattern['bendLines'] = [];
+  const baseFrame: Frame2 = {
+    origin: [0, 0],
+    u: [1, 0],
+    v: [0, 1],
+    uLen: part.baseLength,
+    vLen: part.width,
+  };
+
+  for (const cf of part.contourFlanges ?? []) {
+    const { along, out, edgeOrigin } = edgeBasis2(baseFrame, cf.side);
+    const base = add2(edgeOrigin, scale2(along, cf.offset));
+    strips.push(
+      rectFromCorners(base, add2(add2(base, scale2(along, cf.span)), scale2(out, cf.developedLength)))
+    );
+
+    let cumulative = 0;
+    for (const seg of cf.segments) {
+      if (seg.kind === 'arc') {
+        const a = add2(base, scale2(out, cumulative));
+        const b = add2(a, scale2(along, cf.span));
+        bendLines.push({
+          id: seg.bendId ?? cf.id,
+          line: line([a[0], a[1], 0], [b[0], b[1], 0]),
+          angleDeg: seg.angleDeg ?? 0,
+          direction: seg.direction ?? 'up',
+          inward: [-out[0], -out[1]] as [number, number],
+        });
+      }
+      cumulative += seg.dev;
+    }
+  }
+  return ok({ strips, bendLines });
 }
 
 /** Trace a closed developed-plane loop (≥ 3 points) into a brepjs {@link Wire}. */

--- a/packages/brepjs-sheetmetal/tests/contourloft.test.ts
+++ b/packages/brepjs-sheetmetal/tests/contourloft.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume, isValid, isSolid, getSolids, getEdges } from 'brepjs';
+import { authorPart } from '../src/authorFns.js';
+import { authorContourFlange } from '../src/contourFlangeFns.js';
+import { authorLoftedFlange } from '../src/loftedFlangeFns.js';
+import { unfold } from '../src/unfoldFns.js';
+import { developedLength } from '../src/allowanceFns.js';
+import type { BendRule, ProfileSegment, SheetMetalPart } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const T = 1;
+const rule: BendRule = { innerRadius: 2, kFactor: 0.44 };
+
+function singleSolid(part: SheetMetalPart): boolean {
+  const s = part.solid;
+  if (s === undefined) return false;
+  if (isSolid(s)) return true;
+  return getSolids(s).length === 1;
+}
+
+describe('contour flange — exact development', () => {
+  it('lays the developed strip length as the exact sum of segment developed lengths', () => {
+    const base = authorPart({ thickness: T, base: { length: 50, width: 30 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+
+    // A return / hat-style profile: flat → 90° arc → flat → 90° arc → flat.
+    const profile: ProfileSegment[] = [
+      { kind: 'line', length: 8 },
+      { kind: 'arc', radius: 2, angleDeg: 90, direction: 'up' },
+      { kind: 'line', length: 12 },
+      { kind: 'arc', radius: 2, angleDeg: 90, direction: 'up' },
+      { kind: 'line', length: 8 },
+    ];
+
+    const cf = authorContourFlange(base.value, { id: 'hat', side: 'xmax', profile, rule });
+    expect(cf.ok).toBe(true);
+    if (!cf.ok) return;
+    const part = cf.value;
+
+    expect(singleSolid(part)).toBe(true);
+    if (part.solid !== undefined) expect(isValid(part.solid)).toBe(true);
+
+    // #bends == #arc segments.
+    const arcCount = profile.filter((s) => s.kind === 'arc').length;
+    expect(part.contourFlanges?.[0]?.segments.filter((s) => s.kind === 'arc').length).toBe(arcCount);
+    expect(part.bends.filter((b) => b.id.startsWith('contour::')).length).toBe(arcCount);
+
+    // Exact developed length = Σ line lengths + Σ arc developed lengths.
+    const arc1 = developedLength(90, T, rule);
+    const arc2 = developedLength(90, T, rule);
+    expect(arc1.ok && arc2.ok).toBe(true);
+    if (!arc1.ok || !arc2.ok) return;
+    const expectedDev = 8 + arc1.value + 12 + arc2.value + 8;
+    expect(part.contourFlanges?.[0]?.developedLength).toBeCloseTo(expectedDev, 9);
+
+    // The unfold lays the strip out straight: its developed strip length is exact.
+    const unfolded = unfold(part);
+    expect(unfolded.ok).toBe(true);
+    if (!unfolded.ok) return;
+    // One bend line per arc on the contour strip, plus none from flanges (no flanges).
+    expect(unfolded.value.pattern.bendLines.length).toBe(arcCount);
+  });
+
+  it('rejects an out-of-bounds contour flange', () => {
+    const base = authorPart({ thickness: T, base: { length: 50, width: 30 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+    const cf = authorContourFlange(base.value, {
+      id: 'over',
+      side: 'xmax',
+      profile: [{ kind: 'line', length: 5 }],
+      offset: 10,
+      width: 40,
+    });
+    expect(cf.ok).toBe(false);
+  });
+
+  it('rejects an empty profile', () => {
+    const base = authorPart({ thickness: T, base: { length: 50, width: 30 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+    const cf = authorContourFlange(base.value, { id: 'empty', side: 'xmax', profile: [] });
+    expect(cf.ok).toBe(false);
+  });
+});
+
+describe('lofted flange — triangulated development', () => {
+  it('builds a valid single solid for a developable trapezoidal transition', () => {
+    const base = authorPart({ thickness: T, base: { length: 60, width: 40 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+
+    // Symmetric trapezoid: bottom edge wider than top, both centered — a developable
+    // truncated-wedge ruled transition (planar quads).
+    const height = 20;
+    const lf = authorLoftedFlange(base.value, {
+      id: 'chute',
+      profileA: [
+        [0, 0],
+        [40, 0],
+      ],
+      profileB: [
+        [10, 0],
+        [30, 0],
+      ],
+      height,
+      thickness: T,
+    });
+    expect(lf.ok).toBe(true);
+    if (!lf.ok) return;
+    const part = lf.value;
+    expect(singleSolid(part)).toBe(true);
+
+    const feature = part.loftedFlanges?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+    expect(feature.approximate).toBe(false);
+
+    // Analytic ruled-surface area of the trapezoidal transition (a single planar
+    // trapezoid here: parallel edges 40 and 20, slant height = height since profiles
+    // are symmetric in x with the same y). Area = (a + b)/2 * h.
+    const slant = height; // both edges at y=0, perpendicular separation along z
+    const analyticArea = ((40 + 20) / 2) * slant;
+    expect(feature.developedArea).toBeCloseTo(analyticArea, 3);
+
+    // For a developable transition the flat layout preserves area exactly: the
+    // shoelace area of the developed loop equals the analytic 3D surface area.
+    const loop = feature.developedLoop;
+    let shoelace = 0;
+    for (let i = 0; i < loop.length; i += 1) {
+      const p = loop[i];
+      const q = loop[(i + 1) % loop.length];
+      if (p === undefined || q === undefined) continue;
+      shoelace += p[0] * q[1] - q[0] * p[1];
+    }
+    expect(Math.abs(shoelace) / 2).toBeCloseTo(analyticArea, 3);
+
+    // The developed loop is a valid closed wire (≥ 3 edges).
+    const unfolded = unfold(part);
+    expect(unfolded.ok).toBe(true);
+    if (!unfolded.ok) return;
+    expect(unfolded.value.pattern.loftedDevelopments.length).toBe(1);
+    const devWire = unfolded.value.pattern.loftedDevelopments[0];
+    expect(devWire).toBeDefined();
+    if (devWire === undefined) return;
+    expect(getEdges(devWire).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('keeps a large-scale developable transition exact (scale-invariant developability)', () => {
+    const base = authorPart({ thickness: T, base: { length: 4000, width: 2000 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+
+    // Same developable trapezoid as above but scaled up 100×. With an absolute
+    // out-of-plane tolerance, numerical noise at these coordinates could false-flag
+    // the planar quad as approximate; the relative tolerance must keep it exact.
+    const height = 2000;
+    const lf = authorLoftedFlange(base.value, {
+      id: 'bigchute',
+      profileA: [
+        [0, 0],
+        [4000, 0],
+      ],
+      profileB: [
+        [1000, 0],
+        [3000, 0],
+      ],
+      height,
+      thickness: T,
+    });
+    expect(lf.ok).toBe(true);
+    if (!lf.ok) return;
+    const feature = lf.value.loftedFlanges?.[0];
+    expect(feature?.approximate).toBe(false);
+
+    const analyticArea = ((4000 + 2000) / 2) * height;
+    expect(feature?.developedArea).toBeCloseTo(analyticArea, 0);
+  });
+
+  it('emits DEVELOPMENT_APPROXIMATE for a non-developable transition', () => {
+    const base = authorPart({ thickness: T, base: { length: 60, width: 40 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+
+    // A square-to-rotated transition is non-developable: rulings twist between the
+    // two profiles (a classic square-to-square 45°-rotated hopper segment).
+    const lf = authorLoftedFlange(base.value, {
+      id: 'twist',
+      profileA: [
+        [0, 0],
+        [20, 0],
+        [20, 20],
+      ],
+      profileB: [
+        [10, -7],
+        [27, 10],
+        [10, 27],
+      ],
+      height: 25,
+      thickness: T,
+    });
+    expect(lf.ok).toBe(true);
+    if (!lf.ok) return;
+    const part = lf.value;
+    expect(part.loftedFlanges?.[0]?.approximate).toBe(true);
+
+    const unfolded = unfold(part);
+    expect(unfolded.ok).toBe(true);
+    if (!unfolded.ok) return;
+    expect(unfolded.value.warnings.some((w) => w.code === 'DEVELOPMENT_APPROXIMATE')).toBe(true);
+
+    // Even an approximate transition must still produce a valid measurable solid.
+    if (part.solid !== undefined) {
+      const vol = measureVolume(part.solid);
+      expect(vol.ok).toBe(true);
+      if (vol.ok) expect(vol.value).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects mismatched profile vertex counts', () => {
+    const base = authorPart({ thickness: T, base: { length: 60, width: 40 }, flanges: [] });
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+    const lf = authorLoftedFlange(base.value, {
+      id: 'bad',
+      profileA: [
+        [0, 0],
+        [10, 0],
+      ],
+      profileB: [
+        [0, 0],
+        [5, 0],
+        [10, 0],
+      ],
+      height: 10,
+    });
+    expect(lf.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 2 · PR6 of a stacked sequence

Extends the domain past straight cylindrical bends to **profile-defined** and **ruled-transition** flanges — the geometry-heaviest PR.

### What's new
- **Contour flange** (`authorContourFlange`): a flange built from an open 2D profile (lines + circular arcs) swept along a base edge. Each arc is a recorded bend; frames chain tangentially like multi-bend flanges. The developed strip length is **exact** — `Σ(line length + arc developedLength)` — laid out straight with one bend line per arc at its cumulative arc-length offset.
- **Lofted / ruled transition flange** (`authorLoftedFlange`): a ruled transition between two open profiles, built as fused extruded triangle plates (robust on OCCT-WASM for twisted quads). Development is by **triangulation** preserving true edge lengths.

### Honesty about developability
This is where sheet metal stops being exactly unfoldable. The triangulated development is **exact for developable quads** (verified: a trapezoidal transition's developed area equals the analytic ruled-surface area, 600 mm²) and a controlled approximation otherwise — in which case `unfold` emits a `DEVELOPMENT_APPROXIMATE` warning inside the Ok payload. The developable test uses a **scale-invariant relative tolerance** so a small twist can't be silently developed as exact. No feature claims more than it does.

### Design
- `ProfileSegment`, `ContourFlangeSpec`/`Feature`, `LoftedFlangeSpec`/`Feature`; `FlatPattern.loftedDevelopments`; `SheetMetalPart.contourFlanges?`/`loftedFlanges?`; `DEVELOPMENT_APPROXIMATE` code.
- `featureTreeFns` skips `contour::` bends (they develop independently, like `seam::`). Surfaced in `unfold`/`dxfFns`/`api`/`facade`/`index`.
- Contour/lofted developments are non-rectilinear, so (like miters/tabs) they ride as recorded features outside the strict outline round-trip oracle; verification leans on exact developed-length/area invariants + validity.

### Verification
- typecheck / lint / build clean; **161 tests** (154 prior + 7 new) green against occt-wasm; snapshot adds `contour-flange` (top-hat profile) + `lofted-chute` demos.
- Built via a multi-agent Workflow (implement → adversarial review → fix); review verified no fake features and the fix made the developability tolerance scale-invariant.

### Stack
PR1–PR5 merged (#1177, #1180, #1182, #1184, #1186). Remaining: foreign-solid import & unfold (the lone kernel-touching PR). OCCT-WASM-first.