### PR TITLE
fix(manifold): native shapeType + OCCT-family resolution

### DIFF
--- a/src/kernel/manifold/kernel2dOps.ts
+++ b/src/kernel/manifold/kernel2dOps.ts
@@ -12,8 +12,8 @@
 
 import type { Kernel2DCapability } from '@/kernel/kernel2dTypes.js';
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
-import { getKernel } from '@/kernel/index.js';
 import type { ManifoldModule } from './helpers.js';
+import { resolveOcct } from './meshHandle.js';
 
 const KERNEL_2D_METHODS: readonly (keyof Kernel2DCapability)[] = [
   'createPoint2d',
@@ -84,10 +84,8 @@ const KERNEL_2D_METHODS: readonly (keyof Kernel2DCapability)[] = [
 function resolveOcct2D(
   method: keyof Kernel2DCapability
 ): Record<keyof Kernel2DCapability, (...a: unknown[]) => unknown> {
-  let occt: KernelAdapter;
-  try {
-    occt = getKernel('occt');
-  } catch {
+  const occt: KernelAdapter | undefined = resolveOcct();
+  if (!occt) {
     throw new Error(
       `manifold: ${method} unsupported on manifold kernel; no B-rep kernel registered`
     );

--- a/src/kernel/manifold/meshHandle.ts
+++ b/src/kernel/manifold/meshHandle.ts
@@ -30,12 +30,21 @@ export function asManifoldShape(shape: KernelShape): ManifoldShape | undefined {
   return undefined;
 }
 
+// OCCT-family kernel ids the op-graph can replay onto, in preference order.
+// Both register an OCCT B-rep kernel; `occt-wasm` is the common browser setup
+// (e.g. gridfinity registers only `occt-wasm` alongside `manifold`), so accept
+// it as a fallback rather than hard-requiring the literal `occt` id.
+const OCCT_FAMILY_IDS = ['occt', 'occt-wasm'] as const;
+
 export function resolveOcct(): KernelAdapter | undefined {
-  try {
-    return getKernel('occt');
-  } catch {
-    return undefined;
+  for (const id of OCCT_FAMILY_IDS) {
+    try {
+      return getKernel(id);
+    } catch {
+      // not registered under this id — try the next
+    }
   }
+  return undefined;
 }
 
 export function occtOrThrow(method: string): KernelAdapter {

--- a/src/kernel/manifold/topologyOps.ts
+++ b/src/kernel/manifold/topologyOps.ts
@@ -25,106 +25,91 @@ function brepOf(shape: KernelShape, method: string): { occt: KernelAdapter; brep
   return { occt, brep };
 }
 
+function shapeType(shape: KernelShape): ShapeType {
+  // A manifold-3d solid is, by construction, a watertight solid. Answer
+  // natively so castShape() can wrap boolean/primitive results without
+  // replaying the whole op-graph onto OCCT — the replay would erase the
+  // point of a fast mesh-CSG preview kernel (and require an occt kernel to
+  // even classify a shape). Non-manifold handles still classify via OCCT.
+  if (asManifoldShape(shape)) return 'solid';
+  const { occt, brep } = brepOf(shape, 'shapeType');
+  return occt.shapeType(brep);
+}
+
+function isSame(a: KernelShape, b: KernelShape): boolean {
+  const sa = asManifoldShape(a);
+  const sb = asManifoldShape(b);
+  if (!sa || !sb) return false;
+  return sa.manifold === sb.manifold;
+}
+
+function hashCode(shape: KernelShape, upperBound: number): number {
+  const ms = asManifoldShape(shape);
+  if (!ms) return 0;
+  // No per-node cache: occt.hashCode depends on upperBound (a node-keyed cache
+  // returns a stale out-of-range value when the bound changes). The expensive
+  // replay is already memoized in brepCache via brepOf.
+  const { occt, brep } = brepOf(shape, 'hashCode');
+  return occt.hashCode(brep, upperBound);
+}
+
+function isNull(shape: KernelShape): boolean {
+  const s = asManifoldShape(shape);
+  if (!s) return true;
+  const solid = unwrap(s);
+  return !solid || (typeof solid.isEmpty === 'function' && solid.isEmpty());
+}
+
+function iterShapes(shape: KernelShape, type: ShapeType): KernelShape[] {
+  const s = asManifoldShape(shape);
+  if (!s) return [];
+  if (type === 'solid') return [shape];
+  if (type !== 'edge' && type !== 'face') return [];
+  // Manifold has no B-rep edges/faces; replay to OCCT, then expose each
+  // sub-shape as a witness handle carrying its OCCT bounding box. Subset
+  // fillet/chamfer/shell selection re-identifies these by box center on replay.
+  if (!s.node.replayable) return [];
+  const occt = resolveOcct();
+  if (!occt) return [];
+  const brep =
+    brepCache.get(s.node) ??
+    (() => {
+      const b = replay(s.node, occt);
+      brepCache.set(s.node, b);
+      return b;
+    })();
+  return occt.iterShapes(brep, type).map((sub, index) => ({
+    __manifoldSub: true,
+    index,
+    box: occt.boundingBox(sub),
+  }));
+}
+
+function edgeToFaceMap(shape: KernelShape): string {
+  const { occt, brep } = brepOf(shape, 'edgeToFaceMap');
+  return occt.edgeToFaceMap(brep);
+}
+
+function adjacentFaces(shape: KernelShape, face: KernelShape): KernelShape[] {
+  const { occt, brep } = brepOf(shape, 'adjacentFaces');
+  return occt.adjacentFaces(brep, face);
+}
+
 export function makeTopologyOps(_module: ManifoldModule): KernelTopologyOps {
-  function shapeType(shape: KernelShape): ShapeType {
-    // A manifold-3d solid is, by construction, a watertight solid. Answer
-    // natively so castShape() can wrap boolean/primitive results without
-    // replaying the whole op-graph onto OCCT — the replay would erase the
-    // point of a fast mesh-CSG preview kernel (and require an occt kernel to
-    // even classify a shape). Non-manifold handles still classify via OCCT.
-    if (asManifoldShape(shape)) return 'solid';
-    const { occt, brep } = brepOf(shape, 'shapeType');
-    return occt.shapeType(brep);
-  }
-
-  function isSame(a: KernelShape, b: KernelShape): boolean {
-    const sa = asManifoldShape(a);
-    const sb = asManifoldShape(b);
-    if (!sa || !sb) return false;
-    return sa.manifold === sb.manifold;
-  }
-
-  function isEqual(a: KernelShape, b: KernelShape): boolean {
-    return isSame(a, b);
-  }
-
-  function hashCode(shape: KernelShape, upperBound: number): number {
-    const ms = asManifoldShape(shape);
-    if (!ms) return 0;
-    // No per-node cache: occt.hashCode depends on upperBound (a node-keyed cache
-    // returns a stale out-of-range value when the bound changes). The expensive
-    // replay is already memoized in brepCache via brepOf.
-    const { occt, brep } = brepOf(shape, 'hashCode');
-    return occt.hashCode(brep, upperBound);
-  }
-
-  function isNull(shape: KernelShape): boolean {
-    const s = asManifoldShape(shape);
-    if (!s) return true;
-    const solid = unwrap(s);
-    return !solid || (typeof solid.isEmpty === 'function' && solid.isEmpty());
-  }
-
-  function shapeOrientation(_shape: KernelShape): ShapeOrientation {
-    return 'forward';
-  }
-
-  function iterShapes(shape: KernelShape, type: ShapeType): KernelShape[] {
-    const s = asManifoldShape(shape);
-    if (!s) return [];
-    if (type === 'solid') return [shape];
-    if (type !== 'edge' && type !== 'face') return [];
-    // Manifold has no B-rep edges/faces; replay to OCCT, then expose each
-    // sub-shape as a witness handle carrying its OCCT bounding box. Subset
-    // fillet/chamfer/shell selection re-identifies these by box center on replay.
-    if (!s.node.replayable) return [];
-    const occt = resolveOcct();
-    if (!occt) return [];
-    const brep =
-      brepCache.get(s.node) ??
-      (() => {
-        const b = replay(s.node, occt);
-        brepCache.set(s.node, b);
-        return b;
-      })();
-    return occt.iterShapes(brep, type).map((sub, index) => ({
-      __manifoldSub: true,
-      index,
-      box: occt.boundingBox(sub),
-    }));
-  }
-
-  function iterShapeList(list: KernelShape, callback: (item: KernelShape) => void): void {
-    occtOrThrow('iterShapeList').iterShapeList(list, callback);
-  }
-
-  function edgeToFaceMap(shape: KernelShape): string {
-    const { occt, brep } = brepOf(shape, 'edgeToFaceMap');
-    return occt.edgeToFaceMap(brep);
-  }
-
-  function sharedEdges(faceA: KernelShape, faceB: KernelShape): KernelShape[] {
-    const occt = occtOrThrow('sharedEdges');
-    return occt.sharedEdges(faceA, faceB);
-  }
-
-  function adjacentFaces(shape: KernelShape, face: KernelShape): KernelShape[] {
-    const { occt, brep } = brepOf(shape, 'adjacentFaces');
-    return occt.adjacentFaces(brep, face);
-  }
-
   return {
     iterShapes,
-    iterShapeList,
+    iterShapeList: (list, callback) => {
+      occtOrThrow('iterShapeList').iterShapeList(list, callback);
+    },
     shapeType,
     isSame,
-    isEqual,
+    isEqual: isSame,
     downcast: (shape) => shape,
     hashCode,
     isNull,
-    shapeOrientation,
+    shapeOrientation: (_shape: KernelShape): ShapeOrientation => 'forward',
     edgeToFaceMap,
-    sharedEdges,
+    sharedEdges: (faceA, faceB) => occtOrThrow('sharedEdges').sharedEdges(faceA, faceB),
     adjacentFaces,
     sew: () => {
       throw new Error('manifold: sew is unsupported on the mesh kernel; use a B-rep kernel');

--- a/src/kernel/manifold/topologyOps.ts
+++ b/src/kernel/manifold/topologyOps.ts
@@ -27,6 +27,12 @@ function brepOf(shape: KernelShape, method: string): { occt: KernelAdapter; brep
 
 export function makeTopologyOps(_module: ManifoldModule): KernelTopologyOps {
   function shapeType(shape: KernelShape): ShapeType {
+    // A manifold-3d solid is, by construction, a watertight solid. Answer
+    // natively so castShape() can wrap boolean/primitive results without
+    // replaying the whole op-graph onto OCCT — the replay would erase the
+    // point of a fast mesh-CSG preview kernel (and require an occt kernel to
+    // even classify a shape). Non-manifold handles still classify via OCCT.
+    if (asManifoldShape(shape)) return 'solid';
     const { occt, brep } = brepOf(shape, 'shapeType');
     return occt.shapeType(brep);
   }


### PR DESCRIPTION
## What

Three correctness/perf fixes to the manifold kernel adapter, found while exercising it against a real sketch→extrude workload.

### 1. Native `shapeType` (the headline — a latent perf bug)
`shapeType` replayed the **entire op-graph onto OCCT** just to classify a shape. Because `castShape()` calls `shapeType` to wrap *every* boolean/primitive result, this meant **every manifold operation triggered a full OCCT rebuild** — and it threw outright when no OCCT kernel was registered, making the manifold kernel unusable standalone. A `manifold-3d` solid is by construction a watertight solid, so it now answers `'solid'` natively (matching what `iterShapes` already assumed). Non-manifold handles still classify via OCCT.

### 2. OCCT-family resolution in `resolveOcct` (`meshHandle.ts`)
`resolveOcct()` only looked up the literal kernel id `'occt'`. A common browser setup registers `'occt-wasm'` alongside `manifold`, so op-graph replay (exact B-rep for STEP/STL export, NURBS/topology queries) silently failed. Now prefers `'occt'`, falls back to the `'occt-wasm'` family. Replay is adapter-generic, so this is safe.

### 3. 2D-op delegation through `resolveOcct` (`kernel2dOps.ts`)
`resolveOcct2D` had its own hard-coded `'occt'` lookup with the same bug; routed it through the shared `resolveOcct()` so 2D curve construction delegates onto `occt-wasm` too.

Plus a small refactor hoisting `makeTopologyOps`'s stateless helpers to module scope (the shapeType comment pushed the factory over the 60-line patterns gate; no behavior change).

## Verification
- 116 manifold parity tests green (`tests/parity/manifold`)
- typecheck + lint + patterns-gate clean

## Notes
`shapeType` returning `'solid'` natively is also a meaningful speedup for anyone using the manifold kernel today — it removes a full OCCT replay from every wrapped result.