### PR TITLE
fix(manifold): orient sketch extrudes by full plane basis, not just the axis

### DIFF
--- a/src/kernel/manifold/sweepOps.ts
+++ b/src/kernel/manifold/sweepOps.ts
@@ -37,7 +37,11 @@ import {
   sub,
 } from './approximations.js';
 
-type ManifoldOriented = { rotate(r: Vec3): unknown; translate(t: Vec3): unknown };
+type ManifoldOriented = {
+  rotate(r: Vec3): unknown;
+  translate(t: Vec3): unknown;
+  transform(m: number[]): unknown;
+};
 type ManifoldMeshLike = { numProp: number; vertProperties: Float32Array };
 
 const RAD_PER_DEG = Math.PI / 180;
@@ -170,18 +174,27 @@ export function orientExtrusion(
   section: CrossSection,
   dir: Vec3
 ): ManifoldOriented {
-  let placed = solid;
-  const alignedZ = Math.abs(dir[0]) < 1e-9 && Math.abs(dir[1]) < 1e-9 && dir[2] > 0;
-  if (!alignedZ) {
-    const pitch = Math.atan2(Math.hypot(dir[0], dir[1]), dir[2]) * (180 / Math.PI);
-    const yaw = Math.atan2(dir[1], dir[0]) * (180 / Math.PI);
-    placed = placed.rotate([0, pitch, yaw]) as ManifoldOriented;
-  }
+  // The base is built in manifold-local space: the outline lives in XY (local
+  // x = outline.x, local y = outline.y) extruded along +Z. Re-base it onto the
+  // section's world frame with a full basis transform — manifold X→xAxis,
+  // Y→yAxis, Z→extrude dir — then translate to the plane origin.
+  //
+  // A basis transform (not an Euler rotate) is required: the previous rotate
+  // aligned ONLY the extrude axis to `dir` and left the in-plane (x,y) axes at
+  // their defaults, so any sketch on a non-XY plane was mis-oriented — e.g. a
+  // 'YZ' scoop ramp landed mirrored below Z=0. Manifold's Mat4 is column-major
+  // (cols 0-2 = where local X/Y/Z map, col 3 = translation).
+  const x = section.xAxis;
+  const y = section.yAxis;
   const o = section.origin;
-  if (o[0] !== 0 || o[1] !== 0 || o[2] !== 0) {
-    placed = placed.translate([o[0], o[1], o[2]]) as ManifoldOriented;
-  }
-  return placed;
+  // prettier-ignore
+  const matrix = [
+    x[0], x[1], x[2], 0,
+    y[0], y[1], y[2], 0,
+    dir[0], dir[1], dir[2], 0,
+    o[0], o[1], o[2], 1,
+  ];
+  return solid.transform(matrix) as ManifoldOriented;
 }
 
 /**

--- a/tests/parity/planeExtrudeOrientation.test.ts
+++ b/tests/parity/planeExtrudeOrientation.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+/**
+ * Regression: a sketch extruded on a non-XY plane must land in the same world
+ * position on Manifold as on OCCT. The Manifold extrude used to align only the
+ * extrude axis (Euler rotate) and drop the in-plane basis, so 'YZ'/'XZ' sketches
+ * were mis-oriented — e.g. a gridfinity scoop ramp (drawn on 'YZ') extruded
+ * mirrored below Z=0 instead of across the bin. See manifold sweepOps
+ * `orientExtrusion`.
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initKernel, initOCCT } from '../setup.js';
+import { draw, mesh, withKernel, getKernel } from '@/index.js';
+
+let haveManifold = false;
+beforeAll(async () => {
+  await initOCCT();
+  try {
+    await initKernel('manifold');
+    getKernel('manifold');
+    haveManifold = true;
+  } catch {
+    haveManifold = false;
+  }
+}, 60_000);
+
+function bounds(v: Float32Array) {
+  const lo = [Infinity, Infinity, Infinity];
+  const hi = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < v.length; i += 3) {
+    for (let a = 0; a < 3; a++) {
+      lo[a] = Math.min(lo[a], v[i + a]);
+      hi[a] = Math.max(hi[a], v[i + a]);
+    }
+  }
+  return [...lo, ...hi];
+}
+
+describe('plane-extrude orientation parity (manifold vs occt)', () => {
+  for (const plane of ['XY', 'YZ', 'XZ'] as const) {
+    it(`extrude on ${plane} lands in the same place on both kernels`, () => {
+      if (!haveManifold) return;
+      const build = () =>
+        bounds(
+          mesh(
+            draw([0, 0])
+              .lineTo([0, 5])
+              .lineTo([4, 5])
+              .lineTo([4, 0])
+              .close()
+              .sketchOnPlane(plane)
+              .extrude(10),
+            { cache: false }
+          ).vertices
+        );
+      const occt = withKernel('occt', build);
+      const manifold = withKernel('manifold', build);
+      for (let i = 0; i < 6; i++) {
+        expect(manifold[i]).toBeCloseTo(occt[i], 1);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Extruding a sketch on a **non-XY plane** (`'YZ'`, `'XZ'`, …) placed the solid in the wrong world position on the Manifold kernel. `orientExtrusion` aligned only the *extrude axis* to `dir` with an Euler `rotate([0, pitch, yaw])` and left the in-plane (x, y) basis at its manifold-local defaults, so the profile was mis-oriented for any plane other than XY.

Concretely: a gridfinity finger-scoop ramp (drawn on `'YZ'` and extruded across the bin) landed **mirrored ~one interior-height below Z=0** — geometry protruding under the bin. The bug scales with bin height (−8.5mm at 3u → −102mm at 16u). OCCT builds the same sketch correctly.

## Fix

Replace the axis-only Euler rotate with a full **basis transform** — manifold local X→`section.xAxis`, Y→`section.yAxis`, Z→extrude `dir`, then translate to the plane origin (Manifold's column-major `Mat4`).

- XY-plane extrudes are unchanged (identity basis + origin translate — same as before).
- Non-XY planes now match OCCT exactly.

## Testing

- New `tests/parity/planeExtrudeOrientation.test.ts` — a square sketched on XY/YZ/XZ and extruded must land at the same mesh bounds on Manifold as on OCCT.
- Full manifold parity suite passes (215) with the fix; XY-plane sketch/extrude parity (`sketchToSolid`, `profileExtrude`) unchanged.

This unblocks gridfinity's Manifold draft preview for any bin with a scoop.