### PR TITLE
docs(brepjs-verify): comprehensive plugin + CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,36 @@ Layer 0  kernel/, utils/                  WASM bindings
 
 Imports flow downward only. Boundaries are enforced in CI.
 
+## Authoring CAD with AI (brepjs-verify)
+
+[`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) helps an AI agent (or you) author parametric CAD in brepjs and **prove it is correct** before handing it off. An LLM can't see geometry — so it writes a `.brep.ts` part, runs it on a real kernel, and reads a deterministic report instead of guessing from how the code reads. It ships as two cooperating pieces: a **Claude Code skill** (the authoring loop) and a **verification CLI** (validity + measured dimensions + multi-view snapshots + STEP export).
+
+Install both — they ride on two rails:
+
+```bash
+# 1. The skill — Claude Code plugin (delivered via this repo's marketplace)
+/plugin marketplace add andymai/brepjs
+/plugin install brepjs-verify@brepjs
+
+# 2. The runtime — the CLI the skill drives
+npm i -D brepjs-verify
+```
+
+`brepjs-verify` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory; inside an existing brepjs project it prefers your installed versions so verified parts match what you ship. A model is a module that default-exports a zero-arg function returning a shape:
+
+```typescript
+// bracket.brep.ts
+import { box } from 'brepjs';
+export const expected = { volume: 8000, tolerancePct: 1 }; // optional: assert intent
+export default () => box(40, 20, 10, { centered: true });
+```
+
+```bash
+npx -y brepjs-verify bracket.brep.ts --check --step bracket.step --json report.json
+```
+
+The command exits non-zero unless the report is `ok` (valid **and** every declared dimension within tolerance), so it drops straight into CI or an agent loop. See the [**Authoring with AI**](https://brepjs.dev/agent/overview) guide for the full loop, CLI reference, examples, and the measurement eval.
+
 ## Projects Using brepjs
 
 - [Gridfinity Layout Tool](https://github.com/andymai/gridfinity-layout-tool): Web-based layout generator for Gridfinity storage systems

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -67,6 +67,7 @@ export default withMermaid(
       siteTitle: 'brepjs',
       nav: [
         { text: 'Guide', link: '/introduction/why-brepjs' },
+        { text: 'Authoring with AI', link: '/agent/overview' },
         { text: 'API Reference', link: 'https://andymai.github.io/brepjs/' },
         { text: 'Playground', link: '/playground', target: '_blank', rel: 'noopener noreferrer' },
         {
@@ -92,6 +93,16 @@ export default withMermaid(
             { text: 'Install & Initialize', link: '/getting-started/install' },
             { text: 'Your First Solid', link: '/getting-started/first-solid' },
             { text: 'Cheat Sheet', link: '/getting-started/cheat-sheet' },
+          ],
+        },
+        {
+          text: 'Authoring with AI',
+          items: [
+            { text: 'Overview', link: '/agent/overview' },
+            { text: 'The Verify Loop', link: '/agent/the-loop' },
+            { text: 'CLI Reference', link: '/agent/cli' },
+            { text: 'Examples', link: '/agent/examples' },
+            { text: 'Eval & Scorecard', link: '/agent/eval' },
           ],
         },
         {

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -1,0 +1,94 @@
+---
+title: CLI Reference
+description: 'Every brepjs-verify subcommand, flag, and exit code — verify, init, watch, export, measure, diff, snapshot, serve — plus the expected-dimensions contract and troubleshooting.'
+---
+
+# CLI Reference
+
+The `brepjs-verify` bin is a multi-command CLI. `verify` is the default command, so `brepjs-verify part.brep.ts` runs it directly. Every command writes a single machine-readable JSON document to **stdout**; diagnostics (paths, kernel chatter, watch notices) go to **stderr**. Commands exit non-zero when the report is not `ok`, so they slot straight into CI and agent loops.
+
+Prefix any command with `npx -y` to run without installing.
+
+## Commands
+
+| Command                         | What it does                                                                                                                                                                            |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brepjs-verify verify <file>`   | **Default command.** Loads the part, runs deterministic checks, prints the JSON report. Flags: `--check`, `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`. |
+| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                         |
+| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                            |
+| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                 |
+| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                    |
+| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                        |
+| `brepjs-verify snapshot`        | Multi-view PNG capture — usually surfaced via `verify --snapshot <dir>`. Needs the optional `puppeteer`/Chrome dependency.                                                              |
+| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — usually surfaced via `verify --serve`.                                                                                                  |
+
+## `verify` flags
+
+| Flag               | Effect                                                                                                                                                                                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--check`          | Run a TypeScript type-check **before** executing the part. Type errors are surfaced as `TYPECHECK` error infos and the part is not run — wrong-API calls never reach the kernel.                                             |
+| `--json <out>`     | Write the full JSON report to a file (in addition to stdout).                                                                                                                                                                |
+| `--step <out>`     | Export STEP after the validity gate passes. STEP is the validated primary deliverable.                                                                                                                                       |
+| `--glb <out>`      | Export a derived GLB mesh preview. (`--stl` lives on the `export` command, not `verify`.)                                                                                                                                    |
+| `--snapshot <dir>` | Render iso / front / top / right PNGs into `<dir>` (needs `puppeteer`).                                                                                                                                                      |
+| `--serve`          | After a passing verify, start a preview server and print a clickable `?dir=&file=` link rendering the real STEP; it stays running until Ctrl-C. Only serves when the report is `ok` — a failing report still exits non-zero. |
+
+## Common invocations
+
+```bash
+# primary STEP + deterministic report, type-checked first
+npx -y brepjs-verify part.brep.ts --check --step part.step --json report.json
+
+# multi-view PNGs for visual review
+npx -y brepjs-verify part.brep.ts --snapshot shots/
+
+# live re-verify while you edit
+npx -y brepjs-verify watch part.brep.ts
+
+# clickable preview (renders the real STEP)
+npx -y brepjs-verify part.brep.ts --serve
+
+# batch every artifact behind a validity gate
+npx -y brepjs-verify export part.brep.ts --all --out dist/
+```
+
+## The `expected` contract
+
+Declare intended dimensions in the part and the CLI turns them into assertions. The report's `ok` is `true` only when the part is valid **and** every assertion passes within tolerance.
+
+<!-- @no-test -->
+
+```ts
+import { box } from 'brepjs';
+
+// All fields optional; tolerancePct (default 0.5) sets the match window.
+// Values below match a centered 40×20×10 box: 8000 mm³, 2800 mm², bounds ±20/±10/±5.
+export const expected = {
+  volume: 8000,
+  area: 2800,
+  bounds: { xMin: -20, xMax: 20, yMin: -10, yMax: 10, zMin: -5, zMax: 5 },
+  tolerancePct: 1,
+};
+export default () => box(40, 20, 10, { centered: true });
+```
+
+Each declared field appears in `report.assertions` as `{ name, expected, actual, passed }`. `volume` and `area` each produce one assertion; every declared `bounds` edge produces its own (named `bounds.xMin`, `bounds.xMax`, …).
+
+## Snapshots & the preview server
+
+`--snapshot` and `--serve` use the bundled viewer (shipped with the package, including the OCCT WASM) and render the **real exported STEP**, not a code preview. Snapshots require the optional `puppeteer`/Chrome dependency; when it is absent the CLI degrades with a clear message rather than failing, and `--snapshot` is simply skipped. The viewer is read-only display + screenshot.
+
+## Troubleshooting
+
+**`cannot load TypeScript part … (ESM)`** — Author parts in an ESM context. Node strips types natively (requires Node 24+) but only under ESM, so a part in a CommonJS project fails. Fix: set `"type": "module"` in `package.json`, or rename the part to `.mts`. A transpiler fallback is intentionally not used — it would load `brepjs` in a separate module realm and hand the part an uninitialized kernel.
+
+**`kernel not initialized` / version skew** — The runtime prefers your project-local `brepjs` + `occt-wasm` when present, else its own bundled copies, routing both the tool and the part through one instance. Keep `brepjs` and `occt-wasm` in the same project as the part so the resolve hook version-matches them.
+
+**Snapshots / judge skipped** — Install `puppeteer` (it fetches Chromium on first use) to enable `--snapshot` and the live-eval visual judge. Without it, verification still runs on measurements alone.
+
+**Node version** — Native TypeScript type-stripping for `.brep.ts` requires Node 24+. Older Node needs the part precompiled to `.mjs`.
+
+## Next steps
+
+- [The Verify Loop](./the-loop) — how to use these commands as a workflow
+- [Eval & Scorecard](./eval) — the measurement flywheel

--- a/apps/docs/agent/eval.md
+++ b/apps/docs/agent/eval.md
@@ -1,0 +1,44 @@
+---
+title: Eval & Scorecard
+description: 'How brepjs-verify measures itself — a deterministic replay that gates CI, plus an opt-in live flywheel that sends natural-language prompts to a model under the deployed skill and scores validity + visual intent.'
+---
+
+# Eval & Scorecard
+
+`brepjs-verify` measures itself two ways: a **deterministic replay** that runs in CI, and an opt-in **live flywheel** that exercises the actual skill against a real model. Together they keep the skill honest as brepjs and the kernel evolve.
+
+## Deterministic eval (CI gate)
+
+```bash
+npm run eval
+```
+
+`bench/run.ts` replays every `skill/examples/*.brep.ts` through the public `runPart` runtime and compares the measured volume / area / validity / shape-type against the recorded `*.expected.json` baseline, within each file's tolerance (default 0.5%). It prints a PASS/FAIL scorecard and exits non-zero on any regression.
+
+It is fully deterministic — **no LLM, no API key** — so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an _intentional_ geometry change; an unintentional change surfaces as a failure.
+
+## Live eval — the flywheel (`eval:live`)
+
+This is how you measure the skill itself, not just the geometry. It sends ~18 natural-language part prompts (`bench/prompts.ts`) to a real model — using the **deployed `SKILL.md` as the system prompt**, so it measures exactly what an agent sees — then verifies each generated part two ways:
+
+- **Auto (objective):** `runPart --check` → a valid solid with any pinned dimensions inside tolerance.
+- **Judge (intent):** a multimodal Claude call looks at the rendered iso/front/top/right snapshots and decides whether the part matches the request and its rubric.
+
+```bash
+ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify              # opus by default
+ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify -- --model claude-sonnet-4-6
+#   --only <id|category>   run a subset      --keep   keep the generated parts
+```
+
+The scorecard reports per-category `valid` / `judge` / `both` rates and stamps the model + **resolved brepjs version** + date — so trend lines never mix kernel versions.
+
+`eval:live` is **opt-in and billed** — it makes real API calls, so it does not run in CI; the deterministic replay above is the CI gate. Snapshots (and therefore the judge) need `puppeteer`/Chrome; without them the run scores on auto-verify alone and notes the skipped judge.
+
+## Why it stamps the brepjs version
+
+The runtime pins `brepjs` with a caret range, and geometry measurements are floating-point — a kernel bump can legitimately shift a volume by a hair. Stamping the resolved version on every scorecard keeps trend lines comparable instead of silently mixing engine versions across runs.
+
+## Next steps
+
+- [Examples](./examples) — the corpus the deterministic eval replays
+- [The Verify Loop](./the-loop) — the per-part workflow the eval automates at scale

--- a/apps/docs/agent/examples.md
+++ b/apps/docs/agent/examples.md
@@ -1,0 +1,55 @@
+---
+title: Examples
+description: 'The few-shot example gallery brepjs-verify ships — primitives, booleans, 2D sketch-to-solid, modifiers, and gridfinity — each a complete .brep.ts with a recorded measurement baseline.'
+---
+
+# Examples
+
+The skill ships a gallery of complete, verified parts under `skill/examples/<name>.brep.ts`, each paired with a `<name>.expected.json` baseline. They are the few-shot reference the agent reads before authoring — and the corpus the [deterministic eval](./eval) replays. Read the one closest to your task before writing a new part.
+
+Each example is a real `.brep.ts` you can run directly:
+
+```bash
+npx -y brepjs-verify verify mounting-bracket.brep.ts --check --snapshot shots/
+```
+
+## Primitives + booleans
+
+The reliable core — start here.
+
+- **`mounting-bracket`** — base plate + upright web + bolt holes (`box`, `fuse`, `cut`).
+- **`flanged-coupler`** — flange + cylinder + bore, chamfered.
+- **`transform-bracket`** — translate / rotate / mirror composition.
+
+## 2D sketch → solid
+
+A 2D profile driven up into 3D.
+
+- **`extruded-bracket`** — rounded plate + bolt holes (extrude).
+- **`revolved-pulley`** — V-groove profile revolved around an axis.
+- **`swept-gasket`** — a frame profile swept along a spine.
+
+## Modifiers
+
+Validity-sensitive operations — verify carefully.
+
+- **`rounded-block`** — `fillet` on selected edges.
+- **`chamfered-block`** — `chamfer`.
+- **`hollow-enclosure`** — a filleted box, shelled to a wall thickness.
+
+## Gridfinity
+
+Parametric primitives for the [Gridfinity](https://gridfinity.xyz/) ecosystem.
+
+- **`gridfinity-baseplate`**
+- **`gridfinity-bin`**
+- **`gridfinity-divider`**
+
+## Anatomy of an example
+
+Every example follows the [`.brep.ts` contract](./overview): a default-exported zero-arg function plus an `expected` block that pins its measured dimensions. The sibling `<name>.expected.json` records the baseline volume / area / validity / shape-type that the eval replays within tolerance — so an intentional geometry change means re-recording that baseline, and an _unintentional_ one shows up as a failed eval.
+
+## Next steps
+
+- [The Verify Loop](./the-loop) — the workflow these examples were authored with
+- [Eval & Scorecard](./eval) — how the gallery becomes a regression net

--- a/apps/docs/agent/overview.md
+++ b/apps/docs/agent/overview.md
@@ -1,0 +1,104 @@
+---
+title: Authoring CAD with AI
+description: 'brepjs-verify is an agent skill plus a verification CLI that turns natural-language part requirements into valid brepjs solids — type-checked, measured against intent, and snapshot-reviewed before handoff.'
+---
+
+# Authoring CAD with AI
+
+[`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) lets an AI agent author parametric CAD in brepjs and **prove it is correct** before handing it off. An LLM can't see geometry — so it writes a `.brep.ts` part, runs it against a real OpenCascade kernel, and reads the deterministic report instead of guessing from how the code looks.
+
+It ships as **two cooperating pieces**:
+
+- **The skill** — a Claude Code plugin that teaches the agent the authoring loop (brief → author → verify → repair). It carries the API references, examples, and discipline. This is the _brain_.
+- **The runtime** — the `brepjs-verify` CLI the skill drives. It loads the part on a real kernel, checks validity, measures volume/area/bounds, renders snapshots, and exports STEP. This is the _hands_.
+
+You install both — they ride on two different rails because Claude Code discovers skills from plugins (a git marketplace), never from `node_modules`, while the runtime must live where your project's `brepjs` resolves.
+
+## Why a verify loop
+
+The kernel is the only honest judge of a B-Rep model. Code that reads correctly can still produce a non-manifold solid, a zero-volume shape, or a part that is valid but the wrong size. `brepjs-verify` collapses that uncertainty into a single machine-readable verdict:
+
+- **Validity** — is it a real manifold solid with positive volume? (kernel `validSolid` brand)
+- **Intent** — does it match the declared dimensions? (`measureVolume`/`measureArea`/bounds vs an `expected` block)
+- **Shape** — does the render match the request? (multi-view PNG snapshots, for the agent or a human to review)
+
+STEP is the validated primary deliverable; GLB/STL/snapshots are derived previews.
+
+## Install — the skill (Claude Code plugin)
+
+The skill is delivered through the brepjs plugin marketplace, which is just this git repo. Add the marketplace once, then install the plugin:
+
+```
+/plugin marketplace add andymai/brepjs
+/plugin install brepjs-verify@brepjs
+```
+
+Claude Code now knows the authoring workflow and will invoke the CLI on your behalf. There is no npm step for the skill — plugins are not loaded from `node_modules`.
+
+## Install — the runtime (npm)
+
+Add the CLI to the project where you want parts verified:
+
+```bash
+npm i -D brepjs-verify
+```
+
+That's the whole install. `brepjs-verify` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory with nothing else installed. **In an existing brepjs project** it automatically prefers your locally installed `brepjs` and kernel (via a Node module-resolution hook), so your verified parts bind to the exact version you ship — no version skew between what you verify and what you build.
+
+The runtime initializes **occt-wasm** as its sole kernel (`OcctKernel.init()` + `registerKernel`), not the auto-detect fallback chain — so verification results are reproducible on one known engine.
+
+You can also run it without installing, straight from npm:
+
+```bash
+npx -y brepjs-verify part.brep.ts
+```
+
+## The `.brep.ts` contract
+
+A model is a TypeScript module whose **default export is a zero-argument function** returning a shape (or a `Result<shape>`):
+
+<!-- @no-test -->
+
+```ts
+// bracket.brep.ts
+import { box } from 'brepjs';
+
+export default () => box(40, 20, 10, { centered: true });
+```
+
+Optionally declare intent with an `expected` block — the CLI asserts it, so you prove the part is the _right_ part, not merely a valid one:
+
+<!-- @no-test -->
+
+```ts
+// bracket.brep.ts
+import { box } from 'brepjs';
+
+export const expected = { volume: 8000, tolerancePct: 1 };
+export default () => box(40, 20, 10, { centered: true });
+```
+
+Author parts in an ESM context (the CLI's default). A CommonJS project needs `"type": "module"` in `package.json`, or name the file `.mts`.
+
+## Quickstart
+
+```bash
+# scaffold a parameterized part
+npx -y brepjs-verify init bracket
+
+# author bracket/bracket.brep.ts, then verify (type-check + geometry) and write the report
+npx -y brepjs-verify verify bracket/bracket.brep.ts --check --json report.json
+
+# review it visually, then export the validated STEP
+npx -y brepjs-verify verify bracket/bracket.brep.ts --snapshot shots/
+npx -y brepjs-verify verify bracket/bracket.brep.ts --step bracket.step
+```
+
+The command exits non-zero whenever the report is not `ok`, so it drops straight into CI or an agent loop.
+
+## Next steps
+
+- [The Verify Loop](./the-loop) — the author → verify → repair workflow and how to read the report
+- [CLI Reference](./cli) — every subcommand, flag, and exit code
+- [Examples](./examples) — the few-shot gallery the skill learns from
+- [Eval & Scorecard](./eval) — the measurement flywheel that proves the skill

--- a/apps/docs/agent/the-loop.md
+++ b/apps/docs/agent/the-loop.md
@@ -1,0 +1,92 @@
+---
+title: The Verify Loop
+description: 'The author → verify → repair loop at the heart of brepjs-verify: declare intent, run the part on a real kernel, read the JSON report as the source of truth, and repair the smallest responsible section.'
+---
+
+# The Verify Loop
+
+You write a `.brep.ts` part; the `brepjs-verify` CLI runs it against a real geometry kernel and tells you the truth. **Never judge a part by how the code reads — judge it by the report.** This loop is the whole job, whether you are the agent or the human driving it.
+
+## The loop (every part, in order)
+
+1. **Brief.** Convert the request into explicit parameters: dimensions (mm), datums, features, assumptions.
+2. **Author `.brep.ts`.** `export default () => <shape>` using the short API (`box`, `cylinder`, `fuse`, `cut`, `fillet`, …), with named constants at the top. Scaffold with `brepjs-verify init <name>`. Edit _source_, never generated artifacts.
+3. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. The CLI asserts it — this is how you prove the part is the _right_ part, not just a valid one.
+4. **Verify (type + geometry).** `brepjs-verify verify part.brep.ts --check --json report.json`. `--check` type-checks before running (catches wrong-API calls early); the JSON report is the source of truth. Iterate fast with `brepjs-verify watch part.brep.ts`.
+5. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs. Review against the brief. A visual concern is **not** a conclusion — convert it to a measurement ("hole looks off-center → check `bounds`").
+6. **Repair the smallest responsible section** and re-run. Use the report's `hints` to guide the fix.
+7. **Export + hand off.** `brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `brepjs-verify export part.brep.ts --all`. Report the STEP path.
+
+The commands above assume you've installed the package (`npm i -D brepjs-verify`) and call `brepjs-verify` directly. Otherwise prefix every command with `npx -y` to run it straight from npm.
+
+## Reading the report (this is the source of truth)
+
+Every command writes a single JSON document to stdout (diagnostics go to stderr):
+
+```jsonc
+{
+  "ok": false, // true only if no errors AND every check AND every assertion passes
+  "shapeType": "Solid",
+  "checks": [{ "name": "isValidSolid", "passed": false }],
+  "measurements": {
+    "volume": 31200,
+    "area": 6800,
+    "bounds": { "xMin": -20, "xMax": 20, "yMin": -10, "yMax": 10, "zMin": 0, "zMax": 10 },
+  },
+  "assertions": [{ "name": "volume", "expected": 24000, "actual": 31200, "passed": false }],
+  "hints": [{ "code": "FILLET_NO_EDGES", "message": "…", "fix": "…", "nextStep": "…" }],
+  "errorInfos": [{ "code": "…", "message": "…" }],
+}
+```
+
+- **`ok`** is the verdict. `false` → not done. With an `expected` block, `ok` also requires every assertion to pass.
+- **`checks`** = kernel validity (manifold solid, positive volume). A failed check means the geometry is _broken_, not just wrong-sized.
+- **`measurements`** = the kernel's measured volume / area / bounding box.
+- **`assertions`** = your declared intent vs reality. A failed assertion means _valid-but-wrong_ (off dimensions).
+- **`hints`** = an actionable fix + next step keyed on the error code. Read these before guessing.
+- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from — authoring, kernel, or export errors. Cite the `code` when repairing.
+
+Trust this JSON over the rendered image. The render confirms _shape_; the JSON confirms _correctness_.
+
+## Repair discipline
+
+- Change the **smallest responsible section**, re-verify, repeat. Don't rewrite the whole part on one failure.
+- Let the `code`/`hints` localize the cause:
+  - `INVALID_FILLET_RADIUS` → reduce the radius relative to the local edge length.
+  - `*_NOT_3D` → you passed a 2D shape to a 3D operation.
+  - `BOOLEAN_HAS_ERRORS` → the inputs are overlap-degenerate.
+- A part that _runs_ but reports `ok: false` is wrong, not done — same as a crash.
+
+## What's reliable, what needs care
+
+- **Reliable first-try:** primitives, booleans (`fuse`/`cut`/`intersect`), 2D sketch → extrude, `fillet`/`chamfer`, `shell`/`offset`, transforms. Prefer these.
+- **Advanced — verify extra carefully, expect iteration:** sweeps, lofts, revolves, multi-section, assemblies, text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and take small steps.
+
+## Hard rules
+
+- Edit source, not artifacts. STEP/STL/GLB derive from the `.brep.ts`.
+- Booleans and `measureVolume`/`measureArea` return `Result` — unwrap and check the `Err` branch before chaining.
+- `fillet`/`chamfer` need a valid solid; the signature is `fillet(solid, edges, radius)`. Verify validity first.
+- `box(width, depth, height)`: the 2nd arg is depth (Y), the 3rd is height (Z); the positioning option is `at`, not `origin`. Units are mm.
+- Author parts in an ESM context so the kernel loads — a CommonJS project needs `"type": "module"` or a `.mts` file.
+
+## Programmatic use
+
+The same runtime is exported for scripts and your own harnesses:
+
+<!-- @no-test -->
+
+```ts
+import { runPart, serializeReport } from 'brepjs-verify';
+
+const { shape, report, step } = await runPart('part.brep.ts', { step: true, check: true });
+console.log(serializeReport(report)); // { ok, shapeType, checks, measurements, assertions, hints, errorInfos, errors }
+```
+
+`report.shape` is a live WASM-backed handle — release it (`using` / a `DisposalScope`) in long-running callers.
+
+## Next steps
+
+- [CLI Reference](./cli) — every subcommand and flag
+- [Examples](./examples) — the few-shot gallery
+- [Troubleshooting](./cli#troubleshooting) — ESM, snapshots, kernel

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,6 +8,36 @@
 - **Function lookup table**: `docs/function-lookup.md` — alphabetical index mapping every symbol to its sub-path
 - **Which API guide**: `docs/which-api.md` — choosing between Sketcher, functional API, Drawing
 
+## Authoring with an AI Agent (brepjs-verify)
+
+If you are an LLM generating brepjs CAD, use `brepjs-verify` — a CLI that runs your model on a real kernel and returns a deterministic report. **Judge a part by the report, never by how the code reads.** Published on npm as `brepjs-verify`; the companion Claude Code skill installs via `/plugin marketplace add andymai/brepjs` then `/plugin install brepjs-verify@brepjs`.
+
+Install the runtime where `brepjs` resolves (it also bundles its own `brepjs` + `occt-wasm`, so it runs standalone):
+```bash
+npm i -D brepjs-verify
+```
+
+A model is a `.brep.ts` module: a default-exported zero-arg function returning a shape (or `Result<shape>`), optionally with an `expected` block that the CLI asserts:
+```ts
+import { box } from 'brepjs';
+export const expected = { volume: 8000, tolerancePct: 1 }; // optional: volume|area|bounds + tolerancePct
+export default () => box(40, 20, 10, { centered: true });
+```
+
+The loop, in order: brief → author `.brep.ts` → declare `expected` → `brepjs-verify verify part.brep.ts --check --json report.json` → review `--snapshot shots/` → repair the smallest responsible section → `--step part.step` and hand off. Use `npx -y brepjs-verify …` if not installed.
+
+The report (stdout JSON) is the source of truth:
+- `ok` — `true` only if valid AND every assertion passes. `false` → not done.
+- `checks` — kernel validity (manifold solid, positive volume). A failed check = broken geometry.
+- `measurements` — measured `volume`/`area`/`bounds`.
+- `assertions` — declared intent vs reality. A failed assertion = valid-but-wrong (off dimensions).
+- `hints` — actionable fix + next step keyed on an error `code`; read before guessing.
+- `errorInfos` — raw `{code,message}` failures (authoring/kernel/export). Cite the `code` when repairing.
+
+CLI subcommands: `verify <file>` (default; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`), `init <name>` (scaffold), `watch <file>`, `export <file>` (`--step`/`--glb`/`--stl`/`--all` behind a validity gate), `measure <a> [b]`, `diff <a> <b>`. Exits non-zero when not `ok`.
+
+Reliable first-try: primitives, booleans, 2D sketch → extrude, fillet/chamfer, shell/offset, transforms. Advanced (verify carefully, expect iteration): sweeps, lofts, revolves, multi-section, assemblies, text. Author parts in ESM (a CJS project needs `"type":"module"` or a `.mts` file); Node 24+ strips the part's types natively.
+
 ## Setup & Initialization
 
 Install:

--- a/llms.txt
+++ b/llms.txt
@@ -8,6 +8,36 @@
 - **Function lookup table**: `docs/function-lookup.md` — alphabetical index mapping every symbol to its sub-path
 - **Which API guide**: `docs/which-api.md` — choosing between Sketcher, functional API, Drawing
 
+## Authoring with an AI Agent (brepjs-verify)
+
+If you are an LLM generating brepjs CAD, use `brepjs-verify` — a CLI that runs your model on a real kernel and returns a deterministic report. **Judge a part by the report, never by how the code reads.** Published on npm as `brepjs-verify`; the companion Claude Code skill installs via `/plugin marketplace add andymai/brepjs` then `/plugin install brepjs-verify@brepjs`.
+
+Install the runtime where `brepjs` resolves (it also bundles its own `brepjs` + `occt-wasm`, so it runs standalone):
+```bash
+npm i -D brepjs-verify
+```
+
+A model is a `.brep.ts` module: a default-exported zero-arg function returning a shape (or `Result<shape>`), optionally with an `expected` block that the CLI asserts:
+```ts
+import { box } from 'brepjs';
+export const expected = { volume: 8000, tolerancePct: 1 }; // optional: volume|area|bounds + tolerancePct
+export default () => box(40, 20, 10, { centered: true });
+```
+
+The loop, in order: brief → author `.brep.ts` → declare `expected` → `brepjs-verify verify part.brep.ts --check --json report.json` → review `--snapshot shots/` → repair the smallest responsible section → `--step part.step` and hand off. Use `npx -y brepjs-verify …` if not installed.
+
+The report (stdout JSON) is the source of truth:
+- `ok` — `true` only if valid AND every assertion passes. `false` → not done.
+- `checks` — kernel validity (manifold solid, positive volume). A failed check = broken geometry.
+- `measurements` — measured `volume`/`area`/`bounds`.
+- `assertions` — declared intent vs reality. A failed assertion = valid-but-wrong (off dimensions).
+- `hints` — actionable fix + next step keyed on an error `code`; read before guessing.
+- `errorInfos` — raw `{code,message}` failures (authoring/kernel/export). Cite the `code` when repairing.
+
+CLI subcommands: `verify <file>` (default; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`), `init <name>` (scaffold), `watch <file>`, `export <file>` (`--step`/`--glb`/`--stl`/`--all` behind a validity gate), `measure <a> [b]`, `diff <a> <b>`. Exits non-zero when not `ok`.
+
+Reliable first-try: primitives, booleans, 2D sketch → extrude, fillet/chamfer, shell/offset, transforms. Advanced (verify carefully, expect iteration): sweeps, lofts, revolves, multi-section, assemblies, text. Author parts in ESM (a CJS project needs `"type":"module"` or a `.mts` file); Node 24+ strips the part's types natively.
+
 ## Setup & Initialization
 
 Install:


### PR DESCRIPTION
Adds comprehensive install + usage documentation for **brepjs-verify** across all three surfaces, scoped via AskUserQuestion.

## What's added

### Site docs — new "Authoring with AI" section (`apps/docs/agent/`)
A dedicated top-level sidebar group + top-nav entry with five pages:
- **Overview** — what it is, why a verify loop, install **both rails** (plugin via marketplace + CLI via npm), the `.brep.ts` contract, quickstart.
- **The Verify Loop** — the author → verify → repair workflow, reading the JSON report, repair discipline, reliable-vs-advanced scope, hard rules, programmatic API.
- **CLI Reference** — every subcommand + `verify` flag table, the `expected` contract, snapshots/serve, and a troubleshooting section (ESM, kernel/version-skew, puppeteer, Node 24).
- **Examples** — the few-shot gallery by category (primitives/booleans, sketch→solid, modifiers, gridfinity).
- **Eval & Scorecard** — deterministic CI gate (`npm run eval`) + the live flywheel (`eval:live`).

### Root README
New `## Authoring CAD with AI (brepjs-verify)` section: both install rails, the `.brep.ts` contract, a quickstart, and a link to the guide.

### Agent discovery
A `brepjs-verify` section added near the top of `llms.txt` and `llms-full.txt` so an agent reading brepjs's discovery files finds the authoring loop, report contract, and CLI surface.

## Verification
- `vitepress build` passes clean (no dead links).
- Prettier passes on all changed Markdown + the config.
- Docs-only change (no library source touched); the new `.brep.ts` snippets are valid TS for the doc-test extractor (skipped by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)