### PR TITLE
fix(brepkit): implement getSurfaceAxis for cylindrical faces

### DIFF
--- a/src/kernel/brepkit/geometryOps.ts
+++ b/src/kernel/brepkit/geometryOps.ts
@@ -394,6 +394,22 @@ export function getSurfaceCylinderData(
   return null;
 }
 
+export function getSurfaceAxis(
+  bk: BrepkitKernel,
+  face: KernelShape
+): { origin: [number, number, number]; direction: [number, number, number] } | null {
+  const params = JSON.parse(bk.getAnalyticSurfaceParams(unwrap(face, 'face')));
+  if (params.type !== 'cylinder') return null;
+  const [ox, oy, oz] = params.origin;
+  const [ax, ay, az] = params.axis;
+  const len = Math.hypot(ax, ay, az);
+  if (len < 1e-12) return null;
+  return {
+    origin: [ox, oy, oz],
+    direction: [ax / len, ay / len, az / len],
+  };
+}
+
 export function reverseSurfaceU(_bk: BrepkitKernel, surface: KernelType): KernelType {
   return surface; // No-op: brepkit doesn't have separate surface handle direction
 }
@@ -574,8 +590,7 @@ export function makeGeometryOps(bk: BrepkitKernel) {
     createCurveAdaptor: (shape) => createCurveAdaptor(bk, shape),
     getBezierPenultimatePole: (edge) => getBezierPenultimatePole(bk, edge),
     getSurfaceCylinderData: (surface) => getSurfaceCylinderData(bk, surface),
-    // Axis-based mates (concentric) are an OCCT-only feature for now.
-    getSurfaceAxis: () => null,
+    getSurfaceAxis: (face) => getSurfaceAxis(bk, face),
     reverseSurfaceU: (surface) => reverseSurfaceU(bk, surface),
     classifyPointOnFace: (face, u, v, tolerance) => classifyPointOnFace(bk, face, u, v, tolerance),
     classifyPointRobust: (shape, point, tolerance) =>

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -291,14 +291,6 @@ export const divergences: DivergenceMap = {
     },
 
     // -----------------------------------------------------------------------
-    // mateFns.test.ts
-    // -----------------------------------------------------------------------
-    'mateFns.concentricAxis': {
-      kind: 'not-implemented',
-      reason: 'getSurfaceAxis (cylinder axis extraction) is OCCT-only; brepkit returns null',
-    },
-
-    // -----------------------------------------------------------------------
     // meshFns.test.ts
     // -----------------------------------------------------------------------
     'meshFns.stepReadError': {


### PR DESCRIPTION
## Summary

`getSurfaceAxis(face)` returned `null` on the brepkit adapter, so concentric (axis-based) mates couldn't solve on brepkit — `extractEntity` produced no `axis` entity and a pin-in-hole `concentric` mate reported `ASSEMBLY_NOT_CONVERGED`. This was papered over by the `mateFns.concentricAxis` kernel divergence.

brepkit's `getAnalyticSurfaceParams` already returns the cylinder's `axis` and `origin`:

```json
{"axis":[0,0,1],"origin":[0,0,0],"radius":5,"type":"cylinder"}
```

So `getSurfaceAxis` reads them directly (normalizing the direction) — exact, and simpler than the normal-sampling derivation the occt-wasm adapter uses. The issue suggested replicating that sampling; the analytic params make it unnecessary.

## Changes

- `src/kernel/brepkit/geometryOps.ts`: implement `getSurfaceAxis` from analytic surface params; wire it into the factory.
- `tests/helpers/kernelDivergences.ts`: remove the `mateFns.concentricAxis` divergence.

## Verification

The pin-in-hole concentric test (`tests/mateFns.test.ts`) now runs (instead of skipping) and passes on all three kernels:

- brepkit: 27/27
- occt-wasm (default): 27/27
- occt: 27/27

Closes #1297