### PR TITLE
feat(brepjs-verify): auto-open browser on --serve + document the MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ export default () => box(40, 20, 10, { centered: true });
 npx -y brepjs-verify bracket.brep.ts --check --step bracket.step --json report.json
 ```
 
-The command exits non-zero unless the report is `ok` (valid **and** every declared dimension within tolerance), so it drops straight into CI or an agent loop. See the [**Authoring with AI**](https://brepjs.dev/agent/overview) guide for the full loop, CLI reference, examples, and the measurement eval.
+The command exits non-zero unless the report is `ok` (valid **and** every declared dimension within tolerance), so it drops straight into CI or an agent loop. For MCP-capable agents the package also ships a stdio MCP server (`brepjs-verify-mcp`) exposing the same build-and-verify step as a `run_program` tool. See the [**Authoring with AI**](https://brepjs.dev/agent/overview) guide for the full loop, CLI reference, the MCP server, examples, and the measurement eval.
 
 ## Projects Using brepjs
 

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -81,11 +81,11 @@ Each declared field appears in `report.assertions` as `{ name, expected, actual,
 
 `--snapshot` and `--serve` use the bundled viewer (shipped with the package, including the OCCT WASM) and render the **real exported STEP**, not a code preview. Snapshots require the optional `puppeteer`/Chrome dependency; when it is absent the CLI degrades with a clear message rather than failing, and `--snapshot` is simply skipped. The viewer is read-only display + screenshot.
 
-`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted — a reused server (a tab already exists), CI, a non-TTY/piped session (e.g. an agent run), or Linux with no display server — and `--no-open` always suppresses it. Agents therefore get the URL without a browser popping up.
+`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted — a reused server (a tab already exists), CI, a non-TTY/piped session (e.g. an agent run), or Linux with no display server — and `--no-open` always suppresses it. Agents therefore get the URL without a browser launching.
 
 ## MCP server
 
-The package ships a second bin — `brepjs-verify-mcp` — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the verify substrate to MCP-capable agents directly, without spawning the CLI. The `@modelcontextprotocol/sdk` it needs is a regular dependency, so it runs straight from the published package.
+The package ships a second bin — `brepjs-verify-mcp` — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the same build-and-verify step to MCP-capable agents directly, without spawning the CLI. The `@modelcontextprotocol/sdk` it needs is a regular dependency, so it runs straight from the published package.
 
 Register it with an MCP client over stdio:
 

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: 'Every brepjs-verify subcommand, flag, and exit code — verify, init, watch, export, measure, diff, snapshot, serve — plus the expected-dimensions contract and troubleshooting.'
+description: 'Every brepjs-verify subcommand, flag, and exit code — verify, init, watch, export, measure, diff, snapshot, serve — plus the MCP server, the expected-dimensions contract, and troubleshooting.'
 ---
 
 # CLI Reference
@@ -11,27 +11,28 @@ Prefix any command with `npx -y` to run without installing.
 
 ## Commands
 
-| Command                         | What it does                                                                                                                                                                            |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `brepjs-verify verify <file>`   | **Default command.** Loads the part, runs deterministic checks, prints the JSON report. Flags: `--check`, `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`. |
-| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                         |
-| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                            |
-| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                 |
-| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                    |
-| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                        |
-| `brepjs-verify snapshot`        | Multi-view PNG capture — usually surfaced via `verify --snapshot <dir>`. Needs the optional `puppeteer`/Chrome dependency.                                                              |
-| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — usually surfaced via `verify --serve`.                                                                                                  |
+| Command                         | What it does                                                                                                                                                                                               |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brepjs-verify verify <file>`   | **Default command.** Loads the part, runs deterministic checks, prints the JSON report. Flags: `--check`, `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`.                    |
+| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                                            |
+| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                                               |
+| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                                    |
+| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                                       |
+| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                                           |
+| `brepjs-verify snapshot`        | Multi-view PNG capture — usually surfaced via `verify --snapshot <dir>`. Needs the optional `puppeteer`/Chrome dependency.                                                                                 |
+| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — usually surfaced via `verify --serve`. Auto-opens the browser in an interactive terminal; suppressed under CI / non-TTY / no display, or with `--no-open`. |
 
 ## `verify` flags
 
-| Flag               | Effect                                                                                                                                                                                                                       |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--check`          | Run a TypeScript type-check **before** executing the part. Type errors are surfaced as `TYPECHECK` error infos and the part is not run — wrong-API calls never reach the kernel.                                             |
-| `--json <out>`     | Write the full JSON report to a file (in addition to stdout).                                                                                                                                                                |
-| `--step <out>`     | Export STEP after the validity gate passes. STEP is the validated primary deliverable.                                                                                                                                       |
-| `--glb <out>`      | Export a derived GLB mesh preview. (`--stl` lives on the `export` command, not `verify`.)                                                                                                                                    |
-| `--snapshot <dir>` | Render iso / front / top / right PNGs into `<dir>` (needs `puppeteer`).                                                                                                                                                      |
-| `--serve`          | After a passing verify, start a preview server and print a clickable `?dir=&file=` link rendering the real STEP; it stays running until Ctrl-C. Only serves when the report is `ok` — a failing report still exits non-zero. |
+| Flag               | Effect                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--check`          | Run a TypeScript type-check **before** executing the part. Type errors are surfaced as `TYPECHECK` error infos and the part is not run — wrong-API calls never reach the kernel.                                                                                                                                                                                                           |
+| `--json <out>`     | Write the full JSON report to a file (in addition to stdout).                                                                                                                                                                                                                                                                                                                              |
+| `--step <out>`     | Export STEP after the validity gate passes. STEP is the validated primary deliverable.                                                                                                                                                                                                                                                                                                     |
+| `--glb <out>`      | Export a derived GLB mesh preview. (`--stl` lives on the `export` command, not `verify`.)                                                                                                                                                                                                                                                                                                  |
+| `--snapshot <dir>` | Render iso / front / top / right PNGs into `<dir>` (needs `puppeteer`).                                                                                                                                                                                                                                                                                                                    |
+| `--serve`          | After a passing verify, start a preview server and print a clickable `?dir=&file=` link rendering the real STEP; it stays running until Ctrl-C. Only serves when the report is `ok` — a failing report still exits non-zero. In an interactive terminal it also opens your default browser (skipped when the server is reused, under CI, on non-TTY/agent runs, or with no Linux display). |
+| `--no-open`        | With `--serve`, never auto-open the browser — just print the URL.                                                                                                                                                                                                                                                                                                                          |
 
 ## Common invocations
 
@@ -45,8 +46,10 @@ npx -y brepjs-verify part.brep.ts --snapshot shots/
 # live re-verify while you edit
 npx -y brepjs-verify watch part.brep.ts
 
-# clickable preview (renders the real STEP)
+# clickable preview (renders the real STEP), opens your browser
 npx -y brepjs-verify part.brep.ts --serve
+# …or just print the URL without opening a browser
+npx -y brepjs-verify part.brep.ts --serve --no-open
 
 # batch every artifact behind a validity gate
 npx -y brepjs-verify export part.brep.ts --all --out dist/
@@ -77,6 +80,31 @@ Each declared field appears in `report.assertions` as `{ name, expected, actual,
 ## Snapshots & the preview server
 
 `--snapshot` and `--serve` use the bundled viewer (shipped with the package, including the OCCT WASM) and render the **real exported STEP**, not a code preview. Snapshots require the optional `puppeteer`/Chrome dependency; when it is absent the CLI degrades with a clear message rather than failing, and `--snapshot` is simply skipped. The viewer is read-only display + screenshot.
+
+`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted — a reused server (a tab already exists), CI, a non-TTY/piped session (e.g. an agent run), or Linux with no display server — and `--no-open` always suppresses it. Agents therefore get the URL without a browser popping up.
+
+## MCP server
+
+The package ships a second bin — `brepjs-verify-mcp` — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the verify substrate to MCP-capable agents directly, without spawning the CLI. The `@modelcontextprotocol/sdk` it needs is a regular dependency, so it runs straight from the published package.
+
+Register it with an MCP client over stdio:
+
+```json
+{
+  "mcpServers": {
+    "brepjs-verify": { "command": "npx", "args": ["-y", "brepjs-verify-mcp"] }
+  }
+}
+```
+
+It exposes one tool, **`run_program`**:
+
+| Field       | Description                                                                         |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `code`      | A brepjs `.brep.ts` module source with a default-exported part function (required). |
+| `timeoutMs` | Optional wall-clock budget in milliseconds (default `30000`).                       |
+
+It runs the program in the same isolated sandbox as `verify` and returns the verification report (validity, measurements, topology) as JSON. `isError` is set when the part fails checks, times out, or crashes — the closed **build → verify** step of [the loop](./the-loop.md), but as a tool call instead of a subprocess.
 
 ## Troubleshooting
 

--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -51,7 +51,7 @@ npx -y brepjs-verify part.brep.ts --serve --no-open                     # previe
 
 `--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The `--serve` link is interactive: a toolbar offers view presets + fit, solid/wireframe/x-ray modes, edge/grid toggles, a turntable, click-to-inspect face picking, a section/clipping plane, a measurements panel, and an in-browser PNG screenshot. `--snapshot` loads the same page with `ui=0` to suppress the toolbar, and burns the bounding-box size into each PNG (`dims=1`) so the agent can read scale from the image.
 
-`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped automatically when it would be unwanted — when the server is reused (a tab is already open), under CI, when output is piped (non-TTY, e.g. agent runs), or on Linux with no display server. Pass `--no-open` to always suppress it.
+`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted — when the server is reused (a tab is already open), under CI, when output is piped (non-TTY, e.g. agent runs), or on Linux with no display server. Pass `--no-open` to always suppress it.
 
 ## CLI reference
 
@@ -72,7 +72,7 @@ Every command writes a single machine-readable JSON document to stdout; diagnost
 
 ## MCP server
 
-For MCP-capable agents, the package ships a second bin — `brepjs-verify-mcp` — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the same verify substrate as a tool. The `@modelcontextprotocol/sdk` it needs is a regular dependency, so it runs straight from the published package.
+For MCP-capable agents, the package ships a second bin — `brepjs-verify-mcp` — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the same build-and-verify step as a tool. The `@modelcontextprotocol/sdk` it needs is a regular dependency, so it runs straight from the published package.
 
 Point an MCP client at it via stdio:
 

--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -45,27 +45,52 @@ export default () => box(40, 20, 10, { centered: true });
 ```
 npx -y brepjs-verify part.brep.ts --step part.step --json report.json   # primary STEP + deterministic report
 npx -y brepjs-verify part.brep.ts --snapshot shots/                     # iso/front/top/right PNGs
-npx -y brepjs-verify part.brep.ts --serve                               # clickable preview link (renders the real STEP)
+npx -y brepjs-verify part.brep.ts --serve                               # preview server + opens the viewer in your browser
+npx -y brepjs-verify part.brep.ts --serve --no-open                     # preview server; just print the URL (no browser)
 ```
 
 `--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The `--serve` link is interactive: a toolbar offers view presets + fit, solid/wireframe/x-ray modes, edge/grid toggles, a turntable, click-to-inspect face picking, a section/clipping plane, a measurements panel, and an in-browser PNG screenshot. `--snapshot` loads the same page with `ui=0` to suppress the toolbar, and burns the bounding-box size into each PNG (`dims=1`) so the agent can read scale from the image.
+
+`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped automatically when it would be unwanted — when the server is reused (a tab is already open), under CI, when output is piped (non-TTY, e.g. agent runs), or on Linux with no display server. Pass `--no-open` to always suppress it.
 
 ## CLI reference
 
 The `brepjs-verify` bin is a multi-command CLI. `verify` is the default command, so `brepjs-verify part.brep.ts` runs it directly.
 
-| Command                         | What it does                                                                                                                                                                                                                            |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `brepjs-verify verify <file>`   | Default command. Loads the part, runs deterministic checks, prints the JSON report. Flags: `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`. Exits non-zero when the report is not `ok` (unless `--serve`). |
-| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                                                                         |
-| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                                                                            |
-| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                                                                 |
-| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                                                                    |
-| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                                                                        |
-| `brepjs-verify snapshot`        | Multi-view PNG capture — surfaced via `verify --snapshot <dir>`. Requires the optional `puppeteer`/Chrome dependency; degrades with a clear message when absent.                                                                        |
-| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — surfaced via `verify --serve`.                                                                                                                                                          |
+| Command                         | What it does                                                                                                                                                                                                                                                                                       |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brepjs-verify verify <file>`   | Default command. Loads the part, runs deterministic checks, prints the JSON report. Flags: `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`, `--no-open` (with `--serve`, don't auto-open the browser). Exits non-zero when the report is not `ok` (unless `--serve`). |
+| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                                                                                                                                    |
+| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                                                                                                                                       |
+| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                                                                                                                            |
+| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                                                                                                                               |
+| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                                                                                                                                   |
+| `brepjs-verify snapshot`        | Multi-view PNG capture — surfaced via `verify --snapshot <dir>`. Requires the optional `puppeteer`/Chrome dependency; degrades with a clear message when absent.                                                                                                                                   |
+| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — surfaced via `verify --serve`. Auto-opens the browser in an interactive terminal (suppressed under CI / non-TTY / no display, or with `--no-open`).                                                                                                |
 
 Every command writes a single machine-readable JSON document to stdout; diagnostics (paths, kernel chatter, watch notices) go to stderr.
+
+## MCP server
+
+For MCP-capable agents, the package ships a second bin — `brepjs-verify-mcp` — a stdio [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the same verify substrate as a tool. The `@modelcontextprotocol/sdk` it needs is a regular dependency, so it runs straight from the published package.
+
+Point an MCP client at it via stdio:
+
+```json
+{
+  "mcpServers": {
+    "brepjs-verify": { "command": "npx", "args": ["-y", "brepjs-verify-mcp"] }
+  }
+}
+```
+
+It exposes one tool:
+
+| Tool          | Input                                              | Returns                                                                                                                                                          |
+| ------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_program` | `code` (a `.brep.ts` source), `timeoutMs?` (30000) | The verification report (validity, measurements, topology) as JSON. `isError` is set when the part fails checks, times out, or crashes, so the agent can branch. |
+
+This is the closed **build → verify** step the agent loop is built on, without spawning the CLI: the agent sends a brepjs program as a string and reads back the deterministic report.
 
 ## Examples gallery
 

--- a/packages/brepjs-verify/skill/SKILL.md
+++ b/packages/brepjs-verify/skill/SKILL.md
@@ -18,7 +18,7 @@ Commands below use `npx -y brepjs-verify`; if you've installed the package, drop
 5. **Verify (type + geometry).** `npx -y brepjs-verify verify part.brep.ts --check --json report.json`. `--check` type-checks before running (catches wrong-API calls early); the JSON report is the source of truth. Iterate fast with `npx -y brepjs-verify watch part.brep.ts`.
 6. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs — each has the bbox size (`W × D × H`) burned in, so you can read scale from the image. Review against the brief. A visual concern is **not** a conclusion — convert it to a measurement ("hole looks off-center → check `bounds`"). Don't declare done without a snapshot.
 7. **Repair the smallest responsible section** and re-run. Use the report's `hints` to guide the fix.
-8. **Export + hand off.** `npx -y brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `npx -y brepjs-verify export part.brep.ts --all`. `--serve` prints a clickable link to an interactive inspector (view presets, solid/wire/x-ray, face picking, section plane, measurements panel) for the human to eyeball. Report the STEP path.
+8. **Export + hand off.** `npx -y brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `npx -y brepjs-verify export part.brep.ts --all`. `--serve` prints a clickable link to an interactive inspector (view presets, solid/wire/x-ray, face picking, section plane, measurements panel) for the human to eyeball — report that URL. In an interactive terminal it also opens the browser; under agent/CI runs (non-TTY) auto-open is suppressed automatically, so you normally don't need `--no-open` (pass it to be explicit). Report the STEP path.
 
 ## Reading the report (this is the source of truth)
 
@@ -89,7 +89,7 @@ Each is a complete `skill/examples/<name>.brep.ts` with a sibling `<name>.expect
 
 ## CLI subcommands (the `brepjs-verify` bin)
 
-- `verify <file>` (default) — report; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`.
+- `verify <file>` (default) — report; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`, `--no-open` (with `--serve`, never auto-open the browser).
 - `init <name>` — scaffold `<name>.brep.ts` + `tsconfig.json`.
 - `watch <file>` — re-verify on every save.
 - `export <file>` — batch STEP/GLB/STL behind a validity gate (`--step`/`--glb`/`--stl`/`--all`).

--- a/packages/brepjs-verify/src/cli/main.ts
+++ b/packages/brepjs-verify/src/cli/main.ts
@@ -11,6 +11,7 @@ import { runDiff } from '../verify/diff.js';
 import { scaffoldPart } from './scaffold.js';
 import { debounce, DEFAULT_DEBOUNCE_MS } from './watch.js';
 import { exportPart } from './exportPart.js';
+import { openBrowser, shouldAutoOpen } from './openBrowser.js';
 import { disposeShape } from '../disposeShape.js';
 import type { shoot as ShootFn } from '../snapshot/shoot.js';
 
@@ -51,6 +52,7 @@ program
     '--serve',
     'after verifying, start a preview server and print a ?dir=&file= deep link (stays running)'
   )
+  .option('--no-open', 'with --serve, do not auto-open the browser (just print the viewer URL)')
   .action(
     async (
       file: string,
@@ -61,6 +63,7 @@ program
         check?: boolean;
         snapshot?: string;
         serve?: boolean;
+        open?: boolean;
       }
     ) => {
       // The WASM viewer loads a CAD file (it can't run a .brep.ts), so --snapshot/--serve
@@ -105,8 +108,13 @@ program
       const willServe = Boolean(opts.serve) && stepPath !== undefined && reportOk(report);
       if (willServe && stepPath) {
         const { serve } = await import('../snapshot/serve.js'); // lazy: no server deps on the default path
-        const { url } = await serve({ file: stepPath }); // builds a ?dir=&file= URL; server runs until Ctrl-C
+        const { url, reused } = await serve({ file: stepPath }); // builds a ?dir=&file= URL; server runs until Ctrl-C
         process.stderr.write(`viewer: ${url}\n`);
+        // Auto-open only for a freshly started server (a reused one already has
+        // a tab) in an interactive session; `--no-open` always suppresses it.
+        if (!reused && opts.open !== false && shouldAutoOpen()) {
+          openBrowser(url);
+        }
       }
     }
   );

--- a/packages/brepjs-verify/src/cli/main.ts
+++ b/packages/brepjs-verify/src/cli/main.ts
@@ -63,7 +63,9 @@ program
         check?: boolean;
         snapshot?: string;
         serve?: boolean;
-        open?: boolean;
+        // Commander materializes a negated flag as a concrete boolean: true by
+        // default, false when --no-open is passed.
+        open: boolean;
       }
     ) => {
       // The WASM viewer loads a CAD file (it can't run a .brep.ts), so --snapshot/--serve
@@ -111,8 +113,9 @@ program
         const { url, reused } = await serve({ file: stepPath }); // builds a ?dir=&file= URL; server runs until Ctrl-C
         process.stderr.write(`viewer: ${url}\n`);
         // Auto-open only for a freshly started server (a reused one already has
-        // a tab) in an interactive session; `--no-open` always suppresses it.
-        if (!reused && opts.open !== false && shouldAutoOpen()) {
+        // a tab) in an interactive session; `--no-open` (opts.open === false)
+        // always suppresses it.
+        if (!reused && opts.open && shouldAutoOpen()) {
           openBrowser(url);
         }
       }

--- a/packages/brepjs-verify/src/cli/openBrowser.ts
+++ b/packages/brepjs-verify/src/cli/openBrowser.ts
@@ -1,0 +1,51 @@
+import { spawn } from 'node:child_process';
+
+/** Inputs that decide whether auto-opening a browser is appropriate. */
+export interface AutoOpenEnv {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  /** Whether stderr is an interactive terminal. */
+  isTTY?: boolean;
+}
+
+/**
+ * Whether `--serve` should auto-open the browser for the current environment.
+ *
+ * Opens only for an interactive session — suppressed under CI, when stderr is
+ * not a TTY (agent/piped runs), or on Linux without a display server — so
+ * automation never spawns a browser unexpectedly. An explicit `--no-open` is a
+ * separate, always-on override handled by the caller.
+ */
+export function shouldAutoOpen({
+  env = process.env,
+  platform = process.platform,
+  isTTY = Boolean(process.stderr.isTTY),
+}: AutoOpenEnv = {}): boolean {
+  if (env['CI']) return false;
+  if (!isTTY) return false;
+  if (platform === 'linux' && !env['DISPLAY'] && !env['WAYLAND_DISPLAY']) return false;
+  return true;
+}
+
+/** The platform-specific command that opens `url` in the default browser. */
+export function browserCommand(url: string, platform: NodeJS.Platform): [string, string[]] {
+  if (platform === 'darwin') return ['open', [url]];
+  // Windows `start` is a cmd builtin; the empty "" is the (ignored) window title.
+  if (platform === 'win32') return ['cmd', ['/c', 'start', '', url]];
+  return ['xdg-open', [url]];
+}
+
+/**
+ * Best-effort open of `url` in the default browser. Never throws and never
+ * blocks — a missing opener just leaves the printed URL as the fallback.
+ */
+export function openBrowser(url: string, platform: NodeJS.Platform = process.platform): void {
+  try {
+    const [cmd, args] = browserCommand(url, platform);
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => {}); // opener not installed — ignore, URL was printed
+    child.unref();
+  } catch {
+    // Opening the browser must never break the server.
+  }
+}

--- a/packages/brepjs-verify/src/cli/openBrowser.ts
+++ b/packages/brepjs-verify/src/cli/openBrowser.ts
@@ -30,8 +30,10 @@ export function shouldAutoOpen({
 /** The platform-specific command that opens `url` in the default browser. */
 export function browserCommand(url: string, platform: NodeJS.Platform): [string, string[]] {
   if (platform === 'darwin') return ['open', [url]];
-  // Windows `start` is a cmd builtin; the empty "" is the (ignored) window title.
-  if (platform === 'win32') return ['cmd', ['/c', 'start', '', url]];
+  // On Windows, hand the URL to the shell-free protocol handler rather than
+  // `cmd /c start` — our URL contains `&` (?dir=&file=), which `cmd` would
+  // re-parse, and the embedded path comes from a CLI argument.
+  if (platform === 'win32') return ['rundll32', ['url.dll,FileProtocolHandler', url]];
   return ['xdg-open', [url]];
 }
 

--- a/packages/brepjs-verify/tests/openBrowser.test.ts
+++ b/packages/brepjs-verify/tests/openBrowser.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { browserCommand, shouldAutoOpen } from '@/cli/openBrowser.js';
+
+describe('browserCommand', () => {
+  it('uses the platform-appropriate opener', () => {
+    expect(browserCommand('http://x', 'darwin')).toEqual(['open', ['http://x']]);
+    expect(browserCommand('http://x', 'win32')).toEqual(['cmd', ['/c', 'start', '', 'http://x']]);
+    expect(browserCommand('http://x', 'linux')).toEqual(['xdg-open', ['http://x']]);
+  });
+});
+
+describe('shouldAutoOpen', () => {
+  it('opens in an interactive non-CI session', () => {
+    expect(shouldAutoOpen({ env: {}, platform: 'darwin', isTTY: true })).toBe(true);
+  });
+
+  it('is suppressed when stderr is not a TTY (piped / agent runs)', () => {
+    expect(shouldAutoOpen({ env: {}, platform: 'darwin', isTTY: false })).toBe(false);
+  });
+
+  it('is suppressed under CI', () => {
+    expect(shouldAutoOpen({ env: { CI: '1' }, platform: 'darwin', isTTY: true })).toBe(false);
+  });
+
+  it('is suppressed on Linux without a display server', () => {
+    expect(shouldAutoOpen({ env: {}, platform: 'linux', isTTY: true })).toBe(false);
+    expect(shouldAutoOpen({ env: { DISPLAY: ':0' }, platform: 'linux', isTTY: true })).toBe(true);
+    expect(
+      shouldAutoOpen({ env: { WAYLAND_DISPLAY: 'wayland-0' }, platform: 'linux', isTTY: true })
+    ).toBe(true);
+  });
+
+  it('a display server is not required off Linux', () => {
+    expect(shouldAutoOpen({ env: {}, platform: 'win32', isTTY: true })).toBe(true);
+  });
+});

--- a/packages/brepjs-verify/tests/openBrowser.test.ts
+++ b/packages/brepjs-verify/tests/openBrowser.test.ts
@@ -4,7 +4,10 @@ import { browserCommand, shouldAutoOpen } from '@/cli/openBrowser.js';
 describe('browserCommand', () => {
   it('uses the platform-appropriate opener', () => {
     expect(browserCommand('http://x', 'darwin')).toEqual(['open', ['http://x']]);
-    expect(browserCommand('http://x', 'win32')).toEqual(['cmd', ['/c', 'start', '', 'http://x']]);
+    expect(browserCommand('http://x', 'win32')).toEqual([
+      'rundll32',
+      ['url.dll,FileProtocolHandler', 'http://x'],
+    ]);
     expect(browserCommand('http://x', 'linux')).toEqual(['xdg-open', ['http://x']]);
   });
 });


### PR DESCRIPTION
## Summary

Two convenience/docs improvements to `brepjs-verify`:

### 1. `--serve` auto-opens the browser

After printing `viewer: <url>`, `--serve` now opens the viewer in your default browser — but only when it's actually wanted:

- **Fresh server only** — a *reused* server already has a tab, so re-running `--serve` won't spawn duplicates (uses the existing `serve()` `reused` flag).
- **Interactive only** — auto-open is suppressed under **CI**, on a **non-TTY** (piped / agent runs), and on **Linux with no display server** (`DISPLAY`/`WAYLAND_DISPLAY`). Automation never gets a surprise browser.
- **`--no-open`** — explicit always-off override.

The opener is a small **zero-dependency** helper (`open` / `cmd start` / `xdg-open`) that is detached and failure-tolerant — a missing opener just leaves the printed URL as the fallback, and opening the browser can never break the server.

### 2. Document the MCP server

`brepjs-verify` ships a second bin — **`brepjs-verify-mcp`**, a stdio MCP server exposing a `run_program` tool (build a `.brep.ts` in the sandbox → return the verification report) — that was **completely undocumented**. Now covered in the package README, the docs-site CLI page, and a one-line pointer in the root README, with the MCP-client config snippet and the tool's I/O.

## Files

- `src/cli/openBrowser.ts` (new) — `browserCommand` (per-platform) + `shouldAutoOpen` (env guards) + `openBrowser` (best-effort spawn).
- `src/cli/main.ts` — `--no-open` flag; open on fresh+interactive serve.
- `tests/openBrowser.test.ts` (new) — unit-cover the platform command map and every auto-open guard (CI / TTY / display server / platform).
- Docs: `packages/brepjs-verify/README.md`, `skill/SKILL.md`, `apps/docs/agent/cli.md`, root `README.md`.

## Verification

Root typecheck + lint clean; full brepjs-verify suite **106 passed** (incl. 6 new opener tests). Auto-open logic is fully injectable/unit-tested without spawning a real browser.