### PR TITLE
fix(assembly): compose mate constraints down a chain (kinematics Phase 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ For adding a new operation or kernel method, see `.claude/commands/`.
 
 - OCCT Emscripten returns enum objects with `.value` — extract with: `typeof val === 'number' ? val : Number(val?.value ?? val)`
 - `autoHeal` short-circuits valid shapes: `report.alreadyValid=true`, no sew/heal diagnostics run
-- Assembly solver uses original face coordinates — distance constraints don't compose across multiple mates
+- Assembly solver composes constraints down a chain: each positioning mate reads the referenced part's _solved_ pose and resolves in topological order (a `fixed` node anchors the chain). `concentric`/`angle` and non-plane entity pairs are still unsupported (report `ASSEMBLY_NOT_CONVERGED`).
 - `Uint32Array` WASM interop: always convert to regular `Array` before passing to kernel methods
 - `DisposalScope` disposes in LIFO order — register dependencies after their dependees
 - `noUncheckedIndexedAccess` is enabled — array indexing returns `T | undefined`, add bounds checks or use `!` with eslint-disable

--- a/src/kernel/solverAdapter.ts
+++ b/src/kernel/solverAdapter.ts
@@ -41,75 +41,136 @@ const UNSUPPORTED_DOF: Readonly<Record<string, number>> = {
   angle: 1,
 };
 
+type Pose = { position: Vec3; rotation: [number, number, number, number] };
+
+const IDENTITY_ROTATION: [number, number, number, number] = [1, 0, 0, 0];
+
+function add(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+/**
+ * Position a dependent plane against an already-placed reference plane.
+ *
+ * Both entity origins are local (pre-transform); the reference's solved
+ * translation is applied before measuring, so a chain composes down its
+ * already-solved poses instead of reading original geometry. `extra` is the
+ * gap for a distance mate (0 for coincident). Rotation stays identity —
+ * coincident/distance produce pure translations.
+ */
+function solvePlanePair(
+  ref: SolverEntity,
+  refPos: Vec3,
+  dep: SolverEntity,
+  depPos: Vec3,
+  extra: number
+): Pose {
+  const n = ref.normal ?? [0, 0, 1];
+  const refOrigin = add(ref.origin, refPos);
+  const depOrigin = add(dep.origin, depPos);
+  const offset =
+    dot(n, [
+      refOrigin[0] - depOrigin[0],
+      refOrigin[1] - depOrigin[1],
+      refOrigin[2] - depOrigin[2],
+    ]) + extra;
+  return {
+    position: [depPos[0] + offset * n[0], depPos[1] + offset * n[1], depPos[2] + offset * n[2]],
+    rotation: IDENTITY_ROTATION,
+  };
+}
+
 /**
  * Solve assembly constraints analytically.
  *
- * Currently handles: fixed, coincident (plane-plane), distance (plane-plane).
- * Returns `converged: false` with unsupported constraint details for concentric and angle.
+ * Handles: fixed, coincident (plane-plane), distance (plane-plane). For a
+ * positioning mate, entityA is the reference and entityB the dependent. Chain
+ * roots (nodes never positioned by a mate) and explicit `fixed` nodes anchor at
+ * the origin; constraints then resolve in topological order — each places its
+ * dependent against the reference's solved pose, so multi-body chains compose.
+ * Returns `converged: false` with unsupported details for concentric, angle,
+ * non-plane pairs, and any constraint whose reference never resolves.
  */
 export function solveConstraints(nodes: string[], constraints: SolverConstraint[]): SolverResult {
-  const transforms = new Map<
-    string,
-    { position: Vec3; rotation: [number, number, number, number] }
-  >();
+  const transforms = new Map<string, Pose>();
 
   // Initialize all nodes at origin
   for (const node of nodes) {
-    transforms.set(node, {
-      position: [0, 0, 0],
-      rotation: [1, 0, 0, 0],
-    });
+    transforms.set(node, { position: [0, 0, 0], rotation: IDENTITY_ROTATION });
   }
 
   const unsupported: string[] = [];
 
-  // Process fixed constraints first (no-ops, node stays at origin)
-  // Then process positioning constraints
+  // For positioning mates, entityA is the reference and entityB the dependent.
+  const positioning = constraints.filter(
+    (c) => (c.type === 'coincident' || c.type === 'distance') && c.entityA && c.entityB
+  );
+  const dependents = new Set<string>();
+  for (const c of positioning) if (c.entityB) dependents.add(c.entityB.node);
+
+  // Anchors are placed at the origin: any node never positioned by a mate (a
+  // chain root), plus any explicit `fixed` node.
+  const placed = new Set<string>();
+  for (const node of nodes) if (!dependents.has(node)) placed.add(node);
+  for (const c of constraints) if (c.type === 'fixed' && c.entityA) placed.add(c.entityA.node);
+
+  // concentric / angle are not solved yet (Phase 1).
   for (const c of constraints) {
-    if (c.type === 'coincident' && c.entityA && c.entityB) {
-      const a = c.entityA;
-      const b = c.entityB;
-
-      if (a.entity.type === 'plane' && b.entity.type === 'plane') {
-        const aNormal = a.entity.normal ?? [0, 0, 1];
-        const aOrigin = a.entity.origin;
-        const bOrigin = b.entity.origin;
-
-        const dot =
-          aNormal[0] * (aOrigin[0] - bOrigin[0]) +
-          aNormal[1] * (aOrigin[1] - bOrigin[1]) +
-          aNormal[2] * (aOrigin[2] - bOrigin[2]);
-
-        const pos: Vec3 = [dot * aNormal[0], dot * aNormal[1], dot * aNormal[2]];
-        transforms.set(b.node, { position: pos, rotation: [1, 0, 0, 0] });
-      } else {
-        unsupported.push(`coincident(${a.entity.type}-${b.entity.type})`);
-      }
-    } else if (c.type === 'distance' && c.entityA && c.entityB && c.value !== undefined) {
-      const a = c.entityA;
-      const b = c.entityB;
-
-      if (a.entity.type === 'plane' && b.entity.type === 'plane') {
-        const aNormal = a.entity.normal ?? [0, 0, 1];
-        const aOrigin = a.entity.origin;
-        const bOrigin = b.entity.origin;
-
-        const currentDist =
-          aNormal[0] * (aOrigin[0] - bOrigin[0]) +
-          aNormal[1] * (aOrigin[1] - bOrigin[1]) +
-          aNormal[2] * (aOrigin[2] - bOrigin[2]);
-
-        const offset = currentDist + c.value;
-        const pos: Vec3 = [offset * aNormal[0], offset * aNormal[1], offset * aNormal[2]];
-        transforms.set(b.node, { position: pos, rotation: [1, 0, 0, 0] });
-      } else {
-        unsupported.push(`distance(${a.entity.type}-${b.entity.type})`);
-      }
-    } else if (c.type === 'concentric' || c.type === 'angle') {
-      unsupported.push(c.type);
-    }
-    // 'fixed' is a no-op — node stays at origin (handled by initialization)
+    if (c.type === 'concentric' || c.type === 'angle') unsupported.push(c.type);
   }
+
+  // Non-plane positioning pairs are unsupported regardless of order; report them
+  // eagerly and keep only plane-plane pairs for topological resolution.
+  const pending: SolverConstraint[] = [];
+  for (const c of positioning) {
+    if (!c.entityA || !c.entityB) continue;
+    if (c.entityA.entity.type !== 'plane' || c.entityB.entity.type !== 'plane') {
+      unsupported.push(`${c.type}(${c.entityA.entity.type}-${c.entityB.entity.type})`);
+      continue;
+    }
+    pending.push(c);
+  }
+
+  // Resolve in topological rounds: a mate solves once its reference (entityA) is
+  // placed, positioning the dependent (entityB) against the reference's solved
+  // pose so multi-body chains compose.
+  let progress = true;
+  while (progress && pending.length > 0) {
+    progress = false;
+    for (let i = pending.length - 1; i >= 0; i--) {
+      const c = pending[i];
+      if (!c?.entityA || !c.entityB) continue;
+      const ref = c.entityA;
+      const dep = c.entityB;
+      if (!placed.has(ref.node)) continue; // reference not solved yet — defer
+
+      pending.splice(i, 1);
+      progress = true;
+      if (placed.has(dep.node)) continue; // dependent already anchored (fixed) — redundant
+
+      const refPose = transforms.get(ref.node) ?? {
+        position: [0, 0, 0],
+        rotation: IDENTITY_ROTATION,
+      };
+      const depPose = transforms.get(dep.node) ?? {
+        position: [0, 0, 0],
+        rotation: IDENTITY_ROTATION,
+      };
+      const extra = c.type === 'distance' ? (c.value ?? 0) : 0;
+      transforms.set(
+        dep.node,
+        solvePlanePair(ref.entity, refPose.position, dep.entity, depPose.position, extra)
+      );
+      placed.add(dep.node);
+    }
+  }
+
+  // Anything still pending has a reference that never resolved (e.g. a cycle).
+  for (const c of pending) unsupported.push(`${c.type}(unanchored)`);
 
   const dof = unsupported.reduce((sum, type) => {
     // Look up by exact key first, then by base type (before parenthesis)

--- a/src/kernel/solverAdapter.ts
+++ b/src/kernel/solverAdapter.ts
@@ -56,30 +56,25 @@ function dot(a: Vec3, b: Vec3): number {
 /**
  * Position a dependent plane against an already-placed reference plane.
  *
- * Both entity origins are local (pre-transform); the reference's solved
- * translation is applied before measuring, so a chain composes down its
- * already-solved poses instead of reading original geometry. `extra` is the
- * gap for a distance mate (0 for coincident). Rotation stays identity —
- * coincident/distance produce pure translations.
+ * The reference's solved translation is applied to its (local) entity origin
+ * before measuring, so a chain composes down already-solved poses instead of
+ * reading original geometry. The dependent is at the origin (a node is only
+ * solved once, while unplaced), so the returned position is its absolute
+ * translation. `extra` is the gap for a distance mate (0 for coincident).
+ * Rotation stays identity — coincident/distance produce pure translations;
+ * Phase 1 rotational constraints will extend this.
  */
-function solvePlanePair(
-  ref: SolverEntity,
-  refPos: Vec3,
-  dep: SolverEntity,
-  depPos: Vec3,
-  extra: number
-): Pose {
+function solvePlanePair(ref: SolverEntity, refPos: Vec3, dep: SolverEntity, extra: number): Pose {
   const n = ref.normal ?? [0, 0, 1];
   const refOrigin = add(ref.origin, refPos);
-  const depOrigin = add(dep.origin, depPos);
   const offset =
     dot(n, [
-      refOrigin[0] - depOrigin[0],
-      refOrigin[1] - depOrigin[1],
-      refOrigin[2] - depOrigin[2],
+      refOrigin[0] - dep.origin[0],
+      refOrigin[1] - dep.origin[1],
+      refOrigin[2] - dep.origin[2],
     ]) + extra;
   return {
-    position: [depPos[0] + offset * n[0], depPos[1] + offset * n[1], depPos[2] + offset * n[2]],
+    position: [offset * n[0], offset * n[1], offset * n[2]],
     rotation: IDENTITY_ROTATION,
   };
 }
@@ -124,7 +119,10 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
   }
 
   // Non-plane positioning pairs are unsupported regardless of order; report them
-  // eagerly and keep only plane-plane pairs for topological resolution.
+  // eagerly and keep only plane-plane pairs for topological resolution. A node
+  // left unplaced by such a pair (it's a dependent, so not a root) will cause
+  // any downstream plane-plane mate that references it to end up `(unanchored)`
+  // — intended: an unsolved reference can't compose, so the chain doesn't converge.
   const pending: SolverConstraint[] = [];
   for (const c of positioning) {
     if (!c.entityA || !c.entityB) continue;
@@ -156,15 +154,8 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
         position: [0, 0, 0],
         rotation: IDENTITY_ROTATION,
       };
-      const depPose = transforms.get(dep.node) ?? {
-        position: [0, 0, 0],
-        rotation: IDENTITY_ROTATION,
-      };
       const extra = c.type === 'distance' ? (c.value ?? 0) : 0;
-      transforms.set(
-        dep.node,
-        solvePlanePair(ref.entity, refPose.position, dep.entity, depPose.position, extra)
-      );
+      transforms.set(dep.node, solvePlanePair(ref.entity, refPose.position, dep.entity, extra));
       placed.add(dep.node);
     }
   }

--- a/tests/mateFns.test.ts
+++ b/tests/mateFns.test.ts
@@ -421,11 +421,45 @@ describe('solveAssembly — combined mates', () => {
     const midZ = solved.transforms.get('mid')?.position[2];
     expect(midZ).toBeCloseTo(10, 0);
 
-    // Solver uses original (pre-transform) face coordinates.
-    // top of b2 (5-tall) has center at z=5 in local space, bottom of b3 at z=0.
-    // currentDist = 1*(5-0) = 5, offset = 5 + 3 = 8 → top.position[2] = 8
+    // Constraints compose down the chain: the distance mate reads mid's SOLVED
+    // pose, not its original geometry. mid is placed at z=10 (spans 10..15), so
+    // its top face is at world z=15; with a 3-unit gap, top sits at z=18.
     const topZ = solved.transforms.get('top')?.position[2];
-    expect(topZ).toBeCloseTo(8, 0);
+    expect(topZ).toBeCloseTo(18, 0);
+  });
+
+  it('composes a chain regardless of mate declaration order', () => {
+    const b1 = box(10, 10, 10);
+    const b2 = box(5, 5, 5);
+    const b3 = box(5, 5, 5);
+
+    let assembly = createAssemblyNode('root');
+    assembly = addChild(assembly, createAssemblyNode('base', { shape: b1 }));
+    assembly = addChild(assembly, createAssemblyNode('mid', { shape: b2 }));
+    assembly = addChild(assembly, createAssemblyNode('top', { shape: b3 }));
+
+    // Declared leaf-first: the top→mid mate appears before mid→base, so a
+    // naive in-order solver would read mid's unsolved (origin) pose. Topological
+    // resolution must still place mid before solving the distance mate.
+    assembly = addMate(assembly, {
+      type: 'distance',
+      entityA: { node: 'mid', face: topFace(b2) },
+      entityB: { node: 'top', face: bottomFace(b3) },
+      distance: 3,
+    });
+    assembly = addMate(assembly, {
+      type: 'coincident',
+      entityA: { node: 'base', face: topFace(b1) },
+      entityB: { node: 'mid', face: bottomFace(b2) },
+    });
+    assembly = addMate(assembly, { type: 'fixed', entity: { node: 'base' } });
+
+    const result = solveAssembly(assembly);
+    expect(isOk(result)).toBe(true);
+    const solved = unwrap(result);
+    expect(solved.converged).toBe(true);
+    expect(solved.transforms.get('mid')?.position[2]).toBeCloseTo(10, 0);
+    expect(solved.transforms.get('top')?.position[2]).toBeCloseTo(18, 0);
   });
 });
 

--- a/tests/mateFns.test.ts
+++ b/tests/mateFns.test.ts
@@ -15,7 +15,7 @@ import {
   faceCenter,
 } from '@/index.js';
 import type { MateConstraint } from '@/index.js';
-import { solveConstraints } from '@/kernel/solverAdapter.js';
+import { solveConstraints, type SolverEntity } from '@/kernel/solverAdapter.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -583,5 +583,32 @@ describe('solveConstraints — unsupported constraint honesty', () => {
     expect(result.transforms.get('b')?.position[2]).toBeCloseTo(10, 0);
     expect(result.converged).toBe(false);
     expect(result.unsupported).toEqual(['angle']);
+  });
+
+  it('reports a mutual-reference cycle as unanchored (no root to resolve from)', () => {
+    // a→b and b→a with no fixed node and no chain root: neither reference can
+    // ever be placed, so both stay pending and surface as `(unanchored)`.
+    const plane = (z: number): SolverEntity => ({
+      type: 'plane',
+      origin: [0, 0, z],
+      normal: [0, 0, 1],
+    });
+    const result = solveConstraints(
+      ['a', 'b'],
+      [
+        {
+          type: 'coincident',
+          entityA: { node: 'a', entity: plane(0) },
+          entityB: { node: 'b', entity: plane(0) },
+        },
+        {
+          type: 'coincident',
+          entityA: { node: 'b', entity: plane(0) },
+          entityB: { node: 'a', entity: plane(0) },
+        },
+      ]
+    );
+    expect(result.converged).toBe(false);
+    expect(result.unsupported).toEqual(['coincident(unanchored)', 'coincident(unanchored)']);
   });
 });


### PR DESCRIPTION
## Summary

**Phase 0 of the kinematics roadmap (#1287)** — the prerequisite for everything that follows. Addresses gap **A4** documented in #1286: the constraint solver positioned each part from the referenced part's *original* geometry, ignoring any transform a prior mate assigned it, so multi-body chains mis-solved.

## What changed

`solveConstraints` (`src/kernel/solverAdapter.ts`) now resolves positioning mates in **topological order**:

- For a positioning mate, **entityA is the reference** and **entityB the dependent**.
- **Anchors** (placed at the origin): chain roots — nodes never positioned by a mate — plus explicit `fixed` nodes.
- Each `coincident`/`distance` mate solves once its reference is placed, positioning the dependent against the reference's **already-solved pose** (`solvePlanePair` applies the reference's solved translation before measuring).
- Resolution is robust to the **order mates are declared in** (rounds over a worklist, not array order).
- `concentric`/`angle` and non-plane entity pairs remain unsupported (Phase 1); non-plane pairs are still reported eagerly by entity type.

Rotation stays identity — `coincident`/`distance` produce pure translations; full quaternion composition lands in Phase 1 with `angle`/`concentric`.

## Tests

- **Flipped** the composition-bug test (`tests/mateFns.test.ts`) from the buggy `top.z = 8` to the correct **`z = 18`** (mid solved to z=10, spans 10..15; 3-unit gap → top at 18). *(The roadmap's "13" was an arithmetic slip; 18 is the face-gap-faithful value.)*
- **Added** a test proving a chain composes correctly even when mates are declared **leaf-first** (out of order).
- All 26 mateFns + 17 assemblyFns tests green; full changed-file suite (3382 tests) green via pre-push.

## Docs

- Updated the `CLAUDE.md` gotcha that documented the old "original face coordinates" limitation.

## Follow-ups (this roadmap)

- Phase 1 — rotational constraints (`concentric`/`angle`) + reachable `axis` entity
- Phase 2 — joint primitives (`jointFns.ts`)
- Phase 3 — forward kinematics + mechanism DOF

Refs #1287, #1286