### PR TITLE
feat(manifold): exact analytic 1D curve queries (full curves parity)

### DIFF
--- a/src/kernel/manifold/builderOps.ts
+++ b/src/kernel/manifold/builderOps.ts
@@ -66,7 +66,8 @@ export function makeBuilderOps(module: ManifoldModule): KernelBuilderOps {
     makeBezierEdge: (points) => profile.makeBezierEdge(points),
     makeTangentArc: (startPoint, startTangent, endPoint) =>
       profile.makeTangentArc(startPoint, startTangent, endPoint),
-    makeHelixWire: () => notImplemented('makeHelixWire'),
+    makeHelixWire: (pitch, height, radius, center, direction, leftHanded) =>
+      profile.makeHelixWire(pitch, height, radius, center, direction, leftHanded),
     makeWireFromMixed: (items) => profile.makeWireFromMixed(items),
     makeCompound: () => notImplemented('makeCompound'),
     solidFromShell: () => notImplemented('solidFromShell'),

--- a/src/kernel/manifold/curveDesc.ts
+++ b/src/kernel/manifold/curveDesc.ts
@@ -1,0 +1,182 @@
+/**
+ * Analytic descriptors for the manifold kernel's standalone profile edges.
+ *
+ * Profile edges (makeLineEdge / makeCircleEdge / makeArcEdge / makeEllipseEdge /
+ * makeBezierEdge) also record an analytic {@link CurveDesc} alongside their
+ * sampled polyline, so 1D curve queries (length, type, point/tangent at param,
+ * closed/periodic) are answered *exactly* on the mesh kernel — no OCCT replay,
+ * no polyline approximation. Conics (circle/arc/ellipse) are unified as a center
+ * plus two in-plane unit axes and per-axis radii: `point(θ) = C + rx·cosθ·X +
+ * ry·sinθ·Y`, parametrized by angle; lines by signed distance (OCCT convention).
+ * @module
+ */
+
+type Vec3 = [number, number, number];
+type RVec3 = readonly [number, number, number];
+
+export type CurveDesc =
+  | { k: 'line'; p1: RVec3; p2: RVec3 }
+  | {
+      k: 'conic';
+      center: RVec3;
+      x: RVec3; // in-plane unit axis (cos direction)
+      y: RVec3; // in-plane unit axis (sin direction)
+      rx: number;
+      ry: number; // rx === ry ⇒ circle
+      a0: number;
+      a1: number;
+    }
+  | { k: 'bezier'; points: readonly RVec3[] }
+  | {
+      // point(θ) = C + r(cosθ·X + sinθ·Y) + (pitch·θ/2π)·axis, θ ∈ [0, 2π·turns]
+      k: 'helix';
+      center: RVec3;
+      axis: RVec3; // unit
+      x: RVec3; // unit, ⟂ axis
+      y: RVec3; // unit = axis × x
+      radius: number;
+      pitch: number;
+      turns: number;
+    };
+
+const TAU = 2 * Math.PI;
+const hypot3 = (a: RVec3): number => Math.hypot(a[0], a[1], a[2]);
+const sub3 = (a: RVec3, b: RVec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+
+function lineLen(d: { p1: RVec3; p2: RVec3 }): number {
+  return hypot3(sub3(d.p2, d.p1));
+}
+
+function bezierAt(points: readonly RVec3[], t: number): Vec3 {
+  const tmp = points.map((p) => [p[0], p[1], p[2]] as Vec3);
+  for (let k = 1; k < tmp.length; k++)
+    for (let i = 0; i < tmp.length - k; i++) {
+      const a = tmp[i] ?? [0, 0, 0];
+      const b = tmp[i + 1] ?? [0, 0, 0];
+      tmp[i] = [a[0] * (1 - t) + b[0] * t, a[1] * (1 - t) + b[1] * t, a[2] * (1 - t) + b[2] * t];
+    }
+  return tmp[0] ?? [0, 0, 0];
+}
+
+export function descType(d: CurveDesc): string {
+  if (d.k === 'line') return 'LINE';
+  if (d.k === 'bezier') return 'BEZIER';
+  if (d.k === 'helix') return 'BSPLINE';
+  return Math.abs(d.rx - d.ry) < 1e-9 * Math.max(1, d.rx) ? 'CIRCLE' : 'ELLIPSE';
+}
+
+/** Parameter bounds: line → [0, length]; conic → [a0, a1]; helix → [0, 2π·turns]; bezier → [0, 1]. */
+export function descBounds(d: CurveDesc): { first: number; last: number } {
+  if (d.k === 'line') return { first: 0, last: lineLen(d) };
+  if (d.k === 'conic') return { first: d.a0, last: d.a1 };
+  if (d.k === 'helix') return { first: 0, last: TAU * d.turns };
+  return { first: 0, last: 1 };
+}
+
+export function descPointAt(d: CurveDesc, param: number): Vec3 {
+  if (d.k === 'line') {
+    const len = lineLen(d) || 1;
+    const t = param / len;
+    return [
+      d.p1[0] + (d.p2[0] - d.p1[0]) * t,
+      d.p1[1] + (d.p2[1] - d.p1[1]) * t,
+      d.p1[2] + (d.p2[2] - d.p1[2]) * t,
+    ];
+  }
+  if (d.k === 'bezier') return bezierAt(d.points, param);
+  if (d.k === 'helix') {
+    const ct = Math.cos(param);
+    const st = Math.sin(param);
+    const z = (d.pitch * param) / TAU;
+    return [
+      d.center[0] + d.radius * (ct * d.x[0] + st * d.y[0]) + z * d.axis[0],
+      d.center[1] + d.radius * (ct * d.x[1] + st * d.y[1]) + z * d.axis[1],
+      d.center[2] + d.radius * (ct * d.x[2] + st * d.y[2]) + z * d.axis[2],
+    ];
+  }
+  const ct = Math.cos(param);
+  const st = Math.sin(param);
+  return [
+    d.center[0] + d.rx * ct * d.x[0] + d.ry * st * d.y[0],
+    d.center[1] + d.rx * ct * d.x[1] + d.ry * st * d.y[1],
+    d.center[2] + d.rx * ct * d.x[2] + d.ry * st * d.y[2],
+  ];
+}
+
+export function descTangent(d: CurveDesc, param: number): Vec3 {
+  let t: Vec3;
+  if (d.k === 'line') {
+    t = sub3(d.p2, d.p1);
+  } else if (d.k === 'bezier') {
+    const a = bezierAt(d.points, Math.max(0, param - 1e-4));
+    const b = bezierAt(d.points, Math.min(1, param + 1e-4));
+    t = sub3(b, a);
+  } else if (d.k === 'helix') {
+    const ct = Math.cos(param);
+    const st = Math.sin(param);
+    // d/dθ: r(−sinθ X + cosθ Y) + (pitch/2π) axis
+    const k = d.pitch / TAU;
+    t = [
+      d.radius * (-st * d.x[0] + ct * d.y[0]) + k * d.axis[0],
+      d.radius * (-st * d.x[1] + ct * d.y[1]) + k * d.axis[1],
+      d.radius * (-st * d.x[2] + ct * d.y[2]) + k * d.axis[2],
+    ];
+  } else {
+    const ct = Math.cos(param);
+    const st = Math.sin(param);
+    // d/dθ (C + rx cosθ X + ry sinθ Y) = −rx sinθ X + ry cosθ Y
+    t = [
+      -d.rx * st * d.x[0] + d.ry * ct * d.y[0],
+      -d.rx * st * d.x[1] + d.ry * ct * d.y[1],
+      -d.rx * st * d.x[2] + d.ry * ct * d.y[2],
+    ];
+  }
+  const l = hypot3(t) || 1;
+  return [t[0] / l, t[1] / l, t[2] / l];
+}
+
+/** Exact length where closed-form exists; Ramanujan for full ellipses; numeric otherwise. */
+export function descLength(d: CurveDesc): number {
+  if (d.k === 'line') return lineLen(d);
+  if (d.k === 'helix') {
+    const c = TAU * d.radius;
+    return d.turns * Math.sqrt(c * c + d.pitch * d.pitch);
+  }
+  if (d.k === 'conic') {
+    const span = Math.abs(d.a1 - d.a0);
+    if (Math.abs(d.rx - d.ry) < 1e-9 * Math.max(1, d.rx)) return d.rx * span; // circular arc
+    if (Math.abs(span - TAU) < 1e-9) {
+      // Ramanujan II for a full ellipse perimeter
+      const a = d.rx;
+      const b = d.ry;
+      const h = ((a - b) * (a - b)) / ((a + b) * (a + b));
+      return Math.PI * (a + b) * (1 + (3 * h) / (10 + Math.sqrt(4 - 3 * h)));
+    }
+    return numericLength((t) => descPointAt(d, t), d.a0, d.a1, 256);
+  }
+  return numericLength((t) => descPointAt(d, t), 0, 1, 128);
+}
+
+export function descIsClosed(d: CurveDesc): boolean {
+  if (d.k === 'conic') return Math.abs(Math.abs(d.a1 - d.a0) - TAU) < 1e-9;
+  return false;
+}
+
+export function descIsPeriodic(d: CurveDesc): boolean {
+  return descIsClosed(d);
+}
+
+export function descPeriod(d: CurveDesc): number {
+  return d.k === 'conic' ? TAU : 0;
+}
+
+function numericLength(at: (t: number) => Vec3, t0: number, t1: number, n: number): number {
+  let len = 0;
+  let prev = at(t0);
+  for (let i = 1; i <= n; i++) {
+    const p = at(t0 + ((t1 - t0) * i) / n);
+    len += hypot3(sub3(p, prev));
+    prev = p;
+  }
+  return len;
+}

--- a/src/kernel/manifold/geometryOps.ts
+++ b/src/kernel/manifold/geometryOps.ts
@@ -21,6 +21,16 @@ import { asManifoldShape, brepCache, occtOrThrow, resolveOcct, unwrap } from './
 import { replay } from './replay.js';
 import { isNativeFace } from './nativeFaces.js';
 import { isNativeEdge, isNativeVertex, edgePointAt, edgeTangentAt } from './nativeEdges.js';
+import {
+  type CurveDesc,
+  descType,
+  descBounds,
+  descPointAt,
+  descTangent,
+  descIsClosed,
+  descIsPeriodic,
+  descPeriod,
+} from './curveDesc.js';
 
 type Vec3 = [number, number, number];
 
@@ -81,26 +91,59 @@ function viaOcct<T>(
   return query(occtShape, occt);
 }
 
+/** The analytic curve descriptor of a standalone profile edge, if it has one. */
+function descOf(shape: KernelShape): CurveDesc | undefined {
+  const ms = asManifoldShape(shape);
+  if (!ms) return undefined;
+  const node = ms.node as { op?: string; params?: { curve?: CurveDesc } };
+  return node.op === 'profileEdge' ? node.params?.curve : undefined;
+}
+
 export function makeGeometryOps(_module: ManifoldModule): KernelCurveOps & KernelSurfaceOps {
   return {
-    // --- Curve queries: native for mesh-extracted edges, else replay onto OCCT ---
-    curveType: (shape) =>
-      isNativeEdge(shape) ? shape.curveType : viaOcct(shape, (s, occt) => occt.curveType(s)),
-    curveParameters: (shape) =>
-      isNativeEdge(shape)
+    // --- Curve queries: analytic for standalone profile edges (exact), native
+    // for mesh-extracted edges, else replay onto OCCT ---
+    curveType: (shape) => {
+      const d = descOf(shape);
+      if (d) return descType(d);
+      return isNativeEdge(shape) ? shape.curveType : viaOcct(shape, (s, occt) => occt.curveType(s));
+    },
+    curveParameters: (shape) => {
+      const d = descOf(shape);
+      if (d) {
+        const b = descBounds(d);
+        return [b.first, b.last];
+      }
+      return isNativeEdge(shape)
         ? [0, shape.length]
-        : viaOcct(shape, (s, occt) => occt.curveParameters(s)),
-    curvePointAtParam: (shape, param) =>
-      isNativeEdge(shape)
+        : viaOcct(shape, (s, occt) => occt.curveParameters(s));
+    },
+    curvePointAtParam: (shape, param) => {
+      const d = descOf(shape);
+      if (d) return descPointAt(d, param);
+      return isNativeEdge(shape)
         ? edgePointAt(shape, param)
-        : viaOcct(shape, (s, occt) => occt.curvePointAtParam(s, param)),
-    curveTangent: (shape, param) =>
-      isNativeEdge(shape)
+        : viaOcct(shape, (s, occt) => occt.curvePointAtParam(s, param));
+    },
+    curveTangent: (shape, param) => {
+      const d = descOf(shape);
+      if (d) return { point: descPointAt(d, param), tangent: descTangent(d, param) };
+      return isNativeEdge(shape)
         ? { point: edgePointAt(shape, param), tangent: edgeTangentAt(shape, param) }
-        : viaOcct(shape, (s, occt) => occt.curveTangent(s, param)),
-    curveIsClosed: (shape) => viaOcct(shape, (s, occt) => occt.curveIsClosed(s)),
-    curveIsPeriodic: (shape) => viaOcct(shape, (s, occt) => occt.curveIsPeriodic(s)),
-    curvePeriod: (shape) => viaOcct(shape, (s, occt) => occt.curvePeriod(s)),
+        : viaOcct(shape, (s, occt) => occt.curveTangent(s, param));
+    },
+    curveIsClosed: (shape) => {
+      const d = descOf(shape);
+      return d ? descIsClosed(d) : viaOcct(shape, (s, occt) => occt.curveIsClosed(s));
+    },
+    curveIsPeriodic: (shape) => {
+      const d = descOf(shape);
+      return d ? descIsPeriodic(d) : viaOcct(shape, (s, occt) => occt.curveIsPeriodic(s));
+    },
+    curvePeriod: (shape) => {
+      const d = descOf(shape);
+      return d ? descPeriod(d) : viaOcct(shape, (s, occt) => occt.curvePeriod(s));
+    },
     interpolatePoints: (points, options) =>
       occtOrThrow('interpolatePoints').interpolatePoints(points, options),
     approximatePoints: (points, options) =>

--- a/src/kernel/manifold/measureOps.ts
+++ b/src/kernel/manifold/measureOps.ts
@@ -23,6 +23,7 @@ import {
   unwrap,
 } from './meshHandle.js';
 import { replay } from './replay.js';
+import { type CurveDesc, descLength } from './curveDesc.js';
 
 type Vec3 = [number, number, number];
 
@@ -285,6 +286,10 @@ export function makeMeasureOps(_module: ManifoldModule): KernelMeasureOps {
       // Native edge witnesses carry their polyline arc length.
       const e = shape as { __nativeEdge?: boolean; length?: number } | null;
       if (e && e.__nativeEdge && typeof e.length === 'number') return e.length;
+      // Standalone profile edges carry an exact analytic descriptor.
+      const ms = asManifoldShape(shape);
+      const node = ms?.node as { op?: string; params?: { curve?: CurveDesc } } | undefined;
+      if (node?.op === 'profileEdge' && node.params?.curve) return descLength(node.params.curve);
       return notImplemented('length');
     },
     centerOfMass: (shape) => centerOfMass(shape),

--- a/src/kernel/manifold/profileOps.ts
+++ b/src/kernel/manifold/profileOps.ts
@@ -456,7 +456,7 @@ export function makeProfileBuilders(_module: ManifoldModule): ProfileBuilders {
       const axis = normalize3(direction);
       const x = pickPerp(axis);
       const y0 = normalize3(cross(axis, x));
-      const y = leftHanded ? (scaleVec(y0, -1)) : y0;
+      const y = leftHanded ? scaleVec(y0, -1) : y0;
       const turns = pitch !== 0 ? height / pitch : 0;
       const desc: CurveDesc = { k: 'helix', center, axis, x, y, radius, pitch, turns };
       const segs = Math.max(8, Math.ceil(turns * FULL_CIRCLE_SEGMENTS));

--- a/src/kernel/manifold/profileOps.ts
+++ b/src/kernel/manifold/profileOps.ts
@@ -19,6 +19,7 @@ import type { KernelShape } from '@/kernel/types.js';
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
 import type { ManifoldModule } from './helpers.js';
 import { makeNode, type OpNode } from './opGraph.js';
+import { type CurveDesc, descPointAt } from './curveDesc.js';
 import { wrap, nodeOf, asManifoldShape, resolveOcct } from './meshHandle.js';
 import {
   add,
@@ -231,6 +232,14 @@ export interface ProfileBuilders {
   ): KernelShape;
   makeBezierEdge(points: Vec3[]): KernelShape;
   makeTangentArc(startPoint: Vec3, startTangent: Vec3, endPoint: Vec3): KernelShape;
+  makeHelixWire(
+    pitch: number,
+    height: number,
+    radius: number,
+    center?: Vec3,
+    direction?: Vec3,
+    leftHanded?: boolean
+  ): KernelShape;
   makeWire(edges: KernelShape[]): KernelShape;
   makeWireFromMixed(items: KernelShape[]): KernelShape;
   makeFace(wire: KernelShape, planar?: boolean): KernelShape;
@@ -239,8 +248,39 @@ export interface ProfileBuilders {
 }
 
 export function makeProfileBuilders(_module: ManifoldModule): ProfileBuilders {
-  function edge(pts: Pts): KernelShape {
-    return wrap(PLACEHOLDER, makeNode('profileEdge', { pts }, [])) as KernelShape;
+  function edge(pts: Pts, curve?: CurveDesc): KernelShape {
+    const params = curve ? { pts, curve } : { pts };
+    return wrap(PLACEHOLDER, makeNode('profileEdge', params, [])) as KernelShape;
+  }
+
+  /** In-plane orthonormal frame (x, y) for a conic on a plane with the given normal. */
+  function conicFrame(normal: Vec3, xDir?: Vec3): { x: Vec3; y: Vec3 } {
+    const n = normalize3(normal);
+    const x = xDir ? normalize3(xDir) : pickPerp(n);
+    return { x, y: normalize3(cross(n, x)) };
+  }
+
+  /** Analytic conic descriptor for the circle through three points (or null if collinear). */
+  function conicDescFrom3(p1: Vec3, p2: Vec3, p3: Vec3): CurveDesc | undefined {
+    const v1 = sub(p2, p1);
+    const v2 = sub(p3, p1);
+    const n = cross(v1, v2);
+    if (length3(n) < 1e-12) return undefined;
+    const nn = normalize3(n);
+    const b = dot(v1, v1);
+    const c = dot(v2, v2);
+    const dd = dot(v1, v2);
+    const denom = 2 * (b * c - dd * dd);
+    if (Math.abs(denom) < 1e-18) return undefined;
+    const s = (c * (b - dd)) / denom;
+    const t = (b * (c - dd)) / denom;
+    const center = add(p1, add(scaleVec(v1, s), scaleVec(v2, t)));
+    const radius = length3(sub(p1, center));
+    const x = normalize3(sub(p1, center));
+    const y = normalize3(cross(nn, x));
+    let a1 = Math.atan2(dot(sub(p3, center), y), dot(sub(p3, center), x));
+    if (a1 < 0) a1 += 2 * Math.PI;
+    return { k: 'conic', center, x, y, rx: radius, ry: radius, a0: 0, a1 };
   }
 
   // Edge/wire handles carry `pts`/`ring`; OCCT shapes (2D-delegated blueprint
@@ -358,18 +398,74 @@ export function makeProfileBuilders(_module: ManifoldModule): ProfileBuilders {
 
   return {
     makeVertex: (x, y, z) => edge([[x, y, z]]),
-    makeLineEdge: (p1, p2) => edge([p1, p2]),
-    makeCircleEdge: (center, normal, radius) =>
-      edge(sampleArc(center, normal, radius, 0, 2 * Math.PI)),
-    makeCircleArc: (center, normal, radius, startAngle, endAngle) =>
-      edge(sampleArc(center, normal, radius, startAngle, endAngle)),
-    makeArcEdge: (p1, p2, p3) => edge(circleFrom3(p1, p2, p3)),
-    makeEllipseEdge: (center, normal, majorRadius, minorRadius, xDir) =>
-      edge(ellipsePts(center, normal, majorRadius, minorRadius, xDir)),
-    makeBezierEdge: (points) => edge(sampleBezier(points)),
+    makeLineEdge: (p1, p2) => edge([p1, p2], { k: 'line', p1, p2 }),
+    makeCircleEdge: (center, normal, radius) => {
+      const { x, y } = conicFrame(normal);
+      return edge(sampleArc(center, normal, radius, 0, 2 * Math.PI), {
+        k: 'conic',
+        center,
+        x,
+        y,
+        rx: radius,
+        ry: radius,
+        a0: 0,
+        a1: 2 * Math.PI,
+      });
+    },
+    makeCircleArc: (center, normal, radius, startAngle, endAngle) => {
+      const { x, y } = conicFrame(normal);
+      return edge(sampleArc(center, normal, radius, startAngle, endAngle), {
+        k: 'conic',
+        center,
+        x,
+        y,
+        rx: radius,
+        ry: radius,
+        a0: startAngle,
+        a1: endAngle,
+      });
+    },
+    makeArcEdge: (p1, p2, p3) => edge(circleFrom3(p1, p2, p3), conicDescFrom3(p1, p2, p3)),
+    makeEllipseEdge: (center, normal, majorRadius, minorRadius, xDir) => {
+      const { x, y } = conicFrame(normal, xDir);
+      return edge(ellipsePts(center, normal, majorRadius, minorRadius, xDir), {
+        k: 'conic',
+        center,
+        x,
+        y,
+        rx: majorRadius,
+        ry: minorRadius,
+        a0: 0,
+        a1: 2 * Math.PI,
+      });
+    },
+    makeBezierEdge: (points) =>
+      edge(sampleBezier(points), { k: 'bezier', points: points.map((p) => [...p]) }),
     // Tangent arcs are rare in gridfinity profiles; approximate as a chord for
     // now (TODO: sample the true tangent-constrained arc when a profile needs it).
-    makeTangentArc: (startPoint, _startTangent, endPoint) => edge([startPoint, endPoint]),
+    makeTangentArc: (startPoint, _startTangent, endPoint) =>
+      edge([startPoint, endPoint], { k: 'line', p1: startPoint, p2: endPoint }),
+    makeHelixWire: (
+      pitch,
+      height,
+      radius,
+      center = [0, 0, 0],
+      direction = [0, 0, 1],
+      leftHanded = false
+    ) => {
+      const axis = normalize3(direction);
+      const x = pickPerp(axis);
+      const y0 = normalize3(cross(axis, x));
+      const y = leftHanded ? (scaleVec(y0, -1)) : y0;
+      const turns = pitch !== 0 ? height / pitch : 0;
+      const desc: CurveDesc = { k: 'helix', center, axis, x, y, radius, pitch, turns };
+      const segs = Math.max(8, Math.ceil(turns * FULL_CIRCLE_SEGMENTS));
+      const pts: Pts = [];
+      for (let i = 0; i <= segs; i++) {
+        pts.push(descPointAt(desc, (2 * Math.PI * turns * i) / segs));
+      }
+      return edge(pts, desc);
+    },
     makeWire: (edges) => wireFrom(edges),
     makeWireFromMixed: (items) => wireFrom(items),
     makeFace,


### PR DESCRIPTION
## What

Makes the manifold kernel answer **1D curve queries exactly** — length, type, point/tangent at parameter, closed/periodic/period — for standalone profile edges, instead of throwing or returning polyline approximations. Brings `tests/parity/curves.test.ts` to full parity (41 failing → 0).

## How

Each profile edge (`makeLineEdge`/`makeCircleEdge`/`makeCircleArc`/`makeArcEdge`/`makeEllipseEdge`/`makeBezierEdge`, plus a newly-implemented native `makeHelixWire`) records an analytic `CurveDesc` (`curveDesc.ts`) next to its sampled polyline:
- **line** — distance-parametrized; exact length/midpoint/unit-tangent
- **conic** (circle/arc/ellipse) — center + two in-plane unit axes + per-axis radii; exact circumference (Ramanujan II for a full ellipse), closed/periodic/period
- **helix** — closed-form length `turns·√((2πr)² + pitch²)`; `makeHelixWire` was previously `notImplemented` on manifold

`geometryOps` (`curveType`/`curveParameters`/`curvePointAtParam`/`curveTangent`/`curveIsClosed`/`curveIsPeriodic`/`curvePeriod`) and `measureOps.length` read the descriptor for an exact, OCCT-free answer; non-descriptor shapes fall back to the existing native-edge / OCCT-replay paths.

## Validation

- `tests/parity/curves.test.ts` 164/164 (was 41 failing)
- Construction path unchanged (`native2d`, `profileExtrude`, `nativeFaces`, `nativeEdges` all green) — `makeWire`/`makeFace` read `pts`, not the new `curve` param
- Overall manifold parity-suite failures 105 → 66

Follows #1223 (native manifold preview kernel).
