### PR TITLE
fix(brepjs-verify): correct fillet/chamfer arg order in no-edges hints

### DIFF
--- a/packages/brepjs-verify/src/verify/report.ts
+++ b/packages/brepjs-verify/src/verify/report.ts
@@ -100,12 +100,12 @@ const HINT_TABLE: Record<string, { fix: string; nextStep: string }> = {
   FILLET_NO_EDGES: {
     fix: 'Select real edges before filleting — pass an edge query (e.g. find edges by direction/position) or a non-empty edge list, not the whole solid.',
     nextStep:
-      'List the solid’s edges, pick the ones to round, then call fillet(solid, radius, edges).',
+      'List the solid’s edges, pick the ones to round, then call fillet(solid, edges, radius).',
   },
   CHAMFER_NO_EDGES: {
     fix: 'Select real edges before chamfering — pass a non-empty edge query/list rather than relying on a default that matched nothing.',
     nextStep:
-      'Enumerate the solid’s edges, choose the target edges, then call chamfer(solid, distance, edges).',
+      'Enumerate the solid’s edges, choose the target edges, then call chamfer(solid, edges, distance).',
   },
   INVALID_FILLET_RADIUS: {
     fix: 'Use a fillet radius that is > 0 and small enough to fit the adjacent faces (well under half the thinnest wall).',


### PR DESCRIPTION
## Problem

The runtime hint table in `packages/brepjs-verify/src/verify/report.ts` gives the agent **reversed arguments** for the two no-edges hints:

- `FILLET_NO_EDGES` → "call `fillet(solid, radius, edges)`"
- `CHAMFER_NO_EDGES` → "call `chamfer(solid, distance, edges)`"

brepjs's actual API is `fillet(solid, edges, radius)` and `chamfer(solid, edges, distance)` (confirmed against the public docs, the skill's `references/modifiers.md`, and the example parts). An agent that follows the hint verbatim would hit a type error on its next repair attempt — the opposite of what the hint is for.

## Fix

Two one-word swaps in the `nextStep` strings. No logic, types, or test changes; nothing else in the package references the wrong order.

Found during the accuracy audit for the docs PR (#1217). The skill and the new docs already use the correct order — this was the only place with it reversed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)