### PR TITLE
chore: gitignore docs/superpowers working docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .claude/agent-memory-local/
 .claude/scheduled_tasks.lock
 
+# Superpowers brainstorming/spec/plan docs (local working artifacts, not shared)
+docs/superpowers/
+
 # Git worktrees
 .worktrees/
 


### PR DESCRIPTION
Adds `docs/superpowers/` to .gitignore so local brainstorming/spec/plan artifacts (from the superpowers skills) stay out of tracked history.

- Local working docs only; not shared.
- Takes effect immediately (the files are untracked).

Per maintainer preference: never commit superpowers docs.