### PR TITLE
feat(sheetmetal): bend tables with allowance/deduction lookup + interpolation

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -11,9 +11,10 @@ Pipeline: **author part → auto-miter corners → fold to 3D → unfold to flat
 ## Scope
 
 Straight (cylindrical) bends, authoring our own parts (not unfolding foreign solids). The bend model is
-K-factor based with an extensible schema, so it can grow toward bend-tables without a rewrite.
+K-factor based by default, with optional **shop bend tables** (see below) for parts that develop per a
+press-brake's measured allowance/deduction values.
 
-- Bend allowance: `BA = (π/180)·|angle|·(R + K·T)`
+- Bend allowance: `BA = (π/180)·|angle|·(R + K·T)`, or interpolated from a referenced bend table.
 - Defaults: units are mm; K-factor `0.44`; inner radius `= thickness`.
 
 Authoring supports arbitrary bend trees: flanges off any of the four base edges, **chained
@@ -34,6 +35,7 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 | Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)      |
 | Contour flange  | open line/arc profile swept along a base edge (multi-bend section); EXACT development       |
 | Lofted flange   | ruled transition between two open profiles; triangulated development (exact if developable) |
+| Bend tables     | shop allowance/deduction tables, angle-linear + thickness×radius-bilinear interp, clamp-warn |
 | Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings           |
 | API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                     |
 
@@ -208,6 +210,42 @@ sheet-metal structure is detected at all, e.g. a bare sphere). The detection is 
 author a part, take only its `.solid`, run `unfoldSolid`, and confirm the detected unfold reproduces the
 authored unfold's developed area, bend count, flat count, and total flat bbox (single bend, L-bracket,
 U-channel) — reading only the solid, never the feature tree.
+
+## Bend tables
+
+By default a bend develops by the K-factor formula `BA = (π/180)·|angle|·(R + K·T)`. A `BendRule` may
+instead reference a **shop bend table** by id (`rule.bendTableRef`), in which case the developed length is
+**interpolated from the table** — linear in bend angle, bilinear across thickness × inner radius (with
+nearest-radius substitution for sparse one-radius-per-gauge tables), clamping to the nearest tabulated
+entry outside the table's range (and emitting a `MIN_RADIUS` unfold warning rather than extrapolating).
+
+A table is `{ id, kind: 'allowance' | 'deduction', rows: { thickness, radius, angleDeg, value }[] }`. An
+`allowance` table tabulates the developed arc length directly; a `deduction` table tabulates the bend
+deduction and is converted on lookup via the outside-setback relation `OSSB = (R+T)·tan(θ/2)`,
+`BD = 2·OSSB − BA` ⇒ `BA = 2·OSSB − BD` (for a 90° bend, `OSSB = R+T`).
+
+Resolution precedence at the single resolution point (`resolveBendAllowance`, which `developedLength`
+delegates to): **(1) `bendTableRef` table → (2) explicit `rule.allowance` override → (3) K-factor formula**.
+Parts with no `bendTableRef` are byte-for-byte unchanged. Two starter air-bend tables ship auto-registered
+on first access — `steel-airbend` (mild steel) and `aluminum-airbend` (5052-H32) — with published 90°
+allowances scaled across {30, 60, 90, 120}° (sources: SheetMetal.Me charts, Machinery's Handbook 29th ed.).
+
+```ts
+import { registerBendTable, author, unfold } from 'brepjs-sheetmetal';
+
+registerBendTable({
+  id: 'my-shop-steel',
+  kind: 'allowance',
+  rows: [{ thickness: 1.52, radius: 1.5, angleDeg: 90, value: 3.63 }],
+});
+
+const part = author({
+  thickness: 1.52,
+  base: { length: 40, width: 40 },
+  flanges: [{ id: 'fx', length: 18, angleDeg: 90, side: 'xmax', rule: { innerRadius: 1.5, kFactor: 0.44, bendTableRef: 'my-shop-steel' } }],
+});
+// unfold(part.value) now develops the bend at BA = 3.63 mm (the table), not (π/2)·(R + K·T).
+```
 
 ## Design
 

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -17,7 +17,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, measureVolume, isErr, initFromOC } from 'brepjs';
 import type { Solid, Vec3 } from 'brepjs';
-import { author, miterCorner, unfold, unfoldSolid, fold } from '../src/api.js';
+import { author, miterCorner, unfold, unfoldSolid, fold, developed } from '../src/api.js';
 import { addBendRelief, cornerRelief } from '../src/reliefFns.js';
 import { addCutout } from '../src/cutoutFns.js';
 import { addTab, tabAndSlot, type SlotPlacement } from '../src/tabFns.js';
@@ -261,8 +261,33 @@ async function main(): Promise<void> {
     lines.push(...(await renderDemo(demo)));
   }
   lines.push(...(await renderForeignDemo()));
+  lines.push(...renderBendTableDemo());
   lines.push('');
   process.stdout.write(lines.join('\n'));
+}
+
+/**
+ * Bend-table demo (plan PR8): develop one 90° bend two ways — via the published
+ * `steel-airbend` table vs the K-factor formula at the same R/T — and print the
+ * developed-length delta, proving the table path replaces the formula.
+ */
+function renderBendTableDemo(): string[] {
+  const thickness = 1.52;
+  const radius = 1.5;
+  const kRule: BendRule = { innerRadius: radius, kFactor: 0.44 };
+  const tableRule: BendRule = { ...kRule, bendTableRef: 'steel-airbend' };
+
+  const kDev = developed(90, thickness, kRule);
+  const tableDev = developed(90, thickness, tableRule);
+  if (isErr(kDev) || isErr(tableDev)) throw new Error('bend-table demo: developed length failed');
+
+  return [
+    '  [bend-table]',
+    '    table id              : steel-airbend (mild-steel air-bend, SheetMetal.Me / Machinery’s Handbook)',
+    `    K-factor BA (90°)     : ${kDev.value.toFixed(3)} mm`,
+    `    table BA (90°)        : ${tableDev.value.toFixed(3)} mm`,
+    `    Δ developed length    : ${Math.abs(kDev.value - tableDev.value).toFixed(3)} mm`,
+  ];
 }
 
 /**

--- a/packages/brepjs-sheetmetal/src/allowanceFns.ts
+++ b/packages/brepjs-sheetmetal/src/allowanceFns.ts
@@ -1,7 +1,6 @@
 import { type Result, ok, err, validationError } from 'brepjs';
-import type { BendRule } from './types.js';
-
-const DEG_TO_RAD = Math.PI / 180;
+import type { BendRule, SheetMetalWarning } from './types.js';
+import { resolveBendAllowance } from './bendTableFns.js';
 
 function validateRule(rule: BendRule): Result<void> {
   if (!Number.isFinite(rule.innerRadius) || rule.innerRadius < 0) {
@@ -17,40 +16,35 @@ function validateRule(rule: BendRule): Result<void> {
 
 /**
  * Bend allowance — the developed (flat) length of material consumed by a bend,
- * measured along the neutral axis: BA = (π/180)·|angle|·(R + K·T).
- *
- * An explicit `rule.allowance` overrides the computed value.
+ * measured along the neutral axis. Resolution precedence (see
+ * {@link resolveBendAllowance}): a referenced bend table, then an explicit
+ * `rule.allowance` override, then the K-factor formula
+ * BA = (π/180)·|angle|·(R + K·T). An optional `onWarning` receives the clamp
+ * warning when a table query falls outside its tabulated range.
  */
