### PR TITLE
fix(brepjs-cad): run CLI via bin symlink + quality pass

### DIFF
--- a/packages/brepjs-cad/bench/run.ts
+++ b/packages/brepjs-cad/bench/run.ts
@@ -5,13 +5,6 @@ import { runPart } from '../src/verify/runPart.js';
 import { reportOk, type VerifyReport } from '../src/verify/report.js';
 import { disposeShape } from '../src/disposeShape.js';
 
-/**
- * Deterministic eval harness: replay every `skill/examples/*.brep.ts` that has a sibling
- * `*.expected.json` through the public verify runtime (`runPart`), compare measured
- * volume/area/validity to the recorded baseline within each file's tolerance, print a
- * scorecard, and exit non-zero if any example regresses. No LLM / API key — CI-safe.
- */
-
 const here = dirname(fileURLToPath(import.meta.url));
 const examplesDir = resolve(here, '../skill/examples');
 

--- a/packages/brepjs-cad/src/cli/exportPart.ts
+++ b/packages/brepjs-cad/src/cli/exportPart.ts
@@ -27,7 +27,6 @@ export async function exportPart(
   formats: ExportFormats,
   outDir: string,
 ): Promise<ExportResult> {
-  const wantStl = Boolean(formats.stl);
   const { shape, report, step, glb } = await runPart(modulePath, {
     step: Boolean(formats.step),
     glb: Boolean(formats.glb),
@@ -67,7 +66,7 @@ export async function exportPart(
         errors.push('GLB export produced no data');
       }
     }
-    if (wantStl) {
+    if (formats.stl) {
       const r = exportSTL(shape);
       if (isOk(r)) {
         const p = join(outDir, `${base}.stl`);

--- a/packages/brepjs-cad/src/cli/exportPart.ts
+++ b/packages/brepjs-cad/src/cli/exportPart.ts
@@ -39,41 +39,46 @@ export async function exportPart(
   const valid = reportOk(report) && shape !== null;
   if (!valid) {
     disposeShape(shape); // live WASM handle owned by this fn
-    return { ok: false, report, written, errors: report.errors };
+    // Validity failures land in errorInfos (checks.ts keeps them out of `errors` to avoid
+    // double-counting), so derive the diagnostics from there rather than the empty `errors`.
+    const failures = report.errorInfos.map((e) => e.message);
+    return { ok: false, report, written, errors: failures.length > 0 ? failures : report.errors };
   }
 
-  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
-  const base = stem(modulePath);
+  try {
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+    const base = stem(modulePath);
 
-  if (formats.step) {
-    if (step) {
-      const p = join(outDir, `${base}.step`);
-      writeFileSync(p, Buffer.from(step));
-      written.push(p);
-    } else {
-      errors.push('STEP export produced no data');
+    if (formats.step) {
+      if (step) {
+        const p = join(outDir, `${base}.step`);
+        writeFileSync(p, Buffer.from(step));
+        written.push(p);
+      } else {
+        errors.push('STEP export produced no data');
+      }
     }
-  }
-  if (formats.glb) {
-    if (glb) {
-      const p = join(outDir, `${base}.glb`);
-      writeFileSync(p, Buffer.from(glb));
-      written.push(p);
-    } else {
-      errors.push('GLB export produced no data');
+    if (formats.glb) {
+      if (glb) {
+        const p = join(outDir, `${base}.glb`);
+        writeFileSync(p, Buffer.from(glb));
+        written.push(p);
+      } else {
+        errors.push('GLB export produced no data');
+      }
     }
-  }
-  if (wantStl) {
-    const r = exportSTL(shape);
-    if (isOk(r)) {
-      const p = join(outDir, `${base}.stl`);
-      writeFileSync(p, Buffer.from(await r.value.arrayBuffer()));
-      written.push(p);
-    } else {
-      errors.push(`STL export: ${r.error.message}`);
+    if (wantStl) {
+      const r = exportSTL(shape);
+      if (isOk(r)) {
+        const p = join(outDir, `${base}.stl`);
+        writeFileSync(p, Buffer.from(await r.value.arrayBuffer()));
+        written.push(p);
+      } else {
+        errors.push(`STL export: ${r.error.message}`);
+      }
     }
+  } finally {
+    disposeShape(shape);
   }
-
-  disposeShape(shape);
   return { ok: errors.length === 0, report, written, errors };
 }

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { writeFileSync, watch as fsWatch } from 'node:fs';
+import { writeFileSync, watch as fsWatch, realpathSync } from 'node:fs';
 import { resolve, join, basename, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { runPart } from '../verify/runPart.js';
 import { serializeReport } from '../verify/report.js';
 import { runMeasure } from '../verify/measure.js';
@@ -189,6 +189,17 @@ program
 
 // Only drive the CLI when run as the entry script, so tests can import the
 // guarded loaders without commander parsing the test runner's argv.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Resolve symlinks on both sides: the npm-installed bin (node_modules/.bin/brepjs)
+// is a symlink, so process.argv[1] would otherwise never equal the real module path.
+export function isEntrypoint(argv1: string | undefined, moduleUrl: string): boolean {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (isEntrypoint(process.argv[1], import.meta.url)) {
   void program.parseAsync();
 }

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -56,10 +56,8 @@ program
         step: wantStep,
         glb: Boolean(opts.glb),
       });
-      const json = serializeReport(report);
       let stepPath: string | undefined = opts.step;
       try {
-        if (opts.json) writeFileSync(opts.json, json);
         if (opts.glb && glb) writeFileSync(opts.glb, Buffer.from(glb));
 
         if (wantStep && step) {
@@ -83,7 +81,11 @@ program
         // --serve path stays running, so leaking here would persist for the server's lifetime).
         disposeShape(shape);
       }
-      process.stdout.write(serializeReport(report) + '\n');
+      // Serialize once after all artifact writes so the --json file and stdout
+      // reflect the same report (incl. any "artifact write failed" error).
+      const json = serializeReport(report);
+      if (opts.json) writeFileSync(opts.json, json);
+      process.stdout.write(json + '\n');
       if (!reportOk(report)) process.exitCode = 1;
       const willServe = Boolean(opts.serve) && stepPath !== undefined && reportOk(report);
       if (willServe && stepPath) {

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -52,7 +52,7 @@ program
       // The WASM viewer loads a CAD file (it can't run a .brep.ts), so --snapshot/--serve
       // stage the primary STEP and point the viewer at it via ?dir=&file=. --glb is its own artifact.
       const wantStep = Boolean(opts.step) || Boolean(opts.snapshot) || Boolean(opts.serve);
-      const { report, step, glb } = await runPart(resolve(file), {
+      const { report, step, glb, shape } = await runPart(resolve(file), {
         step: wantStep,
         glb: Boolean(opts.glb),
       });
@@ -72,11 +72,17 @@ program
           // Diagnostic paths go to stderr — stdout stays a single clean JSON document.
           for (const p of pngs) process.stderr.write(`snapshot: ${p}\n`);
         }
+      } else if (opts.snapshot) {
+        process.stderr.write('snapshot skipped: STEP export produced no artifact\n');
       }
       process.stdout.write(json + '\n');
       const parsed = JSON.parse(json) as { ok: boolean };
-      if (!opts.serve && parsed.ok !== true) process.exitCode = 1;
-      if (opts.serve && stepPath) {
+      const willServe = Boolean(opts.serve) && stepPath !== undefined;
+      if (!willServe && parsed.ok !== true) process.exitCode = 1;
+      // The shape is a live WASM handle; release it before the server takes over (the
+      // --serve path stays running, so leaking here would persist for the server's lifetime).
+      disposeShape(shape);
+      if (willServe && stepPath) {
         const { serve } = await import('../snapshot/serve.js'); // lazy: no server deps on the default path
         const { url } = await serve({ file: stepPath }); // builds a ?dir=&file= URL; server runs until Ctrl-C
         process.stderr.write(`viewer: ${url}\n`);

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -5,7 +5,7 @@ import { resolve, join, basename, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { runPart } from '../verify/runPart.js';
-import { serializeReport } from '../verify/report.js';
+import { reportOk, serializeReport } from '../verify/report.js';
 import { runMeasure } from '../verify/measure.js';
 import { runDiff } from '../verify/diff.js';
 import { scaffoldPart } from './scaffold.js';
@@ -76,9 +76,8 @@ program
         process.stderr.write('snapshot skipped: STEP export produced no artifact\n');
       }
       process.stdout.write(json + '\n');
-      const parsed = JSON.parse(json) as { ok: boolean };
       const willServe = Boolean(opts.serve) && stepPath !== undefined;
-      if (!willServe && parsed.ok !== true) process.exitCode = 1;
+      if (!willServe && !reportOk(report)) process.exitCode = 1;
       // The shape is a live WASM handle; release it before the server takes over (the
       // --serve path stays running, so leaking here would persist for the server's lifetime).
       disposeShape(shape);

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -5,7 +5,7 @@ import { resolve, join, basename, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { runPart } from '../verify/runPart.js';
-import { reportOk, serializeReport } from '../verify/report.js';
+import { pushError, reportOk, serializeReport } from '../verify/report.js';
 import { runMeasure } from '../verify/measure.js';
 import { runDiff } from '../verify/diff.js';
 import { scaffoldPart } from './scaffold.js';
@@ -57,30 +57,35 @@ program
         glb: Boolean(opts.glb),
       });
       const json = serializeReport(report);
-      if (opts.json) writeFileSync(opts.json, json);
-      if (opts.glb && glb) writeFileSync(opts.glb, Buffer.from(glb));
-
       let stepPath: string | undefined = opts.step;
-      if (wantStep && step) {
-        stepPath = opts.step ?? join(tmpdir(), `brepjs-cad-${basename(file)}.step`);
-        writeFileSync(stepPath, Buffer.from(step));
-      }
-      if (opts.snapshot && stepPath) {
-        const shoot = await loadSnapshotShoot(); // lazy: keeps puppeteer off the default path
-        if (shoot) {
-          const { pngs } = await shoot({ file: stepPath, outDir: opts.snapshot });
-          // Diagnostic paths go to stderr — stdout stays a single clean JSON document.
-          for (const p of pngs) process.stderr.write(`snapshot: ${p}\n`);
+      try {
+        if (opts.json) writeFileSync(opts.json, json);
+        if (opts.glb && glb) writeFileSync(opts.glb, Buffer.from(glb));
+
+        if (wantStep && step) {
+          stepPath = opts.step ?? join(tmpdir(), `brepjs-cad-${basename(file)}.step`);
+          writeFileSync(stepPath, Buffer.from(step));
         }
-      } else if (opts.snapshot) {
-        process.stderr.write('snapshot skipped: STEP export produced no artifact\n');
+        if (opts.snapshot && stepPath) {
+          const shoot = await loadSnapshotShoot(); // lazy: keeps puppeteer off the default path
+          if (shoot) {
+            const { pngs } = await shoot({ file: stepPath, outDir: opts.snapshot });
+            // Diagnostic paths go to stderr — stdout stays a single clean JSON document.
+            for (const p of pngs) process.stderr.write(`snapshot: ${p}\n`);
+          }
+        } else if (opts.snapshot) {
+          process.stderr.write('snapshot skipped: STEP export produced no artifact\n');
+        }
+      } catch (e) {
+        pushError(report, { message: `artifact write failed: ${(e as Error).message}` });
+      } finally {
+        // The shape is a live WASM handle; release it before the server takes over (the
+        // --serve path stays running, so leaking here would persist for the server's lifetime).
+        disposeShape(shape);
       }
-      process.stdout.write(json + '\n');
-      const willServe = Boolean(opts.serve) && stepPath !== undefined;
-      if (!willServe && !reportOk(report)) process.exitCode = 1;
-      // The shape is a live WASM handle; release it before the server takes over (the
-      // --serve path stays running, so leaking here would persist for the server's lifetime).
-      disposeShape(shape);
+      process.stdout.write(serializeReport(report) + '\n');
+      if (!reportOk(report)) process.exitCode = 1;
+      const willServe = Boolean(opts.serve) && stepPath !== undefined && reportOk(report);
       if (willServe && stepPath) {
         const { serve } = await import('../snapshot/serve.js'); // lazy: no server deps on the default path
         const { url } = await serve({ file: stepPath }); // builds a ?dir=&file= URL; server runs until Ctrl-C

--- a/packages/brepjs-cad/src/cli/watch.ts
+++ b/packages/brepjs-cad/src/cli/watch.ts
@@ -1,10 +1,6 @@
 export const DEFAULT_DEBOUNCE_MS = 150;
 
-/**
- * Wraps a handler so bursts of rapid calls collapse into a single trailing
- * invocation after `delayMs` of quiet — fs.watch fires twice per save on many
- * platforms, so the model is re-run once rather than per raw event.
- */
+// fs.watch fires twice per save on many platforms; debounce collapses bursts to one trailing call.
 export function debounce(
   fn: () => void | Promise<void>,
   delayMs: number = DEFAULT_DEBOUNCE_MS,

--- a/packages/brepjs-cad/src/disposeShape.ts
+++ b/packages/brepjs-cad/src/disposeShape.ts
@@ -1,8 +1,4 @@
-/**
- * Release a live WASM-backed kernel shape handle returned by `runPart`.
- * No-op for null/undefined or shapes without a disposer, so callers can pass
- * `result.shape` unconditionally. WASM memory accumulates without this.
- */
+// WASM memory accumulates without this; callers pass result.shape unconditionally (null-safe).
 export function disposeShape(shape: unknown): void {
   const disposer = (shape as { [Symbol.dispose]?: () => void } | null | undefined)?.[Symbol.dispose];
   if (typeof disposer === 'function') disposer.call(shape);

--- a/packages/brepjs-cad/src/snapshot/registry.ts
+++ b/packages/brepjs-cad/src/snapshot/registry.ts
@@ -46,7 +46,7 @@ export async function acquireServer(opts: AcquireOptions = {}): Promise<Acquired
       /* busy/raced — next */
     }
   }
-  if (!server) throw new Error(`no free port in ${ports[0]}..${ports[ports.length - 1]}`);
+  if (!server) throw new Error(`no free port in ${ports[0]}..${ports.at(-1)}`);
   const timer = setTimeout(() => void server?.close(), opts.shutdownAfterMs ?? DEFAULT_SHUTDOWN_AFTER_MS);
   timer.unref();
   const started = server;

--- a/packages/brepjs-cad/src/snapshot/static.ts
+++ b/packages/brepjs-cad/src/snapshot/static.ts
@@ -52,7 +52,8 @@ async function sendFile(res: ServerResponse, absPath: string): Promise<void> {
 
 function safeJoin(root: string, rel: string): string | null {
   const abs = resolve(root, normalize(decodeURIComponent(rel.replace(/^\/+/, ''))));
-  return abs !== root && !abs.startsWith(root + sep) ? null : abs;
+  if (abs !== root && !abs.startsWith(root + sep)) return null;
+  return abs;
 }
 
 async function handle(req: IncomingMessage, res: ServerResponse, port: number): Promise<void> {

--- a/packages/brepjs-cad/src/verify/diff.ts
+++ b/packages/brepjs-cad/src/verify/diff.ts
@@ -9,7 +9,7 @@ import {
   type Shape3D,
 } from 'brepjs';
 import { runPart } from './runPart.js';
-import type { DiffReport } from './report.js';
+import type { BoundsDelta, DiffReport } from './report.js';
 
 function emptyDiff(errors: string[]): DiffReport {
   return {
@@ -36,6 +36,26 @@ function areaOf(shape: AnyShape, errors: string[]): number {
   return 0;
 }
 
+// getBounds → kernel boundingBox can throw on a degenerate/empty shape; keep runDiff's
+// always-return-a-DiffReport contract by recording the failure and falling back to zero.
+function boundsDelta(a: AnyShape, b: AnyShape, errors: string[]): BoundsDelta {
+  try {
+    const ba = getBounds(a);
+    const bb = getBounds(b);
+    return {
+      xMin: bb.xMin - ba.xMin,
+      xMax: bb.xMax - ba.xMax,
+      yMin: bb.yMin - ba.yMin,
+      yMax: bb.yMax - ba.yMax,
+      zMin: bb.zMin - ba.zMin,
+      zMax: bb.zMax - ba.zMax,
+    };
+  } catch (e) {
+    errors.push(`getBounds: ${(e as Error).message}`);
+    return { xMin: 0, xMax: 0, yMin: 0, yMax: 0, zMin: 0, zMax: 0 };
+  }
+}
+
 // One side of the symmetric difference: vol(cut(x, y)) — the part of x not shared with y.
 function cutVolume(x: Shape3D, y: Shape3D, errors: string[]): number {
   const r = cut(x, y);
@@ -52,23 +72,15 @@ export async function runDiff(aPath: string, bPath: string): Promise<DiffReport>
   const errors: string[] = [];
   const a = await runPart(aPath);
   errors.push(...a.report.errors);
-  const b = await runPart(bPath);
-  errors.push(...b.report.errors);
-  if (!a.shape || !b.shape) return emptyDiff(errors);
+  if (!a.shape) return emptyDiff(errors);
   // runPart hands back live kernel shapes; dispose both on every exit path.
   using sa = a.shape;
+  const b = await runPart(bPath);
+  errors.push(...b.report.errors);
+  if (!b.shape) return emptyDiff(errors);
   using sb = b.shape;
 
-  const ba = getBounds(sa);
-  const bb = getBounds(sb);
-  const bboxDelta = {
-    xMin: bb.xMin - ba.xMin,
-    xMax: bb.xMax - ba.xMax,
-    yMin: bb.yMin - ba.yMin,
-    yMax: bb.yMax - ba.yMax,
-    zMin: bb.zMin - ba.zMin,
-    zMax: bb.zMax - ba.zMax,
-  };
+  const bboxDelta = boundsDelta(sa, sb, errors);
 
   const areaDelta = areaOf(sb, errors) - areaOf(sa, errors);
 

--- a/packages/brepjs-cad/src/verify/report.ts
+++ b/packages/brepjs-cad/src/verify/report.ts
@@ -56,7 +56,7 @@ export function emptyReport(): VerifyReport {
   return { shapeType: null, checks: [], measurements: {}, errors: [], errorInfos: [], hints: [] };
 }
 
-/** Record a failure on the report, keeping the flat `errors` string list and structured `errorInfos` in sync. */
+// Keep errors and errorInfos parallel — callers must not push to either directly.
 export function pushError(r: VerifyReport, info: ErrorInfo): void {
   r.errors.push(info.message);
   r.errorInfos.push(info);

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -23,7 +23,6 @@ function isBrepError(v: unknown): v is BrepError {
   return typeof rec['code'] === 'string' && typeof rec['message'] === 'string';
 }
 
-/** Pull structured `{ message, code, suggestion }` out of a `BrepError`, a thrown `Error`, or anything. */
 function toErrorInfo(prefix: string, e: unknown): ErrorInfo {
   if (isBrepError(e)) {
     return { message: `${prefix}: ${e.message}`, code: e.code, suggestion: e.suggestion };
@@ -82,11 +81,11 @@ export async function runPart(
   }
   let shape: AnyShape | null;
   if (isResult(out)) {
-    if (isOk(out)) shape = out.value;
-    else {
+    if (!isOk(out)) {
       pushError(report, toErrorInfo('part returned Err', out.error));
       return finalize({ shape: null, report });
     }
+    shape = out.value;
   } else {
     shape = out as AnyShape;
   }

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -59,8 +59,13 @@ export async function runPart(
   modulePath: string,
   opts: RunPartOptions = {}
 ): Promise<RunPartResult> {
-  await init();
   const report = emptyReport();
+  try {
+    await init();
+  } catch (e) {
+    pushError(report, toErrorInfo('kernel init failed', e));
+    return finalize({ shape: null, report });
+  }
   let mod: { default?: PartFn };
   try {
     mod = (await import(modulePath)) as { default?: PartFn };

--- a/packages/brepjs-cad/tests/entrypoint.test.ts
+++ b/packages/brepjs-cad/tests/entrypoint.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isEntrypoint } from '../src/cli/main.js';
+
+// Regression: the npm-installed bin (node_modules/.bin/brepjs) is a SYMLINK to
+// dist/cli/main.js. A naive `import.meta.url === pathToFileURL(argv[1])` check
+// fails through the symlink, so the CLI silently no-ops for every real user.
+describe('isEntrypoint (symlink-aware)', () => {
+  let dir: string;
+  let real: string;
+  let link: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'brepjs-entry-'));
+    real = join(dir, 'main.js');
+    link = join(dir, 'brepjs-bin');
+    writeFileSync(real, '// stub');
+    symlinkSync(real, link);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('treats a symlinked invocation as the entrypoint', () => {
+    expect(isEntrypoint(link, pathToFileURL(real).href)).toBe(true);
+  });
+
+  it('treats a direct invocation as the entrypoint', () => {
+    expect(isEntrypoint(real, pathToFileURL(real).href)).toBe(true);
+  });
+
+  it('is false for an unrelated argv and for missing argv', () => {
+    expect(isEntrypoint(join(dir, 'other.js'), pathToFileURL(real).href)).toBe(false);
+    expect(isEntrypoint(undefined, pathToFileURL(real).href)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Fixes a **ship-stopper in `brepjs-cad@0.1.0`** plus a quality pass over the package's authored code. A clean-room install smoke test (the way the gridfinity project consumes it) revealed the published CLI silently no-ops via its bin.

## The bug (P0)

The entry guard compared `import.meta.url` to `process.argv[1]` directly. The npm-installed bin (`node_modules/.bin/brepjs`) is a **symlink**, so `argv[1]` (symlink path) never equaled the resolved module path → `program.parseAsync()` was skipped → **the CLI did nothing for every real user**. Unit tests missed it because `cli.test.ts` invokes the file path directly (no symlink).

Fix: resolve symlinks on both sides via `realpathSync` (extracted as `isEntrypoint`), with a regression test that invokes through an actual symlink. Verified end-to-end: `node <symlink> verify … --json` now produces a valid report.

## Quality pass (gaps / review / optimize / simplify)

A looped multi-agent pass (gap-finder + reviewer + comment audit → adversarial verify → optimizer → code-simplifier → second review round, to diminishing returns). Confirmed + applied 11 findings:

- **Contract:** `runPart` now wraps `init()` — a missing/failed kernel returns a clean `ok:false` report instead of throwing, so verify/measure/diff/export all keep stdout a single JSON document.
- **Leaks:** `disposeShape(shape)` now runs in `try/finally` on the verify, export, and diff paths — disposes even if a write throws, and before the long-lived `--serve` server starts.
- **Correctness:** `--serve` no longer reports false success on an invalid part (exit 1, server not started); `export` on an invalid part surfaces the validity diagnostic instead of empty `errors`.
- **diff:** `runDiff` always returns a well-formed `DiffReport` (guarded `getBounds`), mirroring `measure.ts`; fixed a single-part-builds handle leak.
- **Cleanup:** dropped a fragile `JSON.parse(stdout)` round-trip for `reportOk(report)`; removed narration comments (kept the WHY-comments); `ports.at(-1)`, early returns.

## Verification
Gate green: typecheck / lint / test (55) / eval (12/12) / build / knip / root typecheck all exit 0. Full pre-push `test:ci` passed.

Supersedes the broken `0.1.0` — merging triggers a release-please `0.1.1` PR.
