### PR TITLE
feat(brepjs-verify): live text-to-cad eval flywheel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,6 +554,28 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
@@ -3817,6 +3839,13 @@
       "peerDependencies": {
         "size-limit": "12.1.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -7181,6 +7210,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -7951,6 +7987,20 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -10194,6 +10244,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -10678,6 +10739,13 @@
       "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
       "license": "MIT"
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -10835,7 +10903,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12504,12 +12571,14 @@
       "dependencies": {
         "brepjs": "^18.0.0",
         "commander": "^13.0.0",
-        "occt-wasm": "^3.0.0"
+        "occt-wasm": "^3.0.0",
+        "typescript": "^6.0.3"
       },
       "bin": {
         "brepjs-verify": "dist/cli/main.js"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "0.100.1",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
         "@types/node": "^25.9.1",
@@ -12523,10 +12592,10 @@
         "react-dom": "^19.2.6",
         "three": "^0.184.0",
         "tsx": "^4.22.3",
-        "typescript": "^6.0.3",
         "vite": "^8.0.0",
         "vite-plugin-dts": "^5.0.1",
-        "vitest": "^4.0.0"
+        "vitest": "^4.0.0",
+        "zod": "4.4.3"
       },
       "engines": {
         "node": ">=24"

--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -71,6 +71,23 @@ Few-shot examples live under `skill/examples/<name>.brep.ts`, each with a `<name
 
 `npm run eval` (`bench/run.ts`) replays every `skill/examples/*.brep.ts` with a sibling `*.expected.json` through the public `runPart` runtime, compares measured volume/area/validity/shape-type against the recorded baseline within each file's tolerance (default 0.5%), prints a PASS/FAIL scorecard, and exits non-zero on any regression. It is deterministic — no LLM or API key — so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an intentional geometry change.
 
+### Live eval (`npm run eval:live`)
+
+The measurement flywheel: sends ~18 natural-language part prompts (`bench/prompts.ts`) to a real model — using the **deployed `SKILL.md` as the system prompt**, so it measures the actual skill — then verifies each generated part two ways:
+
+- **Auto (objective):** `runPart --check` → valid solid + any pinned dims within tolerance.
+- **Judge (intent):** a multimodal Claude call looks at the rendered iso/front/top/right snapshots and decides whether the part matches the request + rubric.
+
+The scorecard reports per-category `valid` / `judge` / `both` rates and stamps the model + **resolved brepjs version** + date (so trend lines don't mix kernel versions).
+
+```bash
+ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify          # opus by default
+ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify -- --model claude-sonnet-4-6
+#   --only <id|category>   run a subset      --keep   keep the generated parts
+```
+
+Opt-in and **billed** (real API calls), so it does _not_ run in CI — the deterministic replay above is the CI gate. Snapshots (hence the judge) need `puppeteer`/Chrome; without them the run scores on auto-verify alone and notes the skipped judge.
+
 ## Programmatic API
 
 ```ts

--- a/packages/brepjs-verify/bench/judge.ts
+++ b/packages/brepjs-verify/bench/judge.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import type Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { z } from 'zod';
+
+// Multimodal judge: given the rendered views of a generated part plus the original
+// request + rubric, decide whether the geometry matches. Verdict is a structured
+// output (messages.parse + Zod) so the score is a clean boolean, not parsed prose.
+
+const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered views (iso / front / top / right) of a 3D part a model produced from a natural-language request, along with the request and a rubric describing what a correct part must show.
+
+Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.`;
+
+const VERDICT = z.object({
+  pass: z.boolean().describe('true only if the rendered part matches the request and rubric'),
+  reason: z.string().describe('one sentence citing the deciding feature(s)'),
+});
+export type Verdict = z.infer<typeof VERDICT>;
+
+export interface JudgeInput {
+  prompt: string;
+  rubric: string;
+  pngPaths: readonly string[];
+  model: string;
+}
+
+export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdict> {
+  const images = input.pngPaths.slice(0, 4).map((p) => ({
+    type: 'image' as const,
+    source: {
+      type: 'base64' as const,
+      media_type: 'image/png' as const,
+      data: readFileSync(p).toString('base64'),
+    },
+  }));
+
+  const response = await client.messages.parse({
+    model: input.model,
+    max_tokens: 1024,
+    // Frozen across every prompt → cache it (prefix match; verify via cache_read_input_tokens).
+    system: [{ type: 'text', text: JUDGE_SYSTEM, cache_control: { type: 'ephemeral' } }],
+    messages: [
+      {
+        role: 'user',
+        content: [
+          ...images,
+          {
+            type: 'text',
+            text: `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\nDoes the rendered part satisfy the request and rubric?`,
+          },
+        ],
+      },
+    ],
+    output_config: { format: zodOutputFormat(VERDICT) },
+  });
+
+  return response.parsed_output ?? { pass: false, reason: 'judge returned no parseable verdict' };
+}

--- a/packages/brepjs-verify/bench/judge.ts
+++ b/packages/brepjs-verify/bench/judge.ts
@@ -34,25 +34,28 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
     },
   }));
 
-  const response = await client.messages.parse({
-    model: input.model,
-    max_tokens: 1024,
-    // Frozen across every prompt → cache it (prefix match; verify via cache_read_input_tokens).
-    system: [{ type: 'text', text: JUDGE_SYSTEM, cache_control: { type: 'ephemeral' } }],
-    messages: [
-      {
-        role: 'user',
-        content: [
-          ...images,
-          {
-            type: 'text',
-            text: `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\nDoes the rendered part satisfy the request and rubric?`,
-          },
-        ],
-      },
-    ],
-    output_config: { format: zodOutputFormat(VERDICT) },
-  });
+  const response = await client.messages.parse(
+    {
+      model: input.model,
+      max_tokens: 1024,
+      // Frozen across every prompt → cache it (prefix match; verify via cache_read_input_tokens).
+      system: [{ type: 'text', text: JUDGE_SYSTEM, cache_control: { type: 'ephemeral' } }],
+      messages: [
+        {
+          role: 'user',
+          content: [
+            ...images,
+            {
+              type: 'text',
+              text: `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\nDoes the rendered part satisfy the request and rubric?`,
+            },
+          ],
+        },
+      ],
+      output_config: { format: zodOutputFormat(VERDICT) },
+    },
+    { signal: AbortSignal.timeout(120_000) }
+  );
 
   return response.parsed_output ?? { pass: false, reason: 'judge returned no parseable verdict' };
 }

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -1,0 +1,178 @@
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import Anthropic from '@anthropic-ai/sdk';
+import { runPart } from '../src/verify/runPart.js';
+import { disposeShape } from '../src/disposeShape.js';
+import { PROMPTS, type EvalPrompt } from './prompts.js';
+import { checkAuto, formatScorecard, type EvalResult, type Scorecard } from './score.js';
+import { judge } from './judge.js';
+
+// Live text-to-CAD eval (opt-in; needs ANTHROPIC_API_KEY). For each prompt:
+//   author with Claude  →  write a .brep.ts  →  verify (--check + dims)  →
+//   render snapshots  →  multimodal judge  →  two-signal scorecard.
+// The deterministic example replay (`npm run eval`) stays the free CI gate; this
+// measures real first-try success and is run manually to track the plugin/CLI.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+interface Args {
+  model: string;
+  only?: string | undefined;
+  keep: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const args: Args = { model: 'claude-opus-4-8', keep: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--model') args.model = argv[++i] ?? args.model;
+    else if (a === '--only') args.only = argv[++i];
+    else if (a === '--keep') args.keep = true;
+  }
+  return args;
+}
+
+function brepjsVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(require.resolve('brepjs/package.json'), 'utf8')) as {
+      version?: string;
+    };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** The deployed skill IS the author system prompt — so the eval measures the real skill. */
+function authorSystem(): string {
+  const skill = readFileSync(resolve(here, '../skill/SKILL.md'), 'utf8');
+  return `${skill}\n\n---\nYou are now authoring a part. Output ONLY a single complete .brep.ts module — no markdown fences, no prose, no explanation. It must \`export default () => <shape>\` and import what it needs from 'brepjs'.`;
+}
+
+/** Strip accidental markdown fences; tolerate a model that ignores the no-fence instruction. */
+function extractModule(text: string): string {
+  const fence = text.match(/```(?:ts|typescript)?\s*\n([\s\S]*?)```/);
+  return (fence?.[1] ?? text).trim();
+}
+
+async function authorPart(client: Anthropic, system: string, p: EvalPrompt, model: string): Promise<string> {
+  const response = await client.messages.create({
+    model,
+    max_tokens: 16000,
+    thinking: { type: 'adaptive' },
+    system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
+    messages: [{ role: 'user', content: p.prompt }],
+  });
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+  return extractModule(text);
+}
+
+async function snapshot(stepPath: string, outDir: string): Promise<string[]> {
+  // Lazy: snapshots need puppeteer/Chrome + the built viewer. If unavailable, the
+  // judge is skipped and we score on auto-verify alone (reported in the scorecard).
+  try {
+    mkdirSync(outDir, { recursive: true });
+    const { shoot } = await import('../src/snapshot/shoot.js');
+    const { pngs } = await shoot({ file: stepPath, outDir });
+    return pngs;
+  } catch (e) {
+    console.warn(`  snapshot skipped (${(e as Error).message.split('\n')[0]})`);
+    return [];
+  }
+}
+
+async function evalPrompt(
+  client: Anthropic,
+  system: string,
+  p: EvalPrompt,
+  args: Args,
+  workdir: string
+): Promise<EvalResult> {
+  const base: Pick<EvalResult, 'id' | 'category'> = { id: p.id, category: p.category };
+  let code: string;
+  try {
+    code = await authorPart(client, system, p, args.model);
+  } catch (e) {
+    return { ...base, auto: { pass: false, failures: [] }, error: `author failed: ${(e as Error).message}` };
+  }
+
+  const partPath = join(workdir, `${p.id}.brep.ts`);
+  writeFileSync(partPath, code);
+
+  const { shape, report, step } = await runPart(partPath, { check: true, step: true });
+  try {
+    const auto = checkAuto(report, p.expected);
+
+    // Render + judge only when the part built (a STEP came out).
+    let judgePass: boolean | undefined;
+    let judgeReason: string | undefined;
+    if (step) {
+      const stepPath = join(workdir, `${p.id}.step`);
+      writeFileSync(stepPath, Buffer.from(step));
+      const pngs = await snapshot(stepPath, join(workdir, `${p.id}-shots`));
+      if (pngs.length > 0) {
+        const v = await judge(client, { prompt: p.prompt, rubric: p.rubric, pngPaths: pngs, model: args.model });
+        judgePass = v.pass;
+        judgeReason = v.reason;
+      }
+    }
+    return { ...base, auto, judgePass, judgeReason };
+  } finally {
+    disposeShape(shape);
+  }
+}
+
+async function main(): Promise<void> {
+  if (!process.env['ANTHROPIC_API_KEY']) {
+    console.error('eval:live needs ANTHROPIC_API_KEY (it calls the Anthropic API — billed).');
+    console.error('Set it and re-run: ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify');
+    process.exit(2);
+  }
+  const args = parseArgs(process.argv.slice(2));
+  const prompts = PROMPTS.filter((p) => !args.only || p.id === args.only || p.category === args.only);
+  if (prompts.length === 0) {
+    console.error(`no prompts match --only ${args.only ?? ''}`);
+    process.exit(1);
+  }
+
+  const client = new Anthropic();
+  const system = authorSystem();
+  const workdir = mkdtempSync(join(tmpdir(), 'brepjs-verify-eval-'));
+  // Temp parts must load as ESM (Node strips .ts types only in an ESM context).
+  writeFileSync(join(workdir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+  const results: EvalResult[] = [];
+  for (const p of prompts) {
+    console.log(`· ${p.id}`);
+    try {
+      results.push(await evalPrompt(client, system, p, args, workdir));
+    } catch (e) {
+      results.push({
+        id: p.id,
+        category: p.category,
+        auto: { pass: false, failures: [] },
+        error: `eval threw: ${(e as Error).message}`,
+      });
+    }
+  }
+
+  const card: Scorecard = {
+    model: args.model,
+    brepjsVersion: brepjsVersion(),
+    date: new Date().toISOString().slice(0, 10),
+    results,
+  };
+  console.log('\n' + formatScorecard(card));
+
+  if (!args.keep) rmSync(workdir, { recursive: true, force: true });
+  else console.log(`\n(kept generated parts in ${workdir})`);
+}
+
+await main();

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -127,9 +127,15 @@ async function evalPrompt(
       writeFileSync(stepPath, Buffer.from(step));
       const pngs = await snapshot(stepPath, join(workdir, `${p.id}-shots`));
       if (pngs.length > 0) {
-        const v = await judge(client, { prompt: p.prompt, rubric: p.rubric, pngPaths: pngs, model: args.model });
-        judgePass = v.pass;
-        judgeReason = v.reason;
+        // The judge is a secondary signal — if it throws (timeout, API error) keep the
+        // objective `auto` result and leave judgePass undefined (scorecard shows judge:—).
+        try {
+          const v = await judge(client, { prompt: p.prompt, rubric: p.rubric, pngPaths: pngs, model: args.model });
+          judgePass = v.pass;
+          judgeReason = v.reason;
+        } catch (e) {
+          console.warn(`  judge failed (${(e as Error).message.split('\n')[0]})`);
+        }
       }
     }
     return { ...base, auto, judgePass, judgeReason };

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -59,15 +59,24 @@ function extractModule(text: string): string {
   return (fence?.[1] ?? text).trim();
 }
 
+// Per-call abort: with adaptive thinking + 16K tokens a single author call can run
+// minutes; stream (avoids the SDK HTTP timeout on long outputs) and cap it so one
+// hung response can't stall the whole run.
+const CALL_TIMEOUT_MS = 300_000;
+
 async function authorPart(client: Anthropic, system: string, p: EvalPrompt, model: string): Promise<string> {
-  const response = await client.messages.create({
-    model,
-    max_tokens: 16000,
-    thinking: { type: 'adaptive' },
-    system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
-    messages: [{ role: 'user', content: p.prompt }],
-  });
-  const text = response.content
+  const stream = client.messages.stream(
+    {
+      model,
+      max_tokens: 16000,
+      thinking: { type: 'adaptive' },
+      system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
+      messages: [{ role: 'user', content: p.prompt }],
+    },
+    { signal: AbortSignal.timeout(CALL_TIMEOUT_MS) }
+  );
+  const message = await stream.finalMessage();
+  const text = message.content
     .filter((b): b is Anthropic.TextBlock => b.type === 'text')
     .map((b) => b.text)
     .join('');

--- a/packages/brepjs-verify/bench/prompts.ts
+++ b/packages/brepjs-verify/bench/prompts.ts
@@ -1,0 +1,151 @@
+// Hand-authored text-to-CAD prompt corpus for the live eval (`eval:live`).
+// Each prompt is a natural-language part request scoped to the reliable core
+// (primitives, booleans, sketch→extrude, fillet/chamfer, shell, transforms).
+//
+// Scoring is two-signal (see live.ts): an objective auto-verify (the part is a
+// valid solid; plus any pinned `expected` dims within tolerance) AND a
+// multimodal LLM judge that looks at the rendered snapshots and decides whether
+// the part matches `rubric`. `expected` is optional — only pin dims for fully
+// specified parts where placement doesn't change the measurement.
+
+export interface EvalPrompt {
+  id: string;
+  category: 'primitive' | 'boolean' | 'sketch' | 'modifier' | 'transform' | 'gridfinity';
+  /** The natural-language request handed to the model. */
+  prompt: string;
+  /** What a correct part must show — handed to the multimodal judge. */
+  rubric: string;
+  /** Objective dimensional checks, when the prompt pins them unambiguously. */
+  expected?: {
+    volume?: number;
+    bounds?: { x?: [number, number]; y?: [number, number]; z?: [number, number] };
+    tolerancePct?: number;
+  };
+}
+
+export const PROMPTS: readonly EvalPrompt[] = [
+  {
+    id: 'plate-2holes',
+    category: 'sketch',
+    prompt:
+      'A flat rectangular mounting plate 80 mm wide, 40 mm deep, 5 mm thick, with two 6 mm diameter through-holes centered 20 mm in from each short edge along the centerline.',
+    rubric: 'A thin rectangular plate with two round through-holes on its centerline.',
+  },
+  {
+    id: 'l-bracket',
+    category: 'boolean',
+    prompt:
+      'An L-shaped bracket: a 60×40 mm base plate 4 mm thick with a 40 mm tall upright wall along one 60 mm edge, also 4 mm thick.',
+    rubric: 'An L-profile bracket — a flat base meeting a vertical wall at a right angle.',
+  },
+  {
+    id: 'flanged-tube',
+    category: 'boolean',
+    prompt:
+      'A pipe flange: a 50 mm diameter cylinder 30 mm tall with a 10 mm diameter bore all the way through, sitting on a 90 mm square base plate 6 mm thick.',
+    rubric: 'A bored cylinder rising from a square flange plate; the bore runs fully through.',
+  },
+  {
+    id: 'rounded-box',
+    category: 'modifier',
+    prompt: 'A 40×30×20 mm box with all twelve edges rounded with a 3 mm fillet.',
+    rubric: 'A box whose every edge is visibly rounded, not sharp.',
+    expected: { bounds: { x: [0, 40], y: [0, 30], z: [0, 20] }, tolerancePct: 1 },
+  },
+  {
+    id: 'chamfered-cube',
+    category: 'modifier',
+    prompt: 'A 30 mm cube with every edge chamfered at 2 mm.',
+    rubric: 'A cube with flat 45-degree chamfers on all edges.',
+  },
+  {
+    id: 'hollow-enclosure',
+    category: 'modifier',
+    prompt:
+      'A rectangular electronics enclosure 70×50×30 mm, walls 2 mm thick, open at the top (a box shelled to a thin wall with the top face removed).',
+    rubric: 'An open-topped thin-walled box — a tray/enclosure, hollow inside.',
+  },
+  {
+    id: 'washer',
+    category: 'sketch',
+    prompt: 'A flat washer: 20 mm outer diameter, 8 mm inner diameter, 2 mm thick.',
+    rubric: 'A thin flat annulus (ring) with a concentric hole.',
+  },
+  {
+    id: 'hex-standoff',
+    category: 'sketch',
+    prompt:
+      'A hexagonal standoff: a hexagon 12 mm across the flats, extruded 25 mm tall, with a 4 mm hole bored down the center axis.',
+    rubric: 'A six-sided prism with an axial bore — a hex standoff.',
+  },
+  {
+    id: 'revolved-pulley',
+    category: 'sketch',
+    prompt:
+      'A V-groove pulley revolved about its axis: roughly 50 mm outer diameter, 20 mm wide, with a V-shaped groove around the rim and a 8 mm center bore.',
+    rubric: 'A round pulley with a V-groove around the circumference and a center bore.',
+  },
+  {
+    id: 'knob',
+    category: 'modifier',
+    prompt:
+      'A cylindrical control knob 30 mm diameter, 18 mm tall, with the top edge filleted to a 4 mm radius and a 6 mm blind hole in the bottom for a shaft.',
+    rubric: 'A short cylinder with a rounded top edge and a blind hole underneath.',
+  },
+  {
+    id: 'spacer-block',
+    category: 'boolean',
+    prompt:
+      'A 50×50×15 mm spacer block with a 25 mm diameter hole through the thickness and the four vertical corners rounded to a 5 mm radius.',
+    rubric: 'A square block with a big central through-hole and rounded vertical corners.',
+  },
+  {
+    id: 'angle-bracket-ribs',
+    category: 'boolean',
+    prompt:
+      'A 90-degree angle bracket from two 50×30 mm plates 4 mm thick meeting at a right angle, with a triangular gusset rib reinforcing the inside corner.',
+    rubric: 'Two plates at a right angle with a triangular brace in the inner corner.',
+  },
+  {
+    id: 'slotted-plate',
+    category: 'sketch',
+    prompt:
+      'A 100×40 mm plate 5 mm thick with a 40 mm long, 8 mm wide rounded-end slot cut through the middle along its length.',
+    rubric: 'A flat plate with an obround (rounded-end) slot cut through it.',
+  },
+  {
+    id: 'stepped-shaft',
+    category: 'primitive',
+    prompt:
+      'A stepped cylindrical shaft: a 20 mm diameter section 40 mm long, then a 12 mm diameter section 30 mm long, coaxial.',
+    rubric: 'A round shaft with two coaxial diameters — a step partway along.',
+  },
+  {
+    id: 'dome-cap',
+    category: 'boolean',
+    prompt: 'A 30 mm diameter cylinder 10 mm tall capped with a hemispherical dome on top.',
+    rubric: 'A short cylinder topped by a smooth hemispherical dome.',
+  },
+  {
+    id: 'gridfinity-bin-1x1',
+    category: 'gridfinity',
+    prompt:
+      'A 1×1 Gridfinity bin: 42 mm grid footprint, three height units tall (21 mm), with a hollow cavity and walls about 1.2 mm thick.',
+    rubric: 'A small open-top bin on the 42 mm gridfinity footprint, hollow, ~21 mm tall.',
+  },
+  {
+    id: 'gridfinity-baseplate-2x1',
+    category: 'gridfinity',
+    prompt:
+      'A 2×1 Gridfinity baseplate: two 42 mm grid cells side by side, a thin slab with a square socket recess in each cell.',
+    rubric: 'A flat 2-cell gridfinity baseplate with a recessed socket per cell.',
+    expected: { bounds: { x: [0, 84], y: [0, 42] }, tolerancePct: 2 },
+  },
+  {
+    id: 'bracket-mirror-pair',
+    category: 'transform',
+    prompt:
+      'Two mirror-image mounting tabs: a 30×20×4 mm tab with a 5 mm hole, and its mirror across the YZ plane, joined into one part 70 mm wide overall.',
+    rubric: 'Two mirrored tabs (left and right hand) joined as a single part.',
+  },
+] as const;

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -1,0 +1,115 @@
+import { reportOk, type VerifyReport } from '../src/verify/report.js';
+import { DEFAULT_TOLERANCE_PCT, pctDelta } from '../src/verify/expected.js';
+import type { EvalPrompt } from './prompts.js';
+
+// Pure scoring + scorecard formatting for the live eval. No I/O, no network —
+// unit-tested directly (see tests/liveEvalScore.test.ts).
+
+export interface AutoResult {
+  /** Objective signal: valid solid (ok=true) AND any pinned dims within tolerance. */
+  pass: boolean;
+  failures: string[];
+}
+
+export interface EvalResult {
+  id: string;
+  category: EvalPrompt['category'];
+  auto: AutoResult;
+  /** undefined when the judge couldn't run (e.g. snapshots unavailable). */
+  judgePass?: boolean | undefined;
+  judgeReason?: string | undefined;
+  /** undefined when generation/build failed before a report existed. */
+  error?: string | undefined;
+}
+
+/** Objective check: the report is ok (valid solid) and any pinned dims are within tolerance. */
+export function checkAuto(report: VerifyReport, expected: EvalPrompt['expected']): AutoResult {
+  const failures: string[] = [];
+  if (!reportOk(report)) {
+    failures.push('not a valid part (ok=false)');
+    for (const e of report.errors) failures.push(`error: ${e}`);
+  }
+  if (expected) {
+    const tol = expected.tolerancePct ?? DEFAULT_TOLERANCE_PCT;
+    if (expected.volume !== undefined) {
+      const v = report.measurements.volume;
+      if (v === undefined) failures.push('volume: no measurement');
+      else if (pctDelta(v, expected.volume) > tol)
+        failures.push(`volume ${v.toFixed(1)} vs ${expected.volume} (>${tol}%)`);
+    }
+    if (expected.bounds) {
+      const b = report.measurements.bounds;
+      if (!b) failures.push('bounds: no measurement');
+      else {
+        for (const [axis, range] of Object.entries(expected.bounds)) {
+          if (!range) continue;
+          const [emin, emax] = range;
+          const amin = b[`${axis}Min` as keyof typeof b];
+          const amax = b[`${axis}Max` as keyof typeof b];
+          // Tolerance is on the expected span, with a 0.1 mm floor for tiny axes.
+          const eps = Math.max(0.1, (Math.abs(emax - emin) * tol) / 100);
+          if (Math.abs(amin - emin) > eps || Math.abs(amax - emax) > eps)
+            failures.push(`bounds.${axis}: [${amin},${amax}] vs [${emin},${emax}] (±${eps.toFixed(2)})`);
+        }
+      }
+    }
+  }
+  return { pass: failures.length === 0, failures };
+}
+
+export interface Scorecard {
+  model: string;
+  brepjsVersion: string;
+  date: string;
+  results: readonly EvalResult[];
+}
+
+interface Tally {
+  total: number;
+  autoValid: number;
+  judgeMatch: number;
+  both: number;
+}
+
+function tally(results: readonly EvalResult[]): Tally {
+  return {
+    total: results.length,
+    autoValid: results.filter((r) => r.auto.pass).length,
+    judgeMatch: results.filter((r) => r.judgePass === true).length,
+    both: results.filter((r) => r.auto.pass && r.judgePass === true).length,
+  };
+}
+
+const pct = (n: number, d: number): string => (d === 0 ? '—' : `${Math.round((100 * n) / d)}%`);
+
+export function formatScorecard(card: Scorecard): string {
+  const lines: string[] = [];
+  lines.push(`brepjs-verify live eval — model=${card.model} brepjs=${card.brepjsVersion} ${card.date}`);
+  lines.push('='.repeat(64));
+  const pad = Math.max(2, ...card.results.map((r) => r.id.length));
+  for (const r of card.results) {
+    const a = r.error ? 'ERR ' : r.auto.pass ? 'valid' : 'INVALID';
+    const j = r.judgePass === undefined ? 'judge:—' : r.judgePass ? 'judge:✓' : 'judge:✗';
+    lines.push(`  ${r.id.padEnd(pad)}  ${a.padEnd(7)} ${j}`);
+    if (r.error) lines.push(`        ${r.error}`);
+    else {
+      for (const f of r.auto.failures) lines.push(`        auto: ${f}`);
+      if (r.judgePass === false && r.judgeReason) lines.push(`        judge: ${r.judgeReason}`);
+    }
+  }
+  lines.push('='.repeat(64));
+
+  const cats = [...new Set(card.results.map((r) => r.category))].sort();
+  for (const cat of cats) {
+    const t = tally(card.results.filter((r) => r.category === cat));
+    lines.push(
+      `  ${cat.padEnd(10)} valid ${pct(t.autoValid, t.total)}  judge ${pct(t.judgeMatch, t.total)}  both ${pct(t.both, t.total)}  (n=${t.total})`
+    );
+  }
+  const all = tally(card.results);
+  lines.push('-'.repeat(64));
+  lines.push(
+    `  TOTAL      valid ${pct(all.autoValid, all.total)}  judge ${pct(all.judgeMatch, all.total)}  both ${pct(all.both, all.total)}  (n=${all.total})`
+  );
+  return lines.join('\n');
+}

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -44,6 +44,7 @@
     "lint": "eslint src tests viewer bench",
     "test": "vitest run",
     "eval": "tsx bench/run.ts",
+    "eval:live": "tsx bench/live.ts",
     "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8'));if(r.ok!==true||!(r.measurements.volume>0))process.exit(1)\"",
     "smoke:standalone": "node scripts/smokeStandalone.mjs",
     "prepack": "npm run build"
@@ -58,6 +59,7 @@
     "puppeteer": "^25.0.4"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "0.100.1",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
     "@types/node": "^25.9.1",
@@ -73,6 +75,7 @@
     "tsx": "^4.22.3",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^5.0.1",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "zod": "4.4.3"
   }
 }

--- a/packages/brepjs-verify/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalScore.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { checkAuto, formatScorecard, type EvalResult } from '../bench/score.js';
+import { emptyReport, type VerifyReport } from '../src/verify/report.js';
+
+function validReport(over: Partial<VerifyReport['measurements']> = {}): VerifyReport {
+  const r = emptyReport();
+  r.shapeType = 'Solid';
+  r.checks = [
+    { name: 'isValidSolid', passed: true },
+    { name: 'positiveVolume', passed: true },
+  ];
+  r.measurements = { volume: 1000, area: 600, ...over };
+  return r;
+}
+
+describe('checkAuto', () => {
+  it('passes a valid report with no pinned dims', () => {
+    expect(checkAuto(validReport(), undefined).pass).toBe(true);
+  });
+
+  it('fails when the report is not ok and surfaces the errors', () => {
+    const r = emptyReport();
+    r.checks = [{ name: 'isValidSolid', passed: false }];
+    r.errors = ['part returned Err: BOOLEAN_HAS_ERRORS'];
+    const res = checkAuto(r, undefined);
+    expect(res.pass).toBe(false);
+    expect(res.failures.join(' ')).toContain('valid');
+    expect(res.failures.join(' ')).toContain('BOOLEAN_HAS_ERRORS');
+  });
+
+  it('passes pinned volume within tolerance and fails outside it', () => {
+    expect(checkAuto(validReport({ volume: 1004 }), { volume: 1000, tolerancePct: 1 }).pass).toBe(true);
+    const bad = checkAuto(validReport({ volume: 1100 }), { volume: 1000, tolerancePct: 1 });
+    expect(bad.pass).toBe(false);
+    expect(bad.failures.join(' ')).toContain('volume');
+  });
+
+  it('checks pinned bounds per axis with a span-relative tolerance', () => {
+    const bounds = { xMin: 0, xMax: 40, yMin: 0, yMax: 30, zMin: 0, zMax: 20 };
+    expect(checkAuto(validReport({ bounds }), { bounds: { x: [0, 40], z: [0, 20] }, tolerancePct: 1 }).pass).toBe(true);
+    const off = checkAuto(validReport({ bounds }), { bounds: { x: [0, 50] }, tolerancePct: 1 });
+    expect(off.pass).toBe(false);
+    expect(off.failures.join(' ')).toContain('bounds.x');
+  });
+});
+
+describe('formatScorecard', () => {
+  it('renders per-category and total tallies with the version stamp', () => {
+    const results: EvalResult[] = [
+      { id: 'a', category: 'primitive', auto: { pass: true, failures: [] }, judgePass: true },
+      { id: 'b', category: 'primitive', auto: { pass: true, failures: [] }, judgePass: false, judgeReason: 'no bore' },
+      { id: 'c', category: 'boolean', auto: { pass: false, failures: ['not a valid part (ok=false)'] } },
+    ];
+    const out = formatScorecard({ model: 'claude-opus-4-8', brepjsVersion: '18.60.0', date: '2026-06-04', results });
+    expect(out).toContain('brepjs=18.60.0');
+    expect(out).toContain('model=claude-opus-4-8');
+    expect(out).toContain('TOTAL');
+    expect(out).toContain('primitive');
+    // 2/3 valid overall, 1/3 judged matching, 1/3 both.
+    expect(out).toMatch(/TOTAL\s+valid 67%\s+judge 33%\s+both 33%/);
+  });
+});


### PR DESCRIPTION
## What & why

PR C of the strategy — the **measurement flywheel**. The plugin (PR B) and standalone CLI (PR A) are bets ("this helps LLMs produce valid CAD"); this turns them into a measured number and a way to improve systematically.

## Two-layer eval

- **Deterministic replay** (`npm run eval`, unchanged) stays the **CI gate** — replays the example corpus through `runPart`, no LLM/key.
- **Live eval** (`npm run eval:live`, new) — the flywheel: ~18 hand-authored NL part prompts (`bench/prompts.ts`) → Claude → verify → score. **Opt-in + billed; not in CI.**

## How the live eval scores (the bar you chose: valid + dims + visual)

- **Author with the *deployed* skill.** The system prompt is the actual `SKILL.md`, so the eval measures the real plugin, not a stand-in.
- **Auto (objective):** `runPart --check` → valid solid + any pinned dims within tolerance (`bench/score.ts`, unit-tested).
- **Judge (intent, multimodal):** a Claude call looks at the rendered iso/front/top/right snapshots + the request + a rubric and returns a structured `{pass, reason}` (Zod + `messages.parse`).
- **Scorecard** reports per-category `valid` / `judge` / `both` rates and **stamps the resolved brepjs version** + model + date — so trend lines don't silently mix kernel versions (the floating `^18` caveat).

## SDK details (per the claude-api guidance)
Opus 4.8 default (`--model` configurable), adaptive thinking, `cache_control` on the shared system prompts, base64 image blocks, structured-output judge. `@anthropic-ai/sdk` + `zod` are **devDependencies** (maintainer tool — not shipped to CLI users).

## Verification
typecheck / lint / knip clean; deterministic eval **12/12**; new `liveEvalScore` unit tests **5/5** (pure scoring, no key). The live harness typechecks + lints but isn't run in CI (needs a key + puppeteer) — it's structured per the SDK skill and run manually.

Built in an isolated worktree off main, parallel to the ongoing manifold work.
