### PR TITLE
feat(sheetmetal): hems (closed/open/teardrop/rolled) + jogs

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -35,6 +35,8 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 | Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)      |
 | Contour flange  | open line/arc profile swept along a base edge (multi-bend section); EXACT development       |
 | Lofted flange   | ruled transition between two open profiles; triangulated development (exact if developable) |
+| Hems            | edge folded back ~180°+ (closed / open / teardrop / rolled); EXACT development              |
+| Jogs            | two opposite bends stepping a flat by a Z-offset (joggle); EXACT development                |
 | Bend tables     | shop allowance/deduction tables, angle-linear + thickness×radius-bilinear interp, clamp-warn |
 | Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings           |
 | API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                     |
@@ -177,6 +179,41 @@ Both flanges have **non-rectilinear** developments, so — like miters and tabs 
 `patternToFlatInput` outline oracle: verification leans on developed-length/area invariants and solid
 validity rather than a fold round-trip. The contour flange's developed strip still joins the rectilinear
 outline union; the lofted flange's triangulated blank is a separate developed boundary.
+
+## Hems & jogs
+
+Hems and jogs are multi-bend edge features built on the same frame-to-frame profile chainer as the contour
+flange, so their developments are **EXACT** (Σ segment developed lengths, via the table-aware
+`developedLength`). Both attach to any flat **region** — the base (`'base'`/`'root'`) or a named flange —
+edge, record their curl/step sub-bends as `hem::<id>::<n>` / `jog::<id>::<n>` `BendFeature`s (skipped by the
+feature-tree spanning walk, like `contour::` bends), and lay their developed strip out straight along the
+region edge with one bend line per sub-bend.
+
+- `hem(part, { region, side, type, length?, radius?, gap?, offset?, width?, rule? })` folds a region edge
+  back onto its parent. Four `type`s set the curl angle and the gap:
+  - **`closed`** — a tight ~180° fold, the return flat against the parent. The curl radius is inflated by a
+    small **HAIR** clearance (0.05 mm) so the fused solid stays valid (a true zero-gap fold makes the curl's
+    inner cylinder coincide with the parent face → a self-touching, non-manifold solid). `length` is the
+    return-leg length (must be ≥ one thickness).
+  - **`open`** — a ~180° fold with a clear `gap` (default = `radius`) between the return and the parent; the
+    curl radius is sized from the gap, so its developed curl length is the exact 180° allowance at that radius.
+  - **`teardrop`** — a >180° (~210°) curl leaving a small teardrop opening, then a short return.
+  - **`rolled`** — a full ~270° circular roll (a curled / safe edge); no flat return.
+
+  The curl is split into ≤120° sub-arcs (the bend-patch wedge degenerates at ≥180°), each a recorded
+  sub-bend; the bend allowance is linear in angle, so Σ sub-arc allowances == the single-curl allowance. The
+  **developed length** is Σ curl allowances + the return length, laid out straight past the edge.
+- `jog(part, { region, side, position, offsetHeight, angle?, runOut?, radius?, offset?, width?, rule? })`
+  steps a flat by `offsetHeight` perpendicular to its plane with **two opposite bends** (`+θ` then `−θ`,
+  `angle` default 45°), then continues parallel. The connecting step run is solved so the two arcs' rise plus
+  the step rise equals `offsetHeight` exactly — the resulting run-out bottom face sits exactly `offsetHeight`
+  above the base bottom face (verified by measurement, not just construction). The flat carries the **two
+  bend lines** (one `up`, one `down`); the **developed length** is `position + 2·allowance + stepRun +
+  runOut`. `offsetHeight` must exceed the bends' own rise `(T + 2R)(1 − cos θ)`, else the jog is rejected.
+
+Like the contour/lofted flanges, hems and jogs have non-rectilinear developments and so sit outside the
+strict `partToFlatInput → fold` round-trip oracle; verification leans on developed-length invariants, the
+measured jog offset, and solid validity.
 
 ## Foreign-solid import & unfold
 

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -24,6 +24,8 @@ import { addTab, tabAndSlot, type SlotPlacement } from '../src/tabFns.js';
 import { addForm } from '../src/formFns.js';
 import { authorContourFlange } from '../src/contourFlangeFns.js';
 import { authorLoftedFlange } from '../src/loftedFlangeFns.js';
