### PR TITLE
test(voxel): resolution-bound parity/conformance suite

### DIFF
--- a/tests/parity/voxel/README.md
+++ b/tests/parity/voxel/README.md
@@ -1,0 +1,106 @@
+# `tests/parity/voxel/` — voxel-domain behavioral spec
+
+The kernel-agnostic spec for the **voxel / SDF domain** (ADR-0013). It is the
+voxel analog of [`../README.md`](../README.md), but the voxel domain is a
+parallel domain — **not** a `KernelAdapter` — so the kernel-swap harness in
+`../*.ts` does not apply, and the rules differ.
+
+## Why a separate suite
+
+Voxel ops take a triangle-soup `VoxelMeshInput` and return a `KernelMeshResult`
+mesh; they never touch `getKernel`/`ShapeHandle`. So:
+
+- **References are still closed-form math**, not kernel output (volume of a
+  10mm cube is `1000` because `w·d·h = 1000`).
+- **But results are resolution-bound and lossy by construction.** Tolerances are
+  coarse and resolution-dependent, computed from the output mesh — `compareMetrics`
+  (which measures B-rep shapes) cannot be used; `helpers.ts` provides
+  `meshVolume`/`meshArea`/`meshBbox`/`meshTopology` instead.
+- **Invariants are the real guard** (ADR-0013 §11). A single volume number can
+  be right while the mesh is unusable; topology is checked on every op output.
+
+## What it asserts
+
+| File                  | Spec                                                                      |
+| --------------------- | ------------------------------------------------------------------------- |
+| `measurement.test.ts` | voxelized volume / bbox / area ≈ closed-form, within resolution band      |
+| `convergence.test.ts` | error **shrinks as resolution rises** (the voxel analog of exactness)     |
+| `booleans.test.ts`    | union/intersection/difference volumes, inclusion–exclusion, commutativity |
+| `vsOcct.test.ts`      | voxel boolean ≈ exact OCCT fuse (volume + Hausdorff ≤ c·h); offset extent |
+| `invariants.test.ts`  | every op output is **closed** + well-formed (the real guard)              |
+
+## Tolerance policy (calibrated, in `helpers.ts` `VOXEL`)
+
+Measured at the default resolution (40): cube volume err ~0.3–0.9% (bbox exact),
+cylinder ~0.4%, box-union ~0.8%; area inflated ~5%.
+
+- **Volume**: relative `< 3%` (`volTol`). Discretization biases enclosed volume by O(h).
+- **Area**: relative `< 12%` (`areaTol`). Surface Nets is staircase-ish and inflates area.
+- **Bbox**: absolute `< 1.5·h` per corner.
+- **Convergence**: high-res error must beat low-res error and clear a tight floor.
+
+## Documented divergences (these are properties of voxel v1, not bugs)
+
+1. **Not strictly 2-manifold.** Surface Nets v1 output is always **closed** (no
+   boundary edges — asserted), but emits non-manifold edges + degenerate/sliver
+   triangles except on grid-aligned geometry (e.g. a cube at res 32 is clean; at
+   res 24/48 it is not). The suite bounds the bad-triangle fraction (`badTriFraction`,
+   ~8%) as a regression guard, **not** a 2-manifold guarantee. The manifold
+   dual-contouring `Contourer` is the eventual fix (ADR-0013 §6).
+2. **Area inflation.** Contoured area exceeds the true surface area, so `areaTol`
+   is much looser than `volTol`.
+3. **Cost scales with input triangle count, not just resolution.** The FWN sign
+   pass is O(grid · inputTriangles), so a finely-tessellated input (e.g.
+   `sphere()` floors at ~8000 triangles → ~12s) dominates runtime. Spec inputs
+   are low-poly (boxes; cylinders tessellated coarsely) — fidelity comes from the
+   grid resolution, not input density. **Avoid high-poly inputs in this suite.**
+
+## Running
+
+Runs only under the exact `occt-wasm` gate (the `RUN_VOXEL_PARITY` guard; primitives
+are built on the active kernel, so a mesh kernel would double-approximate):
+
+```bash
+npx vitest run --project occt-wasm tests/parity/voxel/
+```
+
+Under other kernel projects the whole suite skips and the WASM engine is not loaded.
+
+## Adding a test
+
+Build a primitive, tessellate it cheaply into the voxel input, run the op, measure
+the mesh:
+
+```ts
+import { box } from '@/index.js';
+import { repairMesh } from '@/voxel/index.js';
+import { unwrap } from '@/core/result.js';
+import { formula } from '../helpers.js';
+import {
+  RUN_VOXEL_PARITY,
+  setupVoxelParity,
+  meshInputOf,
+  meshVolume,
+  relErr,
+  VOXEL,
+} from './helpers.js';
+
+beforeAll(async () => {
+  await setupVoxelParity();
+}, 60000);
+
+describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: …', () => {
+  it('repair(box).volume ≈ w·d·h', () => {
+    const out = unwrap(
+      repairMesh(meshInputOf(box(10, 10, 10)), {
+        resolution: VOXEL.resolution,
+        padding: VOXEL.padding,
+      })
+    );
+    expect(relErr(meshVolume(out), formula.boxVolume(10, 10, 10))).toBeLessThan(VOXEL.volTol);
+  });
+});
+```
+
+Build op outputs in `beforeAll` (never at collection time — the kernel/engine
+are not ready yet); keep `describe`/`it` names static.

