### PR TITLE
chore(release): sync brepjs-voxel-wasm workspace range to ^0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12566,9 +12566,10 @@
       }
     },
     "packages/brepjs-verify": {
-      "version": "0.2.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/node": "^25.9.1",
         "brepjs": "^18.0.0",
         "commander": "^13.0.0",
         "occt-wasm": "^3.0.0",
@@ -12676,11 +12677,11 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "brepjs-voxel-wasm": "^0.1.0"
+        "brepjs-voxel-wasm": "^0.2.0"
       }
     },
     "packages/brepjs-voxel-wasm": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0"
     },
     "packages/brepjs-vscode": {

--- a/packages/brepjs-voxel/package.json
+++ b/packages/brepjs-voxel/package.json
@@ -21,7 +21,7 @@
     "src"
   ],
   "dependencies": {
-    "brepjs-voxel-wasm": "^0.1.0"
+    "brepjs-voxel-wasm": "^0.2.0"
   },
   "exports": {
     ".": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,5 +31,6 @@
       "bump-minor-pre-major": true
     }
   },
+  "plugins": ["node-workspace"],
   "separate-pull-requests": true
 }


### PR DESCRIPTION
## Problem

Two checks are failing on `main`:
- **Deploy API Docs** (`docs.yml`) — `npm ci` fails
- **Dependabot** update job — npm re-resolve fails

Both fail with the same error:
```
npm error 404 Not Found - GET https://registry.npmjs.org/brepjs-voxel-wasm - Not found
npm error 404  The requested resource 'brepjs-voxel-wasm@^0.1.0' could not be found
```

## Root cause

Commit b7f61992 (release-please, #1239) bumped the internal workspace package `brepjs-voxel-wasm` `0.1.0 → 0.2.0`, but left the consumer `brepjs-voxel` pinned to `brepjs-voxel-wasm@^0.1.0`.

On a `0.x` version, `^0.1.0` resolves to `>=0.1.0 <0.2.0`, so `0.2.0` no longer satisfies it. npm therefore rejects the local workspace link and falls back to the npm registry — where the package is unpublished, so it 404s. (The main CI push passed because it predated the bump.)

## Fix

1. Bump `brepjs-voxel`'s dependency to `^0.2.0`.
2. Regenerate the lockfile via `npm install --package-lock-only` (also corrects a separate pre-existing `brepjs-verify` `0.2.1 → 0.4.0` lockfile drift).
3. Add `"plugins": ["node-workspace"]` to `release-please-config.json` so future internal version bumps automatically propagate sibling ranges + the root lockfile, preventing recurrence.

Uses a `chore(release):` subject so this manifest/lockfile sync doesn't trigger a spurious root `brepjs` library release.

## Verification

- `npm ci` now passes (no 404).
- Pre-commit: typecheck, boundaries, 4074 tests green.
- Pre-push: full `test:ci` suite + `knip` passed.