### PR TITLE
feat(verify): validate each body of multi-solid assemblies

### DIFF
--- a/packages/brepjs-verify/src/verify/checks.ts
+++ b/packages/brepjs-verify/src/verify/checks.ts
@@ -34,6 +34,7 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     getEdges,
     getWires,
     getVertices,
+    getSolids,
     getShells,
     isManifoldShell,
     validSolid,
@@ -53,6 +54,22 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
       r.errorInfos.push({ message: `isValidSolid: ${valid.error}`, code: VALIDITY_FAILURE_CODE });
     }
     r.checks.push(validCheck);
+  } else {
+    // Multi-body assemblies (Compound/CompSolid): validate each contained solid so the assembly
+    // isn't reported ok on volume alone while an invalid body hides inside it.
+    const solids = getSolids(shape);
+    if (solids.length > 0) {
+      const invalid = solids.filter((s) => !isOk(validSolid(s))).length;
+      const bodiesCheck: VerifyCheck = { name: 'allBodiesValid', passed: invalid === 0 };
+      if (invalid > 0) {
+        bodiesCheck.detail = `${invalid}/${solids.length} bodies invalid`;
+        r.errorInfos.push({
+          message: `allBodiesValid: ${invalid}/${solids.length} bodies invalid`,
+          code: VALIDITY_FAILURE_CODE,
+        });
+      }
+      r.checks.push(bodiesCheck);
+    }
   }
 
   // Volume + positiveVolume for ANY 3D shape. Booleans/modifiers (cut/fuse/chamfer) routinely

--- a/packages/brepjs-verify/src/verify/checks.ts
+++ b/packages/brepjs-verify/src/verify/checks.ts
@@ -59,12 +59,19 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
     // isn't reported ok on volume alone while an invalid body hides inside it.
     const solids = getSolids(shape);
     if (solids.length > 0) {
-      const invalid = solids.filter((s) => !isOk(validSolid(s))).length;
-      const bodiesCheck: VerifyCheck = { name: 'allBodiesValid', passed: invalid === 0 };
-      if (invalid > 0) {
-        bodiesCheck.detail = `${invalid}/${solids.length} bodies invalid`;
+      // Keep each failing body's BRepCheck message (which body, and why) rather than just a count.
+      const failures: string[] = [];
+      solids.forEach((s, i) => {
+        const v = validSolid(s);
+        if (!isOk(v)) failures.push(`body ${i}: ${v.error}`);
+      });
+      const bodiesCheck: VerifyCheck = { name: 'allBodiesValid', passed: failures.length === 0 };
+      if (failures.length > 0) {
+        bodiesCheck.detail = `${failures.length}/${solids.length} bodies invalid — ${failures.join('; ')}`;
+        // One errorInfo with the shared validity code; buildHints dedupes by code, so the hint
+        // fires once while the per-body detail stays reachable on the check.
         r.errorInfos.push({
-          message: `allBodiesValid: ${invalid}/${solids.length} bodies invalid`,
+          message: `allBodiesValid: ${bodiesCheck.detail}`,
           code: VALIDITY_FAILURE_CODE,
         });
       }

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -103,6 +103,23 @@ describe('runChecks', () => {
     expect(check?.detail).toContain('2/2');
   });
 
+  it('reports a partial failure (1 of 2 bodies invalid)', () => {
+    // Fail only the second body: first call delegates to the real check, later calls force-fail.
+    let call = 0;
+    const faultyBrep = {
+      ...brep,
+      validSolid: ((s: Parameters<typeof brep.validSolid>[0]) =>
+        call++ === 0
+          ? brep.validSolid(s)
+          : { ok: false, error: 'forced invalid' }) as typeof brep.validSolid,
+    };
+    const asm = compound([box(10, 10, 10), box(10, 10, 10, { at: [20, 0, 0] })]);
+    const report = runChecks(faultyBrep, asm);
+    const check = report.checks.find((c) => c.name === 'allBodiesValid');
+    expect(check?.passed).toBe(false);
+    expect(check?.detail).toContain('1/2');
+  });
+
   it('does not add a body-validity check for a shape with no solids', () => {
     const edge = brep.getEdges(box(10, 10, 10))[0];
     if (!edge) throw new Error('expected an edge from the box');

--- a/packages/brepjs-verify/tests/checks.test.ts
+++ b/packages/brepjs-verify/tests/checks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as brep from 'brepjs';
-import { init, box, fuse, unwrap } from 'brepjs';
+import { init, box, fuse, unwrap, compound } from 'brepjs';
 import { runChecks } from '@/verify/checks.js';
 
 beforeAll(async () => {
@@ -79,5 +79,35 @@ describe('runChecks', () => {
     const report = runChecks(brep, edge);
     expect(report.topology).toBeDefined();
     expect(report.topology?.manifold).toBeUndefined();
+  });
+
+  it('validates each body of a multi-solid compound (allBodiesValid)', () => {
+    const asm = compound([box(10, 10, 10), box(10, 10, 10, { at: [20, 0, 0] })]);
+    const report = runChecks(brep, asm);
+    expect(report.shapeType).toBe('Compound');
+    expect(report.checks.find((c) => c.name === 'allBodiesValid')?.passed).toBe(true);
+    // A multi-body assembly does not get the single-solid check.
+    expect(report.checks.find((c) => c.name === 'isValidSolid')).toBeUndefined();
+  });
+
+  it('reports allBodiesValid=false when a body is invalid', () => {
+    // Fault-inject validSolid so a body reads as invalid, exercising the false branch deterministically.
+    const faultyBrep = {
+      ...brep,
+      validSolid: (() => ({ ok: false, error: 'forced invalid' })) as typeof brep.validSolid,
+    };
+    const asm = compound([box(10, 10, 10), box(10, 10, 10, { at: [20, 0, 0] })]);
+    const report = runChecks(faultyBrep, asm);
+    const check = report.checks.find((c) => c.name === 'allBodiesValid');
+    expect(check?.passed).toBe(false);
+    expect(check?.detail).toContain('2/2');
+  });
+
+  it('does not add a body-validity check for a shape with no solids', () => {
+    const edge = brep.getEdges(box(10, 10, 10))[0];
+    if (!edge) throw new Error('expected an edge from the box');
+    const report = runChecks(brep, edge);
+    expect(report.checks.find((c) => c.name === 'allBodiesValid')).toBeUndefined();
+    expect(report.checks.find((c) => c.name === 'isValidSolid')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What
Adds an `allBodiesValid` check for multi-body shapes (Compound/CompSolid): every contained solid is run through `validSolid`, and the check fails (with a `N/M bodies invalid` detail) if any body is invalid.

## Why
Closes a real gap: `runChecks` only ran BRepCheck on a single top-level Solid, so an assembly could report `ok` on positive volume alone while hiding an invalid body. Mass-properties/validity feedback for the agent substrate must hold for assemblies, not just single solids.

## How
- New `else` branch in `runChecks`: for non-Solid shapes, `getSolids(shape)` — if any solids exist, validate each via `validSolid` and push an `allBodiesValid` check (synthetic `VALIDITY_FAILURE_CODE` on failure, mirroring the single-solid path so the hint table fires without double-counting).
- Single solids keep the stronger `isValidSolid` check; shapes with no solids get neither.

## Test
TDD-style coverage of all three branches: valid 2-body compound → `allBodiesValid: true`; fault-injected invalid body → `false` with `2/2` detail; no-solid shape (edge) → no body check. Full suite green (92 tests), typecheck + lint clean.