### PR TITLE
docs(verify): scrub AI-writing tells from verify docs and skill

### DIFF
--- a/.claude/skills/brepjs-verify/SKILL.md
+++ b/.claude/skills/brepjs-verify/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: brepjs-verify
-description: Use when authoring or editing parametric 3D CAD models in TypeScript with the brepjs library — turning natural-language part requirements into solids, then type-checking, verifying deterministically (validity + volume/area/bounds vs intent), and visually (multi-view snapshots) before handing off STEP/GLB artifacts.
+description: Use when authoring or editing parametric 3D CAD models in TypeScript with the brepjs library: turn natural-language part requirements into solids, then type-check, verify deterministically (validity + volume/area/bounds vs intent), and verify visually (multi-view snapshots) before handing off STEP/GLB artifacts.
 ---
 
 # Authoring CAD with brepjs
 
-You write a `.brep.ts` part; the `brepjs-verify` CLI runs it against a real geometry kernel and tells you the truth. Never judge a part by how the code reads — judge it by the report. The loop below is the job.
+You write a `.brep.ts` part; `brepjs-verify` runs it on a geometry kernel and reports what it measured. Judge the part by the report, not by how the code reads. Follow the loop below for every part.
 
 Commands below use `npx -y brepjs-verify`; if you've installed the package, drop the `npx -y` and call `brepjs-verify` directly.
 
 ## The loop (every part, in order)
 
 1. **Brief.** Convert the request to explicit params: dimensions (mm), datums, features, assumptions. Don't ask the user for JSON.
-2. **Load only the reference you need** (index below) — not all at once.
-3. **Author `.brep.ts`** — `export default () => <shape>` with the short API (`box`, `cylinder`, `fuse`, `cut`, `fillet`, …), named consts at the top. Scaffold with `npx -y brepjs-verify init <name>`. Edit *source*, never generated artifacts.
-4. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. The CLI asserts it — this is how you prove the part is the *right* part, not just a valid one.
+2. **Load only the reference you need** (index below), not all at once.
+3. **Author `.brep.ts`**: `export default () => <shape>` with the short API (`box`, `cylinder`, `fuse`, `cut`, `fillet`, …), named consts at the top. Scaffold with `npx -y brepjs-verify init <name>`. Edit _source_, never generated artifacts.
+4. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. The CLI asserts it, catching a part that is valid but wrong-sized.
 5. **Verify (type + geometry).** `npx -y brepjs-verify verify part.brep.ts --check --json report.json`. `--check` type-checks before running (catches wrong-API calls early); the JSON report is the source of truth. Iterate fast with `npx -y brepjs-verify watch part.brep.ts`.
