### PR TITLE
fix(kernel): thread STL tolerance/angularTolerance through brepkit + occt-wasm

### DIFF
--- a/src/kernel/brepkit/ioOps.ts
+++ b/src/kernel/brepkit/ioOps.ts
@@ -18,6 +18,8 @@ import {
   DEFAULT_DEFLECTION,
 } from './helpers.js';
 import { wasmIndex } from '@/utils/vec3.js';
+import { buildAsciiSTL, buildBinarySTL } from '@/kernel/stlBuilder.js';
+import { mesh } from './meshOps.js';
 
 export function exportSTEP(bk: BrepkitKernel, shapes: KernelShape[]): string {
   if (shapes.length === 0) return '';
@@ -36,16 +38,21 @@ export function exportSTEP(bk: BrepkitKernel, shapes: KernelShape[]): string {
 export function exportSTL(
   bk: BrepkitKernel,
   shape: KernelShape,
-  binary?: boolean
+  binary?: boolean,
+  tolerance = DEFAULT_DEFLECTION,
+  angularTolerance = 0
 ): string | ArrayBuffer {
   const solidIds = unwrapSolidsForExport(bk, shape, 'exportSTL');
-  // Use the first solid; STL format doesn't natively support multi-solid
-  if (binary) {
-    const bytes: Uint8Array = bk.exportStl(wasmIndex(solidIds, 0), DEFAULT_DEFLECTION);
-    return bytes.buffer as ArrayBuffer;
-  }
-  const bytes: Uint8Array = bk.exportStlAscii(wasmIndex(solidIds, 0), DEFAULT_DEFLECTION);
-  return new TextDecoder().decode(bytes);
+  // Use the first solid; STL format doesn't natively support multi-solid.
+  // Build STL from the mesh rather than native exportStl so that both tolerance
+  // and angularTolerance are threaded through (native exportStl takes only a
+  // fixed linear deflection) — mirroring the occt-wasm adapter.
+  const { vertices, triangles } = mesh(bk, solidHandle(wasmIndex(solidIds, 0)), {
+    tolerance,
+    angularTolerance,
+    skipNormals: true,
+  });
+  return binary ? buildBinarySTL(vertices, triangles) : buildAsciiSTL(vertices, triangles);
 }
 
 export function importSTEP(bk: BrepkitKernel, data: string | ArrayBuffer): KernelShape[] {
@@ -199,7 +206,8 @@ export function exportSTEPConfigured(
 export function makeIoOps(bk: BrepkitKernel) {
   return {
     exportSTEP: (shapes) => exportSTEP(bk, shapes),
-    exportSTL: (shape, binary) => exportSTL(bk, shape, binary),
+    exportSTL: (shape, binary, tolerance, angularTolerance) =>
+      exportSTL(bk, shape, binary, tolerance, angularTolerance),
     importSTEP: (data) => importSTEP(bk, data),
     importSTL: (data) => importSTL(bk, data),
     exportIGES: (shapes) => exportIGES(bk, shapes),

--- a/src/kernel/brepkit/ioOps.ts
+++ b/src/kernel/brepkit/ioOps.ts
@@ -15,10 +15,14 @@ import {
   copyWasmBytes,
   noop,
   warnOnce,
-  DEFAULT_DEFLECTION,
 } from './helpers.js';
 import { wasmIndex } from '@/utils/vec3.js';
-import { buildAsciiSTL, buildBinarySTL } from '@/kernel/stlBuilder.js';
+import {
+  buildAsciiSTL,
+  buildBinarySTL,
+  DEFAULT_STL_ANGULAR_TOLERANCE,
+  DEFAULT_STL_TOLERANCE,
+} from '@/kernel/stlBuilder.js';
 import { mesh } from './meshOps.js';
 
 export function exportSTEP(bk: BrepkitKernel, shapes: KernelShape[]): string {
@@ -39,8 +43,8 @@ export function exportSTL(
   bk: BrepkitKernel,
   shape: KernelShape,
   binary?: boolean,
-  tolerance = DEFAULT_DEFLECTION,
-  angularTolerance = 0
+  tolerance = DEFAULT_STL_TOLERANCE,
+  angularTolerance = DEFAULT_STL_ANGULAR_TOLERANCE
 ): string | ArrayBuffer {
   const solidIds = unwrapSolidsForExport(bk, shape, 'exportSTL');
   // Use the first solid; STL format doesn't natively support multi-solid.

--- a/src/kernel/occtWasm/ioOps.ts
+++ b/src/kernel/occtWasm/ioOps.ts
@@ -7,7 +7,12 @@
 import type { KernelShape, KernelType, StepAssemblyPart } from '@/kernel/types.js';
 import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
 import { handle, unwrap, wrapResult } from './helpers.js';
-import { buildAsciiSTL, buildBinarySTL } from '@/kernel/stlBuilder.js';
+import {
+  buildAsciiSTL,
+  buildBinarySTL,
+  DEFAULT_STL_ANGULAR_TOLERANCE,
+  DEFAULT_STL_TOLERANCE,
+} from '@/kernel/stlBuilder.js';
 
 interface Vec3Bounds {
   readonly min: [number, number, number];
@@ -113,8 +118,8 @@ export function exportSTL(
   mesh: MeshFn,
   shape: KernelShape,
   binary?: boolean,
-  tolerance = 1e-3,
-  angularTolerance = 0.1
+  tolerance = DEFAULT_STL_TOLERANCE,
+  angularTolerance = DEFAULT_STL_ANGULAR_TOLERANCE
 ): string | ArrayBuffer {
   // Build STL in JS from the triangulation for both formats. The native
   // exportStl returns its payload as a JS string (lossy for binary bytes via

--- a/src/kernel/occtWasm/ioOps.ts
+++ b/src/kernel/occtWasm/ioOps.ts
@@ -7,6 +7,7 @@
 import type { KernelShape, KernelType, StepAssemblyPart } from '@/kernel/types.js';
 import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
 import { handle, unwrap, wrapResult } from './helpers.js';
+import { buildAsciiSTL, buildBinarySTL } from '@/kernel/stlBuilder.js';
 
 interface Vec3Bounds {
   readonly min: [number, number, number];
@@ -109,76 +110,19 @@ export function exportSTEP(
 }
 
 export function exportSTL(
-  k: OcctKernelWasm,
   mesh: MeshFn,
   shape: KernelShape,
   binary?: boolean,
   tolerance = 1e-3,
   angularTolerance = 0.1
 ): string | ArrayBuffer {
-  if (binary) {
-    // Build the binary STL in JS from the triangulation. occt-wasm's native
-    // exportStl returns the binary payload as a JS string, and reconstructing
-    // bytes from it via charCodeAt is lossy — binary bytes outside the ASCII
-    // range get mangled by the WASM string marshalling, producing a truncated,
-    // unparseable buffer for some meshes (e.g. compartment partitions). Building
-    // from the mesh sidesteps the string entirely, mirroring exportGLB/OBJ/PLY.
-    const { vertices, triangles } = mesh(shape, { tolerance, angularTolerance, skipNormals: true });
-    return buildBinarySTL(vertices, triangles);
-  }
-  return k.exportStl(unwrap(shape), tolerance, true);
-}
-
-/** Serialize a triangle soup as a binary STL (80-byte header + uint32 count + 50B/tri). */
-function buildBinarySTL(vertices: Float32Array, triangles: Uint32Array): ArrayBuffer {
-  const triCount = Math.floor(triangles.length / 3);
-  const buffer = new ArrayBuffer(84 + triCount * 50);
-  const view = new DataView(buffer);
-  view.setUint32(80, triCount, true);
-  let offset = 84;
-  for (let i = 0; i < triCount; i++) {
-    const ia = (triangles[i * 3] ?? 0) * 3;
-    const ib = (triangles[i * 3 + 1] ?? 0) * 3;
-    const ic = (triangles[i * 3 + 2] ?? 0) * 3;
-    const ax = vertices[ia] ?? 0,
-      ay = vertices[ia + 1] ?? 0,
-      az = vertices[ia + 2] ?? 0;
-    const bx = vertices[ib] ?? 0,
-      by = vertices[ib + 1] ?? 0,
-      bz = vertices[ib + 2] ?? 0;
-    const cx = vertices[ic] ?? 0,
-      cy = vertices[ic + 1] ?? 0,
-      cz = vertices[ic + 2] ?? 0;
-    // Facet normal from the triangle winding (right-hand rule).
-    const ux = bx - ax,
-      uy = by - ay,
-      uz = bz - az;
-    const vx = cx - ax,
-      vy = cy - ay,
-      vz = cz - az;
-    let nx = uy * vz - uz * vy;
-    let ny = uz * vx - ux * vz;
-    let nz = ux * vy - uy * vx;
-    const len = Math.hypot(nx, ny, nz) || 1;
-    nx /= len;
-    ny /= len;
-    nz /= len;
-    view.setFloat32(offset, nx, true);
-    view.setFloat32(offset + 4, ny, true);
-    view.setFloat32(offset + 8, nz, true);
-    view.setFloat32(offset + 12, ax, true);
-    view.setFloat32(offset + 16, ay, true);
-    view.setFloat32(offset + 20, az, true);
-    view.setFloat32(offset + 24, bx, true);
-    view.setFloat32(offset + 28, by, true);
-    view.setFloat32(offset + 32, bz, true);
-    view.setFloat32(offset + 36, cx, true);
-    view.setFloat32(offset + 40, cy, true);
-    view.setFloat32(offset + 44, cz, true);
-    view.setUint16(offset + 48, 0, true);
-    offset += 50;
-  }
-  return buffer;
+  // Build STL in JS from the triangulation for both formats. The native
+  // exportStl returns its payload as a JS string (lossy for binary bytes via
+  // WASM string marshalling) and only takes linear deflection, so building from
+  // the mesh both sidesteps the marshalling bug and honours angularTolerance —
+  // mirroring exportGLB/OBJ/PLY.
+  const { vertices, triangles } = mesh(shape, { tolerance, angularTolerance, skipNormals: true });
+  return binary ? buildBinarySTL(vertices, triangles) : buildAsciiSTL(vertices, triangles);
 }
 
 export function importSTEP(k: OcctKernelWasm, data: string | ArrayBuffer): KernelShape[] {

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1129,14 +1129,7 @@ export class OcctWasmAdapter implements KernelAdapter {
     tolerance?: number,
     angularTolerance?: number
   ): string | ArrayBuffer {
-    return ioOps.exportSTL(
-      this.k,
-      this.mesh.bind(this),
-      shape,
-      binary,
-      tolerance,
-      angularTolerance
-    );
+    return ioOps.exportSTL(this.mesh.bind(this), shape, binary, tolerance, angularTolerance);
   }
 
   importSTEP(data: string | ArrayBuffer): KernelShape[] {

--- a/src/kernel/stlBuilder.ts
+++ b/src/kernel/stlBuilder.ts
@@ -1,0 +1,100 @@
+/**
+ * Kernel-agnostic STL serializers.
+ *
+ * Both writers take a triangle soup (positions + indices) and emit STL. Facet
+ * normals are derived from triangle winding (right-hand rule) rather than the
+ * mesh's per-vertex normals, matching the per-facet STL format.
+ * @module
+ */
+
+interface Facet {
+  nx: number;
+  ny: number;
+  nz: number;
+  ax: number;
+  ay: number;
+  az: number;
+  bx: number;
+  by: number;
+  bz: number;
+  cx: number;
+  cy: number;
+  cz: number;
+}
+
+function facetAt(vertices: ArrayLike<number>, triangles: ArrayLike<number>, i: number): Facet {
+  const ia = (triangles[i * 3] ?? 0) * 3;
+  const ib = (triangles[i * 3 + 1] ?? 0) * 3;
+  const ic = (triangles[i * 3 + 2] ?? 0) * 3;
+  const ax = vertices[ia] ?? 0,
+    ay = vertices[ia + 1] ?? 0,
+    az = vertices[ia + 2] ?? 0;
+  const bx = vertices[ib] ?? 0,
+    by = vertices[ib + 1] ?? 0,
+    bz = vertices[ib + 2] ?? 0;
+  const cx = vertices[ic] ?? 0,
+    cy = vertices[ic + 1] ?? 0,
+    cz = vertices[ic + 2] ?? 0;
+  const ux = bx - ax,
+    uy = by - ay,
+    uz = bz - az;
+  const vx = cx - ax,
+    vy = cy - ay,
+    vz = cz - az;
+  let nx = uy * vz - uz * vy;
+  let ny = uz * vx - ux * vz;
+  let nz = ux * vy - uy * vx;
+  const len = Math.hypot(nx, ny, nz) || 1;
+  nx /= len;
+  ny /= len;
+  nz /= len;
+  return { nx, ny, nz, ax, ay, az, bx, by, bz, cx, cy, cz };
+}
+
+/** Serialize a triangle soup as a binary STL (80-byte header + uint32 count + 50B/tri). */
+export function buildBinarySTL(
+  vertices: ArrayLike<number>,
+  triangles: ArrayLike<number>
+): ArrayBuffer {
+  const triCount = Math.floor(triangles.length / 3);
+  const buffer = new ArrayBuffer(84 + triCount * 50);
+  const view = new DataView(buffer);
+  view.setUint32(80, triCount, true);
+  let offset = 84;
+  for (let i = 0; i < triCount; i++) {
+    const f = facetAt(vertices, triangles, i);
+    view.setFloat32(offset, f.nx, true);
+    view.setFloat32(offset + 4, f.ny, true);
+    view.setFloat32(offset + 8, f.nz, true);
+    view.setFloat32(offset + 12, f.ax, true);
+    view.setFloat32(offset + 16, f.ay, true);
+    view.setFloat32(offset + 20, f.az, true);
+    view.setFloat32(offset + 24, f.bx, true);
+    view.setFloat32(offset + 28, f.by, true);
+    view.setFloat32(offset + 32, f.bz, true);
+    view.setFloat32(offset + 36, f.cx, true);
+    view.setFloat32(offset + 40, f.cy, true);
+    view.setFloat32(offset + 44, f.cz, true);
+    view.setUint16(offset + 48, 0, true);
+    offset += 50;
+  }
+  return buffer;
+}
+
+/** Serialize a triangle soup as an ASCII STL. */
+export function buildAsciiSTL(vertices: ArrayLike<number>, triangles: ArrayLike<number>): string {
+  const triCount = Math.floor(triangles.length / 3);
+  const lines: string[] = ['solid brepjs'];
+  for (let i = 0; i < triCount; i++) {
+    const f = facetAt(vertices, triangles, i);
+    lines.push(`facet normal ${f.nx} ${f.ny} ${f.nz}`);
+    lines.push('outer loop');
+    lines.push(`vertex ${f.ax} ${f.ay} ${f.az}`);
+    lines.push(`vertex ${f.bx} ${f.by} ${f.bz}`);
+    lines.push(`vertex ${f.cx} ${f.cy} ${f.cz}`);
+    lines.push('endloop');
+    lines.push('endfacet');
+  }
+  lines.push('endsolid brepjs');
+  return lines.join('\n') + '\n';
+}

--- a/src/kernel/stlBuilder.ts
+++ b/src/kernel/stlBuilder.ts
@@ -7,6 +7,15 @@
  * @module
  */
 
+/**
+ * Default tessellation tolerances for STL export, shared by every kernel
+ * adapter so per-adapter defaults can't drift. Callers normally pass explicit
+ * values (the public `exportSTL` derives them from the active quality level);
+ * these apply only to direct kernel-level calls made without arguments.
+ */
+export const DEFAULT_STL_TOLERANCE = 1e-3;
+export const DEFAULT_STL_ANGULAR_TOLERANCE = 0.1;
+
 interface Facet {
   nx: number;
   ny: number;
@@ -21,6 +30,23 @@ interface Facet {
   cy: number;
   cz: number;
 }
+
+// Reused across the serialization loop — each facet is consumed before the next
+// call, so a single mutable scratch object avoids per-triangle allocation.
+const scratch: Facet = {
+  nx: 0,
+  ny: 0,
+  nz: 0,
+  ax: 0,
+  ay: 0,
+  az: 0,
+  bx: 0,
+  by: 0,
+  bz: 0,
+  cx: 0,
+  cy: 0,
+  cz: 0,
+};
 
 function facetAt(vertices: ArrayLike<number>, triangles: ArrayLike<number>, i: number): Facet {
   const ia = (triangles[i * 3] ?? 0) * 3;
@@ -48,7 +74,19 @@ function facetAt(vertices: ArrayLike<number>, triangles: ArrayLike<number>, i: n
   nx /= len;
   ny /= len;
   nz /= len;
-  return { nx, ny, nz, ax, ay, az, bx, by, bz, cx, cy, cz };
+  scratch.nx = nx;
+  scratch.ny = ny;
+  scratch.nz = nz;
+  scratch.ax = ax;
+  scratch.ay = ay;
+  scratch.az = az;
+  scratch.bx = bx;
+  scratch.by = by;
+  scratch.bz = bz;
+  scratch.cx = cx;
+  scratch.cy = cy;
+  scratch.cz = cz;
+  return scratch;
 }
 
 /** Serialize a triangle soup as a binary STL (80-byte header + uint32 count + 50B/tri). */

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -52,6 +52,11 @@ export const divergences: DivergenceMap = {
       reason:
         'Mesh CSG is ambiguous at exactly-coincident faces — fast-check generates concentric, equal-size cubes whose intersection collapses to empty (100% volume loss) where B-rep resolves it exactly. The identity holds on manifold for realistic non-coincident geometry; real designs avoid coincident faces via clearance margins.',
     },
+    'meshFns.exportStlTolerance': {
+      kind: 'skip',
+      reason:
+        'manifold sphere is a fixed-segment primitive — tolerance/angularTolerance do not change its facet count, so coarse and fine STL exports are identical.',
+    },
   },
   brepkit: {
     // -----------------------------------------------------------------------

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -213,6 +213,44 @@ describe('meshFns', () => {
       expect(ascii.size).toBeGreaterThan(0);
     });
 
+    // Triangle count from a binary STL header (uint32 at byte offset 80).
+    const stlTriCount = async (blob: Blob): Promise<number> =>
+      new DataView(await blob.arrayBuffer()).getUint32(80, true);
+
+    it.skipIf(shouldSkipSuite('meshFns.exportStlTolerance'))(
+      'threads linear tolerance through to tessellation (coarse vs fine differ)',
+      async () => {
+        clearMeshCache();
+        // Fresh instances: StlAPI.Write-based adapters serialize the
+        // triangulation already cached on the shape, so reusing one sphere
+        // would export the first tolerance twice.
+        const coarse = await stlTriCount(
+          unwrap(exportSTL(sphere(10), { binary: true, tolerance: 1 }))
+        );
+        const fine = await stlTriCount(
+          unwrap(exportSTL(sphere(10), { binary: true, tolerance: 0.01 }))
+        );
+        expect(coarse).toBeGreaterThan(0);
+        // A finer linear deflection must subdivide the sphere into more facets.
+        expect(fine).toBeGreaterThan(coarse);
+      }
+    );
+
+    it.skipIf(shouldSkipSuite('meshFns.exportStlTolerance'))(
+      'threads angularTolerance through to tessellation',
+      async () => {
+        clearMeshCache();
+        // Loose linear deflection so the angular cap, not chord error, drives density.
+        const coarse = await stlTriCount(
+          unwrap(exportSTL(sphere(10), { binary: true, tolerance: 2, angularTolerance: 1 }))
+        );
+        const fine = await stlTriCount(
+          unwrap(exportSTL(sphere(10), { binary: true, tolerance: 2, angularTolerance: 0.1 }))
+        );
+        expect(fine).toBeGreaterThan(coarse);
+      }
+    );
+
     it('skips re-meshing when shape already has triangulation', () => {
       // mesh() populates triangulation on the shape's underlying kernel object;
       // exportSTL should detect that and skip the BRepMesh step.


### PR DESCRIPTION
## Summary

Fixes #1269. `BrepkitAdapter.exportSTL` silently dropped its `tolerance` and `angularTolerance` arguments and always exported at the fixed `DEFAULT_DEFLECTION = 0.01`, so callers passing a custom tolerance got the default.

The interface `KernelIOOps.exportSTL(shape, binary?, tolerance?, angularTolerance?)` already declared these params — this was an adapter-conformance bug.

## Changes

- **New `src/kernel/stlBuilder.ts`** — kernel-agnostic STL serializers: `buildBinarySTL` (extracted from occt-wasm) + new `buildAsciiSTL`. Facet normals derived from triangle winding.
- **brepkit `exportSTL`** now routes through `mesh()` (which threads both tolerance and angularTolerance to `tessellateSolid`) and builds STL from the triangle soup, instead of calling native `exportStl`/`exportStlAscii` with a hardcoded deflection. Adapter wiring updated to pass the two args through.
- **occt-wasm `exportSTL`** ASCII path now also builds from `mesh()` (it previously used native `exportStl`, which only takes linear deflection), so `angularTolerance` is honoured for both binary and ASCII. Removes the duplicated `buildBinarySTL` in favour of the shared one.

## Tests

- Added two regression tests in `tests/meshFns.test.ts` asserting that coarser vs finer **linear tolerance** and **angularTolerance** produce different STL facet counts — these would have caught the original bug. Pass on occt-wasm, occt, and brepkit.
- Registered a `meshFns.exportStlTolerance` manifold divergence (manifold's sphere is a fixed-segment primitive whose facet count is tolerance-independent).

## Verification

- `typecheck`, `eslint`, `check:boundaries`, `prettier --check`, `knip` — clean.
- `check:patterns` — no new violations from this change (the 21 reported pre-exist on `main` in `src/kernel/manifold/*`).
- STL/IO suites green on occt-wasm; new tests green on occt-wasm/occt/brepkit; manifold skips as registered.