### PR TITLE
test: raise coverage above the 91% functions gate

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: andymai

--- a/src/kernel/occtWasm/adapterShims.ts
+++ b/src/kernel/occtWasm/adapterShims.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Adapter-construction shims for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/booleanOps.ts
+++ b/src/kernel/occtWasm/booleanOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Boolean operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/constructionOps.ts
+++ b/src/kernel/occtWasm/constructionOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Shape construction (builder) operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/curveOps.ts
+++ b/src/kernel/occtWasm/curveOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Curve query operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/evolutionOps.ts
+++ b/src/kernel/occtWasm/evolutionOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Evolution operations (shape history tracking) for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/helpers.ts
+++ b/src/kernel/occtWasm/helpers.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Shared helpers for the occt-wasm adapter — handle wrapping, kernel result
  * unwrapping, and Embind vector marshalling.

--- a/src/kernel/occtWasm/hullOps.ts
+++ b/src/kernel/occtWasm/hullOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Convex hull operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/ioOps.ts
+++ b/src/kernel/occtWasm/ioOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Import / export operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/kernel2dOps.ts
+++ b/src/kernel/occtWasm/kernel2dOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * 2D curve operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/measureOps.ts
+++ b/src/kernel/occtWasm/measureOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Measurement operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/meshOps.ts
+++ b/src/kernel/occtWasm/meshOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Mesh tessellation operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/modifierOps.ts
+++ b/src/kernel/occtWasm/modifierOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Shape modifier operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * OcctWasmAdapter -- KernelAdapter implementation backed by occt-wasm's WASM kernel.
  *

--- a/src/kernel/occtWasm/primitiveOps.ts
+++ b/src/kernel/occtWasm/primitiveOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Primitive shape constructors for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/repairOps.ts
+++ b/src/kernel/occtWasm/repairOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Shape repair / healing operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Surface query operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/sweepOps.ts
+++ b/src/kernel/occtWasm/sweepOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Sweep / loft / revolve / extrusion operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/topologyOps.ts
+++ b/src/kernel/occtWasm/topologyOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Topology query and assembly operations for the occt-wasm adapter.
  *

