### PR TITLE
fix(verify): relax brepjs-viewer devDep to * so workspace links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13582,7 +13582,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^6.0.2",
-        "brepjs-viewer": "^0.1.0",
+        "brepjs-viewer": "*",
         "eslint": "^10.4.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -71,7 +71,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^6.0.2",
-    "brepjs-viewer": "^0.1.0",
+    "brepjs-viewer": "*",
     "eslint": "^10.4.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",


### PR DESCRIPTION
## Problem

The `Publish brepjs-verify` workflow failed at `npm ci`:
```
npm error Missing: brepjs-viewer@0.1.0 from lock file
```

`brepjs-viewer` was published to npm and bumped to **0.2.0** (release-please #1319), but `brepjs-verify` still pinned **`^0.1.0`** — which `0.2.0` no longer satisfies. npm therefore tried to resolve the devDep from the **registry** (`brepjs-viewer@0.1.0`) instead of linking the workspace, and `npm ci` failed because the lockfile records a workspace link, not a registry entry.

## Fix

Relax the range to `*`, matching `apps/playground` (the other in-repo viewer consumer). The workspace then always links regardless of viewer version bumps, so this can't recur on the next viewer release. Safe because `brepjs-verify` only uses the viewer at **build time** — it bundles `viewer/dist` and never ships `brepjs-viewer` as a runtime dependency.

Verified locally: `npm ci` passes. Diff is two one-line changes (package.json + matching lockfile spec); no other lockfile churn.

Unblocks publishing `brepjs-verify@0.8.0`.