-export function bendAllowance(angleDeg: number, thickness: number, rule: BendRule): Result<number> {
-  if (rule.allowance !== undefined) {
-    if (!Number.isFinite(rule.allowance) || rule.allowance < 0) {
-      return err(
-        validationError('INVALID_ALLOWANCE', `allowance override must be a finite, non-negative number, got ${rule.allowance}`)
-      );
-    }
-    return ok(rule.allowance);
-  }
-  if (!Number.isFinite(angleDeg)) {
-    return err(validationError('INVALID_ANGLE', `angleDeg must be finite, got ${angleDeg}`));
-  }
-  if (!Number.isFinite(thickness) || thickness <= 0) {
-    return err(validationError('INVALID_THICKNESS', `thickness must be a finite, positive number, got ${thickness}`));
-  }
-  const ruleCheck = validateRule(rule);
-  if (!ruleCheck.ok) return ruleCheck;
-
-  const neutralRadius = rule.innerRadius + rule.kFactor * thickness;
-  return ok(DEG_TO_RAD * Math.abs(angleDeg) * neutralRadius);
+export function bendAllowance(
+  angleDeg: number,
+  thickness: number,
+  rule: BendRule,
+  onWarning?: (warning: SheetMetalWarning) => void
+): Result<number> {
+  return resolveBendAllowance(rule, angleDeg, thickness, onWarning);
 }
 
 /**
  * Developed length of the bend region when flattened — the neutral-axis arc
  * length that replaces the curved patch in the flat pattern. Identical to the
  * bend allowance (kept distinct in name for the unfold call sites that consume
- * it as a strip width), and likewise honours `rule.allowance`.
+ * it as a strip width), and routed through the same {@link resolveBendAllowance}
+ * resolution (table → explicit allowance → K-factor).
  */
-export function developedLength(angleDeg: number, thickness: number, rule: BendRule): Result<number> {
-  return bendAllowance(angleDeg, thickness, rule);
+export function developedLength(
+  angleDeg: number,
+  thickness: number,
+  rule: BendRule,
+  onWarning?: (warning: SheetMetalWarning) => void
+): Result<number> {
+  return resolveBendAllowance(rule, angleDeg, thickness, onWarning);
 }
 
 /** Neutral-axis radius R + K·T (the radius the developed arc length is measured at). */

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -48,6 +48,12 @@ import {
 } from './reportFns.js';
 import { validatePart as validatePartFn } from './validateFns.js';
 import { bendAllowance as bendAllowanceFn, developedLength as developedLengthFn } from './allowanceFns.js';
+import {
+  registerBendTable as registerBendTableFn,
+  getBendTable as getBendTableFn,
+  resolveBendAllowance as resolveBendAllowanceFn,
+  type BendTable,
+} from './bendTableFns.js';
 import type {
   SheetMetalPart,
   FlatPattern,
@@ -242,13 +248,47 @@ export function validate(part: SheetMetalPart): SheetMetalWarning[] {
 }
 
 /** Bend allowance `BA = (π/180)·|angle|·(R + K·T)` for a single bend. */
-export function allowance(angleDeg: number, thickness: number, rule: BendRule): Result<number> {
-  return bendAllowanceFn(angleDeg, thickness, rule);
+export function allowance(
+  angleDeg: number,
+  thickness: number,
+  rule: BendRule,
+  onWarning?: (warning: SheetMetalWarning) => void
+): Result<number> {
+  return bendAllowanceFn(angleDeg, thickness, rule, onWarning);
 }
 
 /** Neutral-axis developed length of a bend region (numerically equal to the allowance). */
-export function developed(angleDeg: number, thickness: number, rule: BendRule): Result<number> {
-  return developedLengthFn(angleDeg, thickness, rule);
+export function developed(
+  angleDeg: number,
+  thickness: number,
+  rule: BendRule,
+  onWarning?: (warning: SheetMetalWarning) => void
+): Result<number> {
+  return developedLengthFn(angleDeg, thickness, rule, onWarning);
+}
+
+/** Register (or replace) a shop bend table so rules can reference it by id. */
+export function addBendTable(table: BendTable): Result<BendTable> {
+  return registerBendTableFn(table);
+}
+
+/** Look up a registered bend table by id (starter tables included). */
+export function bendTable(id: string): BendTable | undefined {
+  return getBendTableFn(id);
+}
+
+/**
+ * Resolve a bend's developed allowance through the single resolution point:
+ * a referenced bend table, then an explicit `rule.allowance`, then the K-factor
+ * formula. This is what {@link developed} delegates to.
+ */
+export function resolveAllowance(
+  rule: BendRule,
+  angleDeg: number,
+  thickness: number,
+  onWarning?: (warning: SheetMetalWarning) => void
+): Result<number> {
+  return resolveBendAllowanceFn(rule, angleDeg, thickness, onWarning);
 }
 
 export type { AuthorSpec, FlangeSpec, MiterPlane, DxfOptions, SlotPlacement };

--- a/packages/brepjs-sheetmetal/src/bendTableFns.ts
+++ b/packages/brepjs-sheetmetal/src/bendTableFns.ts
@@ -1,0 +1,387 @@
+import { type Result, ok, err, validationError } from 'brepjs';
+import type { BendRule, SheetMetalWarning } from './types.js';
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/**
+ * One row of a shop bend table: the tabulated value for a single
+ * (thickness, innerRadius, bend-angle) operating point. `value` is a bend
+ * allowance (`kind: 'allowance'`) or a bend deduction (`kind: 'deduction'`),
+ * per the owning {@link BendTable}.
+ */
+export interface BendTableRow {
+  /** Material thickness the row was measured at. */
+  thickness: number;
+  /** Inner bend radius the row was measured at. */
+  radius: number;
+  /** Swept bend angle in degrees (90° = a right-angle bend). */
+  angleDeg: number;
+  /** Bend allowance or bend deduction, per the table's {@link BendTable.kind}. */
+  value: number;
+}
+
+/**
+ * A named shop bend table: empirical bend-allowance or bend-deduction values
+ * measured per (thickness, radius, angle). When a {@link BendRule} references a
+ * table by id, {@link resolveBendAllowance} interpolates the table instead of
+ * applying the K-factor formula, so the developed length matches the shop's
+ * actual press-brake results.
+ *
+ * `kind` selects how a row's `value` is interpreted: an `'allowance'` table
+ * tabulates the developed arc length directly; a `'deduction'` table tabulates
+ * the bend deduction, which is converted to an allowance on lookup (see
+ * {@link resolveBendAllowance} for the OSSB conversion).
+ */
+export interface BendTable {
+  id: string;
+  kind: 'allowance' | 'deduction';
+  rows: BendTableRow[];
+}
+
+const registry = new Map<string, BendTable>();
+
+/**
+ * Register (or replace) a bend table under its id, so a {@link BendRule} with a
+ * matching `bendTableRef` resolves against it. Returns the registered table.
+ */
+export function registerBendTable(table: BendTable): Result<BendTable> {
+  if (typeof table.id !== 'string' || table.id.length === 0) {
+    return err(validationError('INVALID_TABLE_ID', `bend table id must be a non-empty string, got ${String(table.id)}`));
+  }
+  if (table.kind !== 'allowance' && table.kind !== 'deduction') {
+    return err(validationError('INVALID_TABLE_KIND', `bend table '${table.id}' kind must be 'allowance' or 'deduction', got ${String(table.kind)}`));
+  }
+  if (!Array.isArray(table.rows) || table.rows.length === 0) {
+    return err(validationError('EMPTY_TABLE', `bend table '${table.id}' must have at least one row`));
+  }
+  for (const row of table.rows) {
+    if (
+      !Number.isFinite(row.thickness) ||
+      row.thickness <= 0 ||
+      !Number.isFinite(row.radius) ||
+      row.radius < 0 ||
+      !Number.isFinite(row.angleDeg) ||
+      !Number.isFinite(row.value) ||
+      row.value < 0
+    ) {
+      return err(
+        validationError(
+          'INVALID_TABLE_ROW',
+          `bend table '${table.id}' has an invalid row: ${JSON.stringify(row)} (thickness>0, radius≥0, finite angle, value≥0 required)`
+        )
+      );
+    }
+  }
+  registry.set(table.id, { id: table.id, kind: table.kind, rows: table.rows.map((r) => ({ ...r })) });
+  const stored = registry.get(table.id);
+  if (stored === undefined) {
+    return err(validationError('REGISTER_FAILED', `bend table '${table.id}' failed to register`));
+  }
+  return ok(stored);
+}
+
+/** Look up a registered bend table by id (registers the starter tables on first use). */
+export function getBendTable(id: string): BendTable | undefined {
+  ensureStarterTables();
+  return registry.get(id);
+}
+
+/**
+ * Linear interpolation of `value` over `angleDeg` within a set of rows that
+ * already share a (thickness, radius) operating point. Clamps to the nearest
+ * endpoint outside the tabulated angle span and records a clamp via `clamped`.
+ */
+function interpAngle(rows: BendTableRow[], angleDeg: number): { value: number; clamped: boolean } {
+  const sorted = [...rows].sort((a, b) => a.angleDeg - b.angleDeg);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  if (first === undefined || last === undefined) return { value: 0, clamped: true };
+  if (angleDeg <= first.angleDeg) {
+    return { value: first.value, clamped: angleDeg < first.angleDeg };
+  }
+  if (angleDeg >= last.angleDeg) {
+    return { value: last.value, clamped: angleDeg > last.angleDeg };
+  }
+  for (let i = 0; i + 1 < sorted.length; i++) {
+    const lo = sorted[i];
+    const hi = sorted[i + 1];
+    if (lo === undefined || hi === undefined) continue;
+    if (angleDeg >= lo.angleDeg && angleDeg <= hi.angleDeg) {
+      const span = hi.angleDeg - lo.angleDeg;
+      if (span === 0) return { value: lo.value, clamped: false };
+      const t = (angleDeg - lo.angleDeg) / span;
+      return { value: lo.value + t * (hi.value - lo.value), clamped: false };
+    }
+  }
+  return { value: last.value, clamped: true };
+}
+
+/** Distinct sorted values of a numeric key across the table rows. */
+function distinct(rows: BendTableRow[], key: 'thickness' | 'radius'): number[] {
+  return [...new Set(rows.map((r) => r[key]))].sort((a, b) => a - b);
+}
+
+/** Bracketing pair `[lo, hi]` of a query value within sorted breakpoints, clamping to ends. */
+function bracket(values: number[], q: number): { lo: number; hi: number; clamped: boolean } {
+  const first = values[0];
+  const last = values[values.length - 1];
+  if (first === undefined || last === undefined) return { lo: q, hi: q, clamped: true };
+  if (q <= first) return { lo: first, hi: first, clamped: q < first };
+  if (q >= last) return { lo: last, hi: last, clamped: q > last };
+  for (let i = 0; i + 1 < values.length; i++) {
+    const lo = values[i];
+    const hi = values[i + 1];
+    if (lo === undefined || hi === undefined) continue;
+    if (q >= lo && q <= hi) return { lo, hi, clamped: false };
+  }
+  return { lo: last, hi: last, clamped: true };
+}
+
+/**
+ * Angle-interpolated value at a (thickness, radius) breakpoint. Prefers rows at
+ * the exact breakpoint; if the grid is sparse (a diagonal R-per-gauge table has
+ * no row at every t×r corner) it falls back to the rows at the nearest
+ * tabulated radius for that thickness, then the nearest thickness, flagging the
+ * substitution as clamped. Returns undefined only when the table is empty.
+ */
+function valueAt(table: BendTable, thickness: number, radius: number, angleDeg: number): { value: number; clamped: boolean } | undefined {
+  const exact = table.rows.filter((r) => r.thickness === thickness && r.radius === radius);
+  if (exact.length > 0) return interpAngle(exact, angleDeg);
+
+  const atThickness = table.rows.filter((r) => r.thickness === thickness);
+  if (atThickness.length > 0) {
+    const nearestR = nearest(distinct(atThickness, 'radius'), radius);
+    const rows = atThickness.filter((r) => r.radius === nearestR);
+    if (rows.length > 0) {
+      // Sparse-grid substitution (a diagonal one-radius-per-gauge table has no row
+      // at this corner) is an internal resolution, NOT a query clamp — genuine
+      // out-of-range thickness/radius is already flagged by `bracket` in interpTable,
+      // and out-of-range angle by interpAngle. Don't over-warn on in-range interior
+      // queries; only propagate the angle clamp.
+      const a = interpAngle(rows, angleDeg);
+      return { value: a.value, clamped: a.clamped };
+    }
+  }
+
+  const nearestT = nearest(distinct(table.rows, 'thickness'), thickness);
+  const atNearestT = table.rows.filter((r) => r.thickness === nearestT);
+  if (atNearestT.length === 0) return undefined;
+  const nearestR = nearest(distinct(atNearestT, 'radius'), radius);
+  const rows = atNearestT.filter((r) => r.radius === nearestR);
+  if (rows.length === 0) return undefined;
+  const a = interpAngle(rows, angleDeg);
+  return { value: a.value, clamped: a.clamped };
+}
+
+/** Nearest value in a set of breakpoints to a query. */
+function nearest(values: number[], q: number): number | undefined {
+  let best: number | undefined;
+  let bestDist = Infinity;
+  for (const v of values) {
+    const d = Math.abs(v - q);
+    if (d < bestDist) {
+      bestDist = d;
+      best = v;
+    }
+  }
+  return best;
+}
+
+/**
+ * Bilinear-in-(thickness, radius) + linear-in-angle interpolation of a bend
+ * table at the query operating point. Brackets the query thickness and radius
+ * to the nearest tabulated breakpoints (clamping outside the table extents),
+ * interpolates angle within each corner, then blends the corners. Sparse grids
+ * (a diagonal one-radius-per-gauge table) resolve each corner by nearest-radius
+ * substitution inside {@link valueAt}. Returns the raw tabulated quantity (an
+ * allowance or a deduction per the table kind).
+ */
+function interpTable(table: BendTable, thickness: number, radius: number, angleDeg: number): { value: number; clamped: boolean } | undefined {
+  const thicknesses = distinct(table.rows, 'thickness');
+  const radii = distinct(table.rows, 'radius');
+  const tB = bracket(thicknesses, thickness);
+  const rB = bracket(radii, radius);
+
+  const c00 = valueAt(table, tB.lo, rB.lo, angleDeg);
+  const c01 = valueAt(table, tB.lo, rB.hi, angleDeg);
+  const c10 = valueAt(table, tB.hi, rB.lo, angleDeg);
+  const c11 = valueAt(table, tB.hi, rB.hi, angleDeg);
+  if (c00 === undefined || c01 === undefined || c10 === undefined || c11 === undefined) {
+    return undefined;
+  }
+
+  const ft = tB.hi === tB.lo ? 0 : (thickness - tB.lo) / (tB.hi - tB.lo);
+  const fr = rB.hi === rB.lo ? 0 : (radius - rB.lo) / (rB.hi - rB.lo);
+
+  const lo = c00.value + fr * (c01.value - c00.value);
+  const hi = c10.value + fr * (c11.value - c10.value);
+  const value = lo + ft * (hi - lo);
+  const clamped = tB.clamped || rB.clamped || c00.clamped || c01.clamped || c10.clamped || c11.clamped;
+  return { value, clamped };
+}
+
+/**
+ * Outside setback OSSB = (R + T)·tan(θ/2) for swept bend angle θ — the run from
+ * the bend's tangent point to the apex of the two outside faces. (90° → tan45° →
+ * OSSB = R + T.)
+ */
+function ossb(radius: number, thickness: number, angleDeg: number): number {
+  return (radius + thickness) * Math.tan((DEG_TO_RAD * Math.abs(angleDeg)) / 2);
+}
+
+/** Bend allowance from a bend deduction: BD = 2·OSSB − BA ⇒ BA = 2·OSSB − BD. */
+function allowanceFromDeduction(deduction: number, radius: number, thickness: number, angleDeg: number): number {
+  return 2 * ossb(radius, thickness, angleDeg) - deduction;
+}
+
+/**
+ * The single source of truth for a bend's developed (neutral-axis) length.
+ *
+ * Precedence:
+ *  1. `rule.bendTableRef` — look up the table and interpolate it (linear in
+ *     angle, bilinear across thickness × radius), converting a deduction table
+ *     to an allowance via {@link allowanceFromDeduction}. Outside the table
+ *     extents the lookup clamps to the nearest breakpoint and reports a
+ *     `MIN_RADIUS`-class warning through `onWarning` rather than extrapolating.
+ *  2. `rule.allowance` — an explicit per-bend override, returned verbatim.
+ *  3. The K-factor formula BA = (π/180)·|angle|·(R + K·T).
+ *
+ * The returned value is in the same units and sense the rest of the package's
+ * `developedLength` consumes (a strip width along the developed pattern).
+ */
+export function resolveBendAllowance(
+  rule: BendRule,
+  angleDeg: number,
+  thickness: number,
+  onWarning?: (warning: SheetMetalWarning) => void
+): Result<number> {
+  if (rule.bendTableRef !== undefined) {
+    if (!Number.isFinite(angleDeg)) {
+      return err(validationError('INVALID_ANGLE', `angleDeg must be finite, got ${angleDeg}`));
+    }
+    if (!Number.isFinite(thickness) || thickness <= 0) {
+      return err(validationError('INVALID_THICKNESS', `thickness must be a finite, positive number, got ${thickness}`));
+    }
+    if (!Number.isFinite(rule.innerRadius) || rule.innerRadius < 0) {
+      return err(validationError('INVALID_RADIUS', `innerRadius must be a finite, non-negative number, got ${rule.innerRadius}`));
+    }
+    const table = getBendTable(rule.bendTableRef);
+    if (table === undefined) {
+      return err(validationError('UNKNOWN_BEND_TABLE', `no bend table registered under id '${rule.bendTableRef}'`));
+    }
+    const angle = Math.abs(angleDeg);
+    const interp = interpTable(table, thickness, rule.innerRadius, angle);
+    if (interp === undefined) {
+      return err(
+        validationError('TABLE_LOOKUP_FAILED', `bend table '${table.id}' has no rows bracketing (t=${thickness}, r=${rule.innerRadius})`)
+      );
+    }
+    const ba = table.kind === 'deduction' ? allowanceFromDeduction(interp.value, rule.innerRadius, thickness, angle) : interp.value;
+    if (!Number.isFinite(ba) || ba < 0) {
+      return err(
+        validationError(
+          'INVALID_TABLE_ALLOWANCE',
+          `bend table '${table.id}' produced a non-positive allowance ${ba} at (t=${thickness}, r=${rule.innerRadius}, θ=${angle})`
+        )
+      );
+    }
+    if (interp.clamped && onWarning !== undefined) {
+      onWarning({
+        code: 'MIN_RADIUS',
+        message: `bend table '${table.id}' query (t=${thickness}, r=${rule.innerRadius}, θ=${angle}) is outside the tabulated range; clamped to the nearest entry`,
+      });
+    }
+    return ok(ba);
+  }
+  return fallbackAllowance(rule, angleDeg, thickness);
+}
+
+/** Explicit-allowance override, then the K-factor formula (the pre-table behaviour). */
+function fallbackAllowance(rule: BendRule, angleDeg: number, thickness: number): Result<number> {
+  if (rule.allowance !== undefined) {
+    if (!Number.isFinite(rule.allowance) || rule.allowance < 0) {
+      return err(
+        validationError('INVALID_ALLOWANCE', `allowance override must be a finite, non-negative number, got ${rule.allowance}`)
+      );
+    }
+    return ok(rule.allowance);
+  }
+  if (!Number.isFinite(angleDeg)) {
+    return err(validationError('INVALID_ANGLE', `angleDeg must be finite, got ${angleDeg}`));
+  }
+  if (!Number.isFinite(thickness) || thickness <= 0) {
+    return err(validationError('INVALID_THICKNESS', `thickness must be a finite, positive number, got ${thickness}`));
+  }
+  if (!Number.isFinite(rule.innerRadius) || rule.innerRadius < 0) {
+    return err(validationError('INVALID_RADIUS', `innerRadius must be a finite, non-negative number, got ${rule.innerRadius}`));
+  }
+  if (!Number.isFinite(rule.kFactor) || rule.kFactor < 0 || rule.kFactor > 1) {
+    return err(validationError('INVALID_K_FACTOR', `kFactor must be in [0, 1], got ${rule.kFactor}`));
+  }
+  const neutralRadius = rule.innerRadius + rule.kFactor * thickness;
+  return ok(DEG_TO_RAD * Math.abs(angleDeg) * neutralRadius);
+}
+
+/**
+ * Starter shop bend tables, auto-registered on first table access. The values
+ * are published 90°-equivalent air-bend allowances scaled across the standard
+ * {30, 60, 90, 120}° set by the linear angle ratio, at a single canonical inner
+ * radius per gauge.
+ *
+ * Sources: SheetMetal.Me air-bend / bend-allowance charts and Machinery's
+ * Handbook (29th ed.) sheet-metal bend-allowance tables for mild steel and
+ * 5052-H32 aluminium. The 90° allowances are the published mid-range air-bend
+ * figures; the other angles are the proportional neutral-axis arc lengths
+ * (allowance scales ~linearly with the swept angle at a fixed radius).
+ */
+const STARTER_TABLES: readonly BendTable[] = [
+  {
+    id: 'steel-airbend',
+    kind: 'allowance',
+    rows: angleSet([
+      { thickness: 0.91, radius: 1.0, ba90: 2.36 },
+      { thickness: 1.52, radius: 1.5, ba90: 3.63 },
+      { thickness: 1.9, radius: 2.0, ba90: 4.62 },
+      { thickness: 2.66, radius: 3.0, ba90: 6.59 },
+    ]),
+  },
+  {
+    id: 'aluminum-airbend',
+    kind: 'allowance',
+    rows: angleSet([
+      { thickness: 0.81, radius: 1.0, ba90: 2.27 },
+      { thickness: 1.29, radius: 1.5, ba90: 3.44 },
+      { thickness: 1.63, radius: 2.0, ba90: 4.49 },
+      { thickness: 2.59, radius: 3.0, ba90: 6.51 },
+    ]),
+  },
+];
+
+/** Expand a per-gauge 90° allowance into the {30, 60, 90, 120}° rows by the angle ratio. */
+function angleSet(seeds: { thickness: number; radius: number; ba90: number }[]): BendTableRow[] {
+  const angles = [30, 60, 90, 120];
+  const rows: BendTableRow[] = [];
+  for (const seed of seeds) {
+    for (const angleDeg of angles) {
+      rows.push({ thickness: seed.thickness, radius: seed.radius, angleDeg, value: (seed.ba90 * angleDeg) / 90 });
+    }
+  }
+  return rows;
+}
+
+let starterTablesRegistered = false;
+
+/**
+ * Register the starter tables exactly once. Done lazily (not at module load) so
+ * the package keeps `sideEffects: false` — importing the package never mutates
+ * the registry; the tables materialise on the first {@link getBendTable} call.
+ */
+function ensureStarterTables(): void {
+  if (starterTablesRegistered) return;
+  starterTablesRegistered = true;
+  for (const table of STARTER_TABLES) {
+    // Never clobber a table a caller registered under a starter id before first access.
+    if (registry.has(table.id)) continue;
+    registry.set(table.id, { id: table.id, kind: table.kind, rows: table.rows.map((r) => ({ ...r })) });
+  }
+}

--- a/packages/brepjs-sheetmetal/src/bendTableFns.ts
+++ b/packages/brepjs-sheetmetal/src/bendTableFns.ts
@@ -72,11 +72,8 @@ export function registerBendTable(table: BendTable): Result<BendTable> {
       );
     }
   }
-  registry.set(table.id, { id: table.id, kind: table.kind, rows: table.rows.map((r) => ({ ...r })) });
-  const stored = registry.get(table.id);
-  if (stored === undefined) {
-    return err(validationError('REGISTER_FAILED', `bend table '${table.id}' failed to register`));
-  }
+  const stored = { id: table.id, kind: table.kind, rows: table.rows.map((r) => ({ ...r })) };
+  registry.set(table.id, stored);
   return ok(stored);
 }
 
@@ -287,7 +284,7 @@ export function resolveBendAllowance(
     }
     if (interp.clamped && onWarning !== undefined) {
       onWarning({
-        code: 'MIN_RADIUS',
+        code: 'TABLE_CLAMP',
         message: `bend table '${table.id}' query (t=${thickness}, r=${rule.innerRadius}, θ=${angle}) is outside the tabulated range; clamped to the nearest entry`,
       });
     }

--- a/packages/brepjs-sheetmetal/src/foreignUnfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/foreignUnfoldFns.ts
@@ -695,7 +695,7 @@ function layoutForeign(
 
   for (const tb of treeBends) {
     const bend = tb.edge.bend;
-    const dev = developedLength(bend.angleDeg, thickness, { innerRadius: bend.innerRadius, kFactor });
+    const dev = developedLength(bend.angleDeg, thickness, { innerRadius: bend.innerRadius, kFactor }, (w) => warnings.push(w));
     if (!dev.ok) return dev;
     const parentPlace = placed.get(tb.parent);
     const parent = flats[tb.parent] as DetectedFlat;

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -8,6 +8,9 @@ export {
 
 export { bendAllowance, developedLength, neutralRadius } from './allowanceFns.js';
 
+export { registerBendTable, getBendTable, resolveBendAllowance } from './bendTableFns.js';
+export type { BendTable, BendTableRow } from './bendTableFns.js';
+
 export {
   ROOT_FLAT_ID,
   buildFeatureGraph,
@@ -79,6 +82,9 @@ export {
   validate,
   allowance,
   developed,
+  addBendTable,
+  bendTable,
+  resolveAllowance,
   contourFlange,
   loftedFlange,
 } from './api.js';

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -418,7 +418,11 @@ export type SheetMetalWarning = {
     /** Foreign unfold: the part is a valid solid but its detected structure is
      * incomplete (non-uniform thickness, a dropped panel, or a bend not joining
      * exactly two flats), so the flat pattern may be partial. */
-    | 'DETECTION_INCOMPLETE';
+    | 'DETECTION_INCOMPLETE'
+    /** A bend-table query fell outside the tabulated (thickness, radius, angle)
+     * range and was clamped to the nearest entry (no extrapolation). Distinct from
+     * MIN_RADIUS, which means a bend's inner radius is below one thickness. */
+    | 'TABLE_CLAMP';
   message: string;
   featureId?: string | undefined;
 };

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -53,7 +53,7 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
 
   const warnings: SheetMetalWarning[] = [...tree.warnings];
 
-  const layoutResult = layoutTree(part, tree, baseLength, width);
+  const layoutResult = layoutTree(part, tree, baseLength, width, (warning) => warnings.push(warning));
   if (!layoutResult.ok) return layoutResult;
   const layout = layoutResult.value;
 
@@ -213,7 +213,8 @@ export function layoutTree(
   part: SheetMetalPart,
   tree: FeatureTree,
   baseLength: number,
-  width: number
+  width: number,
+  onWarning?: (warning: SheetMetalWarning) => void
 ): Result<TreeLayout> {
   const frames = new Map<string, Frame2>();
   frames.set(ROOT_FLAT_ID, {
@@ -250,7 +251,7 @@ export function layoutTree(
       );
     }
 
-    const devResult = developedLength(treeBend.bend.angleDeg, part.thickness, treeBend.bend.rule);
+    const devResult = developedLength(treeBend.bend.angleDeg, part.thickness, treeBend.bend.rule, onWarning);
     if (!devResult.ok) return devResult;
     const dev = devResult.value;
 

--- a/packages/brepjs-sheetmetal/tests/bendTable.test.ts
+++ b/packages/brepjs-sheetmetal/tests/bendTable.test.ts
@@ -201,6 +201,8 @@ describe('resolveBendAllowance — out-of-range clamp + warning hook', () => {
     if (!r.ok) return;
     expect(r.value).toBeCloseTo(3.0, 9); // clamped to the 90° row, not extrapolated
     expect(warnings.length).toBe(1);
+    // A dedicated code, NOT MIN_RADIUS (which means inner radius < thickness).
+    expect(warnings[0]?.code).toBe('TABLE_CLAMP');
   });
 
   it('clamps an above-range thickness without extrapolating', () => {

--- a/packages/brepjs-sheetmetal/tests/bendTable.test.ts
+++ b/packages/brepjs-sheetmetal/tests/bendTable.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import {
+  registerBendTable,
+  getBendTable,
+  resolveBendAllowance,
+  type BendTable,
+} from '../src/bendTableFns.js';
+import { developedLength } from '../src/allowanceFns.js';
+import { unfold } from '../src/unfoldFns.js';
+import type { BendRule, SheetMetalPart, SheetMetalWarning } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const HALF_PI = Math.PI / 2;
+
+// OSSB(90°) = (R+T)·tan45° = R+T. BD = 2·OSSB − BA.
+function ossb90(radius: number, thickness: number): number {
+  return radius + thickness;
+}
+
+describe('bend table registry + starter tables', () => {
+  it('auto-registers the steel/aluminium starter tables on first access', () => {
+    const steel = getBendTable('steel-airbend');
+    const aluminum = getBendTable('aluminum-airbend');
+    expect(steel?.kind).toBe('allowance');
+    expect(aluminum?.kind).toBe('allowance');
+    expect((steel?.rows.length ?? 0) > 0).toBe(true);
+  });
+
+  it('registers and reads back a custom table', () => {
+    const table: BendTable = {
+      id: 'custom-test',
+      kind: 'allowance',
+      rows: [{ thickness: 1, radius: 1, angleDeg: 90, value: 2.5 }],
+    };
+    const reg = registerBendTable(table);
+    expect(reg.ok).toBe(true);
+    expect(getBendTable('custom-test')?.rows[0]?.value).toBe(2.5);
+  });
+
+  it('rejects an empty table', () => {
+    const reg = registerBendTable({ id: 'empty', kind: 'allowance', rows: [] });
+    expect(reg.ok).toBe(false);
+  });
+});
+
+describe('resolveBendAllowance — exact hits and interpolation', () => {
+  const table: BendTable = {
+    id: 'interp-test',
+    kind: 'allowance',
+    rows: [
+      { thickness: 1, radius: 1, angleDeg: 60, value: 2.0 },
+      { thickness: 1, radius: 1, angleDeg: 90, value: 3.0 },
+      { thickness: 2, radius: 1, angleDeg: 60, value: 4.0 },
+      { thickness: 2, radius: 1, angleDeg: 90, value: 6.0 },
+      { thickness: 1, radius: 3, angleDeg: 60, value: 3.0 },
+      { thickness: 1, radius: 3, angleDeg: 90, value: 4.5 },
+      { thickness: 2, radius: 3, angleDeg: 60, value: 5.0 },
+      { thickness: 2, radius: 3, angleDeg: 90, value: 7.5 },
+    ],
+  };
+
+  beforeAll(() => {
+    registerBendTable(table);
+  });
+
+  const rule: BendRule = { innerRadius: 1, kFactor: 0.44, bendTableRef: 'interp-test' };
+
+  it('returns the exact row value on an exact (t, r, angle) hit', () => {
+    const r = resolveBendAllowance(rule, 90, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(3.0, 9);
+  });
+
+  it('linearly interpolates in angle (75° midpoint between 60° and 90°)', () => {
+    // (2.0 + 3.0)/2 = 2.5
+    const r = resolveBendAllowance(rule, 75, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(2.5, 9);
+  });
+
+  it('linearly interpolates in thickness at a fixed (r, angle)', () => {
+    // t between 1 (→3.0) and 2 (→6.0) at t=1.5 → 4.5
+    const r = resolveBendAllowance(rule, 90, 1.5);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(4.5, 9);
+  });
+
+  it('bilinearly interpolates across thickness × radius at fixed angle', () => {
+    // At angle 90, corners: (t1,r1)=3.0 (t2,r1)=6.0 (t1,r3)=4.5 (t2,r3)=7.5
+    // r=2 (fr=0.5): lo edge = 3.0+0.5·(4.5-3.0)=3.75 ; hi edge = 6.0+0.5·(7.5-6.0)=6.75
+    // t=1.5 (ft=0.5): 3.75 + 0.5·(6.75-3.75) = 5.25
+    const r = resolveBendAllowance({ ...rule, innerRadius: 2 }, 90, 1.5);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(5.25, 9);
+  });
+});
+
+describe('resolveBendAllowance — deduction table equals allowance table', () => {
+  const radius = 1.5;
+  const thickness = 1.52;
+  const ba90 = 3.63;
+  const bd90 = 2 * ossb90(radius, thickness) - ba90; // hand-checked: 6.04 − 3.63 = 2.41
+
+  beforeAll(() => {
+    registerBendTable({
+      id: 'ded-test',
+      kind: 'deduction',
+      rows: [{ thickness, radius, angleDeg: 90, value: bd90 }],
+    });
+    registerBendTable({
+      id: 'allow-test',
+      kind: 'allowance',
+      rows: [{ thickness, radius, angleDeg: 90, value: ba90 }],
+    });
+  });
+
+  it('deduction BD90 hand value ≈ 2.41 mm', () => {
+    expect(bd90).toBeCloseTo(2.41, 2);
+  });
+
+  it('converts deduction → allowance equal to the equivalent allowance table', () => {
+    const baseRule: BendRule = { innerRadius: radius, kFactor: 0.44 };
+    const fromDed = resolveBendAllowance({ ...baseRule, bendTableRef: 'ded-test' }, 90, thickness);
+    const fromAllow = resolveBendAllowance({ ...baseRule, bendTableRef: 'allow-test' }, 90, thickness);
+    expect(fromDed.ok && fromAllow.ok).toBe(true);
+    if (!fromDed.ok || !fromAllow.ok) return;
+    expect(fromDed.value).toBeCloseTo(ba90, 6);
+    expect(fromDed.value).toBeCloseTo(fromAllow.value, 9);
+  });
+});
+
+describe('resolveBendAllowance — precedence', () => {
+  beforeAll(() => {
+    registerBendTable({
+      id: 'prec-test',
+      kind: 'allowance',
+      rows: [{ thickness: 1, radius: 1, angleDeg: 90, value: 9.0 }],
+    });
+  });
+
+  it('table wins over an explicit allowance override', () => {
+    const r = resolveBendAllowance(
+      { innerRadius: 1, kFactor: 0.44, allowance: 5, bendTableRef: 'prec-test' },
+      90,
+      1
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(9.0, 9);
+  });
+
+  it('explicit allowance wins when no table is referenced', () => {
+    const r = resolveBendAllowance({ innerRadius: 1, kFactor: 0.44, allowance: 5 }, 90, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBe(5);
+  });
+
+  it('K-factor formula applies with neither table nor override', () => {
+    const r = resolveBendAllowance({ innerRadius: 1, kFactor: 0.44 }, 90, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(HALF_PI * (1 + 0.44 * 1), 9);
+  });
+
+  it('errors when the referenced table does not exist', () => {
+    const r = resolveBendAllowance({ innerRadius: 1, kFactor: 0.44, bendTableRef: 'nope' }, 90, 1);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('resolveBendAllowance — out-of-range clamp + warning hook', () => {
+  beforeAll(() => {
+    registerBendTable({
+      id: 'clamp-test',
+      kind: 'allowance',
+      rows: [
+        { thickness: 1, radius: 1, angleDeg: 60, value: 2.0 },
+        { thickness: 1, radius: 1, angleDeg: 90, value: 3.0 },
+      ],
+    });
+  });
+
+  it('clamps an above-range angle to the nearest entry and warns', () => {
+    const warnings: SheetMetalWarning[] = [];
+    const r = resolveBendAllowance(
+      { innerRadius: 1, kFactor: 0.44, bendTableRef: 'clamp-test' },
+      120,
+      1,
+      (w) => warnings.push(w)
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(3.0, 9); // clamped to the 90° row, not extrapolated
+    expect(warnings.length).toBe(1);
+  });
+
+  it('clamps an above-range thickness without extrapolating', () => {
+    const r = resolveBendAllowance({ innerRadius: 1, kFactor: 0.44, bendTableRef: 'clamp-test' }, 90, 5);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeCloseTo(3.0, 9);
+  });
+
+  it('does NOT warn for an in-range interior query on a diagonal (one-radius-per-gauge) table', () => {
+    // Diagonal grid: each gauge has a single radius, so the off-diagonal corners
+    // of a bracketed query are resolved by nearest-radius substitution. That is an
+    // internal sparse-grid resolution, not an out-of-bounds clamp — an in-range
+    // query must not emit a spurious clamp warning.
+    registerBendTable({
+      id: 'diagonal-test',
+      kind: 'allowance',
+      rows: [
+        { thickness: 1.0, radius: 1.0, angleDeg: 90, value: 2.0 },
+        { thickness: 2.0, radius: 2.0, angleDeg: 90, value: 4.0 },
+      ],
+    });
+    const warnings: SheetMetalWarning[] = [];
+    const r = resolveBendAllowance(
+      { innerRadius: 1.5, kFactor: 0.44, bendTableRef: 'diagonal-test' },
+      90,
+      1.5,
+      (w) => warnings.push(w)
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(warnings.length).toBe(0);
+  });
+});
+
+describe('unfold — a table-referenced part develops per the table, not K·T', () => {
+  const thickness = 1.52;
+  const radius = 1.5;
+  const baseLen = 30;
+  const flangeLen = 20;
+  const tableBA = 3.63;
+
+  beforeAll(() => {
+    registerBendTable({
+      id: 'unfold-steel',
+      kind: 'allowance',
+      rows: [
+        { thickness, radius, angleDeg: 60, value: tableBA * (60 / 90) },
+        { thickness, radius, angleDeg: 90, value: tableBA },
+      ],
+    });
+  });
+
+  function makePart(rule: BendRule): SheetMetalPart {
+    return {
+      thickness,
+      baseLength: baseLen,
+      width: flangeLen,
+      flanges: [
+        {
+          id: 'flange-1',
+          baseEdge: { kind: 'index', faceIndex: 0, edgeIndex: 0 },
+          length: flangeLen,
+          span: flangeLen,
+          angleDeg: 90,
+          rule,
+        },
+      ],
+      bends: [
+        {
+          id: 'flange-1',
+          axisOrigin: [0, 0, 0],
+          axisDir: [0, 1, 0],
+          angleDeg: 90,
+          direction: 'up',
+          rule,
+        },
+      ],
+    };
+  }
+
+  it('developed east run uses the table BA, distinct from the K-factor BA', () => {
+    const tableRule: BendRule = { innerRadius: radius, kFactor: 0.44, bendTableRef: 'unfold-steel' };
+    const kRule: BendRule = { innerRadius: radius, kFactor: 0.44 };
+
+    const kBA = HALF_PI * (radius + 0.44 * thickness);
+    expect(Math.abs(kBA - tableBA)).toBeGreaterThan(0.1); // the two methods genuinely differ
+
+    const tableUnfold = unfold(makePart(tableRule));
+    const kUnfold = unfold(makePart(kRule));
+    expect(tableUnfold.ok && kUnfold.ok).toBe(true);
+    if (!tableUnfold.ok || !kUnfold.ok) return;
+
+    const tableRun = tableUnfold.value.report.totalFlatSize[0];
+    const kRun = kUnfold.value.report.totalFlatSize[0];
+    expect(tableRun).toBeCloseTo(baseLen + tableBA + flangeLen, 5);
+    expect(kRun).toBeCloseTo(baseLen + kBA + flangeLen, 5);
+
+    const bend = tableUnfold.value.report.bends[0];
+    expect(bend?.allowance).toBeCloseTo(tableBA, 5);
+  });
+
+  it('a non-table part is unchanged (K-factor result preserved)', () => {
+    const kRule: BendRule = { innerRadius: radius, kFactor: 0.44 };
+    const direct = developedLength(90, thickness, kRule);
+    expect(direct.ok).toBe(true);
+    if (!direct.ok) return;
+    expect(direct.value).toBeCloseTo(HALF_PI * (radius + 0.44 * thickness), 9);
+  });
+});


### PR DESCRIPTION
## Phase 3 · PR1 of 4 (bend tables · hems/jogs · nesting)

Replaces the K-factor formula with real shop **bend tables** when a part references one. The `BendRule` schema already reserved `allowance`/`deduction`/`bendTableRef` in Phase 2 — this wires them through the single resolution point.

### What's new
- **`bendTableFns.ts`**: `BendTable { id; kind: 'allowance' | 'deduction'; rows }`, a registry, and **`resolveBendAllowance`** — the single source of truth. Precedence: `bendTableRef` (interpolated table) → explicit `rule.allowance` → K-factor.
- **Interpolation**: linear-in-angle + bilinear-in-(thickness, radius); sparse one-radius-per-gauge grids resolve missing corners by nearest-radius substitution; genuinely out-of-range queries **clamp (no extrapolation)** and fire a warning via an optional sink.
- **Deduction↔allowance**: `OSSB = (R+T)·tan(θ/2)`, `BD = 2·OSSB − BA` (hand-verified for a 90° steel case; a deduction table yields the same BA as the equivalent allowance table).
- **Wiring**: `allowanceFns.developedLength`/`bendAllowance` delegate to `resolveBendAllowance`, so a `bendTableRef` part develops per the table *everywhere* (unfold/report/contour/foreign/fold/relief). Non-table parts are byte-for-byte unchanged.
- Starter air-bend tables (`steel-airbend`, `aluminum-airbend`), cited. `api`/`index` surfaces; `unfold` threads a warning sink; harness `bend-table` demo (Δ 0.223 mm vs K-factor).

### Verification
- typecheck / lint / build clean; **192 tests** (174 prior + 18 new) green; snapshot exit 0.
- Tests assert interpolation against hand values (75° midpoint = 2.5, bilinear = 5.25), the deduction-conversion 90° case, table-vs-K-factor divergence end-to-end through `unfold`, out-of-range clamp+warn, and **no spurious warning on in-range sparse-grid queries**.
- Built via a Workflow (implement → adversarial review → fix) in an isolated git worktree. Review hand-verified the math; I additionally fixed a spurious-clamp-warning on diagonal-table interior queries.

### Known minor limitation
The clamp-warning sink is currently threaded only through `unfold`; contour/fold/relief/foreign call `developedLength` without it, so a *table clamp* reached via those paths computes the (safe, clamped) value without surfacing a warning. Math is unaffected — diagnostic only. Can thread it through in a follow-up if desired.

### Stack
Phase 2 (7 PRs) merged. Phase 3 remaining: hems & jogs · bbox nesting · true-shape (NFP) nesting.