--- a/tests/parity/voxel/booleans.test.ts
+++ b/tests/parity/voxel/booleans.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SPEC + INVARIANT: voxel boolean algebra.
+ *
+ * Field-CSG booleans (min/max SDF → Surface Nets) must obey set algebra within
+ * the voxel tolerance: union/intersection/difference recover the closed-form
+ * volumes, inclusion–exclusion holds, union is commutative, and intersecting
+ * disjoint operands is a discoverable error (not a silently-empty mesh).
+ *
+ * Operands (axis-aligned boxes, 12 input triangles each → fast FWN):
+ *   A = [0,10]³                      vol 1000
+ *   B = [5,15]×[0,10]×[0,10]         vol 1000   (overlap [5,10]×… vol 500)
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { box, translate } from '@/index.js';
+import { voxelBoolean } from '@/voxel/index.js';
+import { unwrap, isErr } from '@/core/result.js';
+import {
+  RUN_VOXEL_PARITY,
+  setupVoxelParity,
+  meshInputOf,
+  meshVolume,
+  relErr,
+  VOXEL,
+} from './helpers.js';
+
+const opts = { resolution: VOXEL.resolution, padding: VOXEL.padding };
+// Two compounded voxelized volumes, so allow a touch more than the single-op band.
+const BOOL_TOL = 0.04;
+
+beforeAll(async () => {
+  await setupVoxelParity();
+}, 60000);
+
+describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: boolean volumes match set algebra', () => {
+  const A = () => meshInputOf(box(10, 10, 10));
+  const B = () => meshInputOf(translate(box(10, 10, 10), [5, 0, 0]));
+
+  it('union(A,B) volume ≈ 1500 (1000 + 1000 − 500 overlap)', () => {
+    const vol = meshVolume(unwrap(voxelBoolean(A(), B(), 'union', opts)));
+    expect(relErr(vol, 1500)).toBeLessThan(BOOL_TOL);
+  });
+
+  it('intersection(A,B) volume ≈ 500 (the overlap)', () => {
+    const vol = meshVolume(unwrap(voxelBoolean(A(), B(), 'intersection', opts)));
+    expect(relErr(vol, 500)).toBeLessThan(BOOL_TOL);
+  });
+
+  it('difference(A,B) volume ≈ 500 (A minus the overlap)', () => {
+    const vol = meshVolume(unwrap(voxelBoolean(A(), B(), 'difference', opts)));
+    expect(relErr(vol, 500)).toBeLessThan(BOOL_TOL);
+  });
+});
+
+describe.skipIf(!RUN_VOXEL_PARITY)('INVARIANT: boolean algebra', () => {
+  const A = () => meshInputOf(box(10, 10, 10));
+  const B = () => meshInputOf(translate(box(10, 10, 10), [5, 0, 0]));
+
+  it('inclusion–exclusion: vol(A∪B) + vol(A∩B) ≈ vol(A) + vol(B)', () => {
+    const volU = meshVolume(unwrap(voxelBoolean(A(), B(), 'union', opts)));
+    const volI = meshVolume(unwrap(voxelBoolean(A(), B(), 'intersection', opts)));
+    expect(relErr(volU + volI, 2000)).toBeLessThan(BOOL_TOL);
+  });
+
+  it('union is commutative by volume: vol(A∪B) ≈ vol(B∪A)', () => {
+    const ab = meshVolume(unwrap(voxelBoolean(A(), B(), 'union', opts)));
+    const ba = meshVolume(unwrap(voxelBoolean(B(), A(), 'union', opts)));
+    expect(relErr(ab, ba)).toBeLessThan(0.02);
+  });
+
+  it('intersecting disjoint operands is a discoverable error', () => {
+    const far = meshInputOf(translate(box(10, 10, 10), [50, 0, 0]));
+    expect(isErr(voxelBoolean(A(), far, 'intersection', opts))).toBe(true);
+  });
+});

