### PR TITLE
feat(brepjs-verify): burn bbox dimensions into agent snapshots

### DIFF
--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -48,7 +48,7 @@ npx -y brepjs-verify part.brep.ts --snapshot shots/                     # iso/fr
 npx -y brepjs-verify part.brep.ts --serve                               # clickable preview link (renders the real STEP)
 ```
 
-`--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The `--serve` link is interactive: a toolbar offers view presets + fit, solid/wireframe/x-ray modes, edge/grid toggles, a turntable, and an in-browser PNG screenshot. `--snapshot` loads the same page with `ui=0` to suppress the toolbar, so captured PNGs stay chrome-free.
+`--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The `--serve` link is interactive: a toolbar offers view presets + fit, solid/wireframe/x-ray modes, edge/grid toggles, a turntable, click-to-inspect face picking, a section/clipping plane, a measurements panel, and an in-browser PNG screenshot. `--snapshot` loads the same page with `ui=0` to suppress the toolbar, and burns the bounding-box size into each PNG (`dims=1`) so the agent can read scale from the image.
 
 ## CLI reference
 

--- a/packages/brepjs-verify/src/snapshot/shoot.ts
+++ b/packages/brepjs-verify/src/snapshot/shoot.ts
@@ -16,6 +16,8 @@ export interface ShootOptions extends AcquireOptions {
   views?: readonly ViewName[];
   /** Wall-clock ms to let the camera settle before each capture (default 400; raise on slow CI). */
   settleMs?: number;
+  /** Burn the model's bbox dimensions into each PNG so the agent can read scale (default true). */
+  dimensions?: boolean;
 }
 export interface ShootResult {
   outDir: string;
@@ -39,8 +41,10 @@ export async function shoot(opts: ShootOptions): Promise<ShootResult> {
   try {
     const page = await browser.newPage();
     await page.setViewport({ width: 1200, height: 900 });
-    // ui=0 hides the interactive toolbar so captured PNGs contain only the model.
-    const target = `${server.url}/?dir=${encodeURIComponent(dir)}&file=${encodeURIComponent(rel)}&ui=0`;
+    // ui=0 hides the interactive toolbar so captured PNGs contain only the model; dims=1
+    // overlays the bbox size so the agent can read scale from the image.
+    const dimsParam = opts.dimensions === false ? '' : '&dims=1';
+    const target = `${server.url}/?dir=${encodeURIComponent(dir)}&file=${encodeURIComponent(rel)}&ui=0${dimsParam}`;
     await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 30_000 });
     await page.waitForFunction('window.__ready === true', { timeout: READY_TIMEOUT_MS });
     for (const view of views) {

--- a/packages/brepjs-verify/viewer/main.tsx
+++ b/packages/brepjs-verify/viewer/main.tsx
@@ -22,7 +22,11 @@ import { installScreenshotApi, onViewChange, markReady } from './src/screenshotA
 
 // The agent snapshot pipeline screenshots this same page, so it loads with ?ui=0 to
 // suppress the toolbar and keep PNGs free of chrome. Human `--serve` links omit it.
-const showControls = new URLSearchParams(window.location.search).get('ui') !== '0';
+const params = new URLSearchParams(window.location.search);
+const showControls = params.get('ui') !== '0';
+// Snapshot mode adds ?dims=1 to burn the model's bbox size into the PNG so the agent
+// can read scale from the image. In interactive mode the info panel already shows it.
+const showDims = params.get('dims') === '1';
 
 function downloadCanvasPng(): void {
   const canvas = document.querySelector('canvas');
@@ -161,6 +165,7 @@ function App() {
           valid={state.measurements.valid}
         />
       )}
+      {!showControls && showDims && <ViewerInfoPanel dims={meshSize(state.data)} />}
       {showControls && (
         <ViewerControls
           viewMode={viewMode}


### PR DESCRIPTION
## What

**Phase 5** — the final phase of the viewer overhaul. The agent snapshot pipeline now burns the model's **bounding-box size** into each `iso/front/top/right` PNG, so the agent can read scale directly from the image instead of only from the JSON report.

- The viewer loads with `dims=1` (alongside `ui=0`) and renders a compact dims-only overlay (`Size W × D × H`) — no volume/area/validity clutter, toolbar still suppressed.
- `ShootOptions.dimensions` (default `true`) lets a caller opt out for clean PNGs.
- Interactive `--serve` already shows size in the Phase 2 measurements panel, so the standalone overlay is snapshot-only (`!showControls && showDims`).

## Verification
- typecheck + lint + build green; **83 tests** pass.
- Screenshot-confirmed on `hollow-enclosure`: every view shows `Size 80 × 50 × 30` bottom-left with the toolbar suppressed.

## Viewer overhaul — complete
| Phase | PR |
|---|---|
| 1A shared toolbar | #1275 ✅ |
| 2 measurements panel | #1277 ✅ |
| 3 face-pick inspection | #1278 ✅ |
| 4 section/clipping plane | #1279 ✅ |
| 5 snapshot dimension overlay | this PR |

Remaining follow-up (separate, optional): refactor `apps/playground`'s `ViewerToolbar` to consume the shared `ViewerControls` (Phase 1B), and projection ortho/persp toggle in `ViewerCanvas`.