### PR TITLE
docs(agent): rework Authoring with AI for first-time approachability

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -96,16 +96,6 @@ export default withMermaid(
           ],
         },
         {
-          text: 'Authoring with AI',
-          items: [
-            { text: 'Overview', link: '/agent/overview' },
-            { text: 'The Verify Loop', link: '/agent/the-loop' },
-            { text: 'CLI Reference', link: '/agent/cli' },
-            { text: 'Examples', link: '/agent/examples' },
-            { text: 'Eval & Scorecard', link: '/agent/eval' },
-          ],
-        },
-        {
           text: 'Core Concepts',
           items: [
             { text: 'B-Rep vs Mesh', link: '/concepts/brep-vs-mesh' },
@@ -139,6 +129,16 @@ export default withMermaid(
             { text: 'Web Workers', link: '/advanced/workers' },
             { text: 'Healing & Sewing', link: '/advanced/healing' },
             { text: 'CSG Caching & Optimization', link: '/advanced/csg-caching' },
+          ],
+        },
+        {
+          text: 'Authoring with AI',
+          items: [
+            { text: 'Overview', link: '/agent/overview' },
+            { text: 'The Verify Loop', link: '/agent/the-loop' },
+            { text: 'CLI Reference', link: '/agent/cli' },
+            { text: 'Examples', link: '/agent/examples' },
+            { text: 'Eval & Scorecard', link: '/agent/eval' },
           ],
         },
         {

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -91,4 +91,4 @@ Each declared field appears in `report.assertions` as `{ name, expected, actual,
 ## Next steps
 
 - [The Verify Loop](./the-loop) — how to use these commands as a workflow
-- [Eval & Scorecard](./eval) — the measurement flywheel
+- [Eval & Scorecard](./eval) — how the skill measures itself

--- a/apps/docs/agent/eval.md
+++ b/apps/docs/agent/eval.md
@@ -1,11 +1,11 @@
 ---
 title: Eval & Scorecard
-description: 'How brepjs-verify measures itself — a deterministic replay that gates CI, plus an opt-in live flywheel that sends natural-language prompts to a model under the deployed skill and scores validity + visual intent.'
+description: 'How brepjs-verify measures itself — a deterministic replay that gates CI, plus an opt-in live eval that sends natural-language prompts to a model under the deployed skill and scores validity + visual intent.'
 ---
 
 # Eval & Scorecard
 
-`brepjs-verify` measures itself two ways: a **deterministic replay** that runs in CI, and an opt-in **live flywheel** that exercises the actual skill against a real model. Together they keep the skill honest as brepjs and the kernel evolve.
+A verify loop is only as good as you can prove it is. `brepjs-verify` measures itself two ways: a **deterministic replay** that runs in CI, and an opt-in **live eval** that exercises the actual skill against a real model. Together they keep the skill honest as brepjs and the kernel evolve.
 
 ## Deterministic eval (CI gate)
 
@@ -17,7 +17,7 @@ npm run eval
 
 It is fully deterministic — **no LLM, no API key** — so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an _intentional_ geometry change; an unintentional change surfaces as a failure.
 
-## Live eval — the flywheel (`eval:live`)
+## Live eval (`eval:live`)
 
 This is how you measure the skill itself, not just the geometry. It sends ~18 natural-language part prompts (`bench/prompts.ts`) to a real model — using the **deployed `SKILL.md` as the system prompt**, so it measures exactly what an agent sees — then verifies each generated part two ways:
 

--- a/apps/docs/agent/overview.md
+++ b/apps/docs/agent/overview.md
@@ -1,41 +1,54 @@
 ---
 title: Authoring CAD with AI
-description: 'brepjs-verify is an agent skill plus a verification CLI that turns natural-language part requirements into valid brepjs solids — type-checked, measured against intent, and snapshot-reviewed before handoff.'
+description: 'brepjs-verify lets an AI agent author parametric CAD in brepjs and prove it is correct — type-checked, measured against intent, and snapshot-reviewed — before handing off STEP.'
 ---
 
 # Authoring CAD with AI
 
-[`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) lets an AI agent author parametric CAD in brepjs and **prove it is correct** before handing it off. An LLM can't see geometry — so it writes a `.brep.ts` part, runs it against a real OpenCascade kernel, and reads the deterministic report instead of guessing from how the code looks.
+Ask for a part in plain English. The agent writes it, runs it on a real CAD kernel, and proves it is correct before handing it back.
 
-It ships as **two cooperating pieces**:
+```
+   "a 40×20×10 mm bracket with two M4 holes"
+                  │  agent writes bracket.brep.ts and runs
+                  ▼  it on a real OpenCascade kernel
+   ────────────────────────────────────────────────────
+   ✓ valid solid       ✓ volume ≈ 7,750 mm³ (within 1%)
+   ✓ snapshots rendered    →  bracket.step ready to hand off
+```
 
-- **The skill** — a Claude Code plugin that teaches the agent the authoring loop (brief → author → verify → repair). It carries the API references, examples, and discipline. This is the _brain_.
-- **The runtime** — the `brepjs-verify` CLI the skill drives. It loads the part on a real kernel, checks validity, measures volume/area/bounds, renders snapshots, and exports STEP. This is the _hands_.
+An LLM can't see geometry. Code that reads correctly can still produce a solid that is broken, empty, or simply the wrong size — and the model has no way to notice. [`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) takes the guesswork out: the agent writes the part, runs it against a real kernel, and reads back what the kernel actually measured instead of judging the code by eye.
 
-You install both — they ride on two different rails because Claude Code discovers skills from plugins (a git marketplace), never from `node_modules`, while the runtime must live where your project's `brepjs` resolves.
+## What it checks
 
-## Why a verify loop
+Every part gets three independent verdicts, so a pass means more than "the code ran":
 
-The kernel is the only honest judge of a B-Rep model. Code that reads correctly can still produce a non-manifold solid, a zero-volume shape, or a part that is valid but the wrong size. `brepjs-verify` collapses that uncertainty into a single machine-readable verdict:
+- **Validity** — is it a real manifold solid with positive volume? (the kernel's `validSolid` brand)
+- **Intent** — does it match the dimensions you asked for? (`measureVolume` / `measureArea` / bounds vs an `expected` block)
+- **Shape** — does it actually look like the request? (multi-view PNG snapshots, for the agent or you to review)
 
-- **Validity** — is it a real manifold solid with positive volume? (kernel `validSolid` brand)
-- **Intent** — does it match the declared dimensions? (`measureVolume`/`measureArea`/bounds vs an `expected` block)
-- **Shape** — does the render match the request? (multi-view PNG snapshots, for the agent or a human to review)
+STEP is the validated deliverable; GLB, STL, and snapshots are derived previews.
 
-STEP is the validated primary deliverable; GLB/STL/snapshots are derived previews.
+## What you install
 
-## Install — the skill (Claude Code plugin)
+`brepjs-verify` is two parts that work together:
 
-The skill is delivered through the brepjs plugin marketplace, which is just this git repo. Add the marketplace once, then install the plugin:
+- **The skill** teaches the agent the workflow — brief → author → verify → repair — and carries the API references and examples it learns from.
+- **The runtime** is the CLI the skill drives. It loads your part on a real kernel, checks validity, measures volume / area / bounds, renders snapshots, and exports STEP.
+
+They install separately because Claude Code loads skills from plugins (a git marketplace), while the runtime has to live wherever your project's `brepjs` resolves. You install both once and never think about it again.
+
+### Install the skill (Claude Code plugin)
+
+The skill ships through the brepjs plugin marketplace — which is just this git repo. Add the marketplace once, then install the plugin:
 
 ```
 /plugin marketplace add andymai/brepjs
 /plugin install brepjs-verify@brepjs
 ```
 
-Claude Code now knows the authoring workflow and will invoke the CLI on your behalf. There is no npm step for the skill — plugins are not loaded from `node_modules`.
+Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill — plugins aren't loaded from `node_modules`.
 
-## Install — the runtime (npm)
+### Install the runtime (npm)
 
 Add the CLI to the project where you want parts verified:
 
@@ -43,11 +56,11 @@ Add the CLI to the project where you want parts verified:
 npm i -D brepjs-verify
 ```
 
-That's the whole install. `brepjs-verify` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory with nothing else installed. **In an existing brepjs project** it automatically prefers your locally installed `brepjs` and kernel (via a Node module-resolution hook), so your verified parts bind to the exact version you ship — no version skew between what you verify and what you build.
+That's the whole install. `brepjs-verify` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory with nothing else set up. **In an existing brepjs project** it automatically prefers your locally installed `brepjs` and kernel (via a Node module-resolution hook), so your verified parts bind to the exact version you ship — no drift between what you verify and what you build.
 
-The runtime initializes **occt-wasm** as its sole kernel (`OcctKernel.init()` + `registerKernel`), not the auto-detect fallback chain — so verification results are reproducible on one known engine.
+It runs **occt-wasm** as its only kernel, rather than the auto-detect fallback chain, so verification results are reproducible on one known engine.
 
-You can also run it without installing, straight from npm:
+Prefer not to install anything? Run it straight from npm:
 
 ```bash
 npx -y brepjs-verify part.brep.ts
@@ -66,7 +79,7 @@ import { box } from 'brepjs';
 export default () => box(40, 20, 10, { centered: true });
 ```
 
-Optionally declare intent with an `expected` block — the CLI asserts it, so you prove the part is the _right_ part, not merely a valid one:
+Declare intent with an `expected` block and the CLI asserts it — so you prove the part is the _right_ part, not just a valid one:
 
 <!-- @no-test -->
 
@@ -96,9 +109,13 @@ npx -y brepjs-verify verify bracket/bracket.brep.ts --step bracket.step
 
 The command exits non-zero whenever the report is not `ok`, so it drops straight into CI or an agent loop.
 
+## Why I built this
+
+I write CAD as code, but I can't trust an agent to write it blind — and neither can the agent. Geometry that reads fine on the page is constantly wrong in ways only the kernel can see: a boolean that didn't overlap, a fillet that collapsed a face, a part that's valid but 3 mm too tall. So I gave the agent the one thing it was missing: a way to run the part, measure it, look at it, and find out the truth before claiming it's done. That loop is the whole idea — the rest is plumbing.
+
 ## Next steps
 
 - [The Verify Loop](./the-loop) — the author → verify → repair workflow and how to read the report
 - [CLI Reference](./cli) — every subcommand, flag, and exit code
-- [Examples](./examples) — the few-shot gallery the skill learns from
-- [Eval & Scorecard](./eval) — the measurement flywheel that proves the skill
+- [Examples](./examples) — the example gallery the skill learns from
+- [Eval & Scorecard](./eval) — how the skill measures itself and stays honest


### PR DESCRIPTION
## What

Reworks the **Authoring with AI** docs section (`apps/docs/agent/`) to match the approachability and first-time UX of the rest of the docs (`getting-started/`, `introduction/why-brepjs`).

### Changes
- **`agent/overview.md`** — rewritten to lead with a concrete *"watch it work"* example (plain-English ask → verified part + report) instead of opening cold and abstract. Dropped the marketing metaphors ("the brain / the hands", "two rails", "honest judge"). Both installs kept in place with plainer wording. Added a short first-person *"Why I built this"* note in the voice of `why-brepjs`.
- **Cringe-word purge** — removed "flywheel" (and the brain/hands/rails metaphors) across `overview.md`, `eval.md`, `cli.md`.
- **Sidebar demotion** (`.vitepress/config.ts`) — moved the section out of the #3 slot (right under Getting Started) down below **Advanced**, so it no longer sits above Core Concepts / Common Tasks. Top nav entry left as-is (deliberate discoverability surface).

### Verification
- `vitepress build` passes, **no dead links**
- Doc-test harness regenerates with **zero diff** (all `agent/` code blocks are `@no-test`)
- Prettier clean on all changed files
- Fixed a factual defect found while auditing: the hero diagram's bracket volume (was 7,600 mm³, contradicted the "within 1%" claim next to it) → ≈7,750 mm³

Docs-only; no library code touched.