### PR TITLE
ci(brepjs-cad): build root + viewer prerequisites before publish

### DIFF
--- a/.github/workflows/publish-brepjs-cad.yml
+++ b/.github/workflows/publish-brepjs-cad.yml
@@ -30,10 +30,18 @@ jobs:
 
       - run: npm ci
 
-      # The root `npm run build` is root-only; build the package explicitly so
-      # dist + viewer/dist are present even if prepack does not fire here.
-      - name: Build brepjs-cad
-        run: npm run build --workspace=brepjs-cad
+      # Restore the OCCT WASM the viewer build copies (gitignored).
+      - name: Restore WASM files
+        run: bash scripts/ensure-wasm.sh
+
+      # Build prerequisites first, mirroring the packages-cad CI job: the viewer
+      # worker imports `brepjs`, so the root lib + brepjs-viewer dist must exist
+      # before the brepjs-cad build (which also builds viewer/dist).
+      - name: Build brepjs-cad (root + viewer prerequisites)
+        run: |
+          npm run build
+          npm run build --workspace=brepjs-viewer
+          npm run build --workspace=brepjs-cad
 
       # Authenticates via OIDC trusted publisher (configured for this exact
       # workflow filename on npmjs.com -> brepjs-cad -> Trusted Publisher Mgmt).

--- a/.github/workflows/publish-brepjs-cad.yml
+++ b/.github/workflows/publish-brepjs-cad.yml
@@ -30,9 +30,19 @@ jobs:
 
       - run: npm ci
 
-      # Restore the OCCT WASM the viewer build copies (gitignored).
+      # Restore the OCCT WASM the viewer build copies (gitignored). Retry like the
+      # setup composite — a transient fetch failure shouldn't force a manual re-dispatch.
       - name: Restore WASM files
-        run: bash scripts/ensure-wasm.sh
+        run: |
+          for i in 1 2 3; do
+            bash scripts/ensure-wasm.sh && break
+            if [ "$i" -lt 3 ]; then
+              echo "::warning::ensure-wasm.sh failed (attempt $i/3), retrying in 5s..."
+              sleep 5
+            else
+              exit 1
+            fi
+          done
 
       # Build prerequisites first, mirroring the packages-cad CI job: the viewer
       # worker imports `brepjs`, so the root lib + brepjs-viewer dist must exist


### PR DESCRIPTION
The OIDC publish workflow (`publish-brepjs-cad.yml`) failed: it built `brepjs-cad` without first building the root `brepjs` lib and `brepjs-viewer`, so the viewer worker (which imports `brepjs`) couldn't resolve at publish time.

Mirror the `packages-cad` CI job: restore the OCCT WASM (viewer build copies it), then build root → `brepjs-viewer` → `brepjs-cad` before publishing.

Discovered when the first OIDC publish of `0.2.1` failed at the build step (auth never reached). Once merged, re-dispatching the workflow publishes `0.2.1` token-free.