### PR TITLE
feat(verify): add topology counts to the verify report

### DIFF
--- a/packages/brepjs-verify/src/index.ts
+++ b/packages/brepjs-verify/src/index.ts
@@ -8,6 +8,7 @@ export {
   type VerifyReport,
   type VerifyCheck,
   type VerifyMeasurements,
+  type VerifyTopology,
   type VerifyAssertion,
   type DiffReport,
   type BoundsDelta,

--- a/packages/brepjs-verify/src/verify/checks.ts
+++ b/packages/brepjs-verify/src/verify/checks.ts
@@ -23,8 +23,20 @@ function shapeTypeOf(brep: BrepNs, s: AnyShape): string {
 }
 
 export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
-  const { isSolid, isShape3D, isFace, measureVolume, measureArea, getBounds, validSolid, isOk } =
-    brep;
+  const {
+    isSolid,
+    isShape3D,
+    isFace,
+    measureVolume,
+    measureArea,
+    getBounds,
+    getFaces,
+    getEdges,
+    getWires,
+    getVertices,
+    validSolid,
+    isOk,
+  } = brep;
   const r = emptyReport();
   r.shapeType = shapeTypeOf(brep, shape);
 
@@ -70,6 +82,19 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     r.measurements.bounds = getBounds(shape);
   } catch (e) {
     pushError(r, { message: `getBounds: ${(e as Error).message}` });
+  }
+
+  // Topology counts: an informational structural fingerprint. Traversal is safe on valid shapes;
+  // if it throws on a degenerate shape, leave topology absent rather than failing the report.
+  try {
+    r.topology = {
+      faceCount: getFaces(shape).length,
+      edgeCount: getEdges(shape).length,
+      wireCount: getWires(shape).length,
+      vertexCount: getVertices(shape).length,
+    };
+  } catch {
+    // topology is informational; skip it if traversal fails on a degenerate shape
   }
 
   // Hints from the check-phase errors. Callers that push more errors before

--- a/packages/brepjs-verify/src/verify/report.ts
+++ b/packages/brepjs-verify/src/verify/report.ts
@@ -10,6 +10,14 @@ export interface VerifyMeasurements {
   bounds?: { xMin: number; xMax: number; yMin: number; yMax: number; zMin: number; zMax: number };
 }
 
+/** Topology element counts — a quick structural fingerprint of a shape. */
+export interface VerifyTopology {
+  faceCount: number;
+  edgeCount: number;
+  wireCount: number;
+  vertexCount: number;
+}
+
 /** A failure captured with whatever structured context it carried (a `BrepError` code/suggestion). */
 export interface ErrorInfo {
   message: string;
@@ -37,6 +45,8 @@ export interface VerifyReport {
   shapeType: string | null;
   checks: VerifyCheck[];
   measurements: VerifyMeasurements;
+  /** Topology element counts. Absent when traversal fails on a degenerate shape. */
+  topology?: VerifyTopology;
   errors: string[];
   /** Structured copies of `errors`, carrying any `BrepError` code/suggestion. Drives `hints`. */
   errorInfos: ErrorInfo[];

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -26,4 +26,13 @@ describe('runChecks', () => {
     expect(report.measurements.volume).toBeGreaterThan(0);
     expect(report.checks.some((c) => c.name === 'positiveVolume' && c.passed)).toBe(true);
   });
+
+  it('reports topology counts (faces/edges/wires/vertices) for a solid', () => {
+    const report = runChecks(brep, box(10, 10, 10));
+    expect(report.topology).toBeDefined();
+    expect(report.topology?.faceCount).toBe(6);
+    expect(report.topology?.edgeCount).toBe(12);
+    expect(report.topology?.wireCount).toBe(6);
+    expect(report.topology?.vertexCount).toBe(8);
+  });
 });

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -35,4 +35,19 @@ describe('runChecks', () => {
     expect(report.topology?.wireCount).toBe(6);
     expect(report.topology?.vertexCount).toBe(8);
   });
+
+  it('omits topology (without failing the report) when traversal throws', () => {
+    // Fault-inject a topology extractor to exercise runChecks's defensive fallback: counts must
+    // degrade to "absent" while the rest of the report stays intact and unaffected.
+    const faultyBrep = {
+      ...brep,
+      getFaces: () => {
+        throw new Error('simulated degenerate-shape traversal failure');
+      },
+    };
+    const report = runChecks(faultyBrep, box(10, 10, 10));
+    expect(report.topology).toBeUndefined();
+    expect(report.shapeType).toBe('Solid');
+    expect(report.measurements.volume).toBeCloseTo(1000, 1);
+  });
 });


### PR DESCRIPTION
## What

Adds a `topology` channel to `VerifyReport` — `faceCount` / `edgeCount` / `wireCount` / `vertexCount` — computed in `runChecks` and surfaced automatically through `serializeReport` (whole-report spread).

## Why

First slice of the AI-CAD agent-substrate roadmap: the "topology stats" feedback channel an agent uses to confirm structure (e.g. a part that should have 2 holes). Small, additive, and entirely within the unpublished `brepjs-verify` package.

## How

- New `VerifyTopology` type + optional `VerifyReport.topology`.
- `runChecks` populates it via the public `getFaces/getEdges/getWires/getVertices`; traversal is wrapped so a degenerate shape leaves `topology` absent rather than failing the report (matches the existing `getBounds` defensive pattern).

## Test

TDD: added `runChecks` test asserting a box reports 6 faces / 12 edges / 6 wires / 8 vertices (RED→GREEN). Full package suite green (84 tests), typecheck + lint clean.

Manifold flag and center-of-mass are intentionally deferred to follow-up PRs to keep this atomic.