+import { hem } from '../src/hemFns.js';
+import { jog } from '../src/jogFns.js';
 import { partToFlatInput } from '../src/foldFns.js';
 import type { AuthorSpec } from '../src/authorFns.js';
 import type {
@@ -32,6 +34,8 @@ import type {
   CutoutSpec,
   FlatPattern,
   FormSpec,
+  HemSpec,
+  JogSpec,
   LoftedFlangeSpec,
   SheetMetalPart,
   TabSpec,
@@ -89,6 +93,10 @@ interface Demo {
   contourFlanges?: ContourFlangeSpec[];
   /** Optional lofted / ruled transition flanges between two open profiles. */
   loftedFlanges?: LoftedFlangeSpec[];
+  /** Optional hems (edge folded back ~180°+ onto its parent). */
+  hems?: HemSpec[];
+  /** Optional jogs (two opposite bends stepping the flat by an offset). */
+  jogs?: (JogSpec & { id?: string })[];
 }
 
 const DEMOS: Demo[] = [
@@ -224,6 +232,31 @@ const DEMOS: Demo[] = [
         ],
       },
     ],
+  },
+  {
+    name: 'hemmed-panel',
+    spec: {
+      thickness: T,
+      base: { length: 80, width: 50 },
+      flanges: [],
+    },
+    // A panel with a closed hem along one edge and an open hem along the opposite
+    // edge — a stiffened, safe-edged panel.
+    hems: [
+      { region: 'base', side: 'xmax', type: 'closed', length: 6, radius: R },
+      { region: 'base', side: 'xmin', type: 'open', length: 6, gap: 3 },
+    ],
+  },
+  {
+    name: 'jogged-bracket',
+    spec: {
+      thickness: T,
+      base: { length: 80, width: 40 },
+      flanges: [],
+    },
+    // A bracket whose face steps up by a Z-offset partway along the run (a joggle to
+    // clear an obstruction), then continues parallel.
+    jogs: [{ region: 'base', side: 'xmax', position: 20, offsetHeight: 8, angle: 45, runOut: 30, radius: R }],
   },
   {
     name: 'lofted-chute',
@@ -389,6 +422,16 @@ async function renderDemo(demo: Demo): Promise<string[]> {
     if (isErr(lfResult)) throw new Error(`loftedFlange '${demo.name}' failed: ${lfResult.error.message}`);
     part = lfResult.value;
   }
+  for (const spec of demo.hems ?? []) {
+    const hemResult = hem(part, spec);
+    if (isErr(hemResult)) throw new Error(`hem '${demo.name}' failed: ${hemResult.error.message}`);
+    part = hemResult.value;
+  }
+  for (const spec of demo.jogs ?? []) {
+    const jogResult = jog(part, spec);
+    if (isErr(jogResult)) throw new Error(`jog '${demo.name}' failed: ${jogResult.error.message}`);
+    part = jogResult.value;
+  }
   if (part.solid === undefined) throw new Error(`'${demo.name}' has no solid`);
 
   const unfolded = unfold(part);
@@ -419,8 +462,10 @@ async function renderDemo(demo: Demo): Promise<string[]> {
     demo.miter !== undefined ||
     part.reliefs !== undefined ||
     part.contourFlanges !== undefined ||
-    part.loftedFlanges !== undefined;
-  let roundTrip = '(fold round-trip skipped: mitered/relief’d/contour/lofted part)';
+    part.loftedFlanges !== undefined ||
+    part.hems !== undefined ||
+    part.jogs !== undefined;
+  let roundTrip = '(fold round-trip skipped: mitered/relief’d/contour/lofted/hem/jog part)';
   if (!skipRoundTrip) {
     roundTrip = foldRoundTrip(part);
   }

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -40,6 +40,8 @@ import {
 import { louver as louverFn, emboss as embossFn } from './formFns.js';
 import { authorContourFlange as authorContourFlangeFn } from './contourFlangeFns.js';
 import { authorLoftedFlange as authorLoftedFlangeFn } from './loftedFlangeFns.js';
+import { hem as hemFn } from './hemFns.js';
+import { jog as jogFn } from './jogFns.js';
 import { flatPatternToDXF as flatPatternToDXFFn, type DxfOptions } from './dxfFns.js';
 import {
   buildReport as buildReportFn,
@@ -65,6 +67,8 @@ import type {
   TabSpec,
   ContourFlangeSpec,
   LoftedFlangeSpec,
+  HemSpec,
+  JogSpec,
   UnfoldResult,
   SheetMetalWarning,
 } from './types.js';
@@ -220,6 +224,22 @@ export function contourFlange(part: SheetMetalPart, spec: ContourFlangeSpec): Re
  */
 export function loftedFlange(part: SheetMetalPart, spec: LoftedFlangeSpec): Result<SheetMetalPart> {
   return authorLoftedFlangeFn(part, spec);
+}
+
+/**
+ * Author a hem: fold a region edge back ~180°+ onto its parent and run a short
+ * return leg. The development is exact (Σ curl bend allowances + return length).
+ */
+export function hem(part: SheetMetalPart, spec: HemSpec): Result<SheetMetalPart> {
+  return hemFn(part, spec);
+}
+
+/**
+ * Author a jog (joggle): two opposite bends stepping the flat by `offsetHeight`
+ * perpendicular to its plane, then continuing parallel. Development is exact.
+ */
+export function jog(part: SheetMetalPart, spec: JogSpec): Result<SheetMetalPart> {
+  return jogFn(part, spec);
 }
 
 /** Emit an annotated multi-layer DXF string for a flat pattern. */

--- a/packages/brepjs-sheetmetal/src/contourFlangeFns.ts
+++ b/packages/brepjs-sheetmetal/src/contourFlangeFns.ts
@@ -32,7 +32,7 @@ import type {
 import { normalizeSolid } from './internal.js';
 import { developedLength } from './allowanceFns.js';
 
-interface SegmentFrame {
+export interface SegmentFrame {
   /** Origin of the −normal (bottom) surface at the start of this segment. */
   origin: Vec3;
   /** Outward run direction (the segment's local +X). */
@@ -161,12 +161,12 @@ export function authorContourFlange(
   });
 }
 
-interface BuiltSegment {
+export interface BuiltSegment {
   solid: Solid;
   frame: SegmentFrame;
 }
 
-interface BuiltArc extends BuiltSegment {
+export interface BuiltArc extends BuiltSegment {
   axisOrigin: Vec3;
 }
 
@@ -175,7 +175,7 @@ interface BuiltArc extends BuiltSegment {
  * `frame.run`, full thickness along `frame.n`, across `span` along `frame.axis`.
  * The next segment's frame starts at the leg's far end.
  */
-function buildLineLeg(
+export function buildLineLeg(
   base: Solid,
   frame: SegmentFrame,
   span: number,
@@ -201,7 +201,7 @@ function buildLineLeg(
  * The returned frame's run/normal are rotated by the fold so the next leg continues
  * tangentially.
  */
-function buildArcBend(
+export function buildArcBend(
   base: Solid,
   frame: SegmentFrame,
   span: number,
@@ -285,7 +285,7 @@ function frameTransform(runT: Vec3, axisT: Vec3, nT: Vec3, origin: Vec3): Placed
   };
 }
 
-interface BaseEdge {
+export interface BaseEdge {
   dir: Vec3;
   out: Vec3;
   start: Vec3;
@@ -293,7 +293,7 @@ interface BaseEdge {
 }
 
 /** Resolve one of the four edges of the base flat (the contour-flange root). */
-function baseEdge(part: SheetMetalPart, side: FlatSide): BaseEdge {
+export function baseEdge(part: SheetMetalPart, side: FlatSide): BaseEdge {
   const o: Vec3 = [0, 0, 0];
   const u: Vec3 = [1, 0, 0];
   const v: Vec3 = [0, 1, 0];
@@ -339,6 +339,71 @@ function baseEdge(part: SheetMetalPart, side: FlatSide): BaseEdge {
   const toB = vecSub(b, a);
   const start = vecDot(toB, dir) >= 0 ? a : b;
   return { dir, out, start, length };
+}
+
+/**
+ * Resolve one of the four edges of an arbitrary flat region (its world top-surface
+ * frame), the region-aware generalization of {@link baseEdge}: the base is the
+ * special case where `origin = 0`, `u = +X`, `v = +Y`, `n = +Z`. Used by hems and
+ * jogs to chain their profile off a named flange (or the base) edge.
+ */
+export function regionEdge(
+  frame: { origin: Vec3; u: Vec3; v: Vec3; n: Vec3; uLen: number; vLen: number },
+  side: FlatSide
+): BaseEdge {
+  const o = frame.origin;
+  const uTop = vecAdd(o, vecScale(frame.u, frame.uLen));
+  const vTop = vecAdd(o, vecScale(frame.v, frame.vLen));
+  const uvTop = vecAdd(uTop, vecScale(frame.v, frame.vLen));
+
+  let out: Vec3;
+  let length: number;
+  let a: Vec3;
+  let b: Vec3;
+  switch (side) {
+    case 'xmax':
+      out = frame.u;
+      length = frame.vLen;
+      a = uTop;
+      b = uvTop;
+      break;
+    case 'xmin':
+      out = vecScale(frame.u, -1);
+      length = frame.vLen;
+      a = o;
+      b = vTop;
+      break;
+    case 'ymax':
+      out = frame.v;
+      length = frame.uLen;
+      a = vTop;
+      b = uvTop;
+      break;
+    case 'ymin':
+      out = vecScale(frame.v, -1);
+      length = frame.uLen;
+      a = o;
+      b = uTop;
+      break;
+  }
+  const dir = vecNormalize(vecCross(frame.n, out));
+  const toB = vecSub(b, a);
+  const start = vecDot(toB, dir) >= 0 ? a : b;
+  return { dir, out, start, length };
+}
+
+/**
+ * The starting {@link SegmentFrame} for a profile chained off `edge` at `offset`
+ * along it: contact at the edge, run pointing outward, normal = the region normal,
+ * bend axis along the edge. Shared by the contour-flange, hem and jog builders.
+ */
+export function initialSegmentFrame(edge: BaseEdge, n: Vec3, offset: number): SegmentFrame {
+  return {
+    origin: vecAdd(edge.start, vecScale(edge.dir, offset)),
+    run: edge.out,
+    n,
+    axis: edge.dir,
+  };
 }
 
 /** Cylindrical bend patch (hollow tube ∩ fold wedge), mirroring authorFns. */

--- a/packages/brepjs-sheetmetal/src/facade.ts
+++ b/packages/brepjs-sheetmetal/src/facade.ts
@@ -34,6 +34,8 @@ import {
   emboss,
   contourFlange,
   loftedFlange,
+  hem,
+  jog,
   toDXF,
   report,
   validate,
@@ -49,6 +51,8 @@ import type {
   TabSpec,
   ContourFlangeSpec,
   LoftedFlangeSpec,
+  HemSpec,
+  JogSpec,
   SheetMetalWarning,
   UnfoldResult,
 } from './types.js';
@@ -172,6 +176,16 @@ class SheetMetalPartHandle {
   /** Author a lofted / ruled transition flange between two parallel open profiles. */
   loftedFlange(spec: LoftedFlangeSpec): SheetMetalPartHandle {
     return new SheetMetalPartHandle(unwrapOrThrow(loftedFlange(this.part, spec)));
+  }
+
+  /** Fold a region edge back ~180°+ onto its parent as a hem (closed/open/teardrop/rolled). */
+  hem(spec: HemSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(hem(this.part, spec)));
+  }
+
+  /** Step a region's flat by `offsetHeight` with two opposite bends (a jog/joggle). */
+  jog(spec: JogSpec): SheetMetalPartHandle {
+    return new SheetMetalPartHandle(unwrapOrThrow(jog(this.part, spec)));
   }
 
   /** Flatten into a developed flat pattern + bend report + warnings. */
@@ -345,6 +359,14 @@ class SheetMetalBuilder {
 
   loftedFlange(spec: LoftedFlangeSpec): SheetMetalPartHandle {
     return this.build().loftedFlange(spec);
+  }
+
+  hem(spec: HemSpec): SheetMetalPartHandle {
+    return this.build().hem(spec);
+  }
+
+  jog(spec: JogSpec): SheetMetalPartHandle {
+    return this.build().jog(spec);
   }
 
   unfold(): UnfoldResult {

--- a/packages/brepjs-sheetmetal/src/featureTreeFns.ts
+++ b/packages/brepjs-sheetmetal/src/featureTreeFns.ts
@@ -84,6 +84,12 @@ export function buildFeatureGraph(part: SheetMetalPart): Result<FeatureGraph> {
     // the graph — they would resolve to no flange flat and break the tree.
     if (bend.id.startsWith('contour::')) continue;
 
+    // Hem and jog sub-bends (`hem::<id>::<n>` / `jog::<id>::<n>`) are the curl/step
+    // arcs of a recorded hem or jog. Like contour bends they record their own
+    // developed strip (in `part.hems` / `part.jogs`) and lay out non-rectilinearly,
+    // so they never enter the spanning tree.
+    if (bend.id.startsWith('hem::') || bend.id.startsWith('jog::')) continue;
+
     // A seam bend (`seam::<parent>::<child>`) is an explicit edge between two
     // already-authored flats — the cycle-closing edge of a tube/box profile.
     if (bend.id.startsWith('seam::')) {

--- a/packages/brepjs-sheetmetal/src/hemFns.ts
+++ b/packages/brepjs-sheetmetal/src/hemFns.ts
@@ -1,0 +1,249 @@
+import { type Result, type Solid, ok, err, validationError } from 'brepjs';
+import type {
+  BendFeature,
+  BendRule,
+  HemFeature,
+  HemSpec,
+  SheetMetalPart,
+} from './types.js';
+import { normalizeSolid } from './internal.js';
+import { developedLength } from './allowanceFns.js';
+import { worldFrames } from './authorFns.js';
+import { ROOT_FLAT_ID } from './featureTreeFns.js';
+import {
+  type SegmentFrame,
+  buildLineLeg,
+  buildArcBend,
+  regionEdge,
+  initialSegmentFrame,
+} from './contourFlangeFns.js';
+
+/**
+ * A small clearance baked into a CLOSED hem's curl radius. A true closed hem folds
+ * the return flat against the parent with zero gap; modelling that exactly makes the
+ * curl's inner cylinder coincide with the parent face, so the boolean fuse produces
+ * a self-touching (non-manifold) solid. Inflating the inner radius by this HAIR
+ * leaves a sub-thickness air gap that keeps the fused solid valid while still
+ * reading as a closed hem. Documented so a reader understands the gap is intentional.
+ */
+const CLOSED_HEM_HAIR = 0.05;
+
+/** Sub-arc cap (deg): the bend-patch wedge degenerates at ≥180°, so curls split. */
+const MAX_SUBARC_DEG = 120;
+
+interface HemPlan {
+  /** Total curl angle in degrees (≈180 for closed/open, >180 teardrop, ~270 rolled). */
+  curlDeg: number;
+  /** Inner bend radius used for the curl. */
+  radius: number;
+  /** Flat return-leg length past the curl (0 for rolled). */
+  returnLength: number;
+}
+
+/**
+ * Author a hem: fold a region edge back ~180°+ onto its parent flat, then run a
+ * short return leg. Built on the contour-flange segment chainer — the curl is one
+ * or more ≤120° sub-arcs (each a recorded `hem::<id>::<n>` bend) followed by a flat
+ * return — so the development is EXACT: Σ curl bend allowances (via the table-aware
+ * {@link developedLength}) + the return length, laid out straight past the edge.
+ * Four `type`s set the curl/gap geometry (see {@link HemSpec}). Construction stays
+ * on the public, OCCT-WASM-safe API; the result is guarded to a valid single solid.
+ */
+export function hem(part: SheetMetalPart, spec: HemSpec): Result<SheetMetalPart> {
+  if (part.solid === undefined) {
+    return err(validationError('NO_SOLID', `part has no solid to attach hem '${hemId(spec)}'`));
+  }
+  const id = hemId(spec);
+  if (id.includes('::')) {
+    return err(validationError('INVALID_HEM_ID', `hem id must not contain '::', got '${id}'`));
+  }
+  for (const existing of part.hems ?? []) {
+    if (existing.id === id) {
+      return err(validationError('DUPLICATE_HEM', `duplicate hem id '${id}'`));
+    }
+  }
+
+  const thickness = part.thickness;
+  const planResult = planHem(spec, thickness);
+  if (!planResult.ok) return planResult;
+  const plan = planResult.value;
+
+  const framesResult = worldFrames(part);
+  if (!framesResult.ok) return framesResult;
+  const regionId = resolveRegion(spec.region);
+  const regionFrame = framesResult.value.get(regionId);
+  if (regionFrame === undefined) {
+    return err(validationError('UNKNOWN_REGION', `hem '${id}' references unknown region '${spec.region}'`));
+  }
+
+  const edge = regionEdge(regionFrame, spec.side);
+  const offset = spec.offset ?? 0;
+  const span = spec.width ?? edge.length;
+  if (!Number.isFinite(offset) || offset < -1e-9) {
+    return err(validationError('INVALID_OFFSET', `hem '${id}' offset must be non-negative`));
+  }
+  if (!Number.isFinite(span) || span <= 0) {
+    return err(validationError('INVALID_HEM_WIDTH', `hem '${id}' width must be positive`));
+  }
+  if (offset + span > edge.length + 1e-6) {
+    return err(
+      validationError('HEM_OUT_OF_BOUNDS', `hem '${id}' [${offset}, ${offset + span}] exceeds region edge length ${edge.length}`)
+    );
+  }
+
+  const rule: BendRule = spec.rule ?? { innerRadius: plan.radius, kFactor: 0.44 };
+  const subAngles = splitAngle(plan.curlDeg);
+
+  // The curl is split into ≤120° sub-arcs only because the bend-patch wedge
+  // degenerates at ≥180°; the DEVELOPMENT is one physical curl. Resolve the full
+  // curl angle's allowance as a single table/formula query, then apportion it to
+  // the sub-arcs by angle. Querying each sub-arc separately would over-count a
+  // table sparse in angle (each sub-angle clamps up to the nearest tabulated row).
+  const fullDevResult = developedLength(plan.curlDeg, thickness, { ...rule, innerRadius: plan.radius });
+  if (!fullDevResult.ok) return fullDevResult;
+  const devPerDeg = plan.curlDeg > 0 ? fullDevResult.value / plan.curlDeg : 0;
+
+  let frame: SegmentFrame = initialSegmentFrame(edge, regionFrame.n, offset);
+  let solid: Solid = part.solid;
+  const bends: BendFeature[] = [];
+  const segments: HemFeature['segments'] = [];
+  const subBends: string[] = [];
+  let devTotal = 0;
+
+  for (let i = 0; i < subAngles.length; i += 1) {
+    const subDeg = subAngles[i];
+    if (subDeg === undefined) continue;
+    const built = buildArcBend(solid, frame, span, thickness, {
+      kind: 'arc',
+      radius: plan.radius,
+      angleDeg: subDeg,
+      direction: 'up',
+    });
+    if (!built.ok) return built;
+    solid = built.value.solid;
+    frame = built.value.frame;
+
+    const dev = devPerDeg * subDeg;
+
+    const bendId = `hem::${id}::${i}`;
+    subBends.push(bendId);
+    bends.push({
+      id: bendId,
+      axisOrigin: [built.value.axisOrigin[0], built.value.axisOrigin[1], built.value.axisOrigin[2]],
+      axisDir: [edge.dir[0], edge.dir[1], edge.dir[2]],
+      angleDeg: subDeg,
+      direction: 'up',
+      rule: { ...rule, innerRadius: plan.radius },
+    });
+    segments.push({ kind: 'arc', dev, angleDeg: subDeg, direction: 'up', bendId });
+    devTotal += dev;
+  }
+
+  if (plan.returnLength > 0) {
+    const built = buildLineLeg(solid, frame, span, thickness, plan.returnLength);
+    if (!built.ok) return built;
+    solid = built.value.solid;
+    segments.push({ kind: 'line', dev: plan.returnLength });
+    devTotal += plan.returnLength;
+  }
+
+  const feature: HemFeature = {
+    id,
+    type: spec.type,
+    region: regionId,
+    side: spec.side,
+    offset,
+    span,
+    returnLength: plan.returnLength,
+    developedLength: devTotal,
+    subBends,
+    segments,
+  };
+
+  return ok({
+    ...part,
+    solid: normalizeSolid(solid),
+    bends: [...part.bends, ...bends],
+    hems: [...(part.hems ?? []), feature],
+  });
+}
+
+/** Deterministic hem id from its region/side/type when none is supplied. */
+function hemId(spec: HemSpec): string {
+  return `hem-${spec.region}-${spec.side}-${spec.type}`;
+}
+
+function resolveRegion(region: string): string {
+  return region === 'base' || region === 'face-0' ? ROOT_FLAT_ID : region;
+}
+
+/**
+ * Resolve a {@link HemSpec} into its curl angle, radius and return length. The
+ * radius defaults to one thickness (the tightest practical hem). A closed hem
+ * inflates the radius by {@link CLOSED_HEM_HAIR} so the fused solid stays valid;
+ * an open hem widens the radius to span the requested gap; teardrop/rolled set a
+ * larger curl angle.
+ */
+function planHem(spec: HemSpec, thickness: number): Result<HemPlan> {
+  if (!Number.isFinite(thickness) || thickness <= 0) {
+    return err(validationError('INVALID_THICKNESS', `hem thickness must be positive, got ${thickness}`));
+  }
+  const baseRadius = spec.radius ?? thickness;
+  if (!Number.isFinite(baseRadius) || baseRadius <= 0) {
+    return err(validationError('INVALID_HEM_RADIUS', `hem radius must be positive, got ${baseRadius}`));
+  }
+
+  switch (spec.type) {
+    case 'closed': {
+      const returnLength = spec.length ?? 0;
+      if (!Number.isFinite(returnLength) || returnLength <= 0) {
+        return err(
+          validationError('INVALID_HEM_LENGTH', `closed hem requires a positive return length, got ${spec.length}`)
+        );
+      }
+      if (returnLength < thickness) {
+        return err(
+          validationError('HEM_LENGTH_TOO_SHORT', `closed hem return length ${returnLength} must be ≥ thickness ${thickness}`)
+        );
+      }
+      return ok({ curlDeg: 180, radius: baseRadius + CLOSED_HEM_HAIR, returnLength });
+    }
+    case 'open': {
+      const returnLength = spec.length ?? 0;
+      if (!Number.isFinite(returnLength) || returnLength <= 0) {
+        return err(
+          validationError('INVALID_HEM_LENGTH', `open hem requires a positive return length, got ${spec.length}`)
+        );
+      }
+      // Open-hem gap = the clear distance between the return and the parent. The
+      // curl's inner radius sets that gap directly (the return lands a diameter +
+      // thickness away), so size the radius from the requested gap.
+      const gap = spec.gap ?? baseRadius;
+      if (!Number.isFinite(gap) || gap <= 0) {
+        return err(validationError('INVALID_HEM_GAP', `open hem gap must be positive, got ${gap}`));
+      }
+      return ok({ curlDeg: 180, radius: gap, returnLength });
+    }
+    case 'teardrop': {
+      const returnLength = spec.length ?? 0;
+      if (!Number.isFinite(returnLength) || returnLength <= 0) {
+        return err(
+          validationError('INVALID_HEM_LENGTH', `teardrop hem requires a positive return length, got ${spec.length}`)
+        );
+      }
+      return ok({ curlDeg: 210, radius: baseRadius, returnLength });
+    }
+    case 'rolled':
+      // A full circular roll (curled / safe edge): no flat return.
+      return ok({ curlDeg: 270, radius: baseRadius, returnLength: 0 });
+    default:
+      return spec.type satisfies never;
+  }
+}
+
+/** Split a curl angle into ≤{@link MAX_SUBARC_DEG} equal sub-arcs (the wedge cap). */
+function splitAngle(totalDeg: number): number[] {
+  const n = Math.max(1, Math.ceil(totalDeg / MAX_SUBARC_DEG));
+  const per = totalDeg / n;
+  return Array.from({ length: n }, () => per);
+}

--- a/packages/brepjs-sheetmetal/src/hemFns.ts
+++ b/packages/brepjs-sheetmetal/src/hemFns.ts
@@ -168,9 +168,9 @@ export function hem(part: SheetMetalPart, spec: HemSpec): Result<SheetMetalPart>
   });
 }
 
-/** Deterministic hem id from its region/side/type when none is supplied. */
+/** The hem's id: an explicit `spec.id`, else a deterministic region/side/type key. */
 function hemId(spec: HemSpec): string {
-  return `hem-${spec.region}-${spec.side}-${spec.type}`;
+  return spec.id ?? `hem-${spec.region}-${spec.side}-${spec.type}`;
 }
 
 function resolveRegion(region: string): string {
@@ -188,10 +188,13 @@ function planHem(spec: HemSpec, thickness: number): Result<HemPlan> {
   if (!Number.isFinite(thickness) || thickness <= 0) {
     return err(validationError('INVALID_THICKNESS', `hem thickness must be positive, got ${thickness}`));
   }
-  const baseRadius = spec.radius ?? thickness;
-  if (!Number.isFinite(baseRadius) || baseRadius <= 0) {
-    return err(validationError('INVALID_HEM_RADIUS', `hem radius must be positive, got ${baseRadius}`));
+  if (spec.radius !== undefined && (!Number.isFinite(spec.radius) || spec.radius < 0)) {
+    return err(validationError('INVALID_HEM_RADIUS', `hem radius must be non-negative, got ${spec.radius}`));
   }
+  // Inner-radius default differs by type: a closed hem folds essentially flat
+  // (radius ≈ 0, just the HAIR clearance) so it is actually closed; teardrop/rolled
+  // default to one thickness. Open derives its radius from the requested gap below.
+  const baseRadius = spec.radius ?? thickness;
 
   switch (spec.type) {
     case 'closed': {
@@ -206,7 +209,9 @@ function planHem(spec: HemSpec, thickness: number): Result<HemPlan> {
           validationError('HEM_LENGTH_TOO_SHORT', `closed hem return length ${returnLength} must be ≥ thickness ${thickness}`)
         );
       }
-      return ok({ curlDeg: 180, radius: baseRadius + CLOSED_HEM_HAIR, returnLength });
+      // Default to a tight (≈0) radius so the return folds flat against the parent
+      // (an actually-closed hem); the HAIR keeps the coincident-face fuse valid.
+      return ok({ curlDeg: 180, radius: (spec.radius ?? 0) + CLOSED_HEM_HAIR, returnLength });
     }
     case 'open': {
       const returnLength = spec.length ?? 0;
@@ -215,14 +220,13 @@ function planHem(spec: HemSpec, thickness: number): Result<HemPlan> {
           validationError('INVALID_HEM_LENGTH', `open hem requires a positive return length, got ${spec.length}`)
         );
       }
-      // Open-hem gap = the clear distance between the return and the parent. The
-      // curl's inner radius sets that gap directly (the return lands a diameter +
-      // thickness away), so size the radius from the requested gap.
-      const gap = spec.gap ?? baseRadius;
+      // `gap` is the physical clear distance between the return and the parent. A
+      // 180° fold at inner radius r lands the return 2r away, so the radius is gap/2.
+      const gap = spec.gap ?? thickness;
       if (!Number.isFinite(gap) || gap <= 0) {
         return err(validationError('INVALID_HEM_GAP', `open hem gap must be positive, got ${gap}`));
       }
-      return ok({ curlDeg: 180, radius: gap, returnLength });
+      return ok({ curlDeg: 180, radius: gap / 2, returnLength });
     }
     case 'teardrop': {
       const returnLength = spec.length ?? 0;

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -58,6 +58,9 @@ export { addForm, louver, emboss } from './formFns.js';
 export { authorContourFlange } from './contourFlangeFns.js';
 export { authorLoftedFlange } from './loftedFlangeFns.js';
 
+export { hem } from './hemFns.js';
+export { jog } from './jogFns.js';
+
 export { flatPatternToDXF } from './dxfFns.js';
 export type { DxfOptions } from './dxfFns.js';
 
@@ -122,6 +125,10 @@ export type {
   ContourFlangeFeature,
   LoftedFlangeSpec,
   LoftedFlangeFeature,
+  HemSpec,
+  HemFeature,
+  JogSpec,
+  JogFeature,
   SheetMetalPart,
   FlatPattern,
   FlatInput,

--- a/packages/brepjs-sheetmetal/src/jogFns.ts
+++ b/packages/brepjs-sheetmetal/src/jogFns.ts
@@ -1,0 +1,204 @@
+import { type Result, type Solid, ok, err, validationError } from 'brepjs';
+import type {
+  BendFeature,
+  BendRule,
+  JogFeature,
+  JogSpec,
+  SheetMetalPart,
+} from './types.js';
+import { normalizeSolid } from './internal.js';
+import { developedLength } from './allowanceFns.js';
+import { worldFrames } from './authorFns.js';
+import { ROOT_FLAT_ID } from './featureTreeFns.js';
+import {
+  type SegmentFrame,
+  buildLineLeg,
+  buildArcBend,
+  regionEdge,
+  initialSegmentFrame,
+} from './contourFlangeFns.js';
+
+/**
+ * Author a jog (joggle): two opposite bends (`+θ` then `−θ`) that step a flat by
+ * `offsetHeight` perpendicular to its plane, then continue parallel past the step.
+ * Built on the contour-flange chainer: a flat position leg, a `+θ` up bend
+ * (`jog::<id>::0`), the connecting step run, a `−θ` down bend (`jog::<id>::1`), and
+ * a flat run-out leg. The development is EXACT (Σ legs + Σ bend allowances, via the
+ * table-aware {@link developedLength}). The connecting step run is
+ * `offsetHeight / sin(θ)` so the two bends realize the requested perpendicular step;
+ * the result is guarded to a valid single solid. OCCT-WASM-safe construction only.
+ */
+export function jog(part: SheetMetalPart, spec: JogSpec): Result<SheetMetalPart> {
+  if (part.solid === undefined) {
+    return err(validationError('NO_SOLID', `part has no solid to attach jog '${jogId(spec)}'`));
+  }
+  const id = jogId(spec);
+  if (id.includes('::')) {
+    return err(validationError('INVALID_JOG_ID', `jog id must not contain '::', got '${id}'`));
+  }
+  for (const existing of part.jogs ?? []) {
+    if (existing.id === id) {
+      return err(validationError('DUPLICATE_JOG', `duplicate jog id '${id}'`));
+    }
+  }
+
+  const thickness = part.thickness;
+  if (!Number.isFinite(spec.offsetHeight) || spec.offsetHeight <= 0) {
+    return err(validationError('INVALID_JOG_OFFSET', `jog offsetHeight must be positive, got ${spec.offsetHeight}`));
+  }
+  if (!Number.isFinite(spec.position) || spec.position <= 0) {
+    return err(validationError('INVALID_JOG_POSITION', `jog position must be positive, got ${spec.position}`));
+  }
+  const angleDeg = spec.angle ?? 45;
+  if (!Number.isFinite(angleDeg) || angleDeg <= 0 || angleDeg >= 90) {
+    return err(validationError('INVALID_JOG_ANGLE', `jog angle must be in (0, 90), got ${angleDeg}`));
+  }
+  const radius = spec.radius ?? thickness;
+  if (!Number.isFinite(radius) || radius <= 0) {
+    return err(validationError('INVALID_JOG_RADIUS', `jog radius must be positive, got ${radius}`));
+  }
+  const runOut = spec.runOut ?? spec.position;
+  if (!Number.isFinite(runOut) || runOut <= 0) {
+    return err(validationError('INVALID_JOG_RUNOUT', `jog runOut must be positive, got ${runOut}`));
+  }
+
+  const framesResult = worldFrames(part);
+  if (!framesResult.ok) return framesResult;
+  const regionId = resolveRegion(spec.region);
+  const regionFrame = framesResult.value.get(regionId);
+  if (regionFrame === undefined) {
+    return err(validationError('UNKNOWN_REGION', `jog '${id}' references unknown region '${spec.region}'`));
+  }
+
+  const edge = regionEdge(regionFrame, spec.side);
+  const offset = spec.offset ?? 0;
+  const span = spec.width ?? edge.length;
+  if (!Number.isFinite(offset) || offset < -1e-9) {
+    return err(validationError('INVALID_OFFSET', `jog '${id}' offset must be non-negative`));
+  }
+  if (!Number.isFinite(span) || span <= 0) {
+    return err(validationError('INVALID_JOG_WIDTH', `jog '${id}' width must be positive`));
+  }
+  if (offset + span > edge.length + 1e-6) {
+    return err(
+      validationError('JOG_OUT_OF_BOUNDS', `jog '${id}' [${offset}, ${offset + span}] exceeds region edge length ${edge.length}`)
+    );
+  }
+
+  const rule: BendRule = spec.rule ?? { innerRadius: radius, kFactor: 0.44 };
+  // The connecting step run carries the flat across the offset at angle θ. The two
+  // arcs themselves each rise (T+2r)/2·(1−cosθ) perpendicular to the plane (the
+  // up-bend rises (T+r)(1−cosθ), the down-bend r(1−cosθ)); the step run adds
+  // L·sinθ. Solving for the total perpendicular rise = offsetHeight gives this L, so
+  // the run-out bottom face sits exactly offsetHeight above the base bottom face.
+  const theta = (angleDeg * Math.PI) / 180;
+  const arcRise = (thickness + 2 * radius) * (1 - Math.cos(theta));
+  const stepRun = (spec.offsetHeight - arcRise) / Math.sin(theta);
+  if (!(stepRun > 0)) {
+    return err(
+      validationError(
+        'JOG_OFFSET_TOO_SMALL',
+        `jog offsetHeight ${spec.offsetHeight} is too small for radius ${radius} at ${angleDeg}° (the bends alone rise ${arcRise.toFixed(3)}); increase offsetHeight or reduce radius/angle`
+      )
+    );
+  }
+
+  let frame: SegmentFrame = initialSegmentFrame(edge, regionFrame.n, offset);
+  let solid: Solid = part.solid;
+  const bends: BendFeature[] = [];
+  const segments: JogFeature['segments'] = [];
+  const bendIds: string[] = [];
+  let devTotal = 0;
+
+  // 1) Flat position leg out to the first bend.
+  {
+    const built = buildLineLeg(solid, frame, span, thickness, spec.position);
+    if (!built.ok) return built;
+    solid = built.value.solid;
+    frame = built.value.frame;
+    segments.push({ kind: 'line', dev: spec.position });
+    devTotal += spec.position;
+  }
+
+  // 2) Up bend (+θ), 3) step run, 4) down bend (−θ): the two opposite bends.
+  const order: { dir: 'up' | 'down'; step?: number }[] = [
+    { dir: 'up', step: stepRun },
+    { dir: 'down' },
+  ];
+  for (let i = 0; i < order.length; i += 1) {
+    const o = order[i];
+    if (o === undefined) continue;
+    const built = buildArcBend(solid, frame, span, thickness, {
+      kind: 'arc',
+      radius,
+      angleDeg,
+      direction: o.dir,
+    });
+    if (!built.ok) return built;
+    solid = built.value.solid;
+    frame = built.value.frame;
+
+    const devResult = developedLength(angleDeg, thickness, { ...rule, innerRadius: radius });
+    if (!devResult.ok) return devResult;
+    const dev = devResult.value;
+
+    const bendId = `jog::${id}::${i}`;
+    bendIds.push(bendId);
+    bends.push({
+      id: bendId,
+      axisOrigin: [built.value.axisOrigin[0], built.value.axisOrigin[1], built.value.axisOrigin[2]],
+      axisDir: [edge.dir[0], edge.dir[1], edge.dir[2]],
+      angleDeg,
+      direction: o.dir,
+      rule: { ...rule, innerRadius: radius },
+    });
+    segments.push({ kind: 'arc', dev, angleDeg, direction: o.dir, bendId });
+    devTotal += dev;
+
+    if (o.step !== undefined) {
+      const stepBuilt = buildLineLeg(solid, frame, span, thickness, o.step);
+      if (!stepBuilt.ok) return stepBuilt;
+      solid = stepBuilt.value.solid;
+      frame = stepBuilt.value.frame;
+      segments.push({ kind: 'line', dev: o.step });
+      devTotal += o.step;
+    }
+  }
+
+  // 5) Flat run-out leg, parallel to the original plane, offset by offsetHeight.
+  {
+    const built = buildLineLeg(solid, frame, span, thickness, runOut);
+    if (!built.ok) return built;
+    solid = built.value.solid;
+    segments.push({ kind: 'line', dev: runOut });
+    devTotal += runOut;
+  }
+
+  const feature: JogFeature = {
+    id,
+    region: regionId,
+    side: spec.side,
+    offset,
+    span,
+    offsetHeight: spec.offsetHeight,
+    angleDeg,
+    developedLength: devTotal,
+    bends: bendIds,
+    segments,
+  };
+
+  return ok({
+    ...part,
+    solid: normalizeSolid(solid),
+    bends: [...part.bends, ...bends],
+    jogs: [...(part.jogs ?? []), feature],
+  });
+}
+
+function jogId(spec: JogSpec): string {
+  return `jog-${spec.region}-${spec.side}`;
+}
+
+function resolveRegion(region: string): string {
+  return region === 'base' || region === 'face-0' ? ROOT_FLAT_ID : region;
+}

--- a/packages/brepjs-sheetmetal/src/jogFns.ts
+++ b/packages/brepjs-sheetmetal/src/jogFns.ts
@@ -196,7 +196,7 @@ export function jog(part: SheetMetalPart, spec: JogSpec): Result<SheetMetalPart>
 }
 
 function jogId(spec: JogSpec): string {
-  return `jog-${spec.region}-${spec.side}`;
+  return spec.id ?? `jog-${spec.region}-${spec.side}`;
 }
 
 function resolveRegion(region: string): string {

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -365,11 +365,17 @@ export interface HemSpec {
   region: string;
   side: FlatSide;
   type: 'closed' | 'open' | 'teardrop' | 'rolled';
+  /** Optional unique id; defaults to `hem-<region>-<side>-<type>`. Set this to
+   * place more than one hem of the same type on the same region edge (e.g. at
+   * different offsets). Must not contain `::`. */
+  id?: string | undefined;
   /** Return-leg length out along the parent. Required for closed/open/teardrop. */
   length?: number | undefined;
-  /** Inner bend radius. Default = one material thickness. */
+  /** Inner bend radius. Default = one thickness (closed defaults to ≈0, just the
+   * HAIR clearance, so it folds flat). */
   radius?: number | undefined;
-  /** Open-hem gap between the return and the parent. Default = `radius`. */
+  /** Open-hem physical clear distance between the return and the parent (the inner
+   * radius is set to gap/2). Default = one thickness. */
   gap?: number | undefined;
   /** Start position along the region edge. Default `0`. */
   offset?: number | undefined;
@@ -427,6 +433,10 @@ export interface HemFeature {
 export interface JogSpec {
   region: string;
   side: FlatSide;
+  /** Optional unique id; defaults to `jog-<region>-<side>`. Set this to place more
+   * than one jog on the same region edge (e.g. at different positions). Must not
+   * contain `::`. */
+  id?: string | undefined;
   /** Distance out along the run from the region edge to the first bend. */
   position: number;
   /** The perpendicular step the two opposite bends produce. Must be > 0. */

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -343,6 +343,134 @@ export interface LoftedFlangeFeature {
   approximate: boolean;
 }
 
+/**
+ * A hem: an edge folded back ~180°+ onto its parent flat, then running a short
+ * return leg. `region` names the flat the hem folds off (a flange id, or
+ * `'base'`/`'root'` for the base flat); `side` is that region's local edge. The
+ * four `type`s set the curl angle and the gap between the return and the parent:
+ *
+ * - `closed`   — a tight ~180° fold, the return runs flat against the parent
+ *   (`gap ≈ 0`; a HAIR clearance keeps the fused solid valid). `length` is the
+ *   return-leg length out along the parent.
+ * - `open`     — a ~180° fold with a `gap` (defaults to `radius`) between the
+ *   return and the parent, the return running parallel offset by the gap.
+ * - `teardrop` — a >180° curl leaving a small teardrop opening, then a short
+ *   return tangent to the curl.
+ * - `rolled`   — a full ~270° circular roll (a curled edge / safe edge), no return.
+ *
+ * `radius` is the inner bend radius (defaults to one material thickness). `gap`
+ * applies to `open` only. `rule` overrides the part's per-bend allowance rule.
+ */
+export interface HemSpec {
+  region: string;
+  side: FlatSide;
+  type: 'closed' | 'open' | 'teardrop' | 'rolled';
+  /** Return-leg length out along the parent. Required for closed/open/teardrop. */
+  length?: number | undefined;
+  /** Inner bend radius. Default = one material thickness. */
+  radius?: number | undefined;
+  /** Open-hem gap between the return and the parent. Default = `radius`. */
+  gap?: number | undefined;
+  /** Start position along the region edge. Default `0`. */
+  offset?: number | undefined;
+  /** Extent along the region edge. Default = full edge length. */
+  width?: number | undefined;
+  rule?: BendRule | undefined;
+}
+
+/**
+ * A recorded hem, mirroring {@link ContourFlangeFeature}: enough for the unfold to
+ * lay its developed strip out straight along the parent edge. `subBends` are the
+ * `hem::<id>::<n>` curl bends (one per ≤180° sub-arc); `returnLength` is the flat
+ * return leg past the curl. `developedLength` is the EXACT strip length out from
+ * the edge: Σ curl bend allowances + `returnLength`. `segments` mirrors the
+ * contour-flange developed segment list (a flat leg or a developed bend arc), so
+ * the unfold lays bend lines at their exact cumulative developed offsets.
+ */
+export interface HemFeature {
+  id: string;
+  type: HemSpec['type'];
+  /** The flat region the hem folds off (a flange id, or `'root'` for the base). */
+  region: string;
+  side: FlatSide;
+  /** Start position along the parent edge. */
+  offset: number;
+  /** Extent along the parent edge (the developed strip width). */
+  span: number;
+  /** Flat return-leg length past the curl (0 for a rolled hem). */
+  returnLength: number;
+  /** Exact developed length out from the parent edge (Σ curl allowances + return). */
+  developedLength: number;
+  subBends: string[];
+  segments: {
+    kind: 'line' | 'arc';
+    /** Developed length of this segment along the strip. */
+    dev: number;
+    angleDeg?: number | undefined;
+    direction?: 'up' | 'down' | undefined;
+    /** Id of the recorded {@link BendFeature} for an arc segment. */
+    bendId?: string | undefined;
+  }[];
+}
+
+/**
+ * A jog (joggle): two opposite bends (`+θ` then `−θ`) that step a flat by
+ * `offsetHeight` perpendicular to its plane, then continue parallel past the step.
+ * `region` names the flat the jog runs across (a flange id, or `'base'`/`'root'`);
+ * `side` is the region edge the jog develops out from; `position` is how far out
+ * along the run the jog sits; `offsetHeight` is the Z-step the two bends produce.
+ * `angle` (default 45°) is the magnitude of each bend — a shallower angle gives a
+ * longer, gentler step; the connecting step run is `offsetHeight / sin(angle)`.
+ * `runOut` is the flat leg continuing past the second bend. `rule` overrides the
+ * per-bend allowance rule.
+ */
+export interface JogSpec {
+  region: string;
+  side: FlatSide;
+  /** Distance out along the run from the region edge to the first bend. */
+  position: number;
+  /** The perpendicular step the two opposite bends produce. Must be > 0. */
+  offsetHeight: number;
+  /** Magnitude of each opposite bend, in degrees (0, 90). Default `45`. */
+  angle?: number | undefined;
+  /** Flat leg continuing past the second bend. Default = `position`. */
+  runOut?: number | undefined;
+  /** Inner bend radius. Default = one material thickness. */
+  radius?: number | undefined;
+  /** Start position along the region edge. Default `0`. */
+  offset?: number | undefined;
+  /** Extent along the region edge. Default = full edge length. */
+  width?: number | undefined;
+  rule?: BendRule | undefined;
+}
+
+/**
+ * A recorded jog, mirroring {@link HemFeature}. `bends` are the two opposite curl
+ * bends (`jog::<id>::0` up, `jog::<id>::1` down); `offsetHeight` is the requested
+ * perpendicular step; `segments` is the developed leg/arc list (position leg →
+ * up bend → step run → down bend → runOut leg). `developedLength` is the exact
+ * strip length out from the edge (Σ legs + Σ bend allowances).
+ */
+export interface JogFeature {
+  id: string;
+  /** The flat region the jog runs across (a flange id, or `'root'` for the base). */
+  region: string;
+  side: FlatSide;
+  offset: number;
+  span: number;
+  offsetHeight: number;
+  angleDeg: number;
+  developedLength: number;
+  bends: string[];
+  segments: {
+    kind: 'line' | 'arc';
+    dev: number;
+    angleDeg?: number | undefined;
+    direction?: 'up' | 'down' | undefined;
+    bendId?: string | undefined;
+  }[];
+}
+
 export interface SheetMetalPart {
   thickness: number;
   /** Base flat extent along +X (x∈[0, baseLength]); the east-run length. */
@@ -360,6 +488,8 @@ export interface SheetMetalPart {
   forms?: FormFeature[] | undefined;
   contourFlanges?: ContourFlangeFeature[] | undefined;
   loftedFlanges?: LoftedFlangeFeature[] | undefined;
+  hems?: HemFeature[] | undefined;
+  jogs?: JogFeature[] | undefined;
 }
 
 export interface FlatPattern {

--- a/packages/brepjs-sheetmetal/src/unfoldFns.ts
+++ b/packages/brepjs-sheetmetal/src/unfoldFns.ts
@@ -73,10 +73,16 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
   const contourResult = buildContourDevelopments(part);
   if (!contourResult.ok) return contourResult;
 
+  // Hems and jogs lay their multi-bend developed strips out straight along their
+  // region edge (the base or a flange), exactly like a contour flange.
+  const hemJogResult = buildHemJogDevelopments(part, layout);
+  if (!hemJogResult.ok) return hemJogResult;
+
   const rects: Rect[] = [];
   for (const placed of layout.flats) rects.push(placed.rect);
   for (const strip of layout.strips) rects.push(strip);
   for (const strip of contourResult.value.strips) rects.push(strip);
+  for (const strip of hemJogResult.value.strips) rects.push(strip);
 
   // Tabs are additive protrusions: their developed rectangles join the outer-outline
   // union and add to the developed area.
@@ -125,6 +131,13 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
     layout.developedArea += cf.developedLength * cf.span;
   }
 
+  for (const h of part.hems ?? []) {
+    layout.developedArea += h.developedLength * h.span;
+  }
+  for (const j of part.jogs ?? []) {
+    layout.developedArea += j.developedLength * j.span;
+  }
+
   const bendLines = layout.flats
     .filter((p): p is PlacedFlange => p.kind === 'flange')
     .map((p) => ({
@@ -136,7 +149,8 @@ export function unfold(part: SheetMetalPart): Result<UnfoldResult> {
       // negation. Correct for chained flanges too (it is local to the placement).
       inward: [-p.frame.v[0], -p.frame.v[1]] as [number, number],
     }))
-    .concat(contourResult.value.bendLines);
+    .concat(contourResult.value.bendLines)
+    .concat(hemJogResult.value.bendLines);
 
   const pattern: FlatPattern = {
     outline: outlineResult.value,
@@ -485,6 +499,94 @@ function buildContourDevelopments(part: SheetMetalPart): Result<ContourDevelopme
         const b = add2(a, scale2(along, cf.span));
         bendLines.push({
           id: seg.bendId ?? cf.id,
+          line: line([a[0], a[1], 0], [b[0], b[1], 0]),
+          angleDeg: seg.angleDeg ?? 0,
+          direction: seg.direction ?? 'up',
+          inward: [-out[0], -out[1]] as [number, number],
+        });
+      }
+      cumulative += seg.dev;
+    }
+  }
+  return ok({ strips, bendLines });
+}
+
+interface HemJogDevelopments {
+  /** Developed strip rectangles (one per hem/jog) for the outline union. */
+  strips: Rect[];
+  /** Developed bend lines (one per curl/step sub-bend) in the flat pattern. */
+  bendLines: FlatPattern['bendLines'];
+}
+
+/**
+ * Lay each recorded hem and jog developed strip out STRAIGHT along its region edge
+ * (the base or a flange), mirroring {@link buildContourDevelopments}. The region's
+ * developed-plane {@link Frame2} comes from the tree layout (so a hem on a flange
+ * lands on that flange's developed face). Each sub-bend (a hem curl arc or a jog
+ * step arc) gets a bend line at its EXACT cumulative developed offset out from the
+ * edge — Σ segment developed lengths, so the strip length is exact.
+ */
+function buildHemJogDevelopments(part: SheetMetalPart, layout: TreeLayout): Result<HemJogDevelopments> {
+  const strips: Rect[] = [];
+  const bendLines: FlatPattern['bendLines'] = [];
+
+  const frameFor = (region: string): Frame2 | undefined => {
+    const id = region === 'base' || region === 'face-0' ? ROOT_FLAT_ID : region;
+    for (const p of layout.flats) {
+      if (p.id === id) return p.frame;
+    }
+    return undefined;
+  };
+
+  interface Strip {
+    region: string;
+    side: FlatSide;
+    offset: number;
+    span: number;
+    developedLength: number;
+    segments: {
+      kind: 'line' | 'arc';
+      dev: number;
+      angleDeg?: number | undefined;
+      direction?: 'up' | 'down' | undefined;
+      bendId?: string | undefined;
+    }[];
+  }
+  const allStrips: Strip[] = [
+    ...(part.hems ?? []).map((h) => ({
+      region: h.region,
+      side: h.side,
+      offset: h.offset,
+      span: h.span,
+      developedLength: h.developedLength,
+      segments: h.segments,
+    })),
+    ...(part.jogs ?? []).map((j) => ({
+      region: j.region,
+      side: j.side,
+      offset: j.offset,
+      span: j.span,
+      developedLength: j.developedLength,
+      segments: j.segments,
+    })),
+  ];
+
+  for (const s of allStrips) {
+    const regionFrame = frameFor(s.region);
+    if (regionFrame === undefined) {
+      return err(validationError('UNKNOWN_HEMJOG_REGION', `hem/jog region '${s.region}' missing from layout`));
+    }
+    const { along, out, edgeOrigin } = edgeBasis2(regionFrame, s.side);
+    const base = add2(edgeOrigin, scale2(along, s.offset));
+    strips.push(rectFromCorners(base, add2(add2(base, scale2(along, s.span)), scale2(out, s.developedLength))));
+
+    let cumulative = 0;
+    for (const seg of s.segments) {
+      if (seg.kind === 'arc') {
+        const a = add2(base, scale2(out, cumulative));
+        const b = add2(a, scale2(along, s.span));
+        bendLines.push({
+          id: seg.bendId ?? s.region,
           line: line([a[0], a[1], 0], [b[0], b[1], 0]),
           angleDeg: seg.angleDeg ?? 0,
           direction: seg.direction ?? 'up',

--- a/packages/brepjs-sheetmetal/tests/hemjog.test.ts
+++ b/packages/brepjs-sheetmetal/tests/hemjog.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume, isValid, isSolid, getSolids, getBounds } from 'brepjs';
+import { authorPart } from '../src/authorFns.js';
+import { hem } from '../src/hemFns.js';
+import { jog } from '../src/jogFns.js';
+import { unfold } from '../src/unfoldFns.js';
+import { developedLength } from '../src/allowanceFns.js';
+import { registerBendTable } from '../src/bendTableFns.js';
+import type { BendRule, SheetMetalPart } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const T = 1;
+const rule: BendRule = { innerRadius: 2, kFactor: 0.44 };
+
+function singleSolid(part: SheetMetalPart): boolean {
+  const s = part.solid;
+  if (s === undefined) return false;
+  if (isSolid(s)) return true;
+  return getSolids(s).length === 1;
+}
+
+function basePart(): SheetMetalPart {
+  const base = authorPart({ thickness: T, base: { length: 50, width: 30 }, flanges: [] });
+  if (!base.ok) throw new Error('base author failed');
+  return base.value;
+}
+
+describe('hem — fold-back development', () => {
+  it('develops a closed hem as Σ curl allowances + return length', () => {
+    const radius = 2;
+    const returnLength = 6;
+    const h = hem(basePart(), {
+      region: 'base',
+      side: 'xmax',
+      type: 'closed',
+      length: returnLength,
+      radius,
+      rule,
+    });
+    expect(h.ok).toBe(true);
+    if (!h.ok) return;
+    const part = h.value;
+
+    expect(singleSolid(part)).toBe(true);
+    if (part.solid !== undefined) expect(isValid(part.solid)).toBe(true);
+
+    const feature = part.hems?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+
+    // The developed length is exactly the sum of the recorded curl bend allowances
+    // (the closed hem hair-inflates the radius internally, so this self-consistent
+    // check ties the strip length to the actual recorded sub-bend developments)
+    // plus the flat return leg.
+    const arcDev = feature.segments
+      .filter((s) => s.kind === 'arc')
+      .reduce((acc, s) => acc + s.dev, 0);
+    expect(feature.developedLength).toBeCloseTo(arcDev + returnLength, 9);
+  });
+
+  it('develops an open hem as the exact 180° allowance at the gap radius + return', () => {
+    const gap = 3;
+    const returnLength = 6;
+    // An open hem sizes the curl inner radius directly from the gap (no hair), so
+    // its developed curl length is the exact 180° bend allowance at that radius.
+    const h = hem(basePart(), {
+      region: 'base',
+      side: 'xmax',
+      type: 'open',
+      length: returnLength,
+      gap,
+      rule,
+    });
+    expect(h.ok).toBe(true);
+    if (!h.ok) return;
+    const feature = h.value.hems?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+
+    const fullCurl = developedLength(180, T, { ...rule, innerRadius: gap });
+    expect(fullCurl.ok).toBe(true);
+    if (!fullCurl.ok) return;
+    const arcDev = feature.segments.filter((s) => s.kind === 'arc').reduce((acc, s) => acc + s.dev, 0);
+    // Σ sub-arc allowances == the single 180° allowance (allowance is linear in angle).
+    expect(arcDev).toBeCloseTo(fullCurl.value, 6);
+    expect(feature.developedLength).toBeCloseTo(fullCurl.value + returnLength, 6);
+  });
+
+  it('lays the curl bend lines in the flat pattern', () => {
+    const h = hem(basePart(), { region: 'base', side: 'xmax', type: 'closed', length: 6, radius: 2, rule });
+    expect(h.ok).toBe(true);
+    if (!h.ok) return;
+    const unfolded = unfold(h.value);
+    expect(unfolded.ok).toBe(true);
+    if (!unfolded.ok) return;
+    const feature = h.value.hems?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+    // One bend line per recorded curl sub-bend, all marked 'up'.
+    expect(unfolded.value.pattern.bendLines.length).toBe(feature.subBends.length);
+    expect(unfolded.value.pattern.bendLines.every((b) => b.direction === 'up')).toBe(true);
+  });
+
+  it('builds a valid single solid for every hem type', () => {
+    const types = ['closed', 'open', 'teardrop', 'rolled'] as const;
+    for (const type of types) {
+      const h = hem(basePart(), {
+        region: 'base',
+        side: 'xmax',
+        type,
+        length: type === 'rolled' ? undefined : 6,
+        radius: 2,
+        rule,
+      });
+      expect(h.ok, `hem type ${type}`).toBe(true);
+      if (!h.ok) continue;
+      expect(singleSolid(h.value), `single solid ${type}`).toBe(true);
+      if (h.value.solid !== undefined) {
+        expect(isValid(h.value.solid), `valid ${type}`).toBe(true);
+        const vol = measureVolume(h.value.solid);
+        expect(vol.ok && vol.value > 0, `volume ${type}`).toBe(true);
+      }
+    }
+  });
+
+  it('develops a bendTableRef hem per the table (PR8 ↔ PR9)', () => {
+    const reg = registerBendTable({
+      id: 'hem-test-table',
+      kind: 'allowance',
+      rows: [{ thickness: T, radius: 2, angleDeg: 180, value: 9.5 }],
+    });
+    expect(reg.ok).toBe(true);
+
+    const tableRule: BendRule = { innerRadius: 2, kFactor: 0.44, bendTableRef: 'hem-test-table' };
+    const h = hem(basePart(), { region: 'base', side: 'xmax', type: 'closed', length: 6, radius: 2, rule: tableRule });
+    expect(h.ok).toBe(true);
+    if (!h.ok) return;
+    const feature = h.value.hems?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+
+    // The full 180° curl resolves to the single tabulated value (9.5), distinct
+    // from the K-factor formula. The curl is split into sub-arcs only for geometry;
+    // the development apportions the FULL-curl allowance across them by angle, so the
+    // recorded Σ sub-arc devs equals the table's 180° value — NOT N× a per-sub-angle
+    // clamp (a table sparse in angle would otherwise over-count by the split factor).
+    const tableDev = developedLength(180, T, tableRule);
+    const kDev = developedLength(180, T, { innerRadius: 2, kFactor: 0.44 });
+    expect(tableDev.ok && kDev.ok).toBe(true);
+    if (!tableDev.ok || !kDev.ok) return;
+    expect(tableDev.value).not.toBeCloseTo(kDev.value, 2);
+    const arcDev = feature.segments.filter((s) => s.kind === 'arc').reduce((acc, s) => acc + s.dev, 0);
+    expect(arcDev).toBeCloseTo(tableDev.value, 6);
+    expect(arcDev).not.toBeCloseTo(kDev.value, 2);
+  });
+
+  it('apportions a sparse table across split sub-arcs without over-counting (270° rolled)', () => {
+    // A rolled hem curls 270°, split into 3×90° sub-arcs for geometry. A table with
+    // only a 270° row would clamp each 90° sub-query up to the 270° value, recording
+    // 3× the physical allowance if queried per sub-arc. The development must instead
+    // resolve the full 270° curl once and apportion it, so Σ sub-arc devs == the table
+    // 270° value, regardless of how many sub-arcs the geometry split needs.
+    const reg = registerBendTable({
+      id: 'rolled-test-table',
+      kind: 'allowance',
+      rows: [{ thickness: T, radius: 2, angleDeg: 270, value: 14.2 }],
+    });
+    expect(reg.ok).toBe(true);
+    const tableRule: BendRule = { innerRadius: 2, kFactor: 0.44, bendTableRef: 'rolled-test-table' };
+    const h = hem(basePart(), { region: 'base', side: 'xmax', type: 'rolled', radius: 2, rule: tableRule });
+    expect(h.ok).toBe(true);
+    if (!h.ok) return;
+    const feature = h.value.hems?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+    expect(feature.subBends.length).toBeGreaterThan(1);
+    const arcDev = feature.segments.filter((s) => s.kind === 'arc').reduce((acc, s) => acc + s.dev, 0);
+    expect(arcDev).toBeCloseTo(14.2, 6);
+  });
+
+  it('rejects a closed hem with a return length shorter than thickness', () => {
+    const h = hem(basePart(), { region: 'base', side: 'xmax', type: 'closed', length: 0.5, radius: 2, rule });
+    expect(h.ok).toBe(false);
+  });
+
+  it('rejects a closed hem with no return length', () => {
+    const h = hem(basePart(), { region: 'base', side: 'xmax', type: 'closed', radius: 2, rule });
+    expect(h.ok).toBe(false);
+  });
+});
+
+describe('jog — two-bend step', () => {
+  it('produces the requested perpendicular offset', () => {
+    const offsetHeight = 5;
+    const j = jog(basePart(), {
+      region: 'base',
+      side: 'xmax',
+      position: 8,
+      offsetHeight,
+      angle: 45,
+      runOut: 8,
+      radius: 2,
+      rule,
+    });
+    expect(j.ok).toBe(true);
+    if (!j.ok) return;
+    const part = j.value;
+    expect(singleSolid(part)).toBe(true);
+    if (part.solid === undefined) return;
+    expect(isValid(part.solid)).toBe(true);
+
+    // The base flat sits in z∈[0, T]; the jog steps the run-out leg up by
+    // offsetHeight, so the part's z-extent grows to ≈ offsetHeight + T.
+    const b = getBounds(part.solid);
+    expect(b.zMax - b.zMin).toBeCloseTo(offsetHeight + T, 1);
+  });
+
+  it('emits two opposite bend lines (one up, one down) in the flat', () => {
+    const j = jog(basePart(), { region: 'base', side: 'xmax', position: 8, offsetHeight: 5, angle: 45, rule });
+    expect(j.ok).toBe(true);
+    if (!j.ok) return;
+    const unfolded = unfold(j.value);
+    expect(unfolded.ok).toBe(true);
+    if (!unfolded.ok) return;
+    const bendLines = unfolded.value.pattern.bendLines;
+    expect(bendLines.length).toBe(2);
+    expect(bendLines.filter((b) => b.direction === 'up').length).toBe(1);
+    expect(bendLines.filter((b) => b.direction === 'down').length).toBe(1);
+  });
+
+  it('develops as 2 bend allowances + the leg runs (position + step + runOut)', () => {
+    const angle = 45;
+    const position = 8;
+    const offsetHeight = 5;
+    const runOut = 10;
+    const j = jog(basePart(), {
+      region: 'base',
+      side: 'xmax',
+      position,
+      offsetHeight,
+      angle,
+      runOut,
+      radius: 2,
+      rule,
+    });
+    expect(j.ok).toBe(true);
+    if (!j.ok) return;
+    const feature = j.value.jogs?.[0];
+    expect(feature).toBeDefined();
+    if (feature === undefined) return;
+
+    const bendDev = developedLength(angle, T, rule);
+    expect(bendDev.ok).toBe(true);
+    if (!bendDev.ok) return;
+    const radius = 2;
+    const theta = (angle * Math.PI) / 180;
+    // The step run is solved so the two arcs' rise + step rise == offsetHeight.
+    const arcRise = (T + 2 * radius) * (1 - Math.cos(theta));
+    const stepRun = (offsetHeight - arcRise) / Math.sin(theta);
+    const expectedDev = position + bendDev.value + stepRun + bendDev.value + runOut;
+    expect(feature.developedLength).toBeCloseTo(expectedDev, 6);
+  });
+
+  it('rejects offsetHeight ≤ 0', () => {
+    const j = jog(basePart(), { region: 'base', side: 'xmax', position: 8, offsetHeight: 0, rule });
+    expect(j.ok).toBe(false);
+  });
+
+  it('rejects an out-of-range angle', () => {
+    const j = jog(basePart(), { region: 'base', side: 'xmax', position: 8, offsetHeight: 5, angle: 90, rule });
+    expect(j.ok).toBe(false);
+  });
+});

--- a/packages/brepjs-sheetmetal/tests/hemjog.test.ts
+++ b/packages/brepjs-sheetmetal/tests/hemjog.test.ts
@@ -81,7 +81,8 @@ describe('hem — fold-back development', () => {
     expect(feature).toBeDefined();
     if (feature === undefined) return;
 
-    const fullCurl = developedLength(180, T, { ...rule, innerRadius: gap });
+    // `gap` is the physical clear distance; the inner bend radius is gap/2.
+    const fullCurl = developedLength(180, T, { ...rule, innerRadius: gap / 2 });
     expect(fullCurl.ok).toBe(true);
     if (!fullCurl.ok) return;
     const arcDev = feature.segments.filter((s) => s.kind === 'arc').reduce((acc, s) => acc + s.dev, 0);
@@ -273,5 +274,30 @@ describe('jog — two-bend step', () => {
   it('rejects an out-of-range angle', () => {
     const j = jog(basePart(), { region: 'base', side: 'xmax', position: 8, offsetHeight: 5, angle: 90, rule });
     expect(j.ok).toBe(false);
+  });
+});
+
+describe('hem/jog — review-fix behaviors', () => {
+  it('a closed hem with no radius folds tighter than one defaulting to a thickness', () => {
+    // The closed default is now ≈0 (HAIR), not one thickness — so its curl
+    // allowance is smaller than an explicit radius=thickness closed hem.
+    const tight = hem(basePart(), { region: 'base', side: 'xmax', type: 'closed', length: 6, rule });
+    const wide = hem(basePart(), { region: 'base', side: 'xmax', type: 'closed', length: 6, radius: T, rule });
+    expect(tight.ok && wide.ok).toBe(true);
+    if (!tight.ok || !wide.ok) return;
+    const dTight = tight.value.hems?.[0]?.developedLength ?? 0;
+    const dWide = wide.value.hems?.[0]?.developedLength ?? 0;
+    expect(dTight).toBeLessThan(dWide);
+  });
+
+  it('places two hems on the same edge via explicit ids (no DUPLICATE_HEM)', () => {
+    const one = hem(basePart(), { region: 'base', side: 'xmax', type: 'open', id: 'h1', length: 6, offset: 0, width: 12, gap: 2, rule });
+    expect(one.ok).toBe(true);
+    if (!one.ok) return;
+    const two = hem(one.value, { region: 'base', side: 'xmax', type: 'open', id: 'h2', length: 6, offset: 18, width: 12, gap: 2, rule });
+    expect(two.ok).toBe(true);
+    if (!two.ok) return;
+    expect(two.value.hems?.length).toBe(2);
+    if (two.value.solid !== undefined) expect(isValid(two.value.solid)).toBe(true);
   });
 });


### PR DESCRIPTION
## Phase 3 · PR2 of 4 (bend tables ✓ · **hems/jogs** · nesting)

Two ergonomic edge features built on the contour-flange segment chainer (PR6) with table-aware developed lengths (PR8).

### Hems — `hem(part, { region, side, type, length?, radius?, gap?, rule? })`
Folds the edge back as a curl + return. Four types:
- **closed** — 180°, inner radius inflated by a documented `CLOSED_HEM_HAIR` so the near-zero-gap fold doesn't self-intersect on fuse;
- **open** — 180° at the gap radius;
- **teardrop** — ~210°;
- **rolled** — ~270°, no return.

The curl is chained as ≤120° sub-arcs (the bend-patch wedge degenerates ≥180°); the full-curl allowance is resolved **once** via `developedLength` and apportioned across sub-arcs, so a sparse bend table can't double-count (a real bug caught in review — the K-factor path's linearity had masked it).

### Jogs — `jog(part, { region, side, position, offsetHeight, angle?, … })`
Two opposite bends + a step run, sized `stepRun = (offsetHeight − (T+2r)(1−cosθ))/sinθ` so the run-out face sits **exactly** `offsetHeight` above the base — measured (not assumed) across all four kernels to 4 decimals. Rejects offsets the bends alone overshoot.

### Integration
- Both reuse the exported contour chainer and are **region-general** (off the base or any flange via `worldFrames → regionEdge`); record `hem::`/`jog::` sub-bends (skipped in the spanning tree like `contour::`); develop via `allowanceFns.developedLength` so **bend tables apply** (tied-in test).
- `unfold` develops strips + bend lines; `api`/`facade`/`index` surfaces; harness `hemmed-panel` + `jogged-bracket` demos.

### Verification
- typecheck / lint / build clean; **205 tests** (192 prior + 13 new) green; snapshot exit 0.
- Reviewer independently verified jog offset exactness across kernels and all four hem types as valid single solids (incl. adversarial tight/sub-thickness cases).
- Built via a Workflow (implement → adversarial review → fix) in an isolated git worktree.

### Stack
Phase 2 (7 PRs) + PR8 (bend tables) merged. Remaining: bbox nesting · true-shape (NFP) nesting.