### PR TITLE
feat(viewer): section/clipping plane in verify --serve

### DIFF
--- a/packages/brepjs-verify/viewer/main.tsx
+++ b/packages/brepjs-verify/viewer/main.tsx
@@ -1,15 +1,19 @@
-import { StrictMode, useCallback, useEffect, useState } from 'react';
+import { StrictMode, useCallback, useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
   ViewerCanvas,
   ViewerControls,
   ViewerInfoPanel,
   ViewerSelectionPanel,
+  ViewerSectionControls,
   Renderer,
   EdgeRenderer,
   SelectionHighlight,
   meshSize,
+  meshBounds,
+  sectionPlane,
   type FaceInfo,
+  type SectionAxis,
   type ViewMode,
   type ViewName,
 } from 'brepjs-viewer';
@@ -40,6 +44,10 @@ function App() {
   const [fitSignal, setFitSignal] = useState(0);
   const [selectedFace, setSelectedFace] = useState<FaceInfo | null>(null);
   const [hoverFaceId, setHoverFaceId] = useState<number | null>(null);
+  const [sectionOn, setSectionOn] = useState(false);
+  const [sectionAxis, setSectionAxis] = useState<SectionAxis>('x');
+  const [sectionPos, setSectionPos] = useState(0);
+  const [sectionFlip, setSectionFlip] = useState(false);
   useEffect(() => onViewChange(setView), []); // bridge window.__renderView -> ViewerCanvas.view
   const handleFit = useCallback(() => {
     setFitSignal((n) => n + 1);
@@ -50,6 +58,38 @@ function App() {
   const handleFaceHover = useCallback((info: FaceInfo | null) => {
     setHoverFaceId(info ? info.faceId : null);
   }, []);
+  const bounds = useMemo(
+    () => (state.status === 'ready' ? meshBounds(state.data) : null),
+    [state],
+  );
+  const axisIndex = sectionAxis === 'x' ? 0 : sectionAxis === 'y' ? 1 : 2;
+  const sectionMin = bounds ? bounds.min[axisIndex] : 0;
+  const sectionMax = bounds ? bounds.max[axisIndex] : 1;
+  const midOfAxis = useCallback(
+    (a: SectionAxis): number => {
+      if (!bounds) return 0;
+      const i = a === 'x' ? 0 : a === 'y' ? 1 : 2;
+      return (bounds.min[i] + bounds.max[i]) / 2;
+    },
+    [bounds],
+  );
+  const handleToggleSection = useCallback(() => {
+    setSectionOn((on) => {
+      if (!on) setSectionPos(midOfAxis(sectionAxis));
+      return !on;
+    });
+  }, [midOfAxis, sectionAxis]);
+  const handleAxisChange = useCallback(
+    (a: SectionAxis) => {
+      setSectionAxis(a);
+      setSectionPos(midOfAxis(a));
+    },
+    [midOfAxis],
+  );
+  const clippingPlanes = useMemo(
+    () => (sectionOn && bounds ? [sectionPlane(sectionAxis, sectionPos, sectionFlip)] : undefined),
+    [sectionOn, bounds, sectionAxis, sectionPos, sectionFlip],
+  );
   if (state.status === 'error')
     return (
       <div style={{ color: '#e88', padding: 16, fontFamily: 'monospace' }}>error: {state.error}</div>
@@ -69,12 +109,16 @@ function App() {
         <Renderer
           data={state.data}
           viewMode={viewMode}
+          {...(clippingPlanes ? { clippingPlanes } : {})}
           {...(showControls
             ? { onFacePick: handleFacePick, onFaceHover: handleFaceHover }
             : {})}
         />
         {showEdges && viewMode !== 'wireframe' && state.data.edges.length > 0 && (
-          <EdgeRenderer edges={state.data.edges} />
+          <EdgeRenderer
+            edges={state.data.edges}
+            {...(clippingPlanes ? { clippingPlanes } : {})}
+          />
         )}
         {showControls && (
           <SelectionHighlight
@@ -89,6 +133,22 @@ function App() {
           face={selectedFace}
           onClear={() => {
             setSelectedFace(null);
+          }}
+        />
+      )}
+      {showControls && (
+        <ViewerSectionControls
+          enabled={sectionOn}
+          onToggle={handleToggleSection}
+          axis={sectionAxis}
+          onAxisChange={handleAxisChange}
+          position={sectionPos}
+          min={sectionMin}
+          max={sectionMax}
+          onPositionChange={setSectionPos}
+          flip={sectionFlip}
+          onToggleFlip={() => {
+            setSectionFlip((v) => !v);
           }}
         />
       )}

--- a/packages/brepjs-viewer/README.md
+++ b/packages/brepjs-viewer/README.md
@@ -11,8 +11,9 @@ It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional
 - `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
 - `ViewerInfoPanel` — controlled, store-agnostic measurements readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are supplied.
 - `ViewerSelectionPanel` — controlled readout for a picked `FaceInfo` (surface type, area, normal) with an optional clear button; renders nothing when no face is selected.
+- `ViewerSectionControls` — controlled section-plane bar (enable, axis, position slider, flip). Pair with `sectionPlane(...)` and pass the result to `Renderer`/`EdgeRenderer` via their `clippingPlanes` prop. `ViewerCanvas` enables local clipping, so only the model is cut (not the grid).
 - `EdgeRenderer`, `SelectionHighlight`, `SceneSetup` — companion components.
-- `buildGeometry`, `findFaceGroupAt`, `meshSize` — pure helpers (`meshSize` returns mesh bbox extents).
+- `buildGeometry`, `findFaceGroupAt`, `meshSize`, `meshBounds`, `sectionPlane` — pure helpers (`meshBounds` returns the bbox; `sectionPlane` builds a model-space clipping plane).
 - Types: `MeshData`, `FaceGroup`, `FaceInfo`, `EdgeGroup`, `EdgeInfo`, `ViewMode`, `ViewName`, `VIEW_NAMES`.
 
 ## Peer dependencies

--- a/packages/brepjs-viewer/src/EdgeRenderer.tsx
+++ b/packages/brepjs-viewer/src/EdgeRenderer.tsx
@@ -7,6 +7,7 @@ export interface EdgeRendererProps {
   edges: Float32Array;
   edgeGroups?: EdgeGroup[];
   edgeInfos?: EdgeInfo[];
+  clippingPlanes?: THREE.Plane[];
   onEdgePick?: (info: EdgeInfo, additive: boolean, pos: ScreenPos) => void;
   onEdgeHover?: (info: EdgeInfo | null, pos?: ScreenPos) => void;
   onEdgeContextMenu?: (info: EdgeInfo, pos: ScreenPos) => void;
@@ -32,6 +33,7 @@ export default function EdgeRenderer({
   edges,
   edgeGroups,
   edgeInfos,
+  clippingPlanes,
   onEdgePick,
   onEdgeHover,
   onEdgeContextMenu,
@@ -156,7 +158,12 @@ export default function EdgeRenderer({
     : {};
   return (
     <lineSegments geometry={geometry} renderOrder={1} raycast={raycastLines} {...handlers}>
-      <lineBasicMaterial color="#000000" depthTest={true} linewidth={2} />
+      <lineBasicMaterial
+        color="#000000"
+        depthTest={true}
+        linewidth={2}
+        clippingPlanes={clippingPlanes ?? null}
+      />
     </lineSegments>
   );
 }

--- a/packages/brepjs-viewer/src/Renderer.tsx
+++ b/packages/brepjs-viewer/src/Renderer.tsx
@@ -7,6 +7,7 @@ import type { MeshData, FaceInfo, ViewMode, ScreenPos } from './types.js';
 export interface RendererProps {
   data: MeshData;
   viewMode?: ViewMode;
+  clippingPlanes?: THREE.Plane[];
   onFacePick?: (info: FaceInfo, additive: boolean, pos: ScreenPos) => void;
   onFaceHover?: (info: FaceInfo | null, pos?: ScreenPos) => void;
   onFaceContextMenu?: (info: FaceInfo, pos: ScreenPos) => void;
@@ -15,6 +16,7 @@ export interface RendererProps {
 export function Renderer({
   data,
   viewMode = 'solid',
+  clippingPlanes,
   onFacePick,
   onFaceHover,
   onFaceContextMenu,
@@ -112,6 +114,7 @@ export function Renderer({
         transparent={viewMode === 'xray'}
         opacity={viewMode === 'xray' ? 0.35 : 1}
         depthWrite={viewMode !== 'xray'}
+        clippingPlanes={clippingPlanes ?? null}
       />
     </mesh>
   );

--- a/packages/brepjs-viewer/src/ViewerCanvas.tsx
+++ b/packages/brepjs-viewer/src/ViewerCanvas.tsx
@@ -71,6 +71,16 @@ function Framing({
   return null;
 }
 
+// Enables material-level (local) clipping planes. Set once; harmless when no material
+// carries a clippingPlanes array, so consumers can opt in per-material without a flag.
+function LocalClipping() {
+  const gl = useThree((s) => s.gl);
+  useEffect(() => {
+    gl.localClippingEnabled = true;
+  }, [gl]);
+  return null;
+}
+
 export function ViewerCanvas({
   data,
   view = 'iso',
@@ -84,6 +94,7 @@ export function ViewerCanvas({
     // `always` while spinning so the turntable advances; `demand` otherwise keeps the
     // GPU idle. preserveDrawingBuffer stays on so screenshots read back in both modes.
     <Canvas frameloop={autoRotate ? 'always' : 'demand'} gl={{ preserveDrawingBuffer: true }}>
+      <LocalClipping />
       <SceneSetup autoRotate={autoRotate} gridVisible={gridVisible} />
       <Framing data={data} view={view} fitSignal={fitSignal} onFirstFrame={onFirstFrame} />
       {children}

--- a/packages/brepjs-viewer/src/ViewerCanvas.tsx
+++ b/packages/brepjs-viewer/src/ViewerCanvas.tsx
@@ -77,6 +77,9 @@ function LocalClipping() {
   const gl = useThree((s) => s.gl);
   useEffect(() => {
     gl.localClippingEnabled = true;
+    return () => {
+      gl.localClippingEnabled = false;
+    };
   }, [gl]);
   return null;
 }

--- a/packages/brepjs-viewer/src/ViewerSectionControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerSectionControls.tsx
@@ -53,11 +53,14 @@ export function ViewerSectionControls({
             max={max}
             step={(max - min) / 200 || 0.01}
             value={position}
+            disabled={min === max}
             onChange={(e) => {
               onPositionChange(Number(e.target.value));
             }}
             aria-label="Section position"
-            style={sliderStyle}
+            // A zero-extent axis (e.g. a sheet body) has nothing to slide along; dim and
+            // disable so the stuck handle reads as intentional rather than broken.
+            style={{ ...sliderStyle, ...(min === max ? { opacity: 0.4 } : null) }}
           />
           <Btn label="Flip" active={flip} onClick={onToggleFlip} />
         </>

--- a/packages/brepjs-viewer/src/ViewerSectionControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerSectionControls.tsx
@@ -1,0 +1,115 @@
+import { type CSSProperties } from 'react';
+import type { SectionAxis } from './geometry.js';
+
+// Controlled, store-agnostic section-plane controls. Shows just the enable toggle when
+// off; reveals axis / position / flip when on. Self-contained inline styles.
+export interface ViewerSectionControlsProps {
+  enabled: boolean;
+  onToggle: () => void;
+  axis: SectionAxis;
+  onAxisChange: (axis: SectionAxis) => void;
+  position: number;
+  min: number;
+  max: number;
+  onPositionChange: (position: number) => void;
+  flip: boolean;
+  onToggleFlip: () => void;
+  className?: string;
+}
+
+const AXES: SectionAxis[] = ['x', 'y', 'z'];
+
+export function ViewerSectionControls({
+  enabled,
+  onToggle,
+  axis,
+  onAxisChange,
+  position,
+  min,
+  max,
+  onPositionChange,
+  flip,
+  onToggleFlip,
+  className,
+}: ViewerSectionControlsProps) {
+  return (
+    <div className={className} style={className ? undefined : containerStyle}>
+      <Btn label="Section" active={enabled} onClick={onToggle} />
+      {enabled && (
+        <>
+          {AXES.map((a) => (
+            <Btn
+              key={a}
+              label={a.toUpperCase()}
+              active={axis === a}
+              onClick={() => {
+                onAxisChange(a);
+              }}
+            />
+          ))}
+          <input
+            type="range"
+            min={min}
+            max={max}
+            step={(max - min) / 200 || 0.01}
+            value={position}
+            onChange={(e) => {
+              onPositionChange(Number(e.target.value));
+            }}
+            aria-label="Section position"
+            style={sliderStyle}
+          />
+          <Btn label="Flip" active={flip} onClick={onToggleFlip} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function Btn({ label, active, onClick }: { label: string; active?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{ ...buttonStyle, ...(active ? activeButtonStyle : null) }}
+    >
+      {label}
+    </button>
+  );
+}
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  bottom: 12,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 10,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: 4,
+  borderRadius: 8,
+  background: 'rgba(26, 29, 33, 0.7)',
+  backdropFilter: 'blur(6px)',
+  border: '1px solid rgba(255, 255, 255, 0.08)',
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+const buttonStyle: CSSProperties = {
+  cursor: 'pointer',
+  padding: '4px 10px',
+  borderRadius: 5,
+  fontSize: 12,
+  fontWeight: 500,
+  lineHeight: 1.2,
+  color: '#9aa3ad',
+  background: 'rgba(255, 255, 255, 0.04)',
+  border: '1px solid transparent',
+};
+const activeButtonStyle: CSSProperties = {
+  color: '#6ee7d7',
+  background: 'rgba(45, 212, 191, 0.16)',
+  borderColor: 'rgba(45, 212, 191, 0.3)',
+};
+const sliderStyle: CSSProperties = { width: 160, accentColor: '#4ACECC', margin: '0 4px' };

--- a/packages/brepjs-viewer/src/geometry.ts
+++ b/packages/brepjs-viewer/src/geometry.ts
@@ -9,12 +9,17 @@ export function buildGeometry(data: MeshData): THREE.BufferGeometry {
   return geo;
 }
 
-// Axis-aligned bounding-box extents (width, depth, height) of the mesh in its own
-// coordinates. Mesh-derived, so it's within tessellation tolerance of the kernel's
-// exact bbox — fine for a viewer readout, not a substitute for the verify report.
-export function meshSize(data: MeshData): [number, number, number] {
+export interface MeshBounds {
+  min: [number, number, number];
+  max: [number, number, number];
+}
+
+// Axis-aligned bounding box of the mesh in its own coordinates. Mesh-derived, so it's
+// within tessellation tolerance of the kernel's exact bbox — fine for a viewer readout
+// or a clip-plane range, not a substitute for the verify report.
+export function meshBounds(data: MeshData): MeshBounds {
   const p = data.position;
-  if (p.length < 3) return [0, 0, 0];
+  if (p.length < 3) return { min: [0, 0, 0], max: [0, 0, 0] };
   let minX = Infinity,
     minY = Infinity,
     minZ = Infinity;
@@ -32,7 +37,29 @@ export function meshSize(data: MeshData): [number, number, number] {
     if (z < minZ) minZ = z;
     if (z > maxZ) maxZ = z;
   }
-  return [maxX - minX, maxY - minY, maxZ - minZ];
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+// Bounding-box extents (width, depth, height).
+export function meshSize(data: MeshData): [number, number, number] {
+  const { min, max } = meshBounds(data);
+  return [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+}
+
+export type SectionAxis = 'x' | 'y' | 'z';
+
+// A clipping plane normal to `axis` at world `position`. three.js clips points where
+// plane.distanceToPoint < 0, so the kept half is `axis·point >= position`; `flip`
+// keeps the other half. Coordinates are model-space (the viewer applies no rotation).
+export function sectionPlane(axis: SectionAxis, position: number, flip = false): THREE.Plane {
+  const normal = new THREE.Vector3(axis === 'x' ? 1 : 0, axis === 'y' ? 1 : 0, axis === 'z' ? 1 : 0);
+  if (flip) normal.negate();
+  const point = new THREE.Vector3(
+    axis === 'x' ? position : 0,
+    axis === 'y' ? position : 0,
+    axis === 'z' ? position : 0,
+  );
+  return new THREE.Plane(normal, -normal.dot(point));
 }
 
 export function findFaceGroupAt(groups: FaceGroup[], triangleIndex: number): FaceGroup | null {

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -6,5 +6,17 @@ export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
 export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
 export { ViewerInfoPanel, type ViewerInfoPanelProps } from './ViewerInfoPanel.js';
 export { ViewerSelectionPanel, type ViewerSelectionPanelProps } from './ViewerSelectionPanel.js';
+export {
+  ViewerSectionControls,
+  type ViewerSectionControlsProps,
+} from './ViewerSectionControls.js';
 export * from './types.js';
-export { buildGeometry, findFaceGroupAt, meshSize } from './geometry.js';
+export {
+  buildGeometry,
+  findFaceGroupAt,
+  meshSize,
+  meshBounds,
+  sectionPlane,
+  type MeshBounds,
+  type SectionAxis,
+} from './geometry.js';

--- a/packages/brepjs-viewer/tests/geometry.test.ts
+++ b/packages/brepjs-viewer/tests/geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildGeometry, findFaceGroupAt } from '@/geometry.js';
+import { buildGeometry, findFaceGroupAt, meshBounds, meshSize, sectionPlane } from '@/geometry.js';
 import type { MeshData } from '@/types.js';
 
 const data: MeshData = {
@@ -20,5 +20,27 @@ describe('render core', () => {
   it('findFaceGroupAt maps a triangle index to its faceId via binary search', () => {
     expect(findFaceGroupAt(data.faceGroups!, 0)?.faceId).toBe(7);
     expect(findFaceGroupAt(data.faceGroups!, 5)).toBeNull();
+  });
+});
+
+describe('bounds + section', () => {
+  const box: MeshData = {
+    position: new Float32Array([-2, -1, -3, 4, 5, 6]),
+    normal: new Float32Array([0, 0, 1, 0, 0, 1]),
+    index: new Uint32Array([0, 1, 0]),
+    edges: new Float32Array([]),
+  };
+  it('meshBounds spans min/max per axis; meshSize is the extent', () => {
+    expect(meshBounds(box)).toEqual({ min: [-2, -1, -3], max: [4, 5, 6] });
+    expect(meshSize(box)).toEqual([6, 6, 9]);
+  });
+  it('sectionPlane keeps axis·point >= position; flip inverts the kept half', () => {
+    const p = sectionPlane('x', 1);
+    // distanceToPoint >= 0 is kept; < 0 is clipped
+    expect(p.distanceToPoint({ x: 3, y: 0, z: 0 } as never)).toBeGreaterThan(0);
+    expect(p.distanceToPoint({ x: -1, y: 0, z: 0 } as never)).toBeLessThan(0);
+    const flipped = sectionPlane('x', 1, true);
+    expect(flipped.distanceToPoint({ x: 3, y: 0, z: 0 } as never)).toBeLessThan(0);
+    expect(flipped.distanceToPoint({ x: -1, y: 0, z: 0 } as never)).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

**Phase 4** of the viewer overhaul. Adds a movable **section plane** to the `--serve` viewer so internal features (bores, shelled cavities, pockets) can be inspected.

### `brepjs-viewer`
- New helpers **`sectionPlane(axis, position, flip)`** (model-space `THREE.Plane`) and **`meshBounds(data)`**.
- `Renderer` and `EdgeRenderer` gain an optional **`clippingPlanes`** prop wired to their materials.
- `ViewerCanvas` enables **local clipping** (`gl.localClippingEnabled`), so only the model is cut — the grid stays intact.
- New **`ViewerSectionControls`** — controlled bar: enable toggle, axis (X/Y/Z), position slider, flip.

### `brepjs-verify`
- The viewer owns the section state, derives the slider range from the model bbox, and feeds the plane to the renderers. **Off by default, gated behind the `ui` flag** — headless snapshots are unaffected.

## Verification
- typecheck + lint + builds green; **87 tests** pass (verify 83 + viewer-lib geometry: new `meshBounds`/`meshSize`/`sectionPlane` cases).
- Screenshot-confirmed on the `hollow-enclosure` example: a mid-X section reveals the internal cavity and wall thickness while the grid is uncut; the section bar shows Section·X active with the slider centered.

## Notes
- The cut is open (no solid cap face) — standard for a quick clip; a stencil cap would be a future enhancement.

## Next
Phase 5 — dimension overlay burned into agent snapshots (the last phase).