### PR TITLE
chore: add GitHub Sponsors funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: andymai


### PR DESCRIPTION
Adds `.github/FUNDING.yml` to show the Sponsor button on the repo.