### PR TITLE
fix(brepjs-verify): point skills entry at ./skill directory, not SKILL.md

### DIFF
--- a/packages/brepjs-verify/.claude-plugin/plugin.json
+++ b/packages/brepjs-verify/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "brepjs-verify",
   "version": "0.1.0",
   "description": "Author and verify parametric brepjs CAD models",
-  "skills": ["./skill/SKILL.md"]
+  "skills": ["./skill"]
 }


### PR DESCRIPTION
## Problem

`/doctor` reports the brepjs-verify plugin failing to load its skill:

> skills load failed from ./skill/SKILL.md: path is a file; skills entries must be directories containing SKILL.md — point to the parent directory './skill' instead

## Cause

Claude Code's plugin loader treats each `skills[]` entry as a **directory** to scan for a `SKILL.md`, not as a path to the file itself. The manifest pointed at `./skill/SKILL.md`, so the loader stat'd that path, found a file where it expected a directory, and bailed — making the skill unavailable.

## Fix

Drop the filename so the entry points at the `./skill` directory.

```diff
-  "skills": ["./skill/SKILL.md"]
+  "skills": ["./skill"]
```

`skill/SKILL.md` is unchanged and still resolved by the loader.