-6. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs. Review against the brief. A visual concern is **not** a conclusion — convert it to a measurement ("hole looks off-center → check `bounds`"). Don't declare done without a snapshot.
+6. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs. Review against the brief. A visual concern is **not** a conclusion: convert it to a measurement ("hole looks off-center → check `bounds`"). Don't declare done without a snapshot.
 7. **Repair the smallest responsible section** and re-run. Use the report's `hints` to guide the fix.
 8. **Export + hand off.** `npx -y brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `npx -y brepjs-verify export part.brep.ts --all`. `--serve` prints a clickable preview link. Report the STEP path.
 
-## Reading the report (this is the source of truth)
+## Reading the report
 
 ```jsonc
 {
@@ -35,32 +35,32 @@ Commands below use `npx -y brepjs-verify`; if you've installed the package, drop
 ```
 
 - **`ok`** is the verdict. `false` → not done. With an `expected` block, `ok` also requires every assertion to pass.
-- **`checks`** = kernel validity (manifold solid, positive volume). A failed check means the geometry is broken, not just wrong-sized.
+- **`checks`** = kernel validity (manifold solid, positive volume). A failed check means the geometry is broken, not wrong-sized.
 - **`assertions`** = your declared intent vs reality. A failed assertion means valid-but-wrong (off dimensions).
 - **`hints`** = actionable fix + next step keyed on the error code. Read these before guessing.
-- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from — authoring, kernel, or export errors. Cite the `code` when repairing.
-- Trust this JSON over the rendered image. The render confirms *shape*; the JSON confirms *correctness*.
+- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from (authoring, kernel, or export errors). Cite the `code` when repairing.
+- Trust the JSON over the render. The render shows _shape_; the JSON shows dimensions and validity.
 
 ## Repair discipline
 
 - Change the **smallest responsible section**, re-verify, repeat. Don't rewrite the whole part on one failure.
 - Let the `code`/`hints` localize the cause (e.g. `INVALID_FILLET_RADIUS` → reduce radius vs local edge length; `*_NOT_3D` → you passed a 2D shape to a 3D op; `BOOLEAN_HAS_ERRORS` → inputs overlap-degenerate).
-- A part that *runs* but reports `ok:false` is wrong, not done — same as a crash.
+- A part that _runs_ but reports `ok:false` is wrong, not done. Treat it like a crash.
 
 ## Reliable scope (be honest)
 
 - **Reliable first-try:** primitives, booleans (`fuse`/`cut`/`intersect`), 2D sketch → extrude, `fillet`/`chamfer`, `shell`/`offset`, transforms. Prefer these.
-- **Advanced — verify extra carefully, expect iteration:** sweeps, lofts, revolves, multi-section, assemblies, text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and small steps.
+- **Advanced (verify carefully, expect iteration):** sweeps, lofts, revolves, multi-section, assemblies, text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and small steps.
 
 ## Hard rules
 
 - Edit source, not artifacts. STEP/STL/GLB derive from the `.brep.ts`.
-- Booleans and `measureVolume`/`measureArea` return `Result` — unwrap and check the `Err` branch before chaining.
+- Booleans and `measureVolume`/`measureArea` return `Result`: unwrap and check the `Err` branch before chaining.
 - `fillet`/`chamfer` need a valid solid (its signature is `fillet(solid, edges, radius)`). Verify validity first.
 - `box(width, depth, height)`: 2nd arg is depth (Y), 3rd is height (Z); positioning option is `at`, not `origin`. Units mm.
-- Author parts in an ESM context (the tool's default) so the kernel loads — a CommonJS project needs `"type": "module"` or a `.mts` file.
+- Author parts in an ESM context (the tool's default) so the kernel loads. A CommonJS project needs `"type": "module"` or a `.mts` file.
 
-## Reference index (progressive — load only what the task needs)
+## Reference index (load only what the task needs)
 
 - Getting started + kernel init → `references/getting-started.md`
 - Primitives → `references/primitives.md`
@@ -71,9 +71,9 @@ Commands below use `npx -y brepjs-verify`; if you've installed the package, drop
 - Measurement + the verify loop → `references/measurement-validation.md`
 - Export formats → `references/export.md`
 
-Full symbol index: the library ships `docs/function-lookup.md` — consult it for anything not covered above.
+Full symbol index: the library ships `docs/function-lookup.md`; consult it for anything not covered above.
 
-## Examples index (few-shot — read the closest one before authoring)
+## Examples index (read the closest one before authoring)
 
 Each is a complete `skill/examples/<name>.brep.ts` with a sibling `<name>.expected.json` baseline (replayed by the `eval` harness).
 
@@ -84,9 +84,9 @@ Each is a complete `skill/examples/<name>.brep.ts` with a sibling `<name>.expect
 
 ## CLI subcommands (the `brepjs-verify` bin)
 
-- `verify <file>` (default) — report; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`.
-- `init <name>` — scaffold `<name>.brep.ts` + `tsconfig.json`.
-- `watch <file>` — re-verify on every save.
-- `export <file>` — batch STEP/GLB/STL behind a validity gate (`--step`/`--glb`/`--stl`/`--all`).
-- `measure <a> [b]` — measurements for one part, or distance between two.
-- `diff <a> <b>` — compare two parts' measurements.
+- `verify <file>` (default): report; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`.
+- `init <name>`: scaffold `<name>.brep.ts` + `tsconfig.json`.
+- `watch <file>`: re-verify on every save.
+- `export <file>`: batch STEP/GLB/STL behind a validity gate (`--step`/`--glb`/`--stl`/`--all`).
+- `measure <a> [b]`: measurements for one part, or distance between two.
+- `diff <a> <b>`: compare two parts' measurements.

--- a/.claude/skills/brepjs-verify/references/booleans.md
+++ b/.claude/skills/brepjs-verify/references/booleans.md
@@ -1,6 +1,6 @@
 # Booleans
 
-Combine solids with CSG. All three return `Result<T>` — unwrap or thread the result through to the default export.
+Combine solids with CSG. All three return `Result<T>`; unwrap or thread the result through to the default export.
 
 | Function    | Signature         | Meaning              |
 | ----------- | ----------------- | -------------------- |
@@ -14,13 +14,13 @@ import { box, cylinder, cut } from 'brepjs';
 export default () => {
   const body = box(40, 20, 10, { centered: true });
   const bore = cylinder(4, 12, { at: [0, 0, -6] });
-  return cut(body, bore); // Result<Solid> — fine to return directly
+  return cut(body, bore); // Result<Solid>, fine to return directly
 };
 ```
 
 ## Pitfalls
 
 - Returning a `Result` from the default export is supported; the verifier unwraps it and reports an `Err`.
-- Booleans on touching-but-not-overlapping solids can yield empty/invalid results — give operands a small overlap.
+- Booleans on touching-but-not-overlapping solids can yield empty/invalid results; give operands a small overlap.
 
 See also: docs/function-lookup.md → brepjs/topology.

--- a/.claude/skills/brepjs-verify/references/export.md
+++ b/.claude/skills/brepjs-verify/references/export.md
@@ -1,6 +1,6 @@
 # Export
 
-STEP is the canonical, lossless output — the source of truth. Mesh formats (STL/3MF/GLB) are **derived sidecars** for preview/printing, never the authoritative artifact.
+STEP is the canonical, lossless output, the source of truth. Mesh formats (STL/3MF/GLB) are **derived sidecars** for preview/printing, never the authoritative artifact.
 
 | Function     | Signature                                     | Role              |
 | ------------ | --------------------------------------------- | ----------------- |
@@ -22,6 +22,6 @@ npx -y brepjs-verify model.brep.ts --step out/model.step --glb out/model.glb
 ## Pitfalls
 
 - Prefer STEP downstream; meshes lose exact surfaces and are tessellation-dependent.
-- All exporters return `Result<Blob>` — check for `Err` before writing.
+- All exporters return `Result<Blob>`; check for `Err` before writing.
 
 See also: docs/function-lookup.md → brepjs/io.

--- a/.claude/skills/brepjs-verify/references/getting-started.md
+++ b/.claude/skills/brepjs-verify/references/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-A brepjs model is a `.brep.ts` module with a default export — a zero-arg function returning a shape (or `Result<shape>`). The verifier imports the module, calls the default export, and runs deterministic checks on the result.
+A brepjs model is a `.brep.ts` module with a default export: a zero-arg function returning a shape (or `Result<shape>`). The verifier imports the module, calls the default export, and runs deterministic checks on the result.
 
 ## The contract
 
@@ -10,7 +10,7 @@ A brepjs model is a `.brep.ts` module with a default export — a zero-arg funct
 | Result-wrapped | `export default () => Result<Solid>`                            |
 | Async setup    | `export default async () => Solid` (kernel already initialized) |
 
-The verifier handles kernel init — never call `initFromOC` yourself in a model.
+The verifier handles kernel init; never call `initFromOC` yourself in a model.
 
 ## Minimal model
 
@@ -30,7 +30,7 @@ Add `--snapshot ./out` for PNGs, `--step ./out/bracket.step` for the primary STE
 
 ## Pitfalls
 
-- The default export must be a **function**, not a shape value — the verifier calls it. `export default box(...)` fails.
+- The default export must be a **function**, not a shape value; the verifier calls it. `export default box(...)` fails.
 - Import from the package root `'brepjs'`, not deep paths.
 
 See also: docs/function-lookup.md → full symbol index.

--- a/.claude/skills/brepjs-verify/references/measurement-validation.md
+++ b/.claude/skills/brepjs-verify/references/measurement-validation.md
@@ -1,6 +1,6 @@
 # Measurement & validation
 
-Deterministic checks are the source of truth — PNGs and previews are only for human spot-checks.
+Deterministic checks are the source of truth; PNGs and previews are only for human spot-checks.
 
 | Function          | Signature                  | Returns                      |
 | ----------------- | -------------------------- | ---------------------------- |
@@ -19,7 +19,7 @@ measureVolume(box(2, 3, 4)); // ok(24)
 
 ## The verify loop
 
-1. `npx -y brepjs-verify model.brep.ts` runs the model + deterministic checks (volume, bounds, validity) — these decide pass/fail.
+1. `npx -y brepjs-verify model.brep.ts` runs the model + deterministic checks (volume, bounds, validity); these decide pass/fail.
 2. `--json out.json` emits machine-readable measurements to diff between iterations; `measure`/`diff` subcommands compare distances and before/after parts.
 3. `--snapshot ./out` writes iso/front/top/right PNGs for a visual sanity pass.
 4. `--serve` opens a clickable, directory-rooted preview rendering the real STEP geometry (read-only).
@@ -28,7 +28,7 @@ Trust the deterministic numbers; treat snapshots/serve as confirmation, not proo
 
 ## Pitfalls
 
-- `measureVolume` returns a `Result` — unwrap before comparing to a number.
+- `measureVolume` returns a `Result`; unwrap before comparing to a number.
 - `getBounds` returns flat `xMin/xMax/...` fields, not min/max vectors.
 
 See also: docs/function-lookup.md → brepjs/measurement.

--- a/.claude/skills/brepjs-verify/references/modifiers.md
+++ b/.claude/skills/brepjs-verify/references/modifiers.md
@@ -18,7 +18,7 @@ export default () => fillet(box(40, 20, 10, { centered: true }), 2);
 
 ## Pitfalls
 
-- A radius/distance larger than the local geometry makes the kernel fail — keep it well below the smallest adjacent edge length.
+- A radius/distance larger than the local geometry makes the kernel fail; keep it well below the smallest adjacent edge length.
 - `fillet`/`chamfer` only accept a `ValidSolid`; wrap a post-boolean shape with `validSolid(...)` before filleting.
 
 See also: docs/function-lookup.md → brepjs/topology.

--- a/.claude/skills/brepjs-verify/references/sketching-2d.md
+++ b/.claude/skills/brepjs-verify/references/sketching-2d.md
@@ -24,7 +24,7 @@ export default () => {
 
 ## Pitfalls
 
-- A `Drawing` is purely 2D — you must `.sketchOnPlane(...)` before `.extrude`.
+- A `Drawing` is purely 2D; you must `.sketchOnPlane(...)` before `.extrude`.
 - Low-level `circle`/`ellipse`/`line` (primitives) return **edges**, not faces; use the `draw*` factories when you need a closed profile to extrude.
 
 See also: docs/function-lookup.md → brepjs/sketching.

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -1,38 +1,38 @@
 ---
 title: CLI Reference
-description: 'Every brepjs-verify subcommand, flag, and exit code — verify, init, watch, export, measure, diff, snapshot, serve — plus the MCP server, the expected-dimensions contract, and troubleshooting.'
+description: 'Every brepjs-verify subcommand, flag, and exit code (verify, init, watch, export, measure, diff, snapshot, serve), plus the MCP server, the expected-dimensions contract, and troubleshooting.'
 ---
 
 # CLI Reference
 
-The `brepjs-verify` bin is a multi-command CLI. `verify` is the default command, so `brepjs-verify part.brep.ts` runs it directly. Every command writes a single machine-readable JSON document to **stdout**; diagnostics (paths, kernel chatter, watch notices) go to **stderr**. Commands exit non-zero when the report is not `ok`, so they slot straight into CI and agent loops.
+The `brepjs-verify` bin is a multi-command CLI. `verify` is the default command, so `brepjs-verify part.brep.ts` runs it directly. Every command writes a single machine-readable JSON document to **stdout**; diagnostics (paths, kernel chatter, watch notices) go to **stderr**. Commands exit non-zero when the report is not `ok`, so they work in CI and agent loops.
 
 Prefix any command with `npx -y` to run without installing.
 
 ## Commands
 
-| Command                         | What it does                                                                                                                                                                                               |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `brepjs-verify verify <file>`   | **Default command.** Loads the part, runs deterministic checks, prints the JSON report. Flags: `--check`, `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`.                    |
-| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                                            |
-| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                                               |
-| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                                    |
-| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                                       |
-| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                                           |
-| `brepjs-verify snapshot`        | Multi-view PNG capture — usually surfaced via `verify --snapshot <dir>`. Needs the optional `puppeteer`/Chrome dependency.                                                                                 |
-| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — usually surfaced via `verify --serve`. Auto-opens the browser in an interactive terminal; suppressed under CI / non-TTY / no display, or with `--no-open`. |
+| Command                         | What it does                                                                                                                                                                                              |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brepjs-verify verify <file>`   | **Default command.** Loads the part, runs deterministic checks, prints the JSON report. Flags: `--check`, `--json <out>`, `--step <out>`, `--glb <out>`, `--snapshot <dir>`, `--serve`.                   |
+| `brepjs-verify init <name>`     | Scaffolds a parameterized `<name>.brep.ts` + `tsconfig.json` + `README.md` into `./<name>` (or `--out <dir>`). Never overwrites existing files.                                                           |
+| `brepjs-verify watch <file>`    | Re-verifies on every save until Ctrl-C (debounced; watches the parent dir to survive editor rename-on-save).                                                                                              |
+| `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                                   |
+| `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                                      |
+| `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                                          |
+| `brepjs-verify snapshot`        | Multi-view PNG capture, usually surfaced via `verify --snapshot <dir>`. Needs the optional `puppeteer`/Chrome dependency.                                                                                 |
+| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link, usually surfaced via `verify --serve`. Auto-opens the browser in an interactive terminal; suppressed under CI / non-TTY / no display, or with `--no-open`. |
 
 ## `verify` flags
 
-| Flag               | Effect                                                                                                                                                                                                                                                                                                                                                                                     |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--check`          | Run a TypeScript type-check **before** executing the part. Type errors are surfaced as `TYPECHECK` error infos and the part is not run — wrong-API calls never reach the kernel.                                                                                                                                                                                                           |
-| `--json <out>`     | Write the full JSON report to a file (in addition to stdout).                                                                                                                                                                                                                                                                                                                              |
-| `--step <out>`     | Export STEP after the validity gate passes. STEP is the validated primary deliverable.                                                                                                                                                                                                                                                                                                     |
-| `--glb <out>`      | Export a derived GLB mesh preview. (`--stl` lives on the `export` command, not `verify`.)                                                                                                                                                                                                                                                                                                  |
-| `--snapshot <dir>` | Render iso / front / top / right PNGs into `<dir>` (needs `puppeteer`).                                                                                                                                                                                                                                                                                                                    |
-| `--serve`          | After a passing verify, start a preview server and print a clickable `?dir=&file=` link rendering the real STEP; it stays running until Ctrl-C. Only serves when the report is `ok` — a failing report still exits non-zero. In an interactive terminal it also opens your default browser (skipped when the server is reused, under CI, on non-TTY/agent runs, or with no Linux display). |
-| `--no-open`        | With `--serve`, never auto-open the browser — just print the URL.                                                                                                                                                                                                                                                                                                                          |
+| Flag               | Effect                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--check`          | Run a TypeScript type-check **before** executing the part. Type errors are surfaced as `TYPECHECK` error infos and the part is not run; wrong-API calls never reach the kernel.                                                                                                                                                                                                           |
+| `--json <out>`     | Write the full JSON report to a file (in addition to stdout).                                                                                                                                                                                                                                                                                                                             |
+| `--step <out>`     | Export STEP after the validity gate passes. STEP is the validated primary deliverable.                                                                                                                                                                                                                                                                                                    |
+| `--glb <out>`      | Export a derived GLB mesh preview. (`--stl` lives on the `export` command, not `verify`.)                                                                                                                                                                                                                                                                                                 |
+| `--snapshot <dir>` | Render iso / front / top / right PNGs into `<dir>` (needs `puppeteer`).                                                                                                                                                                                                                                                                                                                   |
+| `--serve`          | After a passing verify, start a preview server and print a clickable `?dir=&file=` link rendering the real STEP; it stays running until Ctrl-C. Only serves when the report is `ok`; a failing report still exits non-zero. In an interactive terminal it also opens your default browser (skipped when the server is reused, under CI, on non-TTY/agent runs, or with no Linux display). |
+| `--no-open`        | With `--serve`, never auto-open the browser; print the URL only.                                                                                                                                                                                                                                                                                                                          |
 
 ## Common invocations
 
@@ -48,7 +48,7 @@ npx -y brepjs-verify watch part.brep.ts
 
 # clickable preview (renders the real STEP), opens your browser
 npx -y brepjs-verify part.brep.ts --serve
-# …or just print the URL without opening a browser
+# or print the URL without opening a browser
 npx -y brepjs-verify part.brep.ts --serve --no-open
 
 # batch every artifact behind a validity gate
@@ -79,37 +79,37 @@ Each declared field appears in `report.assertions` as `{ name, expected, actual,
 
 ## Snapshots & the preview server
 
-`--snapshot` and `--serve` use the bundled viewer (shipped with the package, including the OCCT WASM) and render the **real exported STEP**, not a code preview. Snapshots require the optional `puppeteer`/Chrome dependency; when it is absent the CLI degrades with a clear message rather than failing, and `--snapshot` is simply skipped. The viewer is read-only display + screenshot.
+`--snapshot` and `--serve` use the bundled viewer (shipped with the package, including the OCCT WASM) and render the **real exported STEP**, not a code preview. Snapshots require the optional `puppeteer`/Chrome dependency; when it is absent the CLI prints a message naming the missing dependency rather than failing, and `--snapshot` is skipped. The viewer is read-only display + screenshot.
 
-`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted — a reused server (a tab already exists), CI, a non-TTY/piped session (e.g. an agent run), or Linux with no display server — and `--no-open` always suppresses it. Agents therefore get the URL without a browser launching.
+`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted (a reused server where a tab already exists, CI, a non-TTY/piped session such as an agent run, or Linux with no display server), and `--no-open` always suppresses it. Agents get the URL without a browser launching.
 
 ## MCP server
 
-The package ships a second bin — `brepjs-verify-mcp` — a stdio [MCP](https://modelcontextprotocol.io) server that exposes the verify substrate to MCP-capable agents (Claude Code, Claude Desktop, any MCP client) directly, without spawning the CLI. It provides one tool:
+The package ships a second bin, `brepjs-verify-mcp`: a stdio [MCP](https://modelcontextprotocol.io) server that exposes the verify substrate to MCP-capable agents (Claude Code, Claude Desktop, any MCP client) directly, without spawning the CLI. It provides one tool:
 
 | Tool          | Input                                  | Returns                                                                                                                                                                                                                    |
 | ------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `run_program` | `{ code: string, timeoutMs?: number }` | Runs the `.brep.ts` source in an isolated, timeout/OOM-bounded sandbox and returns the verification report (validity, measurements, topology) as JSON. `isError` is set when the part fails checks, times out, or crashes. |
 
-It's the closed _build → verify_ step of [the loop](./the-loop.md) as a single call: the agent sends part source, gets back the deterministic report, all in a separate process so a runaway part can't hang the agent. Register it with Claude Code:
+It's the _build → verify_ step of [the loop](./the-loop.md) as a single call: the agent sends part source and gets back the deterministic report, in a separate process so a runaway part can't hang the agent. Register it with Claude Code:
 
 ```bash
 claude mcp add brepjs-verify -- npx -y --package brepjs-verify brepjs-verify-mcp
 ```
 
-Geometry never leaves your machine — the server runs locally as a child process over stdio.
+Geometry never leaves your machine; the server runs locally as a child process over stdio.
 
 ## Troubleshooting
 
-**`cannot load TypeScript part … (ESM)`** — Author parts in an ESM context. Node strips types natively (requires Node 24+) but only under ESM, so a part in a CommonJS project fails. Fix: set `"type": "module"` in `package.json`, or rename the part to `.mts`. A transpiler fallback is intentionally not used — it would load `brepjs` in a separate module realm and hand the part an uninitialized kernel.
+**`cannot load TypeScript part … (ESM)`**: Author parts in an ESM context. Node strips types natively (requires Node 24+) but only under ESM, so a part in a CommonJS project fails. Fix: set `"type": "module"` in `package.json`, or rename the part to `.mts`. A transpiler fallback is intentionally not used; it would load `brepjs` in a separate module realm and hand the part an uninitialized kernel.
 
-**`kernel not initialized` / version skew** — The runtime prefers your project-local `brepjs` + `occt-wasm` when present, else its own bundled copies, routing both the tool and the part through one instance. Keep `brepjs` and `occt-wasm` in the same project as the part so the resolve hook version-matches them.
+**`kernel not initialized` / version skew**: The runtime prefers your project-local `brepjs` + `occt-wasm` when present, else its own bundled copies, routing both the tool and the part through one instance. Keep `brepjs` and `occt-wasm` in the same project as the part so the resolve hook version-matches them.
 
-**Snapshots / judge skipped** — Install `puppeteer` (it fetches Chromium on first use) to enable `--snapshot` and the live-eval visual judge. Without it, verification still runs on measurements alone.
+**Snapshots / judge skipped**: Install `puppeteer` (it fetches Chromium on first use) to enable `--snapshot` and the live-eval visual judge. Without it, verification still runs on measurements alone.
 
-**Node version** — Native TypeScript type-stripping for `.brep.ts` requires Node 24+. Older Node needs the part precompiled to `.mjs`.
+**Node version**: Native TypeScript type-stripping for `.brep.ts` requires Node 24+. Older Node needs the part precompiled to `.mjs`.
 
 ## Next steps
 
-- [The Verify Loop](./the-loop) — how to use these commands as a workflow
-- [Eval & Scorecard](./eval) — how the skill measures itself
+- [The Verify Loop](./the-loop): how to use these commands as a workflow
+- [Eval & Scorecard](./eval): how the skill measures itself

--- a/apps/docs/agent/eval.md
+++ b/apps/docs/agent/eval.md
@@ -1,11 +1,11 @@
 ---
 title: Eval & Scorecard
-description: 'How brepjs-verify measures itself — a deterministic replay that gates CI, plus an opt-in live eval that sends natural-language prompts to a model under the deployed skill and scores validity + visual intent.'
+description: 'How brepjs-verify measures itself: a deterministic replay that gates CI, plus an opt-in live eval that sends natural-language prompts to a model under the deployed skill and scores validity + visual intent.'
 ---
 
 # Eval & Scorecard
 
-A verify loop is only as good as you can prove it is. `brepjs-verify` measures itself two ways: a **deterministic replay** that runs in CI, and an opt-in **live eval** that exercises the actual skill against a real model. Together they keep the skill honest as brepjs and the kernel evolve.
+`brepjs-verify` measures itself two ways: a **deterministic replay** that runs in CI, and an opt-in **live eval** that exercises the deployed skill against a model. Both catch regressions as brepjs and the kernel change.
 
 ## Deterministic eval (CI gate)
 
@@ -15,14 +15,14 @@ npm run eval
 
 `bench/run.ts` replays every `skill/examples/*.brep.ts` through the public `runPart` runtime and compares the measured volume / area / validity / shape-type against the recorded `*.expected.json` baseline, within each file's tolerance (default 0.5%). It prints a PASS/FAIL scorecard and exits non-zero on any regression.
 
-It is fully deterministic — **no LLM, no API key** — so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an _intentional_ geometry change; an unintentional change surfaces as a failure.
+It is fully deterministic (**no LLM, no API key**), so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an _intentional_ geometry change; an unintentional change surfaces as a failure.
 
 ## Live eval (`eval:live`)
 
-This is how you measure the skill itself, not just the geometry. It sends ~18 natural-language part prompts (`bench/prompts.ts`) to a real model — using the **deployed `SKILL.md` as the system prompt**, so it measures exactly what an agent sees — then verifies each generated part two ways:
+The live eval measures the skill, not only the geometry. It sends ~18 natural-language part prompts (`bench/prompts.ts`) to a model using the **deployed `SKILL.md` as the system prompt**, so it measures what an agent sees, then verifies each generated part two ways:
 
 - **Auto (objective):** `runPart --check` → a valid solid with any pinned dimensions inside tolerance.
-- **Judge (intent):** a multimodal Claude call looks at the rendered iso/front/top/right snapshots and decides whether the part matches the request and its rubric.
+- **Judge (intent):** a multimodal Claude call evaluates the rendered iso/front/top/right snapshots against the request and its rubric.
 
 ```bash
 ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify              # opus by default
@@ -30,15 +30,15 @@ ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify -- --model claude-so
 #   --only <id|category>   run a subset      --keep   keep the generated parts
 ```
 
-The scorecard reports per-category `valid` / `judge` / `both` rates and stamps the model + **resolved brepjs version** + date — so trend lines never mix kernel versions.
+The scorecard reports per-category `valid` / `judge` / `both` rates and stamps the model + **resolved brepjs version** + date, so trend lines never mix kernel versions.
 
-`eval:live` is **opt-in and billed** — it makes real API calls, so it does not run in CI; the deterministic replay above is the CI gate. Snapshots (and therefore the judge) need `puppeteer`/Chrome; without them the run scores on auto-verify alone and notes the skipped judge.
+`eval:live` is **opt-in and billed**: it makes real API calls, so it does not run in CI; the deterministic replay above is the CI gate. Snapshots (and therefore the judge) need `puppeteer`/Chrome; without them the run scores on auto-verify alone and notes the skipped judge.
 
 ## Why it stamps the brepjs version
 
-The runtime pins `brepjs` with a caret range, and geometry measurements are floating-point — a kernel bump can legitimately shift a volume by a hair. Stamping the resolved version on every scorecard keeps trend lines comparable instead of silently mixing engine versions across runs.
+The runtime pins `brepjs` with a caret range, and geometry measurements are floating-point: a kernel bump can shift a volume by a small amount. Stamping the resolved version on every scorecard keeps trend lines comparable instead of silently mixing engine versions across runs.
 
 ## Next steps
 
-- [Examples](./examples) — the corpus the deterministic eval replays
-- [The Verify Loop](./the-loop) — the per-part workflow the eval automates at scale
+- [Examples](./examples): the corpus the deterministic eval replays
+- [The Verify Loop](./the-loop): the per-part workflow the eval runs across the corpus

--- a/apps/docs/agent/examples.md
+++ b/apps/docs/agent/examples.md
@@ -1,11 +1,11 @@
 ---
 title: Examples
-description: 'The few-shot example gallery brepjs-verify ships — primitives, booleans, 2D sketch-to-solid, modifiers, and gridfinity — each a complete .brep.ts with a recorded measurement baseline.'
+description: 'The few-shot example gallery brepjs-verify ships (primitives, booleans, 2D sketch-to-solid, modifiers, and gridfinity), each a complete .brep.ts with a recorded measurement baseline.'
 ---
 
 # Examples
 
-The skill ships a gallery of complete, verified parts under `skill/examples/<name>.brep.ts`, each paired with a `<name>.expected.json` baseline. They are the few-shot reference the agent reads before authoring — and the corpus the [deterministic eval](./eval) replays. Read the one closest to your task before writing a new part.
+The skill ships a gallery of complete, verified parts under `skill/examples/<name>.brep.ts`, each paired with a `<name>.expected.json` baseline. They are the few-shot reference the agent reads before authoring, and the corpus the [deterministic eval](./eval) replays. Read the one closest to your task before writing a new part.
 
 Each example is a real `.brep.ts` you can run directly:
 
@@ -15,27 +15,27 @@ npx -y brepjs-verify verify mounting-bracket.brep.ts --check --snapshot shots/
 
 ## Primitives + booleans
 
-The reliable core — start here.
+Reliable first-try. Start here.
 
-- **`mounting-bracket`** — base plate + upright web + bolt holes (`box`, `fuse`, `cut`).
-- **`flanged-coupler`** — flange + cylinder + bore, chamfered.
-- **`transform-bracket`** — translate / rotate / mirror composition.
+- **`mounting-bracket`**: base plate + upright web + bolt holes (`box`, `fuse`, `cut`).
+- **`flanged-coupler`**: flange + cylinder + bore, chamfered.
+- **`transform-bracket`**: translate / rotate / mirror composition.
 
 ## 2D sketch → solid
 
 A 2D profile driven up into 3D.
 
-- **`extruded-bracket`** — rounded plate + bolt holes (extrude).
-- **`revolved-pulley`** — V-groove profile revolved around an axis.
-- **`swept-gasket`** — a frame profile swept along a spine.
+- **`extruded-bracket`**: rounded plate + bolt holes (extrude).
+- **`revolved-pulley`**: V-groove profile revolved around an axis.
+- **`swept-gasket`**: a frame profile swept along a spine.
 
 ## Modifiers
 
-Validity-sensitive operations — verify carefully.
+Validity-sensitive operations. Verify carefully.
 
-- **`rounded-block`** — `fillet` on selected edges.
-- **`chamfered-block`** — `chamfer`.
-- **`hollow-enclosure`** — a filleted box, shelled to a wall thickness.
+- **`rounded-block`**: `fillet` on selected edges.
+- **`chamfered-block`**: `chamfer`.
+- **`hollow-enclosure`**: a filleted box, shelled to a wall thickness.
 
 ## Gridfinity
 
@@ -47,9 +47,9 @@ Parametric primitives for the [Gridfinity](https://gridfinity.xyz/) ecosystem.
 
 ## Anatomy of an example
 
-Every example follows the [`.brep.ts` contract](./overview): a default-exported zero-arg function plus an `expected` block that pins its measured dimensions. The sibling `<name>.expected.json` records the baseline volume / area / validity / shape-type that the eval replays within tolerance — so an intentional geometry change means re-recording that baseline, and an _unintentional_ one shows up as a failed eval.
+Every example follows the [`.brep.ts` contract](./overview): a default-exported zero-arg function plus an `expected` block that pins its measured dimensions. The sibling `<name>.expected.json` records the baseline volume, area, validity, and shape-type that the eval replays within tolerance. An intentional geometry change means re-recording that baseline; an unintentional one shows up as a failed eval.
 
 ## Next steps
 
-- [The Verify Loop](./the-loop) — the workflow these examples were authored with
-- [Eval & Scorecard](./eval) — how the gallery becomes a regression net
+- [The Verify Loop](./the-loop): the workflow these examples were authored with
+- [Eval & Scorecard](./eval): how the gallery becomes a regression net

--- a/apps/docs/agent/overview.md
+++ b/apps/docs/agent/overview.md
@@ -1,30 +1,30 @@
 ---
 title: Authoring CAD with AI
-description: 'brepjs-verify lets an AI agent author parametric CAD in brepjs and prove it is correct — type-checked, measured against intent, and snapshot-reviewed — before handing off STEP.'
+description: 'brepjs-verify lets an AI agent author parametric CAD in brepjs and check it against intent. It type-checks, measures dimensions, and renders snapshots before handing off STEP.'
 ---
 
 # Authoring CAD with AI
 
-Ask for a part in plain English. The agent writes it, runs it on a real CAD kernel, and proves it is correct before handing it back.
+Ask for a part in plain English. The agent writes it, runs it on a CAD kernel, and checks the result before handing it back.
 
 ```
    "a 40×20×10 mm bracket with two M4 holes"
                   │  agent writes bracket.brep.ts and runs
-                  ▼  it on a real OpenCascade kernel
+                  ▼  it on an OpenCascade kernel
    ────────────────────────────────────────────────────
    ✓ valid solid       ✓ volume ≈ 7,750 mm³ (within 1%)
    ✓ snapshots rendered    →  bracket.step ready to hand off
 ```
 
-An LLM can't see geometry. Code that reads correctly can still produce a solid that is broken, empty, or simply the wrong size — and the model has no way to notice. [`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) takes the guesswork out: the agent writes the part, runs it against a real kernel, and reads back what the kernel actually measured instead of judging the code by eye.
+An LLM can't see geometry. Code that reads correctly can still produce a solid that is broken, empty, or the wrong size, and the model has no way to notice. [`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) closes that gap: the agent writes the part, runs it against the kernel, and reads back what the kernel measured instead of judging the code by eye.
 
 ## What it checks
 
-Every part gets three independent verdicts, so a pass means more than "the code ran":
+Every part gets three independent verdicts:
 
-- **Validity** — is it a real manifold solid with positive volume? (the kernel's `validSolid` brand)
-- **Intent** — does it match the dimensions you asked for? (`measureVolume` / `measureArea` / bounds vs an `expected` block)
-- **Shape** — does it actually look like the request? (multi-view PNG snapshots, for the agent or you to review)
+- **Validity**: is it a manifold solid with positive volume? (the kernel's `validSolid` brand)
+- **Intent**: does it match the dimensions you asked for? (`measureVolume` / `measureArea` / bounds vs an `expected` block)
+- **Shape**: does it look like the request? (multi-view PNG snapshots, for the agent or you to review)
 
 STEP is the validated deliverable; GLB, STL, and snapshots are derived previews.
 
@@ -32,21 +32,21 @@ STEP is the validated deliverable; GLB, STL, and snapshots are derived previews.
 
 `brepjs-verify` is two parts that work together:
 
-- **The skill** teaches the agent the workflow — brief → author → verify → repair — and carries the API references and examples it learns from.
-- **The runtime** is the CLI the skill drives. It loads your part on a real kernel, checks validity, measures volume / area / bounds, renders snapshots, and exports STEP.
+- **The skill** teaches the agent the workflow (brief → author → verify → repair) and carries the API references and examples it draws on.
+- **The runtime** is the CLI the skill drives. It loads your part on a kernel, checks validity, measures volume / area / bounds, renders snapshots, and exports STEP.
 
-They install separately because Claude Code loads skills from plugins (a git marketplace), while the runtime has to live wherever your project's `brepjs` resolves. You install both once and never think about it again.
+They install separately because Claude Code loads skills from plugins (a git marketplace), while the runtime has to live wherever your project's `brepjs` resolves. You install both once.
 
 ### Install the skill (Claude Code plugin)
 
-The skill ships through the brepjs plugin marketplace — which is just this git repo. Add the marketplace once, then install the plugin:
+The skill ships through the brepjs plugin marketplace, which is this git repo. Add the marketplace once, then install the plugin:
 
 ```
 /plugin marketplace add andymai/brepjs
 /plugin install brepjs-verify@brepjs
 ```
 
-Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill — plugins aren't loaded from `node_modules`.
+Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill; plugins aren't loaded from `node_modules`.
 
 ### Install the runtime (npm)
 
@@ -56,7 +56,7 @@ Add the CLI to the project where you want parts verified:
 npm i -D brepjs-verify
 ```
 
-That's the whole install. `brepjs-verify` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory with nothing else set up. **In an existing brepjs project** it automatically prefers your locally installed `brepjs` and kernel (via a Node module-resolution hook), so your verified parts bind to the exact version you ship — no drift between what you verify and what you build.
+That's the whole install. `brepjs-verify` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory with nothing else set up. **In an existing brepjs project** it automatically prefers your locally installed `brepjs` and kernel (via a Node module-resolution hook), so your verified parts bind to the exact version you ship. There is no drift between what you verify and what you build.
 
 It runs **occt-wasm** as its only kernel, rather than the auto-detect fallback chain, so verification results are reproducible on one known engine.
 
@@ -79,7 +79,7 @@ import { box } from 'brepjs';
 export default () => box(40, 20, 10, { centered: true });
 ```
 
-Declare intent with an `expected` block and the CLI asserts it — so you prove the part is the _right_ part, not just a valid one:
+Declare intent with an `expected` block and the CLI asserts it, so you confirm the part is the _right_ part, not only a valid one:
 
 <!-- @no-test -->
 
@@ -109,13 +109,9 @@ npx -y brepjs-verify verify bracket/bracket.brep.ts --step bracket.step
 
 The command exits non-zero whenever the report is not `ok`, so it drops straight into CI or an agent loop.
 
-## Why I built this
-
-I write CAD as code, but I can't trust an agent to write it blind — and neither can the agent. Geometry that reads fine on the page is constantly wrong in ways only the kernel can see: a boolean that didn't overlap, a fillet that collapsed a face, a part that's valid but 3 mm too tall. So I gave the agent the one thing it was missing: a way to run the part, measure it, look at it, and find out the truth before claiming it's done. That loop is the whole idea — the rest is plumbing.
-
 ## Next steps
 
-- [The Verify Loop](./the-loop) — the author → verify → repair workflow and how to read the report
-- [CLI Reference](./cli) — every subcommand, flag, and exit code
-- [Examples](./examples) — the example gallery the skill learns from
-- [Eval & Scorecard](./eval) — how the skill measures itself and stays honest
+- [The Verify Loop](./the-loop): the author → verify → repair workflow and how to read the report
+- [CLI Reference](./cli): every subcommand, flag, and exit code
+- [Examples](./examples): the example gallery the skill draws on
+- [Eval & Scorecard](./eval): how the skill measures itself

--- a/apps/docs/agent/the-loop.md
+++ b/apps/docs/agent/the-loop.md
@@ -1,25 +1,25 @@
 ---
 title: The Verify Loop
-description: 'The author → verify → repair loop at the heart of brepjs-verify: declare intent, run the part on a real kernel, read the JSON report as the source of truth, and repair the smallest responsible section.'
+description: 'The author → verify → repair loop in brepjs-verify: declare intent, run the part on the kernel, read the JSON report as the source of truth, and repair the smallest responsible section.'
 ---
 
 # The Verify Loop
 
-You write a `.brep.ts` part; the `brepjs-verify` CLI runs it against a real geometry kernel and tells you the truth. **Never judge a part by how the code reads — judge it by the report.** This loop is the whole job, whether you are the agent or the human driving it.
+You write a `.brep.ts` part; `brepjs-verify` runs it on a geometry kernel and reports what it measured. **Judge the part by the report, not by how the code reads.**
 
 ## The loop (every part, in order)
 
 1. **Brief.** Convert the request into explicit parameters: dimensions (mm), datums, features, assumptions.
 2. **Author `.brep.ts`.** `export default () => <shape>` using the short API (`box`, `cylinder`, `fuse`, `cut`, `fillet`, …), with named constants at the top. Scaffold with `brepjs-verify init <name>`. Edit _source_, never generated artifacts.
-3. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. The CLI asserts it — this is how you prove the part is the _right_ part, not just a valid one.
+3. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. The CLI asserts it, catching a part that is valid but wrong-sized.
 4. **Verify (type + geometry).** `brepjs-verify verify part.brep.ts --check --json report.json`. `--check` type-checks before running (catches wrong-API calls early); the JSON report is the source of truth. Iterate fast with `brepjs-verify watch part.brep.ts`.
-5. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs. Review against the brief. A visual concern is **not** a conclusion — convert it to a measurement ("hole looks off-center → check `bounds`").
+5. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs. Review against the brief. A visual concern is **not** a conclusion: convert it to a measurement ("hole looks off-center → check `bounds`").
 6. **Repair the smallest responsible section** and re-run. Use the report's `hints` to guide the fix.
 7. **Export + hand off.** `brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `brepjs-verify export part.brep.ts --all`. Report the STEP path.
 
 The commands above assume you've installed the package (`npm i -D brepjs-verify`) and call `brepjs-verify` directly. Otherwise prefix every command with `npx -y` to run it straight from npm.
 
-## Reading the report (this is the source of truth)
+## Reading the report
 
 Every command writes a single JSON document to stdout (diagnostics go to stderr):
 
@@ -40,13 +40,13 @@ Every command writes a single JSON document to stdout (diagnostics go to stderr)
 ```
 
 - **`ok`** is the verdict. `false` → not done. With an `expected` block, `ok` also requires every assertion to pass.
-- **`checks`** = kernel validity (manifold solid, positive volume). A failed check means the geometry is _broken_, not just wrong-sized.
+- **`checks`** = kernel validity (manifold solid, positive volume). A failed check means the geometry is _broken_, not wrong-sized.
 - **`measurements`** = the kernel's measured volume / area / bounding box.
 - **`assertions`** = your declared intent vs reality. A failed assertion means _valid-but-wrong_ (off dimensions).
 - **`hints`** = an actionable fix + next step keyed on the error code. Read these before guessing.
-- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from — authoring, kernel, or export errors. Cite the `code` when repairing.
+- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from (authoring, kernel, or export errors). Cite the `code` when repairing.
 
-Trust this JSON over the rendered image. The render confirms _shape_; the JSON confirms _correctness_.
+Trust the JSON over the render. The render shows shape; the JSON shows dimensions and validity.
 
 ## Repair discipline
 
@@ -55,20 +55,20 @@ Trust this JSON over the rendered image. The render confirms _shape_; the JSON c
   - `INVALID_FILLET_RADIUS` → reduce the radius relative to the local edge length.
   - `*_NOT_3D` → you passed a 2D shape to a 3D operation.
   - `BOOLEAN_HAS_ERRORS` → the inputs are overlap-degenerate.
-- A part that _runs_ but reports `ok: false` is wrong, not done — same as a crash.
+- A part that _runs_ but reports `ok: false` is wrong, not done. Treat it like a crash.
 
 ## What's reliable, what needs care
 
 - **Reliable first-try:** primitives, booleans (`fuse`/`cut`/`intersect`), 2D sketch → extrude, `fillet`/`chamfer`, `shell`/`offset`, transforms. Prefer these.
-- **Advanced — verify extra carefully, expect iteration:** sweeps, lofts, revolves, multi-section, assemblies, text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and take small steps.
+- **Advanced (verify carefully, expect iteration):** sweeps, lofts, revolves, multi-section, assemblies, text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and take small steps.
 
 ## Hard rules
 
 - Edit source, not artifacts. STEP/STL/GLB derive from the `.brep.ts`.
-- Booleans and `measureVolume`/`measureArea` return `Result` — unwrap and check the `Err` branch before chaining.
+- Booleans and `measureVolume`/`measureArea` return `Result`: unwrap and check the `Err` branch before chaining.
 - `fillet`/`chamfer` need a valid solid; the signature is `fillet(solid, edges, radius)`. Verify validity first.
 - `box(width, depth, height)`: the 2nd arg is depth (Y), the 3rd is height (Z); the positioning option is `at`, not `origin`. Units are mm.
-- Author parts in an ESM context so the kernel loads — a CommonJS project needs `"type": "module"` or a `.mts` file.
+- Author parts in an ESM context so the kernel loads. A CommonJS project needs `"type": "module"` or a `.mts` file.
 
 ## Programmatic use
 
@@ -83,10 +83,10 @@ const { shape, report, step } = await runPart('part.brep.ts', { step: true, chec
 console.log(serializeReport(report)); // { ok, shapeType, checks, measurements, assertions, hints, errorInfos, errors }
 ```
 
-`report.shape` is a live WASM-backed handle — release it (`using` / a `DisposalScope`) in long-running callers.
+`report.shape` is a live WASM-backed handle. Release it (`using` / a `DisposalScope`) in long-running callers.
 
 ## Next steps
 
-- [CLI Reference](./cli) — every subcommand and flag
-- [Examples](./examples) — the few-shot gallery
-- [Troubleshooting](./cli#troubleshooting) — ESM, snapshots, kernel
+- [CLI Reference](./cli): every subcommand and flag
+- [Examples](./examples): the few-shot gallery
+- [Troubleshooting](./cli#troubleshooting): ESM, snapshots, kernel

--- a/packages/brepjs-verify/skill/SKILL.md
+++ b/packages/brepjs-verify/skill/SKILL.md
@@ -1,24 +1,24 @@
 ---
 name: brepjs-verify
-description: Use when authoring or editing parametric 3D CAD models in TypeScript with the brepjs library — turning natural-language part requirements into solids, then type-checking, verifying deterministically (validity + volume/area/bounds vs intent), and visually (multi-view snapshots) before handing off STEP/GLB artifacts.
+description: Use when authoring or editing parametric 3D CAD models in TypeScript with the brepjs library: turn natural-language part requirements into solids, then type-check, verify deterministically (validity + volume/area/bounds vs intent), and verify visually (multi-view snapshots) before handing off STEP/GLB artifacts.
 ---
 
 # Authoring CAD with brepjs
 
-You write a `.brep.ts` part; the `brepjs-verify` CLI runs it against a real geometry kernel and tells you the truth. Never judge a part by how the code reads — judge it by the report. The loop below is the job.
+You write a `.brep.ts` part; the `brepjs-verify` CLI runs it on a geometry kernel and reports what it measured. Judge the part by the report, not by how the code reads. Follow the loop below for every part.
 
 Commands below use `npx -y brepjs-verify`; if you've installed the package, drop the `npx -y` and call `brepjs-verify` directly.
 
 ## The loop (every part, in order)
 
 1. **Brief.** Convert the request to explicit params: dimensions (mm), datums, features, assumptions. Don't ask the user for JSON.
-2. **Load only the reference you need** (index below) — not all at once.
-3. **Author `.brep.ts`** — `export default () => <shape>` with the short API (`box`, `cylinder`, `fuse`, `cut`, `fillet`, …), named consts at the top. Scaffold with `npx -y brepjs-verify init <name>`. Edit _source_, never generated artifacts.
-4. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. Bounds shape is exactly `bounds: { xMin, xMax, yMin, yMax, zMin, zMax }` (declare any subset) — **not** `{ min, max }` or `{ x, y, z }` (a wrong shape is reported as `EXPECTED_UNKNOWN_KEY`, not silently ignored). The CLI asserts it — this is how you prove the part is the _right_ part, not just a valid one. **Prefer `bounds`** (read straight off your datums/params) over a hand-computed `volume`: multi-feature volume arithmetic is easy to get wrong, and a wrong number fails a _correct_ part. To assert volume, run once and copy the report's measured value.
+2. **Load only the reference you need** (index below), not all at once.
+3. **Author `.brep.ts`**: `export default () => <shape>` with the short API (`box`, `cylinder`, `fuse`, `cut`, `fillet`, …), named consts at the top. Scaffold with `npx -y brepjs-verify init <name>`. Edit _source_, never generated artifacts.
+4. **Declare intent.** Add an `expected` block from your brief, e.g. `export const expected = { volume: 24000, tolerancePct: 1 }`. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. Bounds shape is exactly `bounds: { xMin, xMax, yMin, yMax, zMin, zMax }` (declare any subset), **not** `{ min, max }` or `{ x, y, z }` (a wrong shape is reported as `EXPECTED_UNKNOWN_KEY`, not silently ignored). The CLI asserts it, catching a part that is valid but wrong-sized. **Prefer `bounds`** (read straight off your datums/params) over a hand-computed `volume`: multi-feature volume arithmetic is easy to get wrong, and a wrong number fails a _correct_ part. To assert volume, run once and copy the report's measured value.
 5. **Verify (type + geometry).** `npx -y brepjs-verify verify part.brep.ts --check --json report.json`. `--check` type-checks before running (catches wrong-API calls early); the JSON report is the source of truth. Iterate fast with `npx -y brepjs-verify watch part.brep.ts`.
-6. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs — each has the bbox size (`W × D × H`) burned in, so you can read scale from the image. Review against the brief. A visual concern is **not** a conclusion — convert it to a measurement ("hole looks off-center → check `bounds`"). Don't declare done without a snapshot.
+6. **Verify visually.** Add `--snapshot shots/` for iso/front/top/right PNGs; each has the bbox size (`W × D × H`) burned in, so you can read scale from the image. Review against the brief. A visual concern is **not** a conclusion: convert it to a measurement ("hole looks off-center → check `bounds`"). Don't declare done without a snapshot.
 7. **Repair the smallest responsible section** and re-run. Use the report's `hints` to guide the fix.
-8. **Export + hand off.** `npx -y brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `npx -y brepjs-verify export part.brep.ts --all`. `--serve` prints a clickable link to an interactive inspector (view presets, solid/wire/x-ray, face picking, section plane, measurements panel) for the human to eyeball — report that URL. In an interactive terminal it also opens the browser; under agent/CI runs (non-TTY) auto-open is suppressed automatically, so you normally don't need `--no-open` (pass it to be explicit). Report the STEP path.
+8. **Export + hand off.** `npx -y brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `npx -y brepjs-verify export part.brep.ts --all`. `--serve` prints a clickable link to an interactive inspector (view presets, solid/wire/x-ray, face picking, section plane, measurements panel) for the human to eyeball; report that URL. In an interactive terminal it also opens the browser; under agent/CI runs (non-TTY) auto-open is suppressed automatically, so you normally don't need `--no-open` (pass it to be explicit). Report the STEP path.
 
 ## Reading the report (this is the source of truth)
 
@@ -38,34 +38,34 @@ Commands below use `npx -y brepjs-verify`; if you've installed the package, drop
 - **`checks`** = kernel validity (manifold solid, positive volume). A failed check means the geometry is broken, not just wrong-sized.
 - **`assertions`** = your declared intent vs reality. A failed assertion means valid-but-wrong (off dimensions).
 - **`hints`** = actionable fix + next step keyed on the error code. Read these before guessing.
-- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from — authoring, kernel, or export errors. Cite the `code` when repairing.
+- **`errorInfos`** = the raw structured failures (`code` + `message`) the hints derive from (authoring, kernel, or export errors). Cite the `code` when repairing.
 - Trust this JSON over the rendered image. The render confirms _shape_; the JSON confirms _correctness_.
 
 ## Repair discipline
 
 - Change the **smallest responsible section**, re-verify, repeat. Don't rewrite the whole part on one failure.
 - Let the `code`/`hints` localize the cause (e.g. `INVALID_FILLET_RADIUS` → reduce radius vs local edge length; `*_NOT_3D` → you passed a 2D shape to a 3D op; `BOOLEAN_HAS_ERRORS` → inputs overlap-degenerate).
-- A part that _runs_ but reports `ok:false` is wrong, not done — same as a crash.
+- A part that _runs_ but reports `ok:false` is wrong, not done. Treat it like a crash.
 
 ## Reliable scope (be honest)
 
-- **Reliable first-try:** primitives, booleans (`fuse`/`cut`/`intersect`), `compound` (group many bodies into an assembly — no boolean cost), 2D sketch → extrude, `fillet`/`chamfer`, `shell`/`offset`, transforms. Prefer these.
-- **Advanced — verify extra carefully, expect iteration:** sweeps, lofts, revolves, multi-section, welded assemblies (`fuseAll`), text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and small steps.
-- **Assemblies (furniture, kits, many parts):** reach for `compound([...])`, not `fuseAll` — faster, and each part stays distinct. Only `fuseAll` when you truly need one watertight solid (and use `{ unsafe: true }` over `Shape3D[]`). Color the GLB preview with `export const materials`. See `references/booleans.md`.
+- **Reliable first-try:** primitives, booleans (`fuse`/`cut`/`intersect`), `compound` (group many bodies into an assembly, no boolean cost), 2D sketch → extrude, `fillet`/`chamfer`, `shell`/`offset`, transforms. Prefer these.
+- **Advanced (verify carefully, expect iteration):** sweeps, lofts, revolves, multi-section, welded assemblies (`fuseAll`), text. They fail more often (degenerate profiles, self-intersection); lean harder on the report and small steps.
+- **Assemblies (furniture, kits, many parts):** reach for `compound([...])`, not `fuseAll`: faster, and each part stays distinct. Only `fuseAll` when you truly need one watertight solid (and use `{ unsafe: true }` over `Shape3D[]`). Color the GLB preview with `export const materials`. See `references/booleans.md`.
 
 ## Hard rules
 
 - Edit source, not artifacts. STEP/STL/GLB derive from the `.brep.ts`.
-- Booleans and `measureVolume`/`measureArea` return `Result` — unwrap and check the `Err` branch before chaining.
+- Booleans and `measureVolume`/`measureArea` return `Result`: unwrap and check the `Err` branch before chaining.
 - `fillet`/`chamfer` need a valid solid (its signature is `fillet(solid, edges, radius)`). Verify validity first.
-- **Select edges/faces — don't fillet/chamfer everything.** `fillet(solid, radius)` (no edge list) rounds EVERY edge and frequently fails (`FILLET_FAILED`). Pass an edge list: `edgeFinder().inDirection('Z').findAll(solid)`. Note `inDirection` matches BOTH ± orientations — discriminate a single face/edge by position with `.when(f => getBounds(f).zMax > t)`. (See `references/modifiers.md`.)
-- **`revolve` angle is in RADIANS** (full turn = `Math.PI * 2`, not `360`). Build a revolve profile with `polygon(points3D)`, not `draw().close().sketchOnPlane('XZ').face()` — the latter fails `--check` (`sketchOnPlane` is typed `SketchInterface | Sketches` and `.face()` isn't on both). (See `references/sketching-2d.md`.)
+- **Select edges/faces; don't fillet/chamfer everything.** `fillet(solid, radius)` (no edge list) rounds EVERY edge and frequently fails (`FILLET_FAILED`). Pass an edge list: `edgeFinder().inDirection('Z').findAll(solid)`. Note `inDirection` matches BOTH ± orientations; discriminate a single face/edge by position with `.when(f => getBounds(f).zMax > t)`. (See `references/modifiers.md`.)
+- **`revolve` angle is in RADIANS** (full turn = `Math.PI * 2`, not `360`). Build a revolve profile with `polygon(points3D)`, not `draw().close().sketchOnPlane('XZ').face()`: the latter fails `--check` (`sketchOnPlane` is typed `SketchInterface | Sketches` and `.face()` isn't on both). (See `references/sketching-2d.md`.)
 - `box(width, depth, height)`: 2nd arg is depth (Y), 3rd is height (Z); positioning option is `at`, not `origin`. Units mm.
-- **Parts may be `async`** — `export default async () => {…}` is awaited, so you can `await loadFont(...)` (required before any `sketchText`/`drawText`) or `await importSTEP(...)` inside. `--check` type-checks Node built-ins, so a part may `import { readFile } from 'node:fs/promises'` to load a font/STEP file from disk.
-- **Pattern angles are DEGREES** (`circularPattern`/`rectangularPattern` `fullAngle`, default 360) — _unlike_ `revolve` (radians). brepjs is not uniform; check the unit per op.
-- Author parts in an ESM context (the tool's default) so the kernel loads — a CommonJS project needs `"type": "module"` or a `.mts` file.
+- **Parts may be `async`**: `export default async () => {…}` is awaited, so you can `await loadFont(...)` (required before any `sketchText`/`drawText`) or `await importSTEP(...)` inside. `--check` type-checks Node built-ins, so a part may `import { readFile } from 'node:fs/promises'` to load a font/STEP file from disk.
+- **Pattern angles are DEGREES** (`circularPattern`/`rectangularPattern` `fullAngle`, default 360), _unlike_ `revolve` (radians). brepjs is not uniform; check the unit per op.
+- Author parts in an ESM context (the tool's default) so the kernel loads. A CommonJS project needs `"type": "module"` or a `.mts` file.
 
-## Reference index (progressive — load only what the task needs)
+## Reference index (progressive: load only what the task needs)
 
 - Getting started + kernel init → `references/getting-started.md`
 - Primitives → `references/primitives.md`
@@ -76,9 +76,9 @@ Commands below use `npx -y brepjs-verify`; if you've installed the package, drop
 - Measurement + the verify loop → `references/measurement-validation.md`
 - Export formats → `references/export.md`
 
-**Full API reference (backstop):** for any symbol, signature, or option not covered by the curated references above, consult brepjs's complete `llms-full.txt` — every export with signatures and examples. It ships bundled in the package at `reference/llms-full.txt`, and is online at <https://github.com/andymai/brepjs/blob/main/llms-full.txt>. Reach for it before guessing an API; the curated references are a fast path, not the whole surface.
+**Full API reference (backstop):** for any symbol, signature, or option not covered by the curated references above, consult brepjs's complete `llms-full.txt`, which lists every export with signatures and examples. It ships bundled in the package at `reference/llms-full.txt`, and is online at <https://github.com/andymai/brepjs/blob/main/llms-full.txt>. Reach for it before guessing an API; the curated references are a fast path, not the whole surface.
 
-## Examples index (few-shot — read the closest one before authoring)
+## Examples index (few-shot: read the closest one before authoring)
 
 Each is a complete `skill/examples/<name>.brep.ts` with a sibling `<name>.expected.json` baseline (replayed by the `eval` harness).
 
@@ -89,9 +89,9 @@ Each is a complete `skill/examples/<name>.brep.ts` with a sibling `<name>.expect
 
 ## CLI subcommands (the `brepjs-verify` bin)
 
-- `verify <file>` (default) — report; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`, `--no-open` (with `--serve`, never auto-open the browser).
-- `init <name>` — scaffold `<name>.brep.ts` + `tsconfig.json`.
-- `watch <file>` — re-verify on every save.
-- `export <file>` — batch STEP/GLB/STL behind a validity gate (`--step`/`--glb`/`--stl`/`--all`).
-- `measure <a> [b]` — measurements for one part, or distance between two.
-- `diff <a> <b>` — compare two parts' measurements.
+- `verify <file>` (default): report; flags `--check`, `--json`, `--step`, `--glb`, `--snapshot <dir>`, `--serve`, `--no-open` (with `--serve`, never auto-open the browser).
+- `init <name>`: scaffold `<name>.brep.ts` + `tsconfig.json`.
+- `watch <file>`: re-verify on every save.
+- `export <file>`: batch STEP/GLB/STL behind a validity gate (`--step`/`--glb`/`--stl`/`--all`).
+- `measure <a> [b]`: measurements for one part, or distance between two.
+- `diff <a> <b>`: compare two parts' measurements.

--- a/packages/brepjs-verify/skill/SKILL.md
+++ b/packages/brepjs-verify/skill/SKILL.md
@@ -20,7 +20,7 @@ Commands below use `npx -y brepjs-verify`; if you've installed the package, drop
 7. **Repair the smallest responsible section** and re-run. Use the report's `hints` to guide the fix.
 8. **Export + hand off.** `npx -y brepjs-verify verify part.brep.ts --step part.step` (STEP is the validated primary deliverable; GLB/STL are derived). Batch behind a validity gate with `npx -y brepjs-verify export part.brep.ts --all`. `--serve` prints a clickable link to an interactive inspector (view presets, solid/wire/x-ray, face picking, section plane, measurements panel) for the human to eyeball; report that URL. In an interactive terminal it also opens the browser; under agent/CI runs (non-TTY) auto-open is suppressed automatically, so you normally don't need `--no-open` (pass it to be explicit). Report the STEP path.
 
-## Reading the report (this is the source of truth)
+## Reading the report
 
 ```jsonc
 {

--- a/packages/brepjs-verify/skill/references/booleans.md
+++ b/packages/brepjs-verify/skill/references/booleans.md
@@ -1,6 +1,6 @@
 # Booleans
 
-Combine solids with CSG. All three return `Result<T>` — unwrap or thread the result through to the default export.
+Combine solids with CSG. All three return `Result<T>`; unwrap or thread the result through to the default export.
 
 | Function    | Signature         | Meaning              |
 | ----------- | ----------------- | -------------------- |
@@ -14,17 +14,17 @@ import { box, cylinder, cut } from 'brepjs';
 export default () => {
   const body = box(40, 20, 10, { centered: true });
   const bore = cylinder(4, 12, { at: [0, 0, -6] });
-  return cut(body, bore); // Result<Solid> — fine to return directly
+  return cut(body, bore); // Result<Solid>, fine to return directly
 };
 ```
 
 ## Many bodies: `fuseAll` vs `compound`
 
-- `fuseAll(solids)` welds N solids into ONE watertight solid — but it runs N−1 boolean ops, so it is slow for large N and can time out STEP export on dozens of bodies. Use it only when you genuinely need a single manifold solid. Over mixed `Shape3D[]` (e.g. results of `cut`) the typed overload needs `fuseAll(shapes, { unsafe: true })`.
-- `compound(shapes)` groups bodies into one shape with ZERO boolean cost (returns a `Compound`, not a `Result`). This is the right tool for **assemblies** — furniture, kits, anything that is naturally many distinct parts. STEP/GLB store the assembly tree natively, and each part stays addressable.
+- `fuseAll(solids)` welds N solids into ONE watertight solid, but it runs N−1 boolean ops, so it is slow for large N and can time out STEP export on dozens of bodies. Use it only when you genuinely need a single manifold solid. Over mixed `Shape3D[]` (e.g. results of `cut`) the typed overload needs `fuseAll(shapes, { unsafe: true })`.
+- `compound(shapes)` groups bodies into one shape with ZERO boolean cost (returns a `Compound`, not a `Result`). This is the right tool for **assemblies**: furniture, kits, anything that is naturally many distinct parts. STEP/GLB store the assembly tree natively, and each part stays addressable.
 
 ```ts
-// assembly.brep.ts — 50 slats + posts + legs, no booleans
+// assembly.brep.ts: 50 slats + posts + legs, no booleans
 import { box, compound } from 'brepjs';
 export default () => compound([...posts, ...slats, ...legs]); // Compound, fast
 ```
@@ -33,7 +33,7 @@ Rule of thumb: need one solid (for a downstream fillet/shell, or a watertight pr
 
 ## Coloring an assembly (GLB preview)
 
-A part may `export const materials` to paint its GLB preview (STEP stays geometry-only). It is a per-face selector run at export — return a material per face, or `undefined` for the default:
+A part may `export const materials` to paint its GLB preview (STEP stays geometry-only). It is a per-face selector run at export: return a material per face, or `undefined` for the default:
 
 ```ts
 import type { MaterialFn } from 'brepjs';
@@ -48,6 +48,6 @@ A plain `GltfMaterial` object (not a function) paints the whole part one color. 
 ## Pitfalls
 
 - Returning a `Result` from the default export is supported; the verifier unwraps it and reports an `Err`.
-- Booleans on touching-but-not-overlapping solids can yield empty/invalid results — give operands a small overlap. (A `compound` does NOT need overlap — bodies stay distinct.)
+- Booleans on touching-but-not-overlapping solids can yield empty/invalid results; give operands a small overlap. (A `compound` does NOT need overlap; bodies stay distinct.)
 
 See also: docs/function-lookup.md → brepjs/topology.

--- a/packages/brepjs-verify/skill/references/export.md
+++ b/packages/brepjs-verify/skill/references/export.md
@@ -1,6 +1,6 @@
 # Export
 
-STEP is the canonical, lossless output — the source of truth. Mesh formats (STL/3MF/GLB) are **derived sidecars** for preview/printing, never the authoritative artifact.
+STEP is the canonical, lossless output, the source of truth. Mesh formats (STL/3MF/GLB) are **derived sidecars** for preview/printing, never the authoritative artifact.
 
 | Function     | Signature                                     | Role              |
 | ------------ | --------------------------------------------- | ----------------- |
@@ -10,11 +10,11 @@ STEP is the canonical, lossless output — the source of truth. Mesh formats (ST
 
 GLB/3MF sidecars are emitted by the verify CLI (`--glb`), not authored in the model.
 
-The GLB sidecar is **Y-up** (glTF's required convention) via a root-node rotation, so it opens upright in three.js, model-viewer, Blender, etc. Vertices remain Z-up, matching the STEP/STL. To paint the GLB, a part may `export const materials` (a per-face `MaterialFn`, or one `GltfMaterial` for the whole part) — see `references/booleans.md` → "Coloring an assembly".
+The GLB sidecar is **Y-up** (glTF's required convention) via a root-node rotation, so it opens upright in three.js, model-viewer, Blender, etc. Vertices remain Z-up, matching the STEP/STL. To paint the GLB, a part may `export const materials` (a per-face `MaterialFn`, or one `GltfMaterial` for the whole part); see `references/booleans.md` → "Coloring an assembly".
 
 ## Importing + modifying
 
-`importSTEP(blob)` is **async** and takes a **`Blob`** (not a path or `ArrayBuffer`): `importSTEP(blob): Promise<Result<AnyShape>>`. Read the file bytes yourself, wrap them, and `await` — so the part's default export must be `async`. The result is an `AnyShape`; narrow it before a 3D op like `fillet` (which needs a `ValidSolid`).
+`importSTEP(blob)` is **async** and takes a **`Blob`** (not a path or `ArrayBuffer`): `importSTEP(blob): Promise<Result<AnyShape>>`. Read the file bytes yourself, wrap them, and `await`, so the part's default export must be `async`. The result is an `AnyShape`; narrow it before a 3D op like `fillet` (which needs a `ValidSolid`).
 
 ```ts
 import { readFile } from 'node:fs/promises';
@@ -24,7 +24,7 @@ export default async () => {
   const bytes = await readFile('input.step');
   const imported = unwrap(await importSTEP(new Blob([bytes])));
   if (!isSolid(imported)) throw new Error('expected a solid from the STEP file');
-  const valid = validSolid(imported); // Result<ValidSolid, string> — use isOk/unwrap, NOT .valid
+  const valid = validSolid(imported); // Result<ValidSolid, string>: use isOk/unwrap, NOT .valid
   if (!isOk(valid)) throw new Error(valid.error);
   return unwrap(fillet(valid.value, getEdges(valid.value), 2));
 };
@@ -42,6 +42,6 @@ npx -y brepjs-verify model.brep.ts --step out/model.step --glb out/model.glb
 ## Pitfalls
 
 - Prefer STEP downstream; meshes lose exact surfaces and are tessellation-dependent.
-- All exporters return `Result<Blob>` — check for `Err` before writing.
+- All exporters return `Result<Blob>`; check for `Err` before writing.
 
 See also: docs/function-lookup.md → brepjs/io.

--- a/packages/brepjs-verify/skill/references/getting-started.md
+++ b/packages/brepjs-verify/skill/references/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-A brepjs model is a `.brep.ts` module with a default export — a zero-arg function returning a shape (or `Result<shape>`). The verifier imports the module, calls the default export, and runs deterministic checks on the result.
+A brepjs model is a `.brep.ts` module with a default export: a zero-arg function returning a shape (or `Result<shape>`). The verifier imports the module, calls the default export, and runs deterministic checks on the result.
 
 ## The contract
 
@@ -10,7 +10,7 @@ A brepjs model is a `.brep.ts` module with a default export — a zero-arg funct
 | Result-wrapped | `export default () => Result<Solid>`                            |
 | Async setup    | `export default async () => Solid` (kernel already initialized) |
 
-The verifier handles kernel init — never call `initFromOC` yourself in a model.
+The verifier handles kernel init; never call `initFromOC` yourself in a model.
 
 ## Minimal model
 
@@ -30,7 +30,7 @@ Add `--snapshot ./out` for PNGs (with the bbox size burned into each), `--step .
 
 ## Pitfalls
 
-- The default export must be a **function**, not a shape value — the verifier calls it. `export default box(...)` fails.
+- The default export must be a **function**, not a shape value; the verifier calls it. `export default box(...)` fails.
 - Import from the package root `'brepjs'`, not deep paths.
 
 See also: docs/function-lookup.md → full symbol index.

--- a/packages/brepjs-verify/skill/references/measurement-validation.md
+++ b/packages/brepjs-verify/skill/references/measurement-validation.md
@@ -1,6 +1,6 @@
 # Measurement & validation
 
-Deterministic checks are the source of truth — PNGs and previews are only for human spot-checks.
+Deterministic checks are the source of truth; PNGs and previews are only for human spot-checks.
 
 | Function          | Signature                  | Returns                      |
 | ----------------- | -------------------------- | ---------------------------- |
@@ -19,16 +19,16 @@ measureVolume(box(2, 3, 4)); // ok(24)
 
 ## The verify loop
 
-1. `npx -y brepjs-verify model.brep.ts` runs the model + deterministic checks (volume, bounds, validity) — these decide pass/fail.
+1. `npx -y brepjs-verify model.brep.ts` runs the model + deterministic checks (volume, bounds, validity); these decide pass/fail.
 2. `--json out.json` emits machine-readable measurements to diff between iterations; `measure`/`diff` subcommands compare distances and before/after parts.
-3. `--snapshot ./out` writes iso/front/top/right PNGs for a visual sanity pass. Each PNG has the bounding-box size (`W × D × H`) burned into the corner, so you can read scale straight from the image — but still confirm exact dimensions against `bounds` in the report.
+3. `--snapshot ./out` writes iso/front/top/right PNGs for a visual sanity pass. Each PNG has the bounding-box size (`W × D × H`) burned into the corner, so you can read scale straight from the image, but still confirm exact dimensions against `bounds` in the report.
 4. `--serve` opens a clickable, directory-rooted preview rendering the real STEP geometry. It's an interactive inspector (for the human reviewing the link): view presets + zoom-to-fit, solid/wireframe/x-ray, edge & grid toggles, turntable, ortho/perspective, click-a-face to read its surface type + area, a movable section/clipping plane to inspect internal features, a measurements panel (size · volume · area · validity), and an in-browser screenshot.
 
 Trust the deterministic numbers; treat snapshots/serve as confirmation, not proof.
 
 ## Pitfalls
 
-- `measureVolume` returns a `Result` — unwrap before comparing to a number.
+- `measureVolume` returns a `Result`; unwrap before comparing to a number.
 - `getBounds` returns flat `xMin/xMax/...` fields, not min/max vectors.
 
 See also: docs/function-lookup.md → brepjs/measurement.

--- a/packages/brepjs-verify/skill/references/modifiers.md
+++ b/packages/brepjs-verify/skill/references/modifiers.md
@@ -18,7 +18,7 @@ export default () => fillet(box(40, 20, 10, { centered: true }), 2);
 
 ## Selecting which edges / faces
 
-The no-edge-list forms `fillet(solid, radius)` / `chamfer(solid, distance)` round **every** edge, and `shell` needs the specific faces to open. Pick them with a finder, not by guessing — `findAll(solid)` returns the array these functions expect:
+The no-edge-list forms `fillet(solid, radius)` / `chamfer(solid, distance)` round **every** edge, and `shell` needs the specific faces to open. Pick them with a finder, not by guessing: `findAll(solid)` returns the array these functions expect:
 
 ```ts
 import { box, fillet, shell, edgeFinder, faceFinder, getBounds, unwrap } from 'brepjs';
@@ -40,9 +40,9 @@ Finder vocabulary: `edgeFinder()` / `faceFinder()` then `.inDirection(dir)`, `.o
 
 ## Pitfalls
 
-- **`fillet(solid, radius)` rounds ALL edges and often fails** — a uniform radius rarely fits every edge (e.g. it can't exceed a thin wall). Select the edges you mean with `edgeFinder()`. A failed fillet/chamfer surfaces as `FILLET_FAILED` / `CHAMFER_FAILED`.
-- **`inDirection('Z')` matches BOTH orientations** (+Z and −Z) — it tests the axis, not the sign. To single out one face/edge add `.when(f => getBounds(f).zMax > threshold)` or `.atDistance(...)`.
-- A radius/distance larger than the local geometry makes the kernel fail — keep it well below the smallest adjacent edge length.
+- **`fillet(solid, radius)` rounds ALL edges and often fails:** a uniform radius rarely fits every edge (e.g. it can't exceed a thin wall). Select the edges you mean with `edgeFinder()`. A failed fillet/chamfer surfaces as `FILLET_FAILED` / `CHAMFER_FAILED`.
+- **`inDirection('Z')` matches BOTH orientations** (+Z and −Z): it tests the axis, not the sign. To single out one face/edge add `.when(f => getBounds(f).zMax > threshold)` or `.atDistance(...)`.
+- A radius/distance larger than the local geometry makes the kernel fail; keep it well below the smallest adjacent edge length.
 - `fillet`/`chamfer` only accept a `ValidSolid`; wrap a post-boolean shape with `validSolid(...)` before filleting.
 
 See also: docs/function-lookup.md → brepjs/topology.

--- a/packages/brepjs-verify/skill/references/sketching-2d.md
+++ b/packages/brepjs-verify/skill/references/sketching-2d.md
@@ -29,7 +29,7 @@ export default () => {
 `revolve(face, { axis, at, angle })` spins a planar face around an axis into a solid. Draw the cross-section in the **XZ plane (x = radius, z = height)** and revolve about Z.
 
 ```ts
-// pulley.brep.ts — type-clean revolve
+// pulley.brep.ts: type-clean revolve
 import { polygon, revolve, unwrap } from 'brepjs';
 export default () => {
   // Closed profile in XZ (y = 0): bore → rim → groove → rim → bore.
@@ -48,13 +48,13 @@ export default () => {
 };
 ```
 
-- **`angle` is in RADIANS**, not degrees — a full turn is `Math.PI * 2`. Passing `360` revolves 360 radians (≈57 turns).
+- **`angle` is in RADIANS**, not degrees: a full turn is `Math.PI * 2`. Passing `360` revolves 360 radians (≈57 turns).
 - Build the revolve profile with **`polygon(points3D)`** (a typed `OrientedFace`). The tempting `draw(...).close().sketchOnPlane('XZ').face()` path **fails `--check`**: `sketchOnPlane()` is typed `SketchInterface | Sketches`, and `.face()` / `.sweepSketch()` exist only on the single-profile `SketchInterface`, so `tsc` rejects them even though they work at runtime for a single profile.
 
 ## Pitfalls
 
-- A `Drawing` is purely 2D — you must `.sketchOnPlane(...)` before `.extrude`.
-- `.sketchOnPlane(...)` returns `SketchInterface | Sketches`. `.extrude(...)` works on the union, but `.face()` / `.sweepSketch()` do not — for a single profile that needs a face (revolve), use `polygon(points3D)` instead (see above) to stay `--check`-clean.
+- A `Drawing` is purely 2D; you must `.sketchOnPlane(...)` before `.extrude`.
+- `.sketchOnPlane(...)` returns `SketchInterface | Sketches`. `.extrude(...)` works on the union, but `.face()` / `.sweepSketch()` do not; for a single profile that needs a face (revolve), use `polygon(points3D)` instead (see above) to stay `--check`-clean.
 - Low-level `circle`/`ellipse`/`line` (primitives) return **edges**, not faces; use the `draw*` factories when you need a closed profile to extrude.
 
 See also: docs/function-lookup.md → brepjs/sketching.


### PR DESCRIPTION
Removes AI-writing tells from the recently-added brepjs-verify docs and skill, per a thorough per-file audit.

## What changed
- **Em dashes removed** everywhere in the verify docs and skill (hard style rule). Replaced with colons, commas, parentheses, or sentence splits.
- **Dropped the "Why I built this" section** in `overview.md` (low-value).
- **Cut marketing flourishes and grand closers:** "prove it is correct", "tells you the truth", "takes the guesswork out", "the whole job/idea", "never think about it again", "keep the skill honest", "by a hair", and repeated "real kernel" used for emphasis.
- **Tightened prose** to plain, terse statements; removed filler ("simply", "just", "this is how you...").

## Files
- `apps/docs/agent/{overview,the-loop,cli,eval,examples}.md`
- `.claude/skills/brepjs-verify/SKILL.md` and `references/{booleans,export,getting-started,measurement-validation,modifiers,sketching-2d}.md`

Functional content (CLI flags, the `expected` contract, the report schema, the reference/example indexes) is unchanged.