--- a/tests/parity/voxel/convergence.test.ts
+++ b/tests/parity/voxel/convergence.test.ts
@@ -1,0 +1,53 @@
+/**
+ * SPEC: resolution convergence.
+ *
+ * The voxel domain is approximate by construction, so the meaningful guarantee
+ * is not a fixed error but that error *shrinks as resolution rises* — the
+ * discretization converges to the true geometry. This is the voxel analog of
+ * the exactness the B-rep parity suite asserts. It also pins, empirically, the
+ * "Hausdorff ≤ c·h" claim the vault plan leaves deferred.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { box, cylinder } from '@/index.js';
+import { repairMesh } from '@/voxel/index.js';
+import { unwrap } from '@/core/result.js';
+import { formula } from '../helpers.js';
+import { RUN_VOXEL_PARITY, setupVoxelParity, meshInputOf, meshVolume, relErr } from './helpers.js';
+
+beforeAll(async () => {
+  await setupVoxelParity();
+}, 60000);
+
+describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: volume error shrinks as resolution rises', () => {
+  it('cube volume error: res 48 beats res 24, and is tight', () => {
+    const input = meshInputOf(box(10, 10, 10));
+    const truth = formula.boxVolume(10, 10, 10);
+    const coarse = relErr(
+      meshVolume(unwrap(repairMesh(input, { resolution: 24, padding: 2 }))),
+      truth
+    );
+    const fine = relErr(
+      meshVolume(unwrap(repairMesh(input, { resolution: 48, padding: 2 }))),
+      truth
+    );
+    expect(fine).toBeLessThan(coarse);
+    expect(fine).toBeLessThan(0.01);
+  });
+
+  it('cylinder (curved) volume error: res 40 beats res 24, and is tight', () => {
+    // Coarse input tessellation keeps FWN cheap; the grid sets the fidelity.
+    const input = meshInputOf(cylinder(5, 12), 0.3);
+    const truth = formula.cylinderVolume(5, 12);
+    const coarse = relErr(
+      meshVolume(unwrap(repairMesh(input, { resolution: 24, padding: 2 }))),
+      truth
+    );
+    const fine = relErr(
+      meshVolume(unwrap(repairMesh(input, { resolution: 40, padding: 2 }))),
+      truth
+    );
+    expect(fine).toBeLessThan(coarse);
+    expect(fine).toBeLessThan(0.02);
+  });
+});

--- a/tests/parity/voxel/helpers.ts
+++ b/tests/parity/voxel/helpers.ts
@@ -1,0 +1,256 @@
+/**
+ * Helpers for the voxel-domain parity suite.
+ *
+ * The voxel domain is a parallel domain (ADR-0013), NOT a `KernelAdapter`: its
+ * ops take a triangle-soup {@link VoxelMeshInput} and return a {@link KernelMeshResult}
+ * mesh, never a B-rep `ShapeHandle`. So the kernel-swap parity harness in
+ * `tests/parity/*.ts` (which runs B-rep specs through `getKernel`) does not apply.
+ * Voxel parity is instead **mesh-based and resolution-bound**: closed-form math
+ * is the reference, tolerances are coarse and resolution-dependent, and the
+ * watertight / 2-manifold invariants are the real guard (see ./README.md).
+ *
+ * These helpers provide what the manifold harness's `compareMetrics` cannot:
+ * volume / area / bbox / topology computed directly from a triangle mesh.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import initWasm, * as voxelWasm from 'brepjs-voxel-wasm';
+import { initVoxel, shapeToMeshInput, type VoxelMeshInput } from '@/voxel/index.js';
+import { mesh as meshShape } from '@/topology/meshFns.js';
+import { unwrap } from '@/core/result.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import type { KernelMeshResult } from '@/kernel/types.js';
+import { currentKernel, initOC } from '../../setup.js';
+
+type Vec3 = [number, number, number];
+
+/**
+ * Voxel parity runs only under an exact B-rep gate kernel. Primitives are built
+ * on the active kernel and tessellated as the voxel input, so a mesh kernel
+ * (manifold) would double-approximate; brepkit's tessellation differs too. We
+ * pin to the `occt-wasm` CI gate — the same init-and-skip posture the vault plan
+ * prescribes (reuse the `manifold.test.ts` guard; reserve `alwaysExclude` for
+ * pure invariant tests).
+ */
+export const RUN_VOXEL_PARITY = currentKernel === 'occt-wasm';
+
+/**
+ * Resolution-dependent tolerance policy (the voxel analog of the B-rep parity
+ * tolerance tiers). Every band is a property of discretization + Surface Nets,
+ * not a bug — calibrated against measured output (see ./README.md). Bands carry
+ * generous margin over observed error so the suite is not flaky.
+ *
+ * Measured at the default resolution: cube volErr ~0.3–0.9%, bbox exact;
+ * cylinder volErr ~0.4%; box-union volErr ~0.8%; area inflated ~5% (Surface
+ * Nets is staircase-ish, so area runs looser than volume).
+ */
+export const VOXEL = {
+  /** Default longest-axis voxel count. Cube/box ops at this res run in <100ms. */
+  resolution: 40,
+  /** Air-margin ring Surface Nets needs (>= 1). */
+  padding: 2,
+  /** Volume relative tolerance (observed max ~1.2% at res 24; margin to 3%). */
+  volTol: 0.03,
+  /** Area relative tolerance (Surface Nets inflates area; observed ~5%). */
+  areaTol: 0.12,
+  /** Bbox corner absolute tolerance, in multiples of voxel size h. */
+  bboxVoxels: 1.5,
+  /**
+   * Upper bound on the fraction of output triangles that may be degenerate or
+   * touch a non-manifold edge. This is a DOCUMENTED DIVERGENCE: Surface Nets v1
+   * is closed (no boundary edges) but not strictly 2-manifold and emits some
+   * sliver/degenerate triangles except on grid-aligned geometry (ADR-0013 §6).
+   * The bound is a regression guard, NOT a 2-manifold guarantee — the manifold
+   * dual-contouring `Contourer` is the eventual fix. Observed max ~5%.
+   */
+  badTriFraction: 0.08,
+} as const;
+
+let wasmReady = false;
+
+/** Load the voxel WASM engine + register it + init the B-rep kernel. Idempotent.
+ *  No-op under non-gate kernels — the whole suite skips there, so don't pay the
+ *  WASM load. */
+export async function setupVoxelParity(): Promise<void> {
+  if (!RUN_VOXEL_PARITY) return;
+  if (!wasmReady) {
+    const wasmPath = resolve(__dirname, '../../../packages/brepjs-voxel-wasm/pkg/index_bg.wasm');
+    await initWasm({ module_or_path: readFileSync(wasmPath) });
+    initVoxel(voxelWasm);
+    wasmReady = true;
+  }
+  await initOC();
+}
+
+/** Tessellate a B-rep primitive into the voxel ops' triangle-soup input. */
+export function meshInputOf(shape: AnyShape<Dimension>, deflection = 1e-3): VoxelMeshInput {
+  return unwrap(shapeToMeshInput(shape, deflection));
+}
+
+/**
+ * Tessellate a B-rep shape into a {@link KernelMeshResult} for use as an exact
+ * reference in {@link hausdorff} comparisons. Only `vertices`/`triangles` carry
+ * meaning here; the other fields are present to satisfy the type.
+ */
+export function kernelMeshOf(shape: AnyShape<Dimension>, deflection = 0.2): KernelMeshResult {
+  const m = meshShape(shape, { tolerance: deflection });
+  return {
+    vertices: m.vertices,
+    triangles: m.triangles,
+    normals: new Float32Array(0),
+    uvs: new Float32Array(0),
+    faceGroups: [],
+  };
+}
+
+/** The voxel size h for a mesh of given world extent at a given resolution. */
+export function voxelSize(longestExtent: number, resolution: number = VOXEL.resolution): number {
+  return longestExtent / resolution;
+}
+
+// ---------------------------------------------------------------------------
+// Mesh metrics — computed from the triangle mesh, since voxel output is a bare
+// KernelMeshResult, not a kernel shape that `compareMetrics` could measure.
+// ---------------------------------------------------------------------------
+
+function vertexAt(m: KernelMeshResult, i: number): Vec3 {
+  const b = i * 3;
+  return [m.vertices[b] ?? 0, m.vertices[b + 1] ?? 0, m.vertices[b + 2] ?? 0];
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+}
+
+function sub(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+/**
+ * Enclosed volume of a closed triangle mesh via the divergence theorem:
+ * V = (1/6) Σ v0 · (v1 × v2). Returns the magnitude so winding orientation
+ * never flips the sign.
+ */
+export function meshVolume(m: KernelMeshResult): number {
+  let sixV = 0;
+  for (let t = 0; t < m.triangles.length; t += 3) {
+    const a = vertexAt(m, m.triangles[t] ?? 0);
+    const b = vertexAt(m, m.triangles[t + 1] ?? 0);
+    const c = vertexAt(m, m.triangles[t + 2] ?? 0);
+    sixV +=
+      a[0] * (b[1] * c[2] - b[2] * c[1]) +
+      a[1] * (b[2] * c[0] - b[0] * c[2]) +
+      a[2] * (b[0] * c[1] - b[1] * c[0]);
+  }
+  return Math.abs(sixV) / 6;
+}
+
+/** Total surface area = Σ ½·‖(v1−v0) × (v2−v0)‖. */
+export function meshArea(m: KernelMeshResult): number {
+  let area = 0;
+  for (let t = 0; t < m.triangles.length; t += 3) {
+    const a = vertexAt(m, m.triangles[t] ?? 0);
+    const b = vertexAt(m, m.triangles[t + 1] ?? 0);
+    const c = vertexAt(m, m.triangles[t + 2] ?? 0);
+    const n = cross(sub(b, a), sub(c, a));
+    area += 0.5 * Math.sqrt(n[0] ** 2 + n[1] ** 2 + n[2] ** 2);
+  }
+  return area;
+}
+
+export interface Bbox {
+  readonly min: Vec3;
+  readonly max: Vec3;
+  readonly size: Vec3;
+}
+
+export function meshBbox(m: KernelMeshResult): Bbox {
+  const min: Vec3 = [Infinity, Infinity, Infinity];
+  const max: Vec3 = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < m.vertices.length; i += 3) {
+    for (let axis = 0; axis < 3; axis++) {
+      const v = m.vertices[i + axis] ?? 0;
+      if (v < (min[axis] ?? Infinity)) min[axis] = v;
+      if (v > (max[axis] ?? -Infinity)) max[axis] = v;
+    }
+  }
+  return { min, max, size: [max[0] - min[0], max[1] - min[1], max[2] - min[2]] };
+}
+
+/** Relative error |actual − expected| / max(|expected|, ε). */
+export function relErr(actual: number, expected: number): number {
+  return Math.abs(actual - expected) / Math.max(Math.abs(expected), 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Topology — the real guard. A repaired/contoured surface must be a closed
+// 2-manifold (every edge shared by exactly two triangles) for downstream use.
+// ---------------------------------------------------------------------------
+
+export interface MeshTopology {
+  readonly triangleCount: number;
+  readonly vertexCount: number;
+  /** Edges incident to exactly one triangle — a hole/boundary. */
+  readonly boundaryEdges: number;
+  /** Edges incident to three or more triangles — non-manifold. */
+  readonly nonManifoldEdges: number;
+  /** Triangles with a repeated index or ~zero area. */
+  readonly degenerateTriangles: number;
+  /** Triangle indices pointing outside the vertex array. */
+  readonly outOfRangeIndices: number;
+  /** No boundary and no non-manifold edges → closed 2-manifold. */
+  readonly isWatertight: boolean;
+  /** No edge shared by >2 triangles (manifold, boundary allowed). */
+  readonly isEdgeManifold: boolean;
+}
+
+export function meshTopology(m: KernelMeshResult): MeshTopology {
+  const vertexCount = m.vertices.length / 3;
+  const edgeCounts = new Map<string, number>();
+  let degenerateTriangles = 0;
+  let outOfRangeIndices = 0;
+  const triangleCount = m.triangles.length / 3;
+
+  for (let t = 0; t < m.triangles.length; t += 3) {
+    const i = m.triangles[t] ?? 0;
+    const j = m.triangles[t + 1] ?? 0;
+    const k = m.triangles[t + 2] ?? 0;
+    if (i >= vertexCount || j >= vertexCount || k >= vertexCount) outOfRangeIndices++;
+    if (i === j || j === k || i === k) {
+      degenerateTriangles++;
+      continue;
+    }
+    const a = vertexAt(m, i);
+    const b = vertexAt(m, j);
+    const c = vertexAt(m, k);
+    const n = cross(sub(b, a), sub(c, a));
+    if (Math.sqrt(n[0] ** 2 + n[1] ** 2 + n[2] ** 2) < 1e-12) degenerateTriangles++;
+    for (const [u, v] of [
+      [i, j],
+      [j, k],
+      [k, i],
+    ] as const) {
+      const key = u < v ? `${u}_${v}` : `${v}_${u}`;
+      edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  let boundaryEdges = 0;
+  let nonManifoldEdges = 0;
+  for (const count of edgeCounts.values()) {
+    if (count === 1) boundaryEdges++;
+    else if (count > 2) nonManifoldEdges++;
+  }
+
+  return {
+    triangleCount,
+    vertexCount,
+    boundaryEdges,
+    nonManifoldEdges,
+    degenerateTriangles,
+    outOfRangeIndices,
+    isWatertight: boundaryEdges === 0 && nonManifoldEdges === 0,
+    isEdgeManifold: nonManifoldEdges === 0,
+  };
+}

--- a/tests/parity/voxel/invariants.test.ts
+++ b/tests/parity/voxel/invariants.test.ts
@@ -95,13 +95,15 @@ describe.skipIf(!RUN_VOXEL_PARITY)(
         });
 
         // DOCUMENTED DIVERGENCE: not a 2-manifold guarantee — a regression bound.
-        it('keeps degenerate + non-manifold triangles within the documented band', () => {
+        // Degenerate triangles and non-manifold edges are different units, so
+        // bound each independently (both normalized by triangle count) rather
+        // than summing them.
+        it('keeps degenerate triangles + non-manifold edges within the documented band', () => {
           const out = outs.get(name);
           if (!out) return;
           const top = meshTopology(out);
-          expect((top.degenerateTriangles + top.nonManifoldEdges) / top.triangleCount).toBeLessThan(
-            VOXEL.badTriFraction
-          );
+          expect(top.degenerateTriangles / top.triangleCount).toBeLessThan(VOXEL.badTriFraction);
+          expect(top.nonManifoldEdges / top.triangleCount).toBeLessThan(VOXEL.badTriFraction);
         });
       });
     }

--- a/tests/parity/voxel/invariants.test.ts
+++ b/tests/parity/voxel/invariants.test.ts
@@ -1,0 +1,109 @@
+/**
+ * INVARIANTS: the real guard (ADR-0013 §11 — "the real guard" is a runtime
+ * invariant test, not a contour-algorithm promise).
+ *
+ * Every voxel op output is consumed as a mesh, so the topological contract
+ * matters more than any single measurement. What Surface Nets v1 actually
+ * guarantees, across all ops and resolutions:
+ *
+ *   - CLOSED: no boundary (hole) edges — every edge shared by >= 2 triangles.
+ *   - in-range indices, well-formed normals/uvs/faceGroups.
+ *
+ * What it does NOT guarantee (DOCUMENTED DIVERGENCE, ADR-0013 §6): strict
+ * 2-manifoldness and degenerate-free triangles. Surface Nets emits some
+ * non-manifold edges + sliver triangles except on grid-aligned geometry; the
+ * manifold dual-contouring `Contourer` is the eventual fix. We bound the bad
+ * fraction as a regression guard rather than asserting it is zero.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { box, translate, makeBaseBox } from '@/index.js';
+import { repairMesh, offsetMesh, shellMesh, voxelBoolean } from '@/voxel/index.js';
+import { latticeInfillShape } from '@/lattice/index.js';
+import { unwrap } from '@/core/result.js';
+import type { KernelMeshResult } from '@/kernel/types.js';
+import { RUN_VOXEL_PARITY, setupVoxelParity, meshInputOf, meshTopology, VOXEL } from './helpers.js';
+
+const opts = { resolution: VOXEL.resolution, padding: VOXEL.padding };
+
+// One output per implemented voxel op. Names are static (known at collection);
+// the ops themselves run in beforeAll, after the engine + kernel are ready.
+const OP_NAMES = [
+  'repair',
+  'offset(+)',
+  'offset(-)',
+  'shell',
+  'boolean(union)',
+  'boolean(difference)',
+  'lattice',
+] as const;
+
+const outs = new Map<string, KernelMeshResult>();
+
+beforeAll(async () => {
+  await setupVoxelParity();
+  if (!RUN_VOXEL_PARITY) return;
+  const cube = meshInputOf(box(10, 10, 10));
+  const cubeB = meshInputOf(translate(box(10, 10, 10), [5, 0, 0]));
+  outs.set('repair', unwrap(repairMesh(cube, opts)));
+  outs.set('offset(+)', unwrap(offsetMesh(cube, 0.6, opts)));
+  outs.set('offset(-)', unwrap(offsetMesh(cube, -0.6, opts)));
+  outs.set('shell', unwrap(shellMesh(cube, 0.8, opts)));
+  outs.set('boolean(union)', unwrap(voxelBoolean(cube, cubeB, 'union', opts)));
+  outs.set('boolean(difference)', unwrap(voxelBoolean(cube, cubeB, 'difference', opts)));
+  outs.set(
+    'lattice',
+    unwrap(latticeInfillShape(makeBaseBox(10, 10, 10), { type: 'gyroid', period: 3, thickness: 1 }))
+  );
+}, 90000);
+
+describe.skipIf(!RUN_VOXEL_PARITY)(
+  'INVARIANT: every voxel op output is a closed, well-formed mesh',
+  () => {
+    for (const name of OP_NAMES) {
+      describe(name, () => {
+        it('is non-empty with multiple-of-3 buffers', () => {
+          const out = outs.get(name);
+          expect(out).toBeDefined();
+          if (!out) return;
+          expect(out.vertices.length).toBeGreaterThan(0);
+          expect(out.triangles.length).toBeGreaterThan(0);
+          expect(out.vertices.length % 3).toBe(0);
+          expect(out.triangles.length % 3).toBe(0);
+        });
+
+        it('has all triangle indices in range', () => {
+          const out = outs.get(name);
+          if (!out) return;
+          expect(meshTopology(out).outOfRangeIndices).toBe(0);
+        });
+
+        it('is CLOSED — no boundary/hole edges', () => {
+          const out = outs.get(name);
+          if (!out) return;
+          expect(meshTopology(out).boundaryEdges).toBe(0);
+        });
+
+        it('has well-formed normals, uvs, and a single face group', () => {
+          const out = outs.get(name);
+          if (!out) return;
+          const vertexCount = out.vertices.length / 3;
+          expect(out.normals.length).toBe(out.vertices.length);
+          expect(out.uvs.length).toBe(vertexCount * 2);
+          expect(out.faceGroups).toHaveLength(1);
+          expect(out.faceGroups[0]?.count).toBe(out.triangles.length / 3);
+        });
+
+        // DOCUMENTED DIVERGENCE: not a 2-manifold guarantee — a regression bound.
+        it('keeps degenerate + non-manifold triangles within the documented band', () => {
+          const out = outs.get(name);
+          if (!out) return;
+          const top = meshTopology(out);
+          expect((top.degenerateTriangles + top.nonManifoldEdges) / top.triangleCount).toBeLessThan(
+            VOXEL.badTriFraction
+          );
+        });
+      });
+    }
+  }
+);

--- a/tests/parity/voxel/measurement.test.ts
+++ b/tests/parity/voxel/measurement.test.ts
@@ -1,0 +1,102 @@
+/**
+ * SPEC: voxel measurement parity.
+ *
+ * Voxelizing a primitive (FWN sign → Surface Nets contour, via `repairMesh`)
+ * and measuring the resulting mesh must recover the closed-form volume and
+ * bounding box within the resolution-bound tolerance. Area runs looser because
+ * Surface Nets inflates surface area. References are closed-form math, never
+ * kernel output (see ../README.md).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { box, cylinder } from '@/index.js';
+import { repairMesh } from '@/voxel/index.js';
+import { unwrap } from '@/core/result.js';
+import { formula } from '../helpers.js';
+import {
+  RUN_VOXEL_PARITY,
+  setupVoxelParity,
+  meshInputOf,
+  meshVolume,
+  meshArea,
+  meshBbox,
+  relErr,
+  voxelSize,
+  VOXEL,
+} from './helpers.js';
+
+beforeAll(async () => {
+  await setupVoxelParity();
+}, 60000);
+
+describe.skipIf(!RUN_VOXEL_PARITY)(
+  'SPEC: voxel volume = closed-form, within resolution tolerance',
+  () => {
+    it.each([
+      [10, 10, 10],
+      [20, 10, 6],
+      [8, 14, 5],
+    ])('repair(box(%i,%i,%i)).volume ≈ w·d·h', (w, d, h) => {
+      const out = unwrap(
+        repairMesh(meshInputOf(box(w, d, h)), {
+          resolution: VOXEL.resolution,
+          padding: VOXEL.padding,
+        })
+      );
+      expect(relErr(meshVolume(out), formula.boxVolume(w, d, h))).toBeLessThan(VOXEL.volTol);
+    });
+
+    it('repair(cylinder(r,h)).volume ≈ π·r²·h', () => {
+      // Coarse input tessellation keeps the FWN sign cost low; grid resolution,
+      // not input density, sets the output fidelity.
+      const out = unwrap(
+        repairMesh(meshInputOf(cylinder(5, 12), 0.3), {
+          resolution: VOXEL.resolution,
+          padding: VOXEL.padding,
+        })
+      );
+      expect(relErr(meshVolume(out), formula.cylinderVolume(5, 12))).toBeLessThan(VOXEL.volTol);
+    });
+  }
+);
+
+describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: voxel bounding box = primitive extent', () => {
+  it('repair(box) recovers the exact axis-aligned extent', () => {
+    const [w, d, h] = [12, 8, 6];
+    const out = unwrap(
+      repairMesh(meshInputOf(box(w, d, h)), {
+        resolution: VOXEL.resolution,
+        padding: VOXEL.padding,
+      })
+    );
+    const bb = meshBbox(out);
+    const tol = VOXEL.bboxVoxels * voxelSize(Math.max(w, d, h));
+    // box(w,d,h) spans [0,w]×[0,d]×[0,h] (origin corner).
+    for (const [actual, expected] of [
+      [bb.min[0], 0],
+      [bb.min[1], 0],
+      [bb.min[2], 0],
+      [bb.max[0], w],
+      [bb.max[1], d],
+      [bb.max[2], h],
+    ] as const) {
+      expect(Math.abs(actual - expected)).toBeLessThan(tol);
+    }
+  });
+});
+
+describe.skipIf(!RUN_VOXEL_PARITY)(
+  'SPEC: voxel area ≈ closed-form (loose — Surface Nets inflates area)',
+  () => {
+    it('repair(box).area is within the inflated-area band', () => {
+      const [w, d, h] = [10, 10, 10];
+      const out = unwrap(
+        repairMesh(meshInputOf(box(w, d, h)), {
+          resolution: VOXEL.resolution,
+          padding: VOXEL.padding,
+        })
+      );
+      expect(relErr(meshArea(out), formula.boxArea(w, d, h))).toBeLessThan(VOXEL.areaTol);
+    });
+  }
+);

--- a/tests/parity/voxel/vsOcct.test.ts
+++ b/tests/parity/voxel/vsOcct.test.ts
@@ -1,0 +1,68 @@
+/**
+ * SPEC: voxel ↔ OCCT cross-parity.
+ *
+ * Where the exact B-rep kernel can build the same shape, the voxel result must
+ * agree with it: the voxel boolean's enclosed volume matches OCCT's exact
+ * volume within tolerance, and the two surfaces stay within a few voxels of
+ * each other (symmetric Hausdorff ≤ c·h). Offsets are checked against the
+ * analytic extent, since a uniform offset shifts every face by the distance.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { box, translate, fuse, measureVolume } from '@/index.js';
+import { voxelBoolean, offsetMesh } from '@/voxel/index.js';
+import { unwrap } from '@/core/result.js';
+import { hausdorff } from '../../helpers/meshParity.js';
+import {
+  RUN_VOXEL_PARITY,
+  setupVoxelParity,
+  meshInputOf,
+  kernelMeshOf,
+  meshVolume,
+  meshBbox,
+  relErr,
+  voxelSize,
+  VOXEL,
+} from './helpers.js';
+
+const opts = { resolution: VOXEL.resolution, padding: VOXEL.padding };
+
+beforeAll(async () => {
+  await setupVoxelParity();
+}, 60000);
+
+describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: voxel union agrees with the exact OCCT fuse', () => {
+  it('volume matches OCCT, surface within a few voxels (Hausdorff)', () => {
+    const a = box(10, 10, 10);
+    const b = translate(box(10, 10, 10), [5, 0, 0]);
+
+    const occtVol = unwrap(measureVolume(unwrap(fuse(a, b))));
+    const voxUnion = unwrap(voxelBoolean(meshInputOf(a), meshInputOf(b), 'union', opts));
+
+    expect(relErr(meshVolume(voxUnion), occtVol)).toBeLessThan(0.03);
+
+    const ref = kernelMeshOf(unwrap(fuse(a, b)), 0.2);
+    const h = hausdorff(voxUnion, ref);
+    // Union spans 15mm on its longest axis; allow the surface to sit within
+    // ~3 voxels of the exact B-rep (Surface Nets is staircase-ish on flats).
+    expect(h).toBeLessThan(3 * voxelSize(15));
+  });
+});
+
+describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: uniform offset shifts every face by the distance', () => {
+  it('offset(+0.6) grows the cube extent to ~[−0.6, 10.6]', () => {
+    const cube = meshInputOf(box(10, 10, 10));
+    const bb = meshBbox(unwrap(offsetMesh(cube, 0.6, opts)));
+    const tol = VOXEL.bboxVoxels * voxelSize(11.2);
+    for (const v of bb.min) expect(Math.abs(v - -0.6)).toBeLessThan(tol);
+    for (const v of bb.max) expect(Math.abs(v - 10.6)).toBeLessThan(tol);
+  });
+
+  it('offset(−0.6) shrinks the cube extent to ~[0.6, 9.4]', () => {
+    const cube = meshInputOf(box(10, 10, 10));
+    const bb = meshBbox(unwrap(offsetMesh(cube, -0.6, opts)));
+    const tol = VOXEL.bboxVoxels * voxelSize(10);
+    for (const v of bb.min) expect(Math.abs(v - 0.6)).toBeLessThan(tol);
+    for (const v of bb.max) expect(Math.abs(v - 9.4)).toBeLessThan(tol);
+  });
+});

--- a/tests/parity/voxel/vsOcct.test.ts
+++ b/tests/parity/voxel/vsOcct.test.ts
@@ -36,12 +36,14 @@ describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: voxel union agrees with the exact OCCT
     const a = box(10, 10, 10);
     const b = translate(box(10, 10, 10), [5, 0, 0]);
 
-    const occtVol = unwrap(measureVolume(unwrap(fuse(a, b))));
+    // Fuse once; reuse for both the exact-volume check and the Hausdorff reference.
+    const fused = unwrap(fuse(a, b));
+    const occtVol = unwrap(measureVolume(fused));
     const voxUnion = unwrap(voxelBoolean(meshInputOf(a), meshInputOf(b), 'union', opts));
 
     expect(relErr(meshVolume(voxUnion), occtVol)).toBeLessThan(0.03);
 
-    const ref = kernelMeshOf(unwrap(fuse(a, b)), 0.2);
+    const ref = kernelMeshOf(fused, 0.2);
     const h = hausdorff(voxUnion, ref);
     // Union spans 15mm on its longest axis; allow the surface to sit within
     // ~3 voxels of the exact B-rep (Surface Nets is staircase-ish on flats).


### PR DESCRIPTION
## What

Brings the manifold parity treatment to the **voxel / SDF domain** (ADR-0013), adapted to the key structural difference: voxel is a *parallel domain*, **not** a `KernelAdapter` — its ops take a triangle-soup mesh and return a mesh, so the kernel-swap harness in `tests/parity/*.ts` (which runs B-rep specs through `getKernel`) cannot be pointed at it.

New mesh-based harness in `tests/parity/voxel/helpers.ts` (mesh volume/area/bbox/topology — what `compareMetrics` can't do for a bare mesh) plus five spec files. **52 tests, ~4s**, gated to `occt-wasm` via an init-and-skip guard (skips cleanly under other kernel projects without loading the WASM).

| File | Coverage |
|---|---|
| `measurement.test.ts` | voxelized volume/bbox/area ≈ closed-form, within resolution band |
| `convergence.test.ts` | error shrinks as resolution rises (the voxel analog of exactness) |
| `booleans.test.ts` | ∪/∩/− volumes, inclusion–exclusion, commutativity, disjoint→Err |
| `vsOcct.test.ts` | voxel union vs exact OCCT fuse (volume + Hausdorff ≤ c·h), offset extent |
| `invariants.test.ts` | every op output is closed + well-formed (the real guard) |

## Findings the suite pins down (documented in `tests/parity/voxel/README.md`)

1. **Surface Nets v1 is closed everywhere but NOT strictly 2-manifold** — it emits non-manifold edges + degenerate/sliver triangles except on grid-aligned geometry (cube res 32 clean; res 24/48 not). The suite asserts the invariant that holds (closed / no boundary edges) and *bounds* the bad-triangle fraction as a regression guard rather than asserting it zero. The dual-contouring `Contourer` is the eventual fix (ADR-0013 §6).
2. **FWN sign cost is O(grid × input-triangles)** — a tessellated `sphere()` floors at ~8000 triangles → ~12s/op. The suite uses low-poly inputs (boxes; coarsely-tessellated cylinders); fidelity comes from grid resolution, not input density.

Accuracy itself is strong: volume error 0.1–1.2%, bbox exact for axis-aligned boxes.

## Scope

Tests only — no library code touched. Two adjacent infra gaps were deliberately left out of this PR (the `brepjs-voxel-wasm` release-please entry and ADR-0013's negative layer-boundary tests).