### PR TITLE
fix(manifold): degree contract for composed transforms + implement makeCompound

### DIFF
--- a/src/kernel/manifold/builderOps.ts
+++ b/src/kernel/manifold/builderOps.ts
@@ -32,6 +32,30 @@ export function makeBuilderOps(module: ManifoldModule): KernelBuilderOps {
     );
   }
 
+  function makeCompound(shapes: KernelShape[]): KernelShape {
+    // Mesh CSG has no non-fused grouping, so an n-ary union is the closest
+    // valid semantic. Disjoint members (the common case — pattern compounds)
+    // become a multi-component manifold, geometrically identical to an OCCT
+    // compound; overlapping members merge, which downstream booleans can't
+    // distinguish anyway (cutting by a compound ≡ cutting by the union of its
+    // members). What this can't support is iterating members back out as
+    // separate sub-shapes.
+    const operands = shapes.map((s) => unwrap(s));
+    const first = operands[0];
+    if (!first) {
+      notImplemented('makeCompound (no input shapes on manifold kernel)');
+    }
+    const solid = operands.length === 1 ? first : Manifold.union(operands);
+    return wrap(
+      solid,
+      makeNode(
+        'makeCompound',
+        {},
+        shapes.map((s) => nodeOf(s))
+      )
+    );
+  }
+
   function sewAndSolidify(faces: KernelShape[], tolerance: number): KernelShape {
     // Manifold meshes are already watertight solids; sewing is the identity over
     // the incoming solid. We accept a single operand and record the intent so an
@@ -69,7 +93,7 @@ export function makeBuilderOps(module: ManifoldModule): KernelBuilderOps {
     makeHelixWire: (pitch, height, radius, center, direction, leftHanded) =>
       profile.makeHelixWire(pitch, height, radius, center, direction, leftHanded),
     makeWireFromMixed: (items) => profile.makeWireFromMixed(items),
-    makeCompound: () => notImplemented('makeCompound'),
+    makeCompound,
     solidFromShell: () => notImplemented('solidFromShell'),
     hull,
     hullFromPoints,

--- a/src/kernel/manifold/builderOps.ts
+++ b/src/kernel/manifold/builderOps.ts
@@ -43,7 +43,7 @@ export function makeBuilderOps(module: ManifoldModule): KernelBuilderOps {
     const operands = shapes.map((s) => unwrap(s));
     const first = operands[0];
     if (!first) {
-      notImplemented('makeCompound (no input shapes on manifold kernel)');
+      throw new Error('manifold: makeCompound requires at least one input shape');
     }
     const solid = operands.length === 1 ? first : Manifold.union(operands);
     return wrap(

--- a/src/kernel/manifold/transformOps.ts
+++ b/src/kernel/manifold/transformOps.ts
@@ -236,10 +236,13 @@ export function composeTransform(
 ): { handle: KernelType; dispose: () => void } {
   let acc = identityMatrix();
   for (const o of ops) {
+    // Unlike kernel `rotate` (radians), the `composeTransform` boundary is
+    // degrees: the OCCT adapters convert per-op internally, so this one must
+    // too or composed placements land at radian-sized angles.
     const step =
       o.type === 'translate'
         ? translationMatrix(o.x, o.y, o.z)
-        : rotationMatrix(o.angle, o.axis ?? [0, 0, 1], o.center ?? [0, 0, 0]);
+        : rotationMatrix((o.angle * Math.PI) / 180, o.axis ?? [0, 0, 1], o.center ?? [0, 0, 0]);
     acc = multiplyMatrix(step, acc);
   }
   return { handle: acc as KernelType, dispose: () => {} };
@@ -270,7 +273,9 @@ export function circularPattern(
 ): KernelShape[] {
   const results: KernelShape[] = [shape];
   for (let i = 1; i < count; i++) {
-    results.push(rotate(shape, angleStep * i, axis, center));
+    // `circularPattern` receives degrees (matching the OCCT adapters); kernel
+    // `rotate` expects radians.
+    results.push(rotate(shape, (angleStep * i * Math.PI) / 180, axis, center));
   }
   return results;
 }
@@ -310,7 +315,8 @@ export function transformBatch(entries: TransformEntry[]): KernelShape[] {
       case 'translate':
         return translate(e.shape, e.x, e.y, e.z);
       case 'rotate':
-        return rotate(e.shape, e.angle, e.axis, e.center);
+        // Batch entries carry degrees (the OCCT adapters convert per-entry).
+        return rotate(e.shape, (e.angle * Math.PI) / 180, e.axis, e.center);
       case 'scale':
         return scale(e.shape, e.center, e.factor);
       case 'mirror':

--- a/tests/parity/composedTransformParity.test.ts
+++ b/tests/parity/composedTransformParity.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+/**
+ * Regression: `composeTransform` rotate ops are DEGREES at the kernel boundary
+ * (the OCCT adapters convert to radians internally), but the Manifold adapter
+ * fed them to `rotationMatrix`, which expects radians. A composed 90° rotate
+ * became a 90-radian one, so `transformCopy`-placed shapes (e.g. gridfinity's
+ * honeycomb wall-pattern hex prisms) landed off-target and boolean cuts
+ * silently removed nothing.
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initKernel, initOCCT } from '../setup.js';
+import {
+  circularPattern,
+  compound,
+  composeTransforms,
+  cut,
+  drawPolysides,
+  makeBaseBox,
+  measureVolume,
+  mesh,
+  transformCopy,
+  translate,
+  unwrap,
+  withKernel,
+  getKernel,
+  type TransformOp,
+} from '@/index.js';
+
+let haveManifold = false;
+beforeAll(async () => {
+  await initOCCT();
+  try {
+    await initKernel('manifold');
+    getKernel('manifold');
+    haveManifold = true;
+  } catch {
+    haveManifold = false;
+  }
+}, 60_000);
+
+function bounds(v: Float32Array) {
+  const lo = [Infinity, Infinity, Infinity];
+  const hi = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < v.length; i += 3) {
+    for (let a = 0; a < 3; a++) {
+      lo[a] = Math.min(lo[a], v[i + a]);
+      hi[a] = Math.max(hi[a], v[i + a]);
+    }
+  }
+  return [...lo, ...hi];
+}
+
+function placed(ops: TransformOp[]) {
+  const box = makeBaseBox(10, 4, 2);
+  const trsf = composeTransforms(ops);
+  try {
+    return transformCopy(box, trsf);
+  } finally {
+    trsf.cleanup();
+  }
+}
+
+describe('composed-transform parity (manifold vs occt)', () => {
+  it('rotate inside composeTransforms is degrees on both kernels', () => {
+    if (!haveManifold) return;
+    const build = () =>
+      bounds(
+        mesh(
+          placed([
+            { type: 'rotate', angle: 90, axis: [1, 0, 0] },
+            { type: 'translate', v: [5, 6, 7] },
+          ]),
+          { cache: false }
+        ).vertices
+      );
+    const occt = withKernel('occt', build);
+    const manifold = withKernel('manifold', build);
+    for (let i = 0; i < 6; i++) {
+      expect(manifold[i]).toBeCloseTo(occt[i], 1);
+    }
+  });
+
+  it('chained rotates compose in the same order on both kernels', () => {
+    if (!haveManifold) return;
+    const build = () =>
+      bounds(
+        mesh(
+          placed([
+            { type: 'translate', v: [1, 2, -3] },
+            { type: 'rotate', angle: 90, axis: [1, 0, 0] },
+            { type: 'rotate', angle: 30, axis: [0, 0, 1] },
+            { type: 'translate', v: [4, 0, 9] },
+          ]),
+          { cache: false }
+        ).vertices
+      );
+    const occt = withKernel('occt', build);
+    const manifold = withKernel('manifold', build);
+    for (let i = 0; i < 6; i++) {
+      expect(manifold[i]).toBeCloseTo(occt[i], 1);
+    }
+  });
+
+  it('wall-pattern shaped cut (hex prism compound) removes material on both kernels', () => {
+    if (!haveManifold) return;
+    // Mirrors gridfinity's honeycomb path: hex prisms extruded on XY, placed
+    // onto a vertical wall via composeTransforms + transformCopy, grouped with
+    // compound(), then cut from the wall solid.
+    const build = () => {
+      const wall = makeBaseBox(40, 2, 20);
+      const template = drawPolysides(3, 6).sketchOnPlane('XY').extrude(8);
+      const prisms = [];
+      for (const [cx, cz] of [
+        [-10, 6],
+        [0, 10],
+        [10, 14],
+      ] as const) {
+        const trsf = composeTransforms([
+          { type: 'translate', v: [cx, cz, -4] },
+          { type: 'rotate', angle: 90, axis: [1, 0, 0] },
+          { type: 'translate', v: [0, 1, 0] },
+        ]);
+        try {
+          prisms.push(transformCopy(template, trsf));
+        } finally {
+          trsf.cleanup();
+        }
+      }
+      const tool = compound(prisms);
+      const result = unwrap(cut(wall, tool));
+      return unwrap(measureVolume(result));
+    };
+    const occt = withKernel('occt', build);
+    const manifold = withKernel('manifold', build);
+    const plain = withKernel('occt', () => unwrap(measureVolume(makeBaseBox(40, 2, 20))));
+    expect(occt).toBeLessThan(plain);
+    expect(manifold).toBeCloseTo(occt, 0);
+  });
+
+  it('circularPattern spreads copies over degrees on both kernels', () => {
+    if (!haveManifold) return;
+    const build = () =>
+      bounds(
+        mesh(unwrap(circularPattern(translate(makeBaseBox(2, 2, 2), 8, 0, 0), [0, 0, 1], 4, 270)), {
+          cache: false,
+        }).vertices
+      );
+    const occt = withKernel('occt', build);
+    const manifold = withKernel('manifold', build);
+    for (let i = 0; i < 6; i++) {
+      expect(manifold[i]).toBeCloseTo(occt[i], 1);
+    }
+  });
+});

--- a/tests/parity/composedTransformParity.test.ts
+++ b/tests/parity/composedTransformParity.test.ts
@@ -61,8 +61,8 @@ function placed(ops: TransformOp[]) {
 }
 
 describe('composed-transform parity (manifold vs occt)', () => {
-  it('rotate inside composeTransforms is degrees on both kernels', () => {
-    if (!haveManifold) return;
+  it('rotate inside composeTransforms is degrees on both kernels', (ctx) => {
+    if (!haveManifold) return ctx.skip();
     const build = () =>
       bounds(
         mesh(
@@ -80,8 +80,8 @@ describe('composed-transform parity (manifold vs occt)', () => {
     }
   });
 
-  it('chained rotates compose in the same order on both kernels', () => {
-    if (!haveManifold) return;
+  it('chained rotates compose in the same order on both kernels', (ctx) => {
+    if (!haveManifold) return ctx.skip();
     const build = () =>
       bounds(
         mesh(
@@ -101,8 +101,8 @@ describe('composed-transform parity (manifold vs occt)', () => {
     }
   });
 
-  it('wall-pattern shaped cut (hex prism compound) removes material on both kernels', () => {
-    if (!haveManifold) return;
+  it('wall-pattern shaped cut (hex prism compound) removes material on both kernels', (ctx) => {
+    if (!haveManifold) return ctx.skip();
     // Mirrors gridfinity's honeycomb path: hex prisms extruded on XY, placed
     // onto a vertical wall via composeTransforms + transformCopy, grouped with
     // compound(), then cut from the wall solid.
@@ -137,8 +137,8 @@ describe('composed-transform parity (manifold vs occt)', () => {
     expect(manifold).toBeCloseTo(occt, 0);
   });
 
-  it('circularPattern spreads copies over degrees on both kernels', () => {
-    if (!haveManifold) return;
+  it('circularPattern spreads copies over degrees on both kernels', (ctx) => {
+    if (!haveManifold) return ctx.skip();
     const build = () =>
       bounds(
         mesh(unwrap(circularPattern(translate(makeBaseBox(2, 2, 2), 8, 0, 0), [0, 0, 1], 4, 270)), {


### PR DESCRIPTION
## Summary

Fixes the two stacked Manifold-kernel bugs that made gridfinity's honeycomb wall pattern render as plain walls in draft previews (the cut was a silent no-op — output triangles were exactly identical to a plain bin).

### Bug 1 — `composeTransform` treated degrees as radians
The `composeTransform` kernel boundary receives **degrees** (both OCCT adapters convert per-op internally: `occt/advancedOps.ts`, `occtWasm/transformOps.ts`), but the Manifold adapter fed `o.angle` straight to `rotationMatrix`, which expects **radians**. A composed 90° rotate became a 90-radian one, so every `transformCopy`-placed shape landed off-target. `circularPattern` (public API documents degrees) and `transformBatch` carried the same mismatch.

This is the counterpart of the #1228 rotate fix: kernel `rotate` is radians, `composeTransform`/`circularPattern`/`transformBatch` are degrees — the inconsistency between those contracts is exactly where the second adapter went wrong.

### Bug 2 — `makeCompound` was `notImplemented`
Grouping the placed hex prisms threw before any cut ran (and gridfinity's builder catches + falls back to no pattern, hence the silence). Implemented as an n-ary `Manifold.union`: mesh CSG has no non-fused grouping, and union is geometrically identical to a compound for disjoint members (multi-component manifold) while staying valid for overlapping ones — downstream booleans can't distinguish the two anyway. Member-wise sub-shape iteration is the one semantic this can't support (noted in code).

## Verification
- New `tests/parity/composedTransformParity.test.ts`: composed rotate parity, chained compose order, `circularPattern` spread, and a gridfinity-shaped hex-prism-compound wall cut — all manifold-vs-occt, all failing before the fix, green after (all 4 projections).
- Full `tests/parity/` manifold projection: 222 passed, 0 regressions.
- Fixes 3 pre-existing `transformCopy.test.ts` manifold-projection failures (4 → 1; the remaining one is the per-face evolution-hash test, a known mesh-kernel limitation).
- End-to-end through gridfinity's real `generateBin` (linked dist): honeycomb on manifold now carves — plain 14,154 tris → honeycomb 32,232, minZ = 0 (occt-wasm control: 7,996 → 26,348, minZ = 0).