### PR TITLE
feat(verify): sandbox executor — run agent code in an isolated child process

### DIFF
--- a/packages/brepjs-verify/src/sandbox/runProgram.ts
+++ b/packages/brepjs-verify/src/sandbox/runProgram.ts
@@ -1,0 +1,119 @@
+/**
+ * Sandbox executor — run agent-authored brepjs TypeScript in an isolated child process.
+ *
+ * The program is written to a temp ESM directory and executed by the verify CLI in a separate
+ * process, with a wall-clock timeout and a memory cap. Out-of-process execution is what makes the
+ * loop *unattended-safe*: a runaway (CPU-bound infinite loop) or memory-hungry part is killed
+ * rather than hanging or crashing the host. Results cross the boundary as the serialized verify
+ * report (never live WASM handles), and the temp directory is always cleaned up.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { VerifyReport } from '../verify/report.js';
+
+const execFileAsync = promisify(execFile);
+
+/** The verify report as serialized by the CLI (the report plus the top-level `ok` verdict). */
+export type SerializedReport = VerifyReport & { ok: boolean };
+
+/** Outcome of a sandboxed run. `completed` includes not-ok reports (the part built but failed checks). */
+export type RunProgramResult =
+  | { outcome: 'completed'; report: SerializedReport }
+  | { outcome: 'timeout'; timeoutMs: number }
+  | { outcome: 'crashed'; exitCode: number | null; detail: string };
+
+export interface RunProgramOptions {
+  /** Wall-clock budget; the child is SIGKILLed past it. Default 30000. */
+  timeoutMs?: number;
+  /** Child heap cap (`--max-old-space-size`), in MB. Default 2048. */
+  maxMemoryMb?: number;
+  /**
+   * CLI entry to spawn. Defaults to the in-repo TypeScript CLI (run via `tsx`), which is correct
+   * for dev/test. Production callers pass the built `dist/cli/main.js` (run via `node`). The runner
+   * is inferred from the extension: `.ts` → `npx tsx`, otherwise the current `node`.
+   */
+  cliEntry?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_MEMORY_MB = 2048;
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+function defaultCliEntry(): string {
+  // runProgram and the CLI share a build root (src/ in dev, dist/ in prod); '../cli/main.ts'
+  // resolves to the in-repo TS CLI used by the existing CLI tests.
+  return fileURLToPath(new URL('../cli/main.ts', import.meta.url));
+}
+
+function tryParseReport(out: string | undefined): SerializedReport | null {
+  if (!out || !out.trim()) return null;
+  try {
+    return JSON.parse(out) as SerializedReport;
+  } catch {
+    return null;
+  }
+}
+
+/** Execute `code` (an agent-authored `.brep.ts` module) in an isolated, resource-bounded child. */
+export async function runProgram(
+  code: string,
+  opts: RunProgramOptions = {}
+): Promise<RunProgramResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxMemoryMb = opts.maxMemoryMb ?? DEFAULT_MAX_MEMORY_MB;
+  const cliEntry = opts.cliEntry ?? defaultCliEntry();
+  const useTsx = cliEntry.endsWith('.ts');
+
+  const dir = await mkdtemp(join(tmpdir(), 'brepjs-run-'));
+  try {
+    // Seed an ESM package so the part resolves as a module (matches the verify CLI's expectations).
+    await writeFile(join(dir, 'package.json'), '{"type":"module"}\n');
+    const partPath = join(dir, 'part.brep.ts');
+    await writeFile(partPath, code);
+
+    const cmd = useTsx ? 'npx' : process.execPath;
+    const args = useTsx
+      ? ['tsx', cliEntry, partPath, '--check']
+      : [cliEntry, partPath, '--check'];
+
+    try {
+      const { stdout } = await execFileAsync(cmd, args, {
+        timeout: timeoutMs,
+        killSignal: 'SIGKILL',
+        maxBuffer: MAX_OUTPUT_BYTES,
+        env: { ...process.env, NODE_OPTIONS: `--max-old-space-size=${maxMemoryMb}` },
+      });
+      const report = tryParseReport(stdout);
+      if (report) return { outcome: 'completed', report };
+      return { outcome: 'crashed', exitCode: 0, detail: 'no JSON report on stdout' };
+    } catch (err) {
+      const e = err as {
+        stdout?: string;
+        stderr?: string;
+        killed?: boolean;
+        code?: number | string | null;
+      };
+      // A not-ok part exits 1 but still prints its JSON report — that is a completed run.
+      const report = tryParseReport(e.stdout);
+      if (report) return { outcome: 'completed', report };
+      // Output cap exceeded also kills the child; classify it distinctly from a timeout.
+      if (e.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+        return { outcome: 'crashed', exitCode: null, detail: 'output exceeded size limit' };
+      }
+      if (e.killed) return { outcome: 'timeout', timeoutMs };
+      const detail = e.stderr || (err instanceof Error ? err.message : String(err));
+      return {
+        outcome: 'crashed',
+        exitCode: typeof e.code === 'number' ? e.code : null,
+        detail: detail.slice(0, 2000),
+      };
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/brepjs-verify/src/sandbox/runProgram.ts
+++ b/packages/brepjs-verify/src/sandbox/runProgram.ts
@@ -11,6 +11,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -45,8 +46,10 @@ const DEFAULT_MAX_MEMORY_MB = 2048;
 const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 function defaultCliEntry(): string {
-  // runProgram and the CLI share a build root (src/ in dev, dist/ in prod); '../cli/main.ts'
-  // resolves to the in-repo TS CLI used by the existing CLI tests.
+  // runProgram and the CLI share a build root: dist/cli/main.js in a built/published package,
+  // src/cli/main.ts in dev/test. Prefer the built JS so the default works in production too.
+  const builtJs = fileURLToPath(new URL('../cli/main.js', import.meta.url));
+  if (existsSync(builtJs)) return builtJs;
   return fileURLToPath(new URL('../cli/main.ts', import.meta.url));
 }
 
@@ -86,7 +89,13 @@ export async function runProgram(
         timeout: timeoutMs,
         killSignal: 'SIGKILL',
         maxBuffer: MAX_OUTPUT_BYTES,
-        env: { ...process.env, NODE_OPTIONS: `--max-old-space-size=${maxMemoryMb}` },
+        env: {
+          ...process.env,
+          // Append rather than replace, so an existing NODE_OPTIONS (flags, other limits) survives.
+          NODE_OPTIONS: [process.env['NODE_OPTIONS'], `--max-old-space-size=${maxMemoryMb}`]
+            .filter(Boolean)
+            .join(' '),
+        },
       });
       const report = tryParseReport(stdout);
       if (report) return { outcome: 'completed', report };

--- a/packages/brepjs-verify/tests/runProgram.test.ts
+++ b/packages/brepjs-verify/tests/runProgram.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { runProgram } from '@/sandbox/runProgram.js';
+
+const VALID_PART = `import { box } from 'brepjs';\nexport default () => box(10, 10, 10);\n`;
+// A synchronous infinite loop blocks the child's event loop — only an out-of-process
+// timeout/kill can stop it, which is exactly what the sandbox must guarantee.
+const RUNAWAY_PART = `export default () => {\n  // eslint-disable-next-line\n  while (true) {}\n};\n`;
+
+describe('runProgram (sandbox executor)', () => {
+  it('runs a valid part in a child process and returns a completed report', async () => {
+    const res = await runProgram(VALID_PART);
+    expect(res.outcome).toBe('completed');
+    if (res.outcome === 'completed') {
+      expect(res.report.ok).toBe(true);
+      expect(res.report.measurements.volume).toBeCloseTo(1000, 1);
+    }
+  }, 60000);
+
+  it('kills a runaway (infinite-loop) part and reports a timeout', async () => {
+    const res = await runProgram(RUNAWAY_PART, { timeoutMs: 8000 });
+    expect(res.outcome).toBe('timeout');
+    if (res.outcome === 'timeout') expect(res.timeoutMs).toBe(8000);
+  }, 30000);
+});

--- a/packages/brepjs-verify/tests/runProgram.test.ts
+++ b/packages/brepjs-verify/tests/runProgram.test.ts
@@ -21,4 +21,12 @@ describe('runProgram (sandbox executor)', () => {
     expect(res.outcome).toBe('timeout');
     if (res.outcome === 'timeout') expect(res.timeoutMs).toBe(8000);
   }, 30000);
+
+  it('reports crashed when the runner produces no report (bad CLI entry)', async () => {
+    // A non-existent .js entry runs under `node` and exits non-zero with no JSON on stdout —
+    // exactly the "the child died without a report" path the crashed outcome must catch.
+    const res = await runProgram(VALID_PART, { cliEntry: '/nonexistent/brepjs-verify-cli.js' });
+    expect(res.outcome).toBe('crashed');
+    if (res.outcome === 'crashed') expect(res.detail.length).toBeGreaterThan(0);
+  }, 30000);
 });

