### PR TITLE
fix(brepjs-cad): load .ts parts via native type-stripping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
       - run: npm run build --workspace=brepjs-cad
       # Deterministic eval: replay skill/examples through runPart, gate on volume/area/validity.
       - run: npm run eval --workspace=brepjs-cad
+      # Smoke: run the BUILT cli under plain node on a .ts part — catches the bin/TS-load
+      # failures that only surface for installed users (tsx/vitest hide them in-repo).
+      - run: npm run smoke --workspace=brepjs-cad
 
   packages-sheetmetal:
     # Experimental sheet-metal domain satellite. Build root brepjs first so the

--- a/package-lock.json
+++ b/package-lock.json
@@ -12463,7 +12463,7 @@
       }
     },
     "packages/brepjs-cad": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.0.0"

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -45,7 +45,7 @@
     "lint": "eslint src tests viewer bench",
     "test": "vitest run",
     "eval": "tsx bench/run.ts",
-    "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts",
+    "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8'));if(r.ok!==true||!(r.measurements.volume>0))process.exit(1)\"",
     "prepack": "npm run build"
   },
   "peerDependencies": {

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -45,6 +45,7 @@
     "lint": "eslint src tests viewer bench",
     "test": "vitest run",
     "eval": "tsx bench/run.ts",
+    "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts",
     "prepack": "npm run build"
   },
   "peerDependencies": {

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -8,10 +8,31 @@ import {
   type BrepError,
   type Result,
 } from 'brepjs';
+import { pathToFileURL } from 'node:url';
 import { runChecks } from './checks.js';
 import { buildHints, emptyReport, pushError, type ErrorInfo, type VerifyReport } from './report.js';
 
 type PartFn = () => unknown;
+
+// Author parts are `.brep.ts`. Node strips types natively (engines requires >=24),
+// but only in an ESM context — so a part loaded under a CommonJS project fails. A
+// transpiler fallback (tsx) is NOT viable: it loads `brepjs` in a separate module
+// realm, so the part gets an uninitialized kernel. Surface a clear fix instead.
+async function loadPart(modulePath: string): Promise<{ default?: PartFn }> {
+  try {
+    return (await import(pathToFileURL(modulePath).href)) as { default?: PartFn };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/Cannot use import statement|Unknown file extension|ERR_UNKNOWN_FILE_EXTENSION/i.test(msg)) {
+      throw new Error(
+        `cannot load TypeScript part "${modulePath}": author parts in an ESM project ` +
+          `(set "type": "module" in package.json) or rename the file to .mts. (${msg})`,
+        { cause: e }
+      );
+    }
+    throw e;
+  }
+}
 
 function isResult(v: unknown): v is Result<AnyShape> {
   return typeof v === 'object' && v !== null && 'ok' in v && typeof v.ok === 'boolean';
@@ -68,7 +89,7 @@ export async function runPart(
   }
   let mod: { default?: PartFn };
   try {
-    mod = (await import(modulePath)) as { default?: PartFn };
+    mod = await loadPart(modulePath);
   } catch (e) {
     pushError(report, toErrorInfo('import failed', e));
     return finalize({ shape: null, report });

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -23,7 +23,9 @@ async function loadPart(modulePath: string): Promise<{ default?: PartFn }> {
     return (await import(pathToFileURL(modulePath).href)) as { default?: PartFn };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    if (/Cannot use import statement|Unknown file extension|ERR_UNKNOWN_FILE_EXTENSION/i.test(msg)) {
+    // A TypeScript part (.ts/.mts/.cts/.tsx) that fails to load is almost always a
+    // CommonJS-project module-type issue — point the user at the fix.
+    if (/\.[mc]?tsx?$/.test(modulePath) && /import statement|file extension/i.test(msg)) {
       throw new Error(
         `cannot load TypeScript part "${modulePath}": author parts in an ESM project ` +
           `(set "type": "module" in package.json) or rename the file to .mts. (${msg})`,


### PR DESCRIPTION
## What & why

Fixes a gap a clean-room install surfaced after `0.2.0`: the published CLI **runs** now (the bin fix shipped) but **couldn't load a user's `.brep.ts`** — `runPart` did a bare `import(modulePath)`, which fails for installed users with no TypeScript loader.

## Fix

- `runPart` loads parts via `pathToFileURL` + **Node's native type-stripping** (already required: `engines >=24`). A `.brep.ts` in an **ESM consumer project** (`"type": "module"`) now loads in the *same module graph* as the CLI — so the initialized kernel is shared and verify works.
- A **CommonJS** consumer project gets a clear, actionable error ("author parts in an ESM project or rename to `.mts`") instead of a cryptic `Cannot use import statement outside a module`.

A `tsx` transpiler fallback was tried and **rejected**: vite bundled it (stubbing `node:module`/`createRequire` as a browser external), and even fixed, tsx loads `brepjs` in a *separate realm* → the part's kernel is uninitialized. Native stripping shares the realm; it's both simpler and correct.

## Regression guard

New `smoke` CI step runs the **built CLI under plain `node`** on a `.ts` fixture (wired into the `packages-cad` job). This is the exact failure mode unit tests miss — they run under `tsx`/vitest, which hide it.

## Verification (clean-room, packed tarball)
- ESM project → `npx brepjs verify part.brep.ts` → `ok: true`, valid Solid ✓
- CJS project → clean actionable error, exit 1 (no crash) ✓
- Gate: typecheck / lint / test (55) / eval (12/12) / smoke / build all green; `dist` free of the vite stub.

Merging triggers a release-please `0.3.0` (supersedes the bin/TS-load issues in `0.1.0`/`0.2.0`).
