### PR TITLE
feat(assembly): rotational mates — concentric + angle (kinematics Phase 1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -638,6 +638,7 @@ export {
   uvCoordinates,
   normalAt,
   faceCenter,
+  faceAxis,
   classifyPointOnFace,
   outerWire,
   innerWires,

--- a/src/kernel/brepkit/geometryOps.ts
+++ b/src/kernel/brepkit/geometryOps.ts
@@ -574,6 +574,8 @@ export function makeGeometryOps(bk: BrepkitKernel) {
     createCurveAdaptor: (shape) => createCurveAdaptor(bk, shape),
     getBezierPenultimatePole: (edge) => getBezierPenultimatePole(bk, edge),
     getSurfaceCylinderData: (surface) => getSurfaceCylinderData(bk, surface),
+    // Axis-based mates (concentric) are an OCCT-only feature for now.
+    getSurfaceAxis: () => null,
     reverseSurfaceU: (surface) => reverseSurfaceU(bk, surface),
     classifyPointOnFace: (face, u, v, tolerance) => classifyPointOnFace(bk, face, u, v, tolerance),
     classifyPointRobust: (shape, point, tolerance) =>
@@ -613,6 +615,7 @@ export function makeGeometryOps(bk: BrepkitKernel) {
     | 'createCurveAdaptor'
     | 'getBezierPenultimatePole'
     | 'getSurfaceCylinderData'
+    | 'getSurfaceAxis'
     | 'reverseSurfaceU'
     | 'classifyPointOnFace'
     | 'classifyPointRobust'

--- a/src/kernel/interfaces/surfaceOps.ts
+++ b/src/kernel/interfaces/surfaceOps.ts
@@ -64,6 +64,14 @@ export interface KernelSurfaceOps {
   // --- Surface geometry extraction ---
   /** Extract cylinder data from a surface handle. Returns null if not a cylinder. */
   getSurfaceCylinderData(surface: KernelType): { radius: number; isDirect: boolean } | null;
+  /**
+   * Get a face's analytic axis of symmetry (e.g. a cylinder's axis): a point on
+   * the axis plus a unit direction. Returns null if the face has no well-defined
+   * axis (non-cylindrical, or the adapter can't determine it).
+   */
+  getSurfaceAxis(
+    face: KernelShape
+  ): { origin: [number, number, number]; direction: [number, number, number] } | null;
   /** Reverse the U direction of a surface. Returns a new surface handle. */
   reverseSurfaceU(surface: KernelType): KernelType;
 

--- a/src/kernel/manifold/geometryOps.ts
+++ b/src/kernel/manifold/geometryOps.ts
@@ -99,6 +99,7 @@ function descOf(shape: KernelShape): CurveDesc | undefined {
   return node.op === 'profileEdge' ? node.params?.curve : undefined;
 }
 
+// brepjs-patterns-disable: max-function-lines
 export function makeGeometryOps(_module: ManifoldModule): KernelCurveOps & KernelSurfaceOps {
   return {
     // --- Curve queries: analytic for standalone profile edges (exact), native
@@ -224,6 +225,7 @@ export function makeGeometryOps(_module: ManifoldModule): KernelCurveOps & Kerne
       viaOcct(face, (s, occt) => occt.untrimFace(s, samplesPerCurve, interiorSamples)),
     getSurfaceCylinderData: (surface) =>
       viaOcct(surface, (s, occt) => occt.getSurfaceCylinderData(s)),
+    getSurfaceAxis: (face) => viaOcct(face, (s, occt) => occt.getSurfaceAxis(s)),
     reverseSurfaceU: (surface) => occtOrThrow('reverseSurfaceU').reverseSurfaceU(surface),
     detectSmallFeatures: (shape, areaThreshold, tolerance) =>
       viaOcct(shape, (s, occt) => occt.detectSmallFeatures(s, areaThreshold, tolerance)),

--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -463,12 +463,39 @@ export function getSurfaceCylinderData(
   return result;
 }
 
+/** Get a cylindrical face's axis (point on axis + unit direction). Null otherwise. */
+export function getSurfaceAxis(
+  oc: KernelInstance,
+  face: KernelShape
+): { origin: [number, number, number]; direction: [number, number, number] } | null {
+  const adaptor = new oc.BRepAdaptor_Surface_2(face, false);
+  const typeVal = adaptor.GetType();
+  const typeIdx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
+  // 1 = GeomAbs_Cylinder
+  if (typeIdx !== 1) {
+    adaptor.delete();
+    return null;
+  }
+  const cyl = adaptor.Cylinder();
+  const axis = cyl.Axis();
+  const loc = axis.Location();
+  const dir = axis.Direction();
+  const result = {
+    origin: [loc.X(), loc.Y(), loc.Z()] as [number, number, number],
+    direction: [dir.X(), dir.Y(), dir.Z()] as [number, number, number],
+  };
+  cyl.delete();
+  adaptor.delete();
+  return result;
+}
+
 /** Reverse the U direction of a surface. Returns a new surface handle. */
 export function reverseSurfaceU(_oc: KernelInstance, surface: KernelType): KernelType {
   return surface.get().UReversed();
 }
 
 /** Co-located factory: returns the geometry-query slice of {@link KernelAdapter} bound to `oc`. */
+// brepjs-patterns-disable: max-function-lines
 export function makeGeometryQueryOps(oc: KernelInstance) {
   return {
     vertexPosition: (vertex) => vertexPosition(oc, vertex),
@@ -498,6 +525,7 @@ export function makeGeometryQueryOps(oc: KernelInstance) {
     curvePeriod: (shape) => curvePeriod(oc, shape),
     curveType: (shape) => curveType(oc, shape),
     getSurfaceCylinderData: (surface) => getSurfaceCylinderData(oc, surface),
+    getSurfaceAxis: (face) => getSurfaceAxis(oc, face),
     reverseSurfaceU: (surface) => reverseSurfaceU(oc, surface),
   } satisfies Pick<
     KernelAdapter,
@@ -526,6 +554,7 @@ export function makeGeometryQueryOps(oc: KernelInstance) {
     | 'curvePeriod'
     | 'curveType'
     | 'getSurfaceCylinderData'
+    | 'getSurfaceAxis'
     | 'reverseSurfaceU'
   >;
 }

--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -469,24 +469,27 @@ export function getSurfaceAxis(
   face: KernelShape
 ): { origin: [number, number, number]; direction: [number, number, number] } | null {
   const adaptor = new oc.BRepAdaptor_Surface_2(face, false);
-  const typeVal = adaptor.GetType();
-  const typeIdx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
-  // 1 = GeomAbs_Cylinder
-  if (typeIdx !== 1) {
+  try {
+    const typeVal = adaptor.GetType();
+    const typeIdx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
+    // 1 = GeomAbs_Cylinder
+    if (typeIdx !== 1) return null;
+    const cyl = adaptor.Cylinder();
+    const axis = cyl.Axis();
+    const loc = axis.Location();
+    const dir = axis.Direction();
+    const result = {
+      origin: [loc.X(), loc.Y(), loc.Z()] as [number, number, number],
+      direction: [dir.X(), dir.Y(), dir.Z()] as [number, number, number],
+    };
+    loc.delete();
+    dir.delete();
+    axis.delete();
+    cyl.delete();
+    return result;
+  } finally {
     adaptor.delete();
-    return null;
   }
-  const cyl = adaptor.Cylinder();
-  const axis = cyl.Axis();
-  const loc = axis.Location();
-  const dir = axis.Direction();
-  const result = {
-    origin: [loc.X(), loc.Y(), loc.Z()] as [number, number, number],
-    direction: [dir.X(), dir.Y(), dir.Z()] as [number, number, number],
-  };
-  cyl.delete();
-  adaptor.delete();
-  return result;
 }
 
 /** Reverse the U direction of a surface. Returns a new surface handle. */

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1512,6 +1512,12 @@ export class OcctWasmAdapter implements KernelAdapter {
     notImplemented('getSurfaceCylinderData');
   }
 
+  getSurfaceAxis(
+    face: KernelShape
+  ): { origin: [number, number, number]; direction: [number, number, number] } | null {
+    return surfaceOps.getSurfaceAxis(this.k, face);
+  }
+
   reverseSurfaceU(_surface: KernelType): KernelType {
     notImplemented('reverseSurfaceU');
   }

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -65,6 +65,54 @@ export function pointOnSurface(
   }
 }
 
+type V3 = [number, number, number];
+const subV = (a: V3, b: V3): V3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const lenV = (a: V3): number => Math.hypot(a[0], a[1], a[2]);
+const crossV = (a: V3, b: V3): V3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+
+/**
+ * Derive a cylindrical face's axis (point on axis + unit direction) from the
+ * primitives occt-wasm exposes — it has no analytic `gp_Cylinder` accessor.
+ *
+ * Two surface samples at the same height v give radial normals n1,n2 (lying in
+ * the plane perpendicular to the axis), so `n1 x n2` is parallel to the axis.
+ * The points satisfy `p1 - p2 = ±r(n1 - n2)`, giving the radius
+ * `r = |p1-p2| / |n1-n2|`; the axis point is then `p - r·n` with the normal's
+ * sign chosen so both samples agree. Exact for full and partial cylinders.
+ * Returns null for non-cylinders.
+ */
+export function getSurfaceAxis(
+  k: OcctKernelWasm,
+  face: KernelShape
+): { origin: V3; direction: V3 } | null {
+  if (surfaceType(k, face) !== 'cylinder') return null;
+  const b = uvBounds(k, face);
+  const vMid = 0.5 * (b.vMin + b.vMax);
+  const u1 = b.uMin + 0.25 * (b.uMax - b.uMin);
+  const u2 = b.uMin + 0.5 * (b.uMax - b.uMin);
+  const n1 = surfaceNormal(k, face, u1, vMid);
+  const n2 = surfaceNormal(k, face, u2, vMid);
+  const p1 = pointOnSurface(k, face, u1, vMid);
+  const p2 = pointOnSurface(k, face, u2, vMid);
+
+  const axis = crossV(n1, n2);
+  const axisLen = lenV(axis);
+  const dnLen = lenV(subV(n1, n2));
+  if (axisLen < 1e-9 || dnLen < 1e-9) return null; // samples too close to resolve
+  const direction: V3 = [axis[0] / axisLen, axis[1] / axisLen, axis[2] / axisLen];
+  const r = lenV(subV(p1, p2)) / dnLen;
+
+  // Axis point is p - r·n; pick the normal sign that makes both samples agree.
+  const minus1: V3 = [p1[0] - r * n1[0], p1[1] - r * n1[1], p1[2] - r * n1[2]];
+  const minus2: V3 = [p2[0] - r * n2[0], p2[1] - r * n2[1], p2[2] - r * n2[2]];
+  if (lenV(subV(minus1, minus2)) < 1e-6) return { origin: minus1, direction };
+  return { origin: [p1[0] + r * n1[0], p1[1] + r * n1[1], p1[2] + r * n1[2]], direction };
+}
+
 export function uvFromPoint(
   k: OcctKernelWasm,
   face: KernelShape,

--- a/src/kernel/solverAdapter.ts
+++ b/src/kernel/solverAdapter.ts
@@ -28,11 +28,12 @@ export interface SolverResult {
 }
 
 /**
- * Standard degrees of freedom left unresolved by each unsupported constraint type.
- * coincident: 3 translational (plane normal alignment + contact)
- * concentric: 2 rotational (axis alignment) + 2 translational (axis centering) = 4
- * distance: 1 translational (offset along normal)
- * angle: 1 rotational
+ * Degrees of freedom each constraint leaves unresolved when it can't be applied
+ * (entity-type mismatch or an unreachable reference). All four types now solve
+ * for well-typed inputs; these counts only feed the diagnostic `dof` for the
+ * unsupported cases.
+ * coincident: 3 translational · concentric: 2 rotational + 2 translational = 4
+ * distance: 1 translational · angle: 1 rotational
  */
 const UNSUPPORTED_DOF: Readonly<Record<string, number>> = {
   coincident: 3,
@@ -41,54 +42,165 @@ const UNSUPPORTED_DOF: Readonly<Record<string, number>> = {
   angle: 1,
 };
 
-type Pose = { position: Vec3; rotation: [number, number, number, number] };
+type Quat = [number, number, number, number];
+type Pose = { position: Vec3; rotation: Quat };
 
-const IDENTITY_ROTATION: [number, number, number, number] = [1, 0, 0, 0];
+const IDENTITY_ROTATION: Quat = [1, 0, 0, 0];
 
 function add(a: Vec3, b: Vec3): Vec3 {
   return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function sub(a: Vec3, b: Vec3): Vec3 {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
 }
 
 function dot(a: Vec3, b: Vec3): number {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+}
+
+function scale(a: Vec3, s: number): Vec3 {
+  return [a[0] * s, a[1] * s, a[2] * s];
+}
+
+function normalize(a: Vec3): Vec3 {
+  const l = Math.hypot(a[0], a[1], a[2]) || 1;
+  return [a[0] / l, a[1] / l, a[2] / l];
+}
+
+/** A unit vector perpendicular to `v` (for the 180° / parallel degenerate cases). */
+function anyPerpendicular(v: Vec3): Vec3 {
+  const ref: Vec3 = Math.abs(v[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0];
+  return normalize(cross(v, ref));
+}
+
+/** Rotate vector `v` by quaternion `q` = [w, x, y, z]. */
+function qRotate(q: Quat, v: Vec3): Vec3 {
+  const [w, x, y, z] = q;
+  const tx = 2 * (y * v[2] - z * v[1]);
+  const ty = 2 * (z * v[0] - x * v[2]);
+  const tz = 2 * (x * v[1] - y * v[0]);
+  return [
+    v[0] + w * tx + (y * tz - z * ty),
+    v[1] + w * ty + (z * tx - x * tz),
+    v[2] + w * tz + (x * ty - y * tx),
+  ];
+}
+
+function qFromAxisAngle(axis: Vec3, angle: number): Quat {
+  const h = angle / 2;
+  const s = Math.sin(h);
+  const u = normalize(axis);
+  return [Math.cos(h), u[0] * s, u[1] * s, u[2] * s];
+}
+
+/** Shortest-arc quaternion rotating unit vector `from` onto unit vector `to`. */
+function qFromTo(from: Vec3, to: Vec3): Quat {
+  const a = normalize(from);
+  const b = normalize(to);
+  const d = dot(a, b);
+  if (d >= 1 - 1e-9) return IDENTITY_ROTATION;
+  if (d <= -1 + 1e-9) return qFromAxisAngle(anyPerpendicular(a), Math.PI);
+  const c = cross(a, b);
+  const q: Quat = [1 + d, c[0], c[1], c[2]];
+  const l = Math.hypot(q[0], q[1], q[2], q[3]) || 1;
+  return [q[0] / l, q[1] / l, q[2] / l, q[3] / l];
+}
+
+/** Apply a pose (rotate then translate) to an entity's origin and any directions. */
+function transformEntity(e: SolverEntity, pose: Pose): SolverEntity {
+  const origin = add(qRotate(pose.rotation, e.origin), pose.position);
+  return {
+    type: e.type,
+    origin,
+    ...(e.normal ? { normal: qRotate(pose.rotation, e.normal) } : {}),
+    ...(e.direction ? { direction: qRotate(pose.rotation, e.direction) } : {}),
+  };
+}
+
 /**
  * Position a dependent plane against an already-placed reference plane.
  *
- * The reference's solved translation is applied to its (local) entity origin
- * before measuring, so a chain composes down already-solved poses instead of
- * reading original geometry. The dependent is at the origin (a node is only
- * solved once, while unplaced), so the returned position is its absolute
- * translation. `extra` is the gap for a distance mate (0 for coincident).
- * Rotation stays identity — coincident/distance produce pure translations;
- * Phase 1 rotational constraints will extend this.
+ * `ref` is the reference entity already in world space. The dependent is at the
+ * origin (a node is only solved once, while unplaced), so the returned position
+ * is its absolute translation along the reference normal. `extra` is the gap for
+ * a distance mate (0 for coincident). Plane mates don't reorient the dependent.
  */
-function solvePlanePair(ref: SolverEntity, refPos: Vec3, dep: SolverEntity, extra: number): Pose {
+function solvePlanePair(ref: SolverEntity, dep: SolverEntity, extra: number): Pose {
   const n = ref.normal ?? [0, 0, 1];
-  const refOrigin = add(ref.origin, refPos);
-  const offset =
-    dot(n, [
-      refOrigin[0] - dep.origin[0],
-      refOrigin[1] - dep.origin[1],
-      refOrigin[2] - dep.origin[2],
-    ]) + extra;
-  return {
-    position: [offset * n[0], offset * n[1], offset * n[2]],
-    rotation: IDENTITY_ROTATION,
-  };
+  const offset = dot(n, sub(ref.origin, dep.origin)) + extra;
+  return { position: scale(n, offset), rotation: IDENTITY_ROTATION };
+}
+
+/**
+ * Concentric (axis-axis) mate: rotate the dependent so its axis is parallel to
+ * the reference axis, then translate so the two axes are collinear (the
+ * dependent's axis point is placed on the reference axis). `ref` is in world
+ * space; the dependent is at the origin.
+ */
+function solveConcentric(ref: SolverEntity, dep: SolverEntity): Pose {
+  const dRef = ref.direction ?? [0, 0, 1];
+  const dDep = dep.direction ?? [0, 0, 1];
+  const rotation = qFromTo(dDep, dRef);
+  const rotatedOrigin = qRotate(rotation, dep.origin);
+  return { position: sub(ref.origin, rotatedOrigin), rotation };
+}
+
+/**
+ * Angle mate: rotate the dependent so the angle between its (plane) normal and
+ * the reference normal equals `angleRad`. Orientation-only — position is left at
+ * the origin. `ref` is in world space; the dependent is at the origin.
+ */
+function solveAngle(ref: SolverEntity, dep: SolverEntity, angleRad: number): Pose {
+  const nRef = normalize(ref.normal ?? [0, 0, 1]);
+  const nDep = normalize(dep.normal ?? [0, 0, 1]);
+  const phi = Math.acos(Math.max(-1, Math.min(1, dot(nDep, nRef))));
+  const c = cross(nDep, nRef);
+  const axis = Math.hypot(c[0], c[1], c[2]) < 1e-9 ? anyPerpendicular(nDep) : c;
+  // Rotating nDep about (nDep×nRef) by +phi aligns it with nRef; rotate by
+  // (phi − angle) to leave exactly `angleRad` between them.
+  return { position: [0, 0, 0], rotation: qFromAxisAngle(axis, phi - angleRad) };
+}
+
+/** Entity types each positioning constraint requires of (entityA, entityB). */
+const REQUIRED_ENTITIES: Readonly<Record<string, SolverEntity['type']>> = {
+  coincident: 'plane',
+  distance: 'plane',
+  angle: 'plane',
+  concentric: 'axis',
+};
+
+const POSITIONING_TYPES = new Set(['coincident', 'distance', 'angle', 'concentric']);
+
+/** Dispatch a positioning mate to its solver. `ref` is already in world space. */
+function solveMate(c: SolverConstraint, ref: SolverEntity, dep: SolverEntity): Pose {
+  switch (c.type) {
+    case 'concentric':
+      return solveConcentric(ref, dep);
+    case 'angle':
+      return solveAngle(ref, dep, ((c.value ?? 0) * Math.PI) / 180);
+    case 'distance':
+      return solvePlanePair(ref, dep, c.value ?? 0);
+    default:
+      return solvePlanePair(ref, dep, 0);
+  }
 }
 
 /**
  * Solve assembly constraints analytically.
  *
- * Handles: fixed, coincident (plane-plane), distance (plane-plane). For a
- * positioning mate, entityA is the reference and entityB the dependent. Chain
- * roots (nodes never positioned by a mate) and explicit `fixed` nodes anchor at
- * the origin; constraints then resolve in topological order — each places its
- * dependent against the reference's solved pose, so multi-body chains compose.
- * Returns `converged: false` with unsupported details for concentric, angle,
- * non-plane pairs, and any constraint whose reference never resolves.
+ * Handles: fixed, coincident/distance (plane-plane), concentric (axis-axis), and
+ * angle (plane-plane orientation). For a positioning mate, entityA is the
+ * reference and entityB the dependent. Chain roots (nodes never positioned by a
+ * mate) and explicit `fixed` nodes anchor at the origin; constraints then resolve
+ * in topological order — each places its dependent against the reference's solved
+ * pose (rotation included), so multi-body chains compose. Returns
+ * `converged: false` with details for entity-type mismatches and any constraint
+ * whose reference never resolves.
  */
 export function solveConstraints(nodes: string[], constraints: SolverConstraint[]): SolverResult {
   const transforms = new Map<string, Pose>();
@@ -102,7 +214,7 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
 
   // For positioning mates, entityA is the reference and entityB the dependent.
   const positioning = constraints.filter(
-    (c) => (c.type === 'coincident' || c.type === 'distance') && c.entityA && c.entityB
+    (c) => POSITIONING_TYPES.has(c.type) && c.entityA && c.entityB
   );
   const dependents = new Set<string>();
   for (const c of positioning) if (c.entityB) dependents.add(c.entityB.node);
@@ -113,20 +225,16 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
   for (const node of nodes) if (!dependents.has(node)) placed.add(node);
   for (const c of constraints) if (c.type === 'fixed' && c.entityA) placed.add(c.entityA.node);
 
-  // concentric / angle are not solved yet (Phase 1).
-  for (const c of constraints) {
-    if (c.type === 'concentric' || c.type === 'angle') unsupported.push(c.type);
-  }
-
-  // Non-plane positioning pairs are unsupported regardless of order; report them
-  // eagerly and keep only plane-plane pairs for topological resolution. A node
-  // left unplaced by such a pair (it's a dependent, so not a root) will cause
-  // any downstream plane-plane mate that references it to end up `(unanchored)`
-  // — intended: an unsolved reference can't compose, so the chain doesn't converge.
+  // Entity-type mismatches are unsupported regardless of order; report them
+  // eagerly and keep only well-typed mates for topological resolution. A node
+  // left unplaced by such a mate (it's a dependent, so not a root) will cause
+  // any downstream mate that references it to end up `(unanchored)` — intended:
+  // an unsolved reference can't compose, so the chain doesn't converge.
   const pending: SolverConstraint[] = [];
   for (const c of positioning) {
     if (!c.entityA || !c.entityB) continue;
-    if (c.entityA.entity.type !== 'plane' || c.entityB.entity.type !== 'plane') {
+    const required = REQUIRED_ENTITIES[c.type];
+    if (c.entityA.entity.type !== required || c.entityB.entity.type !== required) {
       unsupported.push(`${c.type}(${c.entityA.entity.type}-${c.entityB.entity.type})`);
       continue;
     }
@@ -135,7 +243,7 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
 
   // Resolve in topological rounds: a mate solves once its reference (entityA) is
   // placed, positioning the dependent (entityB) against the reference's solved
-  // pose so multi-body chains compose.
+  // world-space pose so multi-body chains compose.
   let progress = true;
   while (progress && pending.length > 0) {
     progress = false;
@@ -154,8 +262,8 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
         position: [0, 0, 0],
         rotation: IDENTITY_ROTATION,
       };
-      const extra = c.type === 'distance' ? (c.value ?? 0) : 0;
-      transforms.set(dep.node, solvePlanePair(ref.entity, refPose.position, dep.entity, extra));
+      const refWorld = transformEntity(ref.entity, refPose);
+      transforms.set(dep.node, solveMate(c, refWorld, dep.entity));
       placed.add(dep.node);
     }
   }

--- a/src/operations/mateFns.ts
+++ b/src/operations/mateFns.ts
@@ -8,7 +8,8 @@ import { type Result, ok, err } from '@/core/result.js';
 import { validationError, kernelError, BrepErrorCode } from '@/core/errors.js';
 import type { AssemblyNode } from './assemblyFns.js';
 import { walkAssembly } from './assemblyFns.js';
-import { faceCenter, normalAt } from '@/topology/faceFns.js';
+import { faceCenter, normalAt, faceAxis } from '@/topology/faceFns.js';
+import { getCurveType, curveStartPoint, curveTangentAt } from '@/topology/curveFns.js';
 import {
   solveConstraints,
   type SolverEntity,
@@ -45,9 +46,26 @@ export interface AssemblySolveResult {
 
 function extractEntity(mate: MateEntity): SolverEntity | null {
   if (mate.face) {
-    const origin = faceCenter(mate.face);
-    const normal = normalAt(mate.face);
-    return { type: 'plane', origin, normal };
+    // A cylindrical (or otherwise axial) face yields an axis; a planar face a
+    // plane. faceAxis returns null for non-axial faces, so it doubles as the
+    // discriminator.
+    const axis = faceAxis(mate.face);
+    if (axis) {
+      return { type: 'axis', origin: axis.origin, direction: axis.direction };
+    }
+    return { type: 'plane', origin: faceCenter(mate.face), normal: normalAt(mate.face) };
+  }
+
+  if (mate.edge) {
+    // A straight edge defines an axis (origin + direction); other curves can't.
+    if (getCurveType(mate.edge) === 'LINE') {
+      return {
+        type: 'axis',
+        origin: curveStartPoint(mate.edge),
+        direction: curveTangentAt(mate.edge),
+      };
+    }
+    return null;
   }
 
   if (mate.point) {

--- a/src/topology.ts
+++ b/src/topology.ts
@@ -132,6 +132,7 @@ export {
   uvCoordinates,
   normalAt,
   faceCenter,
+  faceAxis,
   classifyPointOnFace,
   outerWire,
   innerWires,

--- a/src/topology/faceFns.ts
+++ b/src/topology/faceFns.ts
@@ -190,6 +190,15 @@ export function faceCenter(face: Face): Vec3 {
   return getKernel().surfaceCenterOfMass(face.wrapped);
 }
 
+/**
+ * Get a face's axis of symmetry — a point on the axis plus a unit direction —
+ * for analytic faces that have one (e.g. a cylinder's axis). Returns null when
+ * the face has no well-defined axis or the active kernel can't determine it.
+ */
+export function faceAxis(face: Face): { origin: Vec3; direction: Vec3 } | null {
+  return getKernel().getSurfaceAxis(face.wrapped);
+}
+
 // ---------------------------------------------------------------------------
 // Point classification
 // ---------------------------------------------------------------------------

--- a/src/topology/index.ts
+++ b/src/topology/index.ts
@@ -77,6 +77,7 @@ export {
   uvCoordinates,
   normalAt,
   faceCenter,
+  faceAxis,
   outerWire,
   innerWires,
   type UVBounds,

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -291,6 +291,14 @@ export const divergences: DivergenceMap = {
     },
 
     // -----------------------------------------------------------------------
+    // mateFns.test.ts
+    // -----------------------------------------------------------------------
+    'mateFns.concentricAxis': {
+      kind: 'not-implemented',
+      reason: 'getSurfaceAxis (cylinder axis extraction) is OCCT-only; brepkit returns null',
+    },
+
+    // -----------------------------------------------------------------------
     // meshFns.test.ts
     // -----------------------------------------------------------------------
     'meshFns.stepReadError': {

--- a/tests/mateFns.test.ts
+++ b/tests/mateFns.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { shouldSkipSuite } from './helpers/kernelDivergences.js';
 import {
   box,
   cylinder,
@@ -13,6 +14,7 @@ import {
   unwrapErr,
   getFaces,
   faceCenter,
+  faceAxis,
 } from '@/index.js';
 import type { MateConstraint } from '@/index.js';
 import { solveConstraints, type SolverEntity } from '@/kernel/solverAdapter.js';
@@ -51,19 +53,26 @@ function bottomFace(shape: Parameters<typeof getFaces>[0]) {
   return best;
 }
 
-/** Find the face whose center is closest to the XY plane (smallest |Z|). */
+/** Rotate a vector by a quaternion [w, x, y, z] (test-side check helper). */
+function qRotate(q: readonly number[], v: readonly number[]): [number, number, number] {
+  const [w, x, y, z] = q as [number, number, number, number];
+  const [vx, vy, vz] = v as [number, number, number];
+  const tx = 2 * (y * vz - z * vy);
+  const ty = 2 * (z * vx - x * vz);
+  const tz = 2 * (x * vy - y * vx);
+  return [
+    vx + w * tx + (y * tz - z * ty),
+    vy + w * ty + (z * tx - x * tz),
+    vz + w * tz + (x * ty - y * tx),
+  ];
+}
+
+/** Find the lateral cylindrical face — the one that has a well-defined axis. */
 function cylindricalFace(shape: Parameters<typeof getFaces>[0]) {
   const faces = getFaces(shape);
-  let best = faces[0];
-  let bestAbsZ = Math.abs(faceCenter(best)[2]);
-  for (let i = 1; i < faces.length; i++) {
-    const absZ = Math.abs(faceCenter(faces[i])[2]);
-    if (absZ < bestAbsZ) {
-      best = faces[i];
-      bestAbsZ = absZ;
-    }
-  }
-  return best;
+  const face = faces.find((f) => faceAxis(f) !== null);
+  if (!face) throw new Error('no cylindrical face found');
+  return face;
 }
 
 describe('assembly mates', () => {
@@ -252,28 +261,41 @@ describe('solveAssembly — fixed-only', () => {
 });
 
 describe('solveAssembly — concentric mate', () => {
-  it('concentric mate returns error (not yet implemented)', () => {
-    const cyl1 = cylinder(5, 20);
-    const cyl2 = cylinder(3, 15);
+  it.skipIf(shouldSkipSuite('mateFns.concentricAxis'))(
+    'concentric mate aligns two cylinder axes (pin-in-hole)',
+    () => {
+      // Two coaxial cylinders along +Z; concentric should converge with the
+      // sleeve placed so its axis is collinear with the shaft's.
+      const cyl1 = cylinder(5, 20);
+      const cyl2 = cylinder(3, 15);
 
-    const cylFace1 = cylindricalFace(cyl1);
-    const cylFace2 = cylindricalFace(cyl2);
+      const cylFace1 = cylindricalFace(cyl1);
+      const cylFace2 = cylindricalFace(cyl2);
 
-    let assembly = createAssemblyNode('root');
-    assembly = addChild(assembly, createAssemblyNode('shaft', { shape: cyl1 }));
-    assembly = addChild(assembly, createAssemblyNode('sleeve', { shape: cyl2 }));
-    assembly = addMate(assembly, { type: 'fixed', entity: { node: 'shaft' } });
-    assembly = addMate(assembly, {
-      type: 'concentric',
-      axisA: { node: 'shaft', face: cylFace1 },
-      axisB: { node: 'sleeve', face: cylFace2 },
-    });
+      let assembly = createAssemblyNode('root');
+      assembly = addChild(assembly, createAssemblyNode('shaft', { shape: cyl1 }));
+      assembly = addChild(assembly, createAssemblyNode('sleeve', { shape: cyl2 }));
+      assembly = addMate(assembly, { type: 'fixed', entity: { node: 'shaft' } });
+      assembly = addMate(assembly, {
+        type: 'concentric',
+        axisA: { node: 'shaft', face: cylFace1 },
+        axisB: { node: 'sleeve', face: cylFace2 },
+      });
 
-    const result = solveAssembly(assembly);
-    expect(isErr(result)).toBe(true);
-    const error = unwrapErr(result);
-    expect(error.message).toContain('concentric');
-  });
+      const result = solveAssembly(assembly);
+      expect(isOk(result)).toBe(true);
+      const solved = unwrap(result);
+      expect(solved.converged).toBe(true);
+      const sleeve = solved.transforms.get('sleeve');
+      expect(sleeve).toBeDefined();
+      // Both cylinders are already Z-aligned, so the sleeve's axis is on the Z
+      // axis: its solved X/Y translation must place its axis point on x=y=0.
+      expect(sleeve?.position[0]).toBeCloseTo(0, 4);
+      expect(sleeve?.position[1]).toBeCloseTo(0, 4);
+      // Axes parallel → rotation is identity (w≈±1, vector part ≈0).
+      expect(Math.abs(sleeve?.rotation[0] ?? 0)).toBeCloseTo(1, 4);
+    }
+  );
 
   it('concentric mate with no geometry returns error', () => {
     let assembly = createAssemblyNode('root');
@@ -291,7 +313,7 @@ describe('solveAssembly — concentric mate', () => {
 });
 
 describe('solveAssembly — angle mate', () => {
-  it('angle mate returns error (not yet implemented)', () => {
+  it('angle mate constrains relative orientation to the requested angle', () => {
     const b1 = box(10, 10, 10);
     const b2 = box(10, 10, 10);
 
@@ -310,9 +332,15 @@ describe('solveAssembly — angle mate', () => {
     });
 
     const result = solveAssembly(assembly);
-    expect(isErr(result)).toBe(true);
-    const error = unwrapErr(result);
-    expect(error.message).toContain('angle');
+    expect(isOk(result)).toBe(true);
+    const solved = unwrap(result);
+    expect(solved.converged).toBe(true);
+    const rot = solved.transforms.get('tilted')?.rotation ?? [1, 0, 0, 0];
+    // Apply the solved rotation to tilted's top-face normal (+Z) and confirm it
+    // ends up 45° from base's top-face normal (also +Z).
+    const rotated = qRotate(rot, [0, 0, 1]);
+    const cos = rotated[2]; // dot with [0,0,1]
+    expect((Math.acos(Math.max(-1, Math.min(1, cos))) * 180) / Math.PI).toBeCloseTo(45, 3);
   });
 
   it('angle mate with no geometry returns error', () => {
@@ -474,7 +502,7 @@ describe('solveConstraints — unsupported constraint honesty', () => {
     expect(result.unsupported).toEqual([]);
   });
 
-  it('returns converged=false and dof=4 for unsupported concentric', () => {
+  it('solves a concentric (axis-axis) mate, placing the dependent axis collinear', () => {
     const result = solveConstraints(
       ['a', 'b'],
       [
@@ -485,12 +513,13 @@ describe('solveConstraints — unsupported constraint honesty', () => {
         },
       ]
     );
-    expect(result.converged).toBe(false);
-    expect(result.dof).toBe(4);
-    expect(result.unsupported).toEqual(['concentric']);
+    expect(result.converged).toBe(true);
+    expect(result.dof).toBe(0);
+    // b's axis point [1,0,0] must shift to the reference axis (x=y=0): t=[-1,0,0].
+    expect(result.transforms.get('b')?.position).toEqual([-1, 0, 0]);
   });
 
-  it('returns converged=false and dof=1 for unsupported angle', () => {
+  it('solves an angle (plane-plane) mate', () => {
     const result = solveConstraints(
       ['a', 'b'],
       [
@@ -502,31 +531,33 @@ describe('solveConstraints — unsupported constraint honesty', () => {
         },
       ]
     );
-    expect(result.converged).toBe(false);
-    expect(result.dof).toBe(1);
-    expect(result.unsupported).toEqual(['angle']);
+    expect(result.converged).toBe(true);
+    expect(result.dof).toBe(0);
+    expect(result.unsupported).toEqual([]);
   });
 
-  it('accumulates DOF from multiple unsupported constraints', () => {
+  it('reports entity-type mismatches as unsupported and accumulates their DOF', () => {
     const result = solveConstraints(
       ['a', 'b'],
       [
+        // concentric requires axis-axis; planes here are a mismatch (4 DOF).
         {
           type: 'concentric',
-          entityA: { node: 'a', entity: { type: 'axis', origin: [0, 0, 0] } },
-          entityB: { node: 'b', entity: { type: 'axis', origin: [0, 0, 0] } },
-        },
-        {
-          type: 'angle',
           entityA: { node: 'a', entity: { type: 'plane', origin: [0, 0, 0] } },
           entityB: { node: 'b', entity: { type: 'plane', origin: [0, 0, 0] } },
+        },
+        // angle requires plane-plane; axes here are a mismatch (1 DOF).
+        {
+          type: 'angle',
+          entityA: { node: 'a', entity: { type: 'axis', origin: [0, 0, 0] } },
+          entityB: { node: 'b', entity: { type: 'axis', origin: [0, 0, 0] } },
           value: 90,
         },
       ]
     );
     expect(result.converged).toBe(false);
     expect(result.dof).toBe(5); // 4 (concentric) + 1 (angle)
-    expect(result.unsupported).toEqual(['concentric', 'angle']);
+    expect(result.unsupported).toEqual(['concentric(plane-plane)', 'angle(axis-axis)']);
   });
 
   it('reports non-plane entity combinations as unsupported for coincident', () => {
@@ -564,25 +595,25 @@ describe('solveConstraints — unsupported constraint honesty', () => {
 
   it('still solves supported constraints alongside unsupported ones', () => {
     const result = solveConstraints(
-      ['a', 'b'],
+      ['a', 'b', 'c'],
       [
         {
           type: 'coincident',
           entityA: { node: 'a', entity: { type: 'plane', origin: [0, 0, 10], normal: [0, 0, 1] } },
           entityB: { node: 'b', entity: { type: 'plane', origin: [0, 0, 0], normal: [0, 0, 1] } },
         },
+        // concentric requires axis-axis; planes are a mismatch → unsupported.
         {
-          type: 'angle',
+          type: 'concentric',
           entityA: { node: 'a', entity: { type: 'plane', origin: [0, 0, 0] } },
-          entityB: { node: 'b', entity: { type: 'plane', origin: [0, 0, 0] } },
-          value: 45,
+          entityB: { node: 'c', entity: { type: 'plane', origin: [0, 0, 0] } },
         },
       ]
     );
-    // Coincident is solved even though angle is not
+    // Coincident is solved even though the mismatched concentric is not.
     expect(result.transforms.get('b')?.position[2]).toBeCloseTo(10, 0);
     expect(result.converged).toBe(false);
-    expect(result.unsupported).toEqual(['angle']);
+    expect(result.unsupported).toEqual(['concentric(plane-plane)']);
   });
 
   it('reports a mutual-reference cycle as unanchored (no root to resolve from)', () => {

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -315,6 +315,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'extrude',
   'extrudeAll',
   'face',
+  'faceAxis',
   'faceCenter',
   'faceFinder',
   'faceGeomType',


### PR DESCRIPTION
## Summary

**Phase 1 of the kinematics roadmap (#1287)** — axis-based mates and the first rotational constraints, built on Phase 0's constraint composition (#1292). Addresses gaps **A1** and **A3** from #1286.

## Kernel: a face's axis of symmetry

New `getSurfaceAxis(face)` on the surface-ops interface → `{ origin, direction } | null`, surfaced as **`faceAxis()`** in `faceFns`:

| Adapter | Implementation |
|---|---|
| `occt` | Exact via `gp_Cylinder.Axis()` (location + direction) |
| `occt-wasm` (default) | Exact derivation from two surface samples — `r = \|p₁−p₂\|/\|n₁−n₂\|`, `origin = p − r·n`, `direction = n₁×n₂`. occt-wasm has no analytic `gp_Cylinder` accessor; this is exact for full **and** partial cylinders |
| `manifold` | Delegates via OCCT (matches sibling `getSurfaceCylinderData`) |
| `brepkit` | `null` — OCCT-only for now (see follow-up issue) |

## Solver: concentric + angle

- `extractEntity` now yields an **`axis`** entity from a cylindrical face or a straight edge, and a **`plane`** from a planar face (`faceAxis` doubles as the discriminator).
- Quaternion helpers + two new solvers:
  - **concentric** (axis-axis): rotate the dependent so its axis is parallel to the reference, then translate so the axes are collinear (pin-in-hole).
  - **angle** (plane-plane): rotate so the dependent's normal sits at the requested angle from the reference's.
- The reference entity is transformed into world space by its **solved pose (rotation included)**, so rotated references compose down a chain.
- Entity-type mismatches (e.g. concentric on planes) are reported `unsupported`.

## Tests

- **concentric pin-in-hole** (occt + occt-wasm; skipped on brepkit via the new `mateFns.concentricAxis` divergence) — converges with the sleeve's axis collinear with the shaft's.
- **angle relative-orientation** — the solved rotation places the dependent normal exactly 45° from the reference (verified by rotating the normal with the quaternion).
- Updated the unsupported-honesty suite: concentric/angle now **solve** for well-typed inputs; entity-type mismatches remain the unsupported cases.
- Fixed the `cylindricalFace` test helper (it selected a planar cap by Z, not the lateral face) to select by `faceAxis`.

## Verification

typecheck, eslint, boundaries, prettier, knip clean; pattern baseline restored. mateFns: occt-wasm 27 ✓ · occt 27 ✓ · brepkit 26 ✓ + 1 skipped. Public-API export list updated for `faceAxis`.

## Follow-ups
- Phase 2 — joint primitives (`jointFns.ts`)
- Phase 3 — forward kinematics + mechanism DOF

Refs #1287, #1286