### PR TITLE
feat(sheetmetal): true-shape (no-fit-polygon) nesting for interlocking parts

### DIFF
--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -217,35 +217,61 @@ measured jog offset, and solid validity.
 
 ## Nesting
 
-`nest(patterns, { sheet, margin?, spacing?, allowRotation? })` arranges a set of developed flat patterns onto
-stock sheets to reduce waste, returning `Result<NestResult>` (`{ sheets, unplaced, warnings }`). Each sheet
-carries its `placements` (`{ patternIndex, x, y, rotationDeg }`, where `rotationDeg` is `0` or `90`) and a
-`utilization`. `nestToDXF(result, patterns, sheetIndex)` then emits one fabrication-ready, multi-layer DXF per
-sheet, translating and rotating every placed pattern (outline + bend lines + holes + forms) onto the sheet via
-the same bounding boxes the packer used.
+`nest(patterns, { sheet, margin?, spacing?, allowRotation?, strategy? })` arranges a set of developed flat
+patterns onto stock sheets to reduce waste, returning `Result<NestResult>` (`{ sheets, unplaced, warnings }`).
+Each sheet carries its `placements` (`{ patternIndex, x, y, rotationDeg }`) and a `utilization`.
+`nestToDXF(result, patterns, sheetIndex)` then emits one fabrication-ready, multi-layer DXF per sheet,
+translating and rotating every placed pattern (outline + bend lines + holes + forms) onto the sheet.
 
-> **Scope — bounding-box nesting only.** This packs each part as its axis-aligned **outline bounding box**, so
-> parts do **not** interlock: a concave or L-shaped part reserves its full rectangular footprint and leaves the
-> in-bbox waste unused. True-shape **no-fit-polygon (NFP)** nesting — where parts nest into each other's
-> concavities — is the planned follow-up. Treat the reported utilization as a conservative lower bound on what
-> NFP nesting could achieve.
+Two strategies are available via `strategy`:
+
+### `strategy: "bbox"` (default) — bounding-box nesting
+
+Packs each part as its axis-aligned **outline bounding box**, so parts do **not** interlock: a concave or
+L-shaped part reserves its full rectangular footprint and leaves the in-bbox waste unused. `rotationDeg` is
+`0` or `90`. This remains the default so existing callers are unchanged.
 
 - **Algorithm.** A shelf (level) packing heuristic. Parts are sorted largest-first (by bbox height, then area)
   and placed left-to-right into horizontal shelves; a new shelf opens below when the current row fills, and a
