### PR TITLE
feat(sheetmetal): bounding-box nesting of flat patterns onto stock sheets

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -215,6 +215,39 @@ Like the contour/lofted flanges, hems and jogs have non-rectilinear developments
 strict `partToFlatInput → fold` round-trip oracle; verification leans on developed-length invariants, the
 measured jog offset, and solid validity.
 
+## Nesting
+
+`nest(patterns, { sheet, margin?, spacing?, allowRotation? })` arranges a set of developed flat patterns onto
+stock sheets to reduce waste, returning `Result<NestResult>` (`{ sheets, unplaced, warnings }`). Each sheet
+carries its `placements` (`{ patternIndex, x, y, rotationDeg }`, where `rotationDeg` is `0` or `90`) and a
+`utilization`. `nestToDXF(result, patterns, sheetIndex)` then emits one fabrication-ready, multi-layer DXF per
+sheet, translating and rotating every placed pattern (outline + bend lines + holes + forms) onto the sheet via
+the same bounding boxes the packer used.
+
+> **Scope — bounding-box nesting only.** This packs each part as its axis-aligned **outline bounding box**, so
+> parts do **not** interlock: a concave or L-shaped part reserves its full rectangular footprint and leaves the
+> in-bbox waste unused. True-shape **no-fit-polygon (NFP)** nesting — where parts nest into each other's
+> concavities — is the planned follow-up. Treat the reported utilization as a conservative lower bound on what
+> NFP nesting could achieve.
+
+- **Algorithm.** A shelf (level) packing heuristic. Parts are sorted largest-first (by bbox height, then area)
+  and placed left-to-right into horizontal shelves; a new shelf opens below when the current row fills, and a
+  **new sheet** opens when the next shelf would overflow the usable height. Placements stay inside the usable
+  area `[margin, sheet − margin]` and are separated by at least `spacing`.
+- **Rotation.** With `allowRotation`, each part is tried at both `0°` and `90°` and the orientation that fits
+  (or packs shorter) is kept — letting a tall part fit a short sheet.
+- **Unplaceable parts.** A part larger than the usable sheet even rotated is reported in `unplaced` with a
+  warning; it is never dropped silently and never loops.
+- **Utilization.** Σ placed part **bounding-box** areas ÷ usable-sheet area, in `(0, 1]`. Inter-part spacing
+  gaps and intra-bbox waste are not credited, so it is a conservative material-use measure.
+
+```ts
+const patterns = parts.map((p) => unfold(p).value.pattern);
+const nested = nest(patterns, { sheet: { width: 1250, height: 2500 }, margin: 5, spacing: 3, allowRotation: true });
+// nested.value.sheets.length, nested.value.sheets[i].utilization, nested.value.unplaced
+const dxf = nestToDXF(nested.value, patterns, 0); // fabrication-ready DXF for sheet 0
+```
+
 ## Foreign-solid import & unfold
 
 `unfoldSolid(solid, { kFactor? })` (fluent: `fromSolid(solid).unfold()`) flattens an **arbitrary imported
@@ -310,6 +343,8 @@ the headline L-bracket with a mitered corner, a tray, reliefs, a cutout panel, a
 **tab-and-slot box** (self-locating corner joint), and a **louvered panel** (vent
 flaps + emboss/dimple) — then renders each folded 3D part next to its developed
 flat pattern as a single side-by-side SVG and also writes the folded solid as STEP.
+It also runs a **nesting** demo (a handful of parts bbox-packed onto one sheet),
+printing the sheet count + utilization and writing the nested sheet as DXF + SVG.
 
 ```bash
 npm run snapshot --workspace=brepjs-sheetmetal

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -17,7 +17,8 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, measureVolume, isErr, initFromOC } from 'brepjs';
 import type { Solid, Vec3 } from 'brepjs';
-import { author, miterCorner, unfold, unfoldSolid, fold, developed } from '../src/api.js';
+import { author, miterCorner, unfold, unfoldSolid, fold, developed, nest, nestToDXF } from '../src/api.js';
+import type { NestResult } from '../src/nestFns.js';
 import { addBendRelief, cornerRelief } from '../src/reliefFns.js';
 import { addCutout } from '../src/cutoutFns.js';
 import { addTab, tabAndSlot, type SlotPlacement } from '../src/tabFns.js';
@@ -294,9 +295,108 @@ async function main(): Promise<void> {
     lines.push(...(await renderDemo(demo)));
   }
   lines.push(...(await renderForeignDemo()));
+  lines.push(...(await renderNestDemo()));
   lines.push(...renderBendTableDemo());
   lines.push('');
   process.stdout.write(lines.join('\n'));
+}
+
+/**
+ * Nesting demo (plan PR10): author a handful of different parts, unfold each to a
+ * flat pattern, then bbox-nest them onto a stock sheet. Prints the sheet count and
+ * per-sheet utilization, writes the first nested sheet as a fabrication-ready DXF,
+ * and renders that sheet (sheet frame + each placed part bbox) as an SVG. This is
+ * BOUNDING-BOX nesting (parts do not interlock) — true-shape NFP nesting is the
+ * follow-up.
+ */
+async function renderNestDemo(): Promise<string[]> {
+  const specs: AuthorSpec[] = [
+    { thickness: T, base: { length: 60, width: 40 }, flanges: [{ id: 'f', length: 16, angleDeg: 90, rule, side: 'xmax' }] },
+    { thickness: T, base: { length: 40, width: 40 }, flanges: [] },
+    { thickness: T, base: { length: 80, width: 24 }, flanges: [] },
+    { thickness: T, base: { length: 30, width: 50 }, flanges: [{ id: 'f', length: 12, angleDeg: 90, rule, side: 'ymax' }] },
+    { thickness: T, base: { length: 45, width: 30 }, flanges: [] },
+    { thickness: T, base: { length: 25, width: 25 }, flanges: [] },
+  ];
+
+  const patterns: FlatPattern[] = [];
+  for (const spec of specs) {
+    const authored = author(spec);
+    if (isErr(authored)) throw new Error(`nest author failed: ${authored.error.message}`);
+    const unfolded = unfold(authored.value);
+    if (isErr(unfolded)) throw new Error(`nest unfold failed: ${unfolded.error.message}`);
+    patterns.push(unfolded.value.pattern);
+  }
+
+  const sheet = { width: 200, height: 120 };
+  const margin = 4;
+  const spacing = 3;
+  const nested = nest(patterns, { sheet, margin, spacing, allowRotation: true });
+  if (isErr(nested)) throw new Error(`nest failed: ${nested.error.message}`);
+  const result = nested.value;
+
+  const dxf = nestToDXF(result, patterns, 0);
+  let dxfPath = '(nest DXF skipped: no sheet)';
+  if (!isErr(dxf)) {
+    dxfPath = resolve(OUT_DIR, 'nest-sheet-0.dxf');
+    await writeFile(dxfPath, dxf.value, 'utf8');
+  }
+
+  const svgPath = resolve(OUT_DIR, 'nest-sheet-0.svg');
+  await writeFile(svgPath, renderNestSheetSvg(result, patterns, 0, sheet), 'utf8');
+
+  const utils = result.sheets.map((s) => `${(s.utilization * 100).toFixed(1)}%`).join(', ');
+  return [
+    '  [nesting]',
+    `    parts                : ${patterns.length}`,
+    `    sheet                : ${sheet.width}×${sheet.height} mm (margin ${margin}, spacing ${spacing})`,
+    `    sheets used          : ${result.sheets.length}`,
+    `    utilization / sheet  : ${utils}`,
+    `    unplaced             : ${result.unplaced.length}`,
+    `    nested sheet-0 DXF   : ${dxfPath}`,
+    `    nested sheet-0 SVG   : ${svgPath}`,
+  ];
+}
+
+/** Render one nested sheet: the stock frame plus each placed part's bbox + index. */
+function renderNestSheetSvg(
+  result: NestResult,
+  patterns: FlatPattern[],
+  sheetIndex: number,
+  sheet: { width: number; height: number }
+): string {
+  const placed = result.sheets[sheetIndex];
+  const scale = Math.min((PANEL_W - 2 * PAD) / sheet.width, (PANEL_H - 2 * PAD) / sheet.height);
+  const sx = (x: number): number => PAD + x * scale;
+  const sy = (y: number): number => PANEL_H - PAD - y * scale; // +Y up
+  const parts: string[] = [
+    `<rect x="${fmt(sx(0))}" y="${fmt(sy(sheet.height))}" width="${fmt(sheet.width * scale)}" height="${fmt(sheet.height * scale)}" fill="#fafafa" stroke="#333" />`,
+  ];
+  for (const p of placed?.placements ?? []) {
+    const pattern = patterns[p.patternIndex];
+    if (pattern === undefined) continue;
+    const b = patternBboxLocal(pattern);
+    const w = (p.rotationDeg === 90 ? b.height : b.width) * scale;
+    const h = (p.rotationDeg === 90 ? b.width : b.height) * scale;
+    parts.push(
+      `<rect x="${fmt(sx(p.x))}" y="${fmt(sy(p.y) - h)}" width="${fmt(w)}" height="${fmt(h)}" fill="#b8431d22" stroke="#b8431d" />`,
+      `<text x="${fmt(sx(p.x) + 4)}" y="${fmt(sy(p.y) - h + 14)}" font-family="sans-serif" font-size="11" fill="#b8431d">#${p.patternIndex}${p.rotationDeg === 90 ? ' ⟳' : ''}</text>`
+    );
+  }
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${PANEL_W}" height="${PANEL_H}" viewBox="0 0 ${PANEL_W} ${PANEL_H}">`,
+    `<text x="${PAD}" y="20" font-family="sans-serif" font-size="13" fill="#333">Nested sheet ${sheetIndex}</text>`,
+    parts.join('\n'),
+    `</svg>`,
+    '',
+  ].join('\n');
+}
+
+/** Local bbox read for the nest SVG (origin + extents of the outline). */
+function patternBboxLocal(pattern: FlatPattern): { minX: number; minY: number; width: number; height: number } {
+  const pts = getEdges(pattern.outline).map((e) => to2(curveStartPoint(e)));
+  const box = bounds(pts);
+  return { minX: box.minX, minY: box.minY, width: box.maxX - box.minX, height: box.maxY - box.minY };
 }
 
 /**

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -44,6 +44,12 @@ import { hem as hemFn } from './hemFns.js';
 import { jog as jogFn } from './jogFns.js';
 import { flatPatternToDXF as flatPatternToDXFFn, type DxfOptions } from './dxfFns.js';
 import {
+  nest as nestFn,
+  nestToDXF as nestToDXFFn,
+  type NestOptions,
+  type NestResult,
+} from './nestFns.js';
+import {
   buildReport as buildReportFn,
   reportFromUnfold as reportFromUnfoldFn,
   reportToJSON as reportToJSONFn,
@@ -247,6 +253,25 @@ export function toDXF(pattern: FlatPattern, options?: DxfOptions): Result<string
   return flatPatternToDXFFn(pattern, options);
 }
 
+/**
+ * Bounding-box nest: arrange developed flat patterns onto stock sheets to reduce
+ * waste. Parts are packed as their outline bounding boxes (no interlocking);
+ * true-shape NFP nesting is a follow-up.
+ */
+export function nest(patterns: FlatPattern[], options: NestOptions): Result<NestResult> {
+  return nestFn(patterns, options);
+}
+
+/** Emit one fabrication-ready DXF for a single nested sheet (all parts placed). */
+export function nestToDXF(
+  result: NestResult,
+  patterns: FlatPattern[],
+  sheetIndex: number,
+  options?: DxfOptions
+): Result<string> {
+  return nestToDXFFn(result, patterns, sheetIndex, options);
+}
+
 /** Build a bend report by walking the part's feature tree. */
 export function report(part: SheetMetalPart): Result<BendReport> {
   return buildReportFn(part);
@@ -311,4 +336,4 @@ export function resolveAllowance(
   return resolveBendAllowanceFn(rule, angleDeg, thickness, onWarning);
 }
 
-export type { AuthorSpec, FlangeSpec, MiterPlane, DxfOptions, SlotPlacement };
+export type { AuthorSpec, FlangeSpec, MiterPlane, DxfOptions, SlotPlacement, NestOptions, NestResult };

--- a/packages/brepjs-sheetmetal/src/dxfFns.ts
+++ b/packages/brepjs-sheetmetal/src/dxfFns.ts
@@ -21,6 +21,15 @@ const COLOR_FORM = 4;
 type Pt2 = [number, number];
 
 /**
+ * A 2D point transform applied to every emitted vertex. Used by the nesting writer
+ * to place each pattern at its `(x, y)` and rotation on the sheet; the default
+ * single-pattern writer uses the identity transform.
+ */
+export type Transform2 = (p: Pt2) => Pt2;
+
+const IDENTITY: Transform2 = (p) => p;
+
+/**
  * Package-local DXF writer for sheet-metal flat patterns. The core public writer
  * (`blueprintToDXF`) is R12 LINE/POLYLINE-only with no MTEXT, layer color, or
  * INSUNITS, so it cannot carry the annotated multi-layer output required here.
@@ -32,20 +41,45 @@ type Pt2 = [number, number];
  * R13+ readers (AutoCAD AUDIT, ODA/Teigha) require to parse the file cleanly.
  */
 export function flatPatternToDXF(pattern: FlatPattern, options: DxfOptions = {}): Result<string> {
+  return multiPatternToDXF([{ pattern, transform: IDENTITY }], options);
+}
+
+/** One pattern plus the sheet-placement transform applied to all its geometry. */
+export interface PlacedPattern {
+  pattern: FlatPattern;
+  transform: Transform2;
+}
+
+/**
+ * Emit one DXF for any number of placed patterns (the nesting per-sheet writer).
+ * Each pattern's outline / bend lines / holes / forms are run through its own
+ * {@link Transform2} (translate + rotate onto the sheet) before being written, so
+ * the nested file is fabrication-ready. Layers/colors/handle scheme match the
+ * single-pattern writer exactly.
+ */
+export function multiPatternToDXF(placed: PlacedPattern[], options: DxfOptions = {}): Result<string> {
   const textHeight = options.textHeight ?? DEFAULT_TEXT_HEIGHT;
   if (!Number.isFinite(textHeight) || textHeight <= 0) {
     return err(validationError('INVALID_TEXT_HEIGHT', `textHeight must be a finite, positive number, got ${textHeight}`));
   }
 
-  const outlineResult = outlinePoints(pattern);
-  if (!outlineResult.ok) return outlineResult;
-  const outline = outlineResult.value;
+  const prepared: { pattern: FlatPattern; transform: Transform2; outline: Pt2[] }[] = [];
+  for (const p of placed) {
+    const outlineResult = outlinePoints(p.pattern);
+    if (!outlineResult.ok) return outlineResult;
+    prepared.push({ pattern: p.pattern, transform: p.transform, outline: outlineResult.value });
+  }
 
   // Tables + entities consume handles; the header's $HANDSEED must exceed them,
   // so build the body first and seed the header from the next free handle.
   const body = new DxfWriter();
   writeTables(body);
-  writeEntities(body, outline, pattern, textHeight);
+  body.pair(0, 'SECTION');
+  body.pair(2, 'ENTITIES');
+  for (const p of prepared) {
+    writePatternEntities(body, p.outline, p.pattern, textHeight, p.transform);
+  }
+  body.pair(0, 'ENDSEC');
 
   const head = new DxfWriter();
   writeHeader(head, body.seedHex());
@@ -118,16 +152,13 @@ function writeLayer(w: DxfWriter, name: string, color: number): void {
   w.pair(6, 'CONTINUOUS');
 }
 
-function writeEntities(w: DxfWriter, outline: Pt2[], pattern: FlatPattern, textHeight: number): void {
-  w.pair(0, 'SECTION');
-  w.pair(2, 'ENTITIES');
-
-  writePolyline(w, outline, LAYER_OUTLINE);
+function writePatternEntities(w: DxfWriter, outline: Pt2[], pattern: FlatPattern, textHeight: number, tf: Transform2): void {
+  writePolyline(w, outline.map(tf), LAYER_OUTLINE);
 
   for (const bend of pattern.bendLines) {
     const layer = bend.direction === 'down' ? LAYER_BEND_DOWN : LAYER_BEND_UP;
-    const start = toPt2(curveStartPoint(bend.line));
-    const end = toPt2(curveEndPoint(bend.line));
+    const start = tf(toPt2(curveStartPoint(bend.line)));
+    const end = tf(toPt2(curveEndPoint(bend.line)));
     writeLine(w, start, end, layer);
     const mid: Pt2 = [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2];
     const label = annotation(bend.angleDeg, bend.direction);
@@ -135,29 +166,27 @@ function writeEntities(w: DxfWriter, outline: Pt2[], pattern: FlatPattern, textH
   }
 
   for (const hole of pattern.holes) {
-    writePolyline(w, loopPoints(hole), LAYER_CUTOUT);
+    writePolyline(w, loopPoints(hole).map(tf), LAYER_CUTOUT);
   }
 
   // Lofted/ruled transition developed boundaries: closed triangulated outlines on
   // the OUTLINE layer (each a separate developed blank from the rectilinear outline).
   for (const dev of pattern.loftedDevelopments) {
-    writePolyline(w, loopPoints(dev), LAYER_OUTLINE);
+    writePolyline(w, loopPoints(dev).map(tf), LAYER_OUTLINE);
   }
 
   // Form features: louver U-cuts are OPEN three-side cut paths (the hinge side is
   // left uncut and drawn separately below), emboss footprints are closed marker
   // polylines, louver hinge lines are LINEs — all on the FORM layer.
   for (const cut of pattern.formCuts) {
-    writeOpenPolyline(w, pathPoints(cut), LAYER_FORM);
+    writeOpenPolyline(w, pathPoints(cut).map(tf), LAYER_FORM);
   }
   for (const marker of pattern.formMarkers) {
-    writePolyline(w, loopPoints(marker), LAYER_FORM);
+    writePolyline(w, loopPoints(marker).map(tf), LAYER_FORM);
   }
   for (const hinge of pattern.formHinges) {
-    writeLine(w, toPt2(curveStartPoint(hinge)), toPt2(curveEndPoint(hinge)), LAYER_FORM);
+    writeLine(w, tf(toPt2(curveStartPoint(hinge))), tf(toPt2(curveEndPoint(hinge))), LAYER_FORM);
   }
-
-  w.pair(0, 'ENDSEC');
 }
 
 function writePolyline(w: DxfWriter, points: Pt2[], layer: string): void {

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -61,8 +61,18 @@ export { authorLoftedFlange } from './loftedFlangeFns.js';
 export { hem } from './hemFns.js';
 export { jog } from './jogFns.js';
 
-export { flatPatternToDXF } from './dxfFns.js';
-export type { DxfOptions } from './dxfFns.js';
+export { flatPatternToDXF, multiPatternToDXF } from './dxfFns.js';
+export type { DxfOptions, PlacedPattern, Transform2 } from './dxfFns.js';
+
+export { nest, nestToDXF, patternBbox } from './nestFns.js';
+export type {
+  NestOptions,
+  NestResult,
+  NestSheet,
+  Placement,
+  SheetSpec,
+  Bbox,
+} from './nestFns.js';
 
 export { buildReport, reportFromUnfold, reportToJSON } from './reportFns.js';
 
@@ -90,6 +100,8 @@ export {
   resolveAllowance,
   contourFlange,
   loftedFlange,
+  nest as nestPatterns,
+  nestToDXF as nestSheetToDXF,
 } from './api.js';
 
 export {

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -64,7 +64,7 @@ export { jog } from './jogFns.js';
 export { flatPatternToDXF, multiPatternToDXF } from './dxfFns.js';
 export type { DxfOptions, PlacedPattern, Transform2 } from './dxfFns.js';
 
-export { nest, nestToDXF, patternBbox } from './nestFns.js';
+export { patternBbox } from './nestFns.js';
 export type {
   NestOptions,
   NestResult,
@@ -100,8 +100,8 @@ export {
   resolveAllowance,
   contourFlange,
   loftedFlange,
-  nest as nestPatterns,
-  nestToDXF as nestSheetToDXF,
+  nest,
+  nestToDXF,
 } from './api.js';
 
 export {

--- a/packages/brepjs-sheetmetal/src/nestFns.ts
+++ b/packages/brepjs-sheetmetal/src/nestFns.ts
@@ -82,8 +82,8 @@ export function nest(patterns: FlatPattern[], options: NestOptions): Result<Nest
   if (!Number.isFinite(sheet.width) || sheet.width <= 0 || !Number.isFinite(sheet.height) || sheet.height <= 0) {
     return err(validationError('INVALID_SHEET', `sheet width/height must be positive, got ${sheet.width}×${sheet.height}`));
   }
-  if (margin < 0 || spacing < 0) {
-    return err(validationError('INVALID_NEST_OPTS', `margin and spacing must be non-negative`));
+  if (!Number.isFinite(margin) || margin < 0 || !Number.isFinite(spacing) || spacing < 0) {
+    return err(validationError('INVALID_NEST_OPTS', `margin and spacing must be non-negative finite numbers, got margin=${margin} spacing=${spacing}`));
   }
 
   const usableW = sheet.width - 2 * margin;
@@ -131,7 +131,17 @@ export function nest(patterns: FlatPattern[], options: NestOptions): Result<Nest
     placeable.push(idx);
   }
 
-  const sheets = packShelves(placeable, boxes, usableW, usableH, margin, spacing, allowRotation, usableArea);
+  const { sheets, dropped } = packShelves(placeable, boxes, usableW, usableH, margin, spacing, allowRotation, usableArea);
+  for (const idx of dropped) {
+    // Should be unreachable (pre-filtered parts fit an empty sheet); guards against
+    // a future regression silently dropping a part.
+    unplaced.push(idx);
+    warnings.push({
+      code: 'PART_TOO_LARGE',
+      message: `pattern ${idx} could not be placed on a fresh sheet; left unplaced`,
+      featureId: `pattern-${idx}`,
+    });
+  }
 
   unplaced.sort((a, b) => a - b);
   return ok({ sheets, unplaced, warnings });
@@ -164,8 +174,9 @@ function packShelves(
   spacing: number,
   allowRotation: boolean,
   usableArea: number
-): NestSheet[] {
+): { sheets: NestSheet[]; dropped: number[] } {
   const sheets: NestSheet[] = [];
+  const dropped: number[] = [];
   let state = newSheet(margin);
 
   const commit = (): void => {
@@ -178,16 +189,19 @@ function packShelves(
 
     if (!tryPlace(state, box, idx, usableW, usableH, margin, spacing, allowRotation)) {
       // Current sheet is full for this part — close it and open a fresh one. Every
-      // part in `placeable` fits an empty usable sheet, so this second attempt always
-      // succeeds (no part can stall the loop).
+      // part in `placeable` fits an empty usable sheet, so this second attempt should
+      // always succeed; record it as dropped (caller routes to `unplaced`) as a
+      // self-enforcing safety net rather than relying on that reasoning alone.
       commit();
       state = newSheet(margin);
-      tryPlace(state, box, idx, usableW, usableH, margin, spacing, allowRotation);
+      if (!tryPlace(state, box, idx, usableW, usableH, margin, spacing, allowRotation)) {
+        dropped.push(idx);
+      }
     }
   }
 
   if (state.placements.length > 0) commit();
-  return sheets;
+  return { sheets, dropped };
 }
 
 function newSheet(margin: number): ShelfState {

--- a/packages/brepjs-sheetmetal/src/nestFns.ts
+++ b/packages/brepjs-sheetmetal/src/nestFns.ts
@@ -1,0 +1,339 @@
+import { type Result, ok, err, validationError, getEdges, curveStartPoint } from 'brepjs';
+import type { FlatPattern, SheetMetalWarning } from './types.js';
+import { multiPatternToDXF, type DxfOptions, type Transform2, type PlacedPattern } from './dxfFns.js';
+
+/** Stock sheet the parts are packed onto (the gross blank, before margin). */
+export interface SheetSpec {
+  width: number;
+  height: number;
+}
+
+export interface NestOptions {
+  sheet: SheetSpec;
+  /** Clear border kept empty around the sheet edge (per side). Default `0`. */
+  margin?: number | undefined;
+  /** Minimum clear gap between any two placed parts (and the bbox padding used
+   * for the non-overlap test). Default `0`. */
+  spacing?: number | undefined;
+  /** Try a 90° rotation per part and keep whichever orientation fits/packs better. */
+  allowRotation?: boolean | undefined;
+}
+
+/** Where a single pattern lands on a sheet. `rotationDeg` is `0` or `90`. */
+export interface Placement {
+  /** Index into the `patterns` array passed to {@link nest}. */
+  patternIndex: number;
+  /** Lower-left x of the part's (rotated) bounding box, in sheet coordinates. */
+  x: number;
+  /** Lower-left y of the part's (rotated) bounding box, in sheet coordinates. */
+  y: number;
+  rotationDeg: 0 | 90;
+}
+
+export interface NestSheet {
+  placements: Placement[];
+  /**
+   * Σ placed part bounding-box areas ÷ usable-sheet area, in `(0, 1]`. "Usable"
+   * = `(width − 2·margin) × (height − 2·margin)`. This is BOUNDING-BOX utilization:
+   * the inter-part spacing gaps and intra-bbox waste (a non-rectangular part inside
+   * its box) are NOT credited, so it is a conservative measure of true material use.
+   */
+  utilization: number;
+}
+
+export interface NestResult {
+  sheets: NestSheet[];
+  /** Indices of patterns too large for the usable sheet even rotated. */
+  unplaced: number[];
+  warnings: SheetMetalWarning[];
+}
+
+/** Axis-aligned bounding box of one pattern outline, in developed-plane coords. */
+export interface Bbox {
+  minX: number;
+  minY: number;
+  width: number;
+  height: number;
+}
+
+const EPS = 1e-9;
+
+/**
+ * Bounding-box nest: arrange developed flat patterns onto stock sheets to reduce
+ * waste. This is BOUNDING-BOX nesting — each part is packed as its axis-aligned
+ * outline bounding box, so parts never interlock and concave parts leave their
+ * bounding-box waste unused. True-shape (no-fit-polygon) nesting is a follow-up.
+ *
+ * Algorithm: a shelf (level) packing heuristic. Parts are sorted largest-first by
+ * bbox height then area, then placed left-to-right into horizontal shelves; a new
+ * shelf opens below when the current row is full, and a NEW sheet opens when the
+ * next shelf would overflow the usable height. With `allowRotation`, each part is
+ * tried both at 0° and 90° and the orientation that fits the current shelf (or,
+ * failing that, fits at all) is kept. A part larger than the usable sheet even
+ * rotated is reported in `unplaced` with a warning — never dropped silently, never
+ * retried in an infinite loop.
+ */
+export function nest(patterns: FlatPattern[], options: NestOptions): Result<NestResult> {
+  const { sheet } = options;
+  const margin = options.margin ?? 0;
+  const spacing = options.spacing ?? 0;
+  const allowRotation = options.allowRotation ?? false;
+
+  if (!Number.isFinite(sheet.width) || sheet.width <= 0 || !Number.isFinite(sheet.height) || sheet.height <= 0) {
+    return err(validationError('INVALID_SHEET', `sheet width/height must be positive, got ${sheet.width}×${sheet.height}`));
+  }
+  if (margin < 0 || spacing < 0) {
+    return err(validationError('INVALID_NEST_OPTS', `margin and spacing must be non-negative`));
+  }
+
+  const usableW = sheet.width - 2 * margin;
+  const usableH = sheet.height - 2 * margin;
+  if (usableW <= EPS || usableH <= EPS) {
+    return err(validationError('INVALID_SHEET', `margin ${margin} leaves no usable area on a ${sheet.width}×${sheet.height} sheet`));
+  }
+
+  const boxes: Bbox[] = [];
+  for (const pattern of patterns) {
+    const b = patternBbox(pattern);
+    if (!b.ok) return b;
+    boxes.push(b.value);
+  }
+
+  const usableArea = usableW * usableH;
+  const warnings: SheetMetalWarning[] = [];
+  const unplaced: number[] = [];
+
+  // Largest-first by height then area — the standard shelf-packing sort that keeps
+  // tall parts from fragmenting later shelves.
+  const order = boxes.map((_, i) => i).sort((a, b) => {
+    const ba = boxes[a];
+    const bb = boxes[b];
+    if (ba === undefined || bb === undefined) return 0;
+    if (Math.abs(bb.height - ba.height) > EPS) return bb.height - ba.height;
+    return bb.width * bb.height - ba.width * ba.height;
+  });
+
+  const placeable: number[] = [];
+  for (const idx of order) {
+    const box = boxes[idx];
+    if (box === undefined) continue;
+    const fits = fitsUsable(box, usableW, usableH, false);
+    const fitsRot = allowRotation && fitsUsable(box, usableW, usableH, true);
+    if (!fits && !fitsRot) {
+      unplaced.push(idx);
+      warnings.push({
+        code: 'PART_TOO_LARGE',
+        message: `pattern ${idx} (${box.width.toFixed(2)}×${box.height.toFixed(2)}) does not fit the usable sheet ${usableW.toFixed(2)}×${usableH.toFixed(2)} even rotated; left unplaced`,
+        featureId: `pattern-${idx}`,
+      });
+      continue;
+    }
+    placeable.push(idx);
+  }
+
+  const sheets = packShelves(placeable, boxes, usableW, usableH, margin, spacing, allowRotation, usableArea);
+
+  unplaced.sort((a, b) => a - b);
+  return ok({ sheets, unplaced, warnings });
+}
+
+/** Does a part fit the usable sheet in the given orientation? */
+function fitsUsable(box: Bbox, usableW: number, usableH: number, rotated: boolean): boolean {
+  const w = rotated ? box.height : box.width;
+  const h = rotated ? box.width : box.height;
+  return w <= usableW + EPS && h <= usableH + EPS;
+}
+
+interface ShelfState {
+  placements: Placement[];
+  /** Bottom y (sheet coords) of the current open shelf. */
+  shelfY: number;
+  /** Height of the current open shelf (the tallest part placed in it). */
+  shelfH: number;
+  /** Next free x (sheet coords) on the current shelf. */
+  cursorX: number;
+  placedArea: number;
+}
+
+function packShelves(
+  placeable: number[],
+  boxes: Bbox[],
+  usableW: number,
+  usableH: number,
+  margin: number,
+  spacing: number,
+  allowRotation: boolean,
+  usableArea: number
+): NestSheet[] {
+  const sheets: NestSheet[] = [];
+  let state = newSheet(margin);
+
+  const commit = (): void => {
+    sheets.push({ placements: state.placements, utilization: state.placedArea / usableArea });
+  };
+
+  for (const idx of placeable) {
+    const box = boxes[idx];
+    if (box === undefined) continue;
+
+    if (!tryPlace(state, box, idx, usableW, usableH, margin, spacing, allowRotation)) {
+      // Current sheet is full for this part — close it and open a fresh one. Every
+      // part in `placeable` fits an empty usable sheet, so this second attempt always
+      // succeeds (no part can stall the loop).
+      commit();
+      state = newSheet(margin);
+      tryPlace(state, box, idx, usableW, usableH, margin, spacing, allowRotation);
+    }
+  }
+
+  if (state.placements.length > 0) commit();
+  return sheets;
+}
+
+function newSheet(margin: number): ShelfState {
+  return { placements: [], shelfY: margin, shelfH: 0, cursorX: margin, placedArea: 0 };
+}
+
+/**
+ * Try to place `box` on the current sheet, mutating `state` on success. Tries the
+ * current shelf first (with rotation if allowed), then opens a new shelf below.
+ * Returns false when the part fits neither the current nor a new shelf on this
+ * sheet (the caller then opens a new sheet).
+ */
+function tryPlace(
+  state: ShelfState,
+  box: Bbox,
+  idx: number,
+  usableW: number,
+  usableH: number,
+  margin: number,
+  spacing: number,
+  allowRotation: boolean
+): boolean {
+  const right = margin + usableW;
+  const top = margin + usableH;
+
+  // Candidate orientations: 0° always, 90° when allowed (and the box is not square).
+  const orientations: { rot: 0 | 90; w: number; h: number }[] = [{ rot: 0, w: box.width, h: box.height }];
+  if (allowRotation && Math.abs(box.width - box.height) > EPS) {
+    orientations.push({ rot: 90, w: box.height, h: box.width });
+  }
+
+  const firstOnShelf = state.cursorX <= margin + EPS;
+
+  // 1) Fit on the current open shelf. Prefer the orientation that keeps the shelf
+  //    shortest (least new vertical waste) among those that fit horizontally and
+  //    within the shelf's established height once started.
+  let best: { rot: 0 | 90; w: number; h: number } | undefined;
+  for (const o of orientations) {
+    const xStart = firstOnShelf ? state.cursorX : state.cursorX + spacing;
+    if (xStart + o.w > right + EPS) continue;
+    // A started shelf has a fixed bottom; the part must fit under the usable top
+    // from the shelf bottom (it may grow shelfH up to the top).
+    if (state.shelfY + o.h > top + EPS) continue;
+    if (best === undefined || o.h < best.h - EPS) best = o;
+  }
+  if (best !== undefined) {
+    const xStart = firstOnShelf ? state.cursorX : state.cursorX + spacing;
+    state.placements.push({ patternIndex: idx, x: xStart, y: state.shelfY, rotationDeg: best.rot });
+    state.cursorX = xStart + best.w;
+    state.shelfH = Math.max(state.shelfH, best.h);
+    state.placedArea += best.w * best.h;
+    return true;
+  }
+
+  // 2) Open a new shelf below the current one (if anything is on the current shelf).
+  if (state.placements.length === 0) return false;
+  const nextShelfY = state.shelfY + state.shelfH + spacing;
+  let bestNew: { rot: 0 | 90; w: number; h: number } | undefined;
+  for (const o of orientations) {
+    if (margin + o.w > right + EPS) continue;
+    if (nextShelfY + o.h > top + EPS) continue;
+    if (bestNew === undefined || o.h < bestNew.h - EPS) bestNew = o;
+  }
+  if (bestNew === undefined) return false;
+  state.shelfY = nextShelfY;
+  state.shelfH = bestNew.h;
+  state.cursorX = margin + bestNew.w;
+  state.placements.push({ patternIndex: idx, x: margin, y: nextShelfY, rotationDeg: bestNew.rot });
+  state.placedArea += bestNew.w * bestNew.h;
+  return true;
+}
+
+/**
+ * Axis-aligned bounding box of a pattern's OUTER outline wire, read from the wire
+ * vertices (each edge start point) — the same 2D-coordinate read the DXF/SVG writers
+ * use. Only the outer outline is packed; holes ride inside it.
+ */
+export function patternBbox(pattern: FlatPattern): Result<Bbox> {
+  const edges = getEdges(pattern.outline);
+  if (edges.length === 0) {
+    return err(validationError('EMPTY_OUTLINE', 'pattern outline has no edges to bound'));
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const edge of edges) {
+    const p = curveStartPoint(edge);
+    if (p[0] < minX) minX = p[0];
+    if (p[0] > maxX) maxX = p[0];
+    if (p[1] < minY) minY = p[1];
+    if (p[1] > maxY) maxY = p[1];
+  }
+  const width = maxX - minX;
+  const height = maxY - minY;
+  if (!Number.isFinite(minX) || width <= EPS || height <= EPS) {
+    return err(validationError('EMPTY_OUTLINE', 'pattern outline bounding box is degenerate'));
+  }
+  return ok({ minX, minY, width, height });
+}
+
+/**
+ * Sheet-placement transform for one placement: shift the pattern's bbox lower-left
+ * to the origin, rotate by `rotationDeg` (0 or 90° CCW) about it — which swaps the
+ * bbox extents — then translate the (rotated) bbox lower-left to `(x, y)` on the
+ * sheet. A point at developed `(px, py)` therefore lands inside `[x, x+w]×[y, y+h]`,
+ * matching the box the packer reserved.
+ */
+function placementTransform(box: Bbox, x: number, y: number, rotationDeg: 0 | 90): Transform2 {
+  if (rotationDeg === 90) {
+    // After shifting to origin: (lx, ly) in [0,w]×[0,h]. Rotate 90° CCW: (-ly, lx)
+    // → [-h,0]×[0,w]; add h to bring x back to [0,h], then translate to (x, y).
+    return ([px, py]) => {
+      const lx = px - box.minX;
+      const ly = py - box.minY;
+      return [x + (box.height - ly), y + lx];
+    };
+  }
+  return ([px, py]) => [x + (px - box.minX), y + (py - box.minY)];
+}
+
+/**
+ * Emit one fabrication-ready DXF for a single nested sheet: every pattern placed on
+ * `result.sheets[sheetIndex]` is translated and rotated onto the sheet (via the same
+ * bounding boxes the packer used) and written through {@link multiPatternToDXF}.
+ * `patterns` must be the SAME array passed to {@link nest} (placements index into it).
+ */
+export function nestToDXF(
+  result: NestResult,
+  patterns: FlatPattern[],
+  sheetIndex: number,
+  options?: DxfOptions
+): Result<string> {
+  const sheet = result.sheets[sheetIndex];
+  if (sheet === undefined) {
+    return err(validationError('INVALID_SHEET_INDEX', `no nested sheet at index ${sheetIndex} (have ${result.sheets.length})`));
+  }
+  const placed: PlacedPattern[] = [];
+  for (const p of sheet.placements) {
+    const pattern = patterns[p.patternIndex];
+    if (pattern === undefined) {
+      return err(validationError('INVALID_PATTERN_INDEX', `placement references missing pattern ${p.patternIndex}`));
+    }
+    const box = patternBbox(pattern);
+    if (!box.ok) return box;
+    placed.push({ pattern, transform: placementTransform(box.value, p.x, p.y, p.rotationDeg) });
+  }
+  return multiPatternToDXF(placed, options ?? {});
+}

--- a/packages/brepjs-sheetmetal/src/types.ts
+++ b/packages/brepjs-sheetmetal/src/types.ts
@@ -562,7 +562,10 @@ export type SheetMetalWarning = {
     /** A bend-table query fell outside the tabulated (thickness, radius, angle)
      * range and was clamped to the nearest entry (no extrapolation). Distinct from
      * MIN_RADIUS, which means a bend's inner radius is below one thickness. */
-    | 'TABLE_CLAMP';
+    | 'TABLE_CLAMP'
+    /** Nesting: a flat pattern's outline bounding box does not fit the usable stock
+     * sheet (sheet minus margin) even rotated 90°, so it was left unplaced. */
+    | 'PART_TOO_LARGE';
   message: string;
   featureId?: string | undefined;
 };

--- a/packages/brepjs-sheetmetal/tests/nest.test.ts
+++ b/packages/brepjs-sheetmetal/tests/nest.test.ts
@@ -165,6 +165,13 @@ describe('nest — bbox', () => {
     expect(r.ok).toBe(false);
   });
 
+  it('rejects a non-finite margin/spacing rather than silently producing empty sheets', () => {
+    const r = nest([flatBlank(10, 10)], { sheet: { width: 100, height: 100 }, margin: Number.NaN });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('INVALID_NEST_OPTS');
+  });
+
   it('keeps utilization strictly above 0 for a thin part (the (0,1] contract floor)', () => {
     // A thin-but-real 20×0.5 part still has positive bbox area. patternBbox rejects only
     // sub-EPS-extent (degenerate) boxes, so any part it accepts has positive area and can

--- a/packages/brepjs-sheetmetal/tests/nest.test.ts
+++ b/packages/brepjs-sheetmetal/tests/nest.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { authorPart as author } from '../src/authorFns.js';
+import { unfold } from '../src/unfoldFns.js';
+import { nest, nestToDXF, patternBbox } from '../src/nestFns.js';
+import type { AuthorSpec } from '../src/authorFns.js';
+import type { BendRule, FlatPattern } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const rule: BendRule = { innerRadius: 1, kFactor: 0.44 };
+
+/** A flat rectangular blank (no flanges) — its unfolded outline is exactly length×width. */
+function flatBlank(length: number, width: number): FlatPattern {
+  const spec: AuthorSpec = { thickness: 1, base: { length, width }, flanges: [] };
+  const authored = author(spec);
+  if (!authored.ok) throw new Error(`author failed: ${authored.error.message}`);
+  const unfolded = unfold(authored.value);
+  if (!unfolded.ok) throw new Error(`unfold failed: ${unfolded.error.message}`);
+  return unfolded.value.pattern;
+}
+
+/** A blank with one flange, giving a longer developed outline (for rotation tests). */
+function flangedBlank(length: number, width: number, flangeLen: number): FlatPattern {
+  const spec: AuthorSpec = {
+    thickness: 1,
+    base: { length, width },
+    flanges: [{ id: 'f', length: flangeLen, angleDeg: 90, rule, side: 'xmax' }],
+  };
+  const authored = author(spec);
+  if (!authored.ok) throw new Error(`author failed: ${authored.error.message}`);
+  const unfolded = unfold(authored.value);
+  if (!unfolded.ok) throw new Error(`unfold failed: ${unfolded.error.message}`);
+  return unfolded.value.pattern;
+}
+
+interface Rect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+function placedRect(pattern: FlatPattern, x: number, y: number, rotationDeg: 0 | 90): Rect {
+  const b = patternBbox(pattern);
+  if (!b.ok) throw new Error('bbox failed');
+  const w = rotationDeg === 90 ? b.value.height : b.value.width;
+  const h = rotationDeg === 90 ? b.value.width : b.value.height;
+  return { x0: x, y0: y, x1: x + w, y1: y + h };
+}
+
+/** Two rects overlap iff they overlap on both axes (open-interval test, EPS slack). */
+function overlaps(a: Rect, b: Rect, eps: number): boolean {
+  return a.x0 < b.x1 - eps && b.x0 < a.x1 - eps && a.y0 < b.y1 - eps && b.y0 < a.y1 - eps;
+}
+
+describe('nest — bbox', () => {
+  it('packs N identical small parts onto the hand-computed sheet count', () => {
+    // 20×20 part, 5 of them, sheet 60×40, no margin/spacing.
+    // Shelf packer: 3 per shelf (x=0,20,40) at y=0; shelf 2 at y=20 (3 slots).
+    // 2 shelves of height 20 fit in 40 → 6 slots → all 5 fit on ONE sheet.
+    const parts = Array.from({ length: 5 }, () => flatBlank(20, 20));
+    const r = nest(parts, { sheet: { width: 60, height: 40 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.unplaced).toEqual([]);
+    expect(r.value.sheets).toHaveLength(1);
+    expect(r.value.sheets[0]?.placements).toHaveLength(5);
+  });
+
+  it('opens a second sheet when parts overflow the first', () => {
+    // 20×20 part, 7 of them, sheet 60×40 (6 slots per sheet) → 2 sheets (6 + 1).
+    const parts = Array.from({ length: 7 }, () => flatBlank(20, 20));
+    const r = nest(parts, { sheet: { width: 60, height: 40 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.unplaced).toEqual([]);
+    expect(r.value.sheets).toHaveLength(2);
+    expect(r.value.sheets[0]?.placements).toHaveLength(6);
+    expect(r.value.sheets[1]?.placements).toHaveLength(1);
+  });
+
+  it('NO OVERLAP + WITHIN BOUNDS over all placement pairs (with margin + spacing)', () => {
+    const parts = Array.from({ length: 12 }, (_, i) => flatBlank(15 + (i % 3) * 5, 12 + (i % 4) * 3));
+    const margin = 3;
+    const spacing = 2;
+    const sheet = { width: 120, height: 100 };
+    const r = nest(parts, { sheet, margin, spacing, allowRotation: true });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const eps = 1e-6;
+    for (const s of r.value.sheets) {
+      const rects = s.placements.map((p) => placedRect(parts[p.patternIndex] as FlatPattern, p.x, p.y, p.rotationDeg));
+      // Within usable bounds [margin, sheet - margin].
+      for (const rect of rects) {
+        expect(rect.x0).toBeGreaterThanOrEqual(margin - eps);
+        expect(rect.y0).toBeGreaterThanOrEqual(margin - eps);
+        expect(rect.x1).toBeLessThanOrEqual(sheet.width - margin + eps);
+        expect(rect.y1).toBeLessThanOrEqual(sheet.height - margin + eps);
+      }
+      // Every pair is non-overlapping when each rect is padded by the spacing gap.
+      for (let i = 0; i < rects.length; i += 1) {
+        for (let j = i + 1; j < rects.length; j += 1) {
+          const a = rects[i] as Rect;
+          const b = rects[j] as Rect;
+          const padded: Rect = { x0: a.x0 - spacing, y0: a.y0 - spacing, x1: a.x1 + spacing, y1: a.y1 + spacing };
+          expect(overlaps(padded, b, eps)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('utilization is in (0,1] and matches packed-area / usable-area', () => {
+    // 20×20 ×4 on 50×50, margin 0 → packed = 4·400 = 1600; usable = 2500.
+    const parts = Array.from({ length: 4 }, () => flatBlank(20, 20));
+    const r = nest(parts, { sheet: { width: 50, height: 50 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const u = r.value.sheets[0]?.utilization ?? 0;
+    expect(u).toBeGreaterThan(0);
+    expect(u).toBeLessThanOrEqual(1);
+    expect(u).toBeCloseTo(1600 / 2500, 6);
+  });
+
+  it('allowRotation reduces sheet count for a tall part that only fits rotated', () => {
+    // Part developed bbox is ~50 wide × 20 tall (a 20-wide base + flange runs along x).
+    // Sheet 60 wide × 25 tall: a 50-tall orientation will not fit without rotation.
+    const tall = flangedBlank(20, 50, 18); // base 20 long (x) × 50 wide (y) + flange off xmax
+    const b = patternBbox(tall);
+    if (!b.ok) throw new Error('bbox failed');
+    // Choose a sheet where the un-rotated height (50) exceeds the sheet height.
+    const sheet = { width: Math.ceil(b.value.width) + 40, height: Math.floor(b.value.height) - 5 };
+    const parts = [tall, tall];
+
+    const without = nest(parts, { sheet, allowRotation: false });
+    const withRot = nest(parts, { sheet, allowRotation: true });
+    expect(without.ok && withRot.ok).toBe(true);
+    if (!without.ok || !withRot.ok) return;
+
+    // Un-rotated: the part's height exceeds the sheet → unplaced.
+    expect(without.value.unplaced.length).toBeGreaterThan(0);
+    // Rotated: both fit → none unplaced, at least one sheet.
+    expect(withRot.value.unplaced).toEqual([]);
+    expect(withRot.value.sheets.length).toBeGreaterThan(0);
+  });
+
+  it('a part larger than the sheet goes to unplaced with a warning, no infinite loop', () => {
+    const parts = [flatBlank(20, 20), flatBlank(500, 500), flatBlank(20, 20)];
+    const r = nest(parts, { sheet: { width: 50, height: 50 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.unplaced).toEqual([1]);
+    expect(r.value.warnings.length).toBe(1);
+    expect(r.value.warnings[0]?.featureId).toBe('pattern-1');
+    // The two placeable parts still get placed.
+    const totalPlaced = r.value.sheets.reduce((n, s) => n + s.placements.length, 0);
+    expect(totalPlaced).toBe(2);
+  });
+
+  it('rejects a sheet whose margin leaves no usable area', () => {
+    const r = nest([flatBlank(10, 10)], { sheet: { width: 10, height: 10 }, margin: 6 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('keeps utilization strictly above 0 for a thin part (the (0,1] contract floor)', () => {
+    // A thin-but-real 20×0.5 part still has positive bbox area. patternBbox rejects only
+    // sub-EPS-extent (degenerate) boxes, so any part it accepts has positive area and can
+    // never drive a sheet's utilization to 0 — keeping the documented (0,1] contract true.
+    const thin = flatBlank(20, 0.5);
+    const bb = patternBbox(thin);
+    expect(bb.ok).toBe(true);
+    if (bb.ok) {
+      expect(bb.value.width).toBeGreaterThan(0);
+      expect(bb.value.height).toBeGreaterThan(0);
+    }
+    const r = nest([thin], { sheet: { width: 50, height: 50 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const u = r.value.sheets[0]?.utilization ?? 0;
+    expect(u).toBeGreaterThan(0);
+    expect(u).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('nestToDXF', () => {
+  it('places two parts at their sheet offsets', () => {
+    const a = flatBlank(20, 20);
+    const b = flatBlank(20, 20);
+    const r = nest([a, b], { sheet: { width: 60, height: 30 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.sheets).toHaveLength(1);
+    const placements = r.value.sheets[0]?.placements ?? [];
+    expect(placements).toHaveLength(2);
+
+    const dxf = nestToDXF(r.value, [a, b], 0);
+    expect(dxf.ok).toBe(true);
+    if (!dxf.ok) return;
+
+    // Two outline polylines (one per part), both fabrication-ready on the sheet.
+    const polylineCount = dxf.value.split('LWPOLYLINE').length - 1;
+    expect(polylineCount).toBeGreaterThanOrEqual(2);
+
+    // The second part is shifted: its x offset (placement.x) appears as a vertex x.
+    const second = placements.find((p) => p.x > 0);
+    expect(second).toBeDefined();
+    if (second === undefined) return;
+    // A part placed at x>0 must emit at least one vertex whose x ≈ placement.x.
+    const lines = dxf.value.split('\n');
+    const xs: number[] = [];
+    for (let i = 0; i < lines.length - 1; i += 1) {
+      if (lines[i] === '10') {
+        const v = Number(lines[i + 1]);
+        if (Number.isFinite(v)) xs.push(v);
+      }
+    }
+    const hitsOffset = xs.some((x) => Math.abs(x - second.x) < 1e-3);
+    expect(hitsOffset).toBe(true);
+  });
+
+  it('errors on an out-of-range sheet index', () => {
+    const a = flatBlank(20, 20);
+    const r = nest([a], { sheet: { width: 60, height: 30 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const dxf = nestToDXF(r.value, [a], 5);
+    expect(dxf.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 3 · PR3 of 4 (bend tables ✓ · hems/jogs ✓ · **nesting** · NFP next)

Packs multiple developed flat patterns onto stock sheets to reduce waste — a 2D bin-packing pass over the unfold outputs (not a geometry-on-solid op).

### What's new
- **`nest(patterns, { sheet, margin?, spacing?, allowRotation? })`** → `NestResult { sheets: [{ placements: [{ patternIndex, x, y, rotationDeg }], utilization }], unplaced, warnings }`. Shelf (level) packing, largest-first, optional 90° rotation, opens a new sheet when a part won't fit. A part too large even rotated is pre-filtered into `unplaced` with a `PART_TOO_LARGE` warning (never dropped, never looped). Part bboxes come from the **real outline geometry**.
- **`nestToDXF` / `multiPatternToDXF`**: `dxfFns` refactored to a transform-driven multi-pattern writer (single-pattern `flatPatternToDXF` output byte-identical). Each placement translates+rotates the pattern's outline/bend lines/holes/forms into one per-sheet R2000 DXF.
- `api`/`index` surfaces; harness `nesting` demo; README **Nesting** section documenting the **bbox-only** limitation (true-shape NFP nesting is PR11).

### Correctness
- The **no-overlap + within-[margin]** invariant is asserted exhaustively over all placement pairs. The reviewer independently **fuzzed 200,000 cases (764,718 placements)** — zero overlaps, zero out-of-bounds.
- `patternBbox` rejects degenerate outlines so utilization stays in `(0,1]`.
- No infinite loop on unplaceable parts (oversized parts pre-filtered before packing).

### Verification
- typecheck / lint / build clean; **217 tests** (207 prior + 10 new) green; snapshot exit 0 (6 parts → 1 sheet, 49.6% utilization, DXF+SVG written).
- Built via a Workflow (implement → adversarial review → fix) in an isolated git worktree.

### Stack
Phase 2 (7 PRs) + PR8 (bend tables) + PR9 (hems/jogs) merged. Remaining: PR11 true-shape (NFP) nesting.