--- a/src/kernel/occtWasm/transformOps.ts
+++ b/src/kernel/occtWasm/transformOps.ts
@@ -1,4 +1,3 @@
-/* v8 ignore file -- occt-wasm kernel not available in brepkit test suite */
 /**
  * Transform / pattern operations for the occt-wasm adapter.
  *

--- a/tests/apiCastResolve.test.ts
+++ b/tests/apiCastResolve.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Coverage for the thin public helpers resolve3D (Shapeable→Shape3D) and
+ * castShape3D (raw kernel shape→branded AnyShape). Neither is exercised by
+ * existing suites beyond the export-name check in public-api-types.test.ts.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import { box, resolve3D, castShape3D, isSolid } from '@/index.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('resolve3D', () => {
+  it('returns the underlying Shape3D for a raw solid handle', () => {
+    const solid = box(2, 3, 4);
+    const resolved = resolve3D(solid);
+    expect(isSolid(resolved)).toBe(true);
+  });
+});
+
+describe('castShape3D', () => {
+  it('brands a raw kernel shape back into a Solid handle', () => {
+    const solid = box(2, 3, 4);
+    const cast = castShape3D(solid.wrapped);
+    expect(isSolid(cast)).toBe(true);
+  });
+});

--- a/tests/blueprintFns.test.ts
+++ b/tests/blueprintFns.test.ts
@@ -13,6 +13,11 @@ import {
   mirror2D,
   drawRectangle,
   drawCircle,
+  stretch2D,
+  sketchOnPlane2D,
+  sketchOnFace2D,
+  box,
+  getFaces,
   unwrap,
   isOk,
   isErr,
@@ -216,5 +221,30 @@ describe('blueprintFns', () => {
       mirrored.delete();
       bp.delete();
     });
+  });
+});
+
+describe('blueprint sketching + stretch', () => {
+  it('stretch2D scales the blueprint along a direction', () => {
+    const bp = stretch2D(rect(10, 10), 2, [1, 0]);
+    const bounds = getBounds2D(bp);
+    // Stretching x2 along X widens the 10-unit width to ~20.
+    expect(bounds.width).toBeGreaterThan(15);
+    bp.delete();
+  });
+
+  it('sketchOnPlane2D projects the blueprint onto a 3D plane', () => {
+    const sketch = sketchOnPlane2D(rect(10, 20));
+    expect(sketch).toBeDefined();
+    expect(sketch.wire).toBeDefined();
+  });
+
+  it('sketchOnFace2D maps the blueprint onto a face surface', () => {
+    const solid = box(20, 20, 20);
+    const face = getFaces(solid)[0];
+    expect(face).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- asserted above
+    const sketch = sketchOnFace2D(rect(4, 4), face!);
+    expect(sketch).toBeDefined();
   });
 });

--- a/tests/curve2dGeometry.test.ts
+++ b/tests/curve2dGeometry.test.ts
@@ -24,6 +24,9 @@ import {
   distanceBetweenCurves2d,
   liftCurve2dToPlane,
   extractCurve2dFromEdge,
+  trimCurve2d,
+  copyCurve2d,
+  splitCurve2d,
 } from '@/2d/curve2dGeometryFns.js';
 import { getKernel2D } from '@/kernel/index.js';
 import { unwrap, isOk, isErr } from '@/core/result.js';
@@ -370,6 +373,50 @@ describe('numerical intersection', () => {
     const result = unwrap(intersectCurves2d(arc, bez));
     expect(result.points.length).toBeGreaterThanOrEqual(1);
     result.segments.forEach((s) => {
+      s[Symbol.dispose]();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Modification
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('2D curve modification', () => {
+  it('trims a curve so its endpoints match the original at the trim params', () => {
+    using curve = unwrap(circle2d([0, 0], 5));
+    const bounds = unwrap(boundsCurve2d(curve));
+    const mid = (bounds.first + bounds.last) / 2;
+    const startPt = unwrap(evaluateCurve2d(curve, bounds.first));
+    const midPt = unwrap(evaluateCurve2d(curve, mid));
+    using trimmed = unwrap(trimCurve2d(curve, bounds.first, mid));
+    const tb = unwrap(boundsCurve2d(trimmed));
+    const trimStart = unwrap(evaluateCurve2d(trimmed, tb.first));
+    const trimEnd = unwrap(evaluateCurve2d(trimmed, tb.last));
+    expect(trimStart[0]).toBeCloseTo(startPt[0], 4);
+    expect(trimStart[1]).toBeCloseTo(startPt[1], 4);
+    expect(trimEnd[0]).toBeCloseTo(midPt[0], 4);
+    expect(trimEnd[1]).toBeCloseTo(midPt[1], 4);
+  });
+
+  it('copies a curve into an independent handle', () => {
+    using curve = unwrap(line2d([0, 0], [10, 5]));
+    using copy = unwrap(copyCurve2d(curve));
+    const original = unwrap(boundsCurve2d(curve));
+    const copied = unwrap(boundsCurve2d(copy));
+    expect(copied.first).toBeCloseTo(original.first, 5);
+    expect(copied.last).toBeCloseTo(original.last, 5);
+  });
+
+  it('splits a curve at interior parameters into ordered segments', () => {
+    using curve = unwrap(circle2d([0, 0], 5));
+    const bounds = unwrap(boundsCurve2d(curve));
+    const range = bounds.last - bounds.first;
+    const segments = unwrap(
+      splitCurve2d(curve, [bounds.first + range / 3, bounds.first + (2 * range) / 3])
+    );
+    expect(segments.length).toBe(3);
+    segments.forEach((s) => {
       s[Symbol.dispose]();
     });
   });

--- a/tests/disposalStats.test.ts
+++ b/tests/disposalStats.test.ts
@@ -30,13 +30,17 @@ describe('disposal stats', () => {
     expect(typeof stats.scopeEnters).toBe('number');
   });
 
-  it('resetDisposalStats zeroes the live/peak/scope counters', () => {
+  it('resetDisposalStats zeroes the peak/scope/gc counters', () => {
     resetDisposalStats();
     const stats = getDisposalStats();
-    expect(stats.liveHandles).toBe(0);
     expect(stats.peakHandles).toBe(0);
     expect(stats.scopeEnters).toBe(0);
     expect(stats.scopeExits).toBe(0);
+    expect(stats.gcCollected).toBe(0);
+    // liveHandles is intentionally not asserted: setup (initOC) leaves WASM
+    // handles alive, so the FinalizationRegistry can adjust this counter
+    // asynchronously after the synchronous reset — an absolute assertion would
+    // be fragile and could even go negative for later readers.
   });
 });
 

--- a/tests/disposalStats.test.ts
+++ b/tests/disposalStats.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Kernel-agnostic disposal helpers: stats accessors, the isLive predicate, and
+ * the withScopeResult / withScopeResultAsync wrappers. The legacy disposal.test.ts
+ * suite wraps raw `oc` shapes and is skipped under occt-wasm, leaving these
+ * helpers uncovered on the default kernel; here they are exercised through the
+ * public shape API and plain Result callbacks instead.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import {
+  getDisposalStats,
+  resetDisposalStats,
+  isLive,
+  withScopeResult,
+  withScopeResultAsync,
+} from '@/core/disposal.js';
+import { box } from '@/index.js';
+import { ok, err, unwrap, unwrapErr } from '@/core/result.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('disposal stats', () => {
+  it('getDisposalStats returns a snapshot with the expected counters', () => {
+    const stats = getDisposalStats();
+    expect(stats).toHaveProperty('liveHandles');
+    expect(stats).toHaveProperty('peakHandles');
+    expect(stats).toHaveProperty('gcCollected');
+    expect(typeof stats.scopeEnters).toBe('number');
+  });
+
+  it('resetDisposalStats zeroes the live/peak/scope counters', () => {
+    resetDisposalStats();
+    const stats = getDisposalStats();
+    expect(stats.liveHandles).toBe(0);
+    expect(stats.peakHandles).toBe(0);
+    expect(stats.scopeEnters).toBe(0);
+    expect(stats.scopeExits).toBe(0);
+  });
+});
+
+describe('isLive', () => {
+  it('reports a fresh handle as live and a disposed one as not', () => {
+    const solid = box(1, 1, 1);
+    expect(isLive(solid)).toBe(true);
+    solid[Symbol.dispose]();
+    expect(isLive(solid)).toBe(false);
+  });
+});
+
+describe('withScopeResult', () => {
+  it('passes a scope through and returns the Ok result', () => {
+    const result = withScopeResult((scope) => {
+      expect(scope).toBeDefined();
+      return ok(7);
+    });
+    expect(unwrap(result)).toBe(7);
+  });
+
+  it('propagates an Err result', () => {
+    const result = withScopeResult(() => err('nope'));
+    expect(unwrapErr(result)).toBe('nope');
+  });
+});
+
+describe('withScopeResultAsync', () => {
+  it('awaits the callback and returns its Ok result', async () => {
+    const result = await withScopeResultAsync((scope) => {
+      expect(scope).toBeDefined();
+      return Promise.resolve(ok('done'));
+    });
+    expect(unwrap(result)).toBe('done');
+  });
+
+  it('propagates an async Err result', async () => {
+    const result = await withScopeResultAsync(() => Promise.resolve(err('async-nope')));
+    expect(unwrapErr(result)).toBe('async-nope');
+  });
+});

--- a/tests/ioFilename.test.ts
+++ b/tests/ioFilename.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Tests for uniqueIOFilename — the shared monotonic counter used to give
+ * concurrent I/O operations distinct virtual-filesystem filenames.
+ */
+import { describe, expect, it } from 'vitest';
+import { uniqueIOFilename } from '@/utils/ioFilename.js';
+
+describe('uniqueIOFilename', () => {
+  it('formats prefix, counter, and extension', () => {
+    expect(uniqueIOFilename('_export', 'step')).toMatch(/^_export_\d+\.step$/);
+  });
+
+  it('returns a different name on each call (monotonic counter)', () => {
+    const a = uniqueIOFilename('_x', 'glb');
+    const b = uniqueIOFilename('_x', 'glb');
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/kernelCapabilityGuards.test.ts
+++ b/tests/kernelCapabilityGuards.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Runtime tests for the kernel capability type guards and the importGLB
+ * error path. The guards narrow a KernelAdapter to a capability-bearing
+ * subtype by probing for method presence; public-api-types.test.ts only
+ * asserts they are exported, never invokes them.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOC } from './setup.js';
+import { getKernel } from '@/kernel/index.js';
+import { supportsProjection, supportsConstraintSketch } from '@/kernel/index.js';
+import { importGLB } from '@/io/gltfImportFns.js';
+import { isErr } from '@/core/result.js';
+
+beforeAll(async () => {
+  await initOC();
+}, 30000);
+
+describe('kernel capability guards', () => {
+  it('detects projection support by probing for projectEdges', () => {
+    const kernel = getKernel();
+    expect(supportsProjection(kernel)).toBe('projectEdges' in kernel);
+  });
+
+  it('detects constraint-sketch support by probing for sketchNew/sketchDof', () => {
+    const kernel = getKernel();
+    expect(supportsConstraintSketch(kernel)).toBe('sketchNew' in kernel && 'sketchDof' in kernel);
+  });
+
+  it('returns false for a plain object lacking the capability methods', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exercising the guard's runtime probe
+    const fake = {} as any;
+    expect(supportsProjection(fake)).toBe(false);
+    expect(supportsConstraintSketch(fake)).toBe(false);
+  });
+});
+
+describe('importGLB error handling', () => {
+  it('returns an Err when the kernel cannot import the GLB data', async () => {
+    const blob = new Blob([new Uint8Array([0, 1, 2, 3])]);
+    const result = await importGLB(blob);
+    expect(isErr(result)).toBe(true);
+  });
+});

--- a/tests/multiGuidedSweepNative.test.ts
+++ b/tests/multiGuidedSweepNative.test.ts
@@ -39,39 +39,46 @@ beforeAll(async () => {
 
 describe('multiSectionSweep (public-API fixtures)', () => {
   it('lofts two sections along a spine into a 3D shape', () => {
-    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
-    const result = multiSectionSweep([{ wire: circleWire(10) }, { wire: circleWire(5) }], spine, {
-      solid: true,
-    });
+    using spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using c1 = circleWire(10);
+    using c2 = circleWire(5);
+    const result = multiSectionSweep([{ wire: c1 }, { wire: c2 }], spine, { solid: true });
     expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
+    using shape = unwrap(result);
+    expect(isShape3D(shape)).toBe(true);
   });
 
   it('honours explicit, strictly-increasing section locations', () => {
-    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using c1 = circleWire(8);
+    using c2 = circleWire(6);
     const result = multiSectionSweep(
       [
-        { wire: circleWire(8), location: 0.1 },
-        { wire: circleWire(6), location: 0.9 },
+        { wire: c1, location: 0.1 },
+        { wire: c2, location: 0.9 },
       ],
       spine
     );
     expect(isOk(result)).toBe(true);
+    unwrap(result)[Symbol.dispose]();
   });
 
   it('errors with fewer than 2 sections', () => {
-    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
-    const result = multiSectionSweep([{ wire: circleWire(10) }], spine);
+    using spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using c1 = circleWire(10);
+    const result = multiSectionSweep([{ wire: c1 }], spine);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('MULTI_SWEEP_INSUFFICIENT_SECTIONS');
   });
 
   it('errors when a section location is out of [0, 1]', () => {
-    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using c1 = circleWire(8);
+    using c2 = circleWire(6);
     const result = multiSectionSweep(
       [
-        { wire: circleWire(8), location: 0.2 },
-        { wire: circleWire(6), location: 1.5 },
+        { wire: c1, location: 0.2 },
+        { wire: c2, location: 1.5 },
       ],
       spine
     );
@@ -79,11 +86,13 @@ describe('multiSectionSweep (public-API fixtures)', () => {
   });
 
   it('errors when section locations are not strictly increasing', () => {
-    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    using c1 = circleWire(8);
+    using c2 = circleWire(6);
     const result = multiSectionSweep(
       [
-        { wire: circleWire(8), location: 0.7 },
-        { wire: circleWire(6), location: 0.3 },
+        { wire: c1, location: 0.7 },
+        { wire: c2, location: 0.3 },
       ],
       spine
     );
@@ -93,18 +102,20 @@ describe('multiSectionSweep (public-API fixtures)', () => {
 
 describe('guidedSweep (public-API fixtures)', () => {
   it('sweeps a profile along a spine with a guide wire', () => {
-    const profile = circleWire(3);
-    const spine = lineSpine([0, 0, 0], [0, 0, 30]);
-    const guide = lineSpine([5, 0, 0], [5, 0, 30]);
+    using profile = circleWire(3);
+    using spine = lineSpine([0, 0, 0], [0, 0, 30]);
+    using guide = lineSpine([5, 0, 0], [5, 0, 30]);
     const result = guidedSweep(profile, spine, [guide]);
     expect(isOk(result)).toBe(true);
-    expect(isShape3D(unwrap(result))).toBe(true);
+    using shape = unwrap(result);
+    expect(isShape3D(shape)).toBe(true);
   });
 
   it('sweeps without guides (no auxiliary spine) in shell mode', () => {
-    const profile = circleWire(3);
-    const spine = lineSpine([0, 0, 0], [0, 0, 30]);
+    using profile = circleWire(3);
+    using spine = lineSpine([0, 0, 0], [0, 0, 30]);
     const result = guidedSweep(profile, spine, [], { solid: false });
     expect(isOk(result)).toBe(true);
+    unwrap(result)[Symbol.dispose]();
   });
 });

--- a/tests/multiGuidedSweepNative.test.ts
+++ b/tests/multiGuidedSweepNative.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Kernel-agnostic coverage for multiSectionSweep and guidedSweep.
+ *
+ * The legacy multiSweepFns/guidedSweepFns suites build their section and spine
+ * geometry with raw `oc` (gp_Circ_2, BRepBuilderAPI_MakeEdge), so they are
+ * skipped under occt-wasm — leaving the functions and their validation helpers
+ * (validateSectionLocations / computeSectionParams) uncovered on the default
+ * kernel. These tests build the same fixtures through the public brepjs API so
+ * they run everywhere.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initKernel } from './setup.js';
+import {
+  sketchCircle,
+  line,
+  wire,
+  castShape,
+  multiSectionSweep,
+  guidedSweep,
+  isOk,
+  isErr,
+  unwrap,
+  unwrapErr,
+  isShape3D,
+} from '@/index.js';
+import type { Wire } from '@/core/shapeTypes.js';
+
+function circleWire(radius: number): Wire {
+  return castShape(sketchCircle(radius).wire.wrapped) as Wire;
+}
+
+function lineSpine(from: [number, number, number], to: [number, number, number]): Wire {
+  return castShape(unwrap(wire([line(from, to)])).wrapped) as Wire;
+}
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('multiSectionSweep (public-API fixtures)', () => {
+  it('lofts two sections along a spine into a 3D shape', () => {
+    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    const result = multiSectionSweep([{ wire: circleWire(10) }, { wire: circleWire(5) }], spine, {
+      solid: true,
+    });
+    expect(isOk(result)).toBe(true);
+    expect(isShape3D(unwrap(result))).toBe(true);
+  });
+
+  it('honours explicit, strictly-increasing section locations', () => {
+    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    const result = multiSectionSweep(
+      [
+        { wire: circleWire(8), location: 0.1 },
+        { wire: circleWire(6), location: 0.9 },
+      ],
+      spine
+    );
+    expect(isOk(result)).toBe(true);
+  });
+
+  it('errors with fewer than 2 sections', () => {
+    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    const result = multiSectionSweep([{ wire: circleWire(10) }], spine);
+    expect(isErr(result)).toBe(true);
+    expect(unwrapErr(result).code).toBe('MULTI_SWEEP_INSUFFICIENT_SECTIONS');
+  });
+
+  it('errors when a section location is out of [0, 1]', () => {
+    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    const result = multiSectionSweep(
+      [
+        { wire: circleWire(8), location: 0.2 },
+        { wire: circleWire(6), location: 1.5 },
+      ],
+      spine
+    );
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('errors when section locations are not strictly increasing', () => {
+    const spine = lineSpine([0, 0, 0], [0, 0, 50]);
+    const result = multiSectionSweep(
+      [
+        { wire: circleWire(8), location: 0.7 },
+        { wire: circleWire(6), location: 0.3 },
+      ],
+      spine
+    );
+    expect(isErr(result)).toBe(true);
+  });
+});
+
+describe('guidedSweep (public-API fixtures)', () => {
+  it('sweeps a profile along a spine with a guide wire', () => {
+    const profile = circleWire(3);
+    const spine = lineSpine([0, 0, 0], [0, 0, 30]);
+    const guide = lineSpine([5, 0, 0], [5, 0, 30]);
+    const result = guidedSweep(profile, spine, [guide]);
+    expect(isOk(result)).toBe(true);
+    expect(isShape3D(unwrap(result))).toBe(true);
+  });
+
+  it('sweeps without guides (no auxiliary spine) in shell mode', () => {
+    const profile = circleWire(3);
+    const spine = lineSpine([0, 0, 0], [0, 0, 30]);
+    const result = guidedSweep(profile, spine, [], { solid: false });
+    expect(isOk(result)).toBe(true);
+  });
+});

--- a/tests/result.test.ts
+++ b/tests/result.test.ts
@@ -24,6 +24,8 @@ import {
   collect,
   tryCatch,
   tryCatchAsync,
+  flatten,
+  mapBoth,
   type Result,
 } from '@/core/result.js';
 
@@ -326,5 +328,47 @@ describe('fromNullable', () => {
 
   it('returns Err for undefined', () => {
     expect(unwrapErr(fromNullable(undefined, () => 'was undef'))).toBe('was undef');
+  });
+});
+
+describe('flatten', () => {
+  it('collapses a nested Ok into a single Ok', () => {
+    expect(unwrap(flatten(ok(ok(42))))).toBe(42);
+  });
+
+  it('propagates an inner Err', () => {
+    expect(unwrapErr(flatten(ok(err('inner'))))).toBe('inner');
+  });
+
+  it('propagates an outer Err', () => {
+    expect(unwrapErr(flatten(err('outer') as Result<Result<number, string>, string>))).toBe(
+      'outer'
+    );
+  });
+});
+
+describe('mapBoth', () => {
+  it('applies the ok mapper to an Ok value', () => {
+    expect(
+      unwrap(
+        mapBoth(
+          ok(2),
+          (v) => v * 10,
+          (e) => `err:${String(e)}`
+        )
+      )
+    ).toBe(20);
+  });
+
+  it('applies the err mapper to an Err value', () => {
+    expect(
+      unwrapErr(
+        mapBoth(
+          err('boom'),
+          (v: number) => v * 10,
+          (e) => `err:${e}`
+        )
+      )
+    ).toBe('err:boom');
   });
 });

--- a/tests/sketchFns.test.ts
+++ b/tests/sketchFns.test.ts
@@ -213,3 +213,29 @@ describe('CompoundSketch loftWith mismatch', () => {
     expect(() => c1.loftWith(c2, { ruled: true })).toThrow();
   });
 });
+
+describe('CompoundSketch instance methods', () => {
+  it('face() builds a face with the inner wires as holes', () => {
+    const compound = new CompoundSketch([sketchRectangle(20, 20), sketchCircle(3)]);
+    const area = unwrap(measureArea(compound.face()));
+    expect(area).toBeCloseTo(20 * 20 - Math.PI * 9, -1);
+  });
+
+  it('revolve() produces a positive-volume solid', () => {
+    const outer = new Sketcher('XZ').movePointerTo([10, 0]).hLine(5).vLine(5).hLine(-5).close();
+    const inner = new Sketcher('XZ').movePointerTo([11, 1]).hLine(3).vLine(3).hLine(-3).close();
+    const compound = new CompoundSketch([outer, inner]);
+    expect(unwrap(measureVolume(compound.revolve([0, 0, 1])))).toBeGreaterThan(0);
+  });
+
+  it('delete() releases every sub-sketch without throwing', () => {
+    const compound = new CompoundSketch([sketchRectangle(10, 10), sketchCircle(2)]);
+    expect(() => {
+      compound.delete();
+    }).not.toThrow();
+  });
+
+  it('constructor rejects an empty sketch array', () => {
+    expect(() => new CompoundSketch([])).toThrow();
+  });
+});

--- a/tests/textBlueprints.test.ts
+++ b/tests/textBlueprints.test.ts
@@ -4,6 +4,7 @@ import { loadFont, getFont } from '@/text/fontRegistry.js';
 import { textBlueprints } from '@/text/textBlueprints.js';
 import { sketchText } from '@/text/sketchText.js';
 import { textMetrics, fontMetrics } from '@/text/textMetrics.js';
+import { drawText } from '@/sketching/drawingFactories.js';
 import { unwrap, isOk, isErr } from '@/core/result.js';
 import { readFile, access } from 'node:fs/promises';
 
@@ -100,6 +101,21 @@ describe('textBlueprints', () => {
     // without modifying internals. Instead, verify it works with default fallback.
     const bps = textBlueprints('X', { fontFamily: 'missing' });
     expect(bps).toBeDefined();
+  });
+});
+
+describe('drawText', () => {
+  it('builds a Drawing from text using a loaded font', ({ skip }) => {
+    if (!fontPath) skip();
+    const drawing = drawText('Hi', { fontFamily: 'test', fontSize: 20 });
+    expect(drawing).toBeDefined();
+    expect(typeof drawing.clone).toBe('function');
+  });
+
+  it('honours startX/startY offsets', ({ skip }) => {
+    if (!fontPath) skip();
+    const drawing = drawText('Hi', { fontFamily: 'test', startX: 5, startY: 3 });
+    expect(drawing).toBeDefined();
   });
 });
 

--- a/tests/typeDiscriminants.test.ts
+++ b/tests/typeDiscriminants.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Kernel-agnostic tests for findCurveType — the GeomAbs_CurveType integer
+ * (or boxed `{value}`) to string-discriminant mapping. The existing
+ * geometry.test.ts coverage of this function is OCCT.js-only (it feeds raw
+ * `oc.GeomAbs_CurveType` enums), so it is skipped under occt-wasm; these
+ * tests exercise the same pure mapping using plain integers, which works on
+ * every kernel.
+ */
+import { describe, expect, it } from 'vitest';
+import { findCurveType } from '@/core/typeDiscriminants.js';
+import { isErr, unwrap } from '@/core/result.js';
+
+describe('findCurveType (kernel-agnostic)', () => {
+  const cases: ReadonlyArray<readonly [number, string]> = [
+    [0, 'LINE'],
+    [1, 'CIRCLE'],
+    [2, 'ELLIPSE'],
+    [3, 'HYPERBOLA'],
+    [4, 'PARABOLA'],
+    [5, 'BEZIER_CURVE'],
+    [6, 'BSPLINE_CURVE'],
+    [7, 'OFFSET_CURVE'],
+    [8, 'OTHER_CURVE'],
+  ];
+
+  it.each(cases)('maps integer %i to %s', (value, expected) => {
+    expect(unwrap(findCurveType(value))).toBe(expected);
+  });
+
+  it('accepts a boxed WASM enum object with a .value field', () => {
+    expect(unwrap(findCurveType({ value: 6 }))).toBe('BSPLINE_CURVE');
+  });
+
+  it('errors on an out-of-range enum value', () => {
+    expect(isErr(findCurveType(99))).toBe(true);
+  });
+
+  it('errors on a negative enum value', () => {
+    expect(isErr(findCurveType(-1))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The coverage gate was **red on \`main\`** — functions at **90.57%** vs the 91% threshold (statements/branches/lines passed only by a hair). This PR raises all four metrics, clearing the gate with margin. **6 of 7 commits are tests only; the 7th removes dead coverage config.**

| Metric | Before | After | Threshold |
|---|---|---|---|
| Statements | 85.53% | **86.15%** | 85 ✓ |
| Branches | 71.81% | **72.51%** | 71 ✓ |
| **Functions** | 90.57% ❌ | **91.54%** ✓ | 91 |
| Lines | 88.57% | **89.18%** | 88 ✓ |

Net: **+35 functions, +108 lines, +73 branches** covered.

## Approach

The dominant lever was **un-skipping real feature code**, not just writing new tests. Several suites were skipped under the default occt-wasm kernel only because their *fixtures* used raw \`oc\` API (\`gp_Circ_2\`, \`BRepBuilderAPI_MakeEdge\`, \`oc.GeomAbs_CurveType\`) that occt-wasm doesn't expose — the underlying functions work fine. Rebuilding fixtures through the public brepjs API unlocked them on the default kernel.

## Test commits

- \`findCurveType\`, \`uniqueIOFilename\`, kernel capability guards, \`importGLB\` error path
- \`multiSectionSweep\` + \`guidedSweep\` (native fixtures; ~110 lines in \`sweepFns.ts\`: 39% → 91%)
- \`CompoundSketch\` instance methods + 2D curve \`trim\`/\`copy\`/\`split\`
- \`Result.flatten\`/\`mapBoth\` + disposal stat helpers
- \`stretch2D\` + 2D blueprint projections
- \`resolve3D\`, \`castShape3D\`, \`drawText\`

## Config cleanup

The final commit removes 19 non-functioning \`/* v8 ignore file */\` headers from the occt-wasm adapter. That directive is a **no-op** in vitest 4's v8 provider (the files were measured anyway), and per-kernel \`coverageExcludesFor()\` already handles dir exclusion. Verified **byte-for-byte coverage-neutral**.

## Verification

\`npm run test:full\` passes the gate (EXIT 0). Typecheck, lint, and the full suite (226 files) are green. No \`src/\` behavior changed — tests + dead-comment removal only.