### PR TITLE
feat(verify): add center of mass to the verify report

### DIFF
--- a/packages/brepjs-verify/src/verify/checks.ts
+++ b/packages/brepjs-verify/src/verify/checks.ts
@@ -28,6 +28,7 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     isShape3D,
     isFace,
     measureVolume,
+    measureVolumeProps,
     measureArea,
     getBounds,
     getFaces,
@@ -69,6 +70,11 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
         suggestion: vol.error.suggestion,
       });
     }
+
+    // Center of mass (volume centroid), computed independently of volume so a CoM failure
+    // doesn't drop the volume measurement. Informational: absent (not an error) on failure.
+    const volProps = measureVolumeProps(shape);
+    if (isOk(volProps)) r.measurements.centerOfMass = volProps.value.centerOfMass;
   }
 
   if (isFace(shape) || isShape3D(shape)) {

--- a/packages/brepjs-verify/src/verify/checks.ts
+++ b/packages/brepjs-verify/src/verify/checks.ts
@@ -27,7 +27,6 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     isSolid,
     isShape3D,
     isFace,
-    measureVolume,
     measureVolumeProps,
     measureArea,
     getBounds,
@@ -59,22 +58,21 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
   // isSolid would silently skip validation for ~half of real multi-feature parts (and leave
   // `ok:true` vacuously true with no checks).
   if (isShape3D(shape)) {
-    const vol = measureVolume(shape);
-    if (isOk(vol)) {
-      r.measurements.volume = vol.value;
-      r.checks.push({ name: 'positiveVolume', passed: vol.value > 0 });
+    // Volume and center of mass come from a single kernel measurement: `measureVolume` itself
+    // calls `measureVolumeProps`, so one call yields both (and they share a failure — if the
+    // measurement fails, neither is recorded).
+    const volProps = measureVolumeProps(shape);
+    if (isOk(volProps)) {
+      r.measurements.volume = volProps.value.volume;
+      r.measurements.centerOfMass = volProps.value.centerOfMass;
+      r.checks.push({ name: 'positiveVolume', passed: volProps.value.volume > 0 });
     } else {
       pushError(r, {
-        message: `measureVolume: ${vol.error.message}`,
-        code: vol.error.code,
-        suggestion: vol.error.suggestion,
+        message: `measureVolume: ${volProps.error.message}`,
+        code: volProps.error.code,
+        suggestion: volProps.error.suggestion,
       });
     }
-
-    // Center of mass (volume centroid), computed independently of volume so a CoM failure
-    // doesn't drop the volume measurement. Informational: absent (not an error) on failure.
-    const volProps = measureVolumeProps(shape);
-    if (isOk(volProps)) r.measurements.centerOfMass = volProps.value.centerOfMass;
   }
 
   if (isFace(shape) || isShape3D(shape)) {

--- a/packages/brepjs-verify/src/verify/report.ts
+++ b/packages/brepjs-verify/src/verify/report.ts
@@ -7,6 +7,8 @@ export interface VerifyCheck {
 export interface VerifyMeasurements {
   volume?: number;
   area?: number;
+  /** Volume centroid `[x, y, z]`. Absent when center-of-mass can't be computed. */
+  centerOfMass?: readonly [number, number, number];
   bounds?: { xMin: number; xMax: number; yMin: number; yMax: number; zMin: number; zMax: number };
 }
 

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -50,4 +50,13 @@ describe('runChecks', () => {
     expect(report.shapeType).toBe('Solid');
     expect(report.measurements.volume).toBeCloseTo(1000, 1);
   });
+
+  it('reports center of mass for a solid', () => {
+    // box(10,10,10) spans 0..10 on each axis, so its centroid is (5,5,5).
+    const report = runChecks(brep, box(10, 10, 10));
+    expect(report.measurements.centerOfMass).toBeDefined();
+    expect(report.measurements.centerOfMass?.[0]).toBeCloseTo(5, 3);
+    expect(report.measurements.centerOfMass?.[1]).toBeCloseTo(5, 3);
+    expect(report.measurements.centerOfMass?.[2]).toBeCloseTo(5, 3);
+  });
 });


### PR DESCRIPTION
## What
Adds `centerOfMass` (`[x,y,z]` volume centroid) to `VerifyMeasurements`, surfaced through the existing `serializeReport` spread.

## Why
Second slice of the mass-properties feedback channel for the AI-CAD agent substrate (volume/area/bbox/**CoM** vs intent). Additive, within the unpublished `brepjs-verify` package.

## How
- `runChecks` derives both volume and CoM from a single `measureVolumeProps` call in the existing `isShape3D` block (volume == `mass`; `measureVolume` already delegates to `measureVolumeProps`, so this avoids a redundant call). They share one kernel measurement and one failure.
- Typed as `readonly [number, number, number]` to match the kernel's `Vec3`; `report.ts` stays import-free.

## Test
TDD: box(10,10,10) → CoM (5,5,5). Full package suite green (86 tests), typecheck + lint clean.