### PR TITLE
feat(viewer): shared ViewerControls toolbar; interactive verify --serve

### DIFF
--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -48,7 +48,7 @@ npx -y brepjs-verify part.brep.ts --snapshot shots/                     # iso/fr
 npx -y brepjs-verify part.brep.ts --serve                               # clickable preview link (renders the real STEP)
 ```
 
-`--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The viewer is read-only display + screenshot in v1.
+`--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The `--serve` link is interactive: a toolbar offers view presets + fit, solid/wireframe/x-ray modes, edge/grid toggles, a turntable, and an in-browser PNG screenshot. `--snapshot` loads the same page with `ui=0` to suppress the toolbar, so captured PNGs stay chrome-free.
 
 ## CLI reference
 

--- a/packages/brepjs-verify/src/snapshot/shoot.ts
+++ b/packages/brepjs-verify/src/snapshot/shoot.ts
@@ -39,7 +39,8 @@ export async function shoot(opts: ShootOptions): Promise<ShootResult> {
   try {
     const page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 900 });
-    const target = `${server.url}/?dir=${encodeURIComponent(dir)}&file=${encodeURIComponent(rel)}`;
+    // ui=0 hides the interactive toolbar so captured PNGs contain only the model.
+    const target = `${server.url}/?dir=${encodeURIComponent(dir)}&file=${encodeURIComponent(rel)}&ui=0`;
     await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 30_000 });
     await page.waitForFunction('window.__ready === true', { timeout: READY_TIMEOUT_MS });
     for (const view of views) {

--- a/packages/brepjs-verify/viewer/main.tsx
+++ b/packages/brepjs-verify/viewer/main.tsx
@@ -1,13 +1,42 @@
-import { StrictMode, useState, useEffect } from 'react';
+import { StrictMode, useCallback, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { ViewerCanvas, Renderer, type ViewName } from 'brepjs-viewer';
+import {
+  ViewerCanvas,
+  ViewerControls,
+  Renderer,
+  EdgeRenderer,
+  type ViewMode,
+  type ViewName,
+} from 'brepjs-viewer';
 import { useModel } from './src/useModel.js';
 import { installScreenshotApi, onViewChange, markReady } from './src/screenshotApi.js';
+
+// The agent snapshot pipeline screenshots this same page, so it loads with ?ui=0 to
+// suppress the toolbar and keep PNGs free of chrome. Human `--serve` links omit it.
+const showControls = new URLSearchParams(window.location.search).get('ui') !== '0';
+
+function downloadCanvasPng(): void {
+  const canvas = document.querySelector('canvas');
+  if (!canvas) return;
+  const url = canvas.toDataURL('image/png');
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'brepjs-view.png';
+  a.click();
+}
 
 function App() {
   const state = useModel();
   const [view, setView] = useState<ViewName>('iso');
+  const [viewMode, setViewMode] = useState<ViewMode>('solid');
+  const [showEdges, setShowEdges] = useState(true);
+  const [showGrid, setShowGrid] = useState(true);
+  const [autoRotate, setAutoRotate] = useState(false);
+  const [fitSignal, setFitSignal] = useState(0);
   useEffect(() => onViewChange(setView), []); // bridge window.__renderView -> ViewerCanvas.view
+  const handleFit = useCallback(() => {
+    setFitSignal((n) => n + 1);
+  }, []);
   if (state.status === 'error')
     return (
       <div style={{ color: '#e88', padding: 16, fontFamily: 'monospace' }}>error: {state.error}</div>
@@ -15,15 +44,50 @@ function App() {
   if (state.status !== 'ready')
     return <div style={{ color: '#9aa', padding: 16, fontFamily: 'monospace' }}>loading model…</div>;
   return (
-    <ViewerCanvas data={state.data} view={view} onFirstFrame={markReady}>
-      <Renderer data={state.data} viewMode="solid" />
-    </ViewerCanvas>
+    <>
+      <ViewerCanvas
+        data={state.data}
+        view={view}
+        fitSignal={fitSignal}
+        autoRotate={autoRotate}
+        gridVisible={showGrid}
+        onFirstFrame={markReady}
+      >
+        <Renderer data={state.data} viewMode={viewMode} />
+        {showEdges && viewMode !== 'wireframe' && state.data.edges.length > 0 && (
+          <EdgeRenderer edges={state.data.edges} />
+        )}
+      </ViewerCanvas>
+      {showControls && (
+        <ViewerControls
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+          showEdges={showEdges}
+          onToggleEdges={() => {
+            setShowEdges((v) => !v);
+          }}
+          showGrid={showGrid}
+          onToggleGrid={() => {
+            setShowGrid((v) => !v);
+          }}
+          autoRotate={autoRotate}
+          onToggleAutoRotate={() => {
+            setAutoRotate((v) => !v);
+          }}
+          activeView={view}
+          onView={setView}
+          onFit={handleFit}
+          onScreenshot={downloadCanvasPng}
+        />
+      )}
+    </>
   );
 }
 installScreenshotApi();
 const root = document.getElementById('root');
-if (root) createRoot(root).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+if (root)
+  createRoot(root).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );

--- a/packages/brepjs-viewer/README.md
+++ b/packages/brepjs-viewer/README.md
@@ -7,7 +7,8 @@ It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional
 ## Exports
 
 - `Renderer` — draws a `MeshData` mesh; optional `onFacePick`/`onFaceHover`/`onFaceContextMenu` callbacks for selection.
-- `ViewerCanvas` — R3F `<Canvas frameloop="demand">` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), and fires `onFirstFrame` after first paint. Screenshot-agnostic.
+- `ViewerCanvas` — R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, and toggles `autoRotate`/`gridVisible`. Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
+- `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
 - `EdgeRenderer`, `SelectionHighlight`, `SceneSetup` — companion components.
 - `buildGeometry`, `findFaceGroupAt` — pure helpers.
 - Types: `MeshData`, `FaceGroup`, `FaceInfo`, `EdgeGroup`, `EdgeInfo`, `ViewMode`, `ViewName`, `VIEW_NAMES`.

--- a/packages/brepjs-viewer/src/ViewerCanvas.tsx
+++ b/packages/brepjs-viewer/src/ViewerCanvas.tsx
@@ -8,6 +8,10 @@ import type { MeshData, ViewName } from './types.js';
 export interface ViewerCanvasProps {
   data: MeshData;
   view?: ViewName;
+  /** Bump to re-frame the model on demand (e.g. a "Fit" button). */
+  fitSignal?: number;
+  autoRotate?: boolean;
+  gridVisible?: boolean;
   onFirstFrame?: () => void;
   children?: ReactNode;
 }
@@ -24,10 +28,12 @@ const VIEW_DIR: Record<ViewName, THREE.Vector3> = {
 function Framing({
   data,
   view,
+  fitSignal,
   onFirstFrame,
 }: {
   data: MeshData;
   view: ViewName;
+  fitSignal?: number | undefined;
   onFirstFrame?: (() => void) | undefined;
 }) {
   const camera = useThree((s) => s.camera);
@@ -56,15 +62,25 @@ function Framing({
       fired.current = true;
       onFirstFrame?.();
     }
-  }, [camera, invalidate, center, radius, view, onFirstFrame]);
+  }, [camera, invalidate, center, radius, view, fitSignal, onFirstFrame]);
   return null;
 }
 
-export function ViewerCanvas({ data, view = 'iso', onFirstFrame, children }: ViewerCanvasProps) {
+export function ViewerCanvas({
+  data,
+  view = 'iso',
+  fitSignal,
+  autoRotate = false,
+  gridVisible = true,
+  onFirstFrame,
+  children,
+}: ViewerCanvasProps) {
   return (
-    <Canvas frameloop="demand" gl={{ preserveDrawingBuffer: true }}>
-      <SceneSetup />
-      <Framing data={data} view={view} onFirstFrame={onFirstFrame} />
+    // `always` while spinning so the turntable advances; `demand` otherwise keeps the
+    // GPU idle. preserveDrawingBuffer stays on so screenshots read back in both modes.
+    <Canvas frameloop={autoRotate ? 'always' : 'demand'} gl={{ preserveDrawingBuffer: true }}>
+      <SceneSetup autoRotate={autoRotate} gridVisible={gridVisible} />
+      <Framing data={data} view={view} fitSignal={fitSignal} onFirstFrame={onFirstFrame} />
       {children}
     </Canvas>
   );

--- a/packages/brepjs-viewer/src/ViewerCanvas.tsx
+++ b/packages/brepjs-viewer/src/ViewerCanvas.tsx
@@ -39,6 +39,11 @@ function Framing({
   const camera = useThree((s) => s.camera);
   const invalidate = useThree((s) => s.invalidate);
   const fired = useRef(false);
+  // Hold the latest onFirstFrame in a ref so it stays out of the framing effect's deps:
+  // an inline callback from a consumer would otherwise re-run the effect on every parent
+  // render and snap the camera back to the preset, interrupting an in-progress orbit.
+  const onFirstFrameRef = useRef(onFirstFrame);
+  onFirstFrameRef.current = onFirstFrame;
   const { center, radius } = useMemo(() => {
     // Throwaway geometry just for the bounding sphere — dispose it so its GPU buffers
     // aren't leaked on every `data` change (GC alone won't free them).
@@ -60,9 +65,9 @@ function Framing({
     invalidate();
     if (!fired.current) {
       fired.current = true;
-      onFirstFrame?.();
+      onFirstFrameRef.current?.();
     }
-  }, [camera, invalidate, center, radius, view, fitSignal, onFirstFrame]);
+  }, [camera, invalidate, center, radius, view, fitSignal]);
   return null;
 }
 

--- a/packages/brepjs-viewer/src/ViewerControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerControls.tsx
@@ -105,7 +105,7 @@ function Group({ children }: { children: ReactNode }) {
 
 function Btn({
   label,
-  active = false,
+  active,
   onClick,
 }: {
   label: string;
@@ -116,6 +116,8 @@ function Btn({
     <button
       type="button"
       onClick={onClick}
+      // Omit aria-pressed for one-shot actions (Fit/Snap, active===undefined); set it only
+      // for the toggle buttons so screen readers don't announce actions as unpressed toggles.
       aria-pressed={active}
       style={{ ...buttonStyle, ...(active ? activeButtonStyle : null) }}
     >

--- a/packages/brepjs-viewer/src/ViewerControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerControls.tsx
@@ -1,0 +1,164 @@
+import { type CSSProperties, type ReactNode } from 'react';
+import { VIEW_NAMES, type ViewMode, type ViewName } from './types.js';
+
+// Fully controlled, store-agnostic toolbar. Each control group renders only when
+// its handler is supplied, so a consumer (the verify viewer, the playground) opts
+// into exactly the controls it wires up. Styling defaults to self-contained inline
+// styles so it works without Tailwind; pass `className` to restyle the container.
+export interface ViewerControlsProps {
+  viewMode?: ViewMode;
+  onViewModeChange?: (mode: ViewMode) => void;
+  showEdges?: boolean;
+  onToggleEdges?: () => void;
+  showGrid?: boolean;
+  onToggleGrid?: () => void;
+  autoRotate?: boolean;
+  onToggleAutoRotate?: () => void;
+  activeView?: ViewName | null;
+  onView?: (view: ViewName) => void;
+  onFit?: () => void;
+  onScreenshot?: () => void;
+  className?: string;
+}
+
+const MODE_LABELS: Record<ViewMode, string> = {
+  solid: 'Solid',
+  wireframe: 'Wire',
+  xray: 'X-ray',
+};
+const VIEW_LABELS: Record<ViewName, string> = {
+  iso: 'Iso',
+  front: 'Front',
+  top: 'Top',
+  right: 'Right',
+};
+
+export function ViewerControls({
+  viewMode,
+  onViewModeChange,
+  showEdges,
+  onToggleEdges,
+  showGrid,
+  onToggleGrid,
+  autoRotate,
+  onToggleAutoRotate,
+  activeView,
+  onView,
+  onFit,
+  onScreenshot,
+  className,
+}: ViewerControlsProps) {
+  return (
+    <div className={className} style={className ? undefined : containerStyle}>
+      {(onFit || onScreenshot) && (
+        <Group>
+          {onFit && <Btn label="Fit" onClick={onFit} />}
+          {onScreenshot && <Btn label="Snap" onClick={onScreenshot} />}
+        </Group>
+      )}
+      {viewMode && onViewModeChange && (
+        <Group>
+          {(Object.keys(MODE_LABELS) as ViewMode[]).map((mode) => (
+            <Btn
+              key={mode}
+              label={MODE_LABELS[mode]}
+              active={viewMode === mode}
+              onClick={() => {
+                onViewModeChange(mode);
+              }}
+            />
+          ))}
+        </Group>
+      )}
+      {(onToggleEdges || onToggleGrid || onToggleAutoRotate) && (
+        <Group>
+          {onToggleEdges && (
+            <Btn label="Edges" active={showEdges} onClick={onToggleEdges} />
+          )}
+          {onToggleGrid && <Btn label="Grid" active={showGrid} onClick={onToggleGrid} />}
+          {onToggleAutoRotate && (
+            <Btn label="Spin" active={autoRotate} onClick={onToggleAutoRotate} />
+          )}
+        </Group>
+      )}
+      {onView && (
+        <Group>
+          {VIEW_NAMES.map((view) => (
+            <Btn
+              key={view}
+              label={VIEW_LABELS[view]}
+              active={activeView === view}
+              onClick={() => {
+                onView(view);
+              }}
+            />
+          ))}
+        </Group>
+      )}
+    </div>
+  );
+}
+
+function Group({ children }: { children: ReactNode }) {
+  return <div style={groupStyle}>{children}</div>;
+}
+
+function Btn({
+  label,
+  active = false,
+  onClick,
+}: {
+  label: string;
+  active?: boolean | undefined;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{ ...buttonStyle, ...(active ? activeButtonStyle : null) }}
+    >
+      {label}
+    </button>
+  );
+}
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  top: 12,
+  right: 12,
+  zIndex: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+const groupStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  padding: 4,
+  borderRadius: 8,
+  background: 'rgba(26, 29, 33, 0.7)',
+  backdropFilter: 'blur(6px)',
+  border: '1px solid rgba(255, 255, 255, 0.08)',
+};
+const buttonStyle: CSSProperties = {
+  cursor: 'pointer',
+  padding: '4px 10px',
+  borderRadius: 5,
+  fontSize: 12,
+  fontWeight: 500,
+  lineHeight: 1.2,
+  color: '#9aa3ad',
+  background: 'rgba(255, 255, 255, 0.04)',
+  border: '1px solid transparent',
+  transition: 'color 120ms, background 120ms',
+};
+const activeButtonStyle: CSSProperties = {
+  color: '#6ee7d7',
+  background: 'rgba(45, 212, 191, 0.16)',
+  borderColor: 'rgba(45, 212, 191, 0.3)',
+};

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -3,5 +3,6 @@ export { default as EdgeRenderer } from './EdgeRenderer.js';
 export { default as SelectionHighlight } from './SelectionHighlight.js';
 export { default as SceneSetup } from './SceneSetup.js';
 export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
+export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
 export * from './types.js';
 export { buildGeometry, findFaceGroupAt } from './geometry.js';


### PR DESCRIPTION
## What

Turns the bare, read-only `brepjs-verify --serve` viewer into a lightweight inspector, by **extracting a reusable toolbar into the shared `brepjs-viewer`** rather than rebuilding it. This is **PR A of Phase 1** of a viewer overhaul (inspired by `earthtojake/text-to-cad`'s `cad-viewer`).

### `brepjs-viewer` (shared lib)
- New **`ViewerControls`** — store-agnostic, fully-controlled toolbar: view-mode (solid/wire/x-ray), edges, grid, turntable, view presets (iso/front/top/right), fit, screenshot. Each group renders only when its handler is supplied; self-contained inline styles so it works without Tailwind (`className` to restyle).
- **`ViewerCanvas`** now accepts `autoRotate`, `gridVisible`, and a `fitSignal` (bump to re-frame). Flips `frameloop` to `always` while spinning so the turntable advances, `demand` otherwise.

### `brepjs-verify` (consumer)
- The standalone viewer wires `ViewerControls` with local React state + an in-browser PNG download, and renders edges.
- The agent **snapshot pipeline loads the page with `ui=0`** to suppress the toolbar — captured PNGs stay pixel-clean (verified below).

## Verification
- `brepjs-viewer`: typecheck + lint + build green.
- `brepjs-verify`: typecheck + lint + **78 tests** + viewer build green.
- Snapshot path → chrome-free PNG (ui=0); serve path → full toolbar (both screenshot-confirmed locally).

## Scope / follow-ups
- Projection (ortho/persp) toggle deferred — it needs the camera-bridge work and is the riskiest bit.
- **PR B (next):** refactor the playground `ViewerToolbar` to consume this same `ViewerControls` (pure refactor, no behavior change).
- Later phases: measurements/info panel, face-pick inspection, section plane, snapshot dimension overlay.