### PR TITLE
feat(verify): add manifold flag to the topology channel

### DIFF
--- a/packages/brepjs-verify/src/verify/checks.ts
+++ b/packages/brepjs-verify/src/verify/checks.ts
@@ -34,6 +34,8 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     getEdges,
     getWires,
     getVertices,
+    getShells,
+    isManifoldShell,
     validSolid,
     isOk,
   } = brep;
@@ -99,6 +101,17 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     };
   } catch {
     // topology is informational; skip it if traversal fails on a degenerate shape
+  }
+
+  // Manifold-ness — only meaningful when the shape has shells. Guarded separately so a
+  // manifold-check failure doesn't drop the counts already recorded above.
+  if (r.topology) {
+    try {
+      const shells = getShells(shape);
+      if (shells.length > 0) r.topology.manifold = shells.every((s) => isManifoldShell(s));
+    } catch {
+      // manifold is informational; leave it absent if the check fails
+    }
   }
 
   // Hints from the check-phase errors. Callers that push more errors before

--- a/packages/brepjs-verify/src/verify/report.ts
+++ b/packages/brepjs-verify/src/verify/report.ts
@@ -18,6 +18,8 @@ export interface VerifyTopology {
   edgeCount: number;
   wireCount: number;
   vertexCount: number;
+  /** True when every shell is manifold. Absent for shapes without shells (nothing to assess). */
+  manifold?: boolean;
 }
 
 /** A failure captured with whatever structured context it carried (a `BrepError` code/suggestion). */

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -59,4 +59,9 @@ describe('runChecks', () => {
     expect(report.measurements.centerOfMass?.[1]).toBeCloseTo(5, 3);
     expect(report.measurements.centerOfMass?.[2]).toBeCloseTo(5, 3);
   });
+
+  it('reports manifold=true for a closed solid', () => {
+    const report = runChecks(brep, box(10, 10, 10));
+    expect(report.topology?.manifold).toBe(true);
+  });
 });

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -64,4 +64,20 @@ describe('runChecks', () => {
     const report = runChecks(brep, box(10, 10, 10));
     expect(report.topology?.manifold).toBe(true);
   });
+
+  it('reports manifold=false when a shell is not manifold', () => {
+    // Fault-inject the manifold predicate to exercise the false branch deterministically,
+    // without depending on the kernel to produce a real non-manifold solid.
+    const faultyBrep = { ...brep, isManifoldShell: (() => false) as typeof brep.isManifoldShell };
+    const report = runChecks(faultyBrep, box(10, 10, 10));
+    expect(report.topology?.manifold).toBe(false);
+  });
+
+  it('omits manifold (absent, not false) for a shape with no shells', () => {
+    const edge = brep.getEdges(box(10, 10, 10))[0];
+    if (!edge) throw new Error('expected an edge from the box');
+    const report = runChecks(brep, edge);
+    expect(report.topology).toBeDefined();
+    expect(report.topology?.manifold).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## What
Adds an optional `manifold` boolean to `VerifyTopology` — true when every shell of the shape is manifold.

## Why
Extends the topology feedback channel for the AI-CAD agent substrate: non-manifold geometry is a common, hard-to-spot failure mode an agent needs surfaced. Additive, within the unpublished `brepjs-verify` package.

## How
- `runChecks` computes it via the public `getShells` + `isManifoldShell`.
- **Decoupled from the counts**: computed in a separate guarded block so a manifold-check failure can't drop the already-recorded counts.
- **Absent (not false)** for shapes with no shells (a wire/edge/vertex has nothing to assess) — `exactOptionalPropertyTypes`-safe by conditional assignment.

## Test
TDD: box(10,10,10) → `manifold: true` (RED→GREEN). Full package suite green (87 tests), typecheck + lint clean.