### PR TITLE
refactor(playground): consume shared ViewerControls toolbar

### DIFF
--- a/apps/playground/src/components/playground/ViewerToolbar.tsx
+++ b/apps/playground/src/components/playground/ViewerToolbar.tsx
@@ -1,5 +1,21 @@
-import { useViewerStore, type CameraPreset, type ViewMode } from '../../stores/viewerStore';
+import { ViewerControls, type ViewName } from 'brepjs-viewer';
+import { useViewerStore, type CameraPreset } from '../../stores/viewerStore';
 import { useScreenshot } from '../../hooks/useScreenshot';
+
+// The shared ViewerControls speaks the canonical ViewName vocabulary (iso/front/top/right);
+// the playground store predates it with equivalent directions under different names.
+const VIEW_TO_PRESET: Record<ViewName, CameraPreset> = {
+  iso: 'isometric',
+  front: 'front',
+  top: 'top',
+  right: 'side',
+};
+const PRESET_TO_VIEW: Record<CameraPreset, ViewName> = {
+  isometric: 'iso',
+  front: 'front',
+  top: 'top',
+  side: 'right',
+};
 
 export default function ViewerToolbar() {
   const viewMode = useViewerStore((s) => s.viewMode);
@@ -16,111 +32,21 @@ export default function ViewerToolbar() {
   const handleScreenshot = useScreenshot();
 
   return (
-    <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col gap-1">
-      <ToolbarButton onClick={requestFit} label="Fit" active={false} />
-      <ToolbarButton onClick={handleScreenshot} label="Snap" active={false} />
-      <div className="my-1 border-t border-border-subtle" />
-      <ModeButton mode="solid" label="Solid" active={viewMode} onClick={setViewMode} />
-      <ModeButton mode="wireframe" label="Wire" active={viewMode} onClick={setViewMode} />
-      <ModeButton mode="xray" label="X-ray" active={viewMode} onClick={setViewMode} />
-      <div className="my-1 border-t border-border-subtle" />
-      <ToolbarButton onClick={toggleEdges} label="Edges" active={showEdges} />
-      <ToolbarButton onClick={toggleGrid} label="Grid" active={showGrid} />
-      <ToolbarButton
-        onClick={toggleProjection}
-        label={projection === 'orthographic' ? 'Ortho' : 'Persp'}
-        active={projection === 'orthographic'}
-      />
-      <div className="my-1 border-t border-border-subtle" />
-      <PresetButton preset="front" label="Front" active={activePreset} onClick={setCameraPreset} />
-      <PresetButton preset="side" label="Side" active={activePreset} onClick={setCameraPreset} />
-      <PresetButton preset="top" label="Top" active={activePreset} onClick={setCameraPreset} />
-      <PresetButton
-        preset="isometric"
-        label="Iso"
-        active={activePreset}
-        onClick={setCameraPreset}
-      />
-    </div>
-  );
-}
-
-function ModeButton({
-  mode,
-  label,
-  active,
-  onClick,
-}: {
-  mode: ViewMode;
-  label: string;
-  active: ViewMode;
-  onClick: (mode: ViewMode) => void;
-}) {
-  return (
-    <button
-      onClick={() => {
-        onClick(mode);
+    <ViewerControls
+      viewMode={viewMode}
+      onViewModeChange={setViewMode}
+      showEdges={showEdges}
+      onToggleEdges={toggleEdges}
+      showGrid={showGrid}
+      onToggleGrid={toggleGrid}
+      projection={projection}
+      onToggleProjection={toggleProjection}
+      activeView={activePreset ? PRESET_TO_VIEW[activePreset] : null}
+      onView={(v) => {
+        setCameraPreset(VIEW_TO_PRESET[v]);
       }}
-      aria-pressed={active === mode}
-      className={`pointer-events-auto rounded px-2 py-1 text-xs font-medium transition-colors ${
-        active === mode
-          ? 'bg-teal-primary/20 text-teal-light'
-          : 'bg-surface/70 text-gray-500 hover:text-gray-300'
-      } border border-border-subtle backdrop-blur-sm`}
-    >
-      {label}
-    </button>
-  );
-}
-
-function ToolbarButton({
-  onClick,
-  label,
-  active,
-}: {
-  onClick: () => void;
-  label: string;
-  active: boolean;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      aria-pressed={active}
-      className={`pointer-events-auto rounded px-2 py-1 text-xs font-medium transition-colors ${
-        active
-          ? 'bg-teal-primary/20 text-teal-light'
-          : 'bg-surface/70 text-gray-500 hover:text-gray-300'
-      } border border-border-subtle backdrop-blur-sm`}
-    >
-      {label}
-    </button>
-  );
-}
-
-function PresetButton({
-  preset,
-  label,
-  active,
-  onClick,
-}: {
-  preset: CameraPreset;
-  label: string;
-  active: CameraPreset | null;
-  onClick: (preset: CameraPreset) => void;
-}) {
-  return (
-    <button
-      onClick={() => {
-        onClick(preset);
-      }}
-      aria-pressed={active === preset}
-      className={`pointer-events-auto rounded px-2 py-1 text-xs font-medium transition-colors ${
-        active === preset
-          ? 'bg-teal-primary/20 text-teal-light'
-          : 'bg-surface/70 text-gray-500 hover:text-gray-300'
-      } border border-border-subtle backdrop-blur-sm`}
-    >
-      {label}
-    </button>
+      onFit={requestFit}
+      onScreenshot={handleScreenshot}
+    />
   );
 }

--- a/packages/brepjs-viewer/src/ViewerControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerControls.tsx
@@ -146,6 +146,9 @@ const containerStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: 6,
+  // The toolbar overlays the canvas; let pointer events fall through the container/gaps to
+  // the scene (so e.g. face picking works near the toolbar) and re-enable them on buttons.
+  pointerEvents: 'none',
   fontFamily:
     'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
 };
@@ -161,6 +164,7 @@ const groupStyle: CSSProperties = {
 };
 const buttonStyle: CSSProperties = {
   cursor: 'pointer',
+  pointerEvents: 'auto',
   padding: '4px 10px',
   borderRadius: 5,
   fontSize: 12,


### PR DESCRIPTION
## What

Viewer-overhaul **follow-up A** (the last one). Replaces the playground's bespoke `ViewerToolbar` button markup with the shared `brepjs-viewer` `ViewerControls`, so the toolbar has **one source of truth** across the playground and the verify viewer.

### `apps/playground`
- `ViewerToolbar` is now a thin adapter: it maps the zustand `viewerStore` (viewMode, edges, grid, projection, fit, screenshot, presets) to `ViewerControls`' controlled props.
- Reconciles the two preset vocabularies via small lookup tables: `iso↔isometric`, `right↔side` (`front`/`top` unchanged) — the directions were already identical, only the names differed.

### `brepjs-viewer`
- `ViewerControls` is now click-through: `pointer-events: none` on the container, `auto` on buttons — so the toolbar's gaps don't block canvas interaction (e.g. face picking) near it. Benefits both consumers.

## Notes / tradeoff
- The toolbar now renders with the shared component's self-contained inline styling instead of the playground's Tailwind theme tokens. The look is very close (dark translucent buttons, teal active state) and positions/behavior are preserved; this is the deliberate single-source-of-truth tradeoff. Button-level `className` overrides could be added later if pixel-exact theming is wanted.
- The "Side" preset button now reads **"Right"** (same camera direction).

## Verification
- Playground `tsc -b` typecheck + `vite build` production build both green.
- Behavior preserved: same controls, same store wiring, same camera directions.

## Viewer overhaul — fully complete
Core phases #1275/#1277/#1278/#1279/#1280 + follow-ups #1281 (projection) and this PR. No further planned work.