### PR TITLE
feat(viewer): orthographic/perspective projection toggle

### DIFF
--- a/packages/brepjs-verify/viewer/main.tsx
+++ b/packages/brepjs-verify/viewer/main.tsx
@@ -13,6 +13,7 @@ import {
   meshBounds,
   sectionPlane,
   type FaceInfo,
+  type Projection,
   type SectionAxis,
   type ViewMode,
   type ViewName,
@@ -45,6 +46,7 @@ function App() {
   const [showEdges, setShowEdges] = useState(true);
   const [showGrid, setShowGrid] = useState(true);
   const [autoRotate, setAutoRotate] = useState(false);
+  const [projection, setProjection] = useState<Projection>('perspective');
   const [fitSignal, setFitSignal] = useState(0);
   const [selectedFace, setSelectedFace] = useState<FaceInfo | null>(null);
   const [hoverFaceId, setHoverFaceId] = useState<number | null>(null);
@@ -108,6 +110,7 @@ function App() {
         fitSignal={fitSignal}
         autoRotate={autoRotate}
         gridVisible={showGrid}
+        projection={projection}
         onFirstFrame={markReady}
       >
         <Renderer
@@ -181,6 +184,10 @@ function App() {
           autoRotate={autoRotate}
           onToggleAutoRotate={() => {
             setAutoRotate((v) => !v);
+          }}
+          projection={projection}
+          onToggleProjection={() => {
+            setProjection((p) => (p === 'perspective' ? 'orthographic' : 'perspective'));
           }}
           activeView={view}
           onView={setView}

--- a/packages/brepjs-viewer/README.md
+++ b/packages/brepjs-viewer/README.md
@@ -7,8 +7,8 @@ It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional
 ## Exports
 
 - `Renderer` — draws a `MeshData` mesh; optional `onFacePick`/`onFaceHover`/`onFaceContextMenu` callbacks for selection.
-- `ViewerCanvas` — R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, and toggles `autoRotate`/`gridVisible`. Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
-- `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
+- `ViewerCanvas` — R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, toggles `autoRotate`/`gridVisible`, and switches `projection` between `perspective` and `orthographic` (zoom-fit ortho camera). Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
+- `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, projection, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
 - `ViewerInfoPanel` — controlled, store-agnostic measurements readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are supplied.
 - `ViewerSelectionPanel` — controlled readout for a picked `FaceInfo` (surface type, area, normal) with an optional clear button; renders nothing when no face is selected.
 - `ViewerSectionControls` — controlled section-plane bar (enable, axis, position slider, flip). Pair with `sectionPlane(...)` and pass the result to `Renderer`/`EdgeRenderer` via their `clippingPlanes` prop. `ViewerCanvas` enables local clipping, so only the model is cut (not the grid).

--- a/packages/brepjs-viewer/src/ViewerCanvas.tsx
+++ b/packages/brepjs-viewer/src/ViewerCanvas.tsx
@@ -4,9 +4,7 @@ import { OrthographicCamera } from '@react-three/drei';
 import * as THREE from 'three';
 import SceneSetup from './SceneSetup.js'; // default export; renders its own OrbitControls
 import { buildGeometry } from './geometry.js';
-import type { MeshData, ViewName } from './types.js';
-
-export type Projection = 'perspective' | 'orthographic';
+import type { MeshData, Projection, ViewName } from './types.js';
 
 export interface ViewerCanvasProps {
   data: MeshData;
@@ -83,9 +81,10 @@ function Framing({
   return null;
 }
 
-// Mounts an OrthographicCamera with makeDefault while ortho is active, starting at the
-// perspective camera's current position so the swap is visually continuous. On unmount,
-// drei restores the Canvas's default PerspectiveCamera.
+// Mounts an OrthographicCamera with makeDefault while ortho is active. `initial` only seeds
+// the first frame at the perspective camera's position (avoids a flash at the origin before
+// Framing's passive effect runs); Framing then sets the final position and zoom-fit. On
+// unmount, drei restores the Canvas's default PerspectiveCamera.
 function OrthoCamera() {
   const camera = useThree((s) => s.camera);
   const initial = useRef<[number, number, number]>([

--- a/packages/brepjs-viewer/src/ViewerCanvas.tsx
+++ b/packages/brepjs-viewer/src/ViewerCanvas.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
+import { OrthographicCamera } from '@react-three/drei';
 import * as THREE from 'three';
 import SceneSetup from './SceneSetup.js'; // default export; renders its own OrbitControls
 import { buildGeometry } from './geometry.js';
 import type { MeshData, ViewName } from './types.js';
+
+export type Projection = 'perspective' | 'orthographic';
 
 export interface ViewerCanvasProps {
   data: MeshData;
@@ -12,6 +15,7 @@ export interface ViewerCanvasProps {
   fitSignal?: number;
   autoRotate?: boolean;
   gridVisible?: boolean;
+  projection?: Projection;
   onFirstFrame?: () => void;
   children?: ReactNode;
 }
@@ -29,11 +33,13 @@ function Framing({
   data,
   view,
   fitSignal,
+  projection,
   onFirstFrame,
 }: {
   data: MeshData;
   view: ViewName;
   fitSignal?: number | undefined;
+  projection: Projection;
   onFirstFrame?: (() => void) | undefined;
 }) {
   const camera = useThree((s) => s.camera);
@@ -57,18 +63,37 @@ function Framing({
   useEffect(() => {
     const dir = VIEW_DIR[view].clone().normalize();
     camera.position.copy(center).addScaledVector(dir, radius * 3);
-    const cam = camera as THREE.PerspectiveCamera;
-    cam.near = radius / 100;
-    cam.far = radius * 100;
+    camera.near = radius / 100;
+    camera.far = radius * 100;
+    const ortho = camera as THREE.OrthographicCamera;
+    if (ortho.isOrthographicCamera) {
+      // Ortho has no perspective foreshortening, so framing comes from zoom, not distance:
+      // scale the bounding sphere to ~80% of the smaller viewport dimension.
+      const viewSize = Math.min(ortho.right - ortho.left, ortho.top - ortho.bottom);
+      if (viewSize > 0 && radius > 0) ortho.zoom = viewSize / (radius * 2.4);
+    }
     camera.lookAt(center);
-    cam.updateProjectionMatrix();
+    camera.updateProjectionMatrix();
     invalidate();
     if (!fired.current) {
       fired.current = true;
       onFirstFrameRef.current?.();
     }
-  }, [camera, invalidate, center, radius, view, fitSignal]);
+  }, [camera, invalidate, center, radius, view, fitSignal, projection]);
   return null;
+}
+
+// Mounts an OrthographicCamera with makeDefault while ortho is active, starting at the
+// perspective camera's current position so the swap is visually continuous. On unmount,
+// drei restores the Canvas's default PerspectiveCamera.
+function OrthoCamera() {
+  const camera = useThree((s) => s.camera);
+  const initial = useRef<[number, number, number]>([
+    camera.position.x,
+    camera.position.y,
+    camera.position.z,
+  ]);
+  return <OrthographicCamera makeDefault position={initial.current} zoom={20} near={0.1} far={2000} />;
 }
 
 // Enables material-level (local) clipping planes. Set once; harmless when no material
@@ -90,6 +115,7 @@ export function ViewerCanvas({
   fitSignal,
   autoRotate = false,
   gridVisible = true,
+  projection = 'perspective',
   onFirstFrame,
   children,
 }: ViewerCanvasProps) {
@@ -98,8 +124,15 @@ export function ViewerCanvas({
     // GPU idle. preserveDrawingBuffer stays on so screenshots read back in both modes.
     <Canvas frameloop={autoRotate ? 'always' : 'demand'} gl={{ preserveDrawingBuffer: true }}>
       <LocalClipping />
+      {projection === 'orthographic' && <OrthoCamera />}
       <SceneSetup autoRotate={autoRotate} gridVisible={gridVisible} />
-      <Framing data={data} view={view} fitSignal={fitSignal} onFirstFrame={onFirstFrame} />
+      <Framing
+        data={data}
+        view={view}
+        fitSignal={fitSignal}
+        projection={projection}
+        onFirstFrame={onFirstFrame}
+      />
       {children}
     </Canvas>
   );

--- a/packages/brepjs-viewer/src/ViewerControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerControls.tsx
@@ -1,5 +1,5 @@
 import { type CSSProperties, type ReactNode } from 'react';
-import { VIEW_NAMES, type ViewMode, type ViewName } from './types.js';
+import { VIEW_NAMES, type Projection, type ViewMode, type ViewName } from './types.js';
 
 // Fully controlled, store-agnostic toolbar. Each control group renders only when
 // its handler is supplied, so a consumer (the verify viewer, the playground) opts
@@ -15,7 +15,7 @@ export interface ViewerControlsProps {
   autoRotate?: boolean;
   onToggleAutoRotate?: () => void;
   /** When 'orthographic', the projection button reads "Ortho" and shows active. */
-  projection?: 'perspective' | 'orthographic';
+  projection?: Projection;
   onToggleProjection?: () => void;
   activeView?: ViewName | null;
   onView?: (view: ViewName) => void;

--- a/packages/brepjs-viewer/src/ViewerControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerControls.tsx
@@ -14,6 +14,9 @@ export interface ViewerControlsProps {
   onToggleGrid?: () => void;
   autoRotate?: boolean;
   onToggleAutoRotate?: () => void;
+  /** When 'orthographic', the projection button reads "Ortho" and shows active. */
+  projection?: 'perspective' | 'orthographic';
+  onToggleProjection?: () => void;
   activeView?: ViewName | null;
   onView?: (view: ViewName) => void;
   onFit?: () => void;
@@ -42,6 +45,8 @@ export function ViewerControls({
   onToggleGrid,
   autoRotate,
   onToggleAutoRotate,
+  projection,
+  onToggleProjection,
   activeView,
   onView,
   onFit,
@@ -70,7 +75,7 @@ export function ViewerControls({
           ))}
         </Group>
       )}
-      {(onToggleEdges || onToggleGrid || onToggleAutoRotate) && (
+      {(onToggleEdges || onToggleGrid || onToggleAutoRotate || onToggleProjection) && (
         <Group>
           {onToggleEdges && (
             <Btn label="Edges" active={showEdges} onClick={onToggleEdges} />
@@ -78,6 +83,13 @@ export function ViewerControls({
           {onToggleGrid && <Btn label="Grid" active={showGrid} onClick={onToggleGrid} />}
           {onToggleAutoRotate && (
             <Btn label="Spin" active={autoRotate} onClick={onToggleAutoRotate} />
+          )}
+          {onToggleProjection && (
+            <Btn
+              label={projection === 'orthographic' ? 'Ortho' : 'Persp'}
+              active={projection === 'orthographic'}
+              onClick={onToggleProjection}
+            />
           )}
         </Group>
       )}

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -2,7 +2,7 @@ export { Renderer, type RendererProps } from './Renderer.js';
 export { default as EdgeRenderer } from './EdgeRenderer.js';
 export { default as SelectionHighlight } from './SelectionHighlight.js';
 export { default as SceneSetup } from './SceneSetup.js';
-export { ViewerCanvas, type ViewerCanvasProps, type Projection } from './ViewerCanvas.js';
+export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
 export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
 export { ViewerInfoPanel, type ViewerInfoPanelProps } from './ViewerInfoPanel.js';
 export { ViewerSelectionPanel, type ViewerSelectionPanelProps } from './ViewerSelectionPanel.js';

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -2,7 +2,7 @@ export { Renderer, type RendererProps } from './Renderer.js';
 export { default as EdgeRenderer } from './EdgeRenderer.js';
 export { default as SelectionHighlight } from './SelectionHighlight.js';
 export { default as SceneSetup } from './SceneSetup.js';
-export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
+export { ViewerCanvas, type ViewerCanvasProps, type Projection } from './ViewerCanvas.js';
 export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
 export { ViewerInfoPanel, type ViewerInfoPanelProps } from './ViewerInfoPanel.js';
 export { ViewerSelectionPanel, type ViewerSelectionPanelProps } from './ViewerSelectionPanel.js';

--- a/packages/brepjs-viewer/src/types.ts
+++ b/packages/brepjs-viewer/src/types.ts
@@ -31,6 +31,7 @@ export interface MeshData {
   color?: string;
 }
 export type ViewMode = 'solid' | 'wireframe' | 'xray';
+export type Projection = 'perspective' | 'orthographic';
 export interface ScreenPos {
   x: number;
   y: number;


### PR DESCRIPTION
## What

Viewer-overhaul **follow-up B**. Adds an ortho/persp projection toggle to the `--serve` viewer.

### `brepjs-viewer`
- `ViewerCanvas` gains a **`projection`** prop. When `'orthographic'`, it mounts a `makeDefault` `OrthographicCamera` (starting at the perspective camera's position for a continuous swap) and the framing effect fits via **zoom** instead of distance. Drei restores the perspective camera on switch-back.
- `ViewerControls` gains an optional **projection toggle** button (`Persp`/`Ortho`), rendered only when `onToggleProjection` is supplied.
- Exports a `Projection` type.

### `brepjs-verify`
- The viewer wires projection state + the toggle button, and passes `projection` to `ViewerCanvas`.

## Verification
- typecheck + lint + builds green; 83 verify tests + 4 viewer-lib tests pass.
- Screenshot-confirmed: toggling to Ortho renders a box with parallel edges (true parallelogram top face, no foreshortening); the `Ortho` button shows active.

## Context
This is 1 of 2 viewer-overhaul follow-ups. The next PR refactors the playground's `ViewerToolbar` to consume this shared `ViewerControls` (now that it supports projection) — which also reconciles the two preset vocabularies (`right`↔`side`, `iso`↔`isometric`).