### PR TITLE
docs(verify): document the MCP server and claude mcp add connection

### DIFF
--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -67,6 +67,33 @@ The `brepjs-verify` bin is a multi-command CLI. `verify` is the default command,
 
 Every command writes a single machine-readable JSON document to stdout; diagnostics (paths, kernel chatter, watch notices) go to stderr.
 
+## MCP server
+
+`brepjs-verify-mcp` is a stdio [MCP](https://modelcontextprotocol.io) server that exposes the verify substrate to MCP-capable agents (Claude Code, Claude Desktop, any MCP client). It currently provides one tool:
+
+| Tool          | Input                                  | Returns                                                                                                                                                                                                                               |
+| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_program` | `{ code: string, timeoutMs?: number }` | Executes the brepjs `.brep.ts` source in an isolated, timeout/OOM-bounded sandbox and returns the verification report (validity, measurements, topology) as JSON. `isError` is set when the part fails checks, times out, or crashes. |
+
+This is the closed _build → verify_ loop as a single call: the agent sends part source, gets back the deterministic report. The program runs in a separate process with a wall-clock timeout and a memory cap, so a runaway part can't hang the agent.
+
+### Connect (local build)
+
+Build the package, then register the server by absolute path:
+
+```bash
+npm run build   # emits dist/mcp/server.js
+claude mcp add brepjs-verify -- node "$(pwd)/dist/mcp/server.js"
+```
+
+Once the package is published to npm, the same server is available without a local build:
+
+```bash
+claude mcp add brepjs-verify -- npx -y --package brepjs-verify brepjs-verify-mcp
+```
+
+The server runs locally and in-process to your agent — geometry never leaves your machine.
+
 ## Examples gallery
 
 Few-shot examples live under `skill/examples/<name>.brep.ts`, each with a `<name>.expected.json` baseline. Grouped by category:

--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -79,7 +79,7 @@ This is the closed _build → verify_ loop as a single call: the agent sends par
 
 ### Connect (local build)
 
-Build the package, then register the server by absolute path:
+Build the package, then register the server by absolute path. Run both commands from the package root (`packages/brepjs-verify`), where `dist/` is emitted — `$(pwd)` is resolved by your shell at that location:
 
 ```bash
 npm run build   # emits dist/mcp/server.js
@@ -92,7 +92,7 @@ Once the package is published to npm, the same server is available without a loc
 claude mcp add brepjs-verify -- npx -y --package brepjs-verify brepjs-verify-mcp
 ```
 
-The server runs locally and in-process to your agent — geometry never leaves your machine.
+The server runs locally as a child process of your agent (stdio) — geometry never leaves your machine.
 
 ## Examples gallery
 


### PR DESCRIPTION
## What
Adds an **MCP server** section to the brepjs-verify README: the `run_program` tool contract and how to connect via `claude mcp add` (local build today; `npx` once published).

## Why
PR #1300 merged the MCP server, but nothing told an agent how to *connect* to it. This is the last-mile of the lodestar: a developer/agent can now attach the server and drive the build→verify loop.

## How
- Documents the local-build connection (`npm run build` → `claude mcp add brepjs-verify -- node "$(pwd)/dist/mcp/server.js"`), which works today and matches the vision's local/in-process scope.
- Documents the published form (`npx -y --package brepjs-verify brepjs-verify-mcp`) for after the package is on npm.
- Documents the `run_program` input/output + the sandbox safety (timeout/OOM).

## Scope note
Intentionally **docs-only**. A `plugin.json` `mcpServers` declaration is deferred: `dist/` is gitignored and the package is unpublished, so a declaration pointing at a built/npx path would be broken until a publish/distribution decision is made (tracked as a follow-up). The README documents the connection that works now.

Docs change — prettier-clean; no code/tests affected.