-  **new sheet** opens when the next shelf would overflow the usable height. Placements stay inside the usable
-  area `[margin, sheet − margin]` and are separated by at least `spacing`.
-- **Rotation.** With `allowRotation`, each part is tried at both `0°` and `90°` and the orientation that fits
-  (or packs shorter) is kept — letting a tall part fit a short sheet.
-- **Unplaceable parts.** A part larger than the usable sheet even rotated is reported in `unplaced` with a
-  warning; it is never dropped silently and never loops.
-- **Utilization.** Σ placed part **bounding-box** areas ÷ usable-sheet area, in `(0, 1]`. Inter-part spacing
-  gaps and intra-bbox waste are not credited, so it is a conservative material-use measure.
+  **new sheet** opens when the next shelf would overflow the usable height.
+- **Rotation.** With `allowRotation`, each part is tried at `0°` and `90°` and the orientation that fits (or
+  packs shorter) is kept.
+- **Utilization.** Σ placed part **bounding-box** areas ÷ usable-sheet area — a conservative lower bound that
+  does not credit inter-part gaps or intra-bbox waste.
+
+### `strategy: "nfp"` — true-shape (no-fit-polygon) nesting
+
+Packs the actual **outline polygons** so concave parts interlock — an L-shaped part nests a rotated copy into
+its notch, fitting more material per sheet than bbox packing ever can. `rotationDeg` may be `0/90/180/270`.
+
+> **Heuristic, not optimal.** The nfp packer is a **bottom-left-fill** heuristic (largest-first, with a
+> discretised raster scan over each part's orientations). It finds good interlocks but is **not** a provably
+> optimal solver — a different part order or finer rotation set may pack tighter. What it guarantees: placed
+> outline polygons never overlap (within `spacing`), all placements stay inside `[margin, sheet − margin]`, an
+> oversized part goes to `unplaced` with a `PART_TOO_LARGE` warning (never dropped, never an infinite loop).
+
+- **Correctness backbone.** Overlap is tested at the **polygon** level: two outlines overlap iff any edges
+  cross **or** one contains a vertex of the other (full containment), with a configurable `spacing` clearance.
+  A bbox-only check would let a part collide with a concave neighbour, so the true outline is always used.
+- **Utilization.** Σ placed part **outline-polygon** areas ÷ usable-sheet area, so an L-shaped part credits
+  only its true material — the two strategies' utilizations are directly comparable on the same parts.
+- **Geometry assumption.** Outlines are read as straight-edged polylines (one vertex per edge start point);
+  arc edges are approximated by their endpoints — the same assumption the DXF/SVG writers and the bbox nester
+  make.
+
+On a set of identical L-shaped parts, `"nfp"` interlocks them and typically uses roughly **half the sheets** of
+`"bbox"` (see the snapshot harness's `nfp vs bbox` demo).
 
 ```ts
 const patterns = parts.map((p) => unfold(p).value.pattern);
-const nested = nest(patterns, { sheet: { width: 1250, height: 2500 }, margin: 5, spacing: 3, allowRotation: true });
-// nested.value.sheets.length, nested.value.sheets[i].utilization, nested.value.unplaced
-const dxf = nestToDXF(nested.value, patterns, 0); // fabrication-ready DXF for sheet 0
+
+// Default bounding-box nesting:
+const bbox = nest(patterns, { sheet: { width: 1250, height: 2500 }, margin: 5, spacing: 3, allowRotation: true });
+
+// True-shape nesting — interlocks concave parts for higher utilization:
+const nfp = nest(patterns, { sheet: { width: 1250, height: 2500 }, margin: 5, spacing: 3, allowRotation: true, strategy: 'nfp' });
+
+const dxf = nestToDXF(nfp.value, patterns, 0); // fabrication-ready DXF for sheet 0
 ```
 
 ## Foreign-solid import & unfold
@@ -344,7 +370,9 @@ the headline L-bracket with a mitered corner, a tray, reliefs, a cutout panel, a
 flaps + emboss/dimple) — then renders each folded 3D part next to its developed
 flat pattern as a single side-by-side SVG and also writes the folded solid as STEP.
 It also runs a **nesting** demo (a handful of parts bbox-packed onto one sheet),
-printing the sheet count + utilization and writing the nested sheet as DXF + SVG.
+printing the sheet count + utilization and writing the nested sheet as DXF + SVG,
+plus an **nfp vs bbox** comparison nesting identical L-shaped parts with both
+strategies and printing the true-shape utilization gain.
 
 ```bash
 npm run snapshot --workspace=brepjs-sheetmetal

--- a/packages/brepjs-sheetmetal/harness/snapshot.ts
+++ b/packages/brepjs-sheetmetal/harness/snapshot.ts
@@ -15,7 +15,7 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, measureVolume, isErr, initFromOC } from 'brepjs';
+import { meshEdges, getEdges, curveStartPoint, curveEndPoint, exportSTEP, measureVolume, isErr, initFromOC, polygon, outerWire, unwrap } from 'brepjs';
 import type { Solid, Vec3 } from 'brepjs';
 import { author, miterCorner, unfold, unfoldSolid, fold, developed, nest, nestToDXF } from '../src/api.js';
 import type { NestResult } from '../src/nestFns.js';
@@ -347,7 +347,7 @@ async function renderNestDemo(): Promise<string[]> {
 
   const utils = result.sheets.map((s) => `${(s.utilization * 100).toFixed(1)}%`).join(', ');
   return [
-    '  [nesting]',
+    '  [nesting / bbox]',
     `    parts                : ${patterns.length}`,
     `    sheet                : ${sheet.width}×${sheet.height} mm (margin ${margin}, spacing ${spacing})`,
     `    sheets used          : ${result.sheets.length}`,
@@ -355,6 +355,61 @@ async function renderNestDemo(): Promise<string[]> {
     `    unplaced             : ${result.unplaced.length}`,
     `    nested sheet-0 DXF   : ${dxfPath}`,
     `    nested sheet-0 SVG   : ${svgPath}`,
+    ...(await renderNfpVsBbox()),
+  ];
+}
+
+/**
+ * True-shape (no-fit-polygon) demo (plan PR11): nest a set of identical concave
+ * L-shaped parts with BOTH strategies on the same sheet and print the material-
+ * utilization improvement true-shape interlocking buys over the bounding-box packer.
+ * The nfp packer is a heuristic (bottom-left-fill) — not provably optimal — but on
+ * concave parts it interlocks rotated copies into each other's notches, fitting more
+ * material per sheet than bbox packing ever can.
+ */
+async function renderNfpVsBbox(): Promise<string[]> {
+  // A clean tessellating L: a 40×40 square with a 20×20 notch at the far corner. Two
+  // of them (one rotated 180°) interlock into a 40×60 rectangle with no waste.
+  const lPattern: FlatPattern = {
+    outline: outerWire(
+      unwrap(
+        polygon([
+          [0, 0, 0],
+          [40, 0, 0],
+          [40, 20, 0],
+          [20, 20, 0],
+          [20, 40, 0],
+          [0, 40, 0],
+        ])
+      )
+    ),
+    bendLines: [],
+    holes: [],
+    formCuts: [],
+    formMarkers: [],
+    formHinges: [],
+    loftedDevelopments: [],
+    developedArea: 1200,
+  };
+  const parts = Array.from({ length: 8 }, () => lPattern);
+  const sheet = { width: 45, height: 65 };
+  const opts = { sheet, allowRotation: true } as const;
+
+  const bbox = nest(parts, { ...opts, strategy: 'bbox' });
+  const nfp = nest(parts, { ...opts, strategy: 'nfp' });
+  if (isErr(bbox) || isErr(nfp)) throw new Error('nfp-vs-bbox nest failed');
+
+  const bestU = (r: NestResult): number => r.sheets.reduce((m, s) => Math.max(m, s.utilization), 0);
+  const bU = bestU(bbox.value);
+  const nU = bestU(nfp.value);
+  const improvement = bU > 0 ? ((nU - bU) / bU) * 100 : 0;
+
+  return [
+    '  [nesting / nfp vs bbox — 8 L-shaped parts]',
+    `    sheet                : ${sheet.width}×${sheet.height} mm`,
+    `    bbox  sheets / util  : ${bbox.value.sheets.length} / ${(bU * 100).toFixed(1)}%`,
+    `    nfp   sheets / util  : ${nfp.value.sheets.length} / ${(nU * 100).toFixed(1)}% (interlocked)`,
+    `    utilization gain     : +${improvement.toFixed(1)}%  (heuristic true-shape packer)`,
   ];
 }
 
@@ -376,11 +431,12 @@ function renderNestSheetSvg(
     const pattern = patterns[p.patternIndex];
     if (pattern === undefined) continue;
     const b = patternBboxLocal(pattern);
-    const w = (p.rotationDeg === 90 ? b.height : b.width) * scale;
-    const h = (p.rotationDeg === 90 ? b.width : b.height) * scale;
+    const swapped = p.rotationDeg === 90 || p.rotationDeg === 270;
+    const w = (swapped ? b.height : b.width) * scale;
+    const h = (swapped ? b.width : b.height) * scale;
     parts.push(
       `<rect x="${fmt(sx(p.x))}" y="${fmt(sy(p.y) - h)}" width="${fmt(w)}" height="${fmt(h)}" fill="#b8431d22" stroke="#b8431d" />`,
-      `<text x="${fmt(sx(p.x) + 4)}" y="${fmt(sy(p.y) - h + 14)}" font-family="sans-serif" font-size="11" fill="#b8431d">#${p.patternIndex}${p.rotationDeg === 90 ? ' ⟳' : ''}</text>`
+      `<text x="${fmt(sx(p.x) + 4)}" y="${fmt(sy(p.y) - h + 14)}" font-family="sans-serif" font-size="11" fill="#b8431d">#${p.patternIndex}${p.rotationDeg !== 0 ? ' ⟳' : ''}</text>`
     );
   }
   return [

--- a/packages/brepjs-sheetmetal/src/api.ts
+++ b/packages/brepjs-sheetmetal/src/api.ts
@@ -254,9 +254,12 @@ export function toDXF(pattern: FlatPattern, options?: DxfOptions): Result<string
 }
 
 /**
- * Bounding-box nest: arrange developed flat patterns onto stock sheets to reduce
- * waste. Parts are packed as their outline bounding boxes (no interlocking);
- * true-shape NFP nesting is a follow-up.
+ * Nest developed flat patterns onto stock sheets to reduce waste. The default
+ * `strategy: "bbox"` packs each part as its outline bounding box (fast, no
+ * interlocking). `strategy: "nfp"` is true-shape / no-fit-polygon nesting: the actual
+ * outline polygons are packed so concave (L-shaped) parts interlock for higher
+ * utilization. The NFP packer is a HEURISTIC (bottom-left-fill) — not provably
+ * optimal — but never overlaps parts and never drops a part silently.
  */
 export function nest(patterns: FlatPattern[], options: NestOptions): Result<NestResult> {
   return nestFn(patterns, options);

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -74,6 +74,18 @@ export type {
   Bbox,
 } from './nestFns.js';
 
+export {
+  wireToPolygon,
+  polygonsOverlap,
+  polygonsOverlapWithClearance,
+  segmentsIntersect,
+  pointInPolygon,
+  transformPolygon,
+  polygonBounds,
+  signedArea,
+} from './polygonFns.js';
+export type { Polygon, Pt2 } from './polygonFns.js';
+
 export { buildReport, reportFromUnfold, reportToJSON } from './reportFns.js';
 
 export { validatePart } from './validateFns.js';

--- a/packages/brepjs-sheetmetal/src/nestFns.ts
+++ b/packages/brepjs-sheetmetal/src/nestFns.ts
@@ -1,6 +1,14 @@
 import { type Result, ok, err, validationError, getEdges, curveStartPoint } from 'brepjs';
 import type { FlatPattern, SheetMetalWarning } from './types.js';
 import { multiPatternToDXF, type DxfOptions, type Transform2, type PlacedPattern } from './dxfFns.js';
+import {
+  wireToPolygon,
+  transformPolygon,
+  polygonBounds,
+  polygonsOverlapWithClearance,
+  signedArea,
+  type Polygon,
+} from './polygonFns.js';
 
 /** Stock sheet the parts are packed onto (the gross blank, before margin). */
 export interface SheetSpec {
@@ -17,9 +25,22 @@ export interface NestOptions {
   spacing?: number | undefined;
   /** Try a 90° rotation per part and keep whichever orientation fits/packs better. */
   allowRotation?: boolean | undefined;
+  /**
+   * Packing strategy. Default `"bbox"`: each part is packed as its axis-aligned
+   * bounding box (the original {@link nest} behavior — fast, parts never interlock).
+   * `"nfp"` is true-shape / no-fit-polygon nesting: the actual outline polygons are
+   * packed so concave (L-shaped) parts interlock for higher material utilization.
+   * The NFP packer is a HEURISTIC (bottom-left-fill, largest-first) — not provably
+   * optimal — but it never overlaps parts and never drops a part silently.
+   */
+  strategy?: 'bbox' | 'nfp' | undefined;
 }
 
-/** Where a single pattern lands on a sheet. `rotationDeg` is `0` or `90`. */
+/**
+ * Where a single pattern lands on a sheet. For the bbox strategy `rotationDeg` is
+ * `0` or `90`; the true-shape (nfp) strategy may also emit `180` or `270`. `(x, y)`
+ * is the lower-left of the part's transformed bounding box in sheet coordinates.
+ */
 export interface Placement {
   /** Index into the `patterns` array passed to {@link nest}. */
   patternIndex: number;
@@ -27,16 +48,18 @@ export interface Placement {
   x: number;
   /** Lower-left y of the part's (rotated) bounding box, in sheet coordinates. */
   y: number;
-  rotationDeg: 0 | 90;
+  rotationDeg: number;
 }
 
 export interface NestSheet {
   placements: Placement[];
   /**
-   * Σ placed part bounding-box areas ÷ usable-sheet area, in `(0, 1]`. "Usable"
-   * = `(width − 2·margin) × (height − 2·margin)`. This is BOUNDING-BOX utilization:
-   * the inter-part spacing gaps and intra-bbox waste (a non-rectangular part inside
-   * its box) are NOT credited, so it is a conservative measure of true material use.
+   * Σ placed part areas ÷ usable-sheet area, in `(0, 1]`. "Usable" =
+   * `(width − 2·margin) × (height − 2·margin)`. For the `"bbox"` strategy the part
+   * area is its BOUNDING-BOX area (intra-bbox waste of a non-rectangular part is not
+   * credited — a conservative measure). For the `"nfp"` true-shape strategy it is the
+   * actual OUTLINE-POLYGON area, so an L-shaped part credits only its true material,
+   * making the two strategies' utilizations directly comparable on the same parts.
    */
   utilization: number;
 }
@@ -92,6 +115,10 @@ export function nest(patterns: FlatPattern[], options: NestOptions): Result<Nest
     return err(validationError('INVALID_SHEET', `margin ${margin} leaves no usable area on a ${sheet.width}×${sheet.height} sheet`));
   }
 
+  if (options.strategy === 'nfp') {
+    return nestNfp(patterns, margin, spacing, allowRotation, usableW, usableH);
+  }
+
   const boxes: Bbox[] = [];
   for (const pattern of patterns) {
     const b = patternBbox(pattern);
@@ -145,6 +172,267 @@ export function nest(patterns: FlatPattern[], options: NestOptions): Result<Nest
 
   unplaced.sort((a, b) => a - b);
   return ok({ sheets, unplaced, warnings });
+}
+
+/** A part outline normalised to the developed-plane origin, with its candidate
+ * orientations precomputed. Each orientation's polygon is anchored so its own
+ * bounding box lower-left sits at `(0, 0)`. */
+interface NfpPart {
+  index: number;
+  /** Outline area (orientation-invariant) — used for the largest-first sort. */
+  area: number;
+  /** Candidate orientations to try, largest-first packing keeps the lowest-left fit. */
+  orientations: NfpOrientation[];
+}
+
+interface NfpOrientation {
+  rotationDeg: number;
+  /** Polygon anchored with its bounding-box lower-left at the origin. */
+  poly: Polygon;
+  /** Width/height of the (rotated) bounding box. */
+  w: number;
+  h: number;
+}
+
+/** One concrete placement on the current sheet: the orientation polygon translated
+ * to its sheet position, kept (with its cached bounds) for the overlap test against
+ * later parts. */
+interface PlacedPoly {
+  poly: Polygon;
+  bounds: [number, number, number, number];
+}
+
+const NFP_ROTATIONS = [0, 90, 180, 270];
+
+/**
+ * True-shape (no-fit-polygon) nest. Packs the actual outline polygons so concave
+ * parts interlock. This is a HEURISTIC bottom-left-fill packer (not provably
+ * optimal): parts are placed largest-first; each part slides to the lowest-then-
+ * leftmost feasible position on the current sheet where its outline polygon does not
+ * overlap (within `spacing`) any already-placed polygon and stays inside the usable
+ * area. Feasible positions are found by a discretised raster scan (a finite grid
+ * stepped by a fraction of the smallest part extent), so the search always
+ * terminates and a part can slide into a neighbour's concave notch.
+ *
+ * Each part is tried at 0/90/180/270° (90/270 only when `allowRotation`; 0/180
+ * otherwise — 180° keeps the footprint but enables interlocking); the orientation
+ * giving the lowest-leftmost feasible placement wins. A part that fits no position on
+ * the current sheet opens a new sheet; one that fits no empty sheet in any orientation
+ * goes to `unplaced` with a PART_TOO_LARGE warning — never dropped, never an infinite
+ * loop.
+ */
+function nestNfp(
+  patterns: FlatPattern[],
+  margin: number,
+  spacing: number,
+  allowRotation: boolean,
+  usableW: number,
+  usableH: number
+): Result<NestResult> {
+  const parts: NfpPart[] = [];
+  for (let i = 0; i < patterns.length; i += 1) {
+    const pattern = patterns[i];
+    if (pattern === undefined) continue;
+    const built = buildNfpPart(i, pattern, allowRotation);
+    if (!built.ok) return built;
+    parts.push(built.value);
+  }
+
+  const usableArea = usableW * usableH;
+  const warnings: SheetMetalWarning[] = [];
+  const unplaced: number[] = [];
+
+  // Largest-first by outline area — large concave parts placed first leave pockets
+  // the smaller parts can interlock into.
+  parts.sort((a, b) => b.area - a.area);
+
+  // Bottom-left-fill raster step: a fraction of the smallest part extent. Finer steps
+  // find tighter interlocks at more cost; this fixed ratio keeps the packer
+  // deterministic and bounded (the scan grid is finite, so it always terminates).
+  const step = rasterStep(parts, usableW, usableH);
+
+  // Pre-filter parts that fit no empty usable sheet in any tried orientation.
+  const placeable: NfpPart[] = [];
+  for (const part of parts) {
+    const fits = part.orientations.some((o) => o.w <= usableW + EPS && o.h <= usableH + EPS);
+    if (!fits) {
+      unplaced.push(part.index);
+      const o0 = part.orientations[0];
+      const dims = o0 === undefined ? '?' : `${o0.w.toFixed(2)}×${o0.h.toFixed(2)}`;
+      warnings.push({
+        code: 'PART_TOO_LARGE',
+        message: `pattern ${part.index} (${dims}) does not fit the usable sheet ${usableW.toFixed(2)}×${usableH.toFixed(2)} even rotated; left unplaced`,
+        featureId: `pattern-${part.index}`,
+      });
+      continue;
+    }
+    placeable.push(part);
+  }
+
+  const sheets: NestSheet[] = [];
+  let current: PlacedPoly[] = [];
+  let placements: Placement[] = [];
+  let currentArea = 0;
+
+  const flush = (): void => {
+    if (placements.length === 0) return;
+    sheets.push({ placements, utilization: currentArea / usableArea });
+  };
+
+  for (const part of placeable) {
+    const placed = placeOnSheet(part, current, spacing, margin, usableW, usableH, step);
+    if (placed === undefined) {
+      // Current sheet full for this part — close it and start fresh. Every placeable
+      // part fits an empty usable sheet, so this retry must succeed; if it somehow
+      // does not, route the part to unplaced (self-enforcing safety net, no loop).
+      flush();
+      current = [];
+      placements = [];
+      currentArea = 0;
+      const retry = placeOnSheet(part, current, spacing, margin, usableW, usableH, step);
+      if (retry === undefined) {
+        unplaced.push(part.index);
+        warnings.push({
+          code: 'PART_TOO_LARGE',
+          message: `pattern ${part.index} could not be placed on a fresh sheet; left unplaced`,
+          featureId: `pattern-${part.index}`,
+        });
+        continue;
+      }
+      current.push({ poly: retry.poly, bounds: polygonBounds(retry.poly) });
+      placements.push(retry.placement);
+      currentArea += part.area;
+      continue;
+    }
+    current.push({ poly: placed.poly, bounds: polygonBounds(placed.poly) });
+    placements.push(placed.placement);
+    currentArea += part.area;
+  }
+
+  flush();
+  unplaced.sort((a, b) => a - b);
+  return ok({ sheets, unplaced, warnings });
+}
+
+/** Build the orientation set for one pattern outline (origin-anchored polygons). */
+function buildNfpPart(index: number, pattern: FlatPattern, allowRotation: boolean): Result<NfpPart> {
+  const polyResult = wireToPolygon(pattern.outline);
+  if (!polyResult.ok) return polyResult;
+  let base = polyResult.value;
+  // Normalise to CCW so the area sign and point-in-polygon orientation are consistent.
+  if (signedArea(base) < 0) base = base.slice().reverse();
+  const area = Math.abs(signedArea(base));
+  if (area <= EPS) {
+    return err(validationError('EMPTY_OUTLINE', `pattern ${index} outline has degenerate area`));
+  }
+
+  const rotations = allowRotation ? NFP_ROTATIONS : [0, 180];
+  const orientations: NfpOrientation[] = [];
+  const seen = new Set<string>();
+  for (const rot of rotations) {
+    const rotated = transformPolygon(base, 0, 0, rot);
+    const [minX, minY, maxX, maxY] = polygonBounds(rotated);
+    const anchored = transformPolygon(rotated, -minX, -minY, 0);
+    const w = maxX - minX;
+    const h = maxY - minY;
+    // Skip an orientation whose anchored polygon is identical to an earlier one (e.g.
+    // 180° of a centrally-symmetric part). Keyed on the rounded vertex loop, NOT the
+    // bounding box — a concave part can share its bbox across rotations while its
+    // SHAPE (and thus its interlocking behaviour) differs.
+    const key = anchored.map(([x, y]) => `${x.toFixed(4)},${y.toFixed(4)}`).join(';');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    orientations.push({ rotationDeg: rot, poly: anchored, w, h });
+  }
+  return ok({ index, area, orientations });
+}
+
+/**
+ * Bottom-left-fill raster step. The scan grid steps by a fraction of the smallest
+ * part extent, so a part can slide INTO a neighbour's concave notch (a fit a sparse
+ * bbox-corner candidate set would miss). Clamped to keep the per-sheet scan bounded.
+ */
+function rasterStep(parts: NfpPart[], usableW: number, usableH: number): number {
+  let minExtent = Infinity;
+  for (const part of parts) {
+    for (const o of part.orientations) {
+      minExtent = Math.min(minExtent, o.w, o.h);
+    }
+  }
+  if (!Number.isFinite(minExtent) || minExtent <= EPS) return Math.max(usableW, usableH) / 100;
+  // ~1/8 of the smallest extent gives tight interlocks at a bounded scan count; never
+  // finer than 1/400 of the larger sheet dimension (caps the worst-case grid size).
+  const floor = Math.max(usableW, usableH) / 400;
+  return Math.max(minExtent / 8, floor);
+}
+
+/**
+ * Find the lowest-then-leftmost feasible placement of `part` on the current sheet
+ * across all its orientations, by a discretised bottom-left raster scan. Returns the
+ * translated polygon (for later overlap tests) and the {@link Placement}, or
+ * undefined if nothing fits. The scan is over a finite grid so it always terminates.
+ */
+function placeOnSheet(
+  part: NfpPart,
+  placed: PlacedPoly[],
+  spacing: number,
+  margin: number,
+  usableW: number,
+  usableH: number,
+  step: number
+): { poly: Polygon; placement: Placement } | undefined {
+  let best: { poly: Polygon; placement: Placement; key: [number, number] } | undefined;
+  for (const o of part.orientations) {
+    if (o.w > usableW + EPS || o.h > usableH + EPS) continue;
+    const fit = scanOrientation(part.index, o, placed, spacing, margin, usableW, usableH, step);
+    if (fit === undefined) continue;
+    // Lower y wins; ties broken by lower x — the bottom-left-fill objective.
+    if (
+      best === undefined ||
+      fit.key[1] < best.key[1] - EPS ||
+      (Math.abs(fit.key[1] - best.key[1]) <= EPS && fit.key[0] < best.key[0] - EPS)
+    ) {
+      best = fit;
+    }
+  }
+  if (best === undefined) return undefined;
+  return { poly: best.poly, placement: best.placement };
+}
+
+/** Lowest-then-leftmost feasible raster position of one orientation, or undefined. */
+function scanOrientation(
+  index: number,
+  o: NfpOrientation,
+  placed: PlacedPoly[],
+  spacing: number,
+  margin: number,
+  usableW: number,
+  usableH: number,
+  step: number
+): { poly: Polygon; placement: Placement; key: [number, number] } | undefined {
+  const maxX = margin + usableW - o.w;
+  const maxY = margin + usableH - o.h;
+  // Scan bottom-to-top, left-to-right; the first feasible cell is the bottom-left fit.
+  for (let y = margin; y <= maxY + EPS; y += step) {
+    for (let x = margin; x <= maxX + EPS; x += step) {
+      const candidate = transformPolygon(o.poly, x, y, 0);
+      if (overlapsAny(candidate, placed, spacing)) continue;
+      return { poly: candidate, placement: { patternIndex: index, x, y, rotationDeg: o.rotationDeg }, key: [x, y] };
+    }
+  }
+  return undefined;
+}
+
+function overlapsAny(candidate: Polygon, placed: PlacedPoly[], spacing: number): boolean {
+  // Broad-phase bbox reject first (cheap), then the exact polygon overlap test.
+  const [cMinX, cMinY, cMaxX, cMaxY] = polygonBounds(candidate);
+  for (const pp of placed) {
+    const [pMinX, pMinY, pMaxX, pMaxY] = pp.bounds;
+    if (cMinX > pMaxX + spacing + EPS || pMinX > cMaxX + spacing + EPS) continue;
+    if (cMinY > pMaxY + spacing + EPS || pMinY > cMaxY + spacing + EPS) continue;
+    if (polygonsOverlapWithClearance(candidate, pp.poly, spacing)) return true;
+  }
+  return false;
 }
 
 /** Does a part fit the usable sheet in the given orientation? */
@@ -304,13 +592,18 @@ export function patternBbox(pattern: FlatPattern): Result<Bbox> {
 }
 
 /**
- * Sheet-placement transform for one placement: shift the pattern's bbox lower-left
- * to the origin, rotate by `rotationDeg` (0 or 90° CCW) about it — which swaps the
- * bbox extents — then translate the (rotated) bbox lower-left to `(x, y)` on the
- * sheet. A point at developed `(px, py)` therefore lands inside `[x, x+w]×[y, y+h]`,
- * matching the box the packer reserved.
+ * Sheet-placement transform for one placement: shift the pattern's developed-plane
+ * bbox lower-left to the origin, rotate `rotationDeg` (CCW) about it, then translate
+ * the rotated shape so its rotated bounding box's lower-left lands at `(x, y)` on the
+ * sheet. A point at developed `(px, py)` therefore lands inside the box the packer
+ * reserved. The 0° and 90° branches are kept as closed-form integer-stable maps so
+ * the bbox-strategy DXF output is byte-identical to the pre-NFP writer; finer angles
+ * (180/270 and any nfp-emitted value) take the general rotation path.
  */
-function placementTransform(box: Bbox, x: number, y: number, rotationDeg: 0 | 90): Transform2 {
+function placementTransform(box: Bbox, x: number, y: number, rotationDeg: number): Transform2 {
+  if (rotationDeg === 0) {
+    return ([px, py]) => [x + (px - box.minX), y + (py - box.minY)];
+  }
   if (rotationDeg === 90) {
     // After shifting to origin: (lx, ly) in [0,w]×[0,h]. Rotate 90° CCW: (-ly, lx)
     // → [-h,0]×[0,w]; add h to bring x back to [0,h], then translate to (x, y).
@@ -320,7 +613,32 @@ function placementTransform(box: Bbox, x: number, y: number, rotationDeg: 0 | 90
       return [x + (box.height - ly), y + lx];
     };
   }
-  return ([px, py]) => [x + (px - box.minX), y + (py - box.minY)];
+  // General CCW rotation about the bbox lower-left, then re-anchor the rotated bbox's
+  // lower-left to (x, y) so the placement matches the box the packer reserved.
+  const rad = (rotationDeg * Math.PI) / 180;
+  const c = Math.cos(rad);
+  const s = Math.sin(rad);
+  const corners: [number, number][] = [
+    [0, 0],
+    [box.width, 0],
+    [box.width, box.height],
+    [0, box.height],
+  ];
+  let minRx = Infinity;
+  let minRy = Infinity;
+  for (const [cx, cy] of corners) {
+    const rx = cx * c - cy * s;
+    const ry = cx * s + cy * c;
+    if (rx < minRx) minRx = rx;
+    if (ry < minRy) minRy = ry;
+  }
+  return ([px, py]) => {
+    const lx = px - box.minX;
+    const ly = py - box.minY;
+    const rx = lx * c - ly * s;
+    const ry = lx * s + ly * c;
+    return [x + (rx - minRx), y + (ry - minRy)];
+  };
 }
 
 /**

--- a/packages/brepjs-sheetmetal/src/polygonFns.ts
+++ b/packages/brepjs-sheetmetal/src/polygonFns.ts
@@ -1,0 +1,222 @@
+/**
+ * 2D simple-polygon geometry for true-shape (no-fit-polygon) nesting: an ordered
+ * vertex loop plus the overlap predicate that is the correctness backbone of the
+ * packer. A false negative here would let two parts physically collide on the laser
+ * bed, so the predicate is exhaustive: two simple polygons overlap iff any of their
+ * edges cross OR one polygon contains a vertex of the other (the latter catches full
+ * containment, where no edges cross).
+ *
+ * Sheet-metal flat outlines are straight-edged polylines; an arc edge (rare in a
+ * developed pattern) is approximated by its two endpoints — the same pre-existing
+ * assumption the DXF/SVG writers and the bbox nester make.
+ */
+
+import { type Result, ok, err, validationError, getEdges, curveStartPoint } from 'brepjs';
+import type { Wire } from 'brepjs';
+
+export type Pt2 = [number, number];
+
+/** A simple (non-self-intersecting) polygon as an ordered, non-closing vertex loop. */
+export type Polygon = Pt2[];
+
+const EPS = 1e-9;
+
+/**
+ * Ordered vertex loop of a closed outline wire — one vertex per edge start point, the
+ * same 2D read the DXF writer (`outlinePoints`) and the bbox nester (`patternBbox`)
+ * use. The loop is NOT closed (the last vertex is not repeated); edges are taken as
+ * `v[i] → v[(i+1) % n]`.
+ */
+export function wireToPolygon(outline: Wire): Result<Polygon> {
+  const edges = getEdges(outline);
+  if (edges.length === 0) {
+    return err(validationError('EMPTY_OUTLINE', 'outline wire has no edges to read'));
+  }
+  const poly: Polygon = [];
+  for (const edge of edges) {
+    const p = curveStartPoint(edge);
+    poly.push([p[0], p[1]]);
+  }
+  if (poly.length < 3) {
+    return err(validationError('EMPTY_OUTLINE', 'outline polygon has fewer than 3 vertices'));
+  }
+  return ok(poly);
+}
+
+/** Signed area (CCW positive) — used to normalise orientation and reject degenerates. */
+export function signedArea(poly: Polygon): number {
+  let a = 0;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i, i += 1) {
+    const pi = poly[i];
+    const pj = poly[j];
+    if (pi === undefined || pj === undefined) continue;
+    a += pj[0] * pi[1] - pi[0] * pj[1];
+  }
+  return a / 2;
+}
+
+/** Axis-aligned bounds `[minX, minY, maxX, maxY]` of a polygon. */
+export function polygonBounds(poly: Polygon): [number, number, number, number] {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of poly) {
+    if (p[0] < minX) minX = p[0];
+    if (p[0] > maxX) maxX = p[0];
+    if (p[1] < minY) minY = p[1];
+    if (p[1] > maxY) maxY = p[1];
+  }
+  return [minX, minY, maxX, maxY];
+}
+
+/** Translate then rotate (CCW, degrees about the origin) every vertex. */
+export function transformPolygon(poly: Polygon, dx: number, dy: number, rotationDeg: number): Polygon {
+  const rad = (rotationDeg * Math.PI) / 180;
+  const c = Math.cos(rad);
+  const s = Math.sin(rad);
+  return poly.map(([x, y]) => {
+    const rx = x * c - y * s;
+    const ry = x * s + y * c;
+    return [rx + dx, ry + dy] as Pt2;
+  });
+}
+
+/** Ray-cast point-in-polygon (boundary points count as inside via the EPS slack below). */
+export function pointInPolygon(poly: Polygon, x: number, y: number): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i, i += 1) {
+    const pi = poly[i];
+    const pj = poly[j];
+    if (pi === undefined || pj === undefined) continue;
+    const intersect =
+      pi[1] > y !== pj[1] > y && x < ((pj[0] - pi[0]) * (y - pi[1])) / (pj[1] - pi[1]) + pi[0];
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function orient(ax: number, ay: number, bx: number, by: number, cx: number, cy: number): number {
+  return (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+}
+
+function onSegment(ax: number, ay: number, bx: number, by: number, px: number, py: number): boolean {
+  return (
+    Math.min(ax, bx) - EPS <= px &&
+    px <= Math.max(ax, bx) + EPS &&
+    Math.min(ay, by) - EPS <= py &&
+    py <= Math.max(ay, by) + EPS
+  );
+}
+
+/**
+ * Proper-or-improper segment intersection (`p1p2` vs `p3p4`). Returns true when the
+ * segments cross OR touch (collinear overlap or a shared endpoint), so it is
+ * conservative for the overlap test — never a false negative.
+ */
+export function segmentsIntersect(p1: Pt2, p2: Pt2, p3: Pt2, p4: Pt2): boolean {
+  const d1 = orient(p3[0], p3[1], p4[0], p4[1], p1[0], p1[1]);
+  const d2 = orient(p3[0], p3[1], p4[0], p4[1], p2[0], p2[1]);
+  const d3 = orient(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1]);
+  const d4 = orient(p1[0], p1[1], p2[0], p2[1], p4[0], p4[1]);
+
+  if (((d1 > EPS && d2 < -EPS) || (d1 < -EPS && d2 > EPS)) && ((d3 > EPS && d4 < -EPS) || (d3 < -EPS && d4 > EPS))) {
+    return true;
+  }
+
+  if (Math.abs(d1) <= EPS && onSegment(p3[0], p3[1], p4[0], p4[1], p1[0], p1[1])) return true;
+  if (Math.abs(d2) <= EPS && onSegment(p3[0], p3[1], p4[0], p4[1], p2[0], p2[1])) return true;
+  if (Math.abs(d3) <= EPS && onSegment(p1[0], p1[1], p2[0], p2[1], p3[0], p3[1])) return true;
+  if (Math.abs(d4) <= EPS && onSegment(p1[0], p1[1], p2[0], p2[1], p4[0], p4[1])) return true;
+  return false;
+}
+
+/**
+ * Do two simple polygons overlap? True iff any edge of `a` intersects any edge of
+ * `b`, or one polygon fully contains a vertex of the other. This pair of conditions
+ * is exhaustive for simple polygons: a disjoint pair has no crossing edges and no
+ * mutually-contained vertex; a touching-but-non-overlapping pair (shared edge/vertex,
+ * zero interior overlap) is caught by `segmentsIntersect` and so is reported as
+ * overlapping — callers wanting a clearance gap should inflate via {@link polygonsOverlapWithClearance}.
+ *
+ * Centroid containment is NOT sufficient on its own (a concave part's centroid can
+ * lie outside it), so a representative INTERIOR vertex of each polygon is tested for
+ * containment in the other — combined with the edge-crossing test this covers the
+ * nested-without-crossing case.
+ */
+export function polygonsOverlap(a: Polygon, b: Polygon): boolean {
+  for (let i = 0; i < a.length; i += 1) {
+    const a1 = a[i];
+    const a2 = a[(i + 1) % a.length];
+    if (a1 === undefined || a2 === undefined) continue;
+    for (let j = 0; j < b.length; j += 1) {
+      const b1 = b[j];
+      const b2 = b[(j + 1) % b.length];
+      if (b1 === undefined || b2 === undefined) continue;
+      if (segmentsIntersect(a1, a2, b1, b2)) return true;
+    }
+  }
+  // No edges cross: the only remaining overlap is full containment. If any vertex of
+  // one lies strictly inside the other, the polygons overlap. (With no crossings,
+  // containment of a single vertex implies containment of the whole polygon.)
+  for (const v of a) {
+    if (pointInPolygon(b, v[0], v[1])) return true;
+  }
+  for (const v of b) {
+    if (pointInPolygon(a, v[0], v[1])) return true;
+  }
+  return false;
+}
+
+/**
+ * Overlap test honoring a clearance gap: the two polygons must stay at least
+ * `clearance` apart. Implemented by testing raw overlap and, when disjoint, the
+ * minimum edge-to-edge distance against the clearance. `clearance <= 0` is the plain
+ * {@link polygonsOverlap}.
+ */
+export function polygonsOverlapWithClearance(a: Polygon, b: Polygon, clearance: number): boolean {
+  if (polygonsOverlap(a, b)) return true;
+  if (clearance <= EPS) return false;
+  return minEdgeDistance(a, b) < clearance - EPS;
+}
+
+/** Minimum distance between any edge of `a` and any edge of `b` (both assumed disjoint). */
+function minEdgeDistance(a: Polygon, b: Polygon): number {
+  let min = Infinity;
+  for (let i = 0; i < a.length; i += 1) {
+    const a1 = a[i];
+    const a2 = a[(i + 1) % a.length];
+    if (a1 === undefined || a2 === undefined) continue;
+    for (let j = 0; j < b.length; j += 1) {
+      const b1 = b[j];
+      const b2 = b[(j + 1) % b.length];
+      if (b1 === undefined || b2 === undefined) continue;
+      const d = segmentSegmentDistance(a1, a2, b1, b2);
+      if (d < min) min = d;
+    }
+  }
+  return min;
+}
+
+function segmentSegmentDistance(p1: Pt2, p2: Pt2, p3: Pt2, p4: Pt2): number {
+  if (segmentsIntersect(p1, p2, p3, p4)) return 0;
+  return Math.min(
+    pointSegmentDistance(p1, p3, p4),
+    pointSegmentDistance(p2, p3, p4),
+    pointSegmentDistance(p3, p1, p2),
+    pointSegmentDistance(p4, p1, p2)
+  );
+}
+
+function pointSegmentDistance(p: Pt2, a: Pt2, b: Pt2): number {
+  const vx = b[0] - a[0];
+  const vy = b[1] - a[1];
+  const wx = p[0] - a[0];
+  const wy = p[1] - a[1];
+  const len2 = vx * vx + vy * vy;
+  let t = len2 <= EPS ? 0 : (wx * vx + wy * vy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  const dx = p[0] - (a[0] + t * vx);
+  const dy = p[1] - (a[1] + t * vy);
+  return Math.hypot(dx, dy);
+}

--- a/packages/brepjs-sheetmetal/src/polygonFns.ts
+++ b/packages/brepjs-sheetmetal/src/polygonFns.ts
@@ -70,7 +70,7 @@ export function polygonBounds(poly: Polygon): [number, number, number, number] {
   return [minX, minY, maxX, maxY];
 }
 
-/** Translate then rotate (CCW, degrees about the origin) every vertex. */
+/** Rotate every vertex (CCW, degrees, about the origin), then translate by (dx, dy). */
 export function transformPolygon(poly: Polygon, dx: number, dy: number, rotationDeg: number): Polygon {
   const rad = (rotationDeg * Math.PI) / 180;
   const c = Math.cos(rad);
@@ -82,7 +82,9 @@ export function transformPolygon(poly: Polygon, dx: number, dy: number, rotation
   });
 }
 
-/** Ray-cast point-in-polygon (boundary points count as inside via the EPS slack below). */
+/** Ray-cast point-in-polygon: points strictly inside return true; behaviour for a
+ * point exactly on the boundary is undefined (the overlap predicate handles edge
+ * contact separately via segment-intersection). */
 export function pointInPolygon(poly: Polygon, x: number, y: number): boolean {
   let inside = false;
   for (let i = 0, j = poly.length - 1; i < poly.length; j = i, i += 1) {

--- a/packages/brepjs-sheetmetal/tests/nfpNest.test.ts
+++ b/packages/brepjs-sheetmetal/tests/nfpNest.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { polygon, outerWire, unwrap } from 'brepjs';
+import { authorPart as author } from '../src/authorFns.js';
+import { unfold } from '../src/unfoldFns.js';
+import { nest, nestToDXF } from '../src/nestFns.js';
+import {
+  wireToPolygon,
+  transformPolygon,
+  polygonsOverlap,
+  polygonsOverlapWithClearance,
+  segmentsIntersect,
+  type Polygon,
+} from '../src/polygonFns.js';
+import type { AuthorSpec } from '../src/authorFns.js';
+import type { FlatPattern } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+/**
+ * A clean tessellating L-shaped (concave) flat pattern: a 40×40 outer square with a
+ * 20×20 notch removed at the far (top-right) corner, so two of them — one rotated
+ * 180° — interlock into a 40×60 rectangle with no waste. Built straight from a
+ * polygon outline so the geometry is exact and deterministic (no bend-allowance
+ * arithmetic), which is what the interlocking-win and non-overlap proofs need.
+ */
+function lPart(): FlatPattern {
+  const pts: [number, number, number][] = [
+    [0, 0, 0],
+    [40, 0, 0],
+    [40, 20, 0],
+    [20, 20, 0],
+    [20, 40, 0],
+    [0, 40, 0],
+  ];
+  const wire = outerWire(unwrap(polygon(pts)));
+  return {
+    outline: wire,
+    bendLines: [],
+    holes: [],
+    formCuts: [],
+    formMarkers: [],
+    formHinges: [],
+    loftedDevelopments: [],
+    developedArea: 1200,
+  };
+}
+
+/** A plain rectangular blank (its outline is exactly length×width). */
+function flatBlank(length: number, width: number): FlatPattern {
+  const spec: AuthorSpec = { thickness: 1, base: { length, width }, flanges: [] };
+  const authored = author(spec);
+  if (!authored.ok) throw new Error(`author failed: ${authored.error.message}`);
+  const unfolded = unfold(authored.value);
+  if (!unfolded.ok) throw new Error(`unfold failed: ${unfolded.error.message}`);
+  return unfolded.value.pattern;
+}
+
+/** The placed outline polygon of one placement, transformed onto the sheet. */
+function placedPolygon(pattern: FlatPattern, x: number, y: number, rotationDeg: number): Polygon {
+  const base = wireToPolygon(pattern.outline);
+  if (!base.ok) throw new Error('wireToPolygon failed');
+  // Anchor the rotated outline's bbox lower-left to (x, y), mirroring the packer.
+  const rotated = transformPolygon(base.value, 0, 0, rotationDeg);
+  let minX = Infinity;
+  let minY = Infinity;
+  for (const [px, py] of rotated) {
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+  }
+  return transformPolygon(rotated, x - minX, y - minY, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Polygon-overlap predicate unit tests (the correctness backbone).
+// ---------------------------------------------------------------------------
+
+describe('polygon overlap predicate', () => {
+  const square = (x: number, y: number, s: number): Polygon => [
+    [x, y],
+    [x + s, y],
+    [x + s, y + s],
+    [x, y + s],
+  ];
+
+  it('segmentsIntersect: crossing, collinear, shared endpoint, disjoint', () => {
+    // Proper crossing (an X).
+    expect(segmentsIntersect([0, 0], [10, 10], [0, 10], [10, 0])).toBe(true);
+    // Collinear overlapping.
+    expect(segmentsIntersect([0, 0], [10, 0], [5, 0], [15, 0])).toBe(true);
+    // Shared endpoint (touching).
+    expect(segmentsIntersect([0, 0], [5, 0], [5, 0], [5, 5])).toBe(true);
+    // Disjoint, no touch.
+    expect(segmentsIntersect([0, 0], [1, 0], [3, 3], [4, 4])).toBe(false);
+    // Parallel, non-collinear.
+    expect(segmentsIntersect([0, 0], [10, 0], [0, 1], [10, 1])).toBe(false);
+  });
+
+  it('overlap: crossing edges (interpenetrating squares)', () => {
+    expect(polygonsOverlap(square(0, 0, 10), square(5, 5, 10))).toBe(true);
+  });
+
+  it('overlap: full containment (one inside the other, no edge crossing)', () => {
+    expect(polygonsOverlap(square(0, 0, 20), square(5, 5, 5))).toBe(true);
+    // Order-independent.
+    expect(polygonsOverlap(square(5, 5, 5), square(0, 0, 20))).toBe(true);
+  });
+
+  it('no overlap: disjoint squares', () => {
+    expect(polygonsOverlap(square(0, 0, 10), square(20, 20, 10))).toBe(false);
+  });
+
+  it('touching-but-not-overlapping shares an edge (reported as overlap by the raw predicate)', () => {
+    // Edge-flush squares touch; the raw predicate is conservative and reports overlap.
+    expect(polygonsOverlap(square(0, 0, 10), square(10, 0, 10))).toBe(true);
+    // With a positive clearance, two squares separated by exactly a gap < clearance
+    // are reported overlapping; a gap >= clearance is not.
+    expect(polygonsOverlapWithClearance(square(0, 0, 10), square(12, 0, 10), 1)).toBe(false);
+    expect(polygonsOverlapWithClearance(square(0, 0, 10), square(10.5, 0, 10), 1)).toBe(true);
+  });
+
+  it('clearance: disjoint parts within the gap are reported overlapping', () => {
+    // 2 units apart, clearance 3 → too close.
+    expect(polygonsOverlapWithClearance(square(0, 0, 10), square(12, 0, 10), 3)).toBe(true);
+    // 5 units apart, clearance 3 → fine.
+    expect(polygonsOverlapWithClearance(square(0, 0, 10), square(15, 0, 10), 3)).toBe(false);
+  });
+
+  it('concave (L) containment that bbox-only checking would miss', () => {
+    // An L whose bounding box is 10×10 but whose notch (the [6,10]×[6,10] corner) is
+    // empty. A small square placed in that notch does NOT overlap the L, even though
+    // both bounding boxes overlap — the case true-shape nesting exploits.
+    const lShape: Polygon = [
+      [0, 0],
+      [10, 0],
+      [10, 6],
+      [6, 6],
+      [6, 10],
+      [0, 10],
+    ];
+    const inNotch = square(6.5, 6.5, 3);
+    expect(polygonsOverlap(lShape, inNotch)).toBe(false);
+    // A square straddling the L's solid arm DOES overlap.
+    const onArm = square(2, 2, 3);
+    expect(polygonsOverlap(lShape, onArm)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// True-shape nesting integration.
+// ---------------------------------------------------------------------------
+
+describe('nest — true-shape (nfp)', () => {
+  it('INTERLOCKING WIN: nfp utilization strictly beats bbox on L-shaped parts', () => {
+    // Sheet 45×65: two Ls interlock onto ONE sheet (true-shape) but the bbox packer
+    // fits only one 40×40 box per sheet. So nfp packs twice the material per sheet,
+    // and its (true-area) utilization strictly exceeds bbox's (bbox-area) utilization.
+    const parts = Array.from({ length: 4 }, () => lPart());
+    const sheet = { width: 45, height: 65 };
+    const opts = { sheet, allowRotation: true } as const;
+
+    const bbox = nest(parts, { ...opts, strategy: 'bbox' });
+    const nfp = nest(parts, { ...opts, strategy: 'nfp' });
+    expect(bbox.ok && nfp.ok).toBe(true);
+    if (!bbox.ok || !nfp.ok) return;
+    expect(bbox.value.unplaced).toEqual([]);
+    expect(nfp.value.unplaced).toEqual([]);
+
+    const bestUtil = (r: typeof bbox.value): number =>
+      r.sheets.reduce((m, s) => Math.max(m, s.utilization), 0);
+    const bboxU = bestUtil(bbox.value);
+    const nfpU = bestUtil(nfp.value);
+
+    // bbox: 1 part/sheet (4 sheets); nfp: 2 parts/sheet (2 sheets) by interlocking.
+    expect(bbox.value.sheets.every((s) => s.placements.length === 1)).toBe(true);
+    expect(nfp.value.sheets.some((s) => s.placements.length === 2)).toBe(true);
+    expect(nfp.value.sheets.length).toBeLessThan(bbox.value.sheets.length);
+    // The whole reason PR11 exists: interlocking concave parts uses more material.
+    expect(nfpU).toBeGreaterThan(bboxU + 1e-3);
+  });
+
+  it('NO OVERLAP at the polygon level over all placed pairs, within usable bounds', () => {
+    const parts = [lPart(), lPart(), lPart(), flatBlank(25, 25), lPart()];
+    const margin = 5;
+    const spacing = 2;
+    const sheet = { width: 120, height: 120 };
+    const r = nest(parts, { sheet, margin, spacing, allowRotation: true, strategy: 'nfp' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const eps = 1e-6;
+    for (const s of r.value.sheets) {
+      const polys = s.placements.map((p) =>
+        placedPolygon(parts[p.patternIndex] as FlatPattern, p.x, p.y, p.rotationDeg)
+      );
+      // Every transformed outline lies within [margin, sheet - margin].
+      for (const poly of polys) {
+        for (const [x, y] of poly) {
+          expect(x).toBeGreaterThanOrEqual(margin - eps);
+          expect(y).toBeGreaterThanOrEqual(margin - eps);
+          expect(x).toBeLessThanOrEqual(sheet.width - margin + eps);
+          expect(y).toBeLessThanOrEqual(sheet.height - margin + eps);
+        }
+      }
+      // Exhaustive: NO two placed outline polygons overlap (with spacing clearance).
+      // This is the load-bearing correctness check — concave parts whose bounding
+      // boxes overlap must still not overlap at the true-outline level.
+      for (let i = 0; i < polys.length; i += 1) {
+        for (let j = i + 1; j < polys.length; j += 1) {
+          const a = polys[i] as Polygon;
+          const b = polys[j] as Polygon;
+          expect(polygonsOverlapWithClearance(a, b, spacing - eps)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('rotations: a part that only interlocks rotated is still placed', () => {
+    // Two L-parts on a 45×65 sheet only both fit if the second is rotated 180° into
+    // the first's notch — a 0°-only packer would spill one to a second sheet.
+    const parts = [lPart(), lPart()];
+    const sheet = { width: 45, height: 65 };
+    const r = nest(parts, { sheet, allowRotation: true, strategy: 'nfp' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.unplaced).toEqual([]);
+    // Both interlock onto one sheet; the second is rotated to fit the notch.
+    const onOneSheet = r.value.sheets.some((s) => s.placements.length === 2);
+    expect(onOneSheet).toBe(true);
+    const rotations = r.value.sheets.flatMap((s) => s.placements.map((p) => p.rotationDeg));
+    expect(rotations.some((d) => d === 90 || d === 180 || d === 270)).toBe(true);
+  });
+
+  it('oversized part -> unplaced + warning, no infinite loop', () => {
+    const parts = [lPart(), flatBlank(500, 500), lPart()];
+    const r = nest(parts, { sheet: { width: 80, height: 80 }, strategy: 'nfp' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.unplaced).toEqual([1]);
+    expect(r.value.warnings.length).toBe(1);
+    expect(r.value.warnings[0]?.code).toBe('PART_TOO_LARGE');
+    expect(r.value.warnings[0]?.featureId).toBe('pattern-1');
+    const placed = r.value.sheets.reduce((n, s) => n + s.placements.length, 0);
+    expect(placed).toBe(2);
+  });
+
+  it('opens a new sheet when no feasible placement remains', () => {
+    const parts = Array.from({ length: 4 }, () => flatBlank(40, 40));
+    // 50×50 usable fits exactly one 40×40 per sheet → 4 sheets.
+    const r = nest(parts, { sheet: { width: 50, height: 50 }, strategy: 'nfp' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.unplaced).toEqual([]);
+    expect(r.value.sheets).toHaveLength(4);
+  });
+});
+
+describe('nestToDXF — true-shape sheet', () => {
+  it('places each part at its (x, y, rotation); a second part is shifted', () => {
+    const parts = [lPart(), lPart()];
+    const r = nest(parts, { sheet: { width: 45, height: 65 }, allowRotation: true, strategy: 'nfp' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const sheet = r.value.sheets[0];
+    expect(sheet).toBeDefined();
+    if (sheet === undefined) return;
+    expect(sheet.placements.length).toBeGreaterThanOrEqual(2);
+
+    const dxf = nestToDXF(r.value, parts, 0);
+    expect(dxf.ok).toBe(true);
+    if (!dxf.ok) return;
+    const polylineCount = dxf.value.split('LWPOLYLINE').length - 1;
+    expect(polylineCount).toBeGreaterThanOrEqual(2);
+
+    // A part placed at x>0 must emit at least one vertex near that offset.
+    const second = sheet.placements.find((p) => p.x > 1e-6);
+    expect(second).toBeDefined();
+    if (second === undefined) return;
+    const lines = dxf.value.split('\n');
+    const xs: number[] = [];
+    for (let i = 0; i < lines.length - 1; i += 1) {
+      if (lines[i] === '10') {
+        const v = Number(lines[i + 1]);
+        if (Number.isFinite(v)) xs.push(v);
+      }
+    }
+    const hits = xs.some((x) => Math.abs(x - second.x) < 1e-2);
+    expect(hits).toBe(true);
+  });
+});
+
+describe('nest — strategy routing', () => {
+  it('default (no strategy) is identical to explicit bbox', () => {
+    const parts = Array.from({ length: 5 }, () => flatBlank(20, 20));
+    const sheet = { width: 60, height: 40 };
+    const def = nest(parts, { sheet });
+    const bbox = nest(parts, { sheet, strategy: 'bbox' });
+    expect(def.ok && bbox.ok).toBe(true);
+    if (!def.ok || !bbox.ok) return;
+    expect(def.value.sheets.map((s) => s.placements)).toEqual(bbox.value.sheets.map((s) => s.placements));
+    expect(def.value.sheets.map((s) => s.utilization)).toEqual(bbox.value.sheets.map((s) => s.utilization));
+  });
+});


### PR DESCRIPTION
## Phase 3 · PR4 of 4 (bend tables ✓ · hems/jogs ✓ · bbox nesting ✓ · **true-shape nesting**)

Adds a **true-shape** nesting strategy so concave / L-shaped parts interlock — the documented follow-up to PR10's bounding-box nester.

### What's new
- **`polygonFns.ts`**: 2D polygon geometry + the overlap predicate (the correctness backbone) — two simple polygons overlap iff any edges cross *or* one contains a vertex of the other; `polygonsOverlapWithClearance` adds the spacing gap.
- **`NestOptions.strategy`** (`'bbox'` default | `'nfp'`): the `nfp` packer is bottom-left-fill with a raster scan over 0/90/180/270°, using the polygon predicate as the only feasibility check (slides parts into neighbours' notches). `placementTransform` generalized to arbitrary angles (0/90 output byte-identical). Utilization credits **true outline-polygon area** so the strategies compare directly.
- `index`/`api`/README surface it; harness `nfp-vs-bbox` demo.

### Correctness (the load-bearing concerns)
- **No overlap**: the predicate was verified by the reviewer with a **20,000-pair Monte Carlo** vs a dense interior-point ground truth — **0 false negatives**; the broad-phase reject with **200,000 pairs** — 0 misses. Plus an exhaustive polygon-level non-overlap test over all placed pairs (real transformed outlines, concave cases).
- **Genuine interlocking**: utilization credits true area (1200 < bbox 1600), yet `nfp` still beats `bbox` (0.821 vs 0.547) — only possible by physically fitting 2 parts/sheet. Harness: 8 L-parts → bbox 8 sheets/54.7% vs **nfp 4 sheets/82.1% (+50%)**.
- Within-bounds, finite/terminating raster, no infinite loop, oversized → `unplaced` + warning. `bbox` stays the default so all prior behavior is unchanged.

### Verification
- typecheck / lint / build clean; **232 tests** (218 prior + 14 new) green; snapshot exit 0.
- Built via a Workflow (implement → adversarial review → fix) in an isolated git worktree.

### Stack — Phase 3 complete
PR8 (bend tables) · PR9 (hems/jogs) · PR10 (bbox nesting) merged. This finishes the bend-tables / hems-jogs / nesting plan.