--- a/packages/brepjs-verify/vitest.config.ts
+++ b/packages/brepjs-verify/vitest.config.ts
@@ -7,13 +7,13 @@ const viewerSrc = resolve(__dirname, 'viewer/src');
 
 export default defineConfig({
   resolve: {
-    // `@/verify|snapshot|cli` are this package's own dirs; every other `@/...`
+    // `@/verify|snapshot|cli|sandbox` are this package's own dirs; every other `@/...`
     // belongs to the live brepjs source we alias below, so it must resolve into
     // the root src tree. A single `@`→pkgSrc alias misroutes brepjs's internal
     // `@/utils`/`@/kernel` imports and breaks any test that imports `brepjs`.
     alias: [
       { find: /^@viewer\//, replacement: `${viewerSrc}/` },
-      { find: /^@\/(verify|snapshot|cli)\//, replacement: `${pkgSrc}/$1/` },
+      { find: /^@\/(verify|snapshot|cli|sandbox)\//, replacement: `${pkgSrc}/$1/` },
       { find: /^@\//, replacement: `${rootSrc}/` },
       { find: 'brepjs', replacement: resolve(rootSrc, 'index.ts') },
     ],


### PR DESCRIPTION
## What
Adds `runProgram(code, opts)` (`src/sandbox/runProgram.ts`): executes an agent-authored brepjs `.brep.ts` module in an **isolated child process** with a wall-clock timeout and a memory cap, returning a typed outcome.

## Why
First Phase 0 (beachhead) slice of the AI-CAD agent substrate. The lodestar — an agent building + verifying a part **unattended** — requires that a runaway or memory-hungry part can't hang or crash the host. In-process execution can't kill a CPU-bound infinite loop (single-threaded event loop), so isolation must be out-of-process. This is the foundation the MCP `run_program` tool will wrap.

## How
- Writes the program to a temp ESM dir (`{"type":"module"}`) and spawns the existing verify CLI as a child (reusing the proven runPart + resolve-hook path; results cross the boundary as the serialized report, never live WASM handles).
- `execFile` with `timeout` + `SIGKILL`, `--max-old-space-size` memory cap, and a `maxBuffer` output cap.
- Typed outcomes: `completed` (incl. not-ok reports — the part built but failed checks), `timeout`, `crashed` (distinguishes output-cap from timeout). Temp dir always cleaned up.
- Runner inferred from the CLI entry extension (`.ts` → `npx tsx` for dev/test; `.js` → `node` for the built dist, which production callers pass). Adds `sandbox` to the package's `@/` test-alias whitelist.

## Test
TDD: a valid box part → `completed` with volume ~1000; a `while(true){}` runaway → `timeout` (killed at the budget). Full suite green (95 tests), typecheck + lint + knip clean.

## Note
`runProgram` is intentionally not yet re-exported from the package index — the MCP server PR will wire it to the `run_program` tool.