### PR TITLE
feat(viewer): click-to-inspect face picking in verify --serve

### DIFF
--- a/packages/brepjs-verify/viewer/main.tsx
+++ b/packages/brepjs-verify/viewer/main.tsx
@@ -4,9 +4,12 @@ import {
   ViewerCanvas,
   ViewerControls,
   ViewerInfoPanel,
+  ViewerSelectionPanel,
   Renderer,
   EdgeRenderer,
+  SelectionHighlight,
   meshSize,
+  type FaceInfo,
   type ViewMode,
   type ViewName,
 } from 'brepjs-viewer';
@@ -28,16 +31,24 @@ function downloadCanvasPng(): void {
 }
 
 function App() {
-  const state = useModel();
+  const state = useModel({ inspect: showControls });
   const [view, setView] = useState<ViewName>('iso');
   const [viewMode, setViewMode] = useState<ViewMode>('solid');
   const [showEdges, setShowEdges] = useState(true);
   const [showGrid, setShowGrid] = useState(true);
   const [autoRotate, setAutoRotate] = useState(false);
   const [fitSignal, setFitSignal] = useState(0);
+  const [selectedFace, setSelectedFace] = useState<FaceInfo | null>(null);
+  const [hoverFaceId, setHoverFaceId] = useState<number | null>(null);
   useEffect(() => onViewChange(setView), []); // bridge window.__renderView -> ViewerCanvas.view
   const handleFit = useCallback(() => {
     setFitSignal((n) => n + 1);
+  }, []);
+  const handleFacePick = useCallback((info: FaceInfo) => {
+    setSelectedFace(info);
+  }, []);
+  const handleFaceHover = useCallback((info: FaceInfo | null) => {
+    setHoverFaceId(info ? info.faceId : null);
   }, []);
   if (state.status === 'error')
     return (
@@ -55,11 +66,32 @@ function App() {
         gridVisible={showGrid}
         onFirstFrame={markReady}
       >
-        <Renderer data={state.data} viewMode={viewMode} />
+        <Renderer
+          data={state.data}
+          viewMode={viewMode}
+          {...(showControls
+            ? { onFacePick: handleFacePick, onFaceHover: handleFaceHover }
+            : {})}
+        />
         {showEdges && viewMode !== 'wireframe' && state.data.edges.length > 0 && (
           <EdgeRenderer edges={state.data.edges} />
         )}
+        {showControls && (
+          <SelectionHighlight
+            data={state.data}
+            selectedFaceIds={selectedFace ? [selectedFace.faceId] : []}
+            hoverFaceId={hoverFaceId}
+          />
+        )}
       </ViewerCanvas>
+      {showControls && (
+        <ViewerSelectionPanel
+          face={selectedFace}
+          onClear={() => {
+            setSelectedFace(null);
+          }}
+        />
+      )}
       {showControls && (
         <ViewerInfoPanel
           dims={meshSize(state.data)}

--- a/packages/brepjs-verify/viewer/src/kernelWorker.ts
+++ b/packages/brepjs-verify/viewer/src/kernelWorker.ts
@@ -16,6 +16,8 @@ export interface LoadRequest {
   type: 'load';
   bytes: ArrayBuffer;
   ext: string;
+  /** Collect per-face metadata for click-to-inspect (skipped for headless snapshots). */
+  inspect?: boolean;
 }
 export interface LoadOk {
   type: 'loaded';
@@ -82,7 +84,12 @@ function transferablesFor(md: MeshData): Transferable[] {
 async function handleLoad(req: LoadRequest): Promise<void> {
   try {
     const kernel = await ensureKernel();
-    const { meshData, measurements } = await loadModel(kernel, new Blob([req.bytes]), req.ext);
+    const { meshData, measurements } = await loadModel(
+      kernel,
+      new Blob([req.bytes]),
+      req.ext,
+      req.inspect ?? false,
+    );
     post({ type: 'loaded', meshData, measurements }, transferablesFor(meshData));
   } catch (e) {
     post({ type: 'error', error: e instanceof Error ? e.message : String(e) });

--- a/packages/brepjs-verify/viewer/src/loaders.ts
+++ b/packages/brepjs-verify/viewer/src/loaders.ts
@@ -1,4 +1,4 @@
-import type { MeshData } from 'brepjs-viewer';
+import type { FaceInfo, MeshData } from 'brepjs-viewer';
 import { shapeMeshToMeshData, type ShapeMeshLike } from './convert.js';
 
 // Structural view of the brepjs namespace this module uses; injected by the worker
@@ -16,6 +16,10 @@ export interface BrepjsForLoad {
   measureVolume: (s: unknown) => { ok: boolean; value?: number };
   measureArea: (s: unknown) => { ok: boolean; value?: number };
   isValid: (s: unknown) => boolean;
+  getFaces: (s: unknown) => unknown[];
+  getSurfaceType: (face: unknown) => { ok: boolean; value?: string };
+  normalAt: (face: unknown) => [number, number, number];
+  getHashCode: (face: unknown) => number;
 }
 type Importer = (b: Blob) => Promise<{ ok: boolean }>;
 
@@ -68,7 +72,38 @@ export function importerFor(bk: BrepjsForLoad, ext: string): Importer {
       throw new Error(`unsupported file extension: ${ext}`);
   }
 }
-export async function loadModel(bk: BrepjsForLoad, blob: Blob, ext: string): Promise<LoadedModel> {
+// Per-face metadata for click-to-inspect: surface type, area, and outward normal,
+// keyed by hash code so it matches the mesh's faceGroup faceIds. Per-face try/catch
+// keeps one degenerate face (normalAt can throw on quirky BSpline UVs) from wiping
+// the rest. Mirrors apps/playground's cad.worker collectFaceInfos.
+function collectFaceInfos(bk: BrepjsForLoad, shape: unknown): FaceInfo[] {
+  let faces: unknown[];
+  try {
+    faces = bk.getFaces(shape);
+  } catch {
+    return [];
+  }
+  const infos: FaceInfo[] = [];
+  for (const face of faces) {
+    try {
+      const st = bk.getSurfaceType(face);
+      const surfaceType = bk.isOk(st) && st.value ? st.value : 'OTHER_SURFACE';
+      const areaResult = bk.measureArea(face);
+      const area = bk.isOk(areaResult) && typeof areaResult.value === 'number' ? areaResult.value : NaN;
+      infos.push({ faceId: bk.getHashCode(face), surfaceType, area, normal: bk.normalAt(face) });
+    } catch {
+      // skip this face
+    }
+  }
+  return infos;
+}
+
+export async function loadModel(
+  bk: BrepjsForLoad,
+  blob: Blob,
+  ext: string,
+  inspect = false,
+): Promise<LoadedModel> {
   const result = await importerFor(bk, ext)(blob);
   if (!bk.isOk(result)) {
     const err = (result as { error?: unknown }).error;
@@ -76,5 +111,8 @@ export async function loadModel(bk: BrepjsForLoad, blob: Blob, ext: string): Pro
   }
   const shape = (result as unknown as { value: unknown }).value;
   const meshData = shapeMeshToMeshData(bk.mesh(shape), bk.meshEdges(shape).lines);
+  // Face metadata powers click-to-inspect; skip it for headless snapshots (inspect=false)
+  // so capture stays as fast as before.
+  if (inspect) meshData.faceInfos = collectFaceInfos(bk, shape);
   return { meshData, measurements: measureModel(bk, shape) };
 }

--- a/packages/brepjs-verify/viewer/src/loaders.ts
+++ b/packages/brepjs-verify/viewer/src/loaders.ts
@@ -80,7 +80,8 @@ function collectFaceInfos(bk: BrepjsForLoad, shape: unknown): FaceInfo[] {
   let faces: unknown[];
   try {
     faces = bk.getFaces(shape);
-  } catch {
+  } catch (err) {
+    console.warn('[brepjs-verify] getFaces threw; faces unselectable', err);
     return [];
   }
   const infos: FaceInfo[] = [];
@@ -91,8 +92,10 @@ function collectFaceInfos(bk: BrepjsForLoad, shape: unknown): FaceInfo[] {
       const areaResult = bk.measureArea(face);
       const area = bk.isOk(areaResult) && typeof areaResult.value === 'number' ? areaResult.value : NaN;
       infos.push({ faceId: bk.getHashCode(face), surfaceType, area, normal: bk.normalAt(face) });
-    } catch {
-      // skip this face
+    } catch (err) {
+      // A single degenerate face (normalAt can throw on quirky BSpline UVs) shouldn't
+      // wipe the rest; warn so the missing pickable face is diagnosable, then skip.
+      console.warn('[brepjs-verify] face metadata threw; skipping face', err);
     }
   }
   return infos;

--- a/packages/brepjs-verify/viewer/src/useModel.ts
+++ b/packages/brepjs-verify/viewer/src/useModel.ts
@@ -23,7 +23,11 @@ export type ModelState =
   | { status: 'ready'; data: MeshData; measurements: ModelMeasurements }
   | { status: 'error'; error: string };
 
-export function useModel(): ModelState {
+export interface UseModelOptions {
+  /** Collect per-face metadata so faces are clickable (skipped for headless snapshots). */
+  inspect?: boolean;
+}
+export function useModel({ inspect = false }: UseModelOptions = {}): ModelState {
   const [state, setState] = useState<ModelState>({ status: 'idle' });
   useEffect(() => {
     const params = parseModelParams(window.location.search);
@@ -57,7 +61,7 @@ export function useModel(): ModelState {
         return r.arrayBuffer();
       })
       .then((bytes) => {
-        const msg: LoadRequest = { type: 'load', bytes, ext: extOf(params.file) };
+        const msg: LoadRequest = { type: 'load', bytes, ext: extOf(params.file), inspect };
         worker.postMessage(msg, [bytes]);
       })
       .catch((err: unknown) => {
@@ -68,6 +72,6 @@ export function useModel(): ModelState {
       cancelled = true;
       worker.terminate();
     };
-  }, []);
+  }, [inspect]);
   return state;
 }

--- a/packages/brepjs-verify/viewer/tests/loaders.test.ts
+++ b/packages/brepjs-verify/viewer/tests/loaders.test.ts
@@ -23,6 +23,10 @@ function makeFakeBrepjs() {
     measureVolume: vi.fn(() => ({ ok: true, value: 42 })),
     measureArea: vi.fn(() => ({ ok: true, value: 84 })),
     isValid: vi.fn(() => true),
+    getFaces: vi.fn(() => [{ id: 1 }, { id: 2 }]),
+    getSurfaceType: vi.fn(() => ({ ok: true, value: 'PLANE' })),
+    normalAt: vi.fn(() => [0, 0, 1] as [number, number, number]),
+    getHashCode: vi.fn((f: { id: number }) => f.id),
   };
 }
 describe('importerFor', () => {
@@ -58,6 +62,29 @@ describe('loadModel', () => {
     expect(measurements.volume).toBeUndefined();
     expect(measurements.valid).toBe(false);
     expect(measurements.area).toBe(84);
+  });
+  it('omits face metadata by default (snapshot path)', async () => {
+    const bk = makeFakeBrepjs();
+    const { meshData } = await loadModel(bk, new Blob([new Uint8Array([1])]), '.step');
+    expect(meshData.faceInfos).toBeUndefined();
+    expect(bk.getFaces).not.toHaveBeenCalled();
+  });
+  it('collects per-face metadata when inspecting', async () => {
+    const bk = makeFakeBrepjs();
+    const { meshData } = await loadModel(bk, new Blob([new Uint8Array([1])]), '.step', true);
+    expect(meshData.faceInfos).toEqual([
+      { faceId: 1, surfaceType: 'PLANE', area: 84, normal: [0, 0, 1] },
+      { faceId: 2, surfaceType: 'PLANE', area: 84, normal: [0, 0, 1] },
+    ]);
+  });
+  it('skips a face whose metadata throws', async () => {
+    const bk = makeFakeBrepjs();
+    bk.normalAt = vi.fn((f: { id: number }) => {
+      if (f.id === 1) throw new Error('degenerate UV');
+      return [0, 0, 1];
+    });
+    const { meshData } = await loadModel(bk, new Blob([new Uint8Array([1])]), '.step', true);
+    expect(meshData.faceInfos?.map((f) => f.faceId)).toEqual([2]);
   });
   it('rejects on Err', async () => {
     const bk = makeFakeBrepjs();

--- a/packages/brepjs-viewer/README.md
+++ b/packages/brepjs-viewer/README.md
@@ -10,6 +10,7 @@ It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional
 - `ViewerCanvas` — R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, and toggles `autoRotate`/`gridVisible`. Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
 - `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
 - `ViewerInfoPanel` — controlled, store-agnostic measurements readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are supplied.
+- `ViewerSelectionPanel` — controlled readout for a picked `FaceInfo` (surface type, area, normal) with an optional clear button; renders nothing when no face is selected.
 - `EdgeRenderer`, `SelectionHighlight`, `SceneSetup` — companion components.
 - `buildGeometry`, `findFaceGroupAt`, `meshSize` — pure helpers (`meshSize` returns mesh bbox extents).
 - Types: `MeshData`, `FaceGroup`, `FaceInfo`, `EdgeGroup`, `EdgeInfo`, `ViewMode`, `ViewName`, `VIEW_NAMES`.

--- a/packages/brepjs-viewer/src/ViewerSelectionPanel.tsx
+++ b/packages/brepjs-viewer/src/ViewerSelectionPanel.tsx
@@ -1,0 +1,110 @@
+import { type CSSProperties } from 'react';
+import type { FaceInfo } from './types.js';
+
+// Controlled readout for a picked face. Store-agnostic; renders nothing when no face
+// is selected. Self-contained inline styles so it works without Tailwind.
+export interface ViewerSelectionPanelProps {
+  face?: FaceInfo | null;
+  onClear?: () => void;
+  unit?: string | undefined;
+  className?: string;
+}
+
+const SURFACE_LABELS: Record<string, string> = {
+  PLANE: 'Planar',
+  CYLINDER: 'Cylindrical',
+  CONE: 'Conical',
+  SPHERE: 'Spherical',
+  TORUS: 'Toroidal',
+  BEZIER_SURFACE: 'Bézier',
+  BSPLINE_SURFACE: 'B-spline',
+  REVOLUTION_SURFACE: 'Revolved',
+  EXTRUSION_SURFACE: 'Extruded',
+  OFFSET_SURFACE: 'Offset',
+  OTHER_SURFACE: 'Surface',
+};
+function surfaceLabel(t: string): string {
+  return SURFACE_LABELS[t] ?? 'Surface';
+}
+function fmt(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (Number.isInteger(n)) return n.toLocaleString();
+  return Number(n.toFixed(2)).toLocaleString();
+}
+
+export function ViewerSelectionPanel({
+  face,
+  onClear,
+  unit,
+  className,
+}: ViewerSelectionPanelProps) {
+  if (!face) return null;
+  const [nx, ny, nz] = face.normal;
+  return (
+    <div className={className} style={className ? undefined : containerStyle}>
+      <div style={headerStyle}>
+        <span style={titleStyle}>{surfaceLabel(face.surfaceType)} face</span>
+        {onClear && (
+          <button type="button" onClick={onClear} aria-label="Clear selection" style={closeStyle}>
+            ✕
+          </button>
+        )}
+      </div>
+      <Row label="Area" value={`${fmt(face.area)}${unit ? ` ${unit}²` : ''}`} />
+      <Row label="Normal" value={`${fmt(nx)}, ${fmt(ny)}, ${fmt(nz)}`} />
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={rowStyle}>
+      <span style={labelStyle}>{label}</span>
+      <span style={valueStyle}>{value}</span>
+    </div>
+  );
+}
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  left: 12,
+  top: 12,
+  zIndex: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  padding: '8px 10px',
+  borderRadius: 8,
+  minWidth: 170,
+  background: 'rgba(26, 29, 33, 0.7)',
+  backdropFilter: 'blur(6px)',
+  border: '1px solid rgba(74, 206, 204, 0.3)',
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+const headerStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: 12,
+  marginBottom: 2,
+};
+const titleStyle: CSSProperties = { color: '#6ee7d7', fontSize: 12, fontWeight: 600 };
+const closeStyle: CSSProperties = {
+  cursor: 'pointer',
+  border: 'none',
+  background: 'transparent',
+  color: '#7b8591',
+  fontSize: 12,
+  lineHeight: 1,
+  padding: 0,
+};
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 16,
+  fontSize: 12,
+  lineHeight: 1.5,
+};
+const labelStyle: CSSProperties = { color: '#7b8591' };
+const valueStyle: CSSProperties = { color: '#c8cdd3', fontVariantNumeric: 'tabular-nums' };

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -5,5 +5,6 @@ export { default as SceneSetup } from './SceneSetup.js';
 export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
 export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
 export { ViewerInfoPanel, type ViewerInfoPanelProps } from './ViewerInfoPanel.js';
+export { ViewerSelectionPanel, type ViewerSelectionPanelProps } from './ViewerSelectionPanel.js';
 export * from './types.js';
 export { buildGeometry, findFaceGroupAt, meshSize } from './geometry.js';


### PR DESCRIPTION
## What

**Phase 3** of the viewer overhaul. Click a face in the `--serve` viewer to inspect it — highlighted in the scene, with its surface type, area, and model-space normal in a panel.

### `brepjs-viewer`
- New **`ViewerSelectionPanel`** — controlled readout for a picked `FaceInfo` (surface type, area, normal) with a clear button; renders nothing when no face is selected.

### `brepjs-verify`
- The kernel worker now collects per-face metadata — `getSurfaceType` / `measureArea` / `normalAt`, keyed by `getHashCode` so it matches the mesh's `faceGroup` faceIds — with per-face try/catch (a degenerate face can't wipe the rest). Mirrors `apps/playground`'s `collectFaceInfos`.
- The viewer wires `Renderer.onFacePick`/`onFaceHover`, highlights the picked face via `SelectionHighlight`, and shows the selection panel top-left.
- Collection is gated on an `inspect` flag threaded through `useModel` → worker, so **headless snapshots (`ui=0`) skip the extra per-face kernel work** and capture as fast as before.

## Verification
- typecheck + lint + builds green; **83 tests** pass (+3 new: default-skip, collect, per-face-throw resilience).
- Diagnostic confirmed mesh `faceId` ≡ `getHashCode` and correct axis-aligned normals on a box.
- Screenshot-confirmed: clicking the cube's +Z face highlights it teal and the panel reads `Planar face · Area 100 · Normal 0, 0, 1` (model coordinates, matching the STEP/report frame).

## Next phases
4 — section/clipping plane · 5 — snapshot dimension overlay.