### PR TITLE
feat(viewer): measurements info panel in verify --serve

### DIFF
--- a/packages/brepjs-verify/viewer/main.tsx
+++ b/packages/brepjs-verify/viewer/main.tsx
@@ -3,8 +3,10 @@ import { createRoot } from 'react-dom/client';
 import {
   ViewerCanvas,
   ViewerControls,
+  ViewerInfoPanel,
   Renderer,
   EdgeRenderer,
+  meshSize,
   type ViewMode,
   type ViewName,
 } from 'brepjs-viewer';
@@ -58,6 +60,15 @@ function App() {
           <EdgeRenderer edges={state.data.edges} />
         )}
       </ViewerCanvas>
+      {showControls && (
+        <ViewerInfoPanel
+          dims={meshSize(state.data)}
+          volume={state.measurements.volume}
+          area={state.measurements.area}
+          triangles={state.data.index.length / 3}
+          valid={state.measurements.valid}
+        />
+      )}
       {showControls && (
         <ViewerControls
           viewMode={viewMode}

--- a/packages/brepjs-verify/viewer/src/kernelWorker.ts
+++ b/packages/brepjs-verify/viewer/src/kernelWorker.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { loadModel, type BrepjsForLoad } from './loaders.js';
+import { loadModel, type BrepjsForLoad, type ModelMeasurements } from './loaders.js';
 import type { MeshData } from 'brepjs-viewer';
 
 type BrepjsKernel = BrepjsForLoad & {
@@ -20,6 +20,7 @@ export interface LoadRequest {
 export interface LoadOk {
   type: 'loaded';
   meshData: MeshData;
+  measurements: ModelMeasurements;
 }
 export interface LoadError {
   type: 'error';
@@ -81,8 +82,8 @@ function transferablesFor(md: MeshData): Transferable[] {
 async function handleLoad(req: LoadRequest): Promise<void> {
   try {
     const kernel = await ensureKernel();
-    const meshData = await loadModel(kernel, new Blob([req.bytes]), req.ext);
-    post({ type: 'loaded', meshData }, transferablesFor(meshData));
+    const { meshData, measurements } = await loadModel(kernel, new Blob([req.bytes]), req.ext);
+    post({ type: 'loaded', meshData, measurements }, transferablesFor(meshData));
   } catch (e) {
     post({ type: 'error', error: e instanceof Error ? e.message : String(e) });
   }

--- a/packages/brepjs-verify/viewer/src/loaders.ts
+++ b/packages/brepjs-verify/viewer/src/loaders.ts
@@ -36,7 +36,7 @@ function measureModel(bk: BrepjsForLoad, shape: unknown): ModelMeasurements {
   const vol = safe(() => bk.measureVolume(shape));
   if (vol && bk.isOk(vol) && typeof vol.value === 'number' && vol.value > 0) m.volume = vol.value;
   const area = safe(() => bk.measureArea(shape));
-  if (area && bk.isOk(area) && typeof area.value === 'number') m.area = area.value;
+  if (area && bk.isOk(area) && typeof area.value === 'number' && area.value > 0) m.area = area.value;
   return m;
 }
 function safe<T>(fn: () => T): T | undefined {

--- a/packages/brepjs-verify/viewer/src/loaders.ts
+++ b/packages/brepjs-verify/viewer/src/loaders.ts
@@ -13,8 +13,39 @@ export interface BrepjsForLoad {
   importOBJ: (b: Blob) => Promise<{ ok: boolean }>;
   mesh: (s: unknown) => ShapeMeshLike;
   meshEdges: (s: unknown) => { lines: Float32Array };
+  measureVolume: (s: unknown) => { ok: boolean; value?: number };
+  measureArea: (s: unknown) => { ok: boolean; value?: number };
+  isValid: (s: unknown) => boolean;
 }
 type Importer = (b: Blob) => Promise<{ ok: boolean }>;
+
+export interface ModelMeasurements {
+  volume?: number;
+  area?: number;
+  valid: boolean;
+}
+export interface LoadedModel {
+  meshData: MeshData;
+  measurements: ModelMeasurements;
+}
+
+// Best-effort measurements: a non-solid import has no volume, so guard each call and
+// only surface what the kernel returns cleanly. Validity always resolves to a boolean.
+function measureModel(bk: BrepjsForLoad, shape: unknown): ModelMeasurements {
+  const m: ModelMeasurements = { valid: safe(() => bk.isValid(shape)) ?? false };
+  const vol = safe(() => bk.measureVolume(shape));
+  if (vol && bk.isOk(vol) && typeof vol.value === 'number' && vol.value > 0) m.volume = vol.value;
+  const area = safe(() => bk.measureArea(shape));
+  if (area && bk.isOk(area) && typeof area.value === 'number') m.area = area.value;
+  return m;
+}
+function safe<T>(fn: () => T): T | undefined {
+  try {
+    return fn();
+  } catch {
+    return undefined;
+  }
+}
 
 export function importerFor(bk: BrepjsForLoad, ext: string): Importer {
   switch (ext.replace(/^\./, '').toLowerCase()) {
@@ -37,12 +68,13 @@ export function importerFor(bk: BrepjsForLoad, ext: string): Importer {
       throw new Error(`unsupported file extension: ${ext}`);
   }
 }
-export async function loadModel(bk: BrepjsForLoad, blob: Blob, ext: string): Promise<MeshData> {
+export async function loadModel(bk: BrepjsForLoad, blob: Blob, ext: string): Promise<LoadedModel> {
   const result = await importerFor(bk, ext)(blob);
   if (!bk.isOk(result)) {
     const err = (result as { error?: unknown }).error;
     throw new Error(`import failed: ${typeof err === 'string' ? err : JSON.stringify(err)}`);
   }
   const shape = (result as unknown as { value: unknown }).value;
-  return shapeMeshToMeshData(bk.mesh(shape), bk.meshEdges(shape).lines);
+  const meshData = shapeMeshToMeshData(bk.mesh(shape), bk.meshEdges(shape).lines);
+  return { meshData, measurements: measureModel(bk, shape) };
 }

--- a/packages/brepjs-verify/viewer/src/useModel.ts
+++ b/packages/brepjs-verify/viewer/src/useModel.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { MeshData } from 'brepjs-viewer';
 import type { FromWorker, LoadRequest } from './kernelWorker.js';
+import type { ModelMeasurements } from './loaders.js';
 
 export interface ModelParams {
   dir: string | null;
@@ -19,7 +20,7 @@ export function extOf(file: string): string {
 export type ModelState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'ready'; data: MeshData }
+  | { status: 'ready'; data: MeshData; measurements: ModelMeasurements }
   | { status: 'error'; error: string };
 
 export function useModel(): ModelState {
@@ -41,7 +42,8 @@ export function useModel(): ModelState {
     let cancelled = false;
     worker.addEventListener('message', (e: MessageEvent<FromWorker>) => {
       if (cancelled) return;
-      if (e.data.type === 'loaded') setState({ status: 'ready', data: e.data.meshData });
+      if (e.data.type === 'loaded')
+        setState({ status: 'ready', data: e.data.meshData, measurements: e.data.measurements });
       else setState({ status: 'error', error: e.data.error });
     });
     // Fetch via the Phase D static server's model route: /__model/<rel>?dir=<abs>.

--- a/packages/brepjs-verify/viewer/tests/loaders.test.ts
+++ b/packages/brepjs-verify/viewer/tests/loaders.test.ts
@@ -20,6 +20,9 @@ function makeFakeBrepjs() {
     importOBJ: vi.fn(() => Promise.resolve({ ok: true, value: fakeShape })),
     mesh: vi.fn(() => fakeMesh),
     meshEdges: vi.fn(() => ({ lines: new Float32Array([0, 0, 0, 1, 0, 0]), edgeGroups: [] })),
+    measureVolume: vi.fn(() => ({ ok: true, value: 42 })),
+    measureArea: vi.fn(() => ({ ok: true, value: 84 })),
+    isValid: vi.fn(() => true),
   };
 }
 describe('importerFor', () => {
@@ -37,10 +40,24 @@ describe('importerFor', () => {
 describe('loadModel', () => {
   it('imports, meshes, converts', async () => {
     const bk = makeFakeBrepjs();
-    const md = await loadModel(bk, new Blob([new Uint8Array([1, 2, 3])]), '.step');
+    const { meshData } = await loadModel(bk, new Blob([new Uint8Array([1, 2, 3])]), '.step');
     expect(bk.importSTEP).toHaveBeenCalledOnce();
-    expect(md.position).toBe(fakeMesh.vertices);
-    expect(md.faceGroups).toEqual([{ start: 0, count: 1, faceId: 7 }]);
+    expect(meshData.position).toBe(fakeMesh.vertices);
+    expect(meshData.faceGroups).toEqual([{ start: 0, count: 1, faceId: 7 }]);
+  });
+  it('measures volume, area, and validity', async () => {
+    const bk = makeFakeBrepjs();
+    const { measurements } = await loadModel(bk, new Blob([new Uint8Array([1])]), '.step');
+    expect(measurements).toEqual({ volume: 42, area: 84, valid: true });
+  });
+  it('omits non-positive volume and surfaces invalid shapes', async () => {
+    const bk = makeFakeBrepjs();
+    bk.measureVolume = vi.fn(() => ({ ok: true, value: 0 }));
+    bk.isValid = vi.fn(() => false);
+    const { measurements } = await loadModel(bk, new Blob([new Uint8Array([1])]), '.step');
+    expect(measurements.volume).toBeUndefined();
+    expect(measurements.valid).toBe(false);
+    expect(measurements.area).toBe(84);
   });
   it('rejects on Err', async () => {
     const bk = makeFakeBrepjs();

--- a/packages/brepjs-viewer/README.md
+++ b/packages/brepjs-viewer/README.md
@@ -9,8 +9,9 @@ It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional
 - `Renderer` — draws a `MeshData` mesh; optional `onFacePick`/`onFaceHover`/`onFaceContextMenu` callbacks for selection.
 - `ViewerCanvas` — R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, and toggles `autoRotate`/`gridVisible`. Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
 - `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
+- `ViewerInfoPanel` — controlled, store-agnostic measurements readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are supplied.
 - `EdgeRenderer`, `SelectionHighlight`, `SceneSetup` — companion components.
-- `buildGeometry`, `findFaceGroupAt` — pure helpers.
+- `buildGeometry`, `findFaceGroupAt`, `meshSize` — pure helpers (`meshSize` returns mesh bbox extents).
 - Types: `MeshData`, `FaceGroup`, `FaceInfo`, `EdgeGroup`, `EdgeInfo`, `ViewMode`, `ViewName`, `VIEW_NAMES`.
 
 ## Peer dependencies

--- a/packages/brepjs-viewer/src/ViewerInfoPanel.tsx
+++ b/packages/brepjs-viewer/src/ViewerInfoPanel.tsx
@@ -1,0 +1,112 @@
+import { type CSSProperties, type ReactNode } from 'react';
+
+// Controlled, store-agnostic readout of a model's measurements. Renders only the rows
+// whose values are supplied; self-contained inline styles so it works without Tailwind.
+export interface ViewerInfoPanelProps {
+  /** Bounding-box extents (width, depth, height) in model units. */
+  dims?: [number, number, number] | undefined;
+  volume?: number | undefined;
+  area?: number | undefined;
+  triangles?: number | undefined;
+  valid?: boolean | undefined;
+  /** Unit suffix for lengths (e.g. "mm"). Volume/area get the squared/cubed form. */
+  unit?: string | undefined;
+  className?: string;
+}
+
+export function ViewerInfoPanel({
+  dims,
+  volume,
+  area,
+  triangles,
+  valid,
+  unit,
+  className,
+}: ViewerInfoPanelProps) {
+  const u = unit ? ` ${unit}` : '';
+  const rows: ReactNode[] = [];
+  if (dims)
+    rows.push(
+      <Row
+        key="size"
+        label="Size"
+        value={`${fmt(dims[0])} × ${fmt(dims[1])} × ${fmt(dims[2])}${u}`}
+      />,
+    );
+  if (volume !== undefined)
+    rows.push(<Row key="vol" label="Volume" value={`${fmt(volume)}${unit ? ` ${unit}³` : ''}`} />);
+  if (area !== undefined)
+    rows.push(<Row key="area" label="Area" value={`${fmt(area)}${unit ? ` ${unit}²` : ''}`} />);
+  if (triangles !== undefined)
+    rows.push(<Row key="tris" label="Triangles" value={triangles.toLocaleString()} />);
+  if (valid !== undefined)
+    rows.push(
+      <Row
+        key="valid"
+        label="Validity"
+        value={valid ? 'valid' : 'invalid'}
+        valueColor={valid ? '#6ee7d7' : '#f0a0a0'}
+      />,
+    );
+  if (rows.length === 0) return null;
+
+  return (
+    <div className={className} style={className ? undefined : containerStyle}>
+      {rows}
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+}) {
+  return (
+    <div style={rowStyle}>
+      <span style={labelStyle}>{label}</span>
+      <span style={{ ...valueStyle, ...(valueColor ? { color: valueColor } : null) }}>{value}</span>
+    </div>
+  );
+}
+
+// Compact number: integers as-is, otherwise up to 2 decimals without trailing zeros.
+function fmt(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Number.isInteger(n)) return n.toLocaleString();
+  return Number(n.toFixed(2)).toLocaleString();
+}
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  left: 12,
+  bottom: 12,
+  zIndex: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  padding: '8px 10px',
+  borderRadius: 8,
+  minWidth: 150,
+  background: 'rgba(26, 29, 33, 0.7)',
+  backdropFilter: 'blur(6px)',
+  border: '1px solid rgba(255, 255, 255, 0.08)',
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 16,
+  fontSize: 12,
+  lineHeight: 1.5,
+};
+const labelStyle: CSSProperties = { color: '#7b8591' };
+const valueStyle: CSSProperties = {
+  color: '#c8cdd3',
+  fontVariantNumeric: 'tabular-nums',
+};

--- a/packages/brepjs-viewer/src/geometry.ts
+++ b/packages/brepjs-viewer/src/geometry.ts
@@ -9,6 +9,32 @@ export function buildGeometry(data: MeshData): THREE.BufferGeometry {
   return geo;
 }
 
+// Axis-aligned bounding-box extents (width, depth, height) of the mesh in its own
+// coordinates. Mesh-derived, so it's within tessellation tolerance of the kernel's
+// exact bbox — fine for a viewer readout, not a substitute for the verify report.
+export function meshSize(data: MeshData): [number, number, number] {
+  const p = data.position;
+  if (p.length < 3) return [0, 0, 0];
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+  for (let i = 0; i + 2 < p.length; i += 3) {
+    const x = p[i] as number;
+    const y = p[i + 1] as number;
+    const z = p[i + 2] as number;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
+  }
+  return [maxX - minX, maxY - minY, maxZ - minZ];
+}
+
 export function findFaceGroupAt(groups: FaceGroup[], triangleIndex: number): FaceGroup | null {
   const off = triangleIndex * 3;
   let lo = 0;

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -4,5 +4,6 @@ export { default as SelectionHighlight } from './SelectionHighlight.js';
 export { default as SceneSetup } from './SceneSetup.js';
 export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
 export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
+export { ViewerInfoPanel, type ViewerInfoPanelProps } from './ViewerInfoPanel.js';
 export * from './types.js';
-export { buildGeometry, findFaceGroupAt } from './geometry.js';
+export { buildGeometry, findFaceGroupAt, meshSize } from './geometry.js';


### PR DESCRIPTION
## What

**Phase 2** of the viewer overhaul. Adds a measurements/info panel to the `brepjs-verify --serve` viewer — the most verify-specific feature, since it directly answers *"is this the right part?"* with size · volume · area · validity.

### `brepjs-viewer`
- New **`ViewerInfoPanel`** — controlled, store-agnostic readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are present; self-contained inline styles.
- New pure **`meshSize(data)`** helper — bbox extents from mesh positions.

### `brepjs-verify`
- The kernel worker now measures **volume / area / validity** on the imported shape (`measureVolume`/`measureArea`/`isValid`), best-effort: non-positive volume and failed ops are omitted, validity always resolves. Measurements ship alongside the mesh.
- The standalone viewer renders the panel bottom-left, gated behind the same `ui` flag as the toolbar — **agent snapshots stay chrome-free**.

## Verification
- `brepjs-viewer` + `brepjs-verify`: typecheck + lint + build green; **80 tests** pass (+2 new measurement tests).
- Screenshot-confirmed on a 10×10×10 box: Size `10 × 10 × 10`, Volume `1,000`, Area `600`, Triangles `12`, Validity `valid` — all exact.

## Notes
- Bbox size is mesh-derived (within tessellation tolerance) — a visual aid, not a replacement for the CLI verify report's exact kernel bbox.

## Next phases
3 — face-pick inspection · 4 — section plane · 5 — snapshot dimension overlay.