### PR TITLE
docs: remove em dashes across all authored docs

### DIFF
--- a/.claude/commands/new-kernel-method.md
+++ b/.claude/commands/new-kernel-method.md
@@ -9,13 +9,13 @@ Add a new method to the kernel abstraction layer.
 
 1. **Add to interface** in `src/kernel/types.ts`
    - Use branded types for shape parameters, accept `OcShape` for raw handles
-   - Return `OcShape` or primitives — Layer 2 wraps in `Result`
+   - Return `OcShape` or primitives; Layer 2 wraps in `Result`
 2. **Implement in `*Ops.ts`**
    - Receives `oc` instance as parameter (not via `getKernel()`)
    - All kernel methods are synchronous
    - Handle OCCT enum values: `typeof val === 'number' ? val : Number(val?.value ?? val)`
-3. **Wire in `DefaultAdapter.ts`** — delegate to the `*Ops` function
-4. **Wire in `brepkitAdapter.ts`** — add a stub or implementation for the brepkit kernel (throw `not implemented` if the operation isn't supported yet)
-5. **Use in Layer 2+** via `getKernel().methodName()` — never import `*Ops` directly outside kernel
+3. **Wire in `DefaultAdapter.ts`**: delegate to the `*Ops` function
+4. **Wire in `brepkitAdapter.ts`**: add a stub or implementation for the brepkit kernel (throw `not implemented` if the operation isn't supported yet)
+5. **Use in Layer 2+** via `getKernel().methodName()`; never import `*Ops` directly outside kernel
 
 Tests go through Layer 2 functional API, not by testing `*Ops` directly.

--- a/.claude/commands/new-operation.md
+++ b/.claude/commands/new-operation.md
@@ -7,9 +7,9 @@ Add a new geometric operation to brepjs.
 3. Read an existing `*Fns.ts` in that module as a template (`src/topology/booleanFns.ts` is the canonical reference)
 4. Implement following the template pattern:
    - Validate inputs → `err(validationError(...))`
-   - Call `getKernel().method(shape.wrapped)` — never access `.wrapped` methods directly
+   - Call `getKernel().method(shape.wrapped)`; never access `.wrapped` methods directly
    - Cast with `castShape()`, verify with type guards
-   - Return `ok(shape)` or `err(...)` — never throw in Layer 2+
+   - Return `ok(shape)` or `err(...)`; never throw in Layer 2+
 5. Export from `src/<module>/index.ts`
 6. Re-export from `src/index.ts` and the relevant sub-path entry (e.g., `src/operations.ts`)
 7. Write tests in `tests/fn-<name>.test.ts` (see CLAUDE.md "Writing a test")

--- a/.claude/commands/tech-debt.md
+++ b/.claude/commands/tech-debt.md
@@ -1,6 +1,6 @@
 # Tech Debt Reduction
 
-You are working on this codebase to systematically reduce tech debt. Each session, pick **one item** from the GitHub issue backlog and complete it as a standalone PR. Work incrementally — ship small, safe changes.
+You are working on this codebase to systematically reduce tech debt. Each session, pick **one item** from the GitHub issue backlog and complete it as a standalone PR. Work incrementally; ship small, safe changes.
 
 ## Before Starting
 
@@ -39,7 +39,7 @@ You are working on this codebase to systematically reduce tech debt. Each sessio
 ### Refactoring large files/modules
 
 - Read the existing file completely before restructuring
-- Preserve the public interface exactly — external imports must not change
+- Preserve the public interface exactly; external imports must not change
 - Move code into submodules incrementally; verify the build after each move
 - Check that all consuming code still compiles without changes
 
@@ -53,7 +53,7 @@ You are working on this codebase to systematically reduce tech debt. Each sessio
 
 - Check the changelog for breaking changes before upgrading
 - Pin to a specific version in the PR; widen the range only after tests pass
-- Run the full test suite — not just affected tests — after dependency changes
+- Run the full test suite (not just affected tests) after dependency changes
 
 ---
 
@@ -71,8 +71,8 @@ When starting an item, assign yourself. When the PR merges, close the issue.
 
 ## Ground Rules
 
-- **One item per PR** — keep changes reviewable
-- **No behavioral changes** — tech debt PRs must not change functionality
-- **Tests must pass** — `npm run validate` is the minimum bar
-- **Coverage must not drop** — check `npm run test:full` thresholds
-- **Don't boil the ocean** — if an item is larger than expected, split it further
+- **One item per PR**: keep changes reviewable
+- **No behavioral changes**: tech debt PRs must not change functionality
+- **Tests must pass**: `npm run validate` is the minimum bar
+- **Coverage must not drop**: check `npm run test:full` thresholds
+- **Don't boil the ocean**: if an item is larger than expected, split it further

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ Web CAD library with a layered architecture and pluggable kernel abstraction lay
 
 Layered architecture with enforced boundaries (imports flow downward only):
 
-- **Layer 0** (`kernel/`, `utils/`): Foundation — no internal imports
-- **Layer 1** (`core/`): Memory management, geometry, constants — imports kernel/utils only
-- **Layer 2** (`topology/`, `operations/`, `2d/`, `query/`, `measurement/`, `io/`, `worker/`): Domain — imports layers 0-1 + each other
-- **Layer 3** (`sketching/`, `text/`, `projection/`): High-level API — imports all lower layers
+- **Layer 0** (`kernel/`, `utils/`): Foundation, no internal imports
+- **Layer 1** (`core/`): Memory management, geometry, constants, imports kernel/utils only
+- **Layer 2** (`topology/`, `operations/`, `2d/`, `query/`, `measurement/`, `io/`, `worker/`): Domain, imports layers 0-1 + each other
+- **Layer 3** (`sketching/`, `text/`, `projection/`): High-level API, imports all lower layers
 
 Boundaries enforced by `npm run check:boundaries` (runs in pre-commit and CI).
 
@@ -17,28 +17,28 @@ Boundaries enforced by `npm run check:boundaries` (runs in pre-commit and CI).
 
 Monorepo packages:
 
-- `brepjs` (root) — Core library (published)
-- `packages/brepjs-opencascade` — OpenCascade WASM build (published)
-- `packages/brepjs-bim` — IFC/BIM helpers (experimental, unpublished)
-- `packages/brepjs-manifold` — Manifold mesh/CSG preview kernel (experimental, unpublished)
-- `packages/brepjs-viewer` — Shared React/R3F renderer (consumed by the playground and brepjs-verify; not yet published)
-- `packages/brepjs-verify` — Agent skill + verify/preview CLI + WASM viewer (not yet published; skill ships via the repo Claude-plugin marketplace)
+- `brepjs` (root): Core library (published)
+- `packages/brepjs-opencascade`: OpenCascade WASM build (published)
+- `packages/brepjs-bim`: IFC/BIM helpers (experimental, unpublished)
+- `packages/brepjs-manifold`: Manifold mesh/CSG preview kernel (experimental, unpublished)
+- `packages/brepjs-viewer`: Shared React/R3F renderer (consumed by the playground and brepjs-verify; not yet published)
+- `packages/brepjs-verify`: Agent skill + verify/preview CLI + WASM viewer (not yet published; skill ships via the repo Claude-plugin marketplace)
 
 ## Commands
 
-- `npm run build` — Vite library build (ES + CJS)
-- `npm run typecheck` — TypeScript strict check
-- `npm run lint` / `npm run lint:fix` — ESLint
-- `npm run format` / `npm run format:check` — Prettier
-- `npm run test` — Vitest (changed files only, no coverage)
-- `npm run test:full` — Full test suite with coverage
-- `npm run check:boundaries` — Layer boundary enforcement
-- `npm run knip` — Unused code detection
-- `npm run check:patterns` — AST pattern checker (double-casts, async withKernel, missing `using`, long functions, deep nesting)
-- `npm run check:patterns:baseline` — Regenerate pattern baseline after fixing violations
-- `npm run validate` — typecheck + lint + boundaries + format + changed tests (in order)
-- `npx vitest run tests/booleanFns.test.ts` — Run a single test file
-- `npm run docs:generate-lookup` — Regenerate `docs/function-lookup.md`
+- `npm run build`: Vite library build (ES + CJS)
+- `npm run typecheck`: TypeScript strict check
+- `npm run lint` / `npm run lint:fix`: ESLint
+- `npm run format` / `npm run format:check`: Prettier
+- `npm run test`: Vitest (changed files only, no coverage)
+- `npm run test:full`: Full test suite with coverage
+- `npm run check:boundaries`: Layer boundary enforcement
+- `npm run knip`: Unused code detection
+- `npm run check:patterns`: AST pattern checker (double-casts, async withKernel, missing `using`, long functions, deep nesting)
+- `npm run check:patterns:baseline`: Regenerate pattern baseline after fixing violations
+- `npm run validate`: typecheck + lint + boundaries + format + changed tests (in order)
+- `npx vitest run tests/booleanFns.test.ts`: Run a single test file
+- `npm run docs:generate-lookup`: Regenerate `docs/function-lookup.md`
 
 ## Git hooks
 
@@ -50,15 +50,15 @@ Monorepo packages:
 
 - `getKernel()` from `src/kernel/index.ts` for all kernel operations; `initFromOC(oc)` must be called first
 - `registerKernel(id, adapter)` / `withKernel(id, fn)` for custom or dual kernel usage
-- `withKernel(id, fn)` is **sync-only** — async callbacks silently use the wrong kernel after the first `await`. Use `getKernel(id)` directly for async code.
-- **Layer 2+ code must never call methods on `.wrapped`** — always use `getKernel().method(shape.wrapped)`. ESLint enforces this.
-- Branded types (`Edge`, `Wire`, `Face`, `Solid`, etc.) in `src/core/shapeTypes.ts` — lightweight handles, no class hierarchy. Types carry a phantom `D extends Dimension` parameter for 2D/3D safety.
-- Validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`) in `src/core/shapeTypes.ts` — phantom types encoding topological invariants. Smart constructors (`closedWire()`, `orientedFace()`) prove validity at runtime; type guards (`isClosedWire()`, etc.) narrow in-place.
+- `withKernel(id, fn)` is **sync-only**: async callbacks silently use the wrong kernel after the first `await`. Use `getKernel(id)` directly for async code.
+- **Layer 2+ code must never call methods on `.wrapped`**: always use `getKernel().method(shape.wrapped)`. ESLint enforces this.
+- Branded types (`Edge`, `Wire`, `Face`, `Solid`, etc.) in `src/core/shapeTypes.ts`: lightweight handles, no class hierarchy. Types carry a phantom `D extends Dimension` parameter for 2D/3D safety.
+- Validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`) in `src/core/shapeTypes.ts`: phantom types encoding topological invariants. Smart constructors (`closedWire()`, `orientedFace()`) prove validity at runtime; type guards (`isClosedWire()`, etc.) narrow in-place.
 - **Default kernel: occt-wasm** (`OcctKernel.init()` + `OcctWasmAdapter.fromKernel`, external `occt-wasm` npm package). `init()` and `brepjs/quick` resolve it first, falling back to OpenCascade WASM (`initFromOC`, shipped via `brepjs-opencascade`) then brepkit WASM (`BrepkitAdapter`, external `brepkit-wasm`). The default test gate runs occt-wasm; run the others via `TEST_KERNEL` / `npm run test:occt` / `npm run test:brepkit`.
-- `createHandle()` / `createKernelHandle()` from `src/core/disposal.ts` — use `using` keyword for resource cleanup
-- Functional API in `*Fns.ts` files — pure functions taking/returning branded types; this is the canonical surface for all shape operations. There is no class hierarchy: `Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `CompSolid`, `Compound` are branded `ShapeHandle` types defined in `src/core/shapeTypes.ts`.
+- `createHandle()` / `createKernelHandle()` from `src/core/disposal.ts`: use `using` keyword for resource cleanup
+- Functional API in `*Fns.ts` files: pure functions taking/returning branded types; this is the canonical surface for all shape operations. There is no class hierarchy: `Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `CompSolid`, `Compound` are branded `ShapeHandle` types defined in `src/core/shapeTypes.ts`.
 - **New functionality goes in `*Fns.ts` files first**, then surfaces through `src/topology/api.ts` (short-named public functions accepting `Shapeable<T>`) and optionally through the fluent `shape()` facade in `src/topology/wrapperFns.ts` (chainable `Wrapped<T>` that throws on `Result.Err`). Don't add operations directly to `wrapperFns.ts` without an `*Fns.ts` implementation behind it.
-- `Result<T,E>` in `src/core/result.ts` — prefer over throwing in layers 2-3
+- `Result<T,E>` in `src/core/result.ts`: prefer over throwing in layers 2-3
 - All `.ts` imports must use `.js` extensions for ESM compatibility
 - Cross-directory imports use `@/` alias (e.g. `@/kernel/index.js`); same-directory imports stay relative (`./foo.js`)
 - File naming: camelCase everywhere (no PascalCase, no kebab-case)
@@ -67,7 +67,7 @@ Monorepo packages:
 
 ## Lint rules
 
-- No `any` — use `// eslint-disable-next-line @typescript-eslint/no-explicit-any -- [reason]` for WASM type gaps
+- No `any`: use `// eslint-disable-next-line @typescript-eslint/no-explicit-any -- [reason]` for WASM type gaps
 - No non-null assertions (`!`)
 - Consistent type imports (`import type` enforced)
 - No `var`, strict equality, `prefer-const`, `prefer-readonly`
@@ -82,7 +82,7 @@ Monorepo packages:
 - Tests in `/tests/`, setup in `tests/setup.ts` (WASM init)
 - Test naming: `<moduleName>.test.ts` (e.g. `shapeFns.test.ts`), `api*.test.ts` for public API
 - Vitest globals enabled, 30s timeout, forks pool, `--max-old-space-size=6144`
-- Coverage thresholds enforced — see `vitest.config.ts`
+- Coverage thresholds enforced; see `vitest.config.ts`
 
 ## Commits
 
@@ -95,7 +95,7 @@ Conventional Commits enforced: `type(scope): subject`
 1. File: extend existing `tests/<moduleName>.test.ts` or create new `tests/<name>.test.ts`
 2. Import from `@/index.js` (use `@/` alias for cross-directory imports, always `.js` extension)
 3. Add `beforeAll(async () => { await initOC(); }, 30000)` and import `initOC` from `./setup.js`
-4. Use `toBeCloseTo(expected, precision)` for geometry — never exact equality for floating point
+4. Use `toBeCloseTo(expected, precision)` for geometry; never exact equality for floating point
 5. Use `unwrap(result)` in tests; use `isOk()`/`match()` in production code
 6. Assert shape types with `isSolid()`, `isFace()`, `isWire()`, etc.
 7. Validate geometry with `measureVolume()`, `measureArea()`
@@ -104,10 +104,10 @@ For adding a new operation or kernel method, see `.claude/commands/`.
 
 ## Gotchas
 
-- OCCT Emscripten returns enum objects with `.value` — extract with: `typeof val === 'number' ? val : Number(val?.value ?? val)`
+- OCCT Emscripten returns enum objects with `.value`; extract with: `typeof val === 'number' ? val : Number(val?.value ?? val)`
 - `autoHeal` short-circuits valid shapes: `report.alreadyValid=true`, no sew/heal diagnostics run
 - Assembly solver composes constraints down a chain: each positioning mate reads the referenced part's _solved_ pose and resolves in topological order (a `fixed` node anchors the chain). `concentric`/`angle` and non-plane entity pairs are still unsupported (report `ASSEMBLY_NOT_CONVERGED`).
 - `Uint32Array` WASM interop: always convert to regular `Array` before passing to kernel methods
-- `DisposalScope` disposes in LIFO order — register dependencies after their dependees
-- `noUncheckedIndexedAccess` is enabled — array indexing returns `T | undefined`, add bounds checks or use `!` with eslint-disable
-- `exactOptionalPropertyTypes` is enabled — `undefined` and missing are distinct; use `prop?: T | undefined` in optional fields
+- `DisposalScope` disposes in LIFO order; register dependencies after their dependees
+- `noUncheckedIndexedAccess` is enabled: array indexing returns `T | undefined`, add bounds checks or use `!` with eslint-disable
+- `exactOptionalPropertyTypes` is enabled: `undefined` and missing are distinct; use `prop?: T | undefined` in optional fields

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ npm run docs:api            # build TypeDoc API reference
 npm run docs:generate-lookup # regenerate docs/function-lookup.md from sources
 ```
 
-When you add or modify a code block in a chapter, the doc-test harness picks it up automatically — every fenced ` ```typescript ` block becomes a test that runs against the OCCT kernel. Mark blocks with `<!-- @no-test -->` (immediately preceding) to opt out, or `<!-- @setup -->` for shared setup that's prepended to subsequent blocks in the same file.
+When you add or modify a code block in a chapter, the doc-test harness picks it up automatically. Every fenced ` ```typescript ` block becomes a test that runs against the OCCT kernel. Mark blocks with `<!-- @no-test -->` (immediately preceding) to opt out, or `<!-- @setup -->` for shared setup that's prepended to subsequent blocks in the same file.
 
 ### Docs deployment
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CAD modeling for JavaScript.
 [![Commit activity](https://img.shields.io/github/commit-activity/m/andymai/brepjs?label=commits%2Fmonth)](https://github.com/andymai/brepjs/commits/main)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
-**[▶ Try the live playground](https://brepjs.dev/playground)** — write code, watch the solid render, and export STEP, all in your browser.
+**[▶ Try the live playground](https://brepjs.dev/playground)**: write code, watch the solid render, and export STEP, all in your browser.
 
 **[Getting Started](./docs/getting-started.md)** · **[Cheat Sheet](./docs/cheat-sheet.md)** · **[Docs](https://brepjs.dev/)**
 
@@ -18,7 +18,7 @@ CAD modeling for JavaScript.
 
 </div>
 
-Shapes are exact mathematical boundaries — not triangle meshes — so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
+Shapes are exact mathematical boundaries (not triangle meshes) so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
 
 ```typescript
 // Drill a hole, fillet the vertical edges, export to STEP
@@ -44,11 +44,11 @@ Neither had the type safety I wanted, so brepjs leans hard on it: branded types,
 
 To set expectations, this project deliberately does not:
 
-- **Render or display geometry** — brepjs produces shape data; pass mesh output to Three.js, Babylon.js, or raw WebGL for rendering.
-- **Support organic or sculpting workflows** — the API is built for parametric parts (enclosures, brackets, fixtures); freeform sculpting is out of scope.
-- **Output SVG or 2D files** — 2D drawing primitives exist solely as an intermediate step toward extruded 3D solids, not as a standalone 2D output format.
-- **Run server-side (SSR)** — WASM requires a browser or Node.js environment with WASM support; server-side rendering frameworks (Next.js, Nuxt, Remix) need a client-only import.
-- **Provide a GUI** — brepjs is a pure programmatic API; there is no visual editor, viewport, or file picker.
+- **Render or display geometry**: brepjs produces shape data; pass mesh output to Three.js, Babylon.js, or raw WebGL for rendering.
+- **Support organic or sculpting workflows**: the API is built for parametric parts (enclosures, brackets, fixtures); freeform sculpting is out of scope.
+- **Output SVG or 2D files**: 2D drawing primitives exist solely as an intermediate step toward extruded 3D solids, not as a standalone 2D output format.
+- **Run server-side (SSR)**: WASM requires a browser or Node.js environment with WASM support; server-side rendering frameworks (Next.js, Nuxt, Remix) need a client-only import.
+- **Provide a GUI**: brepjs is a pure programmatic API; there is no visual editor, viewport, or file picker.
 
 ## Status
 
@@ -78,17 +78,17 @@ registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
 
 The chapter-based guide is the recommended starting point:
 
-- **[Why brepjs](https://brepjs.dev/introduction/why-brepjs)** — what makes it different, who it's for
-- **[Install & Initialize](https://brepjs.dev/getting-started/install)** — three init styles, bundler notes
-- **[Your First Solid](https://brepjs.dev/getting-started/first-solid)** — the canonical drill-fillet-export workflow
-- **[Cheat Sheet](https://brepjs.dev/getting-started/cheat-sheet)** — single-page reference
-- **[Core Concepts](https://brepjs.dev/concepts/brep-vs-mesh)** — B-Rep, topology, types, kernels, tolerance
-- **[Common Tasks](https://brepjs.dev/tasks/booleans)** — booleans, fillets, sketching, lofts, sweeps, finders, measurement, IO
-- **[Three.js Integration](https://brepjs.dev/integration/threejs)** — meshing and rendering
-- **[Migration](https://brepjs.dev/migration/replicad)** — coming from Replicad, OpenSCAD, or Three.js
-- **[Extending brepjs](https://brepjs.dev/extending/architecture)** — custom kernels, custom operations, architecture
-- **[Reference](https://brepjs.dev/reference/glossary)** — glossary, function lookup, error codes, ADRs
-- **[API Reference (TypeDoc)](https://andymai.github.io/brepjs/)** — searchable type-level reference
+- **[Why brepjs](https://brepjs.dev/introduction/why-brepjs)**: what makes it different, who it's for
+- **[Install & Initialize](https://brepjs.dev/getting-started/install)**: three init styles, bundler notes
+- **[Your First Solid](https://brepjs.dev/getting-started/first-solid)**: the canonical drill-fillet-export workflow
+- **[Cheat Sheet](https://brepjs.dev/getting-started/cheat-sheet)**: single-page reference
+- **[Core Concepts](https://brepjs.dev/concepts/brep-vs-mesh)**: B-Rep, topology, types, kernels, tolerance
+- **[Common Tasks](https://brepjs.dev/tasks/booleans)**: booleans, fillets, sketching, lofts, sweeps, finders, measurement, IO
+- **[Three.js Integration](https://brepjs.dev/integration/threejs)**: meshing and rendering
+- **[Migration](https://brepjs.dev/migration/replicad)**: coming from Replicad, OpenSCAD, or Three.js
+- **[Extending brepjs](https://brepjs.dev/extending/architecture)**: custom kernels, custom operations, architecture
+- **[Reference](https://brepjs.dev/reference/glossary)**: glossary, function lookup, error codes, ADRs
+- **[API Reference (TypeDoc)](https://andymai.github.io/brepjs/)**: searchable type-level reference
 
 Legacy single-page docs in [./docs/](./docs/) remain available; the chapter site is the canonical location going forward.
 
@@ -105,16 +105,16 @@ Imports flow downward only. Boundaries are enforced in CI.
 
 ## Authoring CAD with AI (brepjs-verify)
 
-[`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) helps an AI agent (or you) author parametric CAD in brepjs and **prove it is correct** before handing it off. An LLM can't see geometry — so it writes a `.brep.ts` part, runs it on a real kernel, and reads a deterministic report instead of guessing from how the code reads. It ships as two cooperating pieces: a **Claude Code skill** (the authoring loop) and a **verification CLI** (validity + measured dimensions + multi-view snapshots + STEP export).
+[`brepjs-verify`](https://www.npmjs.com/package/brepjs-verify) helps an AI agent (or you) author parametric CAD in brepjs and **prove it is correct** before handing it off. An LLM can't see geometry, so it writes a `.brep.ts` part, runs it on a real kernel, and reads a deterministic report instead of guessing from how the code reads. It ships as two cooperating pieces: a **Claude Code skill** (the authoring loop) and a **verification CLI** (validity + measured dimensions + multi-view snapshots + STEP export).
 
-Install both — they ride on two rails:
+Install both; they ride on two rails:
 
 ```bash
-# 1. The skill — Claude Code plugin (delivered via this repo's marketplace)
+# 1. The skill - Claude Code plugin (delivered via this repo's marketplace)
 /plugin marketplace add andymai/brepjs
 /plugin install brepjs-verify@brepjs
 
-# 2. The runtime — the CLI the skill drives
+# 2. The runtime - the CLI the skill drives
 npm i -D brepjs-verify
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CAD modeling for JavaScript.
 
 </div>
 
-Shapes are exact mathematical boundaries (not triangle meshes) so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
+Shapes are exact mathematical boundaries (not triangle meshes), so booleans are precise, measurements are real, and you can export to STEP. TypeScript types prove the geometry is valid at compile time.
 
 ```typescript
 // Drill a hole, fillet the vertical edges, export to STEP

--- a/apps/docs/advanced/csg-caching.md
+++ b/apps/docs/advanced/csg-caching.md
@@ -17,19 +17,19 @@ This page documents the parts of the `csg` namespace that the [walkthrough](/tas
 
 Four parts. Each one is a reason two evaluations might _not_ share a cache entry:
 
-- **`structuralHash`** — the Merkle hash of the node and everything beneath it. Different tree shape, different literal values, even different optional flags → different hash. Computed once at build time, stored on the node.
-- **`kernelId`** — the kernel id resolved at evaluator construction (e.g. `'occt'`, `'brepkit'`). Cache entries are not portable across kernels; an OCCT-evaluated `Solid` cannot be returned to a brepkit caller. The id is resolved once at `new Evaluator()` so cache keys stay stable even if the active kernel changes mid-run.
-- **`projectedEnvHash`** — the FNV hash of _only the env keys this node depends on_, in canonical (sorted) order. This is the mechanism behind incremental re-evaluation: a node whose `freeParams` doesn't contain `K` cannot see its key change when `K` does.
-- **`toleranceHash`** — the default tolerance configured on the evaluator, or a sentinel if undefined. Two evaluators with different tolerances cache independently.
+- **`structuralHash`**: the Merkle hash of the node and everything beneath it. Different tree shape, different literal values, even different optional flags → different hash. Computed once at build time, stored on the node.
+- **`kernelId`**: the kernel id resolved at evaluator construction (e.g. `'occt'`, `'brepkit'`). Cache entries are not portable across kernels; an OCCT-evaluated `Solid` cannot be returned to a brepkit caller. The id is resolved once at `new Evaluator()` so cache keys stay stable even if the active kernel changes mid-run.
+- **`projectedEnvHash`**: the FNV hash of _only the env keys this node depends on_, in canonical (sorted) order. This is the mechanism behind incremental re-evaluation: a node whose `freeParams` doesn't contain `K` cannot see its key change when `K` does.
+- **`toleranceHash`**: the default tolerance configured on the evaluator, or a sentinel if undefined. Two evaluators with different tolerances cache independently.
 
 Two consequences worth internalizing:
 
-1. **Cache reuse is structural, not nominal.** Two separately-constructed but structurally identical trees share entries automatically. You don't need to memoize calls to `csg.box(10, 10, 10)` — every call returns a different object, but they all hash the same.
+1. **Cache reuse is structural, not nominal.** Two separately-constructed but structurally identical trees share entries automatically. You don't need to memoize calls to `csg.box(10, 10, 10)`; every call returns a different object, but they all hash the same.
 2. **A parent hit short-circuits the whole subtree.** When a node hits, its children are never visited. That's why re-evaluating a tree is roughly free: the root usually hits, and that's the only `onStep` event you see.
 
 ## Reading the cache stats
 
-`cacheStats()` returns `{ hits, misses, entries }`. `hits` and `misses` are running totals since the evaluator was constructed or `resetStats()` was last called. `entries` is a live snapshot of the current cache size — it is **not** reset by `resetStats()` and accumulates across the evaluator's lifetime.
+`cacheStats()` returns `{ hits, misses, entries }`. `hits` and `misses` are running totals since the evaluator was constructed or `resetStats()` was last called. `entries` is a live snapshot of the current cache size; it is **not** reset by `resetStats()` and accumulates across the evaluator's lifetime.
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -88,9 +88,9 @@ fine.cacheStats().entries; // 1
 coarse.cacheStats().entries; // 1
 ```
 
-One tree, two cache entries — one per tolerance. Intentional: kernel output can differ at boundary tolerance, and miss-and-rebuild beats returning a shape that doesn't match what the caller asked for.
+One tree, two cache entries, one per tolerance. Intentional: kernel output can differ at boundary tolerance, and miss-and-rebuild beats returning a shape that doesn't match what the caller asked for.
 
-Per-node `tolerance` overrides on `fuse`/`cut`/`intersect`/`fuseAll`/`cutAll` are mixed into the **structuralHash**, not the cache key's tolerance slot — the evaluator-level tolerance stays a global default, per-call overrides ride along in the tree.
+Per-node `tolerance` overrides on `fuse`/`cut`/`intersect`/`fuseAll`/`cutAll` are mixed into the **structuralHash**, not the cache key's tolerance slot; the evaluator-level tolerance stays a global default, per-call overrides ride along in the tree.
 
 ## `optimize()`: tree-level rewrites
 
@@ -116,18 +116,18 @@ const tree = csg.translate(
 );
 
 const opt = csg.optimize(tree);
-opt.kind; // 'Box' — three rewrites collapsed to a single primitive
+opt.kind; // 'Box' - three rewrites collapsed to a single primitive
 ```
 
-The `2 + 3` folded to `5`, the `fuse(empty, …)` short-circuited to its second argument, and the outer `translate(…, [0,0,0])` collapsed to its target — leaving a bare `Box(5, 10, 10)`.
+The `2 + 3` folded to `5`, the `fuse(empty, …)` short-circuited to its second argument, and the outer `translate(…, [0,0,0])` collapsed to its target, leaving a bare `Box(5, 10, 10)`.
 
-You don't have to call `optimize` — the evaluator works on any well-formed tree. But:
+You don't have to call `optimize`; the evaluator works on any well-formed tree. But:
 
 - **It changes cache keys.** An optimized tree has a different `structuralHash` than the original (smaller tree = different hash), so the first post-optimize evaluation will miss even if you'd previously evaluated the un-optimized version.
 - **It's cheap.** Pure tree rewrites, no kernel calls, no allocation pressure. Run it once after the tree is built and you keep its smaller form for the rest of the session.
-- **It only fires on literal inputs.** `translate(x, [param('dx'), 0, 0])` will not collapse even if `dx` happens to be zero at runtime — `optimize` runs before evaluation, so it can't know.
+- **It only fires on literal inputs.** `translate(x, [param('dx'), 0, 0])` will not collapse even if `dx` happens to be zero at runtime; `optimize` runs before evaluation, so it can't know.
 
-## Serialization — `toJSON` / `fromJSON`
+## Serialization: `toJSON` / `fromJSON`
 
 The IR serializes to a JSON envelope versioned by `CSG_VERSION` (currently `1`):
 
@@ -145,15 +145,15 @@ unwrap(restored).structuralHash === tree.structuralHash; // true
 
 The round-trip preserves structural hashes, so a deserialized tree shares cache entries with the original. Useful for:
 
-- **Build pipelines** — serialize the tree at design time, materialize geometry at runtime against the deployed kernel.
-- **Undo/redo** — `JSON.stringify` snapshots are tiny next to materialized B-Rep data.
-- **Sharing builds** — paste a JSON envelope between users without shipping STEP files.
+- **Build pipelines**: serialize the tree at design time, materialize geometry at runtime against the deployed kernel.
+- **Undo/redo**: `JSON.stringify` snapshots are tiny next to materialized B-Rep data.
+- **Sharing builds**: paste a JSON envelope between users without shipping STEP files.
 
-A note on shape: `toJSON` _expands_ the DAG to a tree. If your IR has shared subtrees (the same `Box` node referenced under two `Translate` parents), the JSON contains the box twice. Sharing is rebuilt on `fromJSON` — the rebuilt nodes hash identically, so the evaluator's cache still dedupes them. The JSON is just bigger than it strictly needs to be.
+A note on shape: `toJSON` _expands_ the DAG to a tree. If your IR has shared subtrees (the same `Box` node referenced under two `Translate` parents), the JSON contains the box twice. Sharing is rebuilt on `fromJSON`; the rebuilt nodes hash identically, so the evaluator's cache still dedupes them. The JSON is just bigger than it strictly needs to be.
 
 `fromJSON` is the trust boundary: every field is validated, every expression is reconstructed via builders so `structuralHash` and `freeParams` are correct. Invalid envelopes return `Result.err`, not throw.
 
-## Editing trees — `replaceNode`, `forEachNode`, `nodeCount`
+## Editing trees: `replaceNode`, `forEachNode`, `nodeCount`
 
 The IR is immutable. Edits rebuild from the bottom up via builders, which keeps hashes and free-params correct.
 
@@ -181,20 +181,20 @@ csg.forEachNode(tree, (n) => kinds.push(n.kind));
 // ['Fuse', 'Box', 'Cut', 'Sphere', 'Cylinder']
 ```
 
-`replaceNode` is structural — it can't reach into expressions to change a `Param` name, for instance. For parameter changes, just re-evaluate with a new env; that's what the cache is built for.
+`replaceNode` is structural; it can't reach into expressions to change a `Param` name, for instance. For parameter changes, just re-evaluate with a new env; that's what the cache is built for.
 
 ## What doesn't cache
 
 A few things are deliberately _not_ cached, and it's worth knowing why:
 
 - **The kernel adapter's internal state.** Cached shapes are kernel handles, but cache entries don't persist across kernels. Re-binding the active kernel after evaluation builds a fresh cache if you construct a new `Evaluator`.
-- **Errors.** `Result.err` values aren't cached. A re-evaluation of a node that previously failed will retry — useful when the failure was transient (e.g. boolean tolerance issue resolved by a parent's tolerance override), but it does mean a persistently broken subtree will repeat its work each call.
-- **`Empty` nodes.** They have no kernel realization; trying to evaluate one alone returns `Result.err`. `Empty` exists as the identity element for booleans — `fuse`/`cut` short-circuit on it as a correctness invariant (not just an optimization), so `fuse(empty, x)` evaluates to `x` directly without needing `optimize()`. The optimizer can still strip them eagerly to shrink trees before they reach the cache.
+- **Errors.** `Result.err` values aren't cached. A re-evaluation of a node that previously failed will retry. Useful when the failure was transient (e.g. boolean tolerance issue resolved by a parent's tolerance override), but it does mean a persistently broken subtree will repeat its work each call.
+- **`Empty` nodes.** They have no kernel realization; trying to evaluate one alone returns `Result.err`. `Empty` exists as the identity element for booleans; `fuse`/`cut` short-circuit on it as a correctness invariant (not just an optimization), so `fuse(empty, x)` evaluates to `x` directly without needing `optimize()`. The optimizer can still strip them eagerly to shrink trees before they reach the cache.
 - **DOM-side mesh data.** The cache holds kernel handles, not tessellated meshes. If you tessellate after evaluation, that work isn't cached. Run your mesh cache on the same key the evaluator uses (`node.structuralHash` is a fine starting point).
 
 ## Cache lifecycle
 
-`Evaluator` is a `Disposable`. The cache and all its borrowed kernel handles release when you dispose it — either explicitly via `[Symbol.dispose]()`, automatically via the `using` keyword, or implicitly inside `withEvaluator`.
+`Evaluator` is a `Disposable`. The cache and all its borrowed kernel handles release when you dispose it, either explicitly via `[Symbol.dispose]()`, automatically via the `using` keyword, or implicitly inside `withEvaluator`.
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -216,10 +216,10 @@ csg.withEvaluator({}, (ev) => {
 });
 ```
 
-After disposal, every shape returned by `evaluate` is invalid — they were _borrowed_ from the evaluator's `DisposalScope`, not transferred out. Copy out any persistent data (volumes, mesh arrays, exported STEP strings) before the evaluator's lifetime ends.
+After disposal, every shape returned by `evaluate` is invalid; they were _borrowed_ from the evaluator's `DisposalScope`, not transferred out. Copy out any persistent data (volumes, mesh arrays, exported STEP strings) before the evaluator's lifetime ends.
 
 ## Where to go next
 
-- **[The walkthrough](/tasks/parametric-csg)** — if you skipped here from the index, the gridfinity-bin walkthrough is where the surface API gets exercised end-to-end.
-- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)** — for projects that already built a `Map<key, Solid>` cache around the eager API.
-- **[Memory Management](/advanced/memory)** — for the `DisposalScope`/`using` pattern that `Evaluator` itself is built on.
+- **[The walkthrough](/tasks/parametric-csg)**: if you skipped here from the index, the gridfinity-bin walkthrough is where the surface API gets exercised end-to-end.
+- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)**: for projects that already built a `Map<key, Solid>` cache around the eager API.
+- **[Memory Management](/advanced/memory)**: for the `DisposalScope`/`using` pattern that `Evaluator` itself is built on.

--- a/apps/docs/advanced/healing.md
+++ b/apps/docs/advanced/healing.md
@@ -5,21 +5,21 @@ description: 'Imported STEP and IGES rarely arrive perfectly valid. autoHeal, se
 
 # Healing & Sewing
 
-Imported shapes — STEP from a designer, IGES from an old part library, STL from a 3D scan — almost never arrive perfectly valid. They have gaps between adjacent faces, edges with the wrong precision, vertices that don't quite match. brepjs's healing operations fix these. Read this chapter before you ship anything that imports STEP from third parties.
+Imported shapes (STEP from a designer, IGES from an old part library, STL from a 3D scan) almost never arrive perfectly valid. They have gaps between adjacent faces, edges with the wrong precision, vertices that don't quite match. brepjs's healing operations fix these. Read this chapter before you ship anything that imports STEP from third parties.
 
 ## What "healing" actually means
 
 OpenCascade ships a tool called `ShapeFix_Shape` that runs a battery of repair passes:
 
-1. **Fix wires** — close gaps between consecutive edges, drop tiny edges, reorder edges to be connected.
-2. **Fix face boundaries** — orient outer wires CCW and inner wires CW; ensure the face's natural orientation matches.
-3. **Sew shells** — find adjacent faces with shared boundaries that aren't connected at the topology level, and stitch them together.
-4. **Fix tolerances** — propagate sub-shape tolerances correctly to parent shapes.
-5. **Remove micro-features** — drop edges, faces, and slivers below a configurable size threshold.
+1. **Fix wires**: close gaps between consecutive edges, drop tiny edges, reorder edges to be connected.
+2. **Fix face boundaries**: orient outer wires CCW and inner wires CW; ensure the face's natural orientation matches.
+3. **Sew shells**: find adjacent faces with shared boundaries that aren't connected at the topology level, and stitch them together.
+4. **Fix tolerances**: propagate sub-shape tolerances correctly to parent shapes.
+5. **Remove micro-features**: drop edges, faces, and slivers below a configurable size threshold.
 
-brepjs wraps this as `autoHeal`. There are also lower-level operations — `sew`, `closeShape`, `removeSlivers` — when you need finer control.
+brepjs wraps this as `autoHeal`. There are also lower-level operations (`sew`, `closeShape`, `removeSlivers`) when you need finer control.
 
-## `autoHeal` — the workhorse
+## `autoHeal`: the workhorse
 
 ```typescript
 import { box, autoHeal, unwrap } from 'brepjs/quick';
@@ -41,10 +41,10 @@ import { autoHeal, unwrap } from 'brepjs/quick';
 
 declare const imported: import('brepjs').Shape3D;
 
-// Conservative — only repair gaps below 0.001 mm
+// Conservative - only repair gaps below 0.001 mm
 const tight = unwrap(autoHeal(imported, { tolerance: 0.001 }));
 
-// Aggressive — close gaps up to 0.05 mm (typical for STEP from low-precision sources)
+// Aggressive - close gaps up to 0.05 mm (typical for STEP from low-precision sources)
 const loose = unwrap(autoHeal(imported, { tolerance: 0.05 }));
 void tight;
 void loose;
@@ -54,7 +54,7 @@ The default tolerance is sane for typical STEP from modern CAD tools. Increase i
 
 ### The short-circuit gotcha
 
-If the input is already valid, `autoHeal` does nothing — it returns the input unchanged with `report.alreadyValid = true`:
+If the input is already valid, `autoHeal` does nothing; it returns the input unchanged with `report.alreadyValid = true`:
 
 <!-- @no-test -->
 
@@ -67,9 +67,9 @@ const result = unwrap(autoHeal(valid));
 console.log('Valid box healed (noop):', valid === result);
 ```
 
-This is a performance optimization — there's nothing to do — but it means you cannot use `autoHeal` to "force a recheck". For that, see `brepCheck` below.
+This is a performance optimization (there's nothing to do), but it means you cannot use `autoHeal` to "force a recheck". For that, see `brepCheck` below.
 
-## `brepCheck` — what's actually wrong
+## `brepCheck`: what's actually wrong
 
 When `autoHeal` doesn't fix what you expected, run `brepCheck` to see the underlying validity report:
 
@@ -87,11 +87,11 @@ console.log('Issues:', report.issues);
 // kind: 'WIRE_NOT_CLOSED', 'FACE_INTERSECTS_ITSELF', 'EDGE_BAD_CURVE', etc.
 ```
 
-Each issue points to a sub-shape and a description. Useful for debugging — gives you a concrete reason to send back to the designer or look up in OpenCascade's docs.
+Each issue points to a sub-shape and a description. Useful for debugging: gives you a concrete reason to send back to the designer or look up in OpenCascade's docs.
 
 ## Lower-level operations
 
-### `sew` — connect adjacent faces
+### `sew`: connect adjacent faces
 
 When you have a collection of faces that _should_ be a closed shell but aren't (the most common output of low-precision STL imports):
 
@@ -109,7 +109,7 @@ void sewn;
 
 `sew` takes a collection of faces or shells and stitches them where their boundaries are within tolerance. Use it after STL import, after combining custom-built faces, or after any boolean that produced disconnected pieces.
 
-### `closeShape` — make a shell into a solid
+### `closeShape`: make a shell into a solid
 
 If you have a sewn closed shell and need a `ValidSolid`:
 
@@ -124,11 +124,11 @@ const solid = unwrap(closeShape(closedShell));
 void solid;
 ```
 
-Requires the input to be a `ManifoldShell` — every edge shared by exactly two faces. The runtime check ensures this; the smart constructor `manifoldShell(s)` is the typical way to acquire one.
+Requires the input to be a `ManifoldShell`: every edge shared by exactly two faces. The runtime check ensures this; the smart constructor `manifoldShell(s)` is the typical way to acquire one.
 
-### `removeSlivers` — clean up tiny features
+### `removeSlivers`: clean up tiny features
 
-Booleans on near-coincident geometry sometimes produce sliver faces — degenerate features under a millimetre. `removeSlivers` drops them:
+Booleans on near-coincident geometry sometimes produce sliver faces: degenerate features under a millimetre. `removeSlivers` drops them:
 
 <!-- @no-test -->
 
@@ -155,7 +155,7 @@ import { autoHeal, brepCheck, sew, closeShape, removeSlivers, unwrap } from 'bre
 
 declare const imported: import('brepjs').Shape3D;
 
-// 1. Always autoHeal first — handles 90% of cases.
+// 1. Always autoHeal first - handles 90% of cases.
 let s = unwrap(autoHeal(imported, { tolerance: 0.01 }));
 
 // 2. If still invalid, check why.
@@ -199,10 +199,10 @@ Healing is one of the most expensive brepjs operations. For a complex assembly i
 - Run `autoHeal` on **every** imported shape before further operations.
 - Use `brepCheck` to diagnose what's wrong when `autoHeal` doesn't fix it.
 - For finer control, drop down to `sew`, `closeShape`, `removeSlivers`.
-- Healing is expensive — cache the healed result, or do it in a worker.
+- Healing is expensive; cache the healed result, or do it in a worker.
 
 ## Next steps
 
-- [Tolerance and Validity](../concepts/tolerance) — what `BRepCheck` actually validates
-- [Import & Export](../tasks/import-export) — the operations that create the shapes you'll heal
-- [Performance](./performance) — when healing dominates your runtime
+- [Tolerance and Validity](../concepts/tolerance): what `BRepCheck` actually validates
+- [Import & Export](../tasks/import-export): the operations that create the shapes you'll heal
+- [Performance](./performance): when healing dominates your runtime

--- a/apps/docs/advanced/memory.md
+++ b/apps/docs/advanced/memory.md
@@ -1,11 +1,11 @@
 ---
 title: Memory Management
-description: 'WASM objects are not GC-managed. The four cleanup patterns — using, DisposalScope, manual delete, ownership transfer — and when to use each.'
+description: 'WASM objects are not GC-managed. The four cleanup patterns (using, DisposalScope, manual delete, ownership transfer) and when to use each.'
 ---
 
 # Memory Management
 
-WASM objects are not garbage-collected. Every shape brepjs creates is a handle to memory inside the OpenCascade WASM heap, and that memory lives until you explicitly release it. For a one-shot script the runtime cleans up at exit and you can ignore this. For a long-running app — a webapp, a worker, a server — leaks compound and crash the page. This chapter covers the four cleanup patterns and when to use each.
+WASM objects are not garbage-collected. Every shape brepjs creates is a handle to memory inside the OpenCascade WASM heap, and that memory lives until you explicitly release it. For a one-shot script the runtime cleans up at exit and you can ignore this. For a long-running app (a webapp, a worker, a server) leaks compound and crash the page. This chapter covers the four cleanup patterns and when to use each.
 
 ## The problem
 
@@ -24,7 +24,7 @@ Eventually you OOM. The garbage collector cannot reach into the WASM heap. You h
 
 ## The four patterns, ranked by simplicity
 
-### 1. The fluent wrapper — auto-cleanup on chains
+### 1. The fluent wrapper: auto-cleanup on chains
 
 ```typescript
 import { shape, box, cylinder, measureVolume, unwrap } from 'brepjs/quick';
@@ -37,9 +37,9 @@ const part = shape(box(20, 20, 20)).cut(cylinder(5, 25)).val;
 console.log(unwrap(measureVolume(part)));
 ```
 
-The `shape().chain()` form tracks every intermediate result and disposes them when you call `.val`. The only object that escapes the chain is the final shape. **Use this for any chain of operations** — it's the simplest way to avoid leaks in code that builds a part once.
+The `shape().chain()` form tracks every intermediate result and disposes them when you call `.val`. The only object that escapes the chain is the final shape. **Use this for any chain of operations**; it's the simplest way to avoid leaks in code that builds a part once.
 
-### 2. `using` — automatic block-scoped cleanup
+### 2. `using`: automatic block-scoped cleanup
 
 ```typescript
 import { box, measureVolume, unwrap } from 'brepjs/quick';
@@ -65,7 +65,7 @@ function unionWithTemp(a: import('brepjs').Shape3D, b: import('brepjs').Shape3D)
 console.log(unionWithTemp(box(10, 10, 10), sphere(5)).toFixed(2));
 ```
 
-### 3. `DisposalScope` — manual scoping
+### 3. `DisposalScope`: manual scoping
 
 When you can't use `using` (older TS, environments where the keyword isn't supported, or you need to dispose multiple shapes together):
 
@@ -80,7 +80,7 @@ try {
   // ... work with fused ...
   void fused;
 } finally {
-  scope.dispose(); // releases a, b, fused — in LIFO order
+  scope.dispose(); // releases a, b, fused - in LIFO order
 }
 ```
 
@@ -95,15 +95,15 @@ const result = withScope((scope) => {
   const a = scope.track(box(10, 10, 10));
   const b = scope.track(sphere(5));
   const fused = scope.track(unwrap(fuse(a, b)));
-  return unwrap(measureVolume(fused)); // return what you want to keep — primitives are safe
+  return unwrap(measureVolume(fused)); // return what you want to keep - primitives are safe
 });
 
 console.log(result.toFixed(2));
 ```
 
-`withScope` constructs the scope, runs the callback, and disposes — even on exception.
+`withScope` constructs the scope, runs the callback, and disposes, even on exception.
 
-### 4. Manual `dispose()` — escape hatch
+### 4. Manual `dispose()`: escape hatch
 
 ```typescript
 import { box, dispose } from 'brepjs/quick';
@@ -113,7 +113,7 @@ const temp = box(10, 10, 10);
 dispose(temp); // explicit cleanup
 ```
 
-Necessary when none of the above patterns fit — for instance, when you build a shape on one tick and dispose on a later tick, or when the lifetime crosses an async boundary `using` cannot capture.
+Necessary when none of the above patterns fit, for instance when you build a shape on one tick and dispose on a later tick, or when the lifetime crosses an async boundary `using` cannot capture.
 
 ## Stats and leak detection
 
@@ -132,17 +132,17 @@ void b;
 const stats = getDisposalStats();
 console.log('Allocated:', stats.allocated); // 2
 console.log('Disposed:', stats.disposed); // 0
-console.log('Live:', stats.live); // 2 — should be 0 at the end of a run
+console.log('Live:', stats.live); // 2 - should be 0 at the end of a run
 ```
 
-`getDisposalStats` reports the count of allocated, disposed, and currently-live handles. In a long-running app, periodically log `live` and watch for growth — that's a leak. (gridfinity-layout-tool's regression tests use this.)
+`getDisposalStats` reports the count of allocated, disposed, and currently-live handles. In a long-running app, periodically log `live` and watch for growth; that's a leak. (gridfinity-layout-tool's regression tests use this.)
 
 ## What does _not_ need disposal
 
-- **Primitive numbers, strings, arrays returned from measurements** — `measureVolume(s)` returns a `Result<number>`; once unwrapped to the underlying number, no disposal is needed.
-- **Buffer geometry data from `mesh()`** — `toBufferGeometryData` returns plain TypedArrays. The mesh handle (the brepjs side) does need disposal; the TypedArrays don't.
-- **Imported plain JS objects** — `getBoundingBox`, `getCenterOfMass` return plain objects.
-- **Result wrappers** — `Result<T,E>` is a plain JS object; only the `.value` shape inside needs disposal if it's a shape.
+- **Primitive numbers, strings, arrays returned from measurements**: `measureVolume(s)` returns a `Result<number>`; once unwrapped to the underlying number, no disposal is needed.
+- **Buffer geometry data from `mesh()`**: `toBufferGeometryData` returns plain TypedArrays. The mesh handle (the brepjs side) does need disposal; the TypedArrays don't.
+- **Imported plain JS objects**: `getBoundingBox`, `getCenterOfMass` return plain objects.
+- **Result wrappers**: `Result<T,E>` is a plain JS object; only the `.value` shape inside needs disposal if it's a shape.
 
 ## Common gotchas
 
@@ -158,11 +158,11 @@ import { box, edgeFinder, dispose, measureLength, unwrap } from 'brepjs/quick';
 const b = box(10, 10, 10);
 const edges = edgeFinder().findAll(b);
 dispose(b);
-// edges[0] now points to freed memory — undefined behaviour
+// edges[0] now points to freed memory - undefined behaviour
 console.log(unwrap(measureLength(edges[0]!))); // crash or garbage
 ```
 
-If you need both, dispose the parent only after you're done with the children — or copy the data you need (lengths, positions, types) before disposing.
+If you need both, dispose the parent only after you're done with the children, or copy the data you need (lengths, positions, types) before disposing.
 
 ### Forgetting to track in a scope
 
@@ -170,7 +170,7 @@ If you need both, dispose the parent only after you're done with the children �
 import { withScope, box, fuse, measureVolume, unwrap } from 'brepjs/quick';
 
 withScope((scope) => {
-  const a = box(10, 10, 10); // NOT tracked — will leak
+  const a = box(10, 10, 10); // NOT tracked - will leak
   const b = scope.track(box(5, 5, 5));
   const f = scope.track(unwrap(fuse(a, b)));
   console.log(unwrap(measureVolume(f)));
@@ -224,6 +224,6 @@ For async workflows, prefer `DisposalScope` and dispose explicitly after the asy
 
 ## Next steps
 
-- [Performance](./performance) — caching meshes, reusing handles, batching
-- [Web Workers](./workers) — isolating brepjs in a worker so a leak only kills the worker
-- [Healing & Sewing](./healing) — operations that may allocate intermediate handles
+- [Performance](./performance): caching meshes, reusing handles, batching
+- [Web Workers](./workers): isolating brepjs in a worker so a leak only kills the worker
+- [Healing & Sewing](./healing): operations that may allocate intermediate handles

--- a/apps/docs/advanced/performance.md
+++ b/apps/docs/advanced/performance.md
@@ -5,7 +5,7 @@ description: "What's cheap and what's expensive in brepjs. Batching booleans, ca
 
 # Performance
 
-brepjs operations are bounded by the kernel — booleans on small primitives are microseconds, booleans on heavily-filleted assemblies are seconds. Most of the time you don't think about performance because the cost of one operation is in the noise. When you do hit a wall, this chapter covers what's typically slow and what's typically cheap, and what to do about it.
+brepjs operations are bounded by the kernel: booleans on small primitives are microseconds, booleans on heavily-filleted assemblies are seconds. Most of the time you don't think about performance because the cost of one operation is in the noise. When you do hit a wall, this chapter covers what's typically slow and what's typically cheap, and what to do about it.
 
 ## What's cheap
 
@@ -85,7 +85,7 @@ Same applies to `fuseAll` vs. chained `fuse` and `intersectAll` vs. chained `int
 
 ## Avoiding the kernel altogether
 
-For specific queries you don't always need the kernel. Bounding boxes are cheap and conservative — use them as filters before expensive operations:
+For specific queries you don't always need the kernel. Bounding boxes are cheap and conservative; use them as filters before expensive operations:
 
 ```typescript
 import { box, getBoundingBox, distanceTo, type Shape3D } from 'brepjs/quick';
@@ -136,7 +136,7 @@ void variantB;
 void variantC;
 ```
 
-The kernel doesn't share state between cuts — each is a full operation — but you only built the base once.
+The kernel doesn't share state between cuts (each is a full operation) but you only built the base once.
 
 ## Workers
 
@@ -169,9 +169,9 @@ Halving the tolerance roughly quadruples the triangle count. For screen renderin
 
 These are typical optimizations in mesh libraries that **do not exist** in B-Rep:
 
-- **LOD (level of detail)** — there's one shape; meshing produces one mesh at one tolerance.
-- **Spatial partitioning of the kernel state** — the kernel sees one shape at a time. There's no octree behind the scenes.
-- **Streaming** — operations are atomic. You can't progressively refine a boolean.
+- **LOD (level of detail)**: there's one shape; meshing produces one mesh at one tolerance.
+- **Spatial partitioning of the kernel state**: the kernel sees one shape at a time. There's no octree behind the scenes.
+- **Streaming**: operations are atomic. You can't progressively refine a boolean.
 
 If you need these, you need a mesh library on top of brepjs's output, not a different brepjs configuration.
 
@@ -192,14 +192,14 @@ console.timeEnd('fillet');
 void filleted;
 ```
 
-For sub-operation cost (which face is the slow one in a multi-face fillet, say) you'd need to break the operation up — there's no kernel-side per-face profiling exposed.
+For sub-operation cost (which face is the slow one in a multi-face fillet, say) you'd need to break the operation up; there's no kernel-side per-face profiling exposed.
 
 ## Bench results
 
-The brepjs repo runs benchmarks against both kernels (OpenCascade and brepkit) on every release. Latest results: `benchmarks/results/latest.md` in the repo. Use this for "is brepkit ready for my workload yet?" — generally brepkit wins on simple operations, OpenCascade wins on complex healing and STEP IO.
+The brepjs repo runs benchmarks against both kernels (OpenCascade and brepkit) on every release. Latest results: `benchmarks/results/latest.md` in the repo. Use this for "is brepkit ready for my workload yet?". Generally brepkit wins on simple operations, OpenCascade wins on complex healing and STEP IO.
 
 ## Next steps
 
-- [Web Workers](./workers) — isolating brepjs from the main thread
-- [Memory Management](./memory) — leaks compound and slow your app down
-- [Healing & Sewing](./healing) — the often-slowest operation, when imports require it
+- [Web Workers](./workers): isolating brepjs from the main thread
+- [Memory Management](./memory): leaks compound and slow your app down
+- [Healing & Sewing](./healing): the often-slowest operation, when imports require it

--- a/apps/docs/advanced/workers.md
+++ b/apps/docs/advanced/workers.md
@@ -9,13 +9,13 @@ Long brepjs operations should not run on the main thread. A 200 ms boolean dropp
 
 ## Why a worker
 
-JavaScript is single-threaded. Every `await` in the main thread is a yield to the event loop, which is fine for IO-bound work — but brepjs operations are CPU-bound. Even with `await`, a heavy boolean blocks paint and input handling.
+JavaScript is single-threaded. Every `await` in the main thread is a yield to the event loop, which is fine for IO-bound work, but brepjs operations are CPU-bound. Even with `await`, a heavy boolean blocks paint and input handling.
 
 A worker isolates the kernel: it has its own JS context, its own WASM heap, its own brepjs instance. Crashes in the worker (e.g. an OOM from a runaway operation) kill only the worker, not the page. You restart the worker; the page stays responsive.
 
 ## The two ways to use a worker
 
-### Option 1: brepjs/worker — typed RPC
+### Option 1: brepjs/worker, typed RPC
 
 For apps that build a part on the worker and just need the resulting mesh:
 
@@ -34,7 +34,7 @@ const command: WorkerCommand = {
 };
 
 const { mesh } = await client.run(command);
-// mesh is { position, normal, index } typed arrays — ready for Three.js
+// mesh is { position, normal, index } typed arrays, ready for Three.js
 ```
 
 `createWorkerClient` returns a typed object with `init()` and `run()` methods. Behind the scenes it serializes commands as messages, posts them, and resolves promises when the worker replies.
@@ -102,7 +102,7 @@ self.onmessage = (e: MessageEvent) => {
 };
 ```
 
-The `transfer` argument hands the underlying ArrayBuffers to the main thread without copying — much faster than structured-cloning megabytes of triangle data.
+The `transfer` argument hands the underlying ArrayBuffers to the main thread without copying; much faster than structured-cloning megabytes of triangle data.
 
 ## Initialization in the worker
 
@@ -114,7 +114,7 @@ The worker has to init brepjs just like the main thread. `brepjs/quick` works in
 // worker.js
 import { box } from 'brepjs/quick';
 
-// brepjs/quick auto-initializes via top-level await — works in workers too.
+// brepjs/quick auto-initializes via top-level await; works in workers too.
 self.onmessage = (e) => {
   if (e.data.kind === 'build') {
     self.postMessage({ kind: 'volume', value: box(10, 10, 10) });
@@ -176,11 +176,11 @@ import singleWasm from 'brepjs-opencascade/src/brepjs_single.wasm?url';
 // ...use singleWasm to load via the OpenCascade JS init
 ```
 
-The `?url` suffix tells Vite "emit this WASM as an asset and give me a URL to it" — so your worker can fetch it without bundling the binary into the worker JS.
+The `?url` suffix tells Vite "emit this WASM as an asset and give me a URL to it", so your worker can fetch it without bundling the binary into the worker JS.
 
 ## Transferable types
 
-Worker boundaries copy data by default. For mesh data, that's expensive. Use `Transferable`s — typed arrays whose underlying buffers move from worker to main thread without a copy:
+Worker boundaries copy data by default. For mesh data, that's expensive. Use `Transferable`s: typed arrays whose underlying buffers move from worker to main thread without a copy:
 
 <!-- @no-test -->
 
@@ -188,13 +188,13 @@ Worker boundaries copy data by default. For mesh data, that's expensive. Use `Tr
 self.postMessage({ position, normal, index }, [position.buffer, normal.buffer, index.buffer]);
 ```
 
-After transferring, the worker's view of those arrays is detached — they can no longer be read from the worker side. This is what you want: the data has moved, not been duplicated.
+After transferring, the worker's view of those arrays is detached; they can no longer be read from the worker side. This is what you want: the data has moved, not been duplicated.
 
 The brepjs `toBufferGeometryData` returns plain `Float32Array` and `Uint32Array` (with backing `ArrayBuffer`), so they're directly transferable.
 
 ## Disposing in the worker
 
-Memory management still applies inside a worker — the WASM heap there grows just like in the main thread. Use the same patterns:
+Memory management still applies inside a worker; the WASM heap there grows just like in the main thread. Use the same patterns:
 
 <!-- @no-test -->
 
@@ -208,14 +208,14 @@ self.onmessage = (e) => {
       const b = scope.track(sphere(5));
       const fused = scope.track(unwrap(fuse(a, b)));
       const m = scope.track(shape(fused).mesh({ tolerance: 0.1 }));
-      return toBufferGeometryData(m); // primitives — safe to return
+      return toBufferGeometryData(m); // primitives, safe to return
     });
     self.postMessage(result, [result.position.buffer, result.normal.buffer, result.index.buffer]);
   }
 };
 ```
 
-`withScope` disposes everything inside the scope — by the time the postMessage returns, only the buffer-data references the worker still holds, and those move to the main thread.
+`withScope` disposes everything inside the scope; by the time the postMessage returns, only the buffer-data references the worker still holds, and those move to the main thread.
 
 ## Restarting the worker on failure
 
@@ -247,12 +247,12 @@ A worker-aware app survives kernel hiccups without becoming unusable.
 - One-shot scripts that just produce a STEP file.
 - Static-site generators where the output is built at compile time.
 - Server-side Node CLIs.
-- Apps where every operation completes in < 16 ms — main thread is fine.
+- Apps where every operation completes in < 16 ms: main thread is fine.
 
 For an interactive web app with any boolean over 50 ms, workers pay for themselves quickly.
 
 ## Next steps
 
-- [Performance](./performance) — what's expensive enough to worth moving to a worker
-- [Memory Management](./memory) — leaks in a worker still leak (just elsewhere)
-- [Three.js Integration](../integration/threejs) — receiving mesh data from a worker and rendering
+- [Performance](./performance): what's expensive enough to worth moving to a worker
+- [Memory Management](./memory): leaks in a worker still leak (just elsewhere)
+- [Three.js Integration](../integration/threejs): receiving mesh data from a worker and rendering

--- a/apps/docs/concepts/brep-vs-mesh.md
+++ b/apps/docs/concepts/brep-vs-mesh.md
@@ -5,13 +5,13 @@ description: 'Why exact mathematical boundaries beat triangle meshes for CAD: pr
 
 # B-Rep vs Mesh
 
-If you have used Three.js, Babylon.js, or any other renderer-first 3D library, you have worked with **meshes** — bags of triangles. brepjs models shapes a fundamentally different way: as **boundary representations** (B-Rep). The difference is not cosmetic. It changes which operations are exact, which are approximate, what fillets are possible, and what file formats round-trip with desktop CAD tools.
+If you have used Three.js, Babylon.js, or any other renderer-first 3D library, you have worked with **meshes**: bags of triangles. brepjs models shapes a fundamentally different way: as **boundary representations** (B-Rep). The difference is not cosmetic. It changes which operations are exact, which are approximate, what fillets are possible, and what file formats round-trip with desktop CAD tools.
 
 ## The mental shift
 
 A **mesh** describes a surface as a list of triangles. A cube is 12 triangles. A sphere is hundreds. The triangles approximate the surface; the surface itself has no first-class existence in the data structure.
 
-A **B-Rep** describes a shape as a set of bounded mathematical surfaces stitched together along shared edges. A cube is six planes, each trimmed to a 2D rectangle, sharing twelve straight edges that meet at eight vertices. A sphere is one spherical surface trimmed to a full closed region. The surfaces are exact — `x² + y² + z² = r²` for the sphere, not 200 triangles approximating it.
+A **B-Rep** describes a shape as a set of bounded mathematical surfaces stitched together along shared edges. A cube is six planes, each trimmed to a 2D rectangle, sharing twelve straight edges that meet at eight vertices. A sphere is one spherical surface trimmed to a full closed region. The surfaces are exact: `x² + y² + z² = r²` for the sphere, not 200 triangles approximating it.
 
 ```
 Mesh:    triangles → visual approximation
@@ -25,29 +25,29 @@ Every B-Rep operation can therefore be exact on the underlying mathematics rathe
 
 ### Exact booleans
 
-`fuse`, `cut`, `intersect` operate on the surface mathematics, not on triangle intersections. A cylinder cut from a box leaves an exact cylindrical hole — not a many-sided polygonal approximation. Re-export to STEP and another CAD tool sees the same exact geometry.
+`fuse`, `cut`, `intersect` operate on the surface mathematics, not on triangle intersections. A cylinder cut from a box leaves an exact cylindrical hole, not a many-sided polygonal approximation. Re-export to STEP and another CAD tool sees the same exact geometry.
 
 CSG-on-mesh libraries can produce visually plausible results, but they accumulate floating-point error every time you intersect triangles, and the more operations you stack the more degenerate edges and tiny slivers appear. B-Rep does not have this drift.
 
 ### Real measurements
 
-`measureVolume(s)` returns the exact volume — not a Riemann sum of tetrahedra. `measureArea(face)` returns the exact area of the trimmed surface. For a cylinder, the area is `2πrh + 2πr²`, and brepjs returns precisely that, rounded only to floating-point precision.
+`measureVolume(s)` returns the exact volume, not a Riemann sum of tetrahedra. `measureArea(face)` returns the exact area of the trimmed surface. For a cylinder, the area is `2πrh + 2πr²`, and brepjs returns precisely that, rounded only to floating-point precision.
 
 ### Real fillets and chamfers
 
-A fillet replaces an edge with a curved blend surface. On a B-Rep this is a well-defined geometric construction — find the intersection of the offsets of the two adjacent faces, build a blending surface, trim the result. On a mesh, "fillet" means something fuzzy like "smooth this region" — there's no edge to find, just triangles.
+A fillet replaces an edge with a curved blend surface. On a B-Rep this is a well-defined geometric construction: find the intersection of the offsets of the two adjacent faces, build a blending surface, trim the result. On a mesh, "fillet" means something fuzzy like "smooth this region"; there's no edge to find, just triangles.
 
 brepjs's `fillet`, `chamfer`, and `shell` all rely on the B-Rep structure to do the right thing.
 
 ### Industry-standard exports
 
-STEP, IGES, and BREP files describe B-Rep shapes. They round-trip with SolidWorks, Fusion 360, FreeCAD, OnShape, Rhino — every mechanical CAD tool. Mesh exports (STL, glTF, OBJ) lose the B-Rep structure: a STEP-imported sphere is a single face; an STL-exported sphere is a thousand triangles.
+STEP, IGES, and BREP files describe B-Rep shapes. They round-trip with SolidWorks, Fusion 360, FreeCAD, OnShape, Rhino: every mechanical CAD tool. Mesh exports (STL, glTF, OBJ) lose the B-Rep structure: a STEP-imported sphere is a single face; an STL-exported sphere is a thousand triangles.
 
 ## What you give up
 
 ### Memory ownership
 
-WASM objects are not garbage-collected. brepjs gives you tools to manage this — the `using` keyword, `DisposalScope`, the fluent `shape()` wrapper that disposes intermediate results — but you must think about it for long-running apps. See [Memory Management](../advanced/memory).
+WASM objects are not garbage-collected. brepjs gives you tools to manage this (the `using` keyword, `DisposalScope`, the fluent `shape()` wrapper that disposes intermediate results) but you must think about it for long-running apps. See [Memory Management](../advanced/memory).
 
 ### Speed for trivial operations
 
@@ -85,7 +85,7 @@ console.log('Triangles:', m.indices.length / 3);
 
 `mesh()` triangulates the B-Rep surfaces with a configurable tolerance. Smaller tolerance → more triangles → better visual fidelity → more memory. The output goes straight to a Three.js `BufferGeometry` (see [Three.js Integration](../integration/threejs)).
 
-You only convert in this direction. brepjs has `importSTL` for the reverse, but it produces a B-Rep approximation — useful for measurement and STEP conversion, not for further B-Rep work.
+You only convert in this direction. brepjs has `importSTL` for the reverse, but it produces a B-Rep approximation: useful for measurement and STEP conversion, not for further B-Rep work.
 
 ## In one sentence
 
@@ -93,6 +93,6 @@ If you want **rendering**, you want a mesh; if you want **manufacturing**, you w
 
 ## Next steps
 
-- [The Topology Hierarchy](./topology) — how B-Rep nests vertex inside edge inside wire inside face inside shell inside solid
-- [Types That Prove Geometry Is Valid](./types) — the brand-and-validity type system that catches errors at compile time
-- [Three.js Integration](../integration/threejs) — meshing your B-Rep for in-browser rendering
+- [The Topology Hierarchy](./topology): how B-Rep nests vertex inside edge inside wire inside face inside shell inside solid
+- [Types That Prove Geometry Is Valid](./types): the brand-and-validity type system that catches errors at compile time
+- [Three.js Integration](../integration/threejs): meshing your B-Rep for in-browser rendering

--- a/apps/docs/concepts/brep-vs-mesh.md
+++ b/apps/docs/concepts/brep-vs-mesh.md
@@ -47,7 +47,7 @@ STEP, IGES, and BREP files describe B-Rep shapes. They round-trip with SolidWork
 
 ### Memory ownership
 
-WASM objects are not garbage-collected. brepjs gives you tools to manage this (the `using` keyword, `DisposalScope`, the fluent `shape()` wrapper that disposes intermediate results) but you must think about it for long-running apps. See [Memory Management](../advanced/memory).
+WASM objects are not garbage-collected. brepjs gives you tools to manage this (the `using` keyword, `DisposalScope`, the fluent `shape()` wrapper that disposes intermediate results), but you must think about it for long-running apps. See [Memory Management](../advanced/memory).
 
 ### Speed for trivial operations
 

--- a/apps/docs/concepts/csg-ir.md
+++ b/apps/docs/concepts/csg-ir.md
@@ -1,13 +1,13 @@
 ---
 title: CSG as an Intermediate Representation
-description: 'Build a content-addressed DAG of primitives, booleans, and transforms — then evaluate it against the kernel with subtree-level caching for incremental parametric edits.'
+description: 'Build a content-addressed DAG of primitives, booleans, and transforms, then evaluate it against the kernel with subtree-level caching for incremental parametric edits.'
 ---
 
 # CSG as an Intermediate Representation
 
 Most code-CAD libraries hand you eager geometry: `box(10, 10, 10)` immediately calls into the kernel, returns a real B-Rep solid, and that solid sits in WASM memory until you `.delete()` it. Chain a few operations and you've allocated and freed dozens of intermediate shapes whose only purpose was to feed the next call.
 
-brepjs's `csg` namespace offers a different surface for the same operations. Instead of materializing geometry, the builders construct a **content-addressed DAG** — a tree of `IRNode` values, each describing what to build without actually building it. Geometry is produced on demand by an `Evaluator`, which caches by structural hash so re-evaluating the same subtree is free.
+brepjs's `csg` namespace offers a different surface for the same operations. Instead of materializing geometry, the builders construct a **content-addressed DAG**: a tree of `IRNode` values, each describing what to build without actually building it. Geometry is produced on demand by an `Evaluator`, which caches by structural hash so re-evaluating the same subtree is free.
 
 ## A tree, not a shape
 
@@ -25,7 +25,7 @@ const node = csg.box(10, 20, 30);
 // }
 ```
 
-No kernel call, no WASM allocation. Same for every builder — `cylinder`, `sphere`, `fuse`, `cut`, `translate`, even `compound`. The tree is just description.
+No kernel call, no WASM allocation. Same for every builder: `cylinder`, `sphere`, `fuse`, `cut`, `translate`, even `compound`. The tree is just description.
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -46,7 +46,7 @@ The structure of the tree is the structure of the computation. Nothing has been 
 
 ## Content-addressed hashing
 
-Every node carries a `structuralHash` — a 64-bit FNV-1a Merkle hash of its kind plus its children's hashes. Two trees that describe the _same_ geometry hash identically, regardless of how they were built:
+Every node carries a `structuralHash`: a 64-bit FNV-1a Merkle hash of its kind plus its children's hashes. Two trees that describe the _same_ geometry hash identically, regardless of how they were built:
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -61,14 +61,14 @@ Change _any_ literal anywhere in the tree and the hash changes:
 
 ```typescript
 csg.box(10, 10, 10).structuralHash === csg.box(10, 10, 11).structuralHash;
-// false — last dimension differs
+// false - last dimension differs
 ```
 
 The hash is computed once at build time and stored on the node, so cache lookups during evaluation are O(1) per node rather than O(subtree-size). The hash also normalizes `-0` to `+0` and serializes floats bit-exactly via `DataView.setFloat64`, so identical doubles always hash the same.
 
 ## Free parameters propagate upward
 
-Builders accept literal numbers or expressions. Expressions parameterize the tree — `csg.param('w')` is a placeholder bound at evaluation time. Each node tracks the set of parameter names it transitively depends on:
+Builders accept literal numbers or expressions. Expressions parameterize the tree: `csg.param('w')` is a placeholder bound at evaluation time. Each node tracks the set of parameter names it transitively depends on:
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -82,7 +82,7 @@ const tree = csg.translate(csg.fuse(csg.box(csg.param('w'), 10, 10), csg.sphere(
 [...tree.freeParams].sort(); // ['dx', 'r', 'w']
 ```
 
-`freeParams` is computed bottom-up by the builders at build time. The evaluator uses it to project the env before computing the cache key — a node that doesn't reference `dx` will never see `dx` enter its cache key, so unrelated env edits cannot invalidate it. This is the core mechanism behind incremental re-evaluation:
+`freeParams` is computed bottom-up by the builders at build time. The evaluator uses it to project the env before computing the cache key: a node that doesn't reference `dx` will never see `dx` enter its cache key, so unrelated env edits cannot invalidate it. This is the core mechanism behind incremental re-evaluation:
 
 ```mermaid
 graph TD
@@ -95,7 +95,7 @@ When `dx` changes, only `Translate` invalidates. When `r` changes, `Sphere` + `F
 
 ## Output kinds and structural validity
 
-The IR doesn't have separate node types for solids vs faces vs edges — there's one `IRNode` union with a `kind` discriminator. Output kind is derived structurally via `outputKindOf`:
+The IR doesn't have separate node types for solids vs faces vs edges; there's one `IRNode` union with a `kind` discriminator. Output kind is derived structurally via `outputKindOf`:
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -113,7 +113,7 @@ csg.outputKindOf(
 ); // 'Face'
 ```
 
-Booleans inherit the kind of their `a` argument; transforms inherit from `target`; primitives are fixed. There's no cross-kind boolean — `fuse(box, circle)` is rejected at the kernel boundary, not by the TypeScript types at v1.
+Booleans inherit the kind of their `a` argument; transforms inherit from `target`; primitives are fixed. There's no cross-kind boolean: `fuse(box, circle)` is rejected at the kernel boundary, not by the TypeScript types at v1.
 
 ## Two equivalent ways to compute the same geometry
 
@@ -121,14 +121,14 @@ Both snippets produce the same 1000 - π·125 ≈ 477 mm³ solid:
 
 ::: code-group
 
-```typescript [Eager — topology API]
+```typescript [Eager: topology API]
 import { box, sphere, cut, measureVolume, unwrap } from 'brepjs/quick';
 
 const cube = box(10, 10, 10);
 const ball = sphere(2.5);
 const part = unwrap(cut(cube, ball));
 const v = unwrap(measureVolume(part));
-// 3 kernel allocations: cube, ball, part — all live until disposed
+// 3 kernel allocations: cube, ball, part - all live until disposed
 ```
 
 ```typescript [CSG IR]
@@ -153,7 +153,7 @@ If none of those apply, the topology API is leaner. The IR is a tool, not a repl
 
 ## Where this fits in brepjs
 
-The IR is purely a build-time abstraction layered on top of the kernel adapter — `csg.Evaluator` calls the same `getKernel().fuseSolids(...)` that the topology API does. Everything that works on a `Solid` works on the result of `ev.evaluate(tree)`: finders, fillets, measurement, export. The IR is the parametric _front_ of the pipeline; the topology API picks up where it leaves off.
+The IR is purely a build-time abstraction layered on top of the kernel adapter: `csg.Evaluator` calls the same `getKernel().fuseSolids(...)` that the topology API does. Everything that works on a `Solid` works on the result of `ev.evaluate(tree)`: finders, fillets, measurement, export. The IR is the parametric _front_ of the pipeline; the topology API picks up where it leaves off.
 
 ## The rest of the surface
 
@@ -161,6 +161,6 @@ The examples above touch `box`, `sphere`, `cylinder`, `cut`, `fuse`, and `transl
 
 ## Next steps
 
-- **[Parametric CSG walkthrough](/tasks/parametric-csg)** — build a gridfinity-style bin with named parameters, change a slider, watch the cache absorb the unchanged subtrees.
-- **[CSG caching internals](/advanced/csg-caching)** — `cacheStats`, `optimize`, serialization, what the cache key actually contains, and what _doesn't_ cache.
-- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)** — if you've built your own `Map<key, Solid>` cache around eager geometry, here's the IR equivalent and what you'd inherit by switching.
+- **[Parametric CSG walkthrough](/tasks/parametric-csg)**: build a gridfinity-style bin with named parameters, change a slider, watch the cache absorb the unchanged subtrees.
+- **[CSG caching internals](/advanced/csg-caching)**: `cacheStats`, `optimize`, serialization, what the cache key actually contains, and what _doesn't_ cache.
+- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)**: if you've built your own `Map<key, Solid>` cache around eager geometry, here's the IR equivalent and what you'd inherit by switching.

--- a/apps/docs/concepts/kernels.md
+++ b/apps/docs/concepts/kernels.md
@@ -5,7 +5,7 @@ description: 'How brepjs swaps geometry kernels behind a single API. Pick OpenCa
 
 # Kernels and withKernel
 
-brepjs is not married to OpenCascade. The library sits behind a small abstraction — the `KernelInterface` — that lets multiple WASM-based geometry kernels back the same API. Today there are two: OpenCascade (production) and brepkit (experimental Rust). This chapter explains how to pick one, how to swap, and what `withKernel(...)` does for advanced use cases.
+brepjs is not married to OpenCascade. The library sits behind a small abstraction (the `KernelInterface`) that lets multiple WASM-based geometry kernels back the same API. Today there are two: OpenCascade (production) and brepkit (experimental Rust). This chapter explains how to pick one, how to swap, and what `withKernel(...)` does for advanced use cases.
 
 ## The two kernels
 
@@ -43,9 +43,9 @@ withKernel('brepkit', () => {
 });
 ```
 
-After `registerKernel`, the kernel is available globally — `withKernel(id, fn)` switches the active kernel inside a synchronous block.
+After `registerKernel`, the kernel is available globally; `withKernel(id, fn)` switches the active kernel inside a synchronous block.
 
-## `withKernel` — switching mid-program
+## `withKernel`: switching mid-program
 
 If you've registered multiple kernels (the typical use case is testing or A/B comparison), `withKernel(id, fn)` runs `fn` with that kernel active:
 
@@ -61,21 +61,21 @@ console.log({ occtVolume, brepkitVolume });
 
 The active kernel reverts when `fn` returns. Outside `withKernel`, the default kernel (whichever was init'd last) is used.
 
-### Sync only — the trap
+### Sync only: the trap
 
 `withKernel` is **synchronous**. Async callbacks silently use the wrong kernel after the first `await`:
 
 <!-- @no-test -->
 
 ```typescript
-// WRONG — second await runs against whichever kernel is "current",
+// WRONG: second await runs against whichever kernel is "current",
 // not necessarily 'brepkit'.
 withKernel('brepkit', async () => {
   await someAsyncOp();
   await anotherAsyncOp(); // may use the wrong kernel
 });
 
-// CORRECT — for async work, use getKernel() directly.
+// CORRECT: for async work, use getKernel() directly.
 import { getKernel } from 'brepjs';
 
 const k = getKernel('brepkit');
@@ -93,27 +93,27 @@ Three reasons:
 2. **Testing.** Every operation in brepjs runs against multiple kernels in CI. The default gate runs `occt-wasm` (`npm test`); the other kernels run via `npm run test:occt` and `npm run test:brepkit`. Bugs that show in one kernel and not the other surface immediately.
 3. **Custom kernels.** If you have your own geometry library, you can implement `KernelInterface` and plug it in. See [Writing a Custom Kernel](../extending/custom-kernel).
 
-The kernel interface is intentionally minimal — only the methods brepjs actually calls. New methods are added when new operations are added; the interface is segregated by concern (booleans, mesh, IO, etc.) so partial-conformance kernels are possible.
+The kernel interface is intentionally minimal: only the methods brepjs actually calls. New methods are added when new operations are added; the interface is segregated by concern (booleans, mesh, IO, etc.) so partial-conformance kernels are possible.
 
 ## What "the active kernel" actually means
 
 A handful of brepjs functions call `getKernel()` to dispatch:
 
 ```typescript
-// Internal — not user-facing.
+// Internal: not user-facing.
 function measureVolume(s: Shape3D): Result<number> {
   return ok(getKernel().volume(s.wrapped));
 }
 ```
 
-`getKernel()` returns the current kernel (or throws if none is registered). User code never calls it directly — the dispatch is hidden inside the library. You only encounter the kernel system when you choose to switch (`withKernel`) or when you write a custom adapter.
+`getKernel()` returns the current kernel (or throws if none is registered). User code never calls it directly; the dispatch is hidden inside the library. You only encounter the kernel system when you choose to switch (`withKernel`) or when you write a custom adapter.
 
 ## When you might not need this chapter
 
-If you install `occt-wasm`, run `import 'brepjs/quick'`, and never think about kernels again, that's fine — that's the intended path for 90% of users. This chapter exists for the other 10%: people writing kernel adapters, dual-kernel test suites, or apps that need to compare results between kernels.
+If you install `occt-wasm`, run `import 'brepjs/quick'`, and never think about kernels again, that's fine; that's the intended path for 90% of users. This chapter exists for the other 10%: people writing kernel adapters, dual-kernel test suites, or apps that need to compare results between kernels.
 
 ## Next steps
 
-- [Tolerance and Validity](./tolerance) — what `BRepCheck` validates and how tolerance interacts with kernels
-- [Writing a Custom Kernel](../extending/custom-kernel) — implementing `KernelInterface` for your own backend
-- [Kernel Conformance Suite](../extending/conformance) — verifying a custom kernel against the brepjs test suite
+- [Tolerance and Validity](./tolerance): what `BRepCheck` validates and how tolerance interacts with kernels
+- [Writing a Custom Kernel](../extending/custom-kernel): implementing `KernelInterface` for your own backend
+- [Kernel Conformance Suite](../extending/conformance): verifying a custom kernel against the brepjs test suite

--- a/apps/docs/concepts/result.md
+++ b/apps/docs/concepts/result.md
@@ -5,7 +5,7 @@ description: 'Every fallible brepjs operation returns Result<T, BrepError> inste
 
 # Result and Errors
 
-Every fallible operation in brepjs — every boolean, every fillet, every import, every export — returns a `Result<T, BrepError>` instead of throwing. This chapter explains why, how to handle it, and the patterns that keep error handling clean.
+Every fallible operation in brepjs (every boolean, every fillet, every import, every export) returns a `Result<T, BrepError>` instead of throwing. This chapter explains why, how to handle it, and the patterns that keep error handling clean.
 
 ## What `Result<T, E>` is
 
@@ -15,11 +15,11 @@ type Result<T, E = BrepError> = { ok: true; value: T } | { ok: false; error: E }
 
 A discriminated union with two cases. Either the operation succeeded (`ok: true` with a `value`) or it failed (`ok: false` with an `error`). TypeScript narrows the union based on `ok`, so once you check, the value or error is concretely typed.
 
-This is the same pattern used by Rust's `Result`, Haskell's `Either`, and a thousand other type systems that take error handling seriously. brepjs adopts it because boolean operations on B-Rep shapes are _fundamentally_ fallible — they can fail on near-coincident geometry, on invalid inputs, on tolerance issues — and a thrown exception buries the error several stack frames up from where the user can do anything useful with it.
+This is the same pattern used by Rust's `Result`, Haskell's `Either`, and a thousand other type systems that take error handling seriously. brepjs adopts it because boolean operations on B-Rep shapes are _fundamentally_ fallible (they can fail on near-coincident geometry, on invalid inputs, on tolerance issues) and a thrown exception buries the error several stack frames up from where the user can do anything useful with it.
 
 ## The four ways to handle a Result
 
-### 1. `unwrap` — for scripts and tests
+### 1. `unwrap`: for scripts and tests
 
 ```typescript
 import { box, cylinder, cut, unwrap } from 'brepjs/quick';
@@ -28,9 +28,9 @@ const part = unwrap(cut(box(20, 20, 20), cylinder(5, 25)));
 console.log('Cut succeeded');
 ```
 
-`unwrap()` extracts the value or throws on error. Use it in scripts, examples, and tests — places where a thrown exception is the right outcome on failure. **Do not use it in production code paths** where you want to recover or surface an error.
+`unwrap()` extracts the value or throws on error. Use it in scripts, examples, and tests, places where a thrown exception is the right outcome on failure. **Do not use it in production code paths** where you want to recover or surface an error.
 
-### 2. `isOk` / `isErr` — for control flow
+### 2. `isOk` / `isErr`: for control flow
 
 ```typescript
 import { box, cylinder, cut, isOk } from 'brepjs/quick';
@@ -46,23 +46,23 @@ if (isOk(result)) {
 }
 ```
 
-The most common pattern. Read the error fields and decide what to do — fall back, retry with adjusted parameters, surface to the user.
+The most common pattern. Read the error fields and decide what to do: fall back, retry with adjusted parameters, surface to the user.
 
-### 3. `match` — for exhaustive both-arms handling
+### 3. `match`: for exhaustive both-arms handling
 
 ```typescript
 import { box, cylinder, cut, match, measureVolume, unwrap } from 'brepjs/quick';
 
 const summary = match(cut(box(20, 20, 20), cylinder(5, 25)), {
   ok: (s) => `Volume: ${unwrap(measureVolume(s)).toFixed(2)} mm³`,
-  err: (e) => `Failed: ${e.code} — ${e.suggestion ?? 'no suggestion'}`,
+  err: (e) => `Failed: ${e.code}: ${e.suggestion ?? 'no suggestion'}`,
 });
 console.log(summary);
 ```
 
-Equivalent to the `if/else`, but expression-shaped — both arms produce a value of the same type. Useful when you want a single value out of the operation.
+Equivalent to the `if/else`, but expression-shaped; both arms produce a value of the same type. Useful when you want a single value out of the operation.
 
-### 4. The fluent wrapper — auto-unwrap
+### 4. The fluent wrapper: auto-unwrap
 
 ```typescript
 import { shape, box, cylinder, BrepWrapperError } from 'brepjs/quick';
@@ -83,7 +83,7 @@ The `shape()` wrapper automatically unwraps every operation in the chain. Failur
 
 ```typescript
 type BrepError = {
-  code: string; // stable identifier — e.g. 'BOOLEAN_NO_OVERLAP'
+  code: string; // stable identifier, e.g. 'BOOLEAN_NO_OVERLAP'
   message: string; // human-readable description
   suggestion?: string; // actionable recovery advice when available
   cause?: unknown; // underlying kernel error if applicable
@@ -92,8 +92,8 @@ type BrepError = {
 
 The most useful fields:
 
-- **`code`** — stable across releases. Switch on this for programmatic recovery (`if (e.code === 'FILLET_TOO_LARGE')`).
-- **`suggestion`** — when the kernel returns a known failure mode, brepjs adds a one-line suggestion. Surface this to users when you can.
+- **`code`**: stable across releases. Switch on this for programmatic recovery (`if (e.code === 'FILLET_TOO_LARGE')`).
+- **`suggestion`**: when the kernel returns a known failure mode, brepjs adds a one-line suggestion. Surface this to users when you can.
 
 See [Error Codes](../reference/errors) for the full list.
 
@@ -157,7 +157,7 @@ match(result, {
 
 Three reasons:
 
-1. **Visibility in signatures.** A function that returns `Result<T, BrepError>` is visibly fallible. A function that returns `T` and might throw is not — you have to read the implementation or remember.
+1. **Visibility in signatures.** A function that returns `Result<T, BrepError>` is visibly fallible. A function that returns `T` and might throw is not. You have to read the implementation or remember.
 2. **No silent catches.** `try/catch` around a thrown error catches _every_ error, including programmer mistakes. `Result` requires you to handle the named failure mode and lets unexpected errors propagate.
 3. **Composition.** Sequencing fallible operations is direct with `Result` (chain `match` calls or use `unwrap` in a script). With exceptions, every step needs a `try/catch` if you want to recover at granularity.
 
@@ -182,6 +182,6 @@ console.log('Final shape produced');
 
 ## Next steps
 
-- [Error Codes](../reference/errors) — every error code and its recovery pattern
-- [Healing & Sewing](../advanced/healing) — repairing shapes that don't pass `BRepCheck`
-- [Boolean Operations](../tasks/booleans) — the most common source of `Result` failures and how to read them
+- [Error Codes](../reference/errors): every error code and its recovery pattern
+- [Healing & Sewing](../advanced/healing): repairing shapes that don't pass `BRepCheck`
+- [Boolean Operations](../tasks/booleans): the most common source of `Result` failures and how to read them

--- a/apps/docs/concepts/tolerance.md
+++ b/apps/docs/concepts/tolerance.md
@@ -102,7 +102,7 @@ For sub-shapes, the tolerance can vary across an edge or face; `getShapeToleranc
 
 ## `autoHeal` short-circuits valid shapes
 
-A subtle but important behaviour: if you call `autoHeal` on a shape that already passes `BRepCheck`, the function short-circuits and returns the input unchanged, with `report.alreadyValid = true`. **No sew, heal, or fix diagnostics run.** This is a performance optimisation (there's nothing to do) but it means you can't use `autoHeal` to "force a recheck" of a valid shape.
+A subtle but important behaviour: if you call `autoHeal` on a shape that already passes `BRepCheck`, the function short-circuits and returns the input unchanged, with `report.alreadyValid = true`. **No sew, heal, or fix diagnostics run.** This is a performance optimisation (there's nothing to do), but it means you can't use `autoHeal` to "force a recheck" of a valid shape.
 
 To force a full re-validation:
 

--- a/apps/docs/concepts/tolerance.md
+++ b/apps/docs/concepts/tolerance.md
@@ -5,17 +5,17 @@ description: 'Every B-Rep shape has a tolerance below which two points are the s
 
 # Tolerance and Validity
 
-Every B-Rep shape has a **tolerance** — a small distance below which the kernel treats two points as the same point and two surfaces as touching. Tolerance is fundamental: pick it too large and your shape's edges stop meeting; pick it too small and floating-point noise produces invalidity. This chapter explains what the tolerance is, how brepjs surfaces it, what `BRepCheck` validates, and when to call `autoHeal`.
+Every B-Rep shape has a **tolerance**: a small distance below which the kernel treats two points as the same point and two surfaces as touching. Tolerance is fundamental: pick it too large and your shape's edges stop meeting; pick it too small and floating-point noise produces invalidity. This chapter explains what the tolerance is, how brepjs surfaces it, what `BRepCheck` validates, and when to call `autoHeal`.
 
 ## What tolerance means
 
-When the kernel builds a face from a wire, it doesn't require the wire to close _exactly_ — it requires it to close within a tolerance ε. Two adjacent edges share a vertex if their endpoints are within ε. Two adjacent faces share an edge if the edge curves are within ε along their length. The kernel uses tolerance everywhere — every operation, every check.
+When the kernel builds a face from a wire, it doesn't require the wire to close _exactly_; it requires it to close within a tolerance ε. Two adjacent edges share a vertex if their endpoints are within ε. Two adjacent faces share an edge if the edge curves are within ε along their length. The kernel uses tolerance everywhere: every operation, every check.
 
 The default tolerance for OpenCascade is `1e-7` (0.0000001 mm). For most parametric parts at millimetre scale this is fine; floating-point precision is around `1e-15` for double-precision numbers, so tolerance can be much smaller than your geometry without running out of headroom. Working in micrometres or below changes the calculus.
 
 ## Where tolerance shows up
 
-You typically don't set tolerance — operations propagate it from inputs to outputs, and the kernel adjusts as needed. The places where tolerance is exposed:
+You typically don't set tolerance; operations propagate it from inputs to outputs, and the kernel adjusts as needed. The places where tolerance is exposed:
 
 ### Mesh tolerance
 
@@ -27,7 +27,7 @@ const m = shape(b).mesh({ tolerance: 0.01 }); // smaller = more triangles
 console.log('Triangles:', m.indices.length / 3);
 ```
 
-This is the **mesh** tolerance, not the geometric tolerance — how close the triangulation has to be to the exact surface. Smaller tolerance produces denser meshes. The default is reasonable for screen-size rendering; reduce it for closeup zoom or 3D printing.
+This is the **mesh** tolerance, not the geometric tolerance: how close the triangulation has to be to the exact surface. Smaller tolerance produces denser meshes. The default is reasonable for screen-size rendering; reduce it for closeup zoom or 3D printing.
 
 ### Boolean tolerance hints
 
@@ -48,7 +48,7 @@ void healed;
 
 ## What `BRepCheck` validates
 
-When a primitive returns `ValidSolid`, that means the shape passed `BRepCheck` — OpenCascade's validity checker. Concretely, `BRepCheck` verifies:
+When a primitive returns `ValidSolid`, that means the shape passed `BRepCheck`, OpenCascade's validity checker. Concretely, `BRepCheck` verifies:
 
 | Check                   | Failure means                                                            |
 | ----------------------- | ------------------------------------------------------------------------ |
@@ -68,7 +68,7 @@ Three common situations:
 
 ### 1. Imported shapes from third-party formats
 
-STEP, IGES, BREP, and especially STL imports often arrive with minor invalidity — gaps between adjacent faces, edges with the wrong precision, vertices that don't quite match. Always run `autoHeal` on imported shapes before using them in operations:
+STEP, IGES, BREP, and especially STL imports often arrive with minor invalidity: gaps between adjacent faces, edges with the wrong precision, vertices that don't quite match. Always run `autoHeal` on imported shapes before using them in operations:
 
 ```typescript
 import { importSTEP, autoHeal, unwrap } from 'brepjs/quick';
@@ -81,7 +81,7 @@ void ready;
 
 ### 2. Operations near coincident geometry
 
-When two faces are _almost_ coplanar but not quite, the boolean kernel can produce slivers — tiny faces that aren't really there. The result still passes `BRepCheck` but is geometrically suspect. Running `autoHeal` afterwards consolidates them.
+When two faces are _almost_ coplanar but not quite, the boolean kernel can produce slivers: tiny faces that aren't really there. The result still passes `BRepCheck` but is geometrically suspect. Running `autoHeal` afterwards consolidates them.
 
 ### 3. Bad parameter choices
 
@@ -98,11 +98,11 @@ const b = box(10, 10, 10);
 console.log('Tolerance:', getShapeTolerance(b)); // ~1e-7
 ```
 
-For sub-shapes, the tolerance can vary across an edge or face — `getShapeTolerance` returns the maximum.
+For sub-shapes, the tolerance can vary across an edge or face; `getShapeTolerance` returns the maximum.
 
 ## `autoHeal` short-circuits valid shapes
 
-A subtle but important behaviour: if you call `autoHeal` on a shape that already passes `BRepCheck`, the function short-circuits and returns the input unchanged, with `report.alreadyValid = true`. **No sew, heal, or fix diagnostics run.** This is a performance optimisation — there's nothing to do — but it means you can't use `autoHeal` to "force a recheck" of a valid shape.
+A subtle but important behaviour: if you call `autoHeal` on a shape that already passes `BRepCheck`, the function short-circuits and returns the input unchanged, with `report.alreadyValid = true`. **No sew, heal, or fix diagnostics run.** This is a performance optimisation (there's nothing to do) but it means you can't use `autoHeal` to "force a recheck" of a valid shape.
 
 To force a full re-validation:
 
@@ -126,12 +126,12 @@ if (!report.valid) {
 Two scenarios that show up in real apps:
 
 - **Sub-millimetre scale**: working in micrometres with default tolerance `1e-7` (which is now `1e-7` micrometres = `1e-13` of your unit). The kernel may treat distinct points as identical. Switch units to millimetres at construction time and scale at export.
-- **Very large parts**: working at kilometre scale stresses tolerance the other way — `1e-7` mm relative to a kilometre is `1e-13` relative precision, fine for IEEE-754, but boolean operations on large coordinate values do lose precision. Translate the part near the origin, operate, translate back.
+- **Very large parts**: working at kilometre scale stresses tolerance the other way. `1e-7` mm relative to a kilometre is `1e-13` relative precision, fine for IEEE-754, but boolean operations on large coordinate values do lose precision. Translate the part near the origin, operate, translate back.
 
 When in doubt: keep your geometry within ~10⁰ to 10⁴ in your chosen units, and tolerance takes care of itself.
 
 ## Next steps
 
-- [Healing & Sewing](../advanced/healing) — `autoHeal`, `sew`, manual repair workflows
-- [Error Codes](../reference/errors) — what `INVALID_SHAPE` and tolerance-related codes mean
-- [Boolean Operations](../tasks/booleans) — the operation most sensitive to tolerance
+- [Healing & Sewing](../advanced/healing): `autoHeal`, `sew`, manual repair workflows
+- [Error Codes](../reference/errors): what `INVALID_SHAPE` and tolerance-related codes mean
+- [Boolean Operations](../tasks/booleans): the operation most sensitive to tolerance

--- a/apps/docs/concepts/topology.md
+++ b/apps/docs/concepts/topology.md
@@ -5,13 +5,13 @@ description: 'Solid → Shell → Face → Wire → Edge → Vertex. The recursi
 
 # The Topology Hierarchy
 
-A B-Rep shape is a recursive structure: a solid contains shells, shells contain faces, faces contain wires, wires contain edges, and edges contain vertices. Every modelling operation operates somewhere on this hierarchy, and every query you write picks an entity at one level. Knowing the levels — and the brand on each — is the bedrock of using brepjs effectively.
+A B-Rep shape is a recursive structure: a solid contains shells, shells contain faces, faces contain wires, wires contain edges, and edges contain vertices. Every modelling operation operates somewhere on this hierarchy, and every query you write picks an entity at one level. Knowing the levels (and the brand on each) is the bedrock of using brepjs effectively.
 
 ## The hierarchy
 
 ```
 Compound      collection of any shapes
-  └─ Solid      watertight 3D volume — the goal of most CAD work
+  └─ Solid      watertight 3D volume - the goal of most CAD work
        └─ Shell     closed surface bounding a solid
             └─ Face     bounded region of a mathematical surface
                  └─ Wire     closed loop of edges (face boundary)
@@ -19,7 +19,7 @@ Compound      collection of any shapes
                            └─ Vertex   point in 3D space
 ```
 
-Each level adds geometric meaning to the level below. An edge is just a curve, but a _closed_ edge loop forms a wire that bounds a face. A face is just a trimmed surface, but a _closed_ set of faces forms a shell that bounds a solid. The brepjs type system encodes these "closed" qualifiers as validity brands — see [Types That Prove Geometry Is Valid](./types).
+Each level adds geometric meaning to the level below. An edge is just a curve, but a _closed_ edge loop forms a wire that bounds a face. A face is just a trimmed surface, but a _closed_ set of faces forms a shell that bounds a solid. The brepjs type system encodes these "closed" qualifiers as validity brands; see [Types That Prove Geometry Is Valid](./types).
 
 ## The seven shape kinds
 
@@ -43,12 +43,12 @@ if (firstCorner) {
 
 A curve segment connecting two vertices. The curve is one of:
 
-- `LINE` — straight segment
-- `CIRCLE` — circular arc (or full circle)
-- `ELLIPSE` — elliptical arc
-- `BEZIER` — Bézier curve
-- `BSPLINE` — B-spline (the catch-all for non-analytic curves)
-- `OFFSET` — an offset of another curve
+- `LINE`: straight segment
+- `CIRCLE`: circular arc (or full circle)
+- `ELLIPSE`: elliptical arc
+- `BEZIER`: Bézier curve
+- `BSPLINE`: B-spline (the catch-all for non-analytic curves)
+- `OFFSET`: an offset of another curve
 
 ```typescript
 import { box, edgeFinder, curveLength, getCurveType } from 'brepjs/quick';
@@ -79,13 +79,13 @@ if (oneFace) {
 
 ### Face
 
-A bounded region of a mathematical surface — a plane trimmed to a polygon, a cylinder trimmed to a band, a sphere trimmed to a cap. The surface kind determines what's possible: a planar face can be sketched on, extruded, mirrored; a curved face can be queried for normal at a point.
+A bounded region of a mathematical surface: a plane trimmed to a polygon, a cylinder trimmed to a band, a sphere trimmed to a cap. The surface kind determines what's possible: a planar face can be sketched on, extruded, mirrored; a curved face can be queried for normal at a point.
 
 Face surface kinds:
 
-- `PLANE`, `CYLINDER`, `CONE`, `SPHERE`, `TORUS` — analytic
-- `BSPLINE_SURFACE` — the catch-all
-- `OFFSET_SURFACE`, `EXTRUSION`, `REVOLUTION` — derived
+- `PLANE`, `CYLINDER`, `CONE`, `SPHERE`, `TORUS`: analytic
+- `BSPLINE_SURFACE`: the catch-all
+- `OFFSET_SURFACE`, `EXTRUSION`, `REVOLUTION`: derived
 
 ```typescript
 import { box, faceFinder, measureArea, getSurfaceType, unwrap } from 'brepjs/quick';
@@ -102,19 +102,19 @@ console.log('All faces:', faces.length);
 
 ### Shell
 
-A connected set of faces. A **closed shell** has every edge shared by exactly two faces — it bounds a solid. Open shells exist (think a tea-cup before the bottom is sewn on); they are useful as intermediate results during construction.
+A connected set of faces. A **closed shell** has every edge shared by exactly two faces; it bounds a solid. Open shells exist (think a tea-cup before the bottom is sewn on); they are useful as intermediate results during construction.
 
 ```typescript
 import { box, shellFinder } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
 const shells = shellFinder().findAll(b);
-console.log('Shells:', shells.length); // 1 — the outer shell of the box
+console.log('Shells:', shells.length); // 1: the outer shell of the box
 ```
 
 ### Solid
 
-A 3D volume bounded by one or more shells (one outer, possibly inner shells for cavities). The most common output type. Every primitive (`box`, `cylinder`, `sphere`) returns a `ValidSolid` — a solid that has passed `BRepCheck`.
+A 3D volume bounded by one or more shells (one outer, possibly inner shells for cavities). The most common output type. Every primitive (`box`, `cylinder`, `sphere`) returns a `ValidSolid`: a solid that has passed `BRepCheck`.
 
 ```typescript
 import { box, sphere, measureVolume, unwrap } from 'brepjs/quick';
@@ -142,8 +142,8 @@ A compound containing only solids is a `CompSolid`. Compound is the fallback typ
 
 Some brepjs functions accept any shape regardless of level. Two convenience unions:
 
-- `Shape3D` — `Face | Shell | Solid | CompSolid | Compound<'3D'>`. The argument type for "anything 3D".
-- `AnyShape` — `Vertex | Edge | Wire | Face | Shell | Solid | CompSolid | Compound`. Truly anything.
+- `Shape3D`: `Face | Shell | Solid | CompSolid | Compound<'3D'>`. The argument type for "anything 3D".
+- `AnyShape`: `Vertex | Edge | Wire | Face | Shell | Solid | CompSolid | Compound`. Truly anything.
 
 A phantom dimension parameter (`'2D' | '3D'`) prevents mixing 2D drafts with 3D parts at compile time. See [Types That Prove Geometry Is Valid](./types) for the full story.
 
@@ -162,7 +162,7 @@ edgeFinder().inDirection('Z').findAll(b); // 4 vertical
 faceFinder().ofSurfaceType('PLANE').findAll(b); // 6
 ```
 
-Finders return arrays — empty if nothing matches. They never throw and never return `undefined`. See [Finders & Queries](../tasks/finders) for the full filter vocabulary.
+Finders return arrays, empty if nothing matches. They never throw and never return `undefined`. See [Finders & Queries](../tasks/finders) for the full filter vocabulary.
 
 ## How operations move you up the hierarchy
 
@@ -193,6 +193,6 @@ You start with edges (lines), close them into a wire, the wire becomes a face, t
 
 ## Next steps
 
-- [Types That Prove Geometry Is Valid](./types) — the brand-and-validity types that prevent topology bugs at compile time
-- [Finders & Queries](../tasks/finders) — selecting entities at any level
-- [2D Sketching](../tasks/sketching) — building wires and faces fluently
+- [Types That Prove Geometry Is Valid](./types): the brand-and-validity types that prevent topology bugs at compile time
+- [Finders & Queries](../tasks/finders): selecting entities at any level
+- [2D Sketching](../tasks/sketching): building wires and faces fluently

--- a/apps/docs/concepts/types.md
+++ b/apps/docs/concepts/types.md
@@ -5,7 +5,7 @@ description: 'Branded types, phantom dimensions, and validity brands prove your 
 
 # Types That Prove Geometry Is Valid
 
-This is the chapter that explains what makes brepjs different. Most code-CAD libraries treat shapes as a single "thing" — `Shape`, `Geometry`, `Solid` — and let runtime errors find your bugs. brepjs uses TypeScript's type system to encode topological invariants at compile time. A wire that hasn't been proven closed cannot be passed to `face()`. A face whose normal hasn't been determined cannot be passed to `extrude()`. The compiler refuses, and you find the bug while typing.
+This is the chapter that explains what makes brepjs different. Most code-CAD libraries treat shapes as a single "thing" (`Shape`, `Geometry`, `Solid`) and let runtime errors find your bugs. brepjs uses TypeScript's type system to encode topological invariants at compile time. A wire that hasn't been proven closed cannot be passed to `face()`. A face whose normal hasn't been determined cannot be passed to `extrude()`. The compiler refuses, and you find the bug while typing.
 
 There are three layers of types that work together: **branded types** for shape kind, **phantom dimension types** for 2D/3D safety, and **validity brands** for topological invariants.
 
@@ -20,7 +20,7 @@ type Face<D extends Dimension = '3D'>   = ShapeHandle & { readonly [__brand]: 'f
 type Solid                              = ShapeHandle & { readonly [__brand]: 'solid' };
 ```
 
-The brand is a phantom property — it exists only at the type level, costs zero bytes at runtime, and prevents nominal mixups:
+The brand is a phantom property; it exists only at the type level, costs zero bytes at runtime, and prevents nominal mixups:
 
 ```typescript
 import { box, edgeFinder, type Face } from 'brepjs/quick';
@@ -28,7 +28,7 @@ import { box, edgeFinder, type Face } from 'brepjs/quick';
 const edges = edgeFinder().findAll(box(10, 10, 10));
 const firstEdge = edges[0];
 
-// This does NOT compile — Edge is not assignable to Face
+// This does NOT compile - Edge is not assignable to Face
 // const f: Face = firstEdge;
 void firstEdge;
 ```
@@ -60,11 +60,11 @@ const profile = drawRectangle(40, 20); // Drawing<'2D'>
 
 The dimension parameter has zero runtime cost. `Edge<'2D'>` and `Edge<'3D'>` are the same byte-for-byte at runtime; only the compiler distinguishes them.
 
-`Shell`, `Solid`, and `CompSolid` are always 3D — they have no dimension parameter.
+`Shell`, `Solid`, and `CompSolid` are always 3D; they have no dimension parameter.
 
 ## Layer 3: validity brands for topological invariants
 
-Some operations require shapes that satisfy properties beyond their kind. A face cannot be built from any wire — only from a _closed_ wire. A solid cannot be extruded from any face — only from one with a determined normal. brepjs encodes these as **validity brands**:
+Some operations require shapes that satisfy properties beyond their kind. A face cannot be built from any wire, only from a _closed_ wire. A solid cannot be extruded from any face, only from one with a determined normal. brepjs encodes these as **validity brands**:
 
 ```typescript
 type ClosedWire<D> = Wire<D> & { readonly [__closed]: true };
@@ -94,14 +94,14 @@ declare const myWire: import('brepjs').Wire;
 
 const result = closedWire(myWire); // ValidityResult<ClosedWire>
 if (result.valid) {
-  // result.shape is now ClosedWire — the runtime check passed
+  // result.shape is now ClosedWire: the runtime check passed
   // and the type system has been updated.
   const cw = result.shape;
   void cw;
 }
 ```
 
-`closedWire(w)` performs a runtime check (does this wire form a loop?) and returns a `ValidityResult` — either `{ valid: true, shape: ClosedWire }` or `{ valid: false, reason: ... }`. Use this when you've built a wire from primitives or imported it.
+`closedWire(w)` performs a runtime check (does this wire form a loop?) and returns a `ValidityResult`: either `{ valid: true, shape: ClosedWire }` or `{ valid: false, reason: ... }`. Use this when you've built a wire from primitives or imported it.
 
 ### 2. Type guard (narrow in place)
 
@@ -123,7 +123,7 @@ The type guard combines the runtime check with TypeScript narrowing. Equivalent 
 ```typescript
 import { line, wireLoop, face, extrude, unwrap } from 'brepjs/quick';
 
-// wireLoop returns Result<ClosedWire> — it builds a closed wire by construction
+// wireLoop returns Result<ClosedWire> - it builds a closed wire by construction
 const cw = unwrap(
   wireLoop([
     line([0, 0, 0], [10, 0, 0]),
@@ -146,7 +146,7 @@ console.log('Built a valid solid by construction');
 | ---------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `face(wire)` accepted at compile, may throw at runtime if wire is open | `face(wire)` rejected at compile if wire is not `ClosedWire` |
 | `extrude(face, 10)` accepted, may produce inverted solid               | `extrude(face, 10)` rejected if face is not `OrientedFace`   |
-| Caller has to remember to `if (wire.isClosed)`                         | Caller cannot forget — the compiler refuses                  |
+| Caller has to remember to `if (wire.isClosed)`                         | Caller cannot forget; the compiler refuses                   |
 | Validity checks scattered throughout user code                         | Centralized in smart constructors and builders               |
 
 ## Combining the layers
@@ -173,7 +173,7 @@ All four facts are checked by the compiler.
 
 ## When brands get in the way
 
-Branded types work great until you import a shape from elsewhere — STEP files, deserialized data, or third-party libraries. In those cases, you have a `Wire` and need a `ClosedWire`. Two options:
+Branded types work great until you import a shape from elsewhere: STEP files, deserialized data, or third-party libraries. In those cases, you have a `Wire` and need a `ClosedWire`. Two options:
 
 ```typescript
 import { closedWire, isClosedWire, autoHeal, unwrap } from 'brepjs/quick';
@@ -192,7 +192,7 @@ if (isClosedWire(healed)) {
 }
 ```
 
-`autoHeal` runs OpenCascade's `ShapeFix` to close gaps and stitch faces — see [Healing & Sewing](../advanced/healing).
+`autoHeal` runs OpenCascade's `ShapeFix` to close gaps and stitch faces. See [Healing & Sewing](../advanced/healing).
 
 ## Cost: zero
 
@@ -200,6 +200,6 @@ Every brand is a phantom type. The compiled JS doesn't even know they exist. Bra
 
 ## Next steps
 
-- [Result and Errors](./result) — the `Result<T,E>` type used by every fallible operation
-- [The Topology Hierarchy](./topology) — what each shape kind represents geometrically
-- [Tolerance and Validity](./tolerance) — what `BRepCheck` actually checks, and what tolerance means
+- [Result and Errors](./result): the `Result<T,E>` type used by every fallible operation
+- [The Topology Hierarchy](./topology): what each shape kind represents geometrically
+- [Tolerance and Validity](./tolerance): what `BRepCheck` actually checks, and what tolerance means

--- a/apps/docs/extending/architecture.md
+++ b/apps/docs/extending/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture & Layers
-description: 'The four enforced layers — kernel, core, domain, high-level API — and the rules that keep imports flowing downward only.'
+description: 'The four enforced layers (kernel, core, domain, high-level API) and the rules that keep imports flowing downward only.'
 ---
 
 # Architecture & Layers
@@ -29,24 +29,24 @@ Layer 0 imports nothing internal. Layer 1 imports only Layer 0. Layer 2 modules 
 
 The foundation. Nothing internal-imported here.
 
-- `kernel/` — the WASM kernel abstraction
-  - `types.ts` — `KernelInterface` and shared types (the public stable API for kernel implementers)
-  - `interfaces/` — segregated interface fragments (`KernelBooleans`, `KernelMesh`, etc.)
-  - `occt/` — OpenCascade adapter (private; only the registered kernel id `'occt'` is public)
-  - `brepkit/` — brepkit adapter (private; only `'brepkit'` is public)
-- `utils/` — math helpers, type predicates, generic JS utilities
+- `kernel/`: the WASM kernel abstraction
+  - `types.ts`: `KernelInterface` and shared types (the public stable API for kernel implementers)
+  - `interfaces/`: segregated interface fragments (`KernelBooleans`, `KernelMesh`, etc.)
+  - `occt/`: OpenCascade adapter (private; only the registered kernel id `'occt'` is public)
+  - `brepkit/`: brepkit adapter (private; only `'brepkit'` is public)
+- `utils/`: math helpers, type predicates, generic JS utilities
 
 ### Layer 1: core/
 
 Memory management, errors, branded types, the `Result` type.
 
-- `core/disposal.ts` — `DisposalScope`, `withScope`, `createHandle`, `createKernelHandle`, the `using`-compatible cleanup machinery
-- `core/result.ts` — `Result<T,E>`, `ok`, `err`, `isOk`, `isErr`, `unwrap`, `match`
-- `core/shapeTypes.ts` — branded types (`Edge`, `Wire`, `Face`, `Solid`, etc.) and validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`)
-- `core/errors.ts` — `BrepError` shape and well-known error codes
-- `core/dimensions.ts` — phantom dimension types
-- `core/vectors.ts` — vector math helpers
-- `core/planes.ts` — `Plane` type, plane name resolution
+- `core/disposal.ts`: `DisposalScope`, `withScope`, `createHandle`, `createKernelHandle`, the `using`-compatible cleanup machinery
+- `core/result.ts`: `Result<T,E>`, `ok`, `err`, `isOk`, `isErr`, `unwrap`, `match`
+- `core/shapeTypes.ts`: branded types (`Edge`, `Wire`, `Face`, `Solid`, etc.) and validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`)
+- `core/errors.ts`: `BrepError` shape and well-known error codes
+- `core/dimensions.ts`: phantom dimension types
+- `core/vectors.ts`: vector math helpers
+- `core/planes.ts`: `Plane` type, plane name resolution
 
 Layer 1 is small, stable, and has no external runtime dependencies beyond Layer 0.
 
@@ -54,13 +54,13 @@ Layer 1 is small, stable, and has no external runtime dependencies beyond Layer 
 
 Each module owns one concern. Layer 2 modules import each other peer-to-peer.
 
-- `topology/` — primitives (`box`, `cylinder`, …), shape construction, type guards (`isSolid`, `isFace`)
-- `operations/` — extrude, revolve, loft, sweep, patterns, assembly, history
-- `2d/` — drawings, 2D booleans, blueprints
-- `query/` — finders (`edgeFinder`, `faceFinder`, …)
-- `measurement/` — volume, area, length, distance, curvature
-- `io/` — STEP, IGES, BREP, STL, OBJ, glTF, DXF, 3MF, SVG
-- `worker/` — typed RPC for `brepjs/worker`
+- `topology/`: primitives (`box`, `cylinder`, …), shape construction, type guards (`isSolid`, `isFace`)
+- `operations/`: extrude, revolve, loft, sweep, patterns, assembly, history
+- `2d/`: drawings, 2D booleans, blueprints
+- `query/`: finders (`edgeFinder`, `faceFinder`, …)
+- `measurement/`: volume, area, length, distance, curvature
+- `io/`: STEP, IGES, BREP, STL, OBJ, glTF, DXF, 3MF, SVG
+- `worker/`: typed RPC for `brepjs/worker`
 
 Each Layer 2 module exports through an `index.ts` that brepjs's package.json exposes as a sub-path (`brepjs/topology`, `brepjs/operations`, etc.).
 
@@ -68,9 +68,9 @@ Each Layer 2 module exports through an `index.ts` that brepjs's package.json exp
 
 Composes Layer 2 into ergonomic surfaces.
 
-- `sketching/` — the `Sketcher` builder, sketch-to-shape operations, canned profiles
-- `text/` — text-as-2D-curves (using `opentype.js`)
-- `projection/` — projecting 3D to 2D drawings for laser / SVG export
+- `sketching/`: the `Sketcher` builder, sketch-to-shape operations, canned profiles
+- `text/`: text-as-2D-curves (using `opentype.js`)
+- `projection/`: projecting 3D to 2D drawings for laser / SVG export
 
 Layer 3 is what most users touch indirectly: `Sketcher` underlies most 2D-to-3D pipelines, `text/` underlies any nameplate or label feature.
 
@@ -82,17 +82,17 @@ Every Layer 1 type is depended on by every Layer 2 module. If Layer 1 also impor
 
 ### Layer 2 modules are peers
 
-`topology` and `operations` need each other (operations creates shapes that topology functions consume; topology has primitives that operations transform). Same for `query` and the others. The peer relationship is intentional — they're all "domain logic" — but they all sit above the same foundation.
+`topology` and `operations` need each other (operations creates shapes that topology functions consume; topology has primitives that operations transform). Same for `query` and the others. The peer relationship is intentional (they're all "domain logic") but they all sit above the same foundation.
 
 ### Layer 3 cannot leak into Layer 2
 
-The `Sketcher` is in Layer 3 because it composes `topology`, `operations`, and `2d`. If `topology` could import `Sketcher`, the API would be tangled — tests would have to load the full sketching machinery to test a primitive. The ban keeps each layer testable in isolation.
+The `Sketcher` is in Layer 3 because it composes `topology`, `operations`, and `2d`. If `topology` could import `Sketcher`, the API would be tangled; tests would have to load the full sketching machinery to test a primitive. The ban keeps each layer testable in isolation.
 
 ## The `.wrapped` rule
 
 Each shape brepjs ships is a TypeScript handle wrapping a kernel WASM object. The kernel object is exposed as `.wrapped`. Two rules:
 
-1. **Layer 0 may call methods on `.wrapped` directly** (it's the kernel adapter — that's what it does).
+1. **Layer 0 may call methods on `.wrapped` directly** (it's the kernel adapter; that's what it does).
 2. **Layers 1, 2, 3 must never call methods on `.wrapped`.** Always go through `getKernel().method(shape.wrapped)`.
 
 ESLint enforces this via `no-restricted-syntax`. The reason: by routing through `getKernel()`, the kernel can be swapped at runtime without changing user code. Direct `.wrapped.method()` bypasses the abstraction and breaks dual-kernel testing.
@@ -105,7 +105,7 @@ The pattern checker (`npm run check:patterns`) flags `async` callbacks to `withK
 
 ## The `*Fns.ts` convention
 
-New domain functionality goes in `*Fns.ts` files — flat functions that take and return branded types. The legacy classes (`Shape`, `Solid`, `Edge` in `topology/`) are deprecated and frozen — no new methods. The `*Fns` files are the canonical surface that the fluent `shape()` wrapper composes.
+New domain functionality goes in `*Fns.ts` files: flat functions that take and return branded types. The legacy classes (`Shape`, `Solid`, `Edge` in `topology/`) are deprecated and frozen, with no new methods. The `*Fns` files are the canonical surface that the fluent `shape()` wrapper composes.
 
 This is why the docs and the migration guides emphasize the functional API: it's the API that's still growing. The class-based wrappers are kept for backwards compatibility and removed in the next major.
 
@@ -127,9 +127,9 @@ See [Pattern Checker Rules](./pattern-checker) for the full rule catalog.
 
 Adding a new operation typically touches three layers:
 
-1. **Layer 0** (`kernel/types.ts` + adapter) — extend `KernelInterface` with the new method, implement in the OpenCascade and brepkit adapters.
-2. **Layer 2** (`operations/<newOpFns.ts>`) — write the `*Fns` function that calls `getKernel().newMethod(...)`.
-3. **Layer 3** (`sketching/index.ts` if applicable) — expose via the fluent wrapper.
+1. **Layer 0** (`kernel/types.ts` + adapter): extend `KernelInterface` with the new method, implement in the OpenCascade and brepkit adapters.
+2. **Layer 2** (`operations/<newOpFns.ts>`): write the `*Fns` function that calls `getKernel().newMethod(...)`.
+3. **Layer 3** (`sketching/index.ts` if applicable): expose via the fluent wrapper.
 
 Each step is a separate concern: the kernel says _what's possible_, the operation says _how to invoke it_, the wrapper says _how to compose it_. Decoupling makes each step testable in isolation.
 
@@ -137,18 +137,18 @@ See [Writing Custom Operations](./custom-ops) for the full walkthrough and [Writ
 
 ## Quick reference
 
-| What you're doing                                | Layer                                 |
-| ------------------------------------------------ | ------------------------------------- |
-| Adding a new primitive (`pyramid`, `helixSolid`) | Layer 2 — `topology/`                 |
-| Adding an operation (`twistExtrude`)             | Layer 2 — `operations/`               |
-| Adding an exporter (e.g. JT format)              | Layer 2 — `io/`                       |
-| Adding a measurement                             | Layer 2 — `measurement/`              |
-| Wiring a new kernel method                       | Layer 0 — `kernel/types.ts` + adapter |
-| Adding a fluent wrapper helper                   | Layer 3 — usually in the wrapper file |
-| Adding a new branded type                        | Layer 1 — `core/shapeTypes.ts`        |
+| What you're doing                                | Layer                                |
+| ------------------------------------------------ | ------------------------------------ |
+| Adding a new primitive (`pyramid`, `helixSolid`) | Layer 2: `topology/`                 |
+| Adding an operation (`twistExtrude`)             | Layer 2: `operations/`               |
+| Adding an exporter (e.g. JT format)              | Layer 2: `io/`                       |
+| Adding a measurement                             | Layer 2: `measurement/`              |
+| Wiring a new kernel method                       | Layer 0: `kernel/types.ts` + adapter |
+| Adding a fluent wrapper helper                   | Layer 3: usually in the wrapper file |
+| Adding a new branded type                        | Layer 1: `core/shapeTypes.ts`        |
 
 ## Next steps
 
-- [Writing a Custom Kernel](./custom-kernel) — implementing `KernelInterface` for a new backend
-- [Writing Custom Operations](./custom-ops) — adding to Layer 2
-- [Pattern Checker Rules](./pattern-checker) — the AST checks that protect the architecture
+- [Writing a Custom Kernel](./custom-kernel): implementing `KernelInterface` for a new backend
+- [Writing Custom Operations](./custom-ops): adding to Layer 2
+- [Pattern Checker Rules](./pattern-checker): the AST checks that protect the architecture

--- a/apps/docs/extending/conformance.md
+++ b/apps/docs/extending/conformance.md
@@ -5,7 +5,7 @@ description: 'The kernel conformance test suite. Run the same tests against ever
 
 # Kernel Conformance Suite
 
-The conformance suite is the test suite brepjs runs against every supported kernel. Same tests, two backends — anywhere a test passes on one kernel and fails on the other, you've found either a kernel bug or a divergence in semantics. If you're [writing a custom kernel](./custom-kernel), the conformance suite is how you verify your adapter.
+The conformance suite is the test suite brepjs runs against every supported kernel. Same tests, two backends: anywhere a test passes on one kernel and fails on the other, you've found either a kernel bug or a divergence in semantics. If you're [writing a custom kernel](./custom-kernel), the conformance suite is how you verify your adapter.
 
 ## Running the suite
 
@@ -23,16 +23,16 @@ For dual-kernel runs, brepjs's CI runs both passes in parallel. The matrix runs 
 
 The suite is organized by domain:
 
-- **Primitives** — `box`, `cylinder`, `sphere`, … — each shape's volume, area, vertex count, edge count are asserted exactly.
-- **Booleans** — `fuse`, `cut`, `intersect` over canonical pairs (box-on-box, cylinder-through-box, sphere-cut, etc.) — result volumes within tolerance, expected face counts.
-- **Transforms** — translate, rotate, scale invariance properties (volume preserved by translate/rotate, scaled by `s³` for uniform scale).
-- **Refinement** — fillet / chamfer over canonical edge sets — result topology invariants (face count delta).
-- **Sketching → 3D** — `sketchCircle().extrude()`, `Sketcher` chains, lofts, sweeps.
-- **Finders** — every filter, every shape kind.
-- **Measurement** — exact-value tests for primitives, tolerance-bounded tests for derived shapes.
-- **IO** — round-trip STEP / BREP / IGES; STL conversion.
-- **Healing** — known-broken inputs and the expected fixed outputs.
-- **Validity types** — smart-constructor and type-guard runtime checks.
+- **Primitives**: `box`, `cylinder`, `sphere`, …; each shape's volume, area, vertex count, edge count are asserted exactly.
+- **Booleans**: `fuse`, `cut`, `intersect` over canonical pairs (box-on-box, cylinder-through-box, sphere-cut, etc.); result volumes within tolerance, expected face counts.
+- **Transforms**: translate, rotate, scale invariance properties (volume preserved by translate/rotate, scaled by `s³` for uniform scale).
+- **Refinement**: fillet / chamfer over canonical edge sets; result topology invariants (face count delta).
+- **Sketching → 3D**: `sketchCircle().extrude()`, `Sketcher` chains, lofts, sweeps.
+- **Finders**: every filter, every shape kind.
+- **Measurement**: exact-value tests for primitives, tolerance-bounded tests for derived shapes.
+- **IO**: round-trip STEP / BREP / IGES; STL conversion.
+- **Healing**: known-broken inputs and the expected fixed outputs.
+- **Validity types**: smart-constructor and type-guard runtime checks.
 
 Each domain has both **happy-path tests** (the operation succeeds with expected output) and **failure-mode tests** (the operation should fail with a specific error code).
 
@@ -40,11 +40,11 @@ Each domain has both **happy-path tests** (the operation succeeds with expected 
 
 Conformance tests live in `tests/` alongside the regular brepjs unit tests. They share infrastructure:
 
-- `tests/<moduleName>.test.ts` — tests for one module's functions
-- `tests/api*.test.ts` — public-API integration tests
-- `tests/kernel-*.test.ts` — kernel-specific behaviours that should diverge gracefully
+- `tests/<moduleName>.test.ts`: tests for one module's functions
+- `tests/api*.test.ts`: public-API integration tests
+- `tests/kernel-*.test.ts`: kernel-specific behaviours that should diverge gracefully
 
-The `kernel-*` family contains tests for things like "OpenCascade returns enum objects with `.value` but brepkit returns numbers" — divergences that are _expected_ and that the adapter normalizes.
+The `kernel-*` family contains tests for things like "OpenCascade returns enum objects with `.value` but brepkit returns numbers": divergences that are _expected_ and that the adapter normalizes.
 
 ## Writing a conformance-style test
 
@@ -78,10 +78,10 @@ describe('box primitive', () => {
 
 Key conventions:
 
-- `toBeCloseTo(expected, precision)` for floating-point — never `toBe` for geometry
-- `unwrap(result)` is fine in tests — failures throw, the test name pinpoints the issue
+- `toBeCloseTo(expected, precision)` for floating-point; never `toBe` for geometry
+- `unwrap(result)` is fine in tests; failures throw, the test name pinpoints the issue
 - 30-second timeout on the kernel init; 5 seconds on individual operations
-- Each test is independent — no shared state across tests
+- Each test is independent; no shared state across tests
 
 For the full conventions see the brepjs `CONTRIBUTING.md`.
 
@@ -91,8 +91,8 @@ A custom kernel should produce:
 
 - **Identical** integer counts (face counts, edge counts, vertex counts).
 - **Tolerance-equal** measurements (volumes, areas, distances within `toBeCloseTo(expected, 4)` for normalized inputs).
-- **Identical** error codes for failure modes — `BOOLEAN_NO_OVERLAP`, `FILLET_TOO_LARGE`, etc.
-- **Round-trip identity** for serialization — a STEP file written by your kernel and re-read produces the same shape (with kernel-tolerance epsilon).
+- **Identical** error codes for failure modes: `BOOLEAN_NO_OVERLAP`, `FILLET_TOO_LARGE`, etc.
+- **Round-trip identity** for serialization: a STEP file written by your kernel and re-read produces the same shape (with kernel-tolerance epsilon).
 
 A kernel that produces a slightly different volume (1000.0001 vs 1000.0000) and otherwise matches is conformant. A kernel that produces 1000 sometimes and 1001 sometimes is not.
 
@@ -118,7 +118,7 @@ describe('boolean on near-coincident geometry', () => {
 });
 ```
 
-The override is honest — the test still runs on both kernels and records the divergence.
+The override is honest: the test still runs on both kernels and records the divergence.
 
 ## Performance: don't run conformance on every commit
 
@@ -138,6 +138,6 @@ The pattern: write the simplest happy-path test first, then the failure-mode tes
 
 ## Next steps
 
-- [Writing a Custom Kernel](./custom-kernel) — building the adapter the suite verifies
-- [Writing Custom Operations](./custom-ops) — operations that need new conformance tests
-- [Architecture & Layers](./architecture) — where the test infrastructure sits
+- [Writing a Custom Kernel](./custom-kernel): building the adapter the suite verifies
+- [Writing Custom Operations](./custom-ops): operations that need new conformance tests
+- [Architecture & Layers](./architecture): where the test infrastructure sits

--- a/apps/docs/extending/custom-kernel.md
+++ b/apps/docs/extending/custom-kernel.md
@@ -11,14 +11,14 @@ brepjs is built so the kernel is replaceable. The two shipped kernels (OpenCasca
 
 - **Wrap a Rust geometry library** you already maintain.
 - **Adapt a different OpenCascade build** (different version, different feature flags).
-- **Mock the kernel for tests** — return synthetic shapes for unit testing without loading WASM.
-- **Implement a constrained subset** — e.g. a "mesh-only" kernel that doesn't support exact booleans.
+- **Mock the kernel for tests**: return synthetic shapes for unit testing without loading WASM.
+- **Implement a constrained subset**: e.g. a "mesh-only" kernel that doesn't support exact booleans.
 
 For most apps this chapter is reference, not requirement. You only need it if one of the above applies.
 
 ## What `KernelInterface` looks like
 
-The kernel interface lives at `src/kernel/types.ts`. It's segregated into smaller fragments — `KernelBooleans`, `KernelMesh`, `KernelMeasurement`, `KernelIO`, etc. — composed into the full `KernelInterface`. A custom kernel can implement only the fragments it supports.
+The kernel interface lives at `src/kernel/types.ts`. It's segregated into smaller fragments (`KernelBooleans`, `KernelMesh`, `KernelMeasurement`, `KernelIO`, etc.) composed into the full `KernelInterface`. A custom kernel can implement only the fragments it supports.
 
 A simplified excerpt:
 
@@ -51,7 +51,7 @@ export interface KernelInterface
 }
 ```
 
-`KernelHandle` is your kernel's native shape type — whatever your library calls a shape. brepjs treats it as an opaque value; only your adapter ever calls methods on it.
+`KernelHandle` is your kernel's native shape type: whatever your library calls a shape. brepjs treats it as an opaque value; only your adapter ever calls methods on it.
 
 ## A skeleton adapter
 
@@ -116,18 +116,18 @@ After `registerKernel`, brepjs operations executed inside `withKernel('mygeom', 
 
 Implement at minimum:
 
-- **`KernelTopology`** — primitives (`makeBox`, `makeCylinder`, …), `shapeKind`, sub-shape iteration
-- **`KernelBooleans`** — `fuse`, `cut`, `intersect`, multi-shape variants
-- **`KernelMeasurement`** — `measureVolume`, `measureArea`, `measureLength`, `boundingBox`, `centerOfMass`
-- **`KernelMesh`** — triangulation
-- **`KernelTransforms`** — `translate`, `rotate`, `scale`, `mirror`
-- **`KernelDispose`** — `dispose` (single), batch dispose
+- **`KernelTopology`**: primitives (`makeBox`, `makeCylinder`, …), `shapeKind`, sub-shape iteration
+- **`KernelBooleans`**: `fuse`, `cut`, `intersect`, multi-shape variants
+- **`KernelMeasurement`**: `measureVolume`, `measureArea`, `measureLength`, `boundingBox`, `centerOfMass`
+- **`KernelMesh`**: triangulation
+- **`KernelTransforms`**: `translate`, `rotate`, `scale`, `mirror`
+- **`KernelDispose`**: `dispose` (single), batch dispose
 
 Optional:
 
-- **`KernelIO`** — STEP, IGES, BREP, STL — if you don't implement, those operations throw `KERNEL_NOT_SUPPORTED`
-- **`KernelHealing`** — `autoHeal`, `sew`, etc. If absent, brepjs callers get an explicit error.
-- **`KernelFinders`** — kernel-side query helpers; if absent, brepjs falls back to topology iteration
+- **`KernelIO`**: STEP, IGES, BREP, STL. If you don't implement, those operations throw `KERNEL_NOT_SUPPORTED`
+- **`KernelHealing`**: `autoHeal`, `sew`, etc. If absent, brepjs callers get an explicit error.
+- **`KernelFinders`**: kernel-side query helpers; if absent, brepjs falls back to topology iteration
 
 The conformance suite tests each fragment independently. You can ship a partial kernel that supports only what your backend can do.
 
@@ -137,7 +137,7 @@ Writing a kernel that reaches conformance is non-trivial. Common challenges:
 
 ### Shape kind classification
 
-brepjs has seven shape kinds. Your library may have a different ontology. The mapping isn't always one-to-one — e.g. some kernels don't distinguish `Shell` from `Solid`. Your adapter has to make these decisions consistently.
+brepjs has seven shape kinds. Your library may have a different ontology. The mapping isn't always one-to-one; e.g. some kernels don't distinguish `Shell` from `Solid`. Your adapter has to make these decisions consistently.
 
 ### Tolerance propagation
 
@@ -153,7 +153,7 @@ Every shape your adapter returns has to be disposable. brepjs tracks shapes and 
 
 ## The `BrepkitAdapter` reference
 
-`src/kernel/brepkit/BrepkitAdapter.ts` in the brepjs source is the reference implementation for a Rust-WASM kernel. It's instructive as a complete, working example of the interface — every method is implemented or stubbed with a clear `KERNEL_NOT_SUPPORTED` placeholder.
+`src/kernel/brepkit/BrepkitAdapter.ts` in the brepjs source is the reference implementation for a Rust-WASM kernel. It's instructive as a complete, working example of the interface. Every method is implemented or stubbed with a clear `KERNEL_NOT_SUPPORTED` placeholder.
 
 The brepkit adapter shows the typical structure:
 
@@ -184,7 +184,7 @@ For a single dominant kernel, register it in your app's startup code. For dual-k
 
 ## Testing your adapter
 
-Use the conformance suite ([Kernel Conformance Suite](./conformance)) — it's the same test suite brepjs runs against the OpenCascade and brepkit kernels. Pointing it at your adapter tells you which fragments work, which don't, and which fail subtly.
+Use the conformance suite ([Kernel Conformance Suite](./conformance)). It's the same test suite brepjs runs against the OpenCascade and brepkit kernels. Pointing it at your adapter tells you which fragments work, which don't, and which fail subtly.
 
 The minimal CI:
 
@@ -199,10 +199,10 @@ The conformance suite is parametrized on kernel ID. A passing run means your ada
 ## When to _not_ write a kernel
 
 - If you're targeting a different geometry library to get a particular operation, prefer adding that operation in Layer 2 of brepjs (call into the existing kernel for the boilerplate, your own code for the operation). Most "I want feature X" cases are not kernel-shaped.
-- If you're trying to fake the kernel for tests, prefer a stub that throws on unimplemented methods rather than a full adapter — keeps the test boundary explicit.
+- If you're trying to fake the kernel for tests, prefer a stub that throws on unimplemented methods rather than a full adapter; keeps the test boundary explicit.
 
 ## Next steps
 
-- [Kernel Conformance Suite](./conformance) — testing your adapter
-- [Architecture & Layers](./architecture) — where the kernel sits relative to the rest of brepjs
-- [Kernels & withKernel](../concepts/kernels) — the user-facing view of the kernel system
+- [Kernel Conformance Suite](./conformance): testing your adapter
+- [Architecture & Layers](./architecture): where the kernel sits relative to the rest of brepjs
+- [Kernels & withKernel](../concepts/kernels): the user-facing view of the kernel system

--- a/apps/docs/extending/custom-ops.md
+++ b/apps/docs/extending/custom-ops.md
@@ -5,7 +5,7 @@ description: 'Add a new modelling operation to brepjs: where the file goes, what
 
 # Writing Custom Operations
 
-brepjs ships hundreds of operations, and you might still want one more. This chapter walks through adding a new operation — what files to touch, what tests to write, what types to declare. The examples assume you're contributing to brepjs upstream, but the same structure works for a fork or a local extension.
+brepjs ships hundreds of operations, and you might still want one more. This chapter walks through adding a new operation: what files to touch, what tests to write, what types to declare. The examples assume you're contributing to brepjs upstream, but the same structure works for a fork or a local extension.
 
 ## Where operations live
 
@@ -28,7 +28,7 @@ A new primitive. Goal: add `octahedron(radius)` returning a `ValidSolid` whose 6
 
 ### Step 1: kernel method (Layer 0)
 
-The kernel doesn't have a direct `octahedron` primitive. We compose it from existing kernel calls — make 8 triangular faces, sew them, close into a solid. So Layer 0 doesn't need new methods.
+The kernel doesn't have a direct `octahedron` primitive. We compose it from existing kernel calls: make 8 triangular faces, sew them, close into a solid. So Layer 0 doesn't need new methods.
 
 If we _did_ need a new kernel primitive, we'd extend `src/kernel/types.ts` (`KernelTopology` interface) and implement in both adapters (`src/kernel/occt/...`, `src/kernel/brepkit/...`).
 
@@ -136,11 +136,11 @@ describe('octahedron', () => {
 });
 ```
 
-For a brepjs upstream contribution, the conformance suite picks this up automatically — same test runs against OCCT and brepkit.
+For a brepjs upstream contribution, the conformance suite picks this up automatically; the same test runs against OCCT and brepkit.
 
 ### Step 5: fluent wrapper exposure (Layer 3)
 
-If you want `shape(otherShape).addOctahedron(radius, position)` syntax, add a method to `src/topology/wrapper.ts`. For most operations, the functional API is enough — wrappers are for operations that compose with other shapes.
+If you want `shape(otherShape).addOctahedron(radius, position)` syntax, add a method to `src/topology/wrapper.ts`. For most operations, the functional API is enough; wrappers are for operations that compose with other shapes.
 
 ### Step 6: update the function lookup
 
@@ -159,7 +159,7 @@ This regenerates `docs/function-lookup.md` to include the new symbol. The pre-co
 For an operation to be a good citizen:
 
 1. **Type signature is precise.** Use validity brands. If your op only works on closed wires, take `ClosedWire`. If it produces a valid solid, return `ValidSolid`.
-2. **Failure modes use named codes.** No `throw new Error('something went wrong')` — `err({ code: 'OP_DESCRIPTIVE_CODE', message: '...', suggestion: '...' })`.
+2. **Failure modes use named codes.** No `throw new Error('something went wrong')`; use `err({ code: 'OP_DESCRIPTIVE_CODE', message: '...', suggestion: '...' })`.
 3. **Memory is tracked.** Use `getKernel()` to acquire shapes; the kernel adapter tracks them. If you build many intermediate handles, dispose them inside the function.
 4. **Result is the unique answer.** No randomness, no environment-dependent behaviour. Same input → same output.
 5. **Tests cover counts and measurements.** Vertex / edge / face counts are integer-exact; volumes / areas use `toBeCloseTo`.
@@ -176,15 +176,15 @@ Layer 2+ code never calls methods on `.wrapped`. Always go through `getKernel()`
 
 ### Async `withKernel`
 
-If your operation needs the active kernel, use `getKernel()` inside the synchronous body. Don't wrap an async function in `withKernel` — see [Kernels & withKernel](../concepts/kernels) for the details.
+If your operation needs the active kernel, use `getKernel()` inside the synchronous body. Don't wrap an async function in `withKernel`; see [Kernels & withKernel](../concepts/kernels) for the details.
 
 ### Returning unbranded shapes
 
-`Result<Shape3D>` is a fine return type for a generic operation. For specific guarantees (the result is a solid, the result is a closed wire), return the branded type — the type system is doing useful work, don't throw it away.
+`Result<Shape3D>` is a fine return type for a generic operation. For specific guarantees (the result is a solid, the result is a closed wire), return the branded type. The type system is doing useful work, don't throw it away.
 
 ### Ignoring tolerance
 
-If your operation builds shapes from scratch (like the octahedron above), inherit the kernel's default tolerance. If it operates on existing shapes, use the input shapes' tolerance to set the result tolerance — `Math.max(tolA, tolB)` is the typical rule.
+If your operation builds shapes from scratch (like the octahedron above), inherit the kernel's default tolerance. If it operates on existing shapes, use the input shapes' tolerance to set the result tolerance: `Math.max(tolA, tolB)` is the typical rule.
 
 ## Adding to the wrapper
 
@@ -227,6 +227,6 @@ The TSDoc renders into the TypeDoc API site automatically.
 
 ## Next steps
 
-- [Architecture & Layers](./architecture) — where to place your code
-- [Pattern Checker Rules](./pattern-checker) — automated checks your contribution passes
-- [Kernel Conformance Suite](./conformance) — verifying behaviour across kernels
+- [Architecture & Layers](./architecture): where to place your code
+- [Pattern Checker Rules](./pattern-checker): automated checks your contribution passes
+- [Kernel Conformance Suite](./conformance): verifying behaviour across kernels

--- a/apps/docs/extending/pattern-checker.md
+++ b/apps/docs/extending/pattern-checker.md
@@ -5,7 +5,7 @@ description: "AST-based linter rules that catch issues ESLint can't: kernel rout
 
 # Pattern Checker Rules
 
-`npm run check:patterns` runs `scripts/check-patterns.ts`, an AST-based linter that catches structural issues ESLint can't. The rules protect invariants the architecture depends on — kernel-routing, memory cleanup, code-quality thresholds. This chapter is the rule catalog: what each rule prevents, why, and how to fix or disable a violation.
+`npm run check:patterns` runs `scripts/check-patterns.ts`, an AST-based linter that catches structural issues ESLint can't. The rules protect invariants the architecture depends on: kernel-routing, memory cleanup, code-quality thresholds. This chapter is the rule catalog: what each rule prevents, why, and how to fix or disable a violation.
 
 ## Running the checker
 
@@ -111,7 +111,7 @@ function clean() {
 }
 ```
 
-The rule is heuristic — it can produce false positives when the handle is intentionally returned (in which case the _caller_ is responsible). Use `// brepjs-patterns-disable: missing-using-on-handle` when the lifetime escapes the function.
+The rule is heuristic; it can produce false positives when the handle is intentionally returned (in which case the _caller_ is responsible). Use `// brepjs-patterns-disable: missing-using-on-handle` when the lifetime escapes the function.
 
 ### `function-too-long`
 
@@ -173,7 +173,7 @@ const violatesRule = ...; // disable applies to the next line
 const inline = ...; // brepjs-patterns-disable: <rule-id> (inline)
 ```
 
-Use these sparingly. Each disable should have a comment explaining _why_ the rule doesn't apply — "this is a kernel adapter, .wrapped access is fine here", "the lifetime escapes via the return value", etc.
+Use these sparingly. Each disable should have a comment explaining _why_ the rule doesn't apply: "this is a kernel adapter, .wrapped access is fine here", "the lifetime escapes via the return value", etc.
 
 ## When the rules are wrong
 
@@ -183,7 +183,7 @@ Sometimes a rule is over-eager:
 - **`function-too-long` on switch statements**: a long `switch` with many cases is sometimes the right shape.
 - **`double-cast` in WASM bindings**: occasional unavoidable casts when wrapping untyped C APIs.
 
-For these, inline-disable with a clear reason. If the same disable appears in many places, consider whether the rule needs adjustment — open an issue.
+For these, inline-disable with a clear reason. If the same disable appears in many places, consider whether the rule needs adjustment. Open an issue.
 
 ## Adding a rule
 
@@ -198,12 +198,12 @@ Most useful new rules detect class-of-bug, not single instances. If a recent bug
 
 ## Why these and not ESLint?
 
-ESLint runs at parse-tree level — fast, but limited. The pattern checker runs at the type-checked AST level using the TypeScript compiler API, so it knows the actual types and can make decisions ESLint can't. The trade-off: it's slower (typecheck-then-walk vs. parse-then-walk).
+ESLint runs at parse-tree level: fast, but limited. The pattern checker runs at the type-checked AST level using the TypeScript compiler API, so it knows the actual types and can make decisions ESLint can't. The trade-off: it's slower (typecheck-then-walk vs. parse-then-walk).
 
 In brepjs, ESLint covers the syntax-level rules (`no-explicit-any`, `prefer-const`, `import-extensions`) and the pattern checker covers the semantic-level rules (`wrapped-method-call`, `async-with-kernel`).
 
 ## Next steps
 
-- [Architecture & Layers](./architecture) — the rules the checker protects
-- [Writing Custom Operations](./custom-ops) — building code that passes the checks
-- [Kernel Conformance Suite](./conformance) — the test suite that complements the checks
+- [Architecture & Layers](./architecture): the rules the checker protects
+- [Writing Custom Operations](./custom-ops): building code that passes the checks
+- [Kernel Conformance Suite](./conformance): the test suite that complements the checks

--- a/apps/docs/getting-started/cheat-sheet.md
+++ b/apps/docs/getting-started/cheat-sheet.md
@@ -38,9 +38,9 @@ import { fuse, cut, intersect, fuseAll, box, cylinder, sphere, unwrap } from 'br
 const a = box(20, 20, 20);
 const b = cylinder(8, 30, { at: [10, 10, -5] });
 
-unwrap(fuse(a, b)); // union — glue together
-unwrap(cut(a, b)); // subtraction — drill a hole
-unwrap(intersect(a, b)); // intersection — common volume
+unwrap(fuse(a, b)); // union - glue together
+unwrap(cut(a, b)); // subtraction - drill a hole
+unwrap(intersect(a, b)); // intersection - common volume
 
 unwrap(fuseAll([a, b, sphere(5)])); // fuse a list (faster than chaining)
 ```
@@ -111,7 +111,7 @@ vertexFinder().findAll(b);
 wireFinder().isClosed().findAll(b);
 ```
 
-Filters chain — every call narrows the result.
+Filters chain: every call narrows the result.
 
 ## Measurement
 
@@ -131,9 +131,9 @@ The fluent equivalents: `shape(b).volume()`, `shape(b).area()`.
 import { exportSTEP, exportSTL, exportGltf, box, unwrap } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
-unwrap(exportSTEP(b)); // STEP — round-trips with SolidWorks/Fusion/FreeCAD
-unwrap(exportSTL(b)); // STL — meshing, 3D printing
-unwrap(exportGltf(b)); // glTF — web rendering
+unwrap(exportSTEP(b)); // STEP - round-trips with SolidWorks/Fusion/FreeCAD
+unwrap(exportSTL(b)); // STL - meshing, 3D printing
+unwrap(exportGltf(b)); // glTF - web rendering
 ```
 
 <!-- @no-test -->
@@ -157,7 +157,7 @@ if (isOk(result)) {
   void part;
 }
 
-// Pattern 2: unwrap (throws on error — fine for scripts)
+// Pattern 2: unwrap (throws on error - fine for scripts)
 const part = unwrap(result);
 void part;
 
@@ -214,12 +214,12 @@ void geo;
 
 ## API reference
 
-- [Function Lookup](../reference/function-lookup) — alphabetical index of every export with its sub-path
-- [TypeDoc API Reference](https://andymai.github.io/brepjs/) — full searchable reference
-- [Glossary](../reference/glossary) — B-Rep terminology
+- [Function Lookup](../reference/function-lookup): alphabetical index of every export with its sub-path
+- [TypeDoc API Reference](https://andymai.github.io/brepjs/): full searchable reference
+- [Glossary](../reference/glossary): B-Rep terminology
 
 ## Next steps
 
-- [B-Rep vs Mesh](../concepts/brep-vs-mesh) — what makes B-Rep precise
-- [Types That Prove Geometry Is Valid](../concepts/types) — the type system that catches bugs at compile time
+- [B-Rep vs Mesh](../concepts/brep-vs-mesh): what makes B-Rep precise
+- [Types That Prove Geometry Is Valid](../concepts/types): the type system that catches bugs at compile time
 - Pick a task: [Booleans](../tasks/booleans) · [Sketching](../tasks/sketching) · [Three.js](../integration/threejs)

--- a/apps/docs/getting-started/first-solid.md
+++ b/apps/docs/getting-started/first-solid.md
@@ -1,6 +1,6 @@
 ---
 title: Your First Solid
-description: 'Build a 30×20×10 mm block with a hole, fillet the vertical edges, export to STEP — six type-checked operations end to end.'
+description: 'Build a 30×20×10 mm block with a hole, fillet the vertical edges, export to STEP. Six type-checked operations end to end.'
 ---
 
 # Your First Solid
@@ -49,9 +49,9 @@ const block = box(30, 20, 10);
 const hole = cylinder(5, 15, { at: [15, 10, -2] });
 ```
 
-`box(width, depth, height)` returns a `ValidSolid` — a 30×20×10 mm rectangular solid centred at the origin's lower corner. `cylinder(radius, height, { at })` returns a `ValidSolid` 5 mm radius, 15 mm tall, with its base centre at `[15, 10, -2]` so it pokes through the block.
+`box(width, depth, height)` returns a `ValidSolid`: a 30×20×10 mm rectangular solid centred at the origin's lower corner. `cylinder(radius, height, { at })` returns a `ValidSolid` 5 mm radius, 15 mm tall, with its base centre at `[15, 10, -2]` so it pokes through the block.
 
-The `at` option translates the primitive at construction time. You can also `translate(cylinder(5, 15), [15, 10, -2])` after the fact — the result is identical.
+The `at` option translates the primitive at construction time. You can also `translate(cylinder(5, 15), [15, 10, -2])` after the fact; the result is identical.
 
 ### Step 2: boolean
 
@@ -60,7 +60,7 @@ import { box, cylinder, cut, unwrap } from 'brepjs/quick';
 const drilled = unwrap(cut(box(30, 20, 10), cylinder(5, 15, { at: [15, 10, -2] })));
 ```
 
-`cut(a, b)` removes `b` from `a`. It returns `Result<Shape3D, BrepError>` — the operation can fail, for instance if `b` doesn't intersect `a`. `unwrap()` extracts the value or throws on error; in production code you'd use `isOk()` or `match()` instead. See [Result and Errors](../concepts/result).
+`cut(a, b)` removes `b` from `a`. It returns `Result<Shape3D, BrepError>`. The operation can fail, for instance if `b` doesn't intersect `a`. `unwrap()` extracts the value or throws on error; in production code you'd use `isOk()` or `match()` instead. See [Result and Errors](../concepts/result).
 
 ### Step 3: query
 
@@ -71,7 +71,7 @@ const verticalEdges = edgeFinder()
   .findAll(box(30, 20, 10));
 ```
 
-Finders are how you select features after the fact. `edgeFinder()` starts a query, `.inDirection('Z')` filters to edges aligned with the Z axis, `.findAll(shape)` runs it. Returns an array of `Edge` handles — empty if nothing matched.
+Finders are how you select features after the fact. `edgeFinder()` starts a query, `.inDirection('Z')` filters to edges aligned with the Z axis, `.findAll(shape)` runs it. Returns an array of `Edge` handles; empty if nothing matched.
 
 [Finders & Queries](../tasks/finders) covers the full filter vocabulary.
 
@@ -92,7 +92,7 @@ import { box, measureVolume, unwrap } from 'brepjs/quick';
 console.log('Volume:', unwrap(measureVolume(box(10, 10, 10))).toFixed(2), 'mm³');
 ```
 
-Measurement functions return `Result<number>` — null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. `unwrap()` extracts the number or throws; in production code prefer `isOk()` / `match()`. `measureVolume`, `measureArea`, `measureLength` are the most common; see [Measurement](../tasks/measurement) for the full set.
+Measurement functions return `Result<number>`. Null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. `unwrap()` extracts the number or throws; in production code prefer `isOk()` / `match()`. `measureVolume`, `measureArea`, `measureLength` are the most common; see [Measurement](../tasks/measurement) for the full set.
 
 ### Step 6: export
 
@@ -101,7 +101,7 @@ import { box, exportSTEP, unwrap } from 'brepjs/quick';
 const step = unwrap(exportSTEP(box(10, 10, 10)));
 ```
 
-`exportSTEP` returns `Result<Blob>`. The blob is a STEP file ready to save (in Node, write to disk; in the browser, trigger a download via an `<a>` tag). brepjs ships exporters for STEP, STL, BREP, IGES, glTF, DXF, 3MF, OBJ, and SVG — see [Import & Export](../tasks/import-export).
+`exportSTEP` returns `Result<Blob>`. The blob is a STEP file ready to save (in Node, write to disk; in the browser, trigger a download via an `<a>` tag). brepjs ships exporters for STEP, STL, BREP, IGES, glTF, DXF, 3MF, OBJ, and SVG; see [Import & Export](../tasks/import-export).
 
 ## The fluent equivalent
 
@@ -122,7 +122,7 @@ export default part;
 
 The wrapper auto-unwraps `Result`s and throws `BrepWrapperError` on failure. Each operation returns a typed wrapper (`Wrapped3D`, `WrappedFace`, etc.) so `.fillet`, `.shell`, `.translate`, `.volume` are all available without separate imports. Use `.val` at the end to extract the underlying shape.
 
-The functional API and the wrapper produce the same geometry. Pick whichever feels right — the [Cheat Sheet](./cheat-sheet) shows both side by side.
+The functional API and the wrapper produce the same geometry. Pick whichever feels right; the [Cheat Sheet](./cheat-sheet) shows both side by side.
 
 ## Common variations
 
@@ -145,7 +145,7 @@ const part = unwrap(cut(block, holes));
 export default part;
 ```
 
-Boolean-fuse the holes first, then cut once. Three booleans become two — faster and avoids a class of failure modes when the cuts overlap.
+Boolean-fuse the holes first, then cut once. Three booleans become two: faster and avoids a class of failure modes when the cuts overlap.
 
 ### Sketch-then-extrude profiles
 
@@ -206,7 +206,7 @@ The most common failures and their typical causes:
 
 ## Next steps
 
-- [Cheat Sheet](./cheat-sheet) — single-page reference for the full API
-- [Boolean Operations](../tasks/booleans) — fuse, cut, intersect, and the failure modes
-- [Fillets & Chamfers](../tasks/fillets) — when fillets fail and how to fix them
-- [Memory Management](../advanced/memory) — `using` and DisposalScope for long-running apps
+- [Cheat Sheet](./cheat-sheet): single-page reference for the full API
+- [Boolean Operations](../tasks/booleans): fuse, cut, intersect, and the failure modes
+- [Fillets & Chamfers](../tasks/fillets): when fillets fail and how to fix them
+- [Memory Management](../advanced/memory): `using` and DisposalScope for long-running apps

--- a/apps/docs/getting-started/install.md
+++ b/apps/docs/getting-started/install.md
@@ -1,11 +1,11 @@
 ---
 title: Install & Initialize
-description: 'Pick an init style, run npm install, and you are modelling. Auto-detect, manual init, top-level await — three ways to load brepjs.'
+description: 'Pick an init style, run npm install, and you are modelling. Auto-detect, manual init, top-level await: three ways to load brepjs.'
 ---
 
 # Install & Initialize
 
-Pick an init style, run `npm install`, and you are modelling. The first call to any brepjs function requires the WASM kernel to be loaded — the only choice is **who** triggers the load.
+Pick an init style, run `npm install`, and you are modelling. The first call to any brepjs function requires the WASM kernel to be loaded; the only choice is **who** triggers the load.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ npm install brepjs occt-wasm
 
 All three give you the same API. They differ only in who calls the kernel init.
 
-### `brepjs/quick` — zero ceremony
+### `brepjs/quick`: zero ceremony
 
 ```typescript
 import { box, cylinder, shape } from 'brepjs/quick';
@@ -36,7 +36,7 @@ const part = shape(b).cut(cyl).val;
 
 Best for scripts, prototypes, and any ESM environment with top-level await. The `brepjs/quick` entry resolves the default `occt-wasm` kernel (falling back to `brepjs-opencascade`) at module-load time, then re-exports the full API.
 
-### `init()` — auto-detect
+### `init()`: auto-detect
 
 <!-- @no-test -->
 
@@ -71,7 +71,7 @@ Best for apps that need a loading indicator, explicit error handling, or environ
 
 ### Vite
 
-Vite bundles WASM correctly out of the box. The only quirk: if you load WASM from a Worker, you may want to import the file URL explicitly so Vite emits it as an asset — gridfinitylayouttool.com does this:
+Vite bundles WASM correctly out of the box. The only quirk: if you load WASM from a Worker, you may want to import the file URL explicitly so Vite emits it as an asset; gridfinitylayouttool.com does this:
 
 <!-- @no-test -->
 
@@ -162,6 +162,6 @@ All sub-paths re-export a subset of the main `brepjs` entry. You can mix and mat
 
 ## Next steps
 
-- [Your First Solid](./first-solid) — the canonical drill-fillet-export workflow
-- [Cheat Sheet](./cheat-sheet) — single-page quick reference
-- [B-Rep vs Mesh](../concepts/brep-vs-mesh) — why brepjs is different from Three.js
+- [Your First Solid](./first-solid): the canonical drill-fillet-export workflow
+- [Cheat Sheet](./cheat-sheet): single-page quick reference
+- [B-Rep vs Mesh](../concepts/brep-vs-mesh): why brepjs is different from Three.js

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -22,7 +22,7 @@ hero:
 features:
   - icon: 📐
     title: Exact B-Rep, not triangles
-    details: Shapes are mathematical boundaries (faces, edges, vertices) so booleans are precise, measurements are real, and you can export to STEP.
+    details: Shapes are mathematical boundaries (faces, edges, vertices), so booleans are precise, measurements are real, and you can export to STEP.
   - icon: 🛡️
     title: If it compiles, it's valid
     details: Branded types and validity brands (ClosedWire, OrientedFace, ValidSolid) prove topological invariants at compile time. Not just type-safe: geometry-safe.

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -22,10 +22,10 @@ hero:
 features:
   - icon: 📐
     title: Exact B-Rep, not triangles
-    details: Shapes are mathematical boundaries — faces, edges, vertices — so booleans are precise, measurements are real, and you can export to STEP.
+    details: Shapes are mathematical boundaries (faces, edges, vertices) so booleans are precise, measurements are real, and you can export to STEP.
   - icon: 🛡️
     title: If it compiles, it's valid
-    details: Branded types and validity brands (ClosedWire, OrientedFace, ValidSolid) prove topological invariants at compile time. Not just type-safe — geometry-safe.
+    details: Branded types and validity brands (ClosedWire, OrientedFace, ValidSolid) prove topological invariants at compile time. Not just type-safe: geometry-safe.
   - icon: ⚡
     title: Two kernels, one API
     details: occt-wasm (OpenCascade compiled to WebAssembly) is the default kernel and ships today. brepkit (Rust-based) is a faster drop-in replacement under active development. Switching is one line.
@@ -34,7 +34,7 @@ features:
     details: ESM, top-level await init, Three.js mesh adapter, web-worker friendly. Plays well with Vite, Next.js, and React Three Fiber.
   - icon: ✏️
     title: Sketcher + functional API
-    details: Build 2D profiles fluently, extrude into solids, then chain booleans, fillets, shells. Or stay fully functional — both surfaces are first-class.
+    details: Build 2D profiles fluently, extrude into solids, then chain booleans, fillets, shells. Or stay fully functional; both surfaces are first-class.
   - icon: 📦
     title: Everything imports/exports
     details: STEP, STL, BREP, IGES, glTF, DXF, 3MF, OBJ, SVG. Round-trip with SolidWorks, Fusion, FreeCAD, OpenSCAD.

--- a/apps/docs/integration/compatibility.md
+++ b/apps/docs/integration/compatibility.md
@@ -5,7 +5,7 @@ description: "What's tested and what works: Node.js versions, browser support, b
 
 # Compatibility Matrix
 
-What's tested, what works, what to avoid. brepjs targets modern browsers, Node 24+, and any reasonable WASM-capable runtime. Server-side rendering is unsupported — brepjs requires WASM to execute.
+What's tested, what works, what to avoid. brepjs targets modern browsers, Node 24+, and any reasonable WASM-capable runtime. Server-side rendering is unsupported; brepjs requires WASM to execute.
 
 ## Node.js
 
@@ -14,7 +14,7 @@ What's tested, what works, what to avoid. brepjs targets modern browsers, Node 2
 | 24.x    | ✓ Supported, CI tested                             |
 | 22.x    | ✓ Likely works (no test gate)                      |
 | 20.x    | ✓ Likely works (no test gate); uses fewer features |
-| 18.x    | ✗ End of life — not tested                         |
+| 18.x    | ✗ End of life, not tested                          |
 | < 18    | ✗ Unsupported                                      |
 
 CI runs on Node 24. Anything with first-class WASM and ESM support should work; the version floor is dictated by Vitest's requirements rather than brepjs's.
@@ -51,24 +51,24 @@ WASM performance on mobile is slower than desktop; CAD-quality rendering at 60 f
 
 Strict mode (`"strict": true` in `tsconfig.json`) is required. Specifically:
 
-- `strictNullChecks` — enabled
-- `noUncheckedIndexedAccess` — recommended; brepjs uses it internally
-- `exactOptionalPropertyTypes` — recommended
+- `strictNullChecks`: enabled
+- `noUncheckedIndexedAccess`: recommended; brepjs uses it internally
+- `exactOptionalPropertyTypes`: recommended
 
 ## Frameworks (tested)
 
-| Framework              | Status                                          |
-| ---------------------- | ----------------------------------------------- |
-| Vite                   | ✓ First-class — the brepjs playground uses Vite |
-| React + R3F            | ✓ Documented integration                        |
-| Next.js (app router)   | ✓ With `'use client'` and dynamic import        |
-| Next.js (pages router) | ✓ With `dynamic({ ssr: false })`                |
-| Astro                  | ✓ With `client:only`                            |
-| Nuxt 3                 | ✓ With `<ClientOnly>`                           |
-| SvelteKit              | ✓ With `onMount` and `if (browser)`             |
-| Remix                  | ✓ With `useEffect` deferred import              |
-| webpack 5              | ✓ With `experiments.asyncWebAssembly`           |
-| webpack 4              | ✗ Unsupported — no async WASM                   |
+| Framework              | Status                                         |
+| ---------------------- | ---------------------------------------------- |
+| Vite                   | ✓ First-class; the brepjs playground uses Vite |
+| React + R3F            | ✓ Documented integration                       |
+| Next.js (app router)   | ✓ With `'use client'` and dynamic import       |
+| Next.js (pages router) | ✓ With `dynamic({ ssr: false })`               |
+| Astro                  | ✓ With `client:only`                           |
+| Nuxt 3                 | ✓ With `<ClientOnly>`                          |
+| SvelteKit              | ✓ With `onMount` and `if (browser)`            |
+| Remix                  | ✓ With `useEffect` deferred import             |
+| webpack 5              | ✓ With `experiments.asyncWebAssembly`          |
+| webpack 4              | ✗ Unsupported: no async WASM                   |
 
 See [Vite, Next.js, Astro](./frameworks) for per-framework recipes.
 
@@ -86,9 +86,9 @@ For server-side STEP generation, edge compute is fine for one-off conversions bu
 
 ## Server-side rendering: NOT SUPPORTED
 
-brepjs requires WASM to execute. SSR frameworks render on the server, where instantiating the WASM module is possible but operating on shapes is not — the kernel mutates state, including state that's tied to a particular browser-like execution context.
+brepjs requires WASM to execute. SSR frameworks render on the server, where instantiating the WASM module is possible but operating on shapes is not; the kernel mutates state, including state that's tied to a particular browser-like execution context.
 
-The supported pattern is **client-only rendering** — wrap brepjs-using components in `dynamic({ ssr: false })` (Next.js), `<ClientOnly>` (Nuxt), `client:only` (Astro), or equivalent.
+The supported pattern is **client-only rendering**: wrap brepjs-using components in `dynamic({ ssr: false })` (Next.js), `<ClientOnly>` (Nuxt), `client:only` (Astro), or equivalent.
 
 ## Bundle size
 
@@ -99,7 +99,7 @@ The supported pattern is **client-only rendering** — wrap brepjs-using compone
 | `brepjs-opencascade` WASM (alt)   | ~3.2 MB    |
 | `brepkit-wasm` WASM (alt)         | ~2.4 MB    |
 
-The WASM is the dominant cost. brepjs is treeshakeable per sub-path — importing only `brepjs/measurement` skips the topology bundle.
+The WASM is the dominant cost. brepjs is treeshakeable per sub-path: importing only `brepjs/measurement` skips the topology bundle.
 
 ## What's not supported
 
@@ -135,10 +135,10 @@ If brepjs fails on a tested platform, file a bug at [github.com/andymai/brepjs/i
 - A minimal repro (ideally a playground link)
 - The error message and stack trace
 
-If it fails on an untested platform, please first confirm the runtime supports WASM 1.0+ and ESM modules — those are the only platform requirements.
+If it fails on an untested platform, please first confirm the runtime supports WASM 1.0+ and ESM modules; those are the only platform requirements.
 
 ## Next steps
 
-- [Vite, Next.js, Astro](./frameworks) — per-framework setup recipes
-- [Status, Stability & Versioning](../introduction/stability) — what's covered by semver
-- [Three.js Integration](./threejs) — rendering across the platforms above
+- [Vite, Next.js, Astro](./frameworks): per-framework setup recipes
+- [Status, Stability & Versioning](../introduction/stability): what's covered by semver
+- [Three.js Integration](./threejs): rendering across the platforms above

--- a/apps/docs/integration/frameworks.md
+++ b/apps/docs/integration/frameworks.md
@@ -5,7 +5,7 @@ description: 'Per-framework recipes for Vite, Next.js, Astro, SvelteKit. Where t
 
 # Vite, Next.js, Astro
 
-brepjs is just a JS library — `npm install` and import. The wrinkles are bundler-specific: where the WASM file goes, when it loads, whether your framework runs the code on a server (which can't run WASM) or only in the browser (which can). This chapter has the per-framework recipes.
+brepjs is just a JS library: `npm install` and import. The wrinkles are bundler-specific: where the WASM file goes, when it loads, whether your framework runs the code on a server (which can't run WASM) or only in the browser (which can). This chapter has the per-framework recipes.
 
 ## Vite (the easy case)
 
@@ -91,7 +91,7 @@ export default function CadPage() {
 }
 ```
 
-`ssr: false` is the magic — Next.js skips this component during render and loads it only on the client.
+`ssr: false` is the magic: Next.js skips this component during render and loads it only on the client.
 
 ### `next.config.js` adjustments
 
@@ -154,7 +154,7 @@ export default function BrepViewer() {
 
 ## Nuxt 3
 
-Same pattern as Next.js — wrap the brepjs-using component as client-only:
+Same pattern as Next.js: wrap the brepjs-using component as client-only:
 
 <!-- @no-test -->
 
@@ -216,11 +216,11 @@ For routes that should never SSR-render the brepjs component at all, factor the 
 
 ## Cloudflare Workers / Deno / Bun
 
-brepjs is just WASM + JS — these runtimes work for batch jobs (build a STEP file, return it as a response). The constraints:
+brepjs is just WASM + JS: these runtimes work for batch jobs (build a STEP file, return it as a response). The constraints:
 
-- **No DOM** — anything assuming `window`, `document`, or browser globals fails. brepjs's core doesn't use these, but the playground site does.
-- **Memory limits** — workers have caps (Cloudflare: 128 MB by default). Heavy operations may need bumping.
-- **Bundle size** — WASM is ~3 MB compressed. Cloudflare's bundle budget allows this; some embedded runtimes don't.
+- **No DOM**: anything assuming `window`, `document`, or browser globals fails. brepjs's core doesn't use these, but the playground site does.
+- **Memory limits**: workers have caps (Cloudflare: 128 MB by default). Heavy operations may need bumping.
+- **Bundle size**: WASM is ~3 MB compressed. Cloudflare's bundle budget allows this; some embedded runtimes don't.
 
 For server-side STEP generation in Cloudflare:
 
@@ -244,7 +244,7 @@ export default {
 
 Some bundler configurations don't enable top-level await by default. Either:
 
-- Update the bundler config (Vite, webpack 5+, esbuild — all support it).
+- Update the bundler config (Vite, webpack 5+, esbuild, all support it).
 - Switch from `import 'brepjs/quick'` to `await init()` inside an async function.
 
 ### "WASM file 404" in production
@@ -272,10 +272,10 @@ For multi-threaded WASM (e.g. OpenCascade with pthreads), you need cross-origin 
 }
 ```
 
-The brepjs playground uses single-threaded WASM by default, which doesn't need this — but if you switch to the threaded build, COOP/COEP becomes required.
+The brepjs playground uses single-threaded WASM by default, which doesn't need this, but if you switch to the threaded build, COOP/COEP becomes required.
 
 ## Next steps
 
-- [Compatibility Matrix](./compatibility) — exact tested versions for each framework
-- [Web Workers](../advanced/workers) — bundler-specific worker setup
-- [Three.js](./threejs) and [React Three Fiber](./r3f) — what to do with the meshed output
+- [Compatibility Matrix](./compatibility): exact tested versions for each framework
+- [Web Workers](../advanced/workers): bundler-specific worker setup
+- [Three.js](./threejs) and [React Three Fiber](./r3f): what to do with the meshed output

--- a/apps/docs/integration/r3f.md
+++ b/apps/docs/integration/r3f.md
@@ -103,7 +103,7 @@ function PartFromWorker({ params }: { params: object }) {
 }
 ```
 
-The brepjs handles never cross the React tree — only typed arrays do. This is what gridfinity-layout-tool's worker pipeline looks like.
+The brepjs handles never cross the React tree; only typed arrays do. This is what gridfinity-layout-tool's worker pipeline looks like.
 
 ## Picking and selection
 
@@ -200,21 +200,21 @@ Render the edges alongside the filled mesh; combined they look like proper engin
 
 ## drei helpers worth knowing
 
-- `<OrbitControls>` — drag to rotate, pinch to zoom, the right behaviour for CAD UIs
-- `<Bounds>` — fit-camera-to-content; essential for "I just loaded a STEP, frame it"
-- `<Environment preset="studio" />` — instant-good HDRi reflections
-- `<ContactShadows>` — soft ground shadow that makes parts feel "placed"
-- `<GizmoHelper>` — small axis triad for orientation
+- `<OrbitControls>`: drag to rotate, pinch to zoom, the right behaviour for CAD UIs
+- `<Bounds>`: fit-camera-to-content; essential for "I just loaded a STEP, frame it"
+- `<Environment preset="studio" />`: instant-good HDRi reflections
+- `<ContactShadows>`: soft ground shadow that makes parts feel "placed"
+- `<GizmoHelper>`: small axis triad for orientation
 
 ## Performance
 
-- **Memoize meshing** — `useMemo` keyed on the shape, the tolerance, and any pose params.
-- **Avoid React state for camera position** — use Three.js controls or refs; React state changes re-render the tree.
-- **Lazy-mount heavy parts** — render only what's visible; Suspense or virtualization for assemblies of many parts.
-- **Throttle interactive sliders** — debounce parameter changes that re-mesh.
+- **Memoize meshing**: `useMemo` keyed on the shape, the tolerance, and any pose params.
+- **Avoid React state for camera position**: use Three.js controls or refs; React state changes re-render the tree.
+- **Lazy-mount heavy parts**: render only what's visible; Suspense or virtualization for assemblies of many parts.
+- **Throttle interactive sliders**: debounce parameter changes that re-mesh.
 
 ## Next steps
 
-- [Three.js](./threejs) — the underlying Three.js patterns
-- [Vite, Next.js, Astro](./frameworks) — getting R3F + brepjs working in your bundler
-- [Web Workers](../advanced/workers) — moving heavy meshing off the render thread
+- [Three.js](./threejs): the underlying Three.js patterns
+- [Vite, Next.js, Astro](./frameworks): getting R3F + brepjs working in your bundler
+- [Web Workers](../advanced/workers): moving heavy meshing off the render thread

--- a/apps/docs/integration/threejs.md
+++ b/apps/docs/integration/threejs.md
@@ -5,7 +5,7 @@ description: 'The CAD-on-the-web stack: model in brepjs, mesh, hand the buffer d
 
 # Three.js
 
-brepjs is the kernel; Three.js is the renderer. The combination is the standard CAD-on-the-web stack — model with brepjs, mesh, hand the buffer data to Three.js, render in a `<canvas>`. This chapter covers the conversion pipeline, the buffer format, materials, and shadow / outline patterns common in CAD UIs.
+brepjs is the kernel; Three.js is the renderer. The combination is the standard CAD-on-the-web stack: model with brepjs, mesh, hand the buffer data to Three.js, render in a `<canvas>`. This chapter covers the conversion pipeline, the buffer format, materials, and shadow / outline patterns common in CAD UIs.
 
 ## The pipeline
 
@@ -195,7 +195,7 @@ const lineMaterial = new THREE.LineBasicMaterial({ color: 0x111111 });
 const lines = new THREE.LineSegments(edges, lineMaterial);
 ```
 
-Quick, fully Three.js native, but only finds creases above the angle threshold — smooth filleted edges may disappear.
+Quick, fully Three.js native, but only finds creases above the angle threshold; smooth filleted edges may disappear.
 
 ### brepjs edge meshing (kernel-side)
 
@@ -238,11 +238,11 @@ Combine with a good environment map (e.g. `RGBELoader` HDRi) for realistic refle
 
 - **Re-meshing every frame**: cache the mesh on the brepjs side; only re-mesh when the shape changes.
 - **High-tolerance meshes for distant parts**: mesh at 1 mm tolerance for previews, only refine for the active selection.
-- **Disposing the wrong thing**: dispose Three.js `BufferGeometry`, `Material`, `Mesh` separately when removing — Three.js does not auto-clean.
+- **Disposing the wrong thing**: dispose Three.js `BufferGeometry`, `Material`, `Mesh` separately when removing; Three.js does not auto-clean.
 - **Forgetting brepjs disposal**: meshing allocates a brepjs-side handle. Use `using` or `withScope` to release it.
 
 ## Next steps
 
-- [React Three Fiber](./r3f) — the same pipeline expressed declaratively in React
-- [Web Workers](../advanced/workers) — meshing in a worker to keep the render thread cool
-- [Vite, Next.js, Astro](./frameworks) — bundler and framework specifics
+- [React Three Fiber](./r3f): the same pipeline expressed declaratively in React
+- [Web Workers](../advanced/workers): meshing in a worker to keep the render thread cool
+- [Vite, Next.js, Astro](./frameworks): bundler and framework specifics

--- a/apps/docs/introduction/non-goals.md
+++ b/apps/docs/introduction/non-goals.md
@@ -1,29 +1,29 @@
 ---
 title: What brepjs is NOT
-description: "What brepjs deliberately doesn't do — no renderer, no mesh modeling, no constraint solver, no SubD. Use the right tool for the job."
+description: "What brepjs deliberately doesn't do: no renderer, no mesh modeling, no constraint solver, no SubD. Use the right tool for the job."
 ---
 
 # What brepjs is NOT
 
-Knowing the non-goals matters as much as knowing the goals. brepjs is opinionated, and a few things are deliberately out of scope. If you need any of these, brepjs is the wrong tool — pick something else.
+Knowing the non-goals matters as much as knowing the goals. brepjs is opinionated, and a few things are deliberately out of scope. If you need any of these, brepjs is the wrong tool; pick something else.
 
 ## Not a renderer
 
-brepjs has no graphics, no canvas, no WebGL, no scene graph. The output of every modelling operation is a B-Rep shape; you mesh it (`shape(s).mesh()`) and hand the triangle data to your renderer of choice — Three.js, Babylon.js, raw WebGL, react-three-fiber.
+brepjs has no graphics, no canvas, no WebGL, no scene graph. The output of every modelling operation is a B-Rep shape; you mesh it (`shape(s).mesh()`) and hand the triangle data to your renderer of choice: Three.js, Babylon.js, raw WebGL, react-three-fiber.
 
 The [Three.js Integration](../integration/threejs) chapter covers the meshing → rendering pipeline.
 
 ## Not a mesh library
 
-If you have triangle data and want to do operations on triangle data, use [Three.js](https://threejs.org/), [Babylon.js](https://babylonjs.com), or [Manifold](https://github.com/elalish/manifold). brepjs only ingests meshes via `importSTL`, which converts triangles into a B-Rep approximation — useful for measurement and STEP conversion, not for further triangle work.
+If you have triangle data and want to do operations on triangle data, use [Three.js](https://threejs.org/), [Babylon.js](https://babylonjs.com), or [Manifold](https://github.com/elalish/manifold). brepjs only ingests meshes via `importSTL`, which converts triangles into a B-Rep approximation: useful for measurement and STEP conversion, not for further triangle work.
 
 ## Not an organic modeller
 
-brepjs has no SubD modelling, no T-splines, no sculpting tools, no Blender-style modifier stack. The geometry it can express is whatever OpenCascade's NURBS-based kernel can express — planes, cylinders, cones, spheres, tori, B-spline surfaces, swept and revolved surfaces. Excellent for parts; not the right tool for character modelling, terrain, or hand-sculpted forms.
+brepjs has no SubD modelling, no T-splines, no sculpting tools, no Blender-style modifier stack. The geometry it can express is whatever OpenCascade's NURBS-based kernel can express: planes, cylinders, cones, spheres, tori, B-spline surfaces, swept and revolved surfaces. Excellent for parts; not the right tool for character modelling, terrain, or hand-sculpted forms.
 
 ## Not a real-time CSG library
 
-`fuse`, `cut`, and `intersect` are exact boolean operations on B-Rep shapes — they take milliseconds to seconds depending on shape complexity, not microseconds. If you need real-time CSG (e.g. for live editing of dozens of operations per frame), the kernel will be too slow and a mesh-CSG library is a better fit.
+`fuse`, `cut`, and `intersect` are exact boolean operations on B-Rep shapes; they take milliseconds to seconds depending on shape complexity, not microseconds. If you need real-time CSG (e.g. for live editing of dozens of operations per frame), the kernel will be too slow and a mesh-CSG library is a better fit.
 
 ## Not a constraint solver for 2D drafting
 
@@ -40,11 +40,11 @@ For multi-body kinematic assemblies, use a dedicated mechanical CAD tool. brepjs
 
 ## Not server-side renderable
 
-brepjs requires WASM to run. Server-side rendering frameworks (Next.js SSR, Nuxt SSR, Remix) cannot execute the kernel during render. You must use brepjs in client-side components — `dynamic(import, { ssr: false })` in Next.js, `<ClientOnly>` in Nuxt, etc. The [Frameworks chapter](../integration/frameworks) covers patterns for each framework.
+brepjs requires WASM to run. Server-side rendering frameworks (Next.js SSR, Nuxt SSR, Remix) cannot execute the kernel during render. You must use brepjs in client-side components: `dynamic(import, { ssr: false })` in Next.js, `<ClientOnly>` in Nuxt, etc. The [Frameworks chapter](../integration/frameworks) covers patterns for each framework.
 
 ## Not a multi-user collaboration tool
 
-brepjs is a library, not a service. It has no networking, no shared state, no operational transform, no presence. If you need real-time collaborative CAD editing, you build that on top — brepjs handles the geometry kernel, you handle the syncing.
+brepjs is a library, not a service. It has no networking, no shared state, no operational transform, no presence. If you need real-time collaborative CAD editing, you build that on top; brepjs handles the geometry kernel, you handle the syncing.
 
 ## Not a manufacturing toolpath generator
 
@@ -52,10 +52,10 @@ brepjs models parts. It does not generate G-code, slicer output, or CAM toolpath
 
 ## Not a magic black box
 
-The kernel is OpenCascade. The pitfalls of OpenCascade — boolean failures on near-coincident geometry, fillet failures on tight curvature, healing requirements after STEP imports — are inherited by brepjs. The library wraps them in nicer types and clearer errors, but the underlying geometry concerns are the same. Read [Healing & Sewing](../advanced/healing) before you ship anything that imports STEP from third parties.
+The kernel is OpenCascade. The pitfalls of OpenCascade (boolean failures on near-coincident geometry, fillet failures on tight curvature, healing requirements after STEP imports) are inherited by brepjs. The library wraps them in nicer types and clearer errors, but the underlying geometry concerns are the same. Read [Healing & Sewing](../advanced/healing) before you ship anything that imports STEP from third parties.
 
 ## Next steps
 
-- [Install & Initialize](../getting-started/install) — set up the kernel and run your first script
-- [B-Rep vs Mesh](../concepts/brep-vs-mesh) — what makes B-Rep different from triangles
-- [Migration](../migration/replicad) — switching from another code-CAD library
+- [Install & Initialize](../getting-started/install): set up the kernel and run your first script
+- [B-Rep vs Mesh](../concepts/brep-vs-mesh): what makes B-Rep different from triangles
+- [Migration](../migration/replicad): switching from another code-CAD library

--- a/apps/docs/introduction/stability.md
+++ b/apps/docs/introduction/stability.md
@@ -11,9 +11,9 @@ brepjs is at major version 18. The OpenCascade kernel is production-ready and po
 
 brepjs follows [Semantic Versioning](https://semver.org/). The version number is `MAJOR.MINOR.PATCH`:
 
-- **PATCH** — bug fixes, internal refactors, performance improvements that do not change observed behaviour
-- **MINOR** — new exports, new methods, new error codes, new parameters with safe defaults; backwards-compatible
-- **MAJOR** — removals, signature changes, behavioural changes, kernel-version bumps that change geometric output
+- **PATCH**: bug fixes, internal refactors, performance improvements that do not change observed behaviour
+- **MINOR**: new exports, new methods, new error codes, new parameters with safe defaults; backwards-compatible
+- **MAJOR**: removals, signature changes, behavioural changes, kernel-version bumps that change geometric output
 
 What counts as a breaking change:
 
@@ -38,7 +38,7 @@ Breaking changes ship under conventional commit prefix `feat!:` or `fix!:` and a
 | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | Node.js 24+                                               | Supported (CI tested)                                                           |
 | Modern browsers (Chrome 113+, Firefox 113+, Safari 16.4+) | Supported                                                                       |
-| Cloudflare Workers / Deno                                 | Untested but expected to work — WASM-only                                       |
+| Cloudflare Workers / Deno                                 | Untested but expected to work, WASM-only                                        |
 | TypeScript 5.9+                                           | Recommended (for `using` syntax and stricter branded types)                     |
 | TypeScript 5.0+                                           | Supported with workarounds (use `DisposalScope` instead of `using`)             |
 | Server-side rendering                                     | Client-only; see [Compatibility](../integration/compatibility) for SSR patterns |
@@ -54,7 +54,7 @@ The `using` keyword (TypeScript 5.2+, browsers/Node since 2024) is the recommend
 | 16.x           | `occt-wasm` 2.x or `brepjs-opencascade` 0.13–0.16 | `brepkit-wasm` 2.x        |
 | 15.x           | `brepjs-opencascade` 0.12–0.15                    | `brepkit-wasm` 1.x or 2.x |
 
-A kernel version bump is treated as a breaking change for brepjs even if the brepjs API is unchanged — geometric output can shift between kernel versions.
+A kernel version bump is treated as a breaking change for brepjs even if the brepjs API is unchanged; geometric output can shift between kernel versions.
 
 ## Deprecation policy
 
@@ -71,24 +71,24 @@ The legacy class-based API (`Shape`, `Solid`, `Edge`, `Face` classes in `src/top
 
 These surfaces may change without a major bump:
 
-- Internal-only modules under `src/kernel/occt/` and `src/kernel/brepkit/` — only the `KernelInterface` from `src/kernel/types.ts` is public-stable
+- Internal-only modules under `src/kernel/occt/` and `src/kernel/brepkit/`; only the `KernelInterface` from `src/kernel/types.ts` is public-stable
 - Pattern checker baseline and rule set
 - The exact wording of error messages (codes are stable; messages may improve)
-- The structure of internal `.wrapped` handles — Layer 2+ code must never touch them
+- The structure of internal `.wrapped` handles; Layer 2+ code must never touch them
 
 ## Release cadence
 
-Releases are managed by [release-please](https://github.com/googleapis/release-please) — every commit on `main` that follows Conventional Commits accumulates into the next version. Patch releases are typically weekly when fixes accumulate; minor releases land as features ship; majors are rare and announced in advance.
+Releases are managed by [release-please](https://github.com/googleapis/release-please); every commit on `main` that follows Conventional Commits accumulates into the next version. Patch releases are typically weekly when fixes accumulate; minor releases land as features ship; majors are rare and announced in advance.
 
 See `CHANGELOG.md` in the repository for the full history.
 
 ## Reporting bugs
 
-- **Bug reports**: [github.com/andymai/brepjs/issues](https://github.com/andymai/brepjs/issues) — include a minimal reproduction, ideally a playground link
+- **Bug reports**: [github.com/andymai/brepjs/issues](https://github.com/andymai/brepjs/issues); include a minimal reproduction, ideally a playground link
 - **Security**: see `SECURITY.md` in the repository
 
 ## Next steps
 
-- [What brepjs is NOT](./non-goals) — explicit non-goals before adoption
-- [Compatibility Matrix](../integration/compatibility) — tested environments in detail
-- [Custom Kernels](../extending/custom-kernel) — how to swap or write your own kernel
+- [What brepjs is NOT](./non-goals): explicit non-goals before adoption
+- [Compatibility Matrix](../integration/compatibility): tested environments in detail
+- [Custom Kernels](../extending/custom-kernel): how to swap or write your own kernel

--- a/apps/docs/introduction/why-brepjs.md
+++ b/apps/docs/introduction/why-brepjs.md
@@ -7,7 +7,7 @@ description: 'Code-first CAD for JavaScript: exact B-Rep solids, branded types t
 
 > **Try it live:** the <a href="/playground" target="_blank" rel="noopener">in-browser playground</a> compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds, no install, no setup.
 
-**brepjs** is a code-first CAD library for JavaScript. It models real solids (exact mathematical boundaries, not triangle meshes) so booleans are precise, fillets land on real edges, measurements are real numbers, and STEP export round-trips with SolidWorks, Fusion, FreeCAD, and OpenSCAD. The library is built on top of OpenCascade WASM today and a Rust-based kernel ([brepkit](https://github.com/andymai/brepkit)) tomorrow; the kernel is pluggable behind a small abstraction layer.
+**brepjs** is a code-first CAD library for JavaScript. It models real solids (exact mathematical boundaries, not triangle meshes), so booleans are precise, fillets land on real edges, measurements are real numbers, and STEP export round-trips with SolidWorks, Fusion, FreeCAD, and OpenSCAD. The library is built on top of OpenCascade WASM today and a Rust-based kernel ([brepkit](https://github.com/andymai/brepkit)) tomorrow; the kernel is pluggable behind a small abstraction layer.
 
 The differentiator: brepjs leans on TypeScript's type system to prove geometric invariants at compile time. Branded types separate `Edge` from `Wire` from `Face`. Validity brands like `ClosedWire`, `OrientedFace`, and `ValidSolid` encode topological properties: a wire that forms a loop, a face with a consistent normal, a solid that passes BRepCheck. If your code compiles, the geometry is structurally valid.
 

--- a/apps/docs/introduction/why-brepjs.md
+++ b/apps/docs/introduction/why-brepjs.md
@@ -5,17 +5,17 @@ description: 'Code-first CAD for JavaScript: exact B-Rep solids, branded types t
 
 # Why brepjs
 
-> **Try it live:** the <a href="/playground" target="_blank" rel="noopener">in-browser playground</a> compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds — no install, no setup.
+> **Try it live:** the <a href="/playground" target="_blank" rel="noopener">in-browser playground</a> compiles a TypeScript snippet and renders the resulting solid in a few hundred milliseconds, no install, no setup.
 
-**brepjs** is a code-first CAD library for JavaScript. It models real solids — exact mathematical boundaries, not triangle meshes — so booleans are precise, fillets land on real edges, measurements are real numbers, and STEP export round-trips with SolidWorks, Fusion, FreeCAD, and OpenSCAD. The library is built on top of OpenCascade WASM today and a Rust-based kernel ([brepkit](https://github.com/andymai/brepkit)) tomorrow; the kernel is pluggable behind a small abstraction layer.
+**brepjs** is a code-first CAD library for JavaScript. It models real solids (exact mathematical boundaries, not triangle meshes) so booleans are precise, fillets land on real edges, measurements are real numbers, and STEP export round-trips with SolidWorks, Fusion, FreeCAD, and OpenSCAD. The library is built on top of OpenCascade WASM today and a Rust-based kernel ([brepkit](https://github.com/andymai/brepkit)) tomorrow; the kernel is pluggable behind a small abstraction layer.
 
-The differentiator: brepjs leans on TypeScript's type system to prove geometric invariants at compile time. Branded types separate `Edge` from `Wire` from `Face`. Validity brands like `ClosedWire`, `OrientedFace`, and `ValidSolid` encode topological properties — a wire that forms a loop, a face with a consistent normal, a solid that passes BRepCheck. If your code compiles, the geometry is structurally valid.
+The differentiator: brepjs leans on TypeScript's type system to prove geometric invariants at compile time. Branded types separate `Edge` from `Wire` from `Face`. Validity brands like `ClosedWire`, `OrientedFace`, and `ValidSolid` encode topological properties: a wire that forms a loop, a face with a consistent normal, a solid that passes BRepCheck. If your code compiles, the geometry is structurally valid.
 
 ## What can you build?
 
-The library targets **parametric parts defined by parameters** — enclosures, brackets, fixtures, gridfinity bins, mounts, jigs, signs, name plates, parts that snap to a grid or follow a formula. It is not optimized for organic sculpting (no SubD modeling, no T-splines). The sweet spot is anything you might otherwise write in OpenSCAD or SolidWorks, but as a JavaScript program you can deploy to the web.
+The library targets **parametric parts defined by parameters**: enclosures, brackets, fixtures, gridfinity bins, mounts, jigs, signs, name plates, parts that snap to a grid or follow a formula. It is not optimized for organic sculpting (no SubD modeling, no T-splines). The sweet spot is anything you might otherwise write in OpenSCAD or SolidWorks, but as a JavaScript program you can deploy to the web.
 
-The default unit is millimetres, but brepjs is unit-agnostic — pick whatever your kernel is configured for. The OpenCascade kernel uses double-precision floating point throughout.
+The default unit is millimetres, but brepjs is unit-agnostic. Pick whatever your kernel is configured for. The OpenCascade kernel uses double-precision floating point throughout.
 
 ## Where does it fit?
 
@@ -28,11 +28,11 @@ The default unit is millimetres, but brepjs is unit-agnostic — pick whatever y
 | [Three.js + CSG](https://threejs.org/)          | Mesh                      | CSG hacks        | Standard                 | Yes            |
 | [OpenSCAD](https://openscad.org/)               | CSG tree                  | Exact            | None (custom DSL)        | No             |
 
-The closest peer is Replicad — same kernel family, same code-CAD ethos. brepjs's pitch over Replicad is the type system: you do not need to wonder whether a wire is closed before passing it to `face()`, because the compiler already proved it.
+The closest peer is Replicad: same kernel family, same code-CAD ethos. brepjs's pitch over Replicad is the type system: you do not need to wonder whether a wire is closed before passing it to `face()`, because the compiler already proved it.
 
 ## Why I built this
 
-brepjs grew out of [gridfinitylayouttool.com](https://gridfinitylayouttool.com). I needed parametric CAD in the browser, I'm not a 3D modeler, but I know TypeScript. OpenSCAD nailed code-first CAD but lives outside the JS ecosystem. Replicad proved OpenCascade works in JS but I kept fighting the API — too easy to pass the wrong shape to the wrong function and discover it at runtime.
+brepjs grew out of [gridfinitylayouttool.com](https://gridfinitylayouttool.com). I needed parametric CAD in the browser, I'm not a 3D modeler, but I know TypeScript. OpenSCAD nailed code-first CAD but lives outside the JS ecosystem. Replicad proved OpenCascade works in JS but I kept fighting the API: too easy to pass the wrong shape to the wrong function and discover it at runtime.
 
 Neither had the type safety I wanted, so brepjs leans hard on it: branded types, `Result<T,E>`, phantom dimension parameters, validity brands. **If it compiles, the geometry is valid.**
 

--- a/apps/docs/migration/manual-csg-cache.md
+++ b/apps/docs/migration/manual-csg-cache.md
@@ -1,21 +1,21 @@
 ---
 title: Migrating from a Hand-Rolled Cache
-description: 'If you built your own Map<key, Solid> around the eager fuse/cut API, here is the side-by-side translation to the CSG IR — what you keep, what you replace, and what you inherit by switching.'
+description: 'If you built your own Map<key, Solid> around the eager fuse/cut API, here is the side-by-side translation to the CSG IR: what you keep, what you replace, and what you inherit by switching.'
 ---
 
 # Migrating from a Hand-Rolled Cache
 
-A common pattern in code-CAD apps: wrap the eager `box`/`fuse`/`cut` API in a `Map<string, Solid>` keyed by the input parameters, so re-renders during a slider drag don't recompute identical geometry. It works, but it has rough edges — every cache key is hand-derived, invalidation is all-or-nothing per top-level entry, and you own a `.delete()` lifecycle that's easy to leak.
+A common pattern in code-CAD apps: wrap the eager `box`/`fuse`/`cut` API in a `Map<string, Solid>` keyed by the input parameters, so re-renders during a slider drag don't recompute identical geometry. It works, but it has rough edges: every cache key is hand-derived, invalidation is all-or-nothing per top-level entry, and you own a `.delete()` lifecycle that's easy to leak.
 
 The `csg` namespace gives you the same caching semantics without the bookkeeping.
 
-If you haven't read **[CSG as an IR](/concepts/csg-ir)** yet, do that first — this page focuses on the diff, not the model.
+If you haven't read **[CSG as an IR](/concepts/csg-ir)** yet, do that first. This page focuses on the diff, not the model.
 
 ## The scenario
 
 A live-preview UI lets the user tweak the radius of a hole drilled through a fixed-size cube. The naive eager version recomputes everything on every slider event; the manual-cache version memoizes by stringified parameters; the IR version replaces the cache plumbing entirely.
 
-## Version A — eager, no cache
+## Version A: eager, no cache
 
 ```typescript
 import { box, sphere, cut, unwrap, measureVolume } from 'brepjs/quick';
@@ -31,9 +31,9 @@ const part = makePart(slider.value);
 const v = unwrap(measureVolume(part));
 ```
 
-Every slider event allocates one new cube, one new sphere, one new cut — three live B-Rep solids in WASM memory. The cube has nothing to do with the slider but gets rebuilt anyway. Repeat 30× per second during a drag and you're allocating a thousand intermediate handles a minute.
+Every slider event allocates one new cube, one new sphere, one new cut: three live B-Rep solids in WASM memory. The cube has nothing to do with the slider but gets rebuilt anyway. Repeat 30× per second during a drag and you're allocating a thousand intermediate handles a minute.
 
-## Version B — manual `Map` cache
+## Version B: manual `Map` cache
 
 Most projects converge on this pattern once Version A's allocation rate shows up in the profiler. Keys are stringified parameters, values are materialized solids, and you carry an explicit dispose path because the cache owns the handles.
 
@@ -91,11 +91,11 @@ This works, but look at what it costs:
 2. **Manual key derivation.** `${L},${W},${H}` works until floats need precision normalization, until you forget to include the tolerance, until you add a parameter and miss a key site.
 3. **Manual invalidation.** Change the cube size and you need to know which composite cache entries depended on it. The cache structure doesn't capture the dependency graph; you do.
 4. **Lifetime is your problem.** Every cache entry is a live kernel handle. Forget to dispose one cache on unmount → leak. Dispose twice → kernel error.
-5. **Edges of the cache key.** Did you remember the kernel id? The boolean tolerance? Two evaluators with different tolerance settings should not share entries — but the manual cache happily returns the wrong shape if you don't think to include it in the key.
+5. **Edges of the cache key.** Did you remember the kernel id? The boolean tolerance? Two evaluators with different tolerance settings should not share entries; but the manual cache happily returns the wrong shape if you don't think to include it in the key.
 
 Each one is solvable individually, but each one is also a place where the next engineer to touch the file makes a subtle mistake. The CSG IR makes the whole class go away.
 
-## Version C — CSG IR
+## Version C: CSG IR
 
 ```typescript
 import { csg, unwrap, measureVolume } from 'brepjs/quick';
@@ -112,11 +112,11 @@ const v = unwrap(measureVolume(shape));
 That's the whole file. Compare what disappeared:
 
 - **Three caches collapsed into one.** The evaluator caches every node by structural hash, so the cube, the sphere, and the cut each get their own entry automatically.
-- **No string keys.** The cache key is `(structuralHash, kernelId, projectedEnvHash, toleranceHash)` — derived from the tree, not from your formatting choices. Floats are hashed bit-exactly via `DataView.setFloat64` with `-0` normalized; the kernel id is captured at evaluator construction; tolerance is a first-class field.
+- **No string keys.** The cache key is `(structuralHash, kernelId, projectedEnvHash, toleranceHash)`, derived from the tree, not from your formatting choices. Floats are hashed bit-exactly via `DataView.setFloat64` with `-0` normalized; the kernel id is captured at evaluator construction; tolerance is a first-class field.
 - **Invalidation is automatic and granular.** When `r` changes, only the sphere and the cut invalidate. The cube hits the cache because `r` isn't in its `freeParams`. You didn't have to think about which composites depend on which primitives.
 - **Lifetime is structural.** `using ev = new csg.Evaluator()` releases every cached handle when the block exits. No per-cache iteration, no risk of double-dispose, no risk of partial cleanup.
 
-The behavior on a slider drag — which is what you actually care about:
+The behavior on a slider drag, which is what you actually care about:
 
 ```mermaid
 graph TD
@@ -133,29 +133,29 @@ The cube subtree hits; only the sphere re-materializes and the cut recomputes. S
 
 A few things the IR gives you on top of the cache that the manual version doesn't have:
 
-- **`csg.optimize(tree)`** — pure tree rewrites: constant folding, identity elimination, translate fusion. Run once after building; the rest of the session works on a smaller tree. See [CSG caching internals](/advanced/csg-caching#optimize-tree-level-rewrites).
-- **`csg.toJSON` / `csg.fromJSON`** — serialize the build recipe to JSON. The deserialized tree shares cache entries with the original because structural hashes are reconstructed correctly. Useful for build pipelines, undo/redo snapshots, or sharing models without shipping STEP files.
-- **`csg.replaceNode`** — swap a subtree by predicate. The rebuild walks bottom-up via builders so hashes stay correct.
-- **`onStep` instrumentation** — install a callback to trace every cache hit/miss per node. The thing you want when the profiler says "still too slow" and you need to know which subtree's cache key keeps changing.
+- **`csg.optimize(tree)`**: pure tree rewrites: constant folding, identity elimination, translate fusion. Run once after building; the rest of the session works on a smaller tree. See [CSG caching internals](/advanced/csg-caching#optimize-tree-level-rewrites).
+- **`csg.toJSON` / `csg.fromJSON`**: serialize the build recipe to JSON. The deserialized tree shares cache entries with the original because structural hashes are reconstructed correctly. Useful for build pipelines, undo/redo snapshots, or sharing models without shipping STEP files.
+- **`csg.replaceNode`**: swap a subtree by predicate. The rebuild walks bottom-up via builders so hashes stay correct.
+- **`onStep` instrumentation**: install a callback to trace every cache hit/miss per node. The thing you want when the profiler says "still too slow" and you need to know which subtree's cache key keeps changing.
 
-The manual version can grow all of these — but each one is its own subsystem in your codebase that the IR gives you in 50 lines.
+The manual version can grow all of these; but each one is its own subsystem in your codebase that the IR gives you in 50 lines.
 
 ## When the manual cache is still the right answer
 
 Switching costs aren't zero. Stay on the manual cache when:
 
 - **Your tree never changes shape, only inputs.** If the user can only resize a single primitive (no add/remove features, no swap operations, no per-feature toggles), Version B's three-line `cachedFoo` wrappers are easy to skim and your team already understands them.
-- **You need fine-grained control over what's kept hot.** The CSG cache is bounded by the evaluator's lifetime, not a configurable size; large trees with many distinct parameter values can grow it large. (LRU caps are on the [roadmap](https://github.com/andymai/brepjs/issues) — file an issue if this would unblock you.)
+- **You need fine-grained control over what's kept hot.** The CSG cache is bounded by the evaluator's lifetime, not a configurable size; large trees with many distinct parameter values can grow it large. (LRU caps are on the [roadmap](https://github.com/andymai/brepjs/issues). File an issue if this would unblock you.)
 - **You're integrating with code that already speaks `Solid`.** The manual cache returns `Solid` values directly; the IR returns them through `ev.evaluate(node, env)`. Adapting the call sites can be more work than the win for a small project.
 
-For the gridfinity-style live-preview case — slider drag rebuilds a multi-feature parametric tree — the IR wins decisively. For a one-shot CAD batch where you build, export, and exit, neither cache matters.
+For the gridfinity-style live-preview case (slider drag rebuilds a multi-feature parametric tree) the IR wins decisively. For a one-shot CAD batch where you build, export, and exit, neither cache matters.
 
 ## Migration checklist
 
 If you've decided to migrate:
 
 1. **Translate primitives.** `box(...)` → `csg.box(...)`, `sphere(...)` → `csg.sphere(...)`, etc. Same arguments. The return type changes from `Solid` to `SolidNode`.
-2. **Translate composites.** `unwrap(cut(a, b))` → `csg.cut(aNode, bNode)`. Same for `fuse`, `intersect`. No `unwrap` — the IR builders never fail.
+2. **Translate composites.** `unwrap(cut(a, b))` → `csg.cut(aNode, bNode)`. Same for `fuse`, `intersect`. No `unwrap`. The IR builders never fail.
 3. **Translate transforms.** `translate(s, [x,y,z])` → `csg.translate(node, [x,y,z])`. Same for `rotate`, `scale`, `mirror`. Note that `csg.rotate` takes its axis/anchor via an options object, not positional args.
 4. **Wrap with an evaluator.** `using ev = new csg.Evaluator()` once at the top of your render loop, then `unwrap(ev.evaluate(tree))` (or with `env` for parametric trees) at each render.
 5. **Drop the cache plumbing.** Remove your `Map<string, Solid>` declarations, your stringified-key helpers, and your `dispose-all-on-unmount` loops. The `using` keyword on the evaluator handles the lifetime.
@@ -165,6 +165,6 @@ End state: a single tree built once, a single evaluator reused across renders. A
 
 ## See also
 
-- **[CSG as an IR](/concepts/csg-ir)** — the mental model this migration assumes you have.
-- **[The walkthrough](/tasks/parametric-csg)** — a multi-parameter gridfinity-style bin if you want a fuller example before committing to a migration.
-- **[CSG caching internals](/advanced/csg-caching)** — for the full surface of the IR you're inheriting.
+- **[CSG as an IR](/concepts/csg-ir)**: the mental model this migration assumes you have.
+- **[The walkthrough](/tasks/parametric-csg)**: a multi-parameter gridfinity-style bin if you want a fuller example before committing to a migration.
+- **[CSG caching internals](/advanced/csg-caching)**: for the full surface of the IR you're inheriting.

--- a/apps/docs/migration/openscad.md
+++ b/apps/docs/migration/openscad.md
@@ -5,7 +5,7 @@ description: 'Switching from OpenSCAD to brepjs: TypeScript instead of a DSL, ex
 
 # Coming from OpenSCAD
 
-[OpenSCAD](https://openscad.org/) is many people's first code-CAD tool — small, focused, two decades of history. brepjs is a different beast: TypeScript instead of OpenSCAD's custom DSL, B-Rep instead of CSG-tree-of-meshes, exact mathematical surfaces instead of polygon approximations, browser-native instead of desktop-only. If you've outgrown OpenSCAD or want to ship a parametric configurator on the web, this chapter is the bridge.
+[OpenSCAD](https://openscad.org/) is many people's first code-CAD tool: small, focused, two decades of history. brepjs is a different beast: TypeScript instead of OpenSCAD's custom DSL, B-Rep instead of CSG-tree-of-meshes, exact mathematical surfaces instead of polygon approximations, browser-native instead of desktop-only. If you've outgrown OpenSCAD or want to ship a parametric configurator on the web, this chapter is the bridge.
 
 ## What's the same
 
@@ -18,7 +18,7 @@ description: 'Switching from OpenSCAD to brepjs: TypeScript instead of a DSL, ex
 
 - **Exact B-Rep, not CSG-of-meshes.** OpenSCAD computes a CSG tree at the end and produces a triangle mesh. Every operation in brepjs operates on exact surfaces and produces a B-Rep shape. Booleans are exact, fillets are real, STEP export round-trips with desktop CAD.
 - **TypeScript.** You get type checking, autocomplete, and the standard JS/TS ecosystem (npm, bundlers, frameworks, libraries).
-- **Browser-native.** Ship a configurator as a web app — no install, no separate viewer.
+- **Browser-native.** Ship a configurator as a web app, no install, no separate viewer.
 - **Real fillets and shells.** OpenSCAD has the `minkowski` hack for rounding. brepjs has first-class `fillet`, `chamfer`, `shell`.
 - **Industry-format export.** STEP for desktop CAD round-trip, glTF for web rendering, IGES for legacy tools, 3MF for modern slicers.
 
@@ -74,7 +74,7 @@ For multi-shape unions, prefer `fuseAll([a, b, c])` over chained `fuse`.
 
 ### Refinement (no OpenSCAD equivalents)
 
-These have no native OpenSCAD analogue — `minkowski` is the closest people use:
+These have no native OpenSCAD analogue; `minkowski` is the closest people use:
 
 | OpenSCAD                                    | brepjs                                             |
 | ------------------------------------------- | -------------------------------------------------- |
@@ -179,8 +179,8 @@ Two more lines than the SCAD version. In return: type-safe parameters, `.tsx` if
 If you have an existing OpenSCAD model:
 
 1. Identify the parameters (top-level variables in the SCAD file). These become TypeScript constants.
-2. Identify the primitives — translate to `box`, `cylinder`, `sphere`.
-3. Identify the boolean tree — flatten to `fuseAll` / `cutAll` where possible.
+2. Identify the primitives. Translate to `box`, `cylinder`, `sphere`.
+3. Identify the boolean tree. Flatten to `fuseAll` / `cutAll` where possible.
 4. Replace transforms with brepjs's `translate`, `rotate`, `scale`, `mirror`.
 5. Replace `for` loops over translates with `linearPattern` / `circularPattern`.
 6. Add fillets / chamfers / shells where you previously used `minkowski` workarounds.
@@ -190,6 +190,6 @@ For trivial models, the conversion takes minutes. For complex assemblies, expect
 
 ## Next steps
 
-- [Your First Solid](../getting-started/first-solid) — the canonical brepjs flow
-- [Boolean Operations](../tasks/booleans) — the workhorse, with multi-shape variants
-- [Three.js](../integration/threejs) — if you want a web viewer for your parts
+- [Your First Solid](../getting-started/first-solid): the canonical brepjs flow
+- [Boolean Operations](../tasks/booleans): the workhorse, with multi-shape variants
+- [Three.js](../integration/threejs): if you want a web viewer for your parts

--- a/apps/docs/migration/replicad.md
+++ b/apps/docs/migration/replicad.md
@@ -1,6 +1,6 @@
 ---
 title: Coming from Replicad
-description: 'Coming from Replicad — both wrap OpenCascade. What is the same, what differs, and the search-and-replace map for working code.'
+description: 'Coming from Replicad. Both wrap OpenCascade. What is the same, what differs, and the search-and-replace map for working code.'
 ---
 
 # Coming from Replicad
@@ -9,7 +9,7 @@ description: 'Coming from Replicad — both wrap OpenCascade. What is the same, 
 
 ## What's the same
 
-- The kernel is OpenCascade in both libraries — same precision, same tolerances, same booleans, same fillets.
+- The kernel is OpenCascade in both libraries: same precision, same tolerances, same booleans, same fillets.
 - 2D drawing → sketch → extrude is the canonical shape-building flow.
 - STEP / STL / glTF export.
 - Web-first, ESM-first, browser-friendly.
@@ -17,7 +17,7 @@ description: 'Coming from Replicad — both wrap OpenCascade. What is the same, 
 ## What's different
 
 - **Branded types and validity types.** brepjs distinguishes `Edge`, `Wire`, `Face` at the type level, and stamps `ClosedWire`, `OrientedFace`, `ValidSolid` on shapes proven to satisfy invariants. Replicad treats most shapes as a single `Shape` type.
-- **`Result<T, BrepError>`** for fallible operations. brepjs returns `Result` from booleans, fillets, imports, exports — Replicad throws.
+- **`Result<T, BrepError>`** for fallible operations. brepjs returns `Result` from booleans, fillets, imports, exports; Replicad throws.
 - **Two API styles.** Functional (`fuse(a, b)`, `fillet(s, edges, r)`) is the canonical surface; the fluent `shape()` wrapper provides a chainable view that matches Replicad's `.fuse().fillet()` style.
 - **Pluggable kernel.** brepjs supports OpenCascade and brepkit (Rust-based) behind one API; Replicad is OpenCascade-only.
 
@@ -186,7 +186,7 @@ if (isClosedWire(someWire)) {
 
 - **Replicad's workbench.** brepjs has <a href="/playground" target="_blank" rel="noopener">a similar playground</a>. Same idea, slightly different UI.
 - **Some operation names.** `revolution` → `revolve`. `loft` is the same. `pipe` → `sweep`.
-- **Replicad's higher-order helpers.** Some niche helpers (e.g. `genericSweep`) don't have direct brepjs equivalents — usually composing two operations covers the case.
+- **Replicad's higher-order helpers.** Some niche helpers (e.g. `genericSweep`) don't have direct brepjs equivalents; usually composing two operations covers the case.
 
 ## When to keep Replicad
 
@@ -196,9 +196,9 @@ If you're not running into Replicad's pain points (silent failures, runtime topo
 
 For a moderate codebase:
 
-1. Add brepjs alongside Replicad. They can coexist — different imports.
+1. Add brepjs alongside Replicad. They can coexist, different imports.
 2. Pick one module (one part / one feature) and migrate it. Use the function map above.
-3. Embrace `Result` — change error-handling sites to use `isOk` or the wrapper.
+3. Embrace `Result`: change error-handling sites to use `isOk` or the wrapper.
 4. Add validity-type assertions at boundaries (where shapes enter/leave your code).
 5. Repeat for the next module.
 
@@ -206,6 +206,6 @@ A search-and-replace (replacing Replicad's class methods with brepjs's functiona
 
 ## Next steps
 
-- [Cheat Sheet](../getting-started/cheat-sheet) — the brepjs API at a glance
-- [Result and Errors](../concepts/result) — handling fallible operations
-- [Types That Prove Geometry Is Valid](../concepts/types) — the differentiator
+- [Cheat Sheet](../getting-started/cheat-sheet): the brepjs API at a glance
+- [Result and Errors](../concepts/result): handling fallible operations
+- [Types That Prove Geometry Is Valid](../concepts/types): the differentiator

--- a/apps/docs/migration/threejs.md
+++ b/apps/docs/migration/threejs.md
@@ -5,11 +5,11 @@ description: "If you've tried CAD in Three.js with three-csg-ts and hit the wall
 
 # Coming from Three.js (mesh modeling)
 
-If you've tried to do CAD in [Three.js](https://threejs.org/) — building parts with `THREE.BoxGeometry` and `three-csg-ts` for booleans — you've hit walls. CSG on meshes is unreliable for anything past simple shapes, fillets don't exist, measurements are approximate, and STEP export is impossible. brepjs is the precision layer above Three.js: model in B-Rep, render in Three.js. This chapter is the conceptual shift and the practical pipeline.
+If you've tried to do CAD in [Three.js](https://threejs.org/) (building parts with `THREE.BoxGeometry` and `three-csg-ts` for booleans) you've hit walls. CSG on meshes is unreliable for anything past simple shapes, fillets don't exist, measurements are approximate, and STEP export is impossible. brepjs is the precision layer above Three.js: model in B-Rep, render in Three.js. This chapter is the conceptual shift and the practical pipeline.
 
 ## The realisation
 
-Three.js is a **renderer**. Its geometry classes (`BoxGeometry`, `SphereGeometry`, `BufferGeometry`) describe what to display, not what to model. You can do CSG on meshes, but the operations approximate — they accumulate error, produce slivers, and fail unpredictably on near-coincident geometry.
+Three.js is a **renderer**. Its geometry classes (`BoxGeometry`, `SphereGeometry`, `BufferGeometry`) describe what to display, not what to model. You can do CSG on meshes, but the operations approximate: they accumulate error, produce slivers, and fail unpredictably on near-coincident geometry.
 
 brepjs is a **modeller**. It produces exact B-Rep shapes that you can boolean reliably, fillet, measure, export to industry CAD formats, and _then_ mesh for Three.js to render.
 
@@ -35,13 +35,13 @@ Two libraries, one role each.
 | Hand-tuned ray traversal for measurement               | `measureVolume`, `measureArea`, `distanceTo`                                |
 | Approximate STL export from `BufferGeometry`           | `exportSTEP`, `exportSTL` directly from B-Rep                               |
 
-Three.js stays in the picture — for rendering, controls, materials, lights, post-processing. The modelling moves to brepjs.
+Three.js stays in the picture, for rendering, controls, materials, lights, post-processing. The modelling moves to brepjs.
 
 ## Concept-by-concept
 
 ### Mesh vs. B-Rep
 
-A `BoxGeometry` is 12 triangles. A brepjs `box` is 6 planar surfaces, 12 line edges, 8 vertices, exact. The brepjs box can be `cut` with a cylinder and the resulting hole is exactly cylindrical — not 12-sided. See [B-Rep vs Mesh](../concepts/brep-vs-mesh).
+A `BoxGeometry` is 12 triangles. A brepjs `box` is 6 planar surfaces, 12 line edges, 8 vertices, exact. The brepjs box can be `cut` with a cylinder and the resulting hole is exactly cylindrical, not 12-sided. See [B-Rep vs Mesh](../concepts/brep-vs-mesh).
 
 ### Booleans
 
@@ -114,7 +114,7 @@ Exact mathematical values, not Riemann sums.
 
 ### Export to CAD formats
 
-Three.js exporters (`STLExporter`, `GLTFExporter`) work on triangle data — STL out is fine. STEP / IGES export from triangles is impossible.
+Three.js exporters (`STLExporter`, `GLTFExporter`) work on triangle data; STL out is fine. STEP / IGES export from triangles is impossible.
 
 brepjs exports STEP from B-Rep:
 
@@ -128,7 +128,7 @@ console.log('STEP size:', step.size, 'bytes');
 export default part;
 ```
 
-The output round-trips with SolidWorks, Fusion 360, FreeCAD, OnShape — every desktop CAD tool.
+The output round-trips with SolidWorks, Fusion 360, FreeCAD, OnShape: every desktop CAD tool.
 
 ## The integration pattern
 
@@ -165,7 +165,7 @@ scene.add(mesh);
 
 Some workflows are fundamentally mesh-based:
 
-- **Sculpting** — pushing vertices around. B-Rep can't express most sculpted forms.
+- **Sculpting**: pushing vertices around. B-Rep can't express most sculpted forms.
 - **Real-time CSG** at hundreds of operations per second. B-Rep is too slow.
 - **Procedural terrain / heightmaps.** B-Rep would explode in face count.
 - **Voxel art / Minecraft-style.** Mesh territory.
@@ -184,12 +184,12 @@ For an existing Three.js + CSG codebase:
 2. Replace `three-csg-ts` calls with `fuse` / `cut` / `intersect`.
 3. Mesh the brepjs results to feed back to Three.js.
 4. Add fillets, shells, and measurements where you previously avoided them.
-5. Add STEP export — this is the killer feature most users didn't know they wanted.
+5. Add STEP export: this is the killer feature most users didn't know they wanted.
 
-The integration is incremental — start with one part, prove the pipeline, expand.
+The integration is incremental: start with one part, prove the pipeline, expand.
 
 ## Next steps
 
-- [Three.js Integration](../integration/threejs) — the full B-Rep → render pipeline
-- [Boolean Operations](../tasks/booleans) — exact booleans you can rely on
-- [Why brepjs](../introduction/why-brepjs) — the broader case for B-Rep modelling on the web
+- [Three.js Integration](../integration/threejs): the full B-Rep → render pipeline
+- [Boolean Operations](../tasks/booleans): exact booleans you can rely on
+- [Why brepjs](../introduction/why-brepjs): the broader case for B-Rep modelling on the web

--- a/apps/docs/reference/decisions.md
+++ b/apps/docs/reference/decisions.md
@@ -1,6 +1,6 @@
 ---
 title: Design Decisions
-description: 'Index of architectural decision records — short ADRs explaining context, choice, alternatives, and consequences for major decisions.'
+description: 'Index of architectural decision records: short ADRs explaining context, choice, alternatives, and consequences for major decisions.'
 ---
 
 # Design Decisions
@@ -9,9 +9,9 @@ The brepjs repository tracks architectural decision records (ADRs) under `docs/d
 
 ## Why ADRs
 
-Architecture decisions accumulate over a project's lifetime. Without records, future contributors (and future me) have to reverse-engineer the decision from the code, often missing the context that justified it. ADRs make the rationale durable — they survive when the original author forgets, leaves, or simply moves on.
+Architecture decisions accumulate over a project's lifetime. Without records, future contributors (and future me) have to reverse-engineer the decision from the code, often missing the context that justified it. ADRs make the rationale durable: they survive when the original author forgets, leaves, or simply moves on.
 
-The brepjs ADRs are intentionally short — typically a page or two each. Longer than a comment, shorter than a chapter.
+The brepjs ADRs are intentionally short, typically a page or two each. Longer than a comment, shorter than a chapter.
 
 ## The ADRs
 
@@ -70,23 +70,23 @@ Roughly: when a decision affects more than one module, when there's a real alter
 - Choosing between two approaches with different long-term consequences (e.g. "should tolerance be a type parameter or a runtime field?")
 - Defining a public API contract (e.g. "what's the canonical surface for query operations?")
 
-Don't write an ADR for routine code changes — bug fixes, performance improvements, dependency bumps. The git history is enough for those.
+Don't write an ADR for routine code changes: bug fixes, performance improvements, dependency bumps. The git history is enough for those.
 
 ## Reading order
 
 If you want to understand the brepjs architecture from first principles:
 
-1. **0001 — Layered architecture** — the foundation
-2. **0002 — Kernel abstraction** — why the kernel is replaceable
-3. **0003 — Branded types** — the type-system foundation
-4. **0004 — Phantom dimension types** — extends 0003 for 2D/3D safety
-5. **0005 — Topological validity types** + **0011 — Geometric validity brands** — the validity layer
-6. **0006 — Domain boundaries** + **0008, 0010 — audits** — what's in each module
+1. **0001: Layered architecture**: the foundation
+2. **0002: Kernel abstraction**: why the kernel is replaceable
+3. **0003: Branded types**: the type-system foundation
+4. **0004: Phantom dimension types**: extends 0003 for 2D/3D safety
+5. **0005: Topological validity types** + **0011: Geometric validity brands**: the validity layer
+6. **0006: Domain boundaries** + **0008, 0010: audits**: what's in each module
 
 The rest are deeper drills into specific subsystems.
 
 ## Next steps
 
-- [Architecture & Layers](../extending/architecture) — the user-facing summary of these decisions
-- [Types That Prove Geometry Is Valid](../concepts/types) — the type system the ADRs justify
-- [GitHub repository](https://github.com/andymai/brepjs) — for the latest ADRs
+- [Architecture & Layers](../extending/architecture): the user-facing summary of these decisions
+- [Types That Prove Geometry Is Valid](../concepts/types): the type system the ADRs justify
+- [GitHub repository](https://github.com/andymai/brepjs): for the latest ADRs

--- a/apps/docs/reference/errors.md
+++ b/apps/docs/reference/errors.md
@@ -57,7 +57,7 @@ The two operands don't share volume. For `cut`, this is occasionally not an erro
 
 One of the inputs failed `BRepCheck`. The kernel refuses to operate on invalid shapes.
 
-**Fix**: Run `autoHeal(input)` on each operand before the boolean. For imported shapes, this should be the default — see [Healing & Sewing](../advanced/healing).
+**Fix**: Run `autoHeal(input)` on each operand before the boolean. For imported shapes, this should be the default. See [Healing & Sewing](../advanced/healing).
 
 ### `BOOLEAN_NEAR_COINCIDENT`
 
@@ -81,15 +81,15 @@ The boolean succeeded but the result didn't pass `BRepCheck`. Usually means the 
 
 ### `FILLET_TOO_LARGE`
 
-The radius is bigger than the local edge geometry can support. A 6 mm fillet on a 10 mm-thick part doesn't fit — the fillet would consume both faces.
+The radius is bigger than the local edge geometry can support. A 6 mm fillet on a 10 mm-thick part doesn't fit. The fillet would consume both faces.
 
-**Fix**: Smaller radius. Or: fewer edges (radius and edge selection interact — a fillet that would propagate to a too-tight neighbour fails).
+**Fix**: Smaller radius. Or: fewer edges (radius and edge selection interact; a fillet that would propagate to a too-tight neighbour fails).
 
 ### `FILLET_INVALID_EDGE`
 
 The selected edge has geometry the fillet algorithm can't handle. Common with imported shapes: sharp creases, edges shorter than the radius, non-tangent meeting edges.
 
-**Fix**: Heal first (`autoHeal`). Or skip the problematic edge by refining the finder. Or use `chamfer` — it has fewer requirements.
+**Fix**: Heal first (`autoHeal`). Or skip the problematic edge by refining the finder. Or use `chamfer`. It has fewer requirements.
 
 ### `FILLET_AMBIGUOUS_PROPAGATION`
 
@@ -105,7 +105,7 @@ Same as `FILLET_TOO_LARGE` but for chamfer.
 
 ### `SHELL_TOO_THICK`
 
-The wall thickness in `shell(solid, faces, t)` is larger than the local geometry can support — the offset surfaces would self-intersect.
+The wall thickness in `shell(solid, faces, t)` is larger than the local geometry can support. The offset surfaces would self-intersect.
 
 **Fix**: Thinner wall. Or remove faces that allow more offset clearance.
 
@@ -121,7 +121,7 @@ You passed a face to `shell` that isn't part of the input solid. This usually me
 
 You tried to build a face from a wire that isn't a closed loop. Usually means you forgot `.close()` on a `Sketcher`.
 
-**Fix**: Call `.close()`. The compiler should normally catch this — you've probably done a runtime cast that bypassed the type system.
+**Fix**: Call `.close()`. The compiler should normally catch this. You've probably done a runtime cast that bypassed the type system.
 
 ### `WIRE_SELF_INTERSECTS`
 
@@ -143,9 +143,9 @@ The revolution axis passes through the profile. The result would self-intersect.
 
 ### `LOFT_PROFILE_MISMATCH`
 
-The profiles passed to `loft` have very different topologies — e.g. one is closed, another is open.
+The profiles passed to `loft` have very different topologies, e.g. one is closed, another is open.
 
-**Fix**: Make all profiles consistent — all closed, all the same general topology.
+**Fix**: Make all profiles consistent, all closed, all the same general topology.
 
 ### `SWEEP_PATH_INVALID`
 
@@ -163,7 +163,7 @@ The path has self-intersections, sharp corners, or non-tangent meeting edges. Th
 
 ### `SEW_FAILED`
 
-`sew` couldn't connect the input faces — the gaps are larger than tolerance, or the topology is incompatible.
+`sew` couldn't connect the input faces. The gaps are larger than tolerance, or the topology is incompatible.
 
 **Fix**: Increase tolerance. Or pre-process the faces (e.g. heal each individually first).
 
@@ -191,7 +191,7 @@ The file ends unexpectedly. Likely a download or upload problem.
 
 An exporter (STL, glTF, 3MF) couldn't triangulate the input. Usually a tolerance issue with very small or very large shapes.
 
-**Fix**: Heal the input first. Adjust tolerance — too small (1e-9) can fail; too large (1.0) can also fail for fine geometry.
+**Fix**: Heal the input first. Adjust tolerance. Too small (1e-9) can fail; too large (1.0) can also fail for fine geometry.
 
 ## Validity / type checks
 
@@ -260,11 +260,11 @@ The `cause` field carries the underlying kernel error (often a string from the O
 
 - **Codes are stable** across patch and minor versions.
 - **Suggestions can improve** in any version (the wording, not the code).
-- **New codes can be added** in minor versions — don't write `default: throw` unless you really mean it.
+- **New codes can be added** in minor versions. Don't write `default: throw` unless you really mean it.
 - **Codes are removed** only in major versions, with deprecation warnings in advance.
 
 ## Next steps
 
-- [Result and Errors](../concepts/result) — the type and patterns above
-- [Healing & Sewing](../advanced/healing) — for the recovery paths
-- [Boolean Operations](../tasks/booleans) — the most common error source
+- [Result and Errors](../concepts/result): the type and patterns above
+- [Healing & Sewing](../advanced/healing): for the recovery paths
+- [Boolean Operations](../tasks/booleans): the most common error source

--- a/apps/docs/reference/function-lookup.md
+++ b/apps/docs/reference/function-lookup.md
@@ -42,7 +42,7 @@ import { exportSTEP } from 'brepjs/io';
 The complete index is one of:
 
 - **In the repository**: `docs/function-lookup.md` on the [main branch](https://github.com/andymai/brepjs/blob/main/docs/function-lookup.md)
-- **Searchable API reference**: [andymai.github.io/brepjs](https://andymai.github.io/brepjs/) — full TypeDoc with type signatures, examples, source links
+- **Searchable API reference**: [andymai.github.io/brepjs](https://andymai.github.io/brepjs/): full TypeDoc with type signatures, examples, source links
 
 ## Available sub-paths
 
@@ -75,6 +75,6 @@ The pre-commit hook reminds you to run this when `*Fns.ts` files have changed.
 
 ## Next steps
 
-- [TypeDoc API Reference](https://andymai.github.io/brepjs/) — searchable type-level reference
-- [Cheat Sheet](../getting-started/cheat-sheet) — task-oriented code snippets
-- [Glossary](./glossary) — concept-oriented terms
+- [TypeDoc API Reference](https://andymai.github.io/brepjs/): searchable type-level reference
+- [Cheat Sheet](../getting-started/cheat-sheet): task-oriented code snippets
+- [Glossary](./glossary): concept-oriented terms

--- a/apps/docs/reference/glossary.md
+++ b/apps/docs/reference/glossary.md
@@ -9,198 +9,198 @@ Terms used throughout brepjs documentation, in alphabetical order. Where a term 
 
 ## A
 
-**`autoHeal`** — operation that runs OpenCascade's `ShapeFix_Shape` to repair gaps, sew faces, fix orientations, and propagate tolerances. Always call on imported shapes before further operations. See [Healing & Sewing](../advanced/healing).
+**`autoHeal`**: operation that runs OpenCascade's `ShapeFix_Shape` to repair gaps, sew faces, fix orientations, and propagate tolerances. Always call on imported shapes before further operations. See [Healing & Sewing](../advanced/healing).
 
-**Adapter** (kernel adapter) — a class implementing `KernelInterface` that bridges brepjs to a specific geometry kernel. Two ship: OCCT and brepkit. See [Writing a Custom Kernel](../extending/custom-kernel).
+**Adapter** (kernel adapter): a class implementing `KernelInterface` that bridges brepjs to a specific geometry kernel. Two ship: OCCT and brepkit. See [Writing a Custom Kernel](../extending/custom-kernel).
 
 ## B
 
-**B-Rep** (Boundary Representation) — a 3D shape representation as a set of mathematical surfaces (faces) bounded by curves (edges) connected at points (vertices). Contrast with mesh (triangles). See [B-Rep vs Mesh](../concepts/brep-vs-mesh).
+**B-Rep** (Boundary Representation): a 3D shape representation as a set of mathematical surfaces (faces) bounded by curves (edges) connected at points (vertices). Contrast with mesh (triangles). See [B-Rep vs Mesh](../concepts/brep-vs-mesh).
 
-**`box`** — primitive function returning a `ValidSolid` rectangular volume. `box(width, depth, height)`.
+**`box`**: primitive function returning a `ValidSolid` rectangular volume. `box(width, depth, height)`.
 
-**Boolean operation** — `fuse` (union), `cut` (subtraction), `intersect` (intersection). The primary composition tool. See [Boolean Operations](../tasks/booleans).
+**Boolean operation**: `fuse` (union), `cut` (subtraction), `intersect` (intersection). The primary composition tool. See [Boolean Operations](../tasks/booleans).
 
-**Branded type** — a TypeScript phantom property attached to a base type to enforce nominal typing. `Edge`, `Wire`, `Face` are all the same JavaScript object shape but cannot be substituted for each other. See [Types That Prove Geometry Is Valid](../concepts/types).
+**Branded type**: a TypeScript phantom property attached to a base type to enforce nominal typing. `Edge`, `Wire`, `Face` are all the same JavaScript object shape but cannot be substituted for each other. See [Types That Prove Geometry Is Valid](../concepts/types).
 
-**`BRepCheck`** — OpenCascade's validity checker. A solid passing `BRepCheck` is a `ValidSolid`. See [Tolerance and Validity](../concepts/tolerance).
+**`BRepCheck`**: OpenCascade's validity checker. A solid passing `BRepCheck` is a `ValidSolid`. See [Tolerance and Validity](../concepts/tolerance).
 
-**`BrepError`** — the error type carried by `Result.error`. Has `code` (stable string), `message` (human-readable), `suggestion` (optional recovery hint), `cause` (optional underlying error).
+**`BrepError`**: the error type carried by `Result.error`. Has `code` (stable string), `message` (human-readable), `suggestion` (optional recovery hint), `cause` (optional underlying error).
 
-**`BrepWrapperError`** — thrown by the fluent `shape()` wrapper when an underlying operation fails. Carries the same fields as `BrepError`.
+**`BrepWrapperError`**: thrown by the fluent `shape()` wrapper when an underlying operation fails. Carries the same fields as `BrepError`.
 
-**brepkit** — Rust-based geometry kernel, in active development as a faster alternative to OpenCascade. Used via `brepkit-wasm` package and `BrepkitAdapter`. See [Kernels](../concepts/kernels).
+**brepkit**: Rust-based geometry kernel, in active development as a faster alternative to OpenCascade. Used via `brepkit-wasm` package and `BrepkitAdapter`. See [Kernels](../concepts/kernels).
 
 ## C
 
-**Chamfer** — beveled edge replacement. `chamfer(shape, edges, distance)`. See [Fillets & Chamfers](../tasks/fillets).
+**Chamfer**: beveled edge replacement. `chamfer(shape, edges, distance)`. See [Fillets & Chamfers](../tasks/fillets).
 
-**`ClosedWire`** — validity-branded wire that has been proven to form a closed loop. Required by `face()`. See [Types](../concepts/types).
+**`ClosedWire`**: validity-branded wire that has been proven to form a closed loop. Required by `face()`. See [Types](../concepts/types).
 
-**Compound** — a collection of shapes that aren't necessarily connected. The catch-all type for operations that may return multiple disconnected pieces.
+**Compound**: a collection of shapes that aren't necessarily connected. The catch-all type for operations that may return multiple disconnected pieces.
 
-**CompSolid** — a compound containing only solids.
+**CompSolid**: a compound containing only solids.
 
-**Conformance suite** — the test suite that runs against every supported kernel to verify behaviour parity. See [Kernel Conformance Suite](../extending/conformance).
+**Conformance suite**: the test suite that runs against every supported kernel to verify behaviour parity. See [Kernel Conformance Suite](../extending/conformance).
 
-**Curvature** — a number describing how sharply a curve or surface bends. For a circle of radius r, curvature is 1/r. Returned by `curveCurvatureAt` and `faceCurvatureAt`.
+**Curvature**: a number describing how sharply a curve or surface bends. For a circle of radius r, curvature is 1/r. Returned by `curveCurvatureAt` and `faceCurvatureAt`.
 
 ## D
 
-**Drawing** (`Drawing<'2D'>`) — a 2D shape used in the Drawing API. Built with `drawCircle`, `drawRectangle`, etc. Operates on with `drawingFuse`, `drawingCut`, `drawingFillet`. Projected to a `Sketch` via `drawingToSketchOnPlane`.
+**Drawing** (`Drawing<'2D'>`): a 2D shape used in the Drawing API. Built with `drawCircle`, `drawRectangle`, etc. Operates on with `drawingFuse`, `drawingCut`, `drawingFillet`. Projected to a `Sketch` via `drawingToSketchOnPlane`.
 
-**`DisposalScope`** — manual scope for tracking and disposing handles. `scope.track(shape)` registers; `scope.dispose()` releases in LIFO order. See [Memory Management](../advanced/memory).
+**`DisposalScope`**: manual scope for tracking and disposing handles. `scope.track(shape)` registers; `scope.dispose()` releases in LIFO order. See [Memory Management](../advanced/memory).
 
 ## E
 
-**Edge** — a curve segment between two vertices. Curve types: `LINE`, `CIRCLE`, `ELLIPSE`, `BEZIER`, `BSPLINE`, `OFFSET`. See [The Topology Hierarchy](../concepts/topology).
+**Edge**: a curve segment between two vertices. Curve types: `LINE`, `CIRCLE`, `ELLIPSE`, `BEZIER`, `BSPLINE`, `OFFSET`. See [The Topology Hierarchy](../concepts/topology).
 
-**`edgeFinder`** — query builder for selecting edges. Filters chain (`inDirection`, `withLength`, `ofCurveType`, etc.). See [Finders & Queries](../tasks/finders).
+**`edgeFinder`**: query builder for selecting edges. Filters chain (`inDirection`, `withLength`, `ofCurveType`, etc.). See [Finders & Queries](../tasks/finders).
 
-**`extrude`** — operation that pushes a face along its normal to make a solid. `extrude(face, height)`. See [Lofts, Sweeps, Revolves](../tasks/lofts-sweeps).
+**`extrude`**: operation that pushes a face along its normal to make a solid. `extrude(face, height)`. See [Lofts, Sweeps, Revolves](../tasks/lofts-sweeps).
 
 ## F
 
-**Face** — a bounded region of a mathematical surface. The most common surface types: `PLANE`, `CYLINDER`, `CONE`, `SPHERE`, `TORUS`, `BSPLINE_SURFACE`. See [Topology](../concepts/topology).
+**Face**: a bounded region of a mathematical surface. The most common surface types: `PLANE`, `CYLINDER`, `CONE`, `SPHERE`, `TORUS`, `BSPLINE_SURFACE`. See [Topology](../concepts/topology).
 
-**`faceFinder`** — query builder for selecting faces. Filters chain (`inDirection`, `withArea`, `ofSurfaceType`, etc.).
+**`faceFinder`**: query builder for selecting faces. Filters chain (`inDirection`, `withArea`, `ofSurfaceType`, etc.).
 
-**Fillet** — circular-arc edge rounding. `fillet(shape, edges, radius)`. See [Fillets & Chamfers](../tasks/fillets).
+**Fillet**: circular-arc edge rounding. `fillet(shape, edges, radius)`. See [Fillets & Chamfers](../tasks/fillets).
 
-**Fluent wrapper** — the `shape()` API that returns chainable wrappers (`Wrapped3D`, `WrappedFace`, etc.). Auto-unwraps `Result` and throws `BrepWrapperError` on failure.
+**Fluent wrapper**: the `shape()` API that returns chainable wrappers (`Wrapped3D`, `WrappedFace`, etc.). Auto-unwraps `Result` and throws `BrepWrapperError` on failure.
 
-**Functional API** — the canonical API: standalone functions in `*Fns.ts` files that take and return branded types. Returns `Result<T,E>` for fallible operations.
+**Functional API**: the canonical API: standalone functions in `*Fns.ts` files that take and return branded types. Returns `Result<T,E>` for fallible operations.
 
 ## G
 
-**glTF / GLB** — web-friendly mesh format. Exported via `exportGltf`. See [Import & Export](../tasks/import-export).
+**glTF / GLB**: web-friendly mesh format. Exported via `exportGltf`. See [Import & Export](../tasks/import-export).
 
 ## H
 
-**Handle** — a brepjs shape value at runtime; a TypeScript object wrapping a kernel WASM resource. Wraps `.wrapped` (the kernel object).
+**Handle**: a brepjs shape value at runtime; a TypeScript object wrapping a kernel WASM resource. Wraps `.wrapped` (the kernel object).
 
-**Healing** — repairing minor invalidities in shapes (gaps, mis-orientations, tolerance issues). The primary operation is `autoHeal`. See [Healing & Sewing](../advanced/healing).
+**Healing**: repairing minor invalidities in shapes (gaps, mis-orientations, tolerance issues). The primary operation is `autoHeal`. See [Healing & Sewing](../advanced/healing).
 
-**Helix** — a 3D curve resembling a spring. Built with `helix({ pitch, height, radius })`. Use as a sweep path for threads.
+**Helix**: a 3D curve resembling a spring. Built with `helix({ pitch, height, radius })`. Use as a sweep path for threads.
 
 ## I
 
-**`init()`** — auto-detect kernel initializer. Resolves with the kernel ID picked.
+**`init()`**: auto-detect kernel initializer. Resolves with the kernel ID picked.
 
-**`initFromOC(oc)`** — manual initializer using a pre-loaded OpenCascade module.
+**`initFromOC(oc)`**: manual initializer using a pre-loaded OpenCascade module.
 
-**Intersect** — boolean returning the volume common to two shapes.
+**Intersect**: boolean returning the volume common to two shapes.
 
-**`isOk` / `isErr`** — type guards on `Result<T,E>` that narrow `result.value` or `result.error`.
+**`isOk` / `isErr`**: type guards on `Result<T,E>` that narrow `result.value` or `result.error`.
 
 ## K
 
-**Kernel** — the WASM-based geometry library underlying brepjs. Two ship: OpenCascade (production) and brepkit (development). See [Kernels](../concepts/kernels).
+**Kernel**: the WASM-based geometry library underlying brepjs. Two ship: OpenCascade (production) and brepkit (development). See [Kernels](../concepts/kernels).
 
-**`KernelInterface`** — the abstract interface every kernel adapter implements. Located at `src/kernel/types.ts`.
+**`KernelInterface`**: the abstract interface every kernel adapter implements. Located at `src/kernel/types.ts`.
 
 ## L
 
-**Layer** (architecture) — brepjs is layered 0–3 with downward-only imports. See [Architecture](../extending/architecture).
+**Layer** (architecture): brepjs is layered 0–3 with downward-only imports. See [Architecture](../extending/architecture).
 
-**Loft** — operation interpolating between two or more profiles. `loft([profile1, profile2, ...])`. See [Lofts, Sweeps, Revolves](../tasks/lofts-sweeps).
+**Loft**: operation interpolating between two or more profiles. `loft([profile1, profile2, ...])`. See [Lofts, Sweeps, Revolves](../tasks/lofts-sweeps).
 
 ## M
 
-**`ManifoldShell`** — validity-branded shell where every edge is shared by exactly two faces. The shell bounds a solid.
+**`ManifoldShell`**: validity-branded shell where every edge is shared by exactly two faces. The shell bounds a solid.
 
-**`match`** — pattern-match operation on `Result<T,E>` that takes `{ ok, err }` handlers and returns a value.
+**`match`**: pattern-match operation on `Result<T,E>` that takes `{ ok, err }` handlers and returns a value.
 
-**Manifold** (in geometry) — a shape whose surface is locally flat at every point. Manifold shells are watertight.
+**Manifold** (in geometry): a shape whose surface is locally flat at every point. Manifold shells are watertight.
 
-**Mesh** — triangle representation. Produced from B-Rep via `shape(s).mesh({ tolerance })`. The integration point with Three.js. See [Three.js Integration](../integration/threejs).
+**Mesh**: triangle representation. Produced from B-Rep via `shape(s).mesh({ tolerance })`. The integration point with Three.js. See [Three.js Integration](../integration/threejs).
 
-**Minkowski sum** — operation in OpenSCAD often used as a workaround for fillets. brepjs does not ship a generic Minkowski; use `fillet`, `chamfer`, `shell` for the common cases.
+**Minkowski sum**: operation in OpenSCAD often used as a workaround for fillets. brepjs does not ship a generic Minkowski; use `fillet`, `chamfer`, `shell` for the common cases.
 
 ## O
 
-**OCCT** (OpenCascade Technology) — the C++ geometry kernel underlying `brepjs-opencascade`.
+**OCCT** (OpenCascade Technology): the C++ geometry kernel underlying `brepjs-opencascade`.
 
-**`OrientedFace`** — validity-branded face with a determined normal direction. Required by `extrude`, `revolve`.
+**`OrientedFace`**: validity-branded face with a determined normal direction. Required by `extrude`, `revolve`.
 
 ## P
 
-**Pattern checker** — `npm run check:patterns`. AST-based linter for architectural invariants. See [Pattern Checker Rules](../extending/pattern-checker).
+**Pattern checker**: `npm run check:patterns`. AST-based linter for architectural invariants. See [Pattern Checker Rules](../extending/pattern-checker).
 
-**Pattern operation** (geometric) — `linearPattern`, `circularPattern`. Distribute copies of a shape on a grid or around an axis.
+**Pattern operation** (geometric): `linearPattern`, `circularPattern`. Distribute copies of a shape on a grid or around an axis.
 
-**Phantom type / phantom property** — a type-level marker with no runtime presence. brepjs uses phantoms for shape brand, dimension, and validity.
+**Phantom type / phantom property**: a type-level marker with no runtime presence. brepjs uses phantoms for shape brand, dimension, and validity.
 
-**Plane** — a 2D coordinate system in 3D space. Sketches are built on planes. Built-in names: `'XY'`, `'YZ'`, `'XZ'`. Custom planes via `Plane` value (origin + normal).
+**Plane**: a 2D coordinate system in 3D space. Sketches are built on planes. Built-in names: `'XY'`, `'YZ'`, `'XZ'`. Custom planes via `Plane` value (origin + normal).
 
 ## R
 
-**Replicad** — a peer code-CAD library wrapping OpenCascade. brepjs's closest comparison. See [Coming from Replicad](../migration/replicad).
+**Replicad**: a peer code-CAD library wrapping OpenCascade. brepjs's closest comparison. See [Coming from Replicad](../migration/replicad).
 
-**`Result<T, E>`** — discriminated-union type for fallible operations. `{ ok: true, value }` or `{ ok: false, error }`. See [Result and Errors](../concepts/result).
+**`Result<T, E>`**: discriminated-union type for fallible operations. `{ ok: true, value }` or `{ ok: false, error }`. See [Result and Errors](../concepts/result).
 
-**Revolve** — operation rotating a 2D profile around an axis. `revolve(face)` (default 360°), `revolve(face, { angle, axis })`.
+**Revolve**: operation rotating a 2D profile around an axis. `revolve(face)` (default 360°), `revolve(face, { angle, axis })`.
 
 ## S
 
-**Shell** — a connected set of faces. Closed shells bound solids. Open shells are intermediate construction results.
+**Shell**: a connected set of faces. Closed shells bound solids. Open shells are intermediate construction results.
 
-**Shell operation** — `shell(solid, openFaces, thickness)`. Hollows a solid, removing the listed faces and adding a wall.
+**Shell operation**: `shell(solid, openFaces, thickness)`. Hollows a solid, removing the listed faces and adding a wall.
 
-**`shape()`** — the fluent wrapper. `shape(b).cut(c).fillet(2).val`.
+**`shape()`**: the fluent wrapper. `shape(b).cut(c).fillet(2).val`.
 
-**Sketch** — a planar face built from a closed wire. The output of `Sketcher.close()` and `sketchCircle()` etc.
+**Sketch**: a planar face built from a closed wire. The output of `Sketcher.close()` and `sketchCircle()` etc.
 
-**`Sketcher`** — the 2D builder class. `new Sketcher('XY').movePointerTo([0,0]).lineTo([10,0]).close().extrude(5)`. See [2D Sketching](../tasks/sketching).
+**`Sketcher`**: the 2D builder class. `new Sketcher('XY').movePointerTo([0,0]).lineTo([10,0]).close().extrude(5)`. See [2D Sketching](../tasks/sketching).
 
-**Smart constructor** — function that performs a runtime check and returns a validity-branded type if the check passes. Examples: `closedWire(w)`, `manifoldShell(s)`.
+**Smart constructor**: function that performs a runtime check and returns a validity-branded type if the check passes. Examples: `closedWire(w)`, `manifoldShell(s)`.
 
-**Solid** — a 3D volume bounded by one or more closed shells. The output of most CAD operations.
+**Solid**: a 3D volume bounded by one or more closed shells. The output of most CAD operations.
 
-**STEP** — ISO 10303 file format for B-Rep shapes. Round-trips with desktop CAD. Exported via `exportSTEP`, imported via `importSTEP`.
+**STEP**: ISO 10303 file format for B-Rep shapes. Round-trips with desktop CAD. Exported via `exportSTEP`, imported via `importSTEP`.
 
-**STL** — triangle-mesh file format for 3D printing. Exported via `exportSTL`, imported via `importSTL` (lossy).
+**STL**: triangle-mesh file format for 3D printing. Exported via `exportSTL`, imported via `importSTL` (lossy).
 
-**Sweep** — operation dragging a profile along a path. `sweep(profile, path)`. See [Lofts, Sweeps, Revolves](../tasks/lofts-sweeps).
+**Sweep**: operation dragging a profile along a path. `sweep(profile, path)`. See [Lofts, Sweeps, Revolves](../tasks/lofts-sweeps).
 
 ## T
 
-**Tolerance** — a small distance below which the kernel treats two points as the same. Default `1e-7` for OpenCascade. See [Tolerance and Validity](../concepts/tolerance).
+**Tolerance**: a small distance below which the kernel treats two points as the same. Default `1e-7` for OpenCascade. See [Tolerance and Validity](../concepts/tolerance).
 
-**Topology** (in B-Rep) — the connectivity structure of a shape: which edges meet at which vertices, which wires bound which faces, which faces compose which shells. See [The Topology Hierarchy](../concepts/topology).
+**Topology** (in B-Rep): the connectivity structure of a shape: which edges meet at which vertices, which wires bound which faces, which faces compose which shells. See [The Topology Hierarchy](../concepts/topology).
 
-**Type guard** — function returning a typed boolean (`isClosedWire(w): w is ClosedWire`). Narrows the input type in conditionals.
+**Type guard**: function returning a typed boolean (`isClosedWire(w): w is ClosedWire`). Narrows the input type in conditionals.
 
 ## U
 
-**`unwrap`** — extracts `result.value` or throws on error. Use in scripts and tests; not in production code that needs recovery.
+**`unwrap`**: extracts `result.value` or throws on error. Use in scripts and tests; not in production code that needs recovery.
 
-**`using`** (TypeScript keyword) — invokes `Symbol.dispose` when the variable goes out of scope. brepjs handles support `using` for automatic cleanup.
+**`using`** (TypeScript keyword): invokes `Symbol.dispose` when the variable goes out of scope. brepjs handles support `using` for automatic cleanup.
 
 ## V
 
-**`ValidSolid`** — validity-branded solid that has passed `BRepCheck`. Returned by primitive constructors (`box`, `cylinder`, `sphere`).
+**`ValidSolid`**: validity-branded solid that has passed `BRepCheck`. Returned by primitive constructors (`box`, `cylinder`, `sphere`).
 
-**Validity brand** — phantom property encoding a topological invariant (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`).
+**Validity brand**: phantom property encoding a topological invariant (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`).
 
-**Vertex** — a point in 3D space. The lowest level of the topology hierarchy.
+**Vertex**: a point in 3D space. The lowest level of the topology hierarchy.
 
-**`vertexFinder`** — query builder for selecting vertices.
+**`vertexFinder`**: query builder for selecting vertices.
 
 ## W
 
-**Wire** — a connected chain of edges. Closed wires (every endpoint shared between two edges) form face boundaries.
+**Wire**: a connected chain of edges. Closed wires (every endpoint shared between two edges) form face boundaries.
 
-**`wireFinder`** — query builder for selecting wires.
+**`wireFinder`**: query builder for selecting wires.
 
-**`withScope`** — `withScope((scope) => { scope.track(...); ... })`. Constructs a `DisposalScope`, runs the callback, disposes everything tracked, even on exception.
+**`withScope`**: `withScope((scope) => { scope.track(...); ... })`. Constructs a `DisposalScope`, runs the callback, disposes everything tracked, even on exception.
 
-**`withKernel`** — `withKernel(id, fn)`. Runs `fn` synchronously with the named kernel active. Don't pass async callbacks. See [Kernels](../concepts/kernels).
+**`withKernel`**: `withKernel(id, fn)`. Runs `fn` synchronously with the named kernel active. Don't pass async callbacks. See [Kernels](../concepts/kernels).
 
-**Workbench** — Replicad's name for its in-browser playground. brepjs has <a href="/playground" target="_blank" rel="noopener">a similar playground</a>.
+**Workbench**: Replicad's name for its in-browser playground. brepjs has <a href="/playground" target="_blank" rel="noopener">a similar playground</a>.
 
 ## Next steps
 
-- [Cheat Sheet](../getting-started/cheat-sheet) — code reference for every concept above
-- [Function Lookup](./function-lookup) — alphabetical index of every brepjs export
-- [API Reference](https://andymai.github.io/brepjs/) — searchable TypeDoc
+- [Cheat Sheet](../getting-started/cheat-sheet): code reference for every concept above
+- [Function Lookup](./function-lookup): alphabetical index of every brepjs export
+- [API Reference](https://andymai.github.io/brepjs/): searchable TypeDoc

--- a/apps/docs/tasks/booleans.md
+++ b/apps/docs/tasks/booleans.md
@@ -1,11 +1,11 @@
 ---
 title: Boolean Operations
-description: 'Fuse, cut, intersect — the three operations that combine primitives into real parts, plus their multi-shape variants and failure modes.'
+description: 'Fuse, cut, intersect: the three operations that combine primitives into real parts, plus their multi-shape variants and failure modes.'
 ---
 
 # Boolean Operations
 
-The three boolean operations — fuse, cut, intersect — are how you combine primitives into real parts. They are also the operation most likely to fail in practice. This chapter covers all three, the multi-shape variants, and the failure modes you will hit eventually.
+The three boolean operations, fuse, cut, intersect, are how you combine primitives into real parts. They are also the operation most likely to fail in practice. This chapter covers all three, the multi-shape variants, and the failure modes you will hit eventually.
 
 ## The three operations
 
@@ -91,7 +91,7 @@ import { box, cut, isOk } from 'brepjs/quick';
 const a = box(10, 10, 10);
 const b = box(10, 10, 10, { at: [100, 0, 0] }); // far away
 const result = cut(a, b);
-console.log('Overlap?', isOk(result)); // true — cut returns a unchanged
+console.log('Overlap?', isOk(result)); // true - cut returns a unchanged
 ```
 
 `cut` with no overlap actually succeeds and returns `a` untouched in OpenCascade's semantics. `intersect` with no overlap returns an empty compound. `fuse` with no overlap returns a compound containing both shapes (a CompSolid). What "no overlap" means for your specific code depends on which operation you used.
@@ -109,7 +109,7 @@ if (
   isOk(result) &&
   Math.abs(unwrap(measureVolume(result.value)) - unwrap(measureVolume(a))) < 1e-6
 ) {
-  console.warn('Cut had no effect — operands did not overlap');
+  console.warn('Cut had no effect - operands did not overlap');
 }
 ```
 
@@ -134,7 +134,7 @@ void result;
 
 ### `BOOLEAN_NEAR_COINCIDENT`
 
-The two operands have geometry that is _almost_ but not exactly coincident. The boolean produces slivers — tiny degenerate faces. Workarounds:
+The two operands have geometry that is _almost_ but not exactly coincident. The boolean produces slivers: tiny degenerate faces. Workarounds:
 
 - **Add overshoot**: extend the cutting tool slightly past the boundary so coincidence becomes unambiguous overlap (the `cylinder(5, 12, { at: [..., -1] })` pattern).
 - **Heal both** with a slightly enlarged tolerance: `autoHeal(s, { tolerance: 0.01 })`.
@@ -146,7 +146,7 @@ The operation has multiple geometrically valid outcomes. Rare. Usually a sign th
 
 ### `KERNEL_INTERNAL_ERROR`
 
-OpenCascade's `BRepAlgoAPI` died with an unrecoverable error. Treat as a programmer error in the inputs — usually the inputs were degenerate (zero volume, self-intersecting, etc.). File a bug if the inputs are clearly valid.
+OpenCascade's `BRepAlgoAPI` died with an unrecoverable error. Treat as a programmer error in the inputs. Usually the inputs were degenerate (zero volume, self-intersecting, etc.). File a bug if the inputs are clearly valid.
 
 [Error Codes](../reference/errors) lists every code with detailed recovery patterns.
 
@@ -159,7 +159,7 @@ Boolean cost roughly tracks (face count of A) × (face count of B). A box-on-box
 
 ## Common patterns
 
-### Drill many holes — cut once
+### Drill many holes: cut once
 
 ```typescript
 import { box, cylinder, cut, fuseAll, unwrap } from 'brepjs/quick';
@@ -188,7 +188,7 @@ Three potential boolean failures become one. If the holes don't overlap each oth
 ```typescript
 import { box, cut, fuse, unwrap } from 'brepjs/quick';
 
-// Through, four-shouldered T-joint between a rail and a stile — the
+// Through, four-shouldered T-joint between a rail and a stile - the
 // canonical furniture joint (chair stretcher into a leg). Rendered
 // exploded along the rail axis so the tenon is visible in mid-air.
 
@@ -233,7 +233,7 @@ const rail = unwrap(
 export default [rail, stile];
 ```
 
-`fuse` adds the tenon as a boss on the rail; `cut` removes the mortise from the stile. Sizing the tenon to about ⅓ the rail thickness leaves enough wood on either side of the mortise that the stile doesn't split — the same rule a hand-tool woodworker would follow. The `clearance` (0.2 mm here) is the sliding fit that lets the joint actually go together; without it, kernel rounding can produce coincident faces and a failed boolean.
+`fuse` adds the tenon as a boss on the rail; `cut` removes the mortise from the stile. Sizing the tenon to about ⅓ the rail thickness leaves enough wood on either side of the mortise that the stile doesn't split, the same rule a hand-tool woodworker would follow. The `clearance` (0.2 mm here) is the sliding fit that lets the joint actually go together; without it, kernel rounding can produce coincident faces and a failed boolean.
 
 ### Carve a label
 
@@ -254,13 +254,13 @@ Shallow, broad cuts are how engraving works in B-Rep. The depth controls how dee
 
 These will fail or produce nonsense regardless of how you frame them:
 
-- **Booleans across different units** — if `a` is in mm and `b` is in metres, the kernel treats them as the same scale. Make sure both inputs are in the same unit space.
-- **Booleans on shapes with self-intersections** — `BRepCheck` will catch this; surface it via `autoHeal`.
-- **Booleans on faces** (without converting to solids first) — `fuse(face, face)` doesn't make geometric sense. Convert to solids by extruding or building shells.
-- **Booleans on shapes with very different tolerances** — the kernel uses the larger of the two and may treat distant geometry as coincident. Normalize first.
+- **Booleans across different units**: if `a` is in mm and `b` is in metres, the kernel treats them as the same scale. Make sure both inputs are in the same unit space.
+- **Booleans on shapes with self-intersections**: `BRepCheck` will catch this; surface it via `autoHeal`.
+- **Booleans on faces** (without converting to solids first): `fuse(face, face)` doesn't make geometric sense. Convert to solids by extruding or building shells.
+- **Booleans on shapes with very different tolerances**: the kernel uses the larger of the two and may treat distant geometry as coincident. Normalize first.
 
 ## Next steps
 
-- [Fillets & Chamfers](./fillets) — refining the edges that appear after booleans
-- [Healing & Sewing](../advanced/healing) — fixing inputs and outputs that don't pass `BRepCheck`
-- [Error Codes](../reference/errors) — every boolean error and its recovery
+- [Fillets & Chamfers](./fillets): refining the edges that appear after booleans
+- [Healing & Sewing](../advanced/healing): fixing inputs and outputs that don't pass `BRepCheck`
+- [Error Codes](../reference/errors): every boolean error and its recovery

--- a/apps/docs/tasks/fillets.md
+++ b/apps/docs/tasks/fillets.md
@@ -5,7 +5,7 @@ description: 'Round edges with arcs, bevel them with chamfers. Edge selection pa
 
 # Fillets & Chamfers
 
-A **fillet** rounds an edge with a circular arc. A **chamfer** bevels it with a flat. Both are edge-refinement operations: pick the edges, pick the size, get a new shape. brepjs ships them as fallible operations because they are — fillets fail more often than booleans, and the failure modes are surprising.
+A **fillet** rounds an edge with a circular arc. A **chamfer** bevels it with a flat. Both are edge-refinement operations: pick the edges, pick the size, get a new shape. brepjs ships them as fallible operations because they are. Fillets fail more often than booleans, and the failure modes are surprising.
 
 ## The basic shape
 
@@ -56,7 +56,7 @@ console.log({
 });
 ```
 
-`edgeFinder()` filters chain — see [Finders & Queries](./finders) for the full vocabulary.
+`edgeFinder()` filters chain; see [Finders & Queries](./finders) for the full vocabulary.
 
 ## With the fluent wrapper
 
@@ -101,20 +101,20 @@ const verticals = edgeFinder().inDirection('Z').findAll(b);
 const horizontals = edgeFinder().inDirection('X').findAll(b);
 
 b = unwrap(fillet(b, verticals, 3));
-// Re-find on the new shape — old handles refer to the old shape.
+// Re-find on the new shape: old handles refer to the old shape.
 const newHorizontals = edgeFinder().inDirection('X').findAll(b);
 b = unwrap(fillet(b, newHorizontals, 1));
 
 console.log('Verticals at r=3, horizontals at r=1');
 ```
 
-Edge handles are bound to the shape they were found on. Filleting consumes the input shape and returns a new one — old handles no longer apply. Always re-find after each operation.
+Edge handles are bound to the shape they were found on. Filleting consumes the input shape and returns a new one, so old handles no longer apply. Always re-find after each operation.
 
 ## Failure modes
 
 ### `FILLET_TOO_LARGE`
 
-The radius is bigger than the geometry around the edge can support. A box 10mm thick cannot have a 6mm fillet on its corner — the fillet would leave no flat region. The kernel detects this:
+The radius is bigger than the geometry around the edge can support. A box 10mm thick cannot have a 6mm fillet on its corner: the fillet would leave no flat region. The kernel detects this:
 
 ```typescript
 import { box, edgeFinder, fillet, isOk } from 'brepjs/quick';
@@ -130,13 +130,13 @@ Fix: smaller radius, or fewer edges.
 
 ### `FILLET_INVALID_EDGE`
 
-The selected edge has a curvature or geometry the fillet algorithm can't handle. Common with imported geometry — sharp creases, non-tangent meeting edges, edges shorter than the fillet radius.
+The selected edge has a curvature or geometry the fillet algorithm can't handle. Common with imported geometry: sharp creases, non-tangent meeting edges, edges shorter than the fillet radius.
 
 Workarounds:
 
 - Heal the input first (`autoHeal`)
 - Skip that edge (refine the finder)
-- Use `chamfer` instead — it has fewer requirements
+- Use `chamfer` instead; it has fewer requirements
 
 ### `FILLET_AMBIGUOUS_PROPAGATION`
 
@@ -147,11 +147,11 @@ When you fillet an edge that meets multiple other edges at a vertex, the fillet 
 Two ways to fillet several groups of edges, only one works reliably:
 
 ```typescript
-// WRONG — fillet operations interact in unobvious ways
+// WRONG: fillet operations interact in unobvious ways
 import { box, edgeFinder, fillet, unwrap } from 'brepjs/quick';
 let b: import('brepjs').Shape3D = box(20, 20, 20);
 b = unwrap(fillet(b, edgeFinder().inDirection('Z').findAll(b), 3));
-// The edges in 'X' have moved/transformed — re-find:
+// The edges in 'X' have moved/transformed, so re-find:
 b = unwrap(fillet(b, edgeFinder().inDirection('X').findAll(b), 3));
 console.log('Filleted in two passes');
 ```
@@ -172,11 +172,11 @@ console.log('One-pass fillet');
 export default filleted;
 ```
 
-For different radii, two passes are unavoidable — just re-find edges after each.
+For different radii, two passes are unavoidable; just re-find edges after each.
 
 ## Tip: chamfer is more forgiving
 
-Chamfer fails less often than fillet. When fillet fails on imported geometry, try chamfer with the same distance — it bevels rather than blends and tolerates more curvature variation.
+Chamfer fails less often than fillet. When fillet fails on imported geometry, try chamfer with the same distance; it bevels rather than blends and tolerates more curvature variation.
 
 ```typescript
 import { box, edgeFinder, fillet, chamfer, isOk, unwrap } from 'brepjs/quick';
@@ -238,6 +238,6 @@ export default part;
 
 ## Next steps
 
-- [Finders & Queries](./finders) — selecting the exact edges you want
-- [Healing & Sewing](../advanced/healing) — when fillets fail on imports
-- [Boolean Operations](./booleans) — the operation that creates the edges fillets refine
+- [Finders & Queries](./finders): selecting the exact edges you want
+- [Healing & Sewing](../advanced/healing): when fillets fail on imports
+- [Boolean Operations](./booleans): the operation that creates the edges fillets refine

--- a/apps/docs/tasks/finders.md
+++ b/apps/docs/tasks/finders.md
@@ -1,11 +1,11 @@
 ---
 title: Finders & Queries
-description: 'edgeFinder, faceFinder, wireFinder, vertexFinder — composable filters that pick exactly the topology your next operation needs.'
+description: 'edgeFinder, faceFinder, wireFinder, vertexFinder: composable filters that pick exactly the topology your next operation needs.'
 ---
 
 # Finders & Queries
 
-You build a part, then you need to do something to a specific feature: round the vertical edges, shell the top face, find the corner where two boolean operations met. Finders are how you select features. They are filters that compose — you start with "all edges of this shape" and narrow down by direction, length, curve type, position, or any combination.
+You build a part, then you need to do something to a specific feature: round the vertical edges, shell the top face, find the corner where two boolean operations met. Finders are how you select features. They are filters that compose: you start with "all edges of this shape" and narrow down by direction, length, curve type, position, or any combination.
 
 ## The four finders
 
@@ -27,7 +27,7 @@ console.log({
 });
 ```
 
-`findAll` returns an array. `find` returns the first match (or `undefined`). Filters chain — every call narrows the result.
+`findAll` returns an array. `find` returns the first match (or `undefined`). Filters chain; every call narrows the result.
 
 ## Filter vocabulary
 
@@ -41,7 +41,7 @@ import { box, edgeFinder, faceFinder } from 'brepjs/quick';
 const b = box(30, 20, 10);
 
 edgeFinder().inDirection('Z').findAll(b); // edges parallel to Z
-edgeFinder().inDirection([1, 1, 0]).findAll(b); // edges along (1,1,0) — none in a box
+edgeFinder().inDirection([1, 1, 0]).findAll(b); // edges along (1,1,0), none in a box
 faceFinder().inDirection('Z').findAll(b); // top + bottom faces
 faceFinder().inDirection([0, 0, -1]).findAll(b); // bottom face only (negative Z normal)
 ```
@@ -92,7 +92,7 @@ const cyl = sketchCircle(10).extrude(20);
 faceFinder().ofSurfaceType('PLANE').findAll(cyl); // 2 (top, bottom)
 faceFinder().ofSurfaceType('CYLINDER').findAll(cyl); // 1 (side)
 
-edgeFinder().ofCurveType('LINE').findAll(cyl); // 0 — sketchCircle has no straight edges
+edgeFinder().ofCurveType('LINE').findAll(cyl); // 0, sketchCircle has no straight edges
 edgeFinder().ofCurveType('CIRCLE').findAll(cyl); // 2
 ```
 
@@ -143,7 +143,7 @@ const topVerticals = edgeFinder()
 console.log('Found', topVerticals.length, 'edges'); // 4 vertical edges
 ```
 
-Order doesn't matter for correctness — filters are additive — but for performance, put the most-selective filter first if you have many candidates.
+Order doesn't matter for correctness (filters are additive) but for performance, put the most-selective filter first if you have many candidates.
 
 ## With the fluent wrapper
 
@@ -176,7 +176,7 @@ const drilled = unwrap(cut(box(30, 20, 10), cylinder(5, 12, { at: [15, 10, -1] }
 // Vertical edges include the hole's edges. Filter by length to exclude them.
 const externalVerticals = edgeFinder()
   .inDirection('Z')
-  .withLength({ min: 9.5 }) // hole edges are 12mm but the box edges are 10mm — adjust filter
+  .withLength({ min: 9.5 }) // hole edges are 12mm but the box edges are 10mm, adjust filter
   .findAll(drilled);
 const filleted = unwrap(fillet(drilled, externalVerticals, 1));
 
@@ -213,7 +213,7 @@ const base = box(40, 40, 5);
 const boss = sketchCircle(8).extrude(10).translate([20, 20, 5]);
 const part = unwrap(fuse(base, boss));
 
-// "The cylindrical face" — easy
+// "The cylindrical face": easy
 const bossSide = faceFinder().ofSurfaceType('CYLINDER').findAll(part)[0];
 console.log('Found boss cylindrical face');
 void bossSide;
@@ -226,8 +226,8 @@ Surface type, area range, and direction together usually pin down a specific fac
 ## What finders don't do
 
 - They don't index by any kind of stable ID. Edge handles are bound to the shape they were found on; after an operation transforms the shape, the handles are stale.
-- They don't traverse compounds across kernel boundaries — finders look at one shape at a time.
-- They are not topology-aware in the sense of "edges connected to face X" — for that, use `edgesOfFace(face)` from `brepjs/topology`.
+- They don't traverse compounds across kernel boundaries; finders look at one shape at a time.
+- They are not topology-aware in the sense of "edges connected to face X"; for that, use `edgesOfFace(face)` from `brepjs/topology`.
 
 ## Edges have direction; finders sometimes don't care
 
@@ -235,6 +235,6 @@ Surface type, area range, and direction together usually pin down a specific fac
 
 ## Next steps
 
-- [Fillets & Chamfers](./fillets) — the operation finders are most often used for
-- [Measurement](./measurement) — measuring the entities you found
-- [The Topology Hierarchy](../concepts/topology) — what each finder operates on
+- [Fillets & Chamfers](./fillets): the operation finders are most often used for
+- [Measurement](./measurement): measuring the entities you found
+- [The Topology Hierarchy](../concepts/topology): what each finder operates on

--- a/apps/docs/tasks/import-export.md
+++ b/apps/docs/tasks/import-export.md
@@ -15,13 +15,13 @@ brepjs reads and writes the formats every CAD pipeline expects. STEP and IGES pr
 | **IGES** (.igs, .iges)  | ✓    | ✓     | Older B-Rep round-trip; STEP preferred  |
 | **BREP** (.brep)        | ✓    | ✓     | OpenCascade-native; smallest, fastest   |
 | **STL** (.stl)          | ✓    | ✓     | 3D printing, mesh-only                  |
-| **OBJ** (.obj)          | —    | ✓     | Mesh export for renderers               |
-| **glTF** (.glb / .gltf) | —    | ✓     | Web-friendly mesh                       |
-| **3MF** (.3mf)          | —    | ✓     | Modern 3D printing format with metadata |
+| **OBJ** (.obj)          | -    | ✓     | Mesh export for renderers               |
+| **glTF** (.glb / .gltf) | -    | ✓     | Web-friendly mesh                       |
+| **3MF** (.3mf)          | -    | ✓     | Modern 3D printing format with metadata |
 | **DXF** (.dxf)          | ✓    | ✓     | 2D laser cutting                        |
-| **SVG** (.svg)          | —    | ✓     | 2D for the web / signage                |
+| **SVG** (.svg)          | -    | ✓     | 2D for the web / signage                |
 
-STL import lossily converts triangles into a B-Rep approximation — useful for STEP conversion and measurement, not for further B-Rep work.
+STL import lossily converts triangles into a B-Rep approximation, useful for STEP conversion and measurement, not for further B-Rep work.
 
 ## Export
 
@@ -32,7 +32,7 @@ import { box, exportSTEP, exportSTL, exportGltf, unwrap } from 'brepjs/quick';
 
 const part = box(30, 20, 10);
 
-const step = unwrap(exportSTEP(part)); // Blob — STEP file
+const step = unwrap(exportSTEP(part)); // Blob: STEP file
 const stl = unwrap(exportSTL(part, { tolerance: 0.1 }));
 const gltf = unwrap(exportGltf(part, { tolerance: 0.1 }));
 
@@ -43,7 +43,7 @@ console.log('glTF:', gltf.size, 'bytes');
 export default part;
 ```
 
-### STEP — the round-trip format
+### STEP: the round-trip format
 
 STEP (ISO 10303) preserves B-Rep structure: faces, edges, surfaces, curves, even sharp/smooth qualifiers. A part written with `exportSTEP` and re-imported with `importSTEP` is geometrically identical (within tolerance):
 
@@ -58,9 +58,9 @@ console.log('Original volume:', unwrap(measureVolume(original))); // 6000
 console.log('Reimported volume:', unwrap(measureVolume(reimported))); // 6000 ± epsilon
 ```
 
-Use STEP for any pipeline that involves desktop CAD — Fusion 360, SolidWorks, FreeCAD, OnShape, Rhino.
+Use STEP for any pipeline that involves desktop CAD: Fusion 360, SolidWorks, FreeCAD, OnShape, Rhino.
 
-### STL — the printing format
+### STL: the printing format
 
 STL is the universal 3D-printing format. brepjs's `exportSTL` triangulates the B-Rep at a configurable tolerance:
 
@@ -81,9 +81,9 @@ export default part;
 
 The defaults are tuned for screen-size rendering. For 3D printing, set `tolerance` to roughly one-tenth your printer's nozzle diameter (so for a 0.4 mm nozzle, ~0.04 mm).
 
-### glTF — the web-friendly format
+### glTF: the web-friendly format
 
-glTF (.glb is binary glTF) carries triangles plus optional materials and normals — designed for the web, smaller than STL, viewable in browsers natively:
+glTF (.glb is binary glTF) carries triangles plus optional materials and normals, designed for the web, smaller than STL, viewable in browsers natively:
 
 ```typescript
 import { box, exportGltf, unwrap } from 'brepjs/quick';
@@ -95,9 +95,9 @@ void glb;
 export default part;
 ```
 
-Use this for "ship the model to the user's browser" — they can open it directly in `<model-viewer>` or load it into Three.js.
+Use this for "ship the model to the user's browser": they can open it directly in `<model-viewer>` or load it into Three.js.
 
-### 3MF — the modern printing format
+### 3MF: the modern printing format
 
 3MF carries the same triangles as STL but adds metadata (units, slicer hints, multiple parts, colour). Modern slicers prefer it:
 
@@ -111,7 +111,7 @@ void threeMF;
 export default part;
 ```
 
-### DXF / SVG — 2D export
+### DXF / SVG: 2D export
 
 For laser cutting and signage, project a 3D part to a 2D drawing:
 
@@ -126,7 +126,7 @@ void svg;
 void dxf;
 ```
 
-These accept `Drawing<'2D'>` values — typically the output of a `drawing*` chain or a `face` flattened to 2D via `projectToPlane`.
+These accept `Drawing<'2D'>` values, typically the output of a `drawing*` chain or a `face` flattened to 2D via `projectToPlane`.
 
 ## Import
 
@@ -155,7 +155,7 @@ All imports return `Result<Shape, BrepError>`. Failures during import almost alw
 
 ### Always heal imported shapes
 
-Imports — especially STEP from third-party tools — often have minor invalidity: gaps between faces, edges with the wrong precision, vertices that don't quite match. Always heal before operating on imported shapes:
+Imports (especially STEP from third-party tools) often have minor invalidity: gaps between faces, edges with the wrong precision, vertices that don't quite match. Always heal before operating on imported shapes:
 
 ```typescript
 import { importSTEP, autoHeal, unwrap } from 'brepjs/quick';
@@ -172,7 +172,7 @@ Without healing, the first boolean against an imported shape is likely to fail w
 
 ## Saving and loading
 
-### Browser — save via download
+### Browser: save via download
 
 <!-- @no-test -->
 
@@ -188,7 +188,7 @@ a.click();
 URL.revokeObjectURL(url);
 ```
 
-### Browser — load via file input
+### Browser: load via file input
 
 <!-- @no-test -->
 
@@ -204,9 +204,9 @@ if (file) {
 }
 ```
 
-`File` is a `Blob` subtype — every `import*` accepts both.
+`File` is a `Blob` subtype; every `import*` accepts both.
 
-### Node — read/write disk
+### Node: read/write disk
 
 <!-- @no-test -->
 
@@ -249,7 +249,7 @@ void stl;
 
 ### STL → STEP (best-effort)
 
-Reverse direction is lossy — STL is triangles, STEP wants surfaces. brepjs converts triangles to a B-Rep approximation:
+Reverse direction is lossy: STL is triangles, STEP wants surfaces. brepjs converts triangles to a B-Rep approximation:
 
 <!-- @no-test -->
 
@@ -268,15 +268,15 @@ The result is a STEP file with one face per input triangle. Acceptable for low-r
 
 ## What can go wrong
 
-| Failure                     | Cause                                                                                   |
-| --------------------------- | --------------------------------------------------------------------------------------- |
-| `IO_PARSE_ERROR`            | The file is malformed or in an unsupported dialect                                      |
-| `IO_UNSUPPORTED_VERSION`    | The file uses a STEP/IGES schema we don't support                                       |
-| `INVALID_SHAPE`             | Imported shape doesn't pass `BRepCheck` — heal it                                       |
-| `MESH_TRIANGULATION_FAILED` | An exporter (STL, glTF, 3MF) couldn't triangulate the input — usually a tolerance issue |
+| Failure                     | Cause                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `IO_PARSE_ERROR`            | The file is malformed or in an unsupported dialect                                     |
+| `IO_UNSUPPORTED_VERSION`    | The file uses a STEP/IGES schema we don't support                                      |
+| `INVALID_SHAPE`             | Imported shape doesn't pass `BRepCheck`: heal it                                       |
+| `MESH_TRIANGULATION_FAILED` | An exporter (STL, glTF, 3MF) couldn't triangulate the input, usually a tolerance issue |
 
 ## Next steps
 
-- [Healing & Sewing](../advanced/healing) — preparing imports for further operations
-- [Three.js Integration](../integration/threejs) — render exported meshes in the browser
-- [Boolean Operations](./booleans) — operating on imported shapes (after healing)
+- [Healing & Sewing](../advanced/healing): preparing imports for further operations
+- [Three.js Integration](../integration/threejs): render exported meshes in the browser
+- [Boolean Operations](./booleans): operating on imported shapes (after healing)

--- a/apps/docs/tasks/lofts-sweeps.md
+++ b/apps/docs/tasks/lofts-sweeps.md
@@ -7,7 +7,7 @@ description: 'Extrude, revolve, sweep, and loft turn 2D profiles into 3D solids.
 
 Three operations turn a 2D profile (or several) into a 3D solid by motion: extrude moves the profile linearly, revolve rotates it around an axis, sweep drags it along a path, loft interpolates between profiles. Combined with sketching, they cover everything that isn't a primitive boolean.
 
-## Extrude — linear motion
+## Extrude: linear motion
 
 The simplest case. A profile pushed along its normal:
 
@@ -21,7 +21,7 @@ console.log('Block:', unwrap(measureVolume(block)).toFixed(2));
 console.log('Cylinder:', unwrap(measureVolume(cyl)).toFixed(2));
 ```
 
-The functional equivalent — `extrude(face, height)` — takes an `OrientedFace` and a distance:
+The functional equivalent, `extrude(face, height)`, takes an `OrientedFace` and a distance:
 
 ```typescript
 import { sketchCircle, extrude, unwrap } from 'brepjs/quick';
@@ -43,7 +43,7 @@ const slanted = unwrap(extrudeAlong(profile, [0, 5, 20])); // extrude along (0,5
 export default slanted;
 ```
 
-The vector replaces the height — its length determines extrusion distance, its direction determines the axis.
+The vector replaces the height: its length determines extrusion distance, its direction determines the axis.
 
 ### Tapered extrude
 
@@ -59,9 +59,9 @@ export default tapered;
 
 Negative taper widens upward; positive narrows.
 
-## Revolve — rotational motion
+## Revolve: rotational motion
 
-A 2D profile rotated around an axis — the basis of every wineglass, vase, axle, and spindle:
+A 2D profile rotated around an axis: the basis of every wineglass, vase, axle, and spindle:
 
 <!-- @run-test -->
 
@@ -84,7 +84,7 @@ const goblet = new Sketcher('XZ')
 export default goblet;
 ```
 
-The axis defaults to the sketch plane's vertical axis. The profile must lie entirely on one side of the axis — the kernel rejects profiles that cross.
+The axis defaults to the sketch plane's vertical axis. The profile must lie entirely on one side of the axis; the kernel rejects profiles that cross.
 
 ### Partial revolves
 
@@ -124,7 +124,7 @@ const ring = unwrap(revolve(profile, { axis: { origin: [0, 0, 0], direction: [0,
 export default ring;
 ```
 
-## Sweep — profile along a path
+## Sweep: profile along a path
 
 Drag a 2D profile along a 3D wire:
 
@@ -140,7 +140,7 @@ const tube = unwrap(sweep(cross, path));
 export default tube;
 ```
 
-`sweep` takes a closed wire (the profile) and a wire (the spine). `line(p1, p2)` returns an `Edge`, so we wrap it with `wire([...])` to promote it to a `Wire`. The path can be any 3D wire — straight, arced, helical, B-spline. The profile rides along it.
+`sweep` takes a closed wire (the profile) and a wire (the spine). `line(p1, p2)` returns an `Edge`, so we wrap it with `wire([...])` to promote it to a `Wire`. The path can be any 3D wire: straight, arced, helical, B-spline. The profile rides along it.
 
 ### Helical sweeps for threads and springs
 
@@ -158,18 +158,18 @@ const thread = unwrap(sweep(profile, path)); // bare helical coil
 export default thread;
 ```
 
-`helix(pitch, height, radius)` returns a wire of the helical curve. Sweep a small circle along it and you get a thread — fuse it onto a shaft to make a screw (see _Threaded fastener_ below).
+`helix(pitch, height, radius)` returns a wire of the helical curve. Sweep a small circle along it and you get a thread; fuse it onto a shaft to make a screw (see _Threaded fastener_ below).
 
 ### Frenet vs auxiliary frame
 
 When the path bends, the kernel has to decide how the profile orients itself. Two modes:
 
-- **`'frenet'` (default)** — the profile rotates with the path's tangent and normal
-- **`'auxiliary'`** — the profile's normal stays aligned with a fixed reference axis
+- **`'frenet'` (default)**: the profile rotates with the path's tangent and normal
+- **`'auxiliary'`**: the profile's normal stays aligned with a fixed reference axis
 
 Most parts work with the default. Specify `{ frame: 'auxiliary' }` when you need the profile to keep a constant up-direction (think extruded handrails).
 
-## Loft — interpolation between profiles
+## Loft: interpolation between profiles
 
 A solid built by smoothly interpolating between two or more profiles:
 
@@ -185,7 +185,7 @@ const bowl = unwrap(loft([base.wire, rim.wire])); // flared truncated cone
 export default bowl;
 ```
 
-The loft passes through every input profile in order. Two parallel circles of different radii produce a flared, bowl-shaped solid — the canonical loft pattern. Hollow it with `shell` (see _Hollowing: shell_ below) to turn it into a usable cup. Profiles must be on parallel planes (or roughly so — non-coplanar lofting works but can produce twisted results).
+The loft passes through every input profile in order. Two parallel circles of different radii produce a flared, bowl-shaped solid: the canonical loft pattern. Hollow it with `shell` (see _Hollowing: shell_ below) to turn it into a usable cup. Profiles must be on parallel planes (or roughly so; non-coplanar lofting works but can produce twisted results).
 
 > Note: `loft` takes `Wire[]`, hence the `.wire` on each sketch. The OO equivalent `sketch.loftWith(otherSketch, opts)` does that unwrapping for you.
 
@@ -210,7 +210,7 @@ Three or more sections produces a smooth blend through every one. Useful for vas
 
 ### Ruled vs smooth
 
-`loft([a, b], { ruled: true })` builds a ruled surface (straight lines between corresponding points on the profiles). The default produces a smooth (B-spline) blend. Ruled is faster but visually angular — common in sheet-metal modelling.
+`loft([a, b], { ruled: true })` builds a ruled surface (straight lines between corresponding points on the profiles). The default produces a smooth (B-spline) blend. Ruled is faster but visually angular, common in sheet-metal modelling.
 
 ## Hollowing: shell
 
@@ -237,10 +237,7 @@ The fluent equivalent:
 ```typescript
 import { shape, sketchCircle } from 'brepjs/quick';
 
-const cup = shape(sketchCircle(20).extrude(40)).shell(
-  (f) => f.atDistance(40, [0, 0, 0]),
-  2
-).val;
+const cup = shape(sketchCircle(20).extrude(40)).shell((f) => f.atDistance(40, [0, 0, 0]), 2).val;
 export default cup;
 ```
 
@@ -251,7 +248,15 @@ export default cup;
 <!-- @run-test -->
 
 ```typescript
-import { sketchCircle, helix, sweep, sketchRoundedRectangle, fuse, translate, unwrap } from 'brepjs/quick';
+import {
+  sketchCircle,
+  helix,
+  sweep,
+  sketchRoundedRectangle,
+  fuse,
+  translate,
+  unwrap,
+} from 'brepjs/quick';
 
 const shaft = sketchCircle(3).extrude(20); // M6-ish, 20 mm long
 const threadProfile = sketchCircle(0.75).wire; // ~12% of shaft dia
@@ -265,7 +270,7 @@ export default screw;
 
 ### Funnel (loft + revolve combined)
 
-A funnel is two truncated cones — but easier as a revolved profile:
+A funnel is two truncated cones, but easier as a revolved profile:
 
 ```typescript
 import { Sketcher } from 'brepjs/quick';
@@ -290,7 +295,7 @@ A profile, two `lineTo`s, a revolve. Simpler than building two cones and fusing.
 
 | Failure                        | Cause                                                                    |
 | ------------------------------ | ------------------------------------------------------------------------ |
-| `EXTRUDE_INVALID_FACE`         | The face isn't `OrientedFace` — usually means the wire isn't closed      |
+| `EXTRUDE_INVALID_FACE`         | The face isn't `OrientedFace`: usually means the wire isn't closed       |
 | `REVOLVE_AXIS_CROSSES_PROFILE` | The axis passes through the profile (would self-intersect)               |
 | `SWEEP_PATH_INVALID`           | Path has self-intersections, sharp corners, or non-tangent meeting edges |
 | `LOFT_PROFILE_MISMATCH`        | Profiles have very different topologies (e.g. one closed, one open)      |
@@ -300,6 +305,6 @@ A profile, two `lineTo`s, a revolve. Simpler than building two cones and fusing.
 
 ## Next steps
 
-- [Boolean Operations](./booleans) — combining the solids you build here
-- [Fillets & Chamfers](./fillets) — refining the edges these operations create
-- [Finders & Queries](./finders) — selecting features to extrude / shell / fillet on
+- [Boolean Operations](./booleans): combining the solids you build here
+- [Fillets & Chamfers](./fillets): refining the edges these operations create
+- [Finders & Queries](./finders): selecting features to extrude / shell / fillet on

--- a/apps/docs/tasks/measurement.md
+++ b/apps/docs/tasks/measurement.md
@@ -1,11 +1,11 @@
 ---
 title: Measurement
-description: 'Volume, area, length, distance, bounding box, centroid, principal axes — every measurement you can ask of a brepjs shape.'
+description: 'Volume, area, length, distance, bounding box, centroid, principal axes: every measurement you can ask of a brepjs shape.'
 ---
 
 # Measurement
 
-Measurement functions return `Result<number>` — null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. For valid inputs, `unwrap()` extracts the number; in production code prefer `isOk()` / `match()`. You ask "what is the volume of this thing?" and you get a `Result`. This chapter is short because the API is small.
+Measurement functions return `Result<number>`. Null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. For valid inputs, `unwrap()` extracts the number; in production code prefer `isOk()` / `match()`. You ask "what is the volume of this thing?" and you get a `Result`. This chapter is short because the API is small.
 
 ## The four core measurements
 
@@ -39,11 +39,11 @@ if (circularEdge) {
 export default cylinder2;
 ```
 
-| Function               | Argument            | Returns                                               |
-| ---------------------- | ------------------- | ----------------------------------------------------- |
-| `measureVolume(shape)` | `Shape3D`           | `Result<number>` — total volume in cubic units        |
-| `measureArea(shape)`   | `Shape3D` or `Face` | `Result<number>` — total surface area in square units |
-| `measureLength(edge)`  | `Edge` or `Wire`    | `Result<number>` — length along the curve             |
+| Function               | Argument            | Returns                                              |
+| ---------------------- | ------------------- | ---------------------------------------------------- |
+| `measureVolume(shape)` | `Shape3D`           | `Result<number>`: total volume in cubic units        |
+| `measureArea(shape)`   | `Shape3D` or `Face` | `Result<number>`: total surface area in square units |
+| `measureLength(edge)`  | `Edge` or `Wire`    | `Result<number>`: length along the curve             |
 
 These are the workhorses. The fluent wrapper exposes them as methods: `shape(s).volume()`, `shape(s).area()`.
 
@@ -170,8 +170,8 @@ For a quick "how complex is this shape" check, count entities at each level. A s
 ## Performance notes
 
 - Volume and area are cheap (kernel mass-properties query).
-- Distance between two shapes can be expensive — proportional to face counts. For repeated distance queries, build a spatial index (`flatbush` is included as a dependency) over your shapes' bounding boxes.
-- Curvature queries are constant-time at a single parameter, but evaluating a dense grid of points is naive — there's no built-in batched API.
+- Distance between two shapes can be expensive, proportional to face counts. For repeated distance queries, build a spatial index (`flatbush` is included as a dependency) over your shapes' bounding boxes.
+- Curvature queries are constant-time at a single parameter, but evaluating a dense grid of points is naive; there's no built-in batched API.
 
 ## Common patterns
 
@@ -226,6 +226,6 @@ console.log(`Mass: ${massGrams.toFixed(2)} g`);
 
 ## Next steps
 
-- [Finders & Queries](./finders) — selecting specific entities to measure
-- [Import & Export](./import-export) — measuring shapes you imported from STEP
-- [The Topology Hierarchy](../concepts/topology) — what each shape kind contributes to area / volume
+- [Finders & Queries](./finders): selecting specific entities to measure
+- [Import & Export](./import-export): measuring shapes you imported from STEP
+- [The Topology Hierarchy](../concepts/topology): what each shape kind contributes to area / volume

--- a/apps/docs/tasks/parametric-csg.md
+++ b/apps/docs/tasks/parametric-csg.md
@@ -1,13 +1,13 @@
 ---
-title: Parametric CSG — a Gridfinity-Style Bin
+title: 'Parametric CSG: a Gridfinity-Style Bin'
 description: 'Build a parametric model with named parameters, evaluate it against the kernel, edit a parameter, and watch the evaluator skip the subtrees that did not change.'
 ---
 
-# Parametric CSG — a Gridfinity-Style Bin
+# Parametric CSG: a Gridfinity-Style Bin
 
-This walkthrough builds a simplified gridfinity-style bin — an outer block with a pocket cut from the top — using `csg` builders and named parameters. By the end you'll have a tree you can re-evaluate with different parameter values, and you'll see directly how the evaluator's cache spares the unchanged subtrees.
+This walkthrough builds a simplified gridfinity-style bin (an outer block with a pocket cut from the top) using `csg` builders and named parameters. By the end you'll have a tree you can re-evaluate with different parameter values, and you'll see directly how the evaluator's cache spares the unchanged subtrees.
 
-If you haven't read **[CSG as an IR](/concepts/csg-ir)** yet, do that first — this page assumes you already know that builders return data, not geometry.
+If you haven't read **[CSG as an IR](/concepts/csg-ir)** yet, do that first. This page assumes you already know that builders return data, not geometry.
 
 ## The shape we're building
 
@@ -16,17 +16,17 @@ Think of a single gridfinity-compatible bin as two pieces:
 - an **outer block** of size `L × W × H`,
 - a **pocket** centered inside it, inset by `wall` on the four sides and `floor` on the bottom.
 
-The pocket gets cut from the outer block. We'll skip the base lips, magnet holes, and label tabs — they distract from the point of this page, which is the parameterization.
+The pocket gets cut from the outer block. We'll skip the base lips, magnet holes, and label tabs; they distract from the point of this page, which is the parameterization.
 
 Real-world gridfinity dimensions: `L = W = 42 mm`, `H = 30 mm`, `wall = 1.2 mm`, `floor = 1.5 mm`.
 
-## Step 1 — Pick what's parametric
+## Step 1: Pick what's parametric
 
 A live-preview UI lets the user drag sliders for length, width, height, and wall thickness; floor thickness is fixed. So `L`, `W`, `H`, and `wall` get `csg.param()` calls; `floor` is a literal.
 
-A subtle but important detail: **`wall` is a separate parameter, not derived from `L`**. If the pocket dimensions were `L - 2*wall` for a hard-coded wall, changing `L` would invalidate every subtree that touched the pocket. By making `wall` its own parameter, the outer box only depends on `{L, W, H}` and survives wall-thickness edits untouched. This is the kind of decision the IR's cache structure rewards — worth thinking about up front.
+A subtle but important detail: **`wall` is a separate parameter, not derived from `L`**. If the pocket dimensions were `L - 2*wall` for a hard-coded wall, changing `L` would invalidate every subtree that touched the pocket. By making `wall` its own parameter, the outer box only depends on `{L, W, H}` and survives wall-thickness edits untouched. This is the kind of decision the IR's cache structure rewards, worth thinking about up front.
 
-## Step 2 — Write the builder
+## Step 2: Write the builder
 
 ```typescript
 import { csg } from 'brepjs/quick';
@@ -48,7 +48,7 @@ function bin(L: csg.Expr, W: csg.Expr, H: csg.Expr, wall: csg.Expr): csg.SolidNo
 
 Two things to notice:
 
-1. **Expression arithmetic is explicit.** `csg.binOp('-', L, ...)` is verbose compared to `L - 2*wall`, but that's the price of keeping the math in the IR — the subtraction is part of the tree and gets folded by `optimize()` when its operands turn into literals. There's no operator overloading in TypeScript, so this is as ergonomic as it gets. For the two common cases, `csg.add(a, b)` and `csg.mul(a, b)` are shortcuts for `binOp('+', ...)` and `binOp('*', ...)`; subtraction and division still need the full form.
+1. **Expression arithmetic is explicit.** `csg.binOp('-', L, ...)` is verbose compared to `L - 2*wall`, but that's the price of keeping the math in the IR. The subtraction is part of the tree and gets folded by `optimize()` when its operands turn into literals. There's no operator overloading in TypeScript, so this is as ergonomic as it gets. For the two common cases, `csg.add(a, b)` and `csg.mul(a, b)` are shortcuts for `binOp('+', ...)` and `binOp('*', ...)`; subtraction and division still need the full form.
 2. **Type narrowing falls out for free.** `csg.box` always returns a `SolidNode`, `csg.cut` of two solids returns a solid, and the function signature says so. You don't lose the "I know this is a solid" knowledge crossing into the IR.
 
 The resulting tree:
@@ -60,7 +60,7 @@ graph TD
   Translate --> InnerBox["Box(L-2·wall, W-2·wall, H-FLOOR)"]
 ```
 
-## Step 3 — Build the tree and evaluate it
+## Step 3: Build the tree and evaluate it
 
 Create the parametric tree once, then evaluate it with an env binding:
 
@@ -80,11 +80,11 @@ const volume = unwrap(measureVolume(shape));
 
 A few subtleties worth flagging:
 
-- **`using ev = new csg.Evaluator()`** — `Evaluator` is a `Disposable`. The `using` keyword (TypeScript 5.2+) ensures the evaluator's cached shapes are released when the block exits. If you're targeting an older runtime, call `ev[Symbol.dispose]()` manually in a `finally`.
-- **`ev.evaluate(tree, env)` returns `Result<AnyShape>`** — `unwrap` throws on error. In production code, prefer `isOk(r)` and explicit handling. See [Result\<T,E\> and Errors](/concepts/result).
+- **`using ev = new csg.Evaluator()`**: `Evaluator` is a `Disposable`. The `using` keyword (TypeScript 5.2+) ensures the evaluator's cached shapes are released when the block exits. If you're targeting an older runtime, call `ev[Symbol.dispose]()` manually in a `finally`.
+- **`ev.evaluate(tree, env)` returns `Result<AnyShape>`**: `unwrap` throws on error. In production code, prefer `isOk(r)` and explicit handling. See [Result\<T,E\> and Errors](/concepts/result).
 - **The returned shape is borrowed.** It lives until the evaluator is disposed. Do NOT call `[Symbol.dispose]()` on it directly; that would corrupt the cache for the next call returning the same handle.
 
-## Step 4 — Edit a parameter
+## Step 4: Edit a parameter
 
 The reason to put work into the IR upfront is moments like this:
 
@@ -95,7 +95,7 @@ ev.cacheStats();
 // { hits: 0, misses: 4, entries: 8 }
 ```
 
-Every subtree references `H` (outer box directly, inner box as `H - FLOOR`, translate and cut transitively), so every cache key changes. Four misses. The cache holds eight entries — four for `H = 30`, four for `H = 42`.
+Every subtree references `H` (outer box directly, inner box as `H - FLOOR`, translate and cut transitively), so every cache key changes. Four misses. The cache holds eight entries: four for `H = 30`, four for `H = 42`.
 
 Now change `wall` instead:
 
@@ -106,11 +106,11 @@ ev.cacheStats();
 // { hits: 1, misses: 3, entries: 11 }
 ```
 
-One hit. The outer `Box(L, W, H)` only depends on `{L, W, H}` — `wall` isn't in its `freeParams`, so its cache key is unchanged. The pocket box, the translate, and the cut all depend on `wall` and miss. Three new misses, eleven entries total.
+One hit. The outer `Box(L, W, H)` only depends on `{L, W, H}`; `wall` isn't in its `freeParams`, so its cache key is unchanged. The pocket box, the translate, and the cut all depend on `wall` and miss. Three new misses, eleven entries total.
 
 In a live-preview UI, this is the difference between "drag the wall slider → entire bin re-renders" and "drag the wall slider → only the pocket subtree re-renders." On non-trivial models with dozens of features, that ratio matters a lot.
 
-## Step 5 — Unrelated env keys are free
+## Step 5: Unrelated env keys are free
 
 The evaluator projects the env to only the keys a node actually depends on, so you can stuff debug tags, UI state, or anything else into the env without invalidating anything:
 
@@ -122,7 +122,7 @@ ev.cacheStats();
 // { hits: 4, misses: 0, entries: 11 }
 ```
 
-No node has `sliderTouched` in its `freeParams`, so no cache key changes — everything hits. Wire the env directly to your application state; no filtering required.
+No node has `sliderTouched` in its `freeParams`, so no cache key changes; everything hits. Wire the env directly to your application state; no filtering required.
 
 ## When you don't need the cache across calls
 
@@ -150,21 +150,21 @@ import { csg, isErr } from 'brepjs/quick';
 // 1. Forgetting to bind a param
 using ev = new csg.Evaluator();
 const r1 = ev.evaluate(csg.box(csg.param('missing'), 10, 10), {});
-isErr(r1); // true — "unbound param: missing"
+isErr(r1); // true - "unbound param: missing"
 
 // 2. Evaluating an Empty alone (it has no kernel realization)
 const r2 = ev.evaluate(csg.emptySolid());
 isErr(r2); // true
 
-// 3. Cut(empty, x) — empty has nothing for the kernel to subtract from
+// 3. Cut(empty, x) - empty has nothing for the kernel to subtract from
 const r3 = ev.evaluate(csg.cut(csg.emptySolid(), csg.box(1, 1, 1)));
 isErr(r3); // true
 ```
 
-`fuse(empty, x)` _does_ work — it short-circuits to `x` directly without calling the kernel's union. `Empty` nodes exist as the identity element of `optimize()`'s simplifications; they're meant to disappear before evaluation.
+`fuse(empty, x)` _does_ work; it short-circuits to `x` directly without calling the kernel's union. `Empty` nodes exist as the identity element of `optimize()`'s simplifications; they're meant to disappear before evaluation.
 
 ## Where to go next
 
-- **[CSG caching internals](/advanced/csg-caching)** — `cacheStats`, what's in the cache key, when to call `optimize()`, JSON round-trip, and tree-editing primitives like `replaceNode`.
-- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)** — if you've already built `Map<key, Solid>` plumbing around the eager API, here's the side-by-side translation.
-- **[The eager topology API](/tasks/booleans)** — when you build a single part and don't need re-evaluation, plain `fuse`/`cut`/`intersect` is leaner.
+- **[CSG caching internals](/advanced/csg-caching)**: `cacheStats`, what's in the cache key, when to call `optimize()`, JSON round-trip, and tree-editing primitives like `replaceNode`.
+- **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)**: if you've already built `Map<key, Solid>` plumbing around the eager API, here's the side-by-side translation.
+- **[The eager topology API](/tasks/booleans)**: when you build a single part and don't need re-evaluation, plain `fuse`/`cut`/`intersect` is leaner.

--- a/apps/docs/tasks/primitives.md
+++ b/apps/docs/tasks/primitives.md
@@ -5,7 +5,7 @@ description: 'Boxes, cylinders, spheres, cones, tori, plus the transform vocabul
 
 # Primitives & Transforms
 
-Every parametric part starts from primitives — boxes, cylinders, spheres, cones, tori — and gets to its final form by transforming and combining them. This chapter covers the primitives brepjs ships, the options each accepts, and the transform vocabulary that moves them around.
+Every parametric part starts from primitives (boxes, cylinders, spheres, cones, tori) and gets to its final form by transforming and combining them. This chapter covers the primitives brepjs ships, the options each accepts, and the transform vocabulary that moves them around.
 
 ## The primitives
 
@@ -21,7 +21,7 @@ torus(20, 3); // major radius, minor radius
 console.log(unwrap(measureVolume(box(10, 10, 10)))); // 1000
 ```
 
-All five return `ValidSolid` — a solid that has passed `BRepCheck`.
+All five return `ValidSolid`: a solid that has passed `BRepCheck`.
 
 ### `box(w, d, h, options?)`
 
@@ -99,7 +99,7 @@ console.log(unwrap(measureVolume(stretched))); // 2000
 
 `rotate(shape, angleDegrees, { axis, origin })`. The axis defaults to `[0, 0, 1]`, origin to `[0, 0, 0]`.
 
-`scale(shape, factor)` — uniform if `factor` is a number, per-axis if it's a `[sx, sy, sz]` tuple.
+`scale(shape, factor)`: uniform if `factor` is a number, per-axis if it's a `[sx, sy, sz]` tuple.
 
 ## Fluent transforms
 
@@ -115,7 +115,7 @@ const positioned = shape(box(10, 10, 10))
   .scale(2).val;
 ```
 
-The shortcuts — `.moveX/Y/Z`, `.rotateX/Y/Z` — exist because they are the most common transforms in practice. For arbitrary axes use `.translate([dx, dy, dz])` and `.rotate(angle, { axis })`.
+The shortcuts (`.moveX/Y/Z`, `.rotateX/Y/Z`) exist because they are the most common transforms in practice. For arbitrary axes use `.translate([dx, dy, dz])` and `.rotate(angle, { axis })`.
 
 ## Constructing at a position
 
@@ -128,7 +128,7 @@ cylinder(5, 20, { at: [10, 10, -2] }); // construct at position
 translate(cylinder(5, 20), [10, 10, -2]); // construct at origin then move
 ```
 
-The `at` option is faster — it avoids one transform — but they produce identical geometry.
+The `at` option is faster (it avoids one transform) but they produce identical geometry.
 
 ## Mirroring
 
@@ -198,7 +198,7 @@ const drilled = unwrap(cut(block, hole));
 export default drilled;
 ```
 
-`cylinder(5, 10, { at: [10, 10, 0] })` would have endpoints exactly on the block's faces — the boolean kernel can produce slivers near coincident geometry. A 1-unit overshoot is the cheap, reliable fix.
+`cylinder(5, 10, { at: [10, 10, 0] })` would have endpoints exactly on the block's faces; the boolean kernel can produce slivers near coincident geometry. A 1-unit overshoot is the cheap, reliable fix.
 
 ### Construct in millimetres (or whatever your unit is)
 
@@ -218,6 +218,6 @@ sphere(5); // already centred
 
 ## Next steps
 
-- [Boolean Operations](./booleans) — `fuse`, `cut`, `intersect`, and the failure modes
-- [Fillets & Chamfers](./fillets) — refining edges after primitives meet
-- [2D Sketching](./sketching) — non-primitive profiles
+- [Boolean Operations](./booleans): `fuse`, `cut`, `intersect`, and the failure modes
+- [Fillets & Chamfers](./fillets): refining edges after primitives meet
+- [2D Sketching](./sketching): non-primitive profiles

--- a/apps/docs/tasks/sketching.md
+++ b/apps/docs/tasks/sketching.md
@@ -5,7 +5,7 @@ description: 'Build 2D profiles fluently with the Sketcher, or use canned shape 
 
 # 2D Sketching with the Sketcher
 
-For shapes you can't build from primitive booleans — anything with a non-rectangular profile, anything tapered, anything organic-mechanical — you sketch in 2D and extrude into 3D. brepjs ships two ways to do this: the `Sketcher` builder (for arbitrary profiles) and the canned shape builders (`sketchCircle`, `sketchRoundedRectangle`, etc., for common ones).
+For shapes you can't build from primitive booleans (anything with a non-rectangular profile, anything tapered, anything organic-mechanical) you sketch in 2D and extrude into 3D. brepjs ships two ways to do this: the `Sketcher` builder (for arbitrary profiles) and the canned shape builders (`sketchCircle`, `sketchRoundedRectangle`, etc., for common ones).
 
 ## The two-step model
 
@@ -21,7 +21,7 @@ A sketch is a planar face. From a face you build a solid by extruding (linear), 
 
 ## Canned profiles
 
-For common cross-sections, use the builder functions — they return a sketch with `.extrude` directly:
+For common cross-sections, use the builder functions; they return a sketch with `.extrude` directly:
 
 ```typescript
 import {
@@ -94,7 +94,7 @@ After `close()`, the sketch is a `ClosedWire<'2D'>` ready to extrude / revolve /
 
 ### Tangent arcs are the workhorse
 
-Most curved profiles in mechanical CAD use tangent arcs — the arc continues smoothly from the previous segment without a corner:
+Most curved profiles in mechanical CAD use tangent arcs: the arc continues smoothly from the previous segment without a corner:
 
 ```typescript
 import { Sketcher } from 'brepjs/quick';
@@ -172,7 +172,7 @@ const rod = sweep(cross, path);
 export default rod;
 ```
 
-The path can be any wire — straight, arced, helical. Common pattern: revolve + sweep produces threaded rods, tubing, springs.
+The path can be any wire: straight, arced, helical. Common pattern: revolve + sweep produces threaded rods, tubing, springs.
 
 ## The Drawing API: 2D booleans before extrude
 
@@ -207,7 +207,7 @@ For most profiles the Sketcher is simpler. Use the Drawing API when you need 2D 
 
 ## Sketching on existing faces
 
-You don't have to sketch on the world planes — you can sketch on any face of an existing shape:
+You don't have to sketch on the world planes; you can sketch on any face of an existing shape:
 
 ```typescript
 import { box, faceFinder, Sketcher, fuse, unwrap } from 'brepjs/quick';
@@ -236,7 +236,7 @@ The Sketcher constructor accepts either a plane name (`'XY'`) or a face. When gi
 
 ### Close every sketch before extruding
 
-`extrude` requires a closed wire (it has type `OrientedFace`, which requires `ClosedWire`). Forgetting `.close()` is the most common Sketcher mistake. The compiler catches it — `OrientedFace` is not assignable from an unclosed sketch.
+`extrude` requires a closed wire (it has type `OrientedFace`, which requires `ClosedWire`). Forgetting `.close()` is the most common Sketcher mistake. The compiler catches it; `OrientedFace` is not assignable from an unclosed sketch.
 
 ### Don't intersect with yourself
 
@@ -244,10 +244,10 @@ A self-intersecting wire produces an invalid face. The kernel will catch it and 
 
 ### Use the canned shapes when possible
 
-`sketchCircle(10)` is _much_ better than building a circle from four arcs — fewer kernel calls, better tolerance, no chance of an open wire.
+`sketchCircle(10)` is _much_ better than building a circle from four arcs: fewer kernel calls, better tolerance, no chance of an open wire.
 
 ## Next steps
 
-- [Lofts, Sweeps, Revolves](./lofts-sweeps) — going from sketch to solid by means other than extrude
-- [Finders & Queries](./finders) — picking specific edges of a sketched part to refine
-- [Boolean Operations](./booleans) — combining sketched solids
+- [Lofts, Sweeps, Revolves](./lofts-sweeps): going from sketch to solid by means other than extrude
+- [Finders & Queries](./finders): picking specific edges of a sketched part to refine
+- [Boolean Operations](./booleans): combining sketched solids

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -71,7 +71,7 @@ Quick reference for navigating the brepjs source. See `CLAUDE.md` for rules and 
 
 | Doc                         | What it answers                                      |
 | --------------------------- | ---------------------------------------------------- |
-| `CLAUDE.md`                 | Rules, patterns, commands — read first               |
+| `CLAUDE.md`                 | Rules, patterns, commands; read first                |
 | `docs/function-lookup.md`   | "Where is function X exported from?" (381+ symbols)  |
 | `docs/architecture.md`      | Layer diagrams, data flow, key patterns              |
 | `docs/errors.md`            | All error codes with recovery hints                  |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -106,12 +106,12 @@ brepjs requires WebAssembly support:
 
 **Alternative kernels** (optional peer dependencies):
 
-| Package              | Description                                                                                                             |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `brepjs-opencascade` | Legacy OpenCascade WASM build — `brepjs_single` (~15 MB), `brepjs_threaded` (~16 MB), `brepjs_with_exceptions` (~17 MB) |
-| `brepkit-wasm`       | Alternative kernel with growing operation coverage                                                                      |
+| Package              | Description                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `brepjs-opencascade` | Legacy OpenCascade WASM build: `brepjs_single` (~15 MB), `brepjs_threaded` (~16 MB), `brepjs_with_exceptions` (~17 MB) |
+| `brepkit-wasm`       | Alternative kernel with growing operation coverage                                                                     |
 
-All kernels are optional peer dependencies — install whichever you need. See [Custom Kernel Guide](./kernel-swap.md) for initialization details.
+All kernels are optional peer dependencies; install whichever you need. See [Custom Kernel Guide](./kernel-swap.md) for initialization details.
 
 ## Known Limitations
 

--- a/docs/decisions/0001-layered-architecture.md
+++ b/docs/decisions/0001-layered-architecture.md
@@ -11,10 +11,10 @@ brepjs is a CAD library with complex internal dependencies between geometry, top
 
 Adopt a strict four-layer architecture with enforced unidirectional imports:
 
-- **Layer 0** (`kernel/`, `utils/`): Foundation — no internal imports
-- **Layer 1** (`core/`): Memory management, geometry, constants — imports kernel/utils only
-- **Layer 2** (`topology/`, `operations/`, `2d/`, `query/`, `measurement/`, `io/`, `worker/`): Domain — imports layers 0-1 + peers
-- **Layer 3** (`sketching/`, `text/`, `projection/`): High-level API — imports all lower layers
+- **Layer 0** (`kernel/`, `utils/`): Foundation, no internal imports
+- **Layer 1** (`core/`): Memory management, geometry, constants, imports kernel/utils only
+- **Layer 2** (`topology/`, `operations/`, `2d/`, `query/`, `measurement/`, `io/`, `worker/`): Domain, imports layers 0-1 + peers
+- **Layer 3** (`sketching/`, `text/`, `projection/`): High-level API, imports all lower layers
 
 Boundaries are enforced by `npm run check:boundaries`, which runs in pre-commit hooks and CI.
 
@@ -34,5 +34,5 @@ Boundaries are enforced by `npm run check:boundaries`, which runs in pre-commit 
 
 ## Related
 
-- `scripts/check-boundaries.ts` — enforcement script
-- `docs/architecture.md` — detailed architecture documentation
+- `scripts/check-boundaries.ts`: enforcement script
+- `docs/architecture.md`: detailed architecture documentation

--- a/docs/decisions/0002-kernel-abstraction.md
+++ b/docs/decisions/0002-kernel-abstraction.md
@@ -17,18 +17,18 @@ Introduce a `KernelAdapter` interface that abstracts all kernel operations. Doma
 
 - Multiple kernels can coexist (OCCT, brepkit, future GPU-accelerated)
 - Enables benchmarking kernels against each other
-- Domain code is kernel-agnostic — cleaner separation of concerns
+- Domain code is kernel-agnostic, cleaner separation of concerns
 - ESLint rules enforce the abstraction (`no-restricted-syntax` bans `.oc` access)
 
 ### Negative / Trade-offs
 
 - Adapter interface is large (~100 methods) and must be kept in sync
 - Some OCCT-specific optimizations are harder to express through the abstraction
-- `withKernel()` is sync-only — async code must use `getKernel(id)` directly
+- `withKernel()` is sync-only; async code must use `getKernel(id)` directly
 
 ## Related
 
 - ADR-0001 (kernel is Layer 0)
-- ADR-0006 (narrows strategic direction — brepkit is the primary kernel)
-- `src/kernel/types.ts` — `KernelAdapter` interface
-- `docs/kernel-swap.md` — user-facing guide
+- ADR-0006 (narrows strategic direction; brepkit is the primary kernel)
+- `src/kernel/types.ts`: `KernelAdapter` interface
+- `docs/kernel-swap.md`: user-facing guide

--- a/docs/decisions/0003-branded-types.md
+++ b/docs/decisions/0003-branded-types.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-CAD shapes (Vertex, Edge, Wire, Face, Shell, Solid) are all opaque handles wrapping kernel pointers. Without type-level discrimination, it's easy to pass a Wire where a Face is expected — the error only surfaces at runtime inside WASM.
+CAD shapes (Vertex, Edge, Wire, Face, Shell, Solid) are all opaque handles wrapping kernel pointers. Without type-level discrimination, it's easy to pass a Wire where a Face is expected; the error only surfaces at runtime inside WASM.
 
 ## Decision
 
@@ -22,8 +22,8 @@ Runtime type guards (`isEdge()`, `isWire()`, etc.) query the kernel and narrow t
 
 ### Positive
 
-- Compile-time shape discrimination — wrong-shape bugs caught before runtime
-- Zero runtime overhead — brands exist only in the type system
+- Compile-time shape discrimination: wrong-shape bugs caught before runtime
+- Zero runtime overhead: brands exist only in the type system
 - Type guards integrate with TypeScript's control flow analysis
 - Factory functions (`createEdge()`, `createWire()`) are the only way to brand a handle
 
@@ -35,4 +35,4 @@ Runtime type guards (`isEdge()`, `isWire()`, etc.) query the kernel and narrow t
 ## Related
 
 - ADR-0004 (phantom dimension types extend this pattern)
-- `src/core/shapeTypes.ts` — type definitions and factories
+- `src/core/shapeTypes.ts`: type definitions and factories

--- a/docs/decisions/0004-phantom-dimension-types.md
+++ b/docs/decisions/0004-phantom-dimension-types.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Shape types (Edge, Wire, Face, etc.) can exist in 2D or 3D space. Mixing dimensions — e.g., fusing a 2D wire with a 3D solid — produces cryptic WASM errors. The type system should prevent this at compile time.
+Shape types (Edge, Wire, Face, etc.) can exist in 2D or 3D space. Mixing dimensions (e.g., fusing a 2D wire with a 3D solid) produces cryptic WASM errors. The type system should prevent this at compile time.
 
 ## Decision
 
@@ -25,7 +25,7 @@ Default is `'3D'` for backward compatibility. Template literal error types produ
 
 - Compile-time rejection of 2D/3D mismatches
 - Zero runtime overhead (phantom parameter)
-- Backward compatible — existing `Edge` means `Edge<'3D'>`
+- Backward compatible: existing `Edge` means `Edge<'3D'>`
 - Foundation for future validity types (ADR-0005)
 
 ### Negative / Trade-offs
@@ -35,6 +35,6 @@ Default is `'3D'` for backward compatibility. Template literal error types produ
 
 ## Related
 
-- ADR-0003 (branded types — the foundation this builds on)
-- ADR-0005 (topological validity types — the next layer of phantom types)
-- `docs/plans/phantom-dimension-types.md` — original implementation plan
+- ADR-0003 (branded types, the foundation this builds on)
+- ADR-0005 (topological validity types, the next layer of phantom types)
+- `docs/plans/phantom-dimension-types.md`: original implementation plan

--- a/docs/decisions/0005-topological-validity-types.md
+++ b/docs/decisions/0005-topological-validity-types.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-brepjs shape types discriminate by _kind_ (Edge, Wire, Face, etc.) and _dimension_ (2D, 3D) at compile time. However, topological _validity_ properties — whether a wire is closed, a face is oriented, a shell is manifold, or a solid passes geometry checks — are only discoverable at runtime.
+brepjs shape types discriminate by _kind_ (Edge, Wire, Face, etc.) and _dimension_ (2D, 3D) at compile time. However, topological _validity_ properties (whether a wire is closed, a face is oriented, a shell is manifold, or a solid passes geometry checks) are only discoverable at runtime.
 
 This matters because many operations have validity preconditions:
 
@@ -18,7 +18,7 @@ Currently, violating these preconditions produces cryptic WASM errors or silentl
 
 1. Operations that require validity can declare it in their signatures
 2. The only way to obtain a validity-branded type is through a function that proves the property at runtime (smart constructor pattern)
-3. Existing code continues to work — validity types are subtypes of their base types
+3. Existing code continues to work; validity types are subtypes of their base types
 
 ## Decision
 
@@ -37,26 +37,26 @@ declare const __valid: unique symbol; // Solid passes BRepCheck validation
 ### Validity Types
 
 ```ts
-// Closed wire — proven to form a loop
+// Closed wire - proven to form a loop
 type ClosedWire<D extends Dimension = '3D'> = Wire<D> & { readonly [__closed]: true };
 
-// Oriented face — proven to have consistent normal
+// Oriented face - proven to have consistent normal
 type OrientedFace<D extends Dimension = '3D'> = Face<D> & { readonly [__oriented]: true };
 
-// Manifold shell — proven to be watertight
+// Manifold shell - proven to be watertight
 type ManifoldShell = Shell & { readonly [__manifold]: true };
 
-// Valid solid — proven to pass BRepCheck
+// Valid solid - proven to pass BRepCheck
 type ValidSolid = Solid & { readonly [__valid]: true };
 ```
 
 ### Subtype Relationships
 
 ```
-ClosedWire<D>  <:  Wire<D>      — assignable to Wire, not vice versa
-OrientedFace<D> <:  Face<D>      — assignable to Face, not vice versa
-ManifoldShell   <:  Shell        — assignable to Shell, not vice versa
-ValidSolid      <:  Solid        — assignable to Solid, not vice versa
+ClosedWire<D>  <:  Wire<D>      - assignable to Wire, not vice versa
+OrientedFace<D> <:  Face<D>      - assignable to Face, not vice versa
+ManifoldShell   <:  Shell        - assignable to Shell, not vice versa
+ValidSolid      <:  Solid        - assignable to Solid, not vice versa
 ```
 
 ### Smart Constructors (Proof Terms)
@@ -99,8 +99,8 @@ function circleWire(radius: number): ClosedWire<'3D'>;
 
 Validity types are **subtypes** with two tiers:
 
-- **Non-breaking (Phase 2)**: Producers return branded types — callers get narrower types automatically
-- **Breaking (Phase 3)**: Constructive operations _require_ branded inputs — callers must prove validity via smart constructors, type guards, or `as` casts where the invariant holds by construction
+- **Non-breaking (Phase 2)**: Producers return branded types; callers get narrower types automatically
+- **Breaking (Phase 3)**: Constructive operations _require_ branded inputs; callers must prove validity via smart constructors, type guards, or `as` casts where the invariant holds by construction
 
 ## Consequences
 
@@ -108,7 +108,7 @@ Validity types are **subtypes** with two tiers:
 
 - **Compile-time safety**: Operations that require validity declare it in types
 - **Self-documenting APIs**: `face(wire: ClosedWire)` is clearer than `face(wire: Wire)` + runtime error
-- **Zero runtime overhead**: Brands are phantom — no wrapper objects, no memory allocation
+- **Zero runtime overhead**: Brands are phantom: no wrapper objects, no memory allocation
 - **Composable**: Brands stack with dimension types: `ClosedWire<'2D'>`
 - **Gradual**: Existing code is unaffected; validity requirements can be added incrementally
 - **Proof-carrying code**: The type system tracks which validations have been performed
@@ -168,7 +168,7 @@ Update functions that produce known-valid shapes to return branded types:
 - `makeFace()` → `OrientedFace` (faces are always oriented)
 - `sewShells()` → conditional `ManifoldShell` or `Shell`
 
-### Phase 3: Consumer Updates (Breaking) — ClosedWire & OrientedFace ✅ Complete
+### Phase 3: Consumer Updates (Breaking): ClosedWire & OrientedFace ✅ Complete
 
 Updated operation signatures to _require_ validity brands at call sites:
 
@@ -187,7 +187,7 @@ Updated operation signatures to _require_ validity brands at call sites:
 
 Internal call sites (Sketch, CompoundSketch, Blueprint, draw, booleanFns, compoundOpsFns) cast with `as ClosedWire`/`as OrientedFace` where the invariant is known to hold by construction.
 
-### Phase 3b: Consumer Updates — ValidSolid ✅ Complete
+### Phase 3b: Consumer Updates: ValidSolid ✅ Complete
 
 Require `ValidSolid` on operations that fail or produce garbage on invalid solids:
 
@@ -208,7 +208,7 @@ Batch variants `fuseAll` and `cutAll` follow the same overload pattern.
 
 ### Phase 4: Convenience & Propagation ✅ Partially Complete
 
-- ✅ `wireLoop(edges)` — assemble + closure check in one step, returns `Result<ClosedWire>`
+- ✅ `wireLoop(edges)`: assemble + closure check in one step, returns `Result<ClosedWire>`
 - ✅ `solid(facesOrShells)` / `makeSolid()` → `Result<ValidSolid>` (was `Result<Solid>`)
 - Transforms (`translate`, `rotate`, `mirror`, `scale`) preserve brands via `<T extends AnyShape<D>>` generics
 - `fillet`, `chamfer`, `shell` (api layer) preserve brands via `<T extends Shape3D>` generics
@@ -223,6 +223,6 @@ See ADR-0011 for `PlanarFace`/`PlanarWire` brands that encode geometric (not jus
 - ADR-0003: Branded types (foundation pattern)
 - ADR-0004: Phantom dimension types (extends the same pattern)
 - ADR-0011: Geometric validity brands (PlanarFace/PlanarWire)
-- `src/core/validityTypes.ts` — validity type definitions
-- `src/core/shapeTypes.ts` — shape type definitions and re-exports
-- `src/topology/healingFns.ts` — validation infrastructure
+- `src/core/validityTypes.ts`: validity type definitions
+- `src/core/shapeTypes.ts`: shape type definitions and re-exports
+- `src/topology/healingFns.ts`: validation infrastructure

--- a/docs/decisions/0006-domain-boundaries.md
+++ b/docs/decisions/0006-domain-boundaries.md
@@ -7,11 +7,11 @@
 
 brepjs is a TypeScript CAD library with a pluggable kernel abstraction (ADR-0002). brepkit is a Rust/WASM kernel implementation. As brepkit matures, problems have emerged:
 
-- **Duplicated logic** — 2D vector math, precision constants, point comparison, and offset algorithms exist in both TypeScript and Rust. Bugs fixed in one are not fixed in the other.
-- **Unclear ownership** — No principled answer to "does this belong in TypeScript or Rust?"
-- **Migration debt** — Code that predates brepkit should move to the kernel, but no plan exists.
+- **Duplicated logic**: 2D vector math, precision constants, point comparison, and offset algorithms exist in both TypeScript and Rust. Bugs fixed in one are not fixed in the other.
+- **Unclear ownership**: No principled answer to "does this belong in TypeScript or Rust?"
+- **Migration debt**: Code that predates brepkit should move to the kernel, but no plan exists.
 
-**Relationship to ADR-0002**: ADR-0002 treats all kernels as equal peers. This ADR narrows that: brepkit is the strategic kernel. OCCT remains supported for compatibility. The `KernelAdapter` interface and mechanisms are unchanged — only the strategic priority shifts.
+**Relationship to ADR-0002**: ADR-0002 treats all kernels as equal peers. This ADR narrows that: brepkit is the strategic kernel. OCCT remains supported for compatibility. The `KernelAdapter` interface and mechanisms are unchanged; only the strategic priority shifts.
 
 ## Decision
 
@@ -28,7 +28,7 @@ When deciding where new code belongs, apply in order:
 3. **Composes kernel operations into a user workflow?** → brepjs. Examples: Sketcher DSL, Blueprint builder, assembly mate sequencing.
 4. **Defines types, error handling, or memory management?** → brepjs. Examples: branded types, `Result<T,E>`, `DisposalScope`.
 
-**When rules conflict**: Rule 1 wins for the computational core; rule 3 wins for the sequencing layer. Split accordingly. Example: assembly mate solving — distance/angle computation is brepkit (rule 1), constraint resolution order is brepjs (rule 3).
+**When rules conflict**: Rule 1 wins for the computational core; rule 3 wins for the sequencing layer. Split accordingly. Example: assembly mate solving. Distance/angle computation is brepkit (rule 1), constraint resolution order is brepjs (rule 3).
 
 **Hot-path exception**: If a pure-TS function is called in a tight inner loop and WASM call overhead dominates computation cost, it may remain in TypeScript with a comment citing this ADR. Profile before deciding. Candidates: `samePoint()`, `distance2d()` in Blueprint boolean inner loops.
 
@@ -36,13 +36,13 @@ For existing code: if a pure-TS function reimplements something the kernel provi
 
 ### Domain Ownership
 
-**brepkit** (Rust/WASM) — all geometry evaluation and topology traversal:
+**brepkit** (Rust/WASM): all geometry evaluation and topology traversal:
 
 Primitives, booleans, shape modification (extrude/revolve/sweep/loft/fillet/chamfer/shell/draft/offset/thicken), tessellation, measurement, queries, healing/validation, data exchange (STEP/IGES round-trip, mesh format import into B-Rep), 2D geometry (curves/booleans/offset/vector math/precision), sketch constraint solving, projection/HLR, transforms.
 
-**brepjs** (TypeScript) — everything between the kernel and end user:
+**brepjs** (TypeScript): everything between the kernel and end user:
 
-Type system (ADRs 0003-0005, `Result<T,E>`), orchestration (composing kernel calls into workflows), `KernelAdapter` interface, memory management (`DisposalScope`, `createHandle()`), error translation, Sketching DSL, Blueprint DSL, text rendering (opentype.js), runtime integration (Web Workers, Three.js), format adapters (SVG/DXF parsing, OBJ/glTF/3MF export formatting), color/material storage (`colorFns.ts` — stays in TS unless the kernel adds native per-shape color), package distribution.
+Type system (ADRs 0003-0005, `Result<T,E>`), orchestration (composing kernel calls into workflows), `KernelAdapter` interface, memory management (`DisposalScope`, `createHandle()`), error translation, Sketching DSL, Blueprint DSL, text rendering (opentype.js), runtime integration (Web Workers, Three.js), format adapters (SVG/DXF parsing, OBJ/glTF/3MF export formatting), color/material storage (`colorFns.ts`, stays in TS unless the kernel adds native per-shape color), package distribution.
 
 **Boundary**: Data crosses the `KernelAdapter` as numeric parameters, coordinate arrays, and `ArrayBuffer` in; opaque shape handles, vertex/index buffers, measurement scalars, and serialized bytes out. brepjs never interprets handle internals. brepkit never knows about branded types or disposal scopes.
 
@@ -62,11 +62,11 @@ brepkit should expose coarse-grained operations when profiling shows a common wo
 
 Each phase targets TypeScript code that evaluates geometry or reimplements kernel capabilities.
 
-### Phase 1: Pure-TS 2D Math (target: v12) — ✅ Complete
+### Phase 1: Pure-TS 2D Math (target: v12), ✅ Complete
 
-**Target**: `src/2d/lib/vectorOperations.ts`, `src/2d/lib/precision.ts`, `src/2d/lib/utils.ts` — pure TS math (`samePoint`, `add2d`, `distance2d`, `crossProduct2d`, etc.) duplicating brepkit-math.
+**Target**: `src/2d/lib/vectorOperations.ts`, `src/2d/lib/precision.ts`, `src/2d/lib/utils.ts`: pure TS math (`samePoint`, `add2d`, `distance2d`, `crossProduct2d`, etc.) duplicating brepkit-math.
 
-**Not in scope**: `Curve2D.ts` and `BoundingBox2d.ts` (wrapper classes around kernel handles, not duplicated computation). Blueprint DSL (orchestration, brepjs-owned) — migration replaces lib function _implementations_ with kernel calls, not the TS API surface.
+**Not in scope**: `Curve2D.ts` and `BoundingBox2d.ts` (wrapper classes around kernel handles, not duplicated computation). Blueprint DSL (orchestration, brepjs-owned). Migration replaces lib function _implementations_ with kernel calls, not the TS API surface.
 
 **Existing infrastructure**: The `Kernel2D` sub-interface (`src/kernel/kernel2dTypes.ts`) and brepkit implementation (`src/kernel/brepkit2d.ts`) already exist. `BoundingBox2d.ts` already uses `getKernel2D()`. This migration extends that infrastructure, not creates it from scratch.
 
@@ -76,11 +76,11 @@ Each phase targets TypeScript code that evaluates geometry or reimplements kerne
 
 - v11: Consolidated `Point2D` type, 13 vector functions, and 3 precision constants into canonical `src/utils/vec2d.ts` (Layer 0). `vectorOperations.ts`, `precision.ts`, and `definitions.ts` re-export from canonical source. (#422)
 - v11: V8 CPU profiling confirmed all 13 vectorOperations functions are hot-path (~0.02µs/call); WASM call overhead would dominate computation cost. All functions retained in TS under the hot-path exception. (#421)
-- v11: Documented `brepkit2d.ts` struct-field math duplication as architectural — inline `c.ox`/`c.dy` access avoids temporary tuple allocations.
+- v11: Documented `brepkit2d.ts` struct-field math duplication as architectural; inline `c.ox`/`c.dy` access avoids temporary tuple allocations.
 
 **Resolution**: All 13 functions qualify for the hot-path exception. No pure-TS geometry math remains that should migrate to kernel. Acceptance criteria met.
 
-### Phase 2: Tessellation Normals/UVs (target: v12) — ✅ Complete
+### Phase 2: Tessellation Normals/UVs (target: v12), ✅ Complete
 
 **Target**: OCCT mesh path in `src/kernel/meshOps.ts` that builds normals via low-level OCCT API orchestration (`Poly_Connect`, `StdPrs_ToolTriangulatedShape.Normal()`). brepkit already returns normals/UVs. Migrate the OCCT adapter to a single higher-level call matching brepkit's interface.
 
@@ -91,18 +91,18 @@ Each phase targets TypeScript code that evaluates geometry or reimplements kerne
 **Progress**:
 
 - v11: extracted per-face mesh logic into `_meshFace()` helper, isolating normal computation into a single function mirroring brepkit's `meshSingleFace()`. (#426)
-- v12: **BREAKING** — removed JS mesh fallback entirely (`meshJS`, `_meshFace`, `meshEdgesJS`, UV detection cache). C++ `MeshExtractor`/`EdgeMeshExtractor` are now required. All normal/UV computation happens in C++ via single WASM calls. Net -440 lines. (#429)
+- v12: **BREAKING**: removed JS mesh fallback entirely (`meshJS`, `_meshFace`, `meshEdgesJS`, UV detection cache). C++ `MeshExtractor`/`EdgeMeshExtractor` are now required. All normal/UV computation happens in C++ via single WASM calls. Net -440 lines. (#429)
 
 ### Phase 3: Ongoing Boundary Cleanup
 
-- **Projection**: `projectionPlanes.ts` is pure data/type definitions (lookup table, type guard) — stays in TS. `cameraFns.ts` (~110 lines) performs 3D vector math for view setup — evaluated against heuristic: stays in TS (pure coordinate math on Vec3 tuples, no topology/geometry, no WASM benefit). Citation added in v11 (#427).
+- **Projection**: `projectionPlanes.ts` is pure data/type definitions (lookup table, type guard); stays in TS. `cameraFns.ts` (~110 lines) performs 3D vector math for view setup; evaluated against heuristic: stays in TS (pure coordinate math on Vec3 tuples, no topology/geometry, no WASM benefit). Citation added in v11 (#427).
 - **Color storage**: Migrate from TS-side `Map` to kernel storage if brepkit adds native per-shape color.
 - **New capabilities**: Evaluate against decision heuristic before implementation.
 
-### Phase 4: OCCT Adapter Alignment (Ongoing) — ✅ Complete
+### Phase 4: OCCT Adapter Alignment (Ongoing), ✅ Complete
 
-- Core operations (booleans, extrude, fillet, measurement, IO) — OCCT adapter must implement.
-- New `KernelAdapter` methods after migration — OCCT adapter may throw "capability not supported" `BrepError`.
+- Core operations (booleans, extrude, fillet, measurement, IO): OCCT adapter must implement.
+- New `KernelAdapter` methods after migration: OCCT adapter may throw "capability not supported" `BrepError`.
 - `TEST_KERNEL` dual-test matrix continues. brepkit-only tests use `describe.skipIf(kernel === 'occt')`.
 
 **Progress (v11)**:
@@ -134,18 +134,18 @@ For each capability:
 ### Positive
 
 - Clear ownership via decision heuristic
-- Single source of truth for geometry/math — no more duplicated implementations
+- Single source of truth for geometry/math: no more duplicated implementations
 - Numerically intensive code runs in optimized Rust/WASM
 - Each domain testable independently
 
 ### Negative / Trade-offs
 
-- **Migration effort** — Phase 1 touches ~15 files; Blueprint imports must be preserved
-- **Debugging friction** — WASM is harder to debug in browser devtools than TypeScript
-- **WASM boundary overhead** — Fine-grained operations may be slower via WASM; profile before migrating hot paths
-- **Kernel coupling** — brepjs becomes more dependent on brepkit's release cadence
-- **OCCT divergence** — As brepkit gains capabilities OCCT doesn't implement, the dual-kernel promise weakens
-- **Strategic bet** — Declaring brepkit as the strategic kernel narrows optionality
+- **Migration effort**: Phase 1 touches ~15 files; Blueprint imports must be preserved
+- **Debugging friction**: WASM is harder to debug in browser devtools than TypeScript
+- **WASM boundary overhead**: Fine-grained operations may be slower via WASM; profile before migrating hot paths
+- **Kernel coupling**: brepjs becomes more dependent on brepkit's release cadence
+- **OCCT divergence**: As brepkit gains capabilities OCCT doesn't implement, the dual-kernel promise weakens
+- **Strategic bet**: Declaring brepkit as the strategic kernel narrows optionality
 
 ## Alternatives Considered
 
@@ -181,52 +181,52 @@ The only OCCT gap is `gridPattern?` (optional, brepkit-exclusive). Neither adapt
 
 ### Behavioral Differences
 
-| Category        | Method(s)                      | OCCT Behavior                                                    | brepkit Behavior                                                                                                                                                   | Impact                                                               |
-| --------------- | ------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| **Booleans**    | `fuse`, `cut`, `intersect`     | Accepts `BooleanOptions` with configurable tolerance             | Ignores tolerance parameters (fixed internal handling)                                                                                                             | Low — default tolerances work for typical use                        |
-| **Booleans**    | `fuse`, `cut` (compound tools) | Direct operation                                                 | Iteratively decomposes compound tools into child solids                                                                                                            | Medium — may produce different topology for compound inputs          |
-| **Booleans**    | `section`                      | Native section with approximation parameter                      | Extracts plane from face geometry; ignores approximation                                                                                                           | Low — different algorithm, same geometric result                     |
-| **Fillet**      | `fillet`                       | Full variable-radius support (array of radii)                    | Constant radius only (takes first element of array); `filletVariable` WASM API available                                                                           | Medium — adapter still uses constant fallback                        |
-| **Fillet**      | `fillet` (validation)          | Fillet results pass `BRepCheck_Analyzer`                         | `validateSolidRelaxed()` accepts fillet results; strict `validateSolid()` reports NURBS artifacts                                                                  | Low — `isValid()` now returns true (relaxed mode)                    |
-| **Chamfer**     | `chamfer`                      | Two-distance chamfer support                                     | Constant distance only (drops second distance)                                                                                                                     | Medium — asymmetric chamfers silently degrade                        |
-| **Chamfer**     | `chamferDistAngle`             | Native dist-angle support                                        | Approximates via `d2 = d * tan(angle)`, then averages                                                                                                              | Medium — approximation may diverge for steep angles                  |
-| **Shell**       | `shell`                        | Direct face ID operation; passes validation                      | Face ID resolution with normal-matching fallback; `validateSolidRelaxed()` accepts results                                                                         | Low — `isValid()` now returns true (relaxed mode)                    |
-| **Meshing**     | `mesh`                         | Respects both `tolerance` and `angularTolerance`                 | Uses `tolerance` only; hardcoded `DEFAULT_DEFLECTION = 0.01`                                                                                                       | Low — slightly different tessellation density                        |
-| **Meshing**     | `meshEdges`                    | Uses both tolerance parameters; returns all topology edges       | Uses `meshEdgesAll` (unfiltered) for parity; `tolerance` only, enforces `Math.max(tol, 0.001)`                                                                     | Low — tolerance-only difference remains                              |
-| **Meshing**     | `hasTriangulation`             | Checks cached triangulation                                      | Always returns `false` (on-demand tessellation)                                                                                                                    | Low — behavioral, no geometric impact                                |
-| **Sweep**       | `loft`                         | Takes wires directly; supports `ruled`, `startShape`, `endShape` | Converts wires to faces; ignores `ruled`/`startShape`/`endShape`                                                                                                   | Medium — loft options silently ignored                               |
-| **Sweep**       | `sweep`                        | Native sweep with transition mode                                | Extracts NURBS data from spine; ignores `transitionMode`                                                                                                           | Medium — transition mode silently ignored                            |
-| **Transforms**  | `generalTransform`             | Uses OCCT transform objects                                      | Expects 16-element row-major matrix; throws for other inputs                                                                                                       | Low — consistent API, different internal representation              |
-| **Transforms**  | `mirror` (non-solid)           | Delegates all shapes to OCCT                                     | Solids: native `bk.mirror()`; non-solids: computed `mirrorMatrix()`                                                                                                | Low — same result, different code path                               |
-| **Validity**    | `isValid`                      | OCCT `BRepCheck_Analyzer` (strict geometry + topology check)     | `validateSolidRelaxed()` for general checks (tolerates NURBS artifacts); `validateSolid()` strict mode used only for `isManifoldShell` proof via `isValidStrict()` | Low — relaxed validation aligns with OCCT acceptance of NURBS shapes |
-| **Curves**      | `interpolatePoints`            | Configurable tolerance                                           | Fixed degree = min(3, n−1); ignores tolerance                                                                                                                      | Low                                                                  |
-| **Curves**      | `approximatePoints`            | OCCT approximation algorithm                                     | `approximateCurveLspia()` with hardcoded max_iter=100, degree=3                                                                                                    | Low                                                                  |
-| **Curves**      | `makeBezierEdge`               | Native Bezier representation                                     | Converts Bezier to NURBS (degree=n−1, uniform knots)                                                                                                               | Low — mathematically equivalent                                      |
-| **Curves**      | `makeTangentArc`               | Native tangent-arc construction                                  | Approximates as cubic Bezier with control points at 1/3 distance                                                                                                   | Medium — approximation diverges for large arcs                       |
-| **I/O**         | `toBREP` / `fromBREP`          | OCCT's native BREP format                                        | Proxies to STEP export/import (not OCCT BREP format). Native `toBREP` exists but returns JSON, not compatible with OCCT format                                     | High — format mismatch, round-trip not cross-kernel compatible       |
-| **I/O**         | STEP/STL export (multi-shape)  | Native multi-shape export                                        | Exports each solid individually and concatenates                                                                                                                   | Low — same result, different implementation                          |
-| **Measurement** | `volume`, `area`               | OCCT native measurement                                          | Uses `DEFAULT_DEFLECTION = 0.01` for tessellation-based measurement                                                                                                | Low — slight numerical differences expected                          |
+| Category        | Method(s)                      | OCCT Behavior                                                    | brepkit Behavior                                                                                                                                                   | Impact                                                              |
+| --------------- | ------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| **Booleans**    | `fuse`, `cut`, `intersect`     | Accepts `BooleanOptions` with configurable tolerance             | Ignores tolerance parameters (fixed internal handling)                                                                                                             | Low: default tolerances work for typical use                        |
+| **Booleans**    | `fuse`, `cut` (compound tools) | Direct operation                                                 | Iteratively decomposes compound tools into child solids                                                                                                            | Medium: may produce different topology for compound inputs          |
+| **Booleans**    | `section`                      | Native section with approximation parameter                      | Extracts plane from face geometry; ignores approximation                                                                                                           | Low: different algorithm, same geometric result                     |
+| **Fillet**      | `fillet`                       | Full variable-radius support (array of radii)                    | Constant radius only (takes first element of array); `filletVariable` WASM API available                                                                           | Medium: adapter still uses constant fallback                        |
+| **Fillet**      | `fillet` (validation)          | Fillet results pass `BRepCheck_Analyzer`                         | `validateSolidRelaxed()` accepts fillet results; strict `validateSolid()` reports NURBS artifacts                                                                  | Low: `isValid()` now returns true (relaxed mode)                    |
+| **Chamfer**     | `chamfer`                      | Two-distance chamfer support                                     | Constant distance only (drops second distance)                                                                                                                     | Medium: asymmetric chamfers silently degrade                        |
+| **Chamfer**     | `chamferDistAngle`             | Native dist-angle support                                        | Approximates via `d2 = d * tan(angle)`, then averages                                                                                                              | Medium: approximation may diverge for steep angles                  |
+| **Shell**       | `shell`                        | Direct face ID operation; passes validation                      | Face ID resolution with normal-matching fallback; `validateSolidRelaxed()` accepts results                                                                         | Low: `isValid()` now returns true (relaxed mode)                    |
+| **Meshing**     | `mesh`                         | Respects both `tolerance` and `angularTolerance`                 | Uses `tolerance` only; hardcoded `DEFAULT_DEFLECTION = 0.01`                                                                                                       | Low: slightly different tessellation density                        |
+| **Meshing**     | `meshEdges`                    | Uses both tolerance parameters; returns all topology edges       | Uses `meshEdgesAll` (unfiltered) for parity; `tolerance` only, enforces `Math.max(tol, 0.001)`                                                                     | Low: tolerance-only difference remains                              |
+| **Meshing**     | `hasTriangulation`             | Checks cached triangulation                                      | Always returns `false` (on-demand tessellation)                                                                                                                    | Low: behavioral, no geometric impact                                |
+| **Sweep**       | `loft`                         | Takes wires directly; supports `ruled`, `startShape`, `endShape` | Converts wires to faces; ignores `ruled`/`startShape`/`endShape`                                                                                                   | Medium: loft options silently ignored                               |
+| **Sweep**       | `sweep`                        | Native sweep with transition mode                                | Extracts NURBS data from spine; ignores `transitionMode`                                                                                                           | Medium: transition mode silently ignored                            |
+| **Transforms**  | `generalTransform`             | Uses OCCT transform objects                                      | Expects 16-element row-major matrix; throws for other inputs                                                                                                       | Low: consistent API, different internal representation              |
+| **Transforms**  | `mirror` (non-solid)           | Delegates all shapes to OCCT                                     | Solids: native `bk.mirror()`; non-solids: computed `mirrorMatrix()`                                                                                                | Low: same result, different code path                               |
+| **Validity**    | `isValid`                      | OCCT `BRepCheck_Analyzer` (strict geometry + topology check)     | `validateSolidRelaxed()` for general checks (tolerates NURBS artifacts); `validateSolid()` strict mode used only for `isManifoldShell` proof via `isValidStrict()` | Low: relaxed validation aligns with OCCT acceptance of NURBS shapes |
+| **Curves**      | `interpolatePoints`            | Configurable tolerance                                           | Fixed degree = min(3, n−1); ignores tolerance                                                                                                                      | Low                                                                 |
+| **Curves**      | `approximatePoints`            | OCCT approximation algorithm                                     | `approximateCurveLspia()` with hardcoded max_iter=100, degree=3                                                                                                    | Low                                                                 |
+| **Curves**      | `makeBezierEdge`               | Native Bezier representation                                     | Converts Bezier to NURBS (degree=n−1, uniform knots)                                                                                                               | Low: mathematically equivalent                                      |
+| **Curves**      | `makeTangentArc`               | Native tangent-arc construction                                  | Approximates as cubic Bezier with control points at 1/3 distance                                                                                                   | Medium: approximation diverges for large arcs                       |
+| **I/O**         | `toBREP` / `fromBREP`          | OCCT's native BREP format                                        | Proxies to STEP export/import (not OCCT BREP format). Native `toBREP` exists but returns JSON, not compatible with OCCT format                                     | High: format mismatch, round-trip not cross-kernel compatible       |
+| **I/O**         | STEP/STL export (multi-shape)  | Native multi-shape export                                        | Exports each solid individually and concatenates                                                                                                                   | Low: same result, different implementation                          |
+| **Measurement** | `volume`, `area`               | OCCT native measurement                                          | Uses `DEFAULT_DEFLECTION = 0.01` for tessellation-based measurement                                                                                                | Low: slight numerical differences expected                          |
 
 ### Resolved in v0.10.0–v1.0.8 (previously listed)
 
 These differences existed in brepkit-wasm v0.7.3 but have been resolved:
 
-- **Validity: primitives** — `validateSolid()` no longer reports false negatives for cylinders, cones, tori, and spheres. Primitives now pass validation.
-- **Validity: booleans** — `fuse`, `intersect`, `fuseAll` results now pass validation. `cut` and `cutAll` results pass in most cases.
-- **Validity: fillets/shells** — `validateSolidRelaxed()` (v0.10.1) tolerates NURBS approximation artifacts on fillet and shell results. `isValid()` now returns true for these shapes, matching OCCT behavior.
-- **Chamfer: validation** — chamfer and `chamferDistAngle` results now pass validation.
-- **Meshing: smooth-edge filtering** — brepkit-wasm v1.0.8 changed `meshEdges` to auto-filter smooth edges (tangent-continuous edges along fillets/rounds). Adapter switched to `meshEdgesAll` (unfiltered) to restore OCCT parity. Filtered `meshEdges` remains available in brepkit for future use.
+- **Validity: primitives**: `validateSolid()` no longer reports false negatives for cylinders, cones, tori, and spheres. Primitives now pass validation.
+- **Validity: booleans**: `fuse`, `intersect`, `fuseAll` results now pass validation. `cut` and `cutAll` results pass in most cases.
+- **Validity: fillets/shells**: `validateSolidRelaxed()` (v0.10.1) tolerates NURBS approximation artifacts on fillet and shell results. `isValid()` now returns true for these shapes, matching OCCT behavior.
+- **Chamfer: validation**: chamfer and `chamferDistAngle` results now pass validation.
+- **Meshing: smooth-edge filtering**: brepkit-wasm v1.0.8 changed `meshEdges` to auto-filter smooth edges (tangent-continuous edges along fillets/rounds). Adapter switched to `meshEdgesAll` (unfiltered) to restore OCCT parity. Filtered `meshEdges` remains available in brepkit for future use.
 
 ### Key Takeaways
 
-1. **No missing capabilities** — both adapters implement the full interface. Gaps are behavioral, not functional.
-2. **Tolerance divergence** — brepkit generally ignores caller-provided tolerances in favor of hardcoded defaults. This is the most pervasive difference.
-3. **Silent degradation** — variable-radius fillet, asymmetric chamfer, loft options, and sweep transition modes silently fall back to simpler behavior on brepkit. Warnings are emitted via `warnOnce()`.
-4. **Validation divergence** — brepkit now uses a two-tier strategy: `validateSolidRelaxed()` for general `isValid()` checks (accepts NURBS approximation artifacts, matching OCCT behavior) and `validateSolid()` strict mode for `isManifoldShell` proofs via the optional `isValidStrict()` adapter method. This resolves most false negatives from v0.7.3–v0.10.0.
-5. **BREP format** — `toBREP`/`fromBREP` are not cross-kernel compatible. brepkit has a native `toBREP` (JSON format) but the adapter still uses STEP proxy for round-trip compatibility.
+1. **No missing capabilities**: both adapters implement the full interface. Gaps are behavioral, not functional.
+2. **Tolerance divergence**: brepkit generally ignores caller-provided tolerances in favor of hardcoded defaults. This is the most pervasive difference.
+3. **Silent degradation**: variable-radius fillet, asymmetric chamfer, loft options, and sweep transition modes silently fall back to simpler behavior on brepkit. Warnings are emitted via `warnOnce()`.
+4. **Validation divergence**: brepkit now uses a two-tier strategy: `validateSolidRelaxed()` for general `isValid()` checks (accepts NURBS approximation artifacts, matching OCCT behavior) and `validateSolid()` strict mode for `isManifoldShell` proofs via the optional `isValidStrict()` adapter method. This resolves most false negatives from v0.7.3–v0.10.0.
+5. **BREP format**: `toBREP`/`fromBREP` are not cross-kernel compatible. brepkit has a native `toBREP` (JSON format) but the adapter still uses STEP proxy for round-trip compatibility.
 
 ## Related
 
-- [ADR-0001](./0001-layered-architecture.md) — Layered architecture
-- [ADR-0002](./0002-kernel-abstraction.md) — Pluggable kernel abstraction (this ADR narrows the strategic direction)
-- [ADR-0003](./0003-branded-types.md), [ADR-0004](./0004-phantom-dimension-types.md), [ADR-0005](./0005-topological-validity-types.md) — Type system (brepjs-owned)
+- [ADR-0001](./0001-layered-architecture.md): Layered architecture
+- [ADR-0002](./0002-kernel-abstraction.md): Pluggable kernel abstraction (this ADR narrows the strategic direction)
+- [ADR-0003](./0003-branded-types.md), [ADR-0004](./0004-phantom-dimension-types.md), [ADR-0005](./0005-topological-validity-types.md): Type system (brepjs-owned)

--- a/docs/decisions/0007-kernel-interface-segregation.md
+++ b/docs/decisions/0007-kernel-interface-segregation.md
@@ -17,7 +17,7 @@ Principle (ISP):
 - **Cognitive overhead**: New contributors faced a 900-line interface with no domain
   grouping beyond inline comments.
 - **Documentation**: JSDoc for cross-kernel behavioral differences (22 items from
-  ADR-0006 Appendix A) had no structural home — notes floated between unrelated methods.
+  ADR-0006 Appendix A) had no structural home; notes floated between unrelated methods.
 - **Partial implementations**: A future lightweight kernel (e.g., measurement-only or
   mesh-only) would be forced to stub hundreds of irrelevant methods.
 - **OCCT alignment**: OCCT itself organizes into modular packages (BRepAlgoAPI,
@@ -78,7 +78,7 @@ export type KernelAdapter = KernelCore &
 ```
 src/kernel/
   interfaces/
-    index.ts          # Barrel — composes KernelAdapter, re-exports all
+    index.ts          # Barrel - composes KernelAdapter, re-exports all
     core.ts           # KernelCore
     boolean-ops.ts    # KernelBooleanOps
     construction-ops.ts
@@ -154,8 +154,8 @@ it doesn't enable partial implementations or sub-interface-level type narrowing.
 
 ## Related
 
-- ADR-0002: Kernel Abstraction — established the KernelAdapter pattern
-- ADR-0006: Domain Boundaries — documented 22 cross-kernel behavioral differences
+- ADR-0002: Kernel Abstraction, established the KernelAdapter pattern
+- ADR-0006: Domain Boundaries, documented 22 cross-kernel behavioral differences
   that informed sub-interface JSDoc
 - OCCT package structure: BRepAlgoAPI, BRepPrimAPI, BRepFilletAPI, BRepOffsetAPI,
   GProp, BRepBndLib, TopExp, BRep_Tool, ShapeFix

--- a/docs/decisions/0008-layer1-core-audit.md
+++ b/docs/decisions/0008-layer1-core-audit.md
@@ -8,11 +8,11 @@
 Layer 1 (`src/core/`) had grown to 15 files / 2,316 LOC with several structural concerns:
 
 1. **shapeTypes.ts** (479 LOC) mixed three concerns from ADR-0003 (branded types), ADR-0004 (phantom dimensions), and ADR-0005 (validity brands).
-2. **ValidityResult<T>** used `{ valid, shape }` / `{ valid, reason }` — incompatible with the project-standard `Result<T, E>` pattern.
+2. **ValidityResult<T>** used `{ valid, shape }` / `{ valid, reason }`, incompatible with the project-standard `Result<T, E>` pattern.
 3. **geometryHelpers.ts** mixed pure functions with kernel calls (layer boundary smell).
 4. **memory.ts** was a pure re-export hub adding indirection over disposal.ts.
 5. **errors.ts** bundled type definitions with OCCT-specific regex translation logic.
-6. **definitionMaps.ts** was under-scoped — only handled CurveType while getShapeKind lived elsewhere.
+6. **definitionMaps.ts** was under-scoped: only handled CurveType while getShapeKind lived elsewhere.
 7. **is2D()/is3D()** type guards checked a `__is2D` runtime marker that was never set.
 8. No resource tracking capability for debugging WASM memory leaks.
 9. `Result<T,E>` missing `flatten()` and `mapBoth()` combinators.
@@ -25,9 +25,9 @@ Address all findings via nine incremental PRs, each independently verifiable:
 
 ### PR 1: Split shapeTypes.ts into 3 files
 
-- `dimensionTypes.ts` — ADR-0004 dimension types + absorbed `typeErrors.ts`
-- `validityTypes.ts` — ADR-0005 validity brands, type guards, smart constructors
-- `shapeTypes.ts` — slimmed to branded types + re-exports for backward compat
+- `dimensionTypes.ts`: ADR-0004 dimension types + absorbed `typeErrors.ts`
+- `validityTypes.ts`: ADR-0005 validity brands, type guards, smart constructors
+- `shapeTypes.ts`: slimmed to branded types + re-exports for backward compat
 
 ### PR 2: Unify ValidityResult with Result<T, string>
 
@@ -48,7 +48,7 @@ Address all findings via nine incremental PRs, each independently verifiable:
 ### PR 5: Add DisposalStats for WASM memory debugging
 
 - `DisposalStats` interface with live/peak/gc/scope counters
-- `getDisposalStats()` / `resetDisposalStats()` — zero overhead when not called
+- `getDisposalStats()` / `resetDisposalStats()`: zero overhead when not called
 
 ### PR 6: Implement \_\_is2D runtime markers
 
@@ -58,9 +58,9 @@ Address all findings via nine incremental PRs, each independently verifiable:
 
 ### PR 7: Add Result.flatten + Result.mapBoth + normalize2d
 
-- `flatten()` — unwraps `Result<Result<T,E>,E>`
-- `mapBoth()` — maps both Ok and Err in one pass
-- `normalize2d()` in `vec2d.ts` — fills the Layer 0 gap
+- `flatten()`: unwraps `Result<Result<T,E>,E>`
+- `mapBoth()`: maps both Ok and Err in one pass
+- `normalize2d()` in `vec2d.ts`: fills the Layer 0 gap
 
 ### PR 8: Export kernel sub-interfaces from public API
 
@@ -88,11 +88,11 @@ Address all findings via nine incremental PRs, each independently verifiable:
 
 ### Keep shapeTypes.ts as a monolith
 
-Rejected — 479 LOC mixing three ADR concerns makes each concern harder to reason about independently.
+Rejected: 479 LOC mixing three ADR concerns makes each concern harder to reason about independently.
 
 ### Use a separate `ValidityResult` pattern alongside `Result`
 
-Rejected — two incompatible discriminated union patterns for the same purpose creates unnecessary cognitive load and prevents using `Result` combinators on validity proofs.
+Rejected: two incompatible discriminated union patterns for the same purpose creates unnecessary cognitive load and prevents using `Result` combinators on validity proofs.
 
 ## Related
 

--- a/docs/decisions/0009-tolerance-as-type-parameter.md
+++ b/docs/decisions/0009-tolerance-as-type-parameter.md
@@ -7,9 +7,9 @@
 
 Geometric computations in brepjs implicitly assume a global tolerance (typically 1e-6 for points, 1e-7 for curves). This works for single-kernel usage but creates subtle bugs when:
 
-1. **Cross-kernel operations** — OCCT and brepkit may use different internal precisions
-2. **Multi-scale models** — a chip package (microns) and a building (meters) in the same scene
-3. **Round-trip degradation** — STEP export/import can shift vertices by kernel tolerance
+1. **Cross-kernel operations**: OCCT and brepkit may use different internal precisions
+2. **Multi-scale models**: a chip package (microns) and a building (meters) in the same scene
+3. **Round-trip degradation**: STEP export/import can shift vertices by kernel tolerance
 
 CGAL addresses this with an _exact arithmetic kernel_ (`Exact_predicates_exact_constructions_kernel`). OpenCASCADE uses `Precision::Confusion()` globally. Neither approach fits a TypeScript CAD library well, but CGAL's kernel-parameterized types offer an interesting model.
 
@@ -18,7 +18,7 @@ CGAL addresses this with an _exact arithmetic kernel_ (`Exact_predicates_exact_c
 **Explore** (not commit to) encoding tolerance in the type system:
 
 ```typescript
-// Conceptual — NOT a shipping API
+// Conceptual - NOT a shipping API
 interface Tolerance {
   readonly point: number;
   readonly curve: number;
@@ -34,17 +34,17 @@ This ADR documents the vision and open questions. Implementation would be a sepa
 
 ## Open Questions
 
-1. **Ergonomics** — Does a `T extends Tolerance` parameter on every shape type create too much noise for the 99% case?
-2. **Runtime enforcement** — How do we prevent mixing shapes with different tolerances? Phantom brand (like `__dim`) or runtime check?
-3. **Kernel mapping** — Can we map brepjs tolerance to OCCT's `Precision::Confusion()` and brepkit's internal tolerance at adapter boundary?
-4. **Migration path** — Can we default `T = DefaultTolerance` so existing code is unaffected?
-5. **Performance** — Does tolerance-aware comparison (`samePoint(a, b, tol)` vs `samePoint(a, b)`) have measurable overhead in hot paths?
+1. **Ergonomics**: Does a `T extends Tolerance` parameter on every shape type create too much noise for the 99% case?
+2. **Runtime enforcement**: How do we prevent mixing shapes with different tolerances? Phantom brand (like `__dim`) or runtime check?
+3. **Kernel mapping**: Can we map brepjs tolerance to OCCT's `Precision::Confusion()` and brepkit's internal tolerance at adapter boundary?
+4. **Migration path**: Can we default `T = DefaultTolerance` so existing code is unaffected?
+5. **Performance**: Does tolerance-aware comparison (`samePoint(a, b, tol)` vs `samePoint(a, b)`) have measurable overhead in hot paths?
 
 ## Risks
 
-- **Type complexity** — Adding a second phantom parameter increases the already-complex branded type system
-- **WASM boundary** — Kernel tolerance is set globally in OCCT; per-shape tolerance would require kernel-side changes
-- **Diminishing returns** — Most brepjs users work at a single scale with a single kernel
+- **Type complexity**: Adding a second phantom parameter increases the already-complex branded type system
+- **WASM boundary**: Kernel tolerance is set globally in OCCT; per-shape tolerance would require kernel-side changes
+- **Diminishing returns**: Most brepjs users work at a single scale with a single kernel
 
 ## Related
 

--- a/docs/decisions/0010-layer2-domain-audit.md
+++ b/docs/decisions/0010-layer2-domain-audit.md
@@ -11,9 +11,9 @@ Layer 2 (`topology/`, `operations/`, `2d/`, `query/`, `measurement/`, `io/`, `wo
 2. **Metadata propagation** (~20 lines of tag/color/origin propagation) duplicated across booleanFns, modifierFns, and shapeFns.
 3. **Legacy OO wrappers** (extrude.ts, loft.ts) duplicated their \*Fns.ts functional equivalents.
 4. **compoundOpsFns.ts** lived in topology/ but imported from operations/ (architecturally backwards).
-5. **Sweep files fragmented** — sweep logic split across extrudeFns, multiSweepFns, guidedSweepFns.
+5. **Sweep files fragmented**: sweep logic split across extrudeFns, multiSweepFns, guidedSweepFns.
 6. **Query finders** (edge, face, wire) near-identical but in 3 separate files, lacking composition operators.
-7. **Validity type gaps** — Wire→ClosedWire missing in sweep/supportExtrude/roof, Face→OrientedFace missing in measureCurvatureAt.
+7. **Validity type gaps**: Wire→ClosedWire missing in sweep/supportExtrude/roof, Face→OrientedFace missing in measureCurvatureAt.
 8. **topology/index.ts** leaked core types (AnyShape, Shape3D, CurveLike).
 
 ## Decision
@@ -22,9 +22,9 @@ Layer 2 (`topology/`, `operations/`, `2d/`, `query/`, `measurement/`, `io/`, `wo
 
 New `src/topology/metadataPropagation.ts` centralizes:
 
-- `collectInputFaceHashes()` — unified O(1) fast-path check
-- `propagateAllMetadata()` — calls origins + tags + colors propagation
-- `propagateMetadataByHash()` — hash-only fallback
+- `collectInputFaceHashes()`: unified O(1) fast-path check
+- `propagateAllMetadata()`: calls origins + tags + colors propagation
+- `propagateMetadataByHash()`: hash-only fallback
 
 Transforms now propagate all three metadata types (previously only origins).
 
@@ -32,10 +32,10 @@ Transforms now propagate all three metadata types (previously only origins).
 
 753 LOC → 4 focused files:
 
-- `transformFns.ts` — translate, rotate, scale, mirror, applyMatrix, composeTransforms
-- `topologyQueryFns.ts` — getEdges/getFaces/getWires/getVertices, iterators, getBounds, describe
-- `originTrackingFns.ts` — setShapeOrigin, getFaceOrigins, propagation functions
-- `shapeFns.ts` — identity/introspection (clone, toBREP, getHashCode) + re-exports
+- `transformFns.ts`: translate, rotate, scale, mirror, applyMatrix, composeTransforms
+- `topologyQueryFns.ts`: getEdges/getFaces/getWires/getVertices, iterators, getBounds, describe
+- `originTrackingFns.ts`: setShapeOrigin, getFaceOrigins, propagation functions
+- `shapeFns.ts`: identity/introspection (clone, toBREP, getHashCode) + re-exports
 
 ### Sweep consolidation + validity types (PR 3)
 

--- a/docs/decisions/0011-geometric-validity-brands.md
+++ b/docs/decisions/0011-geometric-validity-brands.md
@@ -5,11 +5,11 @@
 
 ## Context
 
-ADR-0005 introduced topological validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`) — phantom types encoding properties like "wire is closed" or "solid passes BRepCheck". These are _topological_ invariants: they describe connectivity and validity, not geometry.
+ADR-0005 introduced topological validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`): phantom types encoding properties like "wire is closed" or "solid passes BRepCheck". These are _topological_ invariants: they describe connectivity and validity, not geometry.
 
 Several operations have _geometric_ preconditions that aren't captured by topological brands:
 
-- `face(w)` / `makeFace(w)` require a **planar** wire — non-planar wires produce corrupt faces with the error "Your wire might be non planar"
+- `face(w)` / `makeFace(w)` require a **planar** wire; non-planar wires produce corrupt faces with the error "Your wire might be non planar"
 - `extrude(face, vec)` documents "The **planar** face to extrude" but accepts any `OrientedFace`
 - `revolve(face, ...)` implicitly requires a planar face
 - `roof(w, ...)` projects wire to XY plane, assuming planarity
@@ -20,11 +20,11 @@ These failures are silent or produce cryptic WASM errors. The type system should
 
 Three candidates were evaluated:
 
-| Candidate                 | Runtime Check                    | Both Kernels? | Operations Protected                             | Verdict                                                                      |
-| ------------------------- | -------------------------------- | ------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
-| **PlanarFace/PlanarWire** | `surfaceType(face) === 'plane'`  | ✅ Yes        | `face`, `makeFace`, `extrude`, `revolve`, `roof` | ✅ Add                                                                       |
-| **ConnectedWire**         | Edge iteration + vertex matching | ⚠️ JS-only    | `sweep`, `loft`                                  | ❌ Skip — wires from API are connected by construction                       |
-| **NonSelfIntersecting**   | No detection API exists          | ❌ No         | Booleans, sweeps                                 | ❌ Skip — no cross-kernel detection; `ValidSolid` catches downstream effects |
+| Candidate                 | Runtime Check                    | Both Kernels? | Operations Protected                             | Verdict                                                                     |
+| ------------------------- | -------------------------------- | ------------- | ------------------------------------------------ | --------------------------------------------------------------------------- |
+| **PlanarFace/PlanarWire** | `surfaceType(face) === 'plane'`  | ✅ Yes        | `face`, `makeFace`, `extrude`, `revolve`, `roof` | ✅ Add                                                                      |
+| **ConnectedWire**         | Edge iteration + vertex matching | ⚠️ JS-only    | `sweep`, `loft`                                  | ❌ Skip: wires from API are connected by construction                       |
+| **NonSelfIntersecting**   | No detection API exists          | ❌ No         | Booleans, sweeps                                 | ❌ Skip: no cross-kernel detection; `ValidSolid` catches downstream effects |
 
 ## Decision
 
@@ -59,7 +59,7 @@ PlanarOrientedFace<D> = PlanarFace<D> & OrientedFace<D>
                       = Face<D> & { __planar } & { __oriented }
 ```
 
-No new combined types are defined — callers use `ClosedWire<D> & PlanarWire<D>` directly, or we provide a convenience alias `ClosedPlanarWire<D>` if usage warrants it.
+No new combined types are defined; callers use `ClosedWire<D> & PlanarWire<D>` directly, or we provide a convenience alias `ClosedPlanarWire<D>` if usage warrants it.
 
 ### Runtime Checks
 
@@ -118,21 +118,21 @@ Functions that produce known-planar shapes return branded types:
 - `makeFace(w)` → `Result<OrientedFace<D> & PlanarFace<D>>` (makeFace only succeeds on planar wires)
 - `face(w)` → `Result<OrientedFace & PlanarFace>` (delegates to makeFace)
 - `polygon(pts)` → `Result<OrientedFace & PlanarFace>` (polygon is always planar)
-- Primitives: `box()` faces, `cylinder()` end caps — these are internal, not user-facing
+- Primitives: `box()` faces, `cylinder()` end caps. These are internal, not user-facing
 
 ## Consequences
 
 ### Positive
 
 - **Compile-time planarity safety**: `face(w)` rejects non-planar wires at the type level
-- **Zero runtime overhead**: Brands are phantom — no wrapper objects
+- **Zero runtime overhead**: Brands are phantom, no wrapper objects
 - **Composable with existing brands**: `ClosedWire & PlanarWire` stacks naturally
 - **Cross-kernel**: `surfaceType()` works on both OCCT and brepkit
 - **Self-documenting**: `extrude(face: OrientedFace & PlanarFace)` is clearer than `extrude(face: OrientedFace)` + JSDoc
 
 ### Negative / Trade-offs
 
-- **Brand stacking verbosity**: `ClosedWire<'2D'> & PlanarWire<'2D'>` is getting long — may warrant a convenience alias
+- **Brand stacking verbosity**: `ClosedWire<'2D'> & PlanarWire<'2D'>` is getting long; may warrant a convenience alias
 - **Wire planarity check cost**: `isPlanarWire()` constructs a temporary face (~1 WASM alloc + dispose). Cheap but not free.
 - **Ergonomic friction**: Users calling `face()` must now prove planarity. Most wires from sketching are planar by construction, so internal code uses justified casts.
 - **Not all planarity is checkable**: A wire may have all-planar edges that don't share a common plane. The `makeFace` fallback catches this but is indirect.
@@ -141,7 +141,7 @@ Functions that produce known-planar shapes return branded types:
 
 ### A: `PlanarWire` only (no `PlanarFace`)
 
-Check planarity at wire level, don't brand faces. Rejected because `extrude` and `revolve` accept faces, not wires — branding only wires leaves these unprotected.
+Check planarity at wire level, don't brand faces. Rejected because `extrude` and `revolve` accept faces, not wires; branding only wires leaves these unprotected.
 
 ### B: Overloads instead of brands
 
@@ -149,11 +149,11 @@ Add `facePlanar(w)` / `faceNonPlanar(w)` as separate functions. Rejected because
 
 ### C: Runtime-only validation (no types)
 
-Keep `isPlanarWire()` as a boolean helper without branding. Rejected for the same reason as ADR-0005 Alternative B — callers can forget to check.
+Keep `isPlanarWire()` as a boolean helper without branding. Rejected for the same reason as ADR-0005 Alternative B: callers can forget to check.
 
 ## Related
 
 - ADR-0003: Branded types (foundation pattern)
 - ADR-0005: Topological validity types (extended here with geometric brands)
-- `src/core/validityTypes.ts` — implementation location
-- `src/kernel/interfaces/surfaceOps.ts` — `surfaceType()` capability
+- `src/core/validityTypes.ts`: implementation location
+- `src/kernel/interfaces/surfaceOps.ts`: `surfaceType()` capability

--- a/docs/decisions/0012-layer3-audit.md
+++ b/docs/decisions/0012-layer3-audit.md
@@ -7,110 +7,110 @@
 
 Layer 3 (`sketching/`, `text/`, `projection/`) had grown to 19 files / ~4,100 LOC
 without ever receiving the kind of audit applied to Layer 1 (ADR-0008) and
-Layer 2 (ADR-0010). A scan against the same lens — file-size outliers, mixed
+Layer 2 (ADR-0010). A scan against the same lens (file-size outliers, mixed
 concerns, duplicated logic, validity-type gaps, barrel leakage, layer-boundary
-violations, and OO/functional duplication — produced 12 findings.
+violations, and OO/functional duplication) produced 12 findings.
 
 ### Findings
 
-1. **F1 — Acknowledged layer boundary violation.** `2d/blueprints/cannedBlueprints.ts`
+1. **F1: Acknowledged layer boundary violation.** `2d/blueprints/cannedBlueprints.ts`
    imported `BlueprintSketcher` from `sketching/sketcher2d.ts` (Layer 2 → Layer 3).
    Whitelisted with a TODO in `scripts/check-layer-boundaries.sh`.
-2. **F2 — `sketcher2d.ts` (692 LOC) mixed three classes** with conflicting layer
+2. **F2: `sketcher2d.ts` (692 LOC) mixed three classes** with conflicting layer
    requirements: `BaseSketcher2d` (pure 2D), `BlueprintSketcher` (returns `Blueprint`,
    a Layer 2 type), `FaceSketcher` (returns `Sketch`, Layer 3).
-3. **F3 — `sketcherlib.ts` (564 LOC) mixed two concerns**: the public
+3. **F3: `sketcherlib.ts` (564 LOC) mixed two concerns**: the public
    `GenericSketcher<T>` interface and SVG elliptical-arc math helpers. The math
    was partially in `ellipseUtils.ts`, which then imported back from `sketcherlib`.
-4. **F4 — `draw.ts` (542 LOC) mixed three concerns**: the immutable `Drawing`
+4. **F4: `draw.ts` (542 LOC) mixed three concerns**: the immutable `Drawing`
    wrapper, the mutable `DrawingPen` builder, and 11 standalone factory functions.
-5. **F5 — `sketchFns.ts` and `drawFns.ts` were pure delegation shims** to class
+5. **F5: `sketchFns.ts` and `drawFns.ts` were pure delegation shims** to class
    methods. CLAUDE.md mandates new functionality goes in `*Fns.ts` files, but
    the implementation lived in classes.
-6. **F6 — 17 validity-brand casts across Layer 3.** Patterns like
+6. **F6: 17 validity-brand casts across Layer 3.** Patterns like
    `wire as ClosedWire & PlanarWire` and `face() as OrientedFace & PlanarFace`
    asserted runtime invariants the type system couldn't see.
-7. **F7 — `Sketches` return-type drift.** `Sketches.{wires,faces,extrude,revolve}`
+7. **F7: `Sketches` return-type drift.** `Sketches.{wires,faces,extrude,revolve}`
    returned `AnyShape` even though `makeCompound()` returns `Compound`.
-8. **F8 — Three small files with overlapping names**: `sketchLib.ts` (52 LOC,
+8. **F8: Three small files with overlapping names**: `sketchLib.ts` (52 LOC,
    only `SketchInterface`), `sketchUtils.ts` (23 LOC, two factories), and
    `sketches.ts` (67 LOC).
-9. **F9 — `drawingToSketchOnPlane` returned `any`** — the only public Layer 3
+9. **F9: `drawingToSketchOnPlane` returned `any`**: the only public Layer 3
    function with an `any` return, papered over with two eslint-disables.
-10. **F10 — `text/textBlueprints.ts` (304 LOC) mixed four concerns**: font
+10. **F10: `text/textBlueprints.ts` (304 LOC) mixed four concerns**: font
     registry, glyph→blueprint conversion, 3D text sketching, and font/text
     metrics. `text/` had only this one source file.
-11. **F11 — `text/` and `projection/` lacked subpath barrels**. Layer 2 exposed
+11. **F11: `text/` and `projection/` lacked subpath barrels**. Layer 2 exposed
     7 subpath modules (`brepjs/2d`, `brepjs/operations`, etc.); Layer 3 had only
     `brepjs/sketching`.
-12. **F12 — Implicit self-disposal.** `Sketch.{revolve,extrude,sweepSketch}`
+12. **F12: Implicit self-disposal.** `Sketch.{revolve,extrude,sweepSketch}`
     silently called `this.delete()` mid-method, but only `loftWith` documented it.
 
 ## Decision
 
 Address the findings via incremental PRs, each independently verifiable:
 
-### PR 1 — Add subpath barrels (F11)
+### PR 1: Add subpath barrels (F11)
 
 `src/text.ts` and `src/projection.ts` for `brepjs/text` and `brepjs/projection`
 imports, matching the seven existing Layer 2 subpath modules.
 
-### PR 2 — Replace `any` return in `drawingToSketchOnPlane` (F9)
+### PR 2: Replace `any` return in `drawingToSketchOnPlane` (F9)
 
 Type as `SketchInterface | Sketches`; runtime branch on `typeof inputPlane`
 to dispatch the overload.
 
-### PR 3 — Consolidate SVG ellipse math (F3)
+### PR 3: Consolidate SVG ellipse math (F3)
 
 Move `convertSvgEllipseParams`, `computeArcAngles`, `radianAngle` from
 `sketcherlib.ts` to `ellipseUtils.ts`. `sketcherlib.ts` becomes interface-only
 (564 → 415 LOC).
 
-### PR 4 — Fold `sketchLib` + `sketchUtils` into `sketch` + `sketchFns` (F8)
+### PR 4: Fold `sketchLib` + `sketchUtils` into `sketch` + `sketchFns` (F8)
 
 `SketchInterface` co-locates with the implementing class in `sketch.ts`;
 `wrapSketchData{,Array}` move into `sketchFns.ts`. Two files deleted.
 
-### PR 5 — Extract base sketchers to Layer 2 (F1 + F2)
+### PR 5: Extract base sketchers to Layer 2 (F1 + F2)
 
 Split `sketcher2d.ts` (692 LOC) into per-class files:
 
-- `src/2d/blueprints/baseSketcher2d.ts` — `BaseSketcher2d`
-- `src/2d/blueprints/blueprintSketcher.ts` — `BlueprintSketcher`
-- `src/sketching/faceSketcher.ts` — `FaceSketcher` (still Layer 3, returns `Sketch`)
+- `src/2d/blueprints/baseSketcher2d.ts`: `BaseSketcher2d`
+- `src/2d/blueprints/blueprintSketcher.ts`: `BlueprintSketcher`
+- `src/sketching/faceSketcher.ts`: `FaceSketcher` (still Layer 3, returns `Sketch`)
 
 Move `sketcherlib.ts` → `2d/blueprints/genericSketcher.ts` and
 `ellipseUtils.ts` → `2d/blueprints/ellipseUtils.ts`. Remove the boundary-checker
 whitelist.
 
-### PR 6 — Split `text/textBlueprints.ts` (F10)
+### PR 6: Split `text/textBlueprints.ts` (F10)
 
 Four focused files:
 
-- `fontRegistry.ts` — `loadFont`, `getFont`, FONT_REGISTER
-- `textBlueprints.ts` — `textBlueprints` + glyph conversion
-- `sketchText.ts` — 3D `sketchText`
-- `textMetrics.ts` — `textMetrics`, `fontMetrics`, result types
+- `fontRegistry.ts`: `loadFont`, `getFont`, FONT_REGISTER
+- `textBlueprints.ts`: `textBlueprints` + glyph conversion
+- `sketchText.ts`: 3D `sketchText`
+- `textMetrics.ts`: `textMetrics`, `fontMetrics`, result types
 
-### PR 7 — Split `draw.ts` (F4)
+### PR 7: Split `draw.ts` (F4)
 
 Three focused files:
 
-- `drawing.ts` — `Drawing` class + `deserializeDrawing`
-- `drawingPen.ts` — `DrawingPen` class + `draw()` factory
-- `drawingFactories.ts` — 10 canned drawing factories
+- `drawing.ts`: `Drawing` class + `deserializeDrawing`
+- `drawingPen.ts`: `DrawingPen` class + `draw()` factory
+- `drawingFactories.ts`: 10 canned drawing factories
 
-### PR 8 — Tighten `Sketches` return types + document consumption (F7 + F12)
+### PR 8: Tighten `Sketches` return types + document consumption (F7 + F12)
 
 `Sketches.{wires,faces,extrude,revolve}` typed as `Compound`. Added
-`@remarks Consumes the sketch — calling this twice throws on the second call.`
+`@remarks Consumes the sketch - calling this twice throws on the second call.`
 to `Sketch.{revolve,extrude,sweepSketch}`.
 
-### PR 9 — Initial ADR
+### PR 9: Initial ADR
 
 This document, in its initial form (findings + first 8 PRs).
 
-### PR 10 — Invert OO/Fns for Sketch (F5 part 1)
+### PR 10: Invert OO/Fns for Sketch (F5 part 1)
 
 Move the implementation bodies of `face`, `wires`, `revolve`, `extrude`,
 `sweepSketch`, and `loftWith` from `Sketch` class methods into `sketchFns.ts`.
@@ -118,19 +118,19 @@ Class methods become 1-line delegations. ESM circular import (`sketch.ts` ↔
 `sketchFns.ts`) is safe because all access happens at call time, not module
 evaluation.
 
-### PR 11 — Invert OO/Fns for CompoundSketch (F5 part 2)
+### PR 11: Invert OO/Fns for CompoundSketch (F5 part 2)
 
 Same inversion applied to `CompoundSketch`. The shell-generator helpers
 (`faceFromWires`, `guessFaceFromWires`, `fixWire`, `solidFromShellGenerator`)
 move into `sketchFns.ts`.
 
-### PR 12 — Tighten `Sketch.wire` to `ClosedWire & PlanarWire` (F6)
+### PR 12: Tighten `Sketch.wire` to `ClosedWire & PlanarWire` (F6)
 
 Promote `Sketch.wire` from `Wire` to `ClosedWire & PlanarWire`, reflecting
 the runtime invariant enforced by all sketcher boundaries. The 16 operation-
 side casts collapse; ~7 casts move to construction sites where the invariant
 is provable. Phantom-type parameter (`Sketch<W>`) was considered but rejected
-for type-system simplicity — the simpler tightening achieves most of the
+for type-system simplicity; the simpler tightening achieves most of the
 value with a clearer mental model.
 
 `Drawing` was deliberately not inverted in PR 11: its methods are mostly
@@ -139,7 +139,7 @@ necessitate exposing `innerShape` publicly (breaking encapsulation) for
 no real reduction in code size. `drawFns.ts` continues as a sugar layer
 for callers who prefer functional style.
 
-### PR 13 — This update
+### PR 13: This update
 
 ## Consequences
 
@@ -164,7 +164,7 @@ for callers who prefer functional style.
 
 - ESM circular import between `sketch.ts` and `sketchFns.ts` (and same for
   `compoundSketch.ts`). Works at runtime because all access happens inside
-  function bodies, but adds a small mental hazard for future refactors —
+  function bodies, but adds a small mental hazard for future refactors;
   watch for top-level reads of either module's exports during module
   evaluation.
 - ~7 casts at `new Sketch(...)` construction sites assert the wire is
@@ -180,12 +180,12 @@ for callers who prefer functional style.
 
 ### Single mega-PR
 
-Rejected — same reason as ADR-0008/ADR-0010. 8 incremental PRs let each finding
+Rejected: same reason as ADR-0008/ADR-0010. 8 incremental PRs let each finding
 land with focused review and bisectable history.
 
 ### Defer the boundary fix (F1) by leaving the whitelist
 
-Rejected — the whitelist comment said "TODO: fix by extracting BlueprintSketcher
+Rejected: the whitelist comment said "TODO: fix by extracting BlueprintSketcher
 into a shared module," and the fix was straightforward once `sketcher2d.ts` was
 ready to split anyway.
 
@@ -198,7 +198,7 @@ every `Sketch` reference, and (c) localises the runtime assertion to the few
 construction boundaries where the invariant is genuinely produced.
 
 A phantom-typed `Sketch<W extends Wire>` could be added later if FaceSketcher's
-non-planar case becomes a problem in practice — the current escape hatch is a
+non-planar case becomes a problem in practice; the current escape hatch is a
 single cast inside `FaceSketcher.done()`.
 
 ### Invert Drawing's OO/Fns relationship

--- a/docs/decisions/0013-voxel-domain.md
+++ b/docs/decisions/0013-voxel-domain.md
@@ -14,13 +14,13 @@ problems that fail across _all_ exact kernels (OCCT, brepkit), not as a tuning i
 - lattices / TPMS (gyroid, Schwarz, diamond) and graded infill,
 - organic / generative geometry, defeaturing, large-N CSG.
 
-A voxel / signed-distance-field (SDF) domain — the approach taken by PicoGK (C# → PicoGKRuntime
-C++ → OpenVDB) — solves these at the cost of exactness (resolution-bound, mesh output). This ADR
+A voxel / signed-distance-field (SDF) domain, the approach taken by PicoGK (C# → PicoGKRuntime
+C++ → OpenVDB), solves these at the cost of exactness (resolution-bound, mesh output). This ADR
 records the architecture so implementation (starting with a P0 spike) can proceed without open
 forks. **No code exists yet.** The broader plan lives in the project owner's design vault; this ADR
 is the in-repo decision record.
 
-Note: this is explicitly **not** a fix for the #1126 STEP-export crash — that is a build-specific
+Note: this is explicitly **not** a fix for the #1126 STEP-export crash; that is a build-specific
 `BOPAlgo` bug resolved by the #1136 migration that made `occt-wasm` the default kernel. A voxel engine cannot pass #1126's
 exact-STEP acceptance (exact faces, exact volume, valid STEP, Hausdorff≈0) by construction; #1126 is
 a _counter-example_ to "exact booleans are unreliable," not motivation for this work.
@@ -47,27 +47,27 @@ Every long-term capability is additive behind exactly one seam:
 | Contour | surface nets                                                  | manifold dual contouring                          | a `Contourer` seam; grid stores edge-crossing normals from day 1 |
 | Bridge  | voxel→mesh (`KernelMeshResult`)                               | brep→voxel, mesh→brep replay                      | shared mesh type + extracted replay helper                       |
 
-### 2. Paradigm & placement — parallel domain, NOT a `KernelAdapter`
+### 2. Paradigm & placement: parallel domain, NOT a `KernelAdapter`
 
 Voxel/SDF vocabulary does not fit `KernelAdapter`'s 14 B-rep sub-interfaces
 (`src/kernel/interfaces/index.ts`); the manifold adapter already `notImplemented()`-stubs much of
 that surface. The voxel domain is a **new top-level parallel domain** that does **not** register via
-`registerKernel`/`getKernel`/`withKernel`. (Note: `brepjs-manifold` _is_ a `KernelAdapter` —
-`registerKernel('manifold', adapter)`, `src/kernel/index.ts` — so a true parallel domain is a new
+`registerKernel`/`getKernel`/`withKernel`. (Note: `brepjs-manifold` _is_ a `KernelAdapter`,
+`registerKernel('manifold', adapter)`, `src/kernel/index.ts`, so a true parallel domain is a new
 pattern here, see ADR-0002, ADR-0007.)
 
-### 3. Context API — `getVoxel(id?)` mirroring `getKernel(id?)`
+### 3. Context API: `getVoxel(id?)` mirroring `getKernel(id?)`
 
 A parallel singleton registry: `registerVoxel(id, adapter)` / `getVoxel(id?)`. The optional `id`
 selector is the multi-module escape hatch (multiple grids / worker instances later), exactly as
 `getKernel(id?)` already scales to multiple kernels. No per-call handle threading (no repo
-precedent; would churn every Layer-2 signature). `withKernel`'s sync-only async pitfall applies —
+precedent; would churn every Layer-2 signature). `withKernel`'s sync-only async pitfall applies;
 async code uses `getVoxel(id)` directly.
 
-### 4. Representation — voxel-grid-first; dense+mask for v1
+### 4. Representation: voxel-grid-first; dense+mask for v1
 
 Materialized narrow-band SDF grid (PicoGK-faithful robustness). **v1: dense 3D array + active-voxel
-mask** (simplest correct structure; O(1/h³) memory — the mask buys traversal speed, not memory — so
+mask** (simplest correct structure; O(1/h³) memory, the mask buys traversal speed, not memory, so
 a hard voxel-count/memory cap returns `Result.Err` rather than OOM). Hashed sparse blocks
 (O(area/h²)) are a later Grid-seam swap; v1 must expose an **accessor abstraction**, never raw
 indexing, so sparse drops in. The grid stores **edge-crossing Hermite normals** from day 1 (cheap)
@@ -77,7 +77,7 @@ so manifold dual contouring can be added without regridding. Do not brand the st
 ### 5. Native Rust → WASM, shipped as a separate published artifact
 
 The core is **native Rust → WASM** (no OpenVDB / PicoGKRuntime port). It ships as its own published
-package **`brepjs-voxel-wasm`** that root brepjs depends on — mirroring `occt-wasm` /
+package **`brepjs-voxel-wasm`** that root brepjs depends on, mirroring `occt-wasm` /
 `brepjs-opencascade`. Consequences: the `brepjs-voxel-wasm` package owns the Rust toolchain and a
 rebuild-and-verify (reproducibility) workflow (precedent: `publish-opencascade.yml`); **root brepjs
 CI, the 4-shard test matrix, and the pre-push hook stay Rust-free** and consume the committed/published
@@ -85,32 +85,32 @@ wasm. An unpublished loader package `packages/brepjs-voxel` (mirroring `initMani
 `initVoxel()` and stays unpublished. `release-please-config.json` gains a third entry for
 `brepjs-voxel-wasm`.
 
-### 6. Contour — surface nets for v1, manifold dual contouring as the target
+### 6. Contour: surface nets for v1, manifold dual contouring as the target
 
 Meshing is pluggable behind a `Contourer` seam. **v1 uses surface nets** (reuse the maintained
 `fast-surface-nets` crate, MIT/Apache, wasm32-clean): fast, robust, watertight, and correct for the
 organic repair fixture where sharp features do not apply. Naive surface nets does **not** recover
-sharp features and is **not** strictly 2-manifold at thin/pinch regions — strict 2-manifoldness and
+sharp features and is **not** strictly 2-manifold at thin/pinch regions; strict 2-manifoldness and
 sharp edges wait for the manifold-DC `Contourer` (v2 upgrade target: the `tessellation` crate, the
 only maintained Rust crate that guarantees both). **Manifold dual contouring remains the target** and
 is added later as a second `Contourer` impl over the same grid (which already carries edge normals).
 Honest claims when DC lands: manifoldness via cell-splitting; self-intersection mitigated (AABB
-vertex clamp) not eliminated — a runtime invariant test is the real guard; sharp-feature loss
+vertex clamp) not eliminated; a runtime invariant test is the real guard; sharp-feature loss
 unbounded in split cells; QEF via truncated SVD with a _relative_ singular-value cutoff + mass-point
 bias, never an absolute threshold.
 
 ### 7. Bridges & mesh contract
 
 `voxelsToMesh` emits the existing `KernelMeshResult` (`src/kernel/types.ts`):
-`vertices`/`normals`/`triangles`(Uint32 index buffer)/`uvs`(mandatory — zero-fill or planar)/
-`faceGroups`(mandatory — one synthetic group; documented, never silently `[]`). Separate wasm linear
-memories mean **no zero-copy** with Emscripten kernels — serialize flat `Float32Array`/`Uint32Array`,
+`vertices`/`normals`/`triangles`(Uint32 index buffer)/`uvs`(mandatory: zero-fill or planar)/
+`faceGroups`(mandatory: one synthetic group; documented, never silently `[]`). Separate wasm linear
+memories mean **no zero-copy** with Emscripten kernels: serialize flat `Float32Array`/`Uint32Array`,
 copied once per direction; apply the `Uint32Array`→`Array` gotcha to `triangles` at kernel-call sites
 only. `meshToBrep` replay reuse (later phase): **extract** the kernel-neutral replay/cache out of
 `src/kernel/manifold/meshHandle.ts` into a shared helper, re-point manifold (no behavior change), and
-consume it from the voxel bridge — legal because the bridge lives in root `src/`.
+consume it from the voxel bridge: legal because the bridge lives in root `src/`.
 
-### 8. Relationship to brepjs-manifold — independent sibling
+### 8. Relationship to brepjs-manifold: independent sibling
 
 The voxel domain is **independent** (not a `KernelAdapter`, not under manifold). Hard scope line:
 **manifold = exact mesh boolean/CSG on watertight meshes (mesh-BSP); voxel = SDF/field CSG +
@@ -125,15 +125,15 @@ replay helper. No duplicated CSG.
 - `scripts/check-layer-boundaries.sh` `get_layer()` currently has **no `voxel`/`lattice` case** →
   returns -1 → silently escapes enforcement. P0 must add `voxel` (Layer 2) and `lattice` (Layer 3) in
   **three places**, writing the _complete_ token set each time. Note the script already has
-  pre-existing legend/header drift, so do **not** copy the current legend/header verbatim — restore the
+  pre-existing legend/header drift, so do **not** copy the current legend/header verbatim; restore the
   missing tokens while adding the new ones:
-  - `get_layer()` arms (the source of truth, currently correct) — L2:
+  - `get_layer()` arms (the source of truth, currently correct): L2:
     `topology|2d|operations|query|measurement|io|worker|csg|voxel`; L3:
     `sketching|text|projection|gear|ns|lattice`.
-  - The printed legend (≈lines 130-131) — L2: `topology/, 2d/, operations/, query/, measurement/, io/,
+  - The printed legend (≈lines 130-131): L2: `topology/, 2d/, operations/, query/, measurement/, io/,
 worker/, csg/, voxel/` (currently **omits `csg/`**); L3: `sketching/, text/, projection/, gear/,
 ns/, lattice/`.
-  - The header comment (≈lines 9, 11) — the same two sets (currently L2 **omits `worker` and `csg`**;
+  - The header comment (≈lines 9, 11): the same two sets (currently L2 **omits `worker` and `csg`**;
     L3 **omits `ns`**).
 
   Then add negative tests proving enforcement is live (an L2→L3 import and a `lattice` upward import the
@@ -148,14 +148,14 @@ ns/, lattice/`.
 `Voxels` / `Field` / `Lattice` are **not** `ShapeHandle` and carry no `[__dim]` phantom (volumetric).
 Use `createKernelHandle<T extends Deletable>` (`src/core/disposal.ts`) exposing `.value` +
 `[Symbol.dispose]`. The wasm object satisfies `Deletable` via a `free()`→`delete()` shim
-(wasm-bindgen emits `free()`). **Explicit disposal is mandatory** — a grid can be hundreds of MB and
+(wasm-bindgen emits `free()`). **Explicit disposal is mandatory**: a grid can be hundreds of MB and
 `FinalizationRegistry` is a no-op where unavailable; all lifetimes use `using` / `withScopeResult`.
 All fallible ops return `Result<T, BrepError>` (no thrown errors in Layers 2-3).
 
 ### 11. v1 scope & motivating fixture
 
 **v1 = the repair slice only**, with the Ops seam built extensible from day 1. Motivating fixture: a
-**non-watertight imported mesh** (holey/self-intersecting STL/OBJ) — the cleanest "an exact kernel
+**non-watertight imported mesh** (holey/self-intersecting STL/OBJ): the cleanest "an exact kernel
 demonstrably errs" gating leg, since OCCT cannot boolean non-watertight input. Pipeline:
 `import → voxelize (sign via hierarchical Fast Winding Number, Barill 2018, + 6-connected flood-fill
 for open inputs) → repair → surface-nets mesh → GLB`. This front-loads the single hardest algorithm
@@ -169,7 +169,7 @@ guarantee it; the manifold-DC `Contourer` does); (iii) Hausdorff ≤ c·h; (iv) 
 Clean-room: no OpenVDB/PicoGK source or structure copied. OpenVDB and PicoGK are both Apache-2.0
 (OpenVDB relicensed from MPL-2.0 in 2020) → the obligation is Apache-2.0 NOTICE attribution if any
 Apache-2.0 idea is used (create a `NOTICE` file; mind the publish `validate-pack` MAX_FILES cap).
-TPMS formulas are textbook trigonometric implicits with no copyright — cite primary literature.
+TPMS formulas are textbook trigonometric implicits with no copyright; cite primary literature.
 
 ## Consequences
 
@@ -178,7 +178,7 @@ TPMS formulas are textbook trigonometric implicits with no copyright — cite pr
 - v1 is the minimal fill of an already-future-proof design; every fill is swappable behind a seam,
   so risk concentrates only in the four seam boundaries.
 - Root brepjs CI / test matrix / pre-push hook stay Rust-free regardless of how large the Rust core
-  grows — the fast feedback loop is preserved.
+  grows; the fast feedback loop is preserved.
 - Context API, layering, handles, disposal, and `Result` usage all reuse existing brepjs conventions
   (ADR-0001/0002/0003/0007), minimizing new surface.
 - Fixes a class of B-rep weaknesses (non-watertight repair, robust offset/shell, lattices) with a
@@ -186,7 +186,7 @@ TPMS formulas are textbook trigonometric implicits with no copyright — cite pr
 
 ### Negative / Trade-offs
 
-- Output is an approximate mesh, never exact B-rep — voxel results do not round-trip through STEP as
+- Output is an approximate mesh, never exact B-rep; voxel results do not round-trip through STEP as
   exact geometry (tessellated at best). Positioned as a preview/repair/lattice kernel.
 - Dense v1 grid is O(1/h³) memory → resolution is capped until the sparse Grid-seam swap.
 - Surface-nets v1 rounds sharp edges; machined-feature fidelity waits for the DC `Contourer`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,7 +156,7 @@ import { measureVolume, measureArea, unwrap } from 'brepjs';
 console.log('Volume:', unwrap(measureVolume(moved)), 'mm³');
 ```
 
-Measurement functions return `Result<number>` — null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. `unwrap()` extracts the number or throws; in production prefer `isOk()` / `match()`.
+Measurement functions return `Result<number>`; null shapes and other inputs that prevent measurement surface as `BrepError` rather than throwing. `unwrap()` extracts the number or throws; in production prefer `isOk()` / `match()`.
 
 ## Step 7: Export
 

--- a/docs/kernel-swap.md
+++ b/docs/kernel-swap.md
@@ -2,9 +2,9 @@
 
 brepjs is kernel-agnostic. All geometry operations go through a `KernelAdapter` interface. Three adapters are provided:
 
-- **occt-wasm** (via `occt-wasm`) — the default kernel: arena-based OCCT V8 compiled to WASM with a handle-based memory model
-- **OpenCascade WASM** (via `brepjs-opencascade`) — the legacy OpenCascade build; mature, still supported as an alternative
-- **brepkit WASM** (via `brepkit-wasm`) — alternative kernel with growing coverage
+- **occt-wasm** (via `occt-wasm`), the default kernel: arena-based OCCT V8 compiled to WASM with a handle-based memory model
+- **OpenCascade WASM** (via `brepjs-opencascade`), the legacy OpenCascade build; mature, still supported as an alternative
+- **brepkit WASM** (via `brepkit-wasm`), alternative kernel with growing coverage
 
 You can also register your own kernel at runtime.
 
@@ -55,11 +55,11 @@ Register a `KernelAdapter` under a unique string ID. The first kernel registered
 
 ### `init()`
 
-Auto-detect and initialize the best available kernel. Tries `occt-wasm` (the default kernel) first, then falls back to `brepjs-opencascade`, then `brepkit-wasm`. Returns a `Promise<string>` with the kernel ID (`'occt-wasm'`, `'occt'`, or `'brepkit'`). Idempotent — calling it again after a kernel is registered returns the current kernel ID immediately.
+Auto-detect and initialize the best available kernel. Tries `occt-wasm` (the default kernel) first, then falls back to `brepjs-opencascade`, then `brepkit-wasm`. Returns a `Promise<string>` with the kernel ID (`'occt-wasm'`, `'occt'`, or `'brepkit'`). Idempotent: calling it again after a kernel is registered returns the current kernel ID immediately.
 
 ### `initFromOC(oc)`
 
-Manual initialization — creates the OpenCascade adapter from a loaded `brepjs-opencascade` WASM instance and registers it as `'occt'` (the alternative kernel; the default is `occt-wasm`).
+Manual initialization: creates the OpenCascade adapter from a loaded `brepjs-opencascade` WASM instance and registers it as `'occt'` (the alternative kernel; the default is `occt-wasm`).
 
 ### `BrepkitAdapter`
 
@@ -67,7 +67,7 @@ Adapter for the external `brepkit-wasm` WASM package. Create with `new BrepkitAd
 
 ### `OcctWasmAdapter`
 
-Adapter for the external `occt-wasm` WASM package. This is an arena-based OCCT V8 kernel compiled to WASM — all geometry is identified by `u32` handles into the arena.
+Adapter for the external `occt-wasm` WASM package. This is an arena-based OCCT V8 kernel compiled to WASM: all geometry is identified by `u32` handles into the arena.
 
 When you use occt-wasm's high-level `OcctKernel` wrapper, build the adapter with `OcctWasmAdapter.fromKernel(kernel)`:
 
@@ -83,7 +83,7 @@ registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
 
 The raw `new OcctWasmAdapter(Module, kernel)` constructor remains for callers that own a raw Embind kernel directly (`new Module.OcctKernel()`), which the adapter already retains.
 
-`occt-wasm` is the default kernel and is auto-detected by `init()` — its `OcctKernel.init()` resolves its own WASM binary, so no build-tool configuration is needed. The manual `registerKernel('occt-wasm', ...)` path above is for callers that want explicit control over init timing or error handling.
+`occt-wasm` is the default kernel and is auto-detected by `init()`; its `OcctKernel.init()` resolves its own WASM binary, so no build-tool configuration is needed. The manual `registerKernel('occt-wasm', ...)` path above is for callers that want explicit control over init timing or error handling.
 
 `OcctWasmAdapter` is exported from the `brepjs` root:
 

--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -24,31 +24,31 @@ edge that the unfold leaves uncut as a `SEAM_CUT`, flattening into a valid conne
 
 ## Status
 
-| Area            | State                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams            |
-| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area      |
-| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`           |
-| Reliefs         | bend reliefs (slots at partial-flange bend-line ends), corner reliefs (notch at a corner)   |
-| Cutouts         | holes / slots (rect + obround) / polygons punched on the base or a folded flange            |
-| Tabs / joints   | additive edge tabs, self-fixturing tab-and-slot joints (tab + matching mating slot)         |
-| Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)      |
-| Contour flange  | open line/arc profile swept along a base edge (multi-bend section); EXACT development       |
-| Lofted flange   | ruled transition between two open profiles; triangulated development (exact if developable) |
-| Hems            | edge folded back ~180°+ (closed / open / teardrop / rolled); EXACT development              |
-| Jogs            | two opposite bends stepping a flat by a Z-offset (joggle); EXACT development                |
+| Area            | State                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| Authoring       | 4-edge flanges, chained bends, up/down, partial/offset flanges, closed-box seams             |
+| Unfold          | recursive BFS tree-walk → rectilinear-union flat pattern + bend lines + developed area       |
+| Fold            | `FlatInput` region-tree → 3D part (inverse of unfold); round-trips `unfold(fold)`            |
+| Reliefs         | bend reliefs (slots at partial-flange bend-line ends), corner reliefs (notch at a corner)    |
+| Cutouts         | holes / slots (rect + obround) / polygons punched on the base or a folded flange             |
+| Tabs / joints   | additive edge tabs, self-fixturing tab-and-slot joints (tab + matching mating slot)          |
+| Form features   | louvers (3-side cut + formed flap), embosses / dimples (round raised / recessed forms)       |
+| Contour flange  | open line/arc profile swept along a base edge (multi-bend section); EXACT development        |
+| Lofted flange   | ruled transition between two open profiles; triangulated development (exact if developable)  |
+| Hems            | edge folded back ~180°+ (closed / open / teardrop / rolled); EXACT development               |
+| Jogs            | two opposite bends stepping a flat by a Z-offset (joggle); EXACT development                 |
 | Bend tables     | shop allowance/deduction tables, angle-linear + thickness×radius-bilinear interp, clamp-warn |
-| Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings           |
-| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                     |
+| Miter / outputs | auto corner-miter, multi-layer DXF (incl. FORM layer), JSON bend report, warnings            |
+| API             | functional `*Fns` → short-named `api.ts` → fluent `sheetMetal()` facade                      |
 
-`fold(input: FlatInput)` folds a flat pattern back up into a 3D part — the inverse of `unfold`. A
+`fold(input: FlatInput)` folds a flat pattern back up into a 3D part, the inverse of `unfold`. A
 `FlatInput` is a region-tree (a base rectangle plus child fold regions, each with a fold line, angle,
 direction, and bend rule), the inverse of the unfold layout. `patternToFlatInput(pattern, { thickness,
-ruleFor })` recovers that region-tree from the **2D flat-pattern geometry alone** — the developed outline
-wire and bend-line edges — reading real coordinates back out with the public `getEdges` / `curveStartPoint`
+ruleFor })` recovers that region-tree from the **2D flat-pattern geometry alone** (the developed outline
+wire and bend-line edges), reading real coordinates back out with the public `getEdges` / `curveStartPoint`
 / `curveEndPoint` readers; only the bend rule (which a flat pattern cannot encode) is a supplied input.
 `partToFlatInput(part)` chains `unfold` → `patternToFlatInput`, so `fold(partToFlatInput(part))` round-trips
-volume, validity, and bend/flange counts through the 2D geometry — making the round-trip a genuine,
+volume, validity, and bend/flange counts through the 2D geometry, making the round-trip a genuine,
 non-circular oracle. Fold reuses the forward authoring bend geometry wholesale (no duplicated bend math),
 and rides SEAM_CUT / MIN_RADIUS warnings inside the Ok payload.
 
@@ -59,10 +59,10 @@ Multi-bend parts tear or collide at corners unless material is relieved. Reliefs
 the developed outline (so they ride in the DXF `OUTLINE` layer and shrink `developedArea`).
 
 - `addBendRelief(part, flangeId, spec?)` cuts a slot at each **mid-edge end** of a partial/offset flange's
-  bend line — the ends that don't reach the parent-edge endpoint, where the parent material would tear.
+  bend line, the ends that don't reach the parent-edge endpoint, where the parent material would tear.
   `autoBendReliefs(part, spec?)` adds one to every partial-span flange (full-span flanges are skipped).
 - `cornerRelief(part, flangeIdA, flangeIdB, spec?)` cuts a square notch centred on the shared corner of two
-  adjacent flanges — the notch alternative to a 45° miter. The square side is `spec.width` when given, else
+  adjacent flanges, the notch alternative to a 45° miter. The square side is `spec.width` when given, else
   the depth clearance. It records the corner as resolved, so the `COLLISION` warning the un-relieved corner
   raised goes away.
 
@@ -77,12 +77,12 @@ parts).
 
 Holes, slots, and polygon cutouts are 2D features punched through a flat region's thickness. They survive
 fold/unfold: each appears in the 3D solid, in the flat pattern (`FlatPattern.holes`, one closed wire per
-cutout), and in the DXF (a `CUTOUT` layer). The outer outline is unchanged — cutouts are interior loops.
+cutout), and in the DXF (a `CUTOUT` layer). The outer outline is unchanged; cutouts are interior loops.
 
 A `CutoutSpec` names the `region` (a flange id, or `'base'`/`'root'` for the base flat) and places the
 feature in that region's **local** frame: `(0, 0)` is the region's near corner, `+x` runs along the region's
 `u` axis and `+y` along its `v` axis. The discriminated union is `hole` (`{ x, y, diameter }`), `slot`
-(`{ x, y, length, width, angleDeg?, round? }` — `round` makes the ends semicircular/obround), or `polygon`
+(`{ x, y, length, width, angleDeg?, round? }`, where `round` makes the ends semicircular/obround), or `polygon`
 (`{ points: [x, y][] }`).
 
 - `addCutout(part, spec)` / `addHole(part, region, x, y, diameter)` / `addSlot(part, region, opts)` /
@@ -103,7 +103,7 @@ still round-trips through the strict outline oracle.
 A **tab** is the additive counterpart of a cutout: a rectangular protrusion of material extending
 **outward** from a flat region's edge. `addTab(part, { region, side, offset, width, length })` builds the
 tab as a region-local rectangle just past the chosen `side`, places it on the correct folded face via the
-region's world frame, extrudes it through the sheet thickness and **fuses** it on — so the volume rises by
+region's world frame, extrudes it through the sheet thickness and **fuses** it on, so the volume rises by
 `width · length · thickness`. The same rectangle is mapped through the region's developed frame and recorded
 as a `TabFeature`, so `unfold` **extends the outer outline** by the protrusion and grows `developedArea` by
 the tab area. Guards a valid, single-bodied result (`TAB_INVALID_SOLID`) and rejects a tab overhanging its
@@ -112,7 +112,7 @@ edge (`TAB_OUT_OF_BOUNDS`).
 `tabAndSlot(part, tab, { region, x, y, clearance? })` is the headline self-locating joint: it fuses a tab on
 one region **and** punches a matching **slot cutout** on the mating region, sized so the tab's cross-section
 (`width × thickness`) inserts into the slot. The slot is `tab.width + clearance` long by `thickness +
-clearance` wide — always strictly larger than the tab cross-section, so the joint mates (clearance defaults
+clearance` wide, always strictly larger than the tab cross-section, so the joint mates (clearance defaults
 to `0.1` mm). Use it to make boxes/enclosures that self-fixture before welding.
 
 Tabs ride through `fold` via `FoldRegion.tabs` / `FlatInput.baseTabs`, so `fold` re-fuses them and a tab'd
@@ -125,28 +125,28 @@ than being silently dropped).
 
 ## Form features (louvers, embosses, dimples)
 
-Form features are **locally formed** — they neither remove nor add net material, so the developed **outline
+Form features are **locally formed**: they neither remove nor add net material, so the developed **outline
 and area are unchanged**; the flat pattern instead carries the fabrication markers on a `FORM` DXF layer.
 
-- `louver(part, { region, x, y, length, width, height, direction? })` — a vent cut on three sides with the
+- `louver(part, { region, x, y, length, width, height, direction? })`: a vent cut on three sides with the
   flap formed up along the hinge. In the **flat pattern** it emits the three cut sides as an **open** cut
-  path in `FlatPattern.formCuts` (the fabricator cuts three of the footprint's four sides — all but the
+  path in `FlatPattern.formCuts` (the fabricator cuts three of the footprint's four sides, all but the
   hinge) plus the hinge fold line in `FlatPattern.formHinges`, so a fabricator cuts the U and folds the flap
   about the uncut hinge. The cut path is emitted as an open LWPOLYLINE on the DXF `FORM` layer (not a closed
   rectangle, which would drop the flap out).
-- `emboss(part, { region, x, y, diameter, height, kind: 'emboss' | 'dimple' })` — a round local form, raised
+- `emboss(part, { region, x, y, diameter, height, kind: 'emboss' | 'dimple' })`: a round local form, raised
   (`emboss`) or recessed (`dimple`). The footprint circle is emitted as a marker (`FlatPattern.formMarkers`).
 
 **3D fidelity (simplified, documented).** The public CSG-only API makes true sheet forming (bending the flap
 continuous with the parent, or stretch-forming a spherical cap) impractical, so the 3D representations are
-deliberately simplified while keeping a **valid single solid** — the flat pattern is the fabrication-critical
+deliberately simplified while keeping a **valid single solid**; the flat pattern is the fabrication-critical
 output:
 
 - _Louver_: the vent opening (`length × width`) is cut fully through the sheet, and the formed flap is
   represented as a thin plate hinged on one side and tilted up to `height`, fused at the hinge so the result
   stays one body. (True forming keeps the flap material continuous with the parent.)
 - _Emboss_: a short cylinder fused onto the formed face (raised by `height`). _Dimple_: a shallow cylinder
-  recess cut into the formed face (recessed by `height`, never through — rejected if `height ≥ thickness`).
+  recess cut into the formed face (recessed by `height`, never through; rejected if `height ≥ thickness`).
   The flat-topped round approximates a true spherical/conical form so the solid stays valid.
 
 Forms ride through `fold` via `FoldRegion.forms` / `FlatInput.baseForms`. Because they are material-neutral
@@ -157,7 +157,7 @@ they don't change the outline, so a **formed part still round-trips** through th
 
 Two profile-driven flanges extend authoring beyond single straight bends:
 
-- `contourFlange(part, { id, side, profile, rule?, offset?, width? })` — an **open 2D profile** (alternating
+- `contourFlange(part, { id, side, profile, rule?, offset?, width? })`: an **open 2D profile** (alternating
   `{ kind: 'line', length }` flats and `{ kind: 'arc', radius, angleDeg, direction }` bends) swept along a
   straight base edge into a multi-bend cross-section (a return, a hat/top-hat, a J). Each arc becomes a
   recorded `BendFeature` (id `contour::<flange>::<n>`) and chains frame-to-frame exactly as flange-off-flange
@@ -165,17 +165,17 @@ Two profile-driven flanges extend authoring beyond single straight bends:
   length (lines: `length`; arcs: the canonical `developedLength` = `(π/180)·|angle|·(R + K·T)`). The unfold
   lays the strip out straight along the base edge with one bend line per arc at its exact cumulative
   arc-length offset.
-- `loftedFlange(part, { id, profileA, profileB, height, thickness? })` — a **ruled transition** between two
+- `loftedFlange(part, { id, profileA, profileB, height, thickness? })`: a **ruled transition** between two
   parallel open profiles (`profileA` at z=0, `profileB` at z=`height`, equal vertex counts), thickened to a
   valid solid by triangulating each quad of the ruled surface and extruding each triangle. The
-  **development is by triangulation** — the standard sheet-metal transition development: each quad is split
+  **development is by triangulation**, the standard sheet-metal transition development: each quad is split
   along a diagonal into two triangles laid out flat preserving their true 3D edge lengths. For a genuinely
   **developable** transition (planar quads / single-curvature) this is **exact to tolerance**; for a
   non-developable (twisted) transition it is an **approximation**, and the unfold emits a
   `DEVELOPMENT_APPROXIMATE` warning (inside the `Ok` payload). The triangulated boundary is emitted as a
   valid closed wire in `FlatPattern.loftedDevelopments`.
 
-Both flanges have **non-rectilinear** developments, so — like miters and tabs — they sit outside the strict
+Both flanges have **non-rectilinear** developments, so, like miters and tabs, they sit outside the strict
 `patternToFlatInput` outline oracle: verification leans on developed-length/area invariants and solid
 validity rather than a fold round-trip. The contour flange's developed strip still joins the rectilinear
 outline union; the lofted flange's triangulated blank is a separate developed boundary.
@@ -184,32 +184,33 @@ outline union; the lofted flange's triangulated blank is a separate developed bo
 
 Hems and jogs are multi-bend edge features built on the same frame-to-frame profile chainer as the contour
 flange, so their developments are **EXACT** (Σ segment developed lengths, via the table-aware
-`developedLength`). Both attach to any flat **region** — the base (`'base'`/`'root'`) or a named flange —
+`developedLength`). Both attach to any flat **region**, the base (`'base'`/`'root'`) or a named flange,
 edge, record their curl/step sub-bends as `hem::<id>::<n>` / `jog::<id>::<n>` `BendFeature`s (skipped by the
 feature-tree spanning walk, like `contour::` bends), and lay their developed strip out straight along the
 region edge with one bend line per sub-bend.
 
 - `hem(part, { region, side, type, length?, radius?, gap?, offset?, width?, rule? })` folds a region edge
   back onto its parent. Four `type`s set the curl angle and the gap:
-  - **`closed`** — a tight ~180° fold, the return flat against the parent. The curl radius is inflated by a
+  - **`closed`**: a tight ~180° fold, the return flat against the parent. The curl radius is inflated by a
     small **HAIR** clearance (0.05 mm) so the fused solid stays valid (a true zero-gap fold makes the curl's
     inner cylinder coincide with the parent face → a self-touching, non-manifold solid). `length` is the
     return-leg length (must be ≥ one thickness).
-  - **`open`** — a ~180° fold with a clear `gap` (default = `radius`) between the return and the parent; the
+  - **`open`**: a ~180° fold with a clear `gap` (default = `radius`) between the return and the parent; the
     curl radius is sized from the gap, so its developed curl length is the exact 180° allowance at that radius.
-  - **`teardrop`** — a >180° (~210°) curl leaving a small teardrop opening, then a short return.
-  - **`rolled`** — a full ~270° circular roll (a curled / safe edge); no flat return.
+  - **`teardrop`**: a >180° (~210°) curl leaving a small teardrop opening, then a short return.
+  - **`rolled`**: a full ~270° circular roll (a curled / safe edge); no flat return.
 
   The curl is split into ≤120° sub-arcs (the bend-patch wedge degenerates at ≥180°), each a recorded
   sub-bend; the bend allowance is linear in angle, so Σ sub-arc allowances == the single-curl allowance. The
   **developed length** is Σ curl allowances + the return length, laid out straight past the edge.
+
 - `jog(part, { region, side, position, offsetHeight, angle?, runOut?, radius?, offset?, width?, rule? })`
   steps a flat by `offsetHeight` perpendicular to its plane with **two opposite bends** (`+θ` then `−θ`,
   `angle` default 45°), then continues parallel. The connecting step run is solved so the two arcs' rise plus
-  the step rise equals `offsetHeight` exactly — the resulting run-out bottom face sits exactly `offsetHeight`
+  the step rise equals `offsetHeight` exactly; the resulting run-out bottom face sits exactly `offsetHeight`
   above the base bottom face (verified by measurement, not just construction). The flat carries the **two
   bend lines** (one `up`, one `down`); the **developed length** is `position + 2·allowance + stepRun +
-  runOut`. `offsetHeight` must exceed the bends' own rise `(T + 2R)(1 − cos θ)`, else the jog is rejected.
+runOut`. `offsetHeight` must exceed the bends' own rise `(T + 2R)(1 − cos θ)`, else the jog is rejected.
 
 Like the contour/lofted flanges, hems and jogs have non-rectilinear developments and so sit outside the
 strict `partToFlatInput → fold` round-trip oracle; verification leans on developed-length invariants, the
@@ -225,7 +226,7 @@ translating and rotating every placed pattern (outline + bend lines + holes + fo
 
 Two strategies are available via `strategy`:
 
-### `strategy: "bbox"` (default) — bounding-box nesting
+### `strategy: "bbox"` (default): bounding-box nesting
 
 Packs each part as its axis-aligned **outline bounding box**, so parts do **not** interlock: a concave or
 L-shaped part reserves its full rectangular footprint and leaves the in-bbox waste unused. `rotationDeg` is
@@ -236,17 +237,17 @@ L-shaped part reserves its full rectangular footprint and leaves the in-bbox was
   **new sheet** opens when the next shelf would overflow the usable height.
 - **Rotation.** With `allowRotation`, each part is tried at `0°` and `90°` and the orientation that fits (or
   packs shorter) is kept.
-- **Utilization.** Σ placed part **bounding-box** areas ÷ usable-sheet area — a conservative lower bound that
+- **Utilization.** Σ placed part **bounding-box** areas ÷ usable-sheet area, a conservative lower bound that
   does not credit inter-part gaps or intra-bbox waste.
 
-### `strategy: "nfp"` — true-shape (no-fit-polygon) nesting
+### `strategy: "nfp"`: true-shape (no-fit-polygon) nesting
 
-Packs the actual **outline polygons** so concave parts interlock — an L-shaped part nests a rotated copy into
+Packs the actual **outline polygons** so concave parts interlock; an L-shaped part nests a rotated copy into
 its notch, fitting more material per sheet than bbox packing ever can. `rotationDeg` may be `0/90/180/270`.
 
 > **Heuristic, not optimal.** The nfp packer is a **bottom-left-fill** heuristic (largest-first, with a
 > discretised raster scan over each part's orientations). It finds good interlocks but is **not** a provably
-> optimal solver — a different part order or finer rotation set may pack tighter. What it guarantees: placed
+> optimal solver; a different part order or finer rotation set may pack tighter. What it guarantees: placed
 > outline polygons never overlap (within `spacing`), all placements stay inside `[margin, sheet − margin]`, an
 > oversized part goes to `unplaced` with a `PART_TOO_LARGE` warning (never dropped, never an infinite loop).
 
@@ -254,9 +255,9 @@ its notch, fitting more material per sheet than bbox packing ever can. `rotation
   cross **or** one contains a vertex of the other (full containment), with a configurable `spacing` clearance.
   A bbox-only check would let a part collide with a concave neighbour, so the true outline is always used.
 - **Utilization.** Σ placed part **outline-polygon** areas ÷ usable-sheet area, so an L-shaped part credits
-  only its true material — the two strategies' utilizations are directly comparable on the same parts.
+  only its true material; the two strategies' utilizations are directly comparable on the same parts.
 - **Geometry assumption.** Outlines are read as straight-edged polylines (one vertex per edge start point);
-  arc edges are approximated by their endpoints — the same assumption the DXF/SVG writers and the bbox nester
+  arc edges are approximated by their endpoints, the same assumption the DXF/SVG writers and the bbox nester
   make.
 
 On a set of identical L-shaped parts, `"nfp"` interlocks them and typically uses roughly **half the sheets** of
@@ -266,10 +267,21 @@ On a set of identical L-shaped parts, `"nfp"` interlocks them and typically uses
 const patterns = parts.map((p) => unfold(p).value.pattern);
 
 // Default bounding-box nesting:
-const bbox = nest(patterns, { sheet: { width: 1250, height: 2500 }, margin: 5, spacing: 3, allowRotation: true });
+const bbox = nest(patterns, {
+  sheet: { width: 1250, height: 2500 },
+  margin: 5,
+  spacing: 3,
+  allowRotation: true,
+});
 
-// True-shape nesting — interlocks concave parts for higher utilization:
-const nfp = nest(patterns, { sheet: { width: 1250, height: 2500 }, margin: 5, spacing: 3, allowRotation: true, strategy: 'nfp' });
+// True-shape nesting - interlocks concave parts for higher utilization:
+const nfp = nest(patterns, {
+  sheet: { width: 1250, height: 2500 },
+  margin: 5,
+  spacing: 3,
+  allowRotation: true,
+  strategy: 'nfp',
+});
 
 const dxf = nestToDXF(nfp.value, patterns, 0); // fabrication-ready DXF for sheet 0
 ```
@@ -277,7 +289,7 @@ const dxf = nestToDXF(nfp.value, patterns, 0); // fabrication-ready DXF for shee
 ## Foreign-solid import & unfold
 
 `unfoldSolid(solid, { kFactor? })` (fluent: `fromSolid(solid).unfold()`) flattens an **arbitrary imported
-sheet-metal solid that has no feature tree** by detecting its geometry numerically — the reverse of the
+sheet-metal solid that has no feature tree** by detecting its geometry numerically, the reverse of the
 authored path. It reads only the B-rep:
 
 - **Classify faces** by surface type: planar faces are panel faces, cylindrical faces are bend faces. Any
@@ -290,7 +302,7 @@ authored path. It reads only the B-rep:
   ⟂ the axis), recovered as the sign-aligned average of cross products of non-parallel normal pairs; the
   axis line and radius come from a least-squares circle fit of the points projected onto the plane ⟂ axis;
   the radius is the mean point-to-axis distance. A fit whose residual exceeds tolerance is rejected (warned).
-  Recovery is high-precision — radius and axis of a known `cylinder()` primitive are recovered to ~1e-6.
+  Recovery is high-precision: radius and axis of a known `cylinder()` primitive are recovered to ~1e-6.
 - **Build the bend graph** (flats = nodes; a bend connects the two flats it shares edges with), take a
   spanning tree from a root flat, and turn non-tree bends into seam cuts (`SEAM_CUT`, warned).
 - **Unfold** by walking the tree, replacing each cylindrical region with a developed strip of length
@@ -299,19 +311,19 @@ authored path. It reads only the B-rep:
   material. Bend direction (up/down) is read from the cylinder centre relative to the parent flat.
 
 **Supported class**: roughly-uniform-thickness solids whose panels are **planar** and whose bends are
-**cylindrical** (straight bends). Outside this class the unfold **warns rather than mis-unfolding** —
+**cylindrical** (straight bends). Outside this class the unfold **warns rather than mis-unfolding**:
 non-uniform thickness, conical/spline bend faces, non-manifold / non-sheet topology, and faces that don't
 fit a cylinder within tolerance all surface as warnings inside the `Ok` payload (or a clear `Err` when no
 sheet-metal structure is detected at all, e.g. a bare sphere). The detection is validated by an oracle:
 author a part, take only its `.solid`, run `unfoldSolid`, and confirm the detected unfold reproduces the
 authored unfold's developed area, bend count, flat count, and total flat bbox (single bend, L-bracket,
-U-channel) — reading only the solid, never the feature tree.
+U-channel), reading only the solid, never the feature tree.
 
 ## Bend tables
 
 By default a bend develops by the K-factor formula `BA = (π/180)·|angle|·(R + K·T)`. A `BendRule` may
 instead reference a **shop bend table** by id (`rule.bendTableRef`), in which case the developed length is
-**interpolated from the table** — linear in bend angle, bilinear across thickness × inner radius (with
+**interpolated from the table**: linear in bend angle, bilinear across thickness × inner radius (with
 nearest-radius substitution for sparse one-radius-per-gauge tables), clamping to the nearest tabulated
 entry outside the table's range (and emitting a `MIN_RADIUS` unfold warning rather than extrapolating).
 
@@ -323,7 +335,7 @@ deduction and is converted on lookup via the outside-setback relation `OSSB = (R
 Resolution precedence at the single resolution point (`resolveBendAllowance`, which `developedLength`
 delegates to): **(1) `bendTableRef` table → (2) explicit `rule.allowance` override → (3) K-factor formula**.
 Parts with no `bendTableRef` are byte-for-byte unchanged. Two starter air-bend tables ship auto-registered
-on first access — `steel-airbend` (mild steel) and `aluminum-airbend` (5052-H32) — with published 90°
+on first access (`steel-airbend` (mild steel) and `aluminum-airbend` (5052-H32)) with published 90°
 allowances scaled across {30, 60, 90, 120}° (sources: SheetMetal.Me charts, Machinery's Handbook 29th ed.).
 
 ```ts
@@ -338,14 +350,22 @@ registerBendTable({
 const part = author({
   thickness: 1.52,
   base: { length: 40, width: 40 },
-  flanges: [{ id: 'fx', length: 18, angleDeg: 90, side: 'xmax', rule: { innerRadius: 1.5, kFactor: 0.44, bendTableRef: 'my-shop-steel' } }],
+  flanges: [
+    {
+      id: 'fx',
+      length: 18,
+      angleDeg: 90,
+      side: 'xmax',
+      rule: { innerRadius: 1.5, kFactor: 0.44, bendTableRef: 'my-shop-steel' },
+    },
+  ],
 });
 // unfold(part.value) now develops the bend at BA = 3.63 mm (the table), not (π/2)·(R + K·T).
 ```
 
 ## Design
 
-All geometry for **authored** parts is computed analytically from the feature tree — bend axis, radius, and
+All geometry for **authored** parts is computed analytically from the feature tree; bend axis, radius, and
 angle are known inputs recorded on each `BendFeature`, so the unfold reads the tree rather than
 reverse-engineering the B-rep. The **foreign-solid** path (`unfoldSolid`) is the exception: it detects bend
 geometry numerically from the public surface queries (no recorded tree). No kernel/WASM changes are required
@@ -364,10 +384,10 @@ All public operations return `Result<T>` (from `brepjs`); non-fatal warnings tra
 ## Snapshot harness
 
 A standalone visual harness lives in `harness/snapshot.ts`. It imports
-`brepjs-sheetmetal` directly (no playground dependency), builds a set of demos —
-the headline L-bracket with a mitered corner, a tray, reliefs, a cutout panel, a
+`brepjs-sheetmetal` directly (no playground dependency), builds a set of demos
+(the headline L-bracket with a mitered corner, a tray, reliefs, a cutout panel, a
 **tab-and-slot box** (self-locating corner joint), and a **louvered panel** (vent
-flaps + emboss/dimple) — then renders each folded 3D part next to its developed
+flaps + emboss/dimple)), then renders each folded 3D part next to its developed
 flat pattern as a single side-by-side SVG and also writes the folded solid as STEP.
 It also runs a **nesting** demo (a handful of parts bbox-packed onto one sheet),
 printing the sheet count + utilization and writing the nested sheet as DXF + SVG,
@@ -381,7 +401,7 @@ npm run snapshot --workspace=brepjs-sheetmetal
 ```
 
 The folded view is an isometric edge-wireframe projection of the kernel mesh, so
-the harness runs as a plain `tsx` script wherever the WASM kernel runs — no
+the harness runs as a plain `tsx` script wherever the WASM kernel runs, with no
 headless browser or GPU required. Output lands in `harness/out/` (gitignored).
 
 ## Development

--- a/packages/brepjs-verify/README.md
+++ b/packages/brepjs-verify/README.md
@@ -2,11 +2,11 @@
 
 Agent skill + verify/preview tooling for authoring parametric CAD with [brepjs](https://github.com/andymai/brepjs).
 
-It ships as **two cooperating pieces on two rails** — install both.
+It ships as **two cooperating pieces on two rails**; install both.
 
 ## 1. The skill (Claude Code plugin)
 
-Teaches an agent the authoring workflow. Delivered via the brepjs marketplace (git), **not** npm — Claude Code discovers skills from plugins, never from `node_modules`:
+Teaches an agent the authoring workflow. Delivered via the brepjs marketplace (git), **not** npm. Claude Code discovers skills from plugins, never from `node_modules`:
 
 ```
 /plugin marketplace add andymai/brepjs
@@ -23,10 +23,10 @@ npm i -D brepjs-verify brepjs occt-wasm
 
 ## API reference
 
-The package bundles brepjs's full API reference for offline/agent use — the complete export surface with signatures and examples:
+The package bundles brepjs's full API reference for offline/agent use: the complete export surface with signatures and examples:
 
-- `reference/llms-full.txt` — every export, full signatures (the deep reference)
-- `reference/llms.txt` — the same content as a quicker index
+- `reference/llms-full.txt`: every export, full signatures (the deep reference)
+- `reference/llms.txt`: the same content as a quicker index
 
 Point your agent at `node_modules/brepjs-verify/reference/llms-full.txt` for anything the skill's curated references don't cover.
 
@@ -51,7 +51,7 @@ npx -y brepjs-verify part.brep.ts --serve --no-open                     # previe
 
 `--snapshot`/`--serve` use the bundled viewer (shipped under `viewer/dist`, including the OCCT WASM). The `--serve` link is interactive: a toolbar offers view presets + fit, solid/wireframe/x-ray modes, edge/grid toggles, a turntable, click-to-inspect face picking, a section/clipping plane, a measurements panel, and an in-browser PNG screenshot. `--snapshot` loads the same page with `ui=0` to suppress the toolbar, and burns the bounding-box size into each PNG (`dims=1`) so the agent can read scale from the image.
 
-`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted — when the server is reused (a tab is already open), under CI, when output is piped (non-TTY, e.g. agent runs), or on Linux with no display server. Pass `--no-open` to always suppress it.
+`--serve` prints the viewer URL and, in an interactive terminal, opens it in your default browser. Auto-open is skipped when it would be unwanted: when the server is reused (a tab is already open), under CI, when output is piped (non-TTY, e.g. agent runs), or on Linux with no display server. Pass `--no-open` to always suppress it.
 
 ## CLI reference
 
@@ -65,8 +65,8 @@ The `brepjs-verify` bin is a multi-command CLI. `verify` is the default command,
 | `brepjs-verify export <file>`   | Batch artifacts behind a validity gate: `--step`, `--glb`, `--stl`, or `--all`; `--out <dir>` (default `.`). Exits non-zero on failure.                                                                                                                                                            |
 | `brepjs-verify measure <a> [b]` | Measurements for one part; with a second module, the distance between the two parts.                                                                                                                                                                                                               |
 | `brepjs-verify diff <a> <b>`    | Compares the measurements of a baseline and a comparison module.                                                                                                                                                                                                                                   |
-| `brepjs-verify snapshot`        | Multi-view PNG capture — surfaced via `verify --snapshot <dir>`. Requires the optional `puppeteer`/Chrome dependency; degrades with a clear message when absent.                                                                                                                                   |
-| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link — surfaced via `verify --serve`. Auto-opens the browser in an interactive terminal (suppressed under CI / non-TTY / no display, or with `--no-open`).                                                                                                |
+| `brepjs-verify snapshot`        | Multi-view PNG capture, surfaced via `verify --snapshot <dir>`. Requires the optional `puppeteer`/Chrome dependency; degrades with a clear message when absent.                                                                                                                                    |
+| `brepjs-verify serve`           | Preview server with a `?dir=&file=` deep link, surfaced via `verify --serve`. Auto-opens the browser in an interactive terminal (suppressed under CI / non-TTY / no display, or with `--no-open`).                                                                                                 |
 
 Every command writes a single machine-readable JSON document to stdout; diagnostics (paths, kernel chatter, watch notices) go to stderr.
 
@@ -82,7 +82,7 @@ This is the closed _build → verify_ loop as a single call: the agent sends par
 
 ### Connect (local build)
 
-Build the package, then register the server by absolute path. Run both commands from the package root (`packages/brepjs-verify`), where `dist/` is emitted — `$(pwd)` is resolved by your shell at that location:
+Build the package, then register the server by absolute path. Run both commands from the package root (`packages/brepjs-verify`), where `dist/` is emitted. `$(pwd)` is resolved by your shell at that location:
 
 ```bash
 npm run build   # emits dist/mcp/server.js
@@ -95,24 +95,24 @@ Once the package is published to npm, the same server is available without a loc
 claude mcp add brepjs-verify -- npx -y --package brepjs-verify brepjs-verify-mcp
 ```
 
-The server runs locally as a child process of your agent (stdio) — geometry never leaves your machine.
+The server runs locally as a child process of your agent (stdio); geometry never leaves your machine.
 
 ## Examples gallery
 
 Few-shot examples live under `skill/examples/<name>.brep.ts`, each with a `<name>.expected.json` baseline. Grouped by category:
 
-- **Primitives + booleans** — `mounting-bracket`, `flanged-coupler`, `transform-bracket`
-- **2D sketch → solid** — `extruded-bracket` (extrude), `revolved-pulley` (revolve), `swept-gasket` (sweep)
-- **Modifiers** — `rounded-block` (fillet), `chamfered-block` (chamfer), `hollow-enclosure` (shell)
-- **Gridfinity primitives** — `gridfinity-baseplate`, `gridfinity-bin`, `gridfinity-divider`
+- **Primitives + booleans**: `mounting-bracket`, `flanged-coupler`, `transform-bracket`
+- **2D sketch → solid**: `extruded-bracket` (extrude), `revolved-pulley` (revolve), `swept-gasket` (sweep)
+- **Modifiers**: `rounded-block` (fillet), `chamfered-block` (chamfer), `hollow-enclosure` (shell)
+- **Gridfinity primitives**: `gridfinity-baseplate`, `gridfinity-bin`, `gridfinity-divider`
 
 ## Eval / scorecard
 
-`npm run eval` (`bench/run.ts`) replays every `skill/examples/*.brep.ts` with a sibling `*.expected.json` through the public `runPart` runtime, compares measured volume/area/validity/shape-type against the recorded baseline within each file's tolerance (default 0.5%), prints a PASS/FAIL scorecard, and exits non-zero on any regression. It is deterministic — no LLM or API key — so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an intentional geometry change.
+`npm run eval` (`bench/run.ts`) replays every `skill/examples/*.brep.ts` with a sibling `*.expected.json` through the public `runPart` runtime, compares measured volume/area/validity/shape-type against the recorded baseline within each file's tolerance (default 0.5%), prints a PASS/FAIL scorecard, and exits non-zero on any regression. It is deterministic (no LLM or API key) so it runs in CI as the package's regression net. Refresh a baseline by re-recording the example's `*.expected.json` after an intentional geometry change.
 
 ### Live eval (`npm run eval:live`)
 
-The measurement flywheel: sends ~18 natural-language part prompts (`bench/prompts.ts`) to a real model — using the **deployed `SKILL.md` as the system prompt**, so it measures the actual skill — then verifies each generated part two ways:
+The measurement flywheel: sends ~18 natural-language part prompts (`bench/prompts.ts`) to a real model (using the **deployed `SKILL.md` as the system prompt**, so it measures the actual skill), then verifies each generated part two ways:
 
 - **Auto (objective):** `runPart --check` → valid solid + any pinned dims within tolerance.
 - **Judge (intent):** a multimodal Claude call looks at the rendered iso/front/top/right snapshots and decides whether the part matches the request + rubric.
@@ -125,7 +125,7 @@ ANTHROPIC_API_KEY=sk-... npm run eval:live -w brepjs-verify -- --model claude-so
 #   --only <id|category>   run a subset      --keep   keep the generated parts
 ```
 
-Opt-in and **billed** (real API calls), so it does _not_ run in CI — the deterministic replay above is the CI gate. Snapshots (hence the judge) need `puppeteer`/Chrome; without them the run scores on auto-verify alone and notes the skipped judge.
+Opt-in and **billed** (real API calls), so it does _not_ run in CI; the deterministic replay above is the CI gate. Snapshots (hence the judge) need `puppeteer`/Chrome; without them the run scores on auto-verify alone and notes the skipped judge.
 
 ## Programmatic API
 
@@ -138,4 +138,4 @@ console.log(serializeReport(report)); // { ok, shapeType, checks, measurements, 
 
 ## How verification works
 
-Deterministic checks are the source of truth — validity brands (`validSolid`), `measureVolume`/`measureArea`, and bounding box — surfaced as a JSON report. Multi-view PNG snapshots are a diagnostic layer, never a substitute for a measurement. STEP is the primary, validated artifact; GLB/STL are derived previews.
+Deterministic checks are the source of truth (validity brands (`validSolid`), `measureVolume`/`measureArea`, and bounding box) surfaced as a JSON report. Multi-view PNG snapshots are a diagnostic layer, never a substitute for a measurement. STEP is the primary, validated artifact; GLB/STL are derived previews.

--- a/packages/brepjs-viewer/README.md
+++ b/packages/brepjs-viewer/README.md
@@ -2,23 +2,23 @@
 
 Shared React + [@react-three/fiber](https://github.com/pmndrs/react-three-fiber) renderer for brepjs meshes. Extracted from the playground so both `apps/playground` and the `brepjs-agent` standalone viewer render through one source of truth (no drift).
 
-It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional selection callbacks — it owns no application state and never imports a consumer.
+It is a thin, store-agnostic rendering layer: it takes a `MeshData` and optional selection callbacks; it owns no application state and never imports a consumer.
 
 ## Exports
 
-- `Renderer` — draws a `MeshData` mesh; optional `onFacePick`/`onFaceHover`/`onFaceContextMenu` callbacks for selection.
-- `ViewerCanvas` — R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, toggles `autoRotate`/`gridVisible`, and switches `projection` between `perspective` and `orthographic` (zoom-fit ortho camera). Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
-- `ViewerControls` — store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, projection, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
-- `ViewerInfoPanel` — controlled, store-agnostic measurements readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are supplied.
-- `ViewerSelectionPanel` — controlled readout for a picked `FaceInfo` (surface type, area, normal) with an optional clear button; renders nothing when no face is selected.
-- `ViewerSectionControls` — controlled section-plane bar (enable, axis, position slider, flip). Pair with `sectionPlane(...)` and pass the result to `Renderer`/`EdgeRenderer` via their `clippingPlanes` prop. `ViewerCanvas` enables local clipping, so only the model is cut (not the grid).
-- `EdgeRenderer`, `SelectionHighlight`, `SceneSetup` — companion components.
-- `buildGeometry`, `findFaceGroupAt`, `meshSize`, `meshBounds`, `sectionPlane` — pure helpers (`meshBounds` returns the bbox; `sectionPlane` builds a model-space clipping plane).
+- `Renderer`: draws a `MeshData` mesh; optional `onFacePick`/`onFaceHover`/`onFaceContextMenu` callbacks for selection.
+- `ViewerCanvas`: R3F `<Canvas>` wrapper that frames the model bbox, re-points the camera from a `view` prop (`iso`/`front`/`top`/`right`), re-frames on a `fitSignal` bump, toggles `autoRotate`/`gridVisible`, and switches `projection` between `perspective` and `orthographic` (zoom-fit ortho camera). Flips to `frameloop="always"` while spinning, `demand` otherwise. Fires `onFirstFrame` after first paint. Screenshot-agnostic.
+- `ViewerControls`: store-agnostic, fully-controlled toolbar (view-mode, edges, grid, turntable, projection, view presets, fit, screenshot). Each group renders only when its handler is supplied; self-contained inline styles, `className` to restyle.
+- `ViewerInfoPanel`: controlled, store-agnostic measurements readout (bbox size, volume, area, triangles, validity); renders only the rows whose values are supplied.
+- `ViewerSelectionPanel`: controlled readout for a picked `FaceInfo` (surface type, area, normal) with an optional clear button; renders nothing when no face is selected.
+- `ViewerSectionControls`: controlled section-plane bar (enable, axis, position slider, flip). Pair with `sectionPlane(...)` and pass the result to `Renderer`/`EdgeRenderer` via their `clippingPlanes` prop. `ViewerCanvas` enables local clipping, so only the model is cut (not the grid).
+- `EdgeRenderer`, `SelectionHighlight`, `SceneSetup`: companion components.
+- `buildGeometry`, `findFaceGroupAt`, `meshSize`, `meshBounds`, `sectionPlane`: pure helpers (`meshBounds` returns the bbox; `sectionPlane` builds a model-space clipping plane).
 - Types: `MeshData`, `FaceGroup`, `FaceInfo`, `EdgeGroup`, `EdgeInfo`, `ViewMode`, `ViewName`, `VIEW_NAMES`.
 
 ## Peer dependencies
 
-`react`, `react-dom`, `three`, `@react-three/fiber`, `@react-three/drei` — pinned to the versions `apps/playground` uses so a single copy resolves across the monorepo.
+`react`, `react-dom`, `three`, `@react-three/fiber`, `@react-three/drei`: pinned to the versions `apps/playground` uses so a single copy resolves across the monorepo.
 
 ## Usage
 

--- a/scripts/hillTetrahedronStudy.md
+++ b/scripts/hillTetrahedronStudy.md
@@ -4,11 +4,11 @@ Quantifying **V vs V\*** for random face-to-face assemblies of N Hill tetrahedra
 
 ## Definitions
 
-- **L** — edge length of the Hill tetrahedron's short edge.
-- **Single tet volume** — exactly `L³ / 6`.
-- **V\*** — ideal volume of an N-tet assembly = `N · L³ / 6`. This is the sum of the part volumes, equal to the actual occupied solid volume when there are no overlaps (always true in our face-to-face placement).
-- **V** — convex-hull volume of all assembly vertices. This models the "vacuum bag shrink-wrap" upper bound: a perfectly inelastic bag pulled tight around the cluster cannot get smaller than the convex hull.
-- **Packing efficiency** — V\* / V. Equals 1.0 when the assembly is convex (no voids); drops toward zero for branchy fractal-like growth.
+- **L**: edge length of the Hill tetrahedron's short edge.
+- **Single tet volume**: exactly `L³ / 6`.
+- **V\***: ideal volume of an N-tet assembly = `N · L³ / 6`. This is the sum of the part volumes, equal to the actual occupied solid volume when there are no overlaps (always true in our face-to-face placement).
+- **V**: convex-hull volume of all assembly vertices. This models the "vacuum bag shrink-wrap" upper bound: a perfectly inelastic bag pulled tight around the cluster cannot get smaller than the convex hull.
+- **Packing efficiency**: V\* / V. Equals 1.0 when the assembly is convex (no voids); drops toward zero for branchy fractal-like growth.
 
 ## Reference points (deterministic, computed exactly)
 
@@ -18,7 +18,7 @@ Quantifying **V vs V\*** for random face-to-face assemblies of N Hill tetrahedra
 | Cube tiling (6-piece)           | 6   | L³              | L³             | **1.000** (perfect) |
 | 8-reptile (doubled Hill tet)    | 8   | (2L)³/6 = 4L³/3 | 8·L³/6 = 4L³/3 | **1.000** (perfect) |
 
-So with _the right_ arrangement, an N-tet assembly has zero void volume — exactly what Matoušek's k-reptile theorem guarantees for k = m³ (m=1,2,3...).
+So with _the right_ arrangement, an N-tet assembly has zero void volume, exactly what Matoušek's k-reptile theorem guarantees for k = m³ (m=1,2,3...).
 
 ## Random face-to-face walk
 
@@ -26,7 +26,7 @@ At each step the algorithm:
 
 1. Picks a random "free" face of the current assembly (a face not yet glued to another tet).
 2. Picks a random chirality (R/L, 50/50) for the new tet.
-3. Picks a compatible face of the template (same edge-length signature — isoceles right (1,1,√2) or scalene right (1,√2,√3)).
+3. Picks a compatible face of the template (same edge-length signature: isoceles right (1,1,√2) or scalene right (1,√2,√3)).
 4. Mates the two faces with opposite outward normals (the only way two solids can share a face).
 5. Rejects any placement whose interior overlaps an already-placed tet.
 
@@ -51,7 +51,7 @@ Result table (L = 1, **20 trials per N**, fresh seed each trial):
 ## Key observations
 
 1. **Efficiency starts at 1.0 (N=1) and drops to ~0.25 by N≈25, then plateaus.**
-   For large random assemblies, the vacuum-bag volume settles around **V ≈ 4 V\*** — roughly 4× the part volume.
+   For large random assemblies, the vacuum-bag volume settles around **V ≈ 4 V\***, roughly 4× the part volume.
 
 2. **N=2 is exactly 0.5.**
    Two Hill tets sharing a face occupy exactly half their convex hull, because the hull always becomes a 5-vertex (6-face) bipyramid whose volume is exactly 2× either component piece.
@@ -60,7 +60,7 @@ Result table (L = 1, **20 trials per N**, fresh seed each trial):
    Perfect tilings give efficiency 1.0 (zero voids); the gap is entirely due to the branchy, fractal-like growth induced by uniform random face selection.
 
 4. **Standard deviation is small (~3% absolute).**
-   Run-to-run V varies a few percent — the asymptotic efficiency ~0.25 is robust.
+   Run-to-run V varies a few percent; the asymptotic efficiency ~0.25 is robust.
 
 ## Reproducing
 
@@ -72,13 +72,13 @@ The math (with brepjs convex-hull volume) is in `scripts/hillTetrahedronStudy.ts
 
 ## Interactive 3D
 
-Four playground examples render the geometry — open `apps/playground` (`npm run dev`) and pick:
+Four playground examples render the geometry. Open `apps/playground` (`npm run dev`) and pick:
 
-- **Hill tetrahedron** — chiral pair mated face-to-face (red = right, white = left)
-- **Hill tetrahedra: 6 tile a cube** — perfect tiling
-- **Hill tetrahedra: 8-reptile** — exploded view of the m³-reptile dissection
-- **Hill tetrahedra: random face-to-face pile** — live random assembly with V\*/V logged to the console
+- **Hill tetrahedron**: chiral pair mated face-to-face (red = right, white = left)
+- **Hill tetrahedra: 6 tile a cube**: perfect tiling
+- **Hill tetrahedra: 8-reptile**: exploded view of the m³-reptile dissection
+- **Hill tetrahedra: random face-to-face pile**: live random assembly with V\*/V logged to the console
 
 ## Companion research repo
 
-A deeper React/Three.js playground with statistical analysis (gyration tensor, pair correlation, fit models, multi-trial CSV export, η_C and η_B both) lives at <https://github.com/andymai/plancktons> — same math, more knobs.
+A deeper React/Three.js playground with statistical analysis (gyration tensor, pair correlation, fit models, multi-trial CSV export, η_C and η_B both) lives at <https://github.com/andymai/plancktons>, same math, more knobs.

--- a/src/2d/README.md
+++ b/src/2d/README.md
@@ -1,6 +1,6 @@
 # 2D
 
-**Layer 2** — 2D curves, blueprints, and 2D boolean operations.
+**Layer 2**: 2D curves, blueprints, and 2D boolean operations.
 
 ```mermaid
 graph TB
@@ -30,51 +30,51 @@ graph TB
 
 ## Subdirectories
 
-| Directory     | Purpose                                                                     |
-| ------------- | --------------------------------------------------------------------------- |
-| `lib/`        | Low-level 2D curve operations — factories, intersections, offset, stitching |
-| `blueprints/` | High-level drawing abstractions (Blueprint, CompoundBlueprint, Blueprints)  |
+| Directory     | Purpose                                                                    |
+| ------------- | -------------------------------------------------------------------------- |
+| `lib/`        | Low-level 2D curve operations: factories, intersections, offset, stitching |
+| `blueprints/` | High-level drawing abstractions (Blueprint, CompoundBlueprint, Blueprints) |
 
 ## Key Files (lib/)
 
-| File                  | Purpose                                                                                                                                                             |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Curve2D.ts`          | Core `Curve2D` class — geomType, firstPoint/lastPoint, boundingBox, value(t), tangentAt, splitAt, distanceFrom, serialize/deserialize. Implements `Symbol.dispose`. |
-| `makeCurves.ts`       | Curve factories — segment, 3-point arc, tangent arc, circle, ellipse, ellipse arc, Bezier, interpolated B-spline                                                    |
-| `intersections.ts`    | `intersectCurves()`, `selfIntersections()`                                                                                                                          |
-| `offset.ts`           | `make2dOffset(curve, offset)`                                                                                                                                       |
-| `definitions.ts`      | `Point2D`, `Matrix2X2` types                                                                                                                                        |
-| `vectorOperations.ts` | 2D vector math utilities                                                                                                                                            |
-| `BoundingBox2d.ts`    | 2D bounding box representation. Implements `Symbol.dispose`.                                                                                                        |
-| `stitching.ts`        | `stitchCurves()` connects curves into continuous paths                                                                                                              |
-| `customCorners.ts`    | `filletCurves()`, `chamferCurves()` for curve connections                                                                                                           |
-| `svgPath.ts`          | SVG path conversion utilities                                                                                                                                       |
+| File                  | Purpose                                                                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Curve2D.ts`          | Core `Curve2D` class: geomType, firstPoint/lastPoint, boundingBox, value(t), tangentAt, splitAt, distanceFrom, serialize/deserialize. Implements `Symbol.dispose`. |
+| `makeCurves.ts`       | Curve factories: segment, 3-point arc, tangent arc, circle, ellipse, ellipse arc, Bezier, interpolated B-spline                                                    |
+| `intersections.ts`    | `intersectCurves()`, `selfIntersections()`                                                                                                                         |
+| `offset.ts`           | `make2dOffset(curve, offset)`                                                                                                                                      |
+| `definitions.ts`      | `Point2D`, `Matrix2X2` types                                                                                                                                       |
+| `vectorOperations.ts` | 2D vector math utilities                                                                                                                                           |
+| `BoundingBox2d.ts`    | 2D bounding box representation. Implements `Symbol.dispose`.                                                                                                       |
+| `stitching.ts`        | `stitchCurves()` connects curves into continuous paths                                                                                                             |
+| `customCorners.ts`    | `filletCurves()`, `chamferCurves()` for curve connections                                                                                                          |
+| `svgPath.ts`          | SVG path conversion utilities                                                                                                                                      |
 
 ## Key Files (blueprints/)
 
-| File                   | Purpose                                                                                                                                                                            |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Blueprint.ts`         | Single closed/open 2D path — `.curves`, `.boundingBox`, `.orientation`, `.sketchOnPlane()`, `.sketchOnFace()`, `.toSVG()`, `.isInside()`, transforms. Implements `Symbol.dispose`. |
-| `CompoundBlueprint.ts` | Outer contour + inner holes representation                                                                                                                                         |
-| `Blueprints.ts`        | Collection of independent blueprints                                                                                                                                               |
-| `boolean2D.ts`         | `fuse2D()`, `cut2D()`, `intersect2D()` — 2D boolean operations                                                                                                                     |
-| `cannedBlueprints.ts`  | Pre-built shapes — `roundedRectangleBlueprint()`, `polysidesBlueprint()`                                                                                                           |
-| `offset.ts`            | Blueprint offsetting operations                                                                                                                                                    |
-| `customCorners.ts`     | Fillet/chamfer operations on blueprints                                                                                                                                            |
-| `svg.ts`               | SVG export for blueprints                                                                                                                                                          |
+| File                   | Purpose                                                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Blueprint.ts`         | Single closed/open 2D path: `.curves`, `.boundingBox`, `.orientation`, `.sketchOnPlane()`, `.sketchOnFace()`, `.toSVG()`, `.isInside()`, transforms. Implements `Symbol.dispose`. |
+| `CompoundBlueprint.ts` | Outer contour + inner holes representation                                                                                                                                        |
+| `Blueprints.ts`        | Collection of independent blueprints                                                                                                                                              |
+| `boolean2D.ts`         | `fuse2D()`, `cut2D()`, `intersect2D()`: 2D boolean operations                                                                                                                     |
+| `cannedBlueprints.ts`  | Pre-built shapes: `roundedRectangleBlueprint()`, `polysidesBlueprint()`                                                                                                           |
+| `offset.ts`            | Blueprint offsetting operations                                                                                                                                                   |
+| `customCorners.ts`     | Fillet/chamfer operations on blueprints                                                                                                                                           |
+| `svg.ts`               | SVG export for blueprints                                                                                                                                                         |
 
 ## Top-Level Files
 
-| File        | Purpose                                                                                                                      |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `curves.ts` | 3D integration — `curvesAsEdgesOnPlane()`, `curvesAsEdgesOnFace()`, `edgeToCurve()`, `Transformation2D` class with factories |
+| File        | Purpose                                                                                                                     |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `curves.ts` | 3D integration: `curvesAsEdgesOnPlane()`, `curvesAsEdgesOnFace()`, `edgeToCurve()`, `Transformation2D` class with factories |
 
 ## Gotchas
 
-1. **Self-contained 2D module** — `Curve2D` and `Blueprint` don't depend on 3D topology; they're pure 2D abstractions
-2. **Bridge to 3D** — `Blueprint.sketchOnPlane()` bridges 2D→3D by creating a `Sketch` on a plane; use this to convert 2D drawings to 3D geometry
-3. **Compound blueprints** — `CompoundBlueprint` has outer + inner contours; inner contours become holes when extruded to 3D
-4. **2D booleans** — `fuse2D()`/`cut2D()`/`intersect2D()` operate on blueprints, not 3D shapes; use before 3D conversion
-5. **Serialization** — `Curve2D.serialize()` enables persistence; curves can be saved and restored
-6. **Kernel-abstracted** — All 2D curve operations (evaluation, type queries, circle/ellipse data, Bezier poles, bounding boxes) go through `getKernel()` / `getKernel2D()` methods. No direct kernel API calls in this module.
-7. **Disposable** — `Blueprint`, `Curve2D`, and `BoundingBox2d` implement `Symbol.dispose`, enabling `using` keyword for deterministic WASM cleanup: `using bp = new BlueprintSketcher().movePointerTo([0,0]).lineTo([10,0]).close();`
+1. **Self-contained 2D module**: `Curve2D` and `Blueprint` don't depend on 3D topology; they're pure 2D abstractions
+2. **Bridge to 3D**: `Blueprint.sketchOnPlane()` bridges 2D→3D by creating a `Sketch` on a plane; use this to convert 2D drawings to 3D geometry
+3. **Compound blueprints**: `CompoundBlueprint` has outer + inner contours; inner contours become holes when extruded to 3D
+4. **2D booleans**: `fuse2D()`/`cut2D()`/`intersect2D()` operate on blueprints, not 3D shapes; use before 3D conversion
+5. **Serialization**: `Curve2D.serialize()` enables persistence; curves can be saved and restored
+6. **Kernel-abstracted**: All 2D curve operations (evaluation, type queries, circle/ellipse data, Bezier poles, bounding boxes) go through `getKernel()` / `getKernel2D()` methods. No direct kernel API calls in this module.
+7. **Disposable**: `Blueprint`, `Curve2D`, and `BoundingBox2d` implement `Symbol.dispose`, enabling `using` keyword for deterministic WASM cleanup: `using bp = new BlueprintSketcher().movePointerTo([0,0]).lineTo([10,0]).close();`

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -290,7 +290,7 @@ function withScopeResultAsync<T, E = BrepError>(
 ): Promise<Result<T, E>>;
 ```
 
-**`using` declaration (preferred — auto-disposes at block end):**
+**`using` declaration (preferred, auto-disposes at block end):**
 
 ```typescript
 using scope = new DisposalScope();
@@ -298,7 +298,7 @@ const pnt = scope.register(new oc.gp_Pnt_3(0, 0, 0));
 // scope.delete() called automatically, pnt deleted
 ```
 
-**`withScopeResult` — for Result-returning functions:**
+**`withScopeResult`: for Result-returning functions:**
 
 ```typescript
 return withScopeResult((scope) => {
@@ -308,7 +308,7 @@ return withScopeResult((scope) => {
 });
 ```
 
-**`withScopeResultAsync` — for async Result-returning functions:**
+**`withScopeResultAsync`: for async Result-returning functions:**
 
 ```typescript
 return withScopeResultAsync(async (scope) => {
@@ -319,7 +319,7 @@ return withScopeResultAsync(async (scope) => {
 });
 ```
 
-> **Note:** The `await` in `return await fn(scope)` inside `withScopeResultAsync` is intentional — the TC39 `using` block is synchronous; without `await`, the scope would be disposed before the promise resolves.
+> **Note:** The `await` in `return await fn(scope)` inside `withScopeResultAsync` is intentional. The TC39 `using` block is synchronous; without `await`, the scope would be disposed before the promise resolves.
 
 ### Lifecycle Guard
 
@@ -358,7 +358,7 @@ kernelCall(fn: () => OcShape, code: string, message: string, kind?: BrepErrorKin
 // Like kernelCall but returns the raw OcShape (no branded wrapping).
 kernelCallRaw(fn: () => OcShape, code: string, message: string, kind?: BrepErrorKind): Result<OcShape>
 
-// Like kernelCall but provides a DisposalScope — for operations that need intermediate kernel objects.
+// Like kernelCall but provides a DisposalScope - for operations that need intermediate kernel objects.
 kernelCallScoped(fn: (scope: DisposalScope) => OcShape, code: string, message: string, kind?: BrepErrorKind): Result<AnyShape>
 ```
 

--- a/src/io/README.md
+++ b/src/io/README.md
@@ -1,15 +1,15 @@
 # I/O
 
-**Layer 2** — STEP, STL, and IGES file import.
+**Layer 2**: STEP, STL, and IGES file import.
 
 ## Key Files
 
-| File           | Purpose                                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------------------------ |
-| `importFns.ts` | Functional API — `importSTEP(blob): Promise<Result<AnyShape>>`, `importSTL(blob): Promise<Result<AnyShape>>` |
+| File           | Purpose                                                                                                     |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `importFns.ts` | Functional API: `importSTEP(blob): Promise<Result<AnyShape>>`, `importSTL(blob): Promise<Result<AnyShape>>` |
 
 ## Gotchas
 
-1. **Async operations** — Import functions are async; they read blobs via ArrayBuffer, write to the kernel's virtual filesystem, then parse
-2. **STL auto-upgrade** — STL imports are automatically upgraded to solids via `ShapeUpgrade_UnifySameDomain`
-3. **Import-only module** — For STEP/STL _export_, see `topology/meshFns.ts` or `operations/exporterFns.ts`; this module handles import only
+1. **Async operations**: Import functions are async; they read blobs via ArrayBuffer, write to the kernel's virtual filesystem, then parse
+2. **STL auto-upgrade**: STL imports are automatically upgraded to solids via `ShapeUpgrade_UnifySameDomain`
+3. **Import-only module**: For STEP/STL _export_, see `topology/meshFns.ts` or `operations/exporterFns.ts`; this module handles import only

--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -1,6 +1,6 @@
 # Kernel
 
-Kernel abstraction layer — all geometry operations go through `KernelAdapter`, making the library kernel-agnostic. Three adapters are provided: OpenCascade WASM (via `brepjs-opencascade`), brepkit WASM (via `brepkit-wasm`), and occt-wasm (via `occt-wasm`). Additional kernels can be registered at runtime.
+Kernel abstraction layer: all geometry operations go through `KernelAdapter`, making the library kernel-agnostic. Three adapters are provided: OpenCascade WASM (via `brepjs-opencascade`), brepkit WASM (via `brepkit-wasm`), and occt-wasm (via `occt-wasm`). Additional kernels can be registered at runtime.
 
 ```mermaid
 graph TD
@@ -32,10 +32,10 @@ This is enforced by an ESLint `no-restricted-syntax` rule that bans `x.wrapped.m
 | `index.ts`                    | Kernel registry: `init()`, `getKernel()`, `getKernel2D()`, `registerKernel()`, `withKernel()`, `initFromOC()`                     |
 | `types.ts`                    | `KernelAdapter` interface (~164 methods), `KernelShape`/`KernelType` opaque handles, `ShapeType`, `BooleanOptions`, `MeshOptions` |
 | `kernel2dTypes.ts`            | `Kernel2DCapability` interface (~40 methods) for 2D curve/sketch operations                                                       |
-| `defaultAdapter.ts`           | Default OCCT adapter class — thin delegation layer implementing both interfaces                                                   |
-| `brepkitAdapter.ts`           | brepkit WASM adapter (`BrepkitAdapter`) — alternative kernel with growing operation coverage                                      |
-| `occtWasm/occtWasmAdapter.ts` | occt-wasm adapter (`OcctWasmAdapter`) — arena-based OCCT V8 kernel with handle-based memory model                                 |
-| `geometry2d.ts`               | Pure-TypeScript 2D geometry engine — kernel-agnostic, used by brepkit and occt-wasm adapters                                      |
+| `defaultAdapter.ts`           | Default OCCT adapter class: thin delegation layer implementing both interfaces                                                    |
+| `brepkitAdapter.ts`           | brepkit WASM adapter (`BrepkitAdapter`): alternative kernel with growing operation coverage                                       |
+| `occtWasm/occtWasmAdapter.ts` | occt-wasm adapter (`OcctWasmAdapter`): arena-based OCCT V8 kernel with handle-based memory model                                  |
+| `geometry2d.ts`               | Pure-TypeScript 2D geometry engine: kernel-agnostic, used by brepkit and occt-wasm adapters                                       |
 | `brepkitWasmTypes.ts`         | TypeScript type definitions for the brepkit WASM module                                                                           |
 
 ### Operation Modules (kernel-specific)
@@ -59,7 +59,7 @@ All raw kernel API calls are isolated in these files. A new kernel replaces `def
 | `advancedOps.ts`            | Patterns, XCAF documents, projection, surface construction, curvature                                                                                           |
 | `healingOps.ts`             | `healSolid`, `healFace`, `healWire`                                                                                                                             |
 | `curveOps.ts`               | `interpolatePoints`, `approximatePoints`                                                                                                                        |
-| `evolutionOps.ts`           | `buildEvolution`, `transformWithEvolution`, `booleanWithEvolution`, `modifierWithEvolution` — face-tracking evolution for topology history                      |
+| `evolutionOps.ts`           | `buildEvolution`, `transformWithEvolution`, `booleanWithEvolution`, `modifierWithEvolution`: face-tracking evolution for topology history                       |
 | `hullOps.ts`                | `hull`, `hullFromPoints`, `buildSolidFromFaces`                                                                                                                 |
 | `kernel2dOps.ts`            | All 2D curve operations: creation, evaluation, transforms, bounding boxes, circle/ellipse/bezier data extraction                                                |
 
@@ -103,10 +103,10 @@ See [Custom Kernel Guide](../../docs/kernel-swap.md) for writing your own kernel
 
 ## Gotchas
 
-1. **Must initialize first** — `getKernel()` throws if no kernel has been registered
-2. **Manual memory management** — All intermediate kernel objects need `.delete()` inside ops modules; only final shapes are returned
-3. **WASM enum values** — Emscripten returns enum objects with `.value` property, not raw numbers. Use `typeof val === 'number' ? val : Number(val?.value ?? val)` pattern
-4. **C++ mesh extraction** — `meshOps.ts` uses `MeshExtractor`/`EdgeMeshExtractor` for all mesh operations (normals, UVs, face groups computed in C++)
-5. **Virtual filesystem** — File I/O uses Emscripten virtual filesystem, not real disk paths
-6. **Degree conversion** — `rotate()` takes degrees, converts internally to radians
-7. **withKernel is sync-only** — The kernel override is restored in `finally`, so async functions would observe the wrong kernel after `await`
+1. **Must initialize first**: `getKernel()` throws if no kernel has been registered
+2. **Manual memory management**: All intermediate kernel objects need `.delete()` inside ops modules; only final shapes are returned
+3. **WASM enum values**: Emscripten returns enum objects with `.value` property, not raw numbers. Use `typeof val === 'number' ? val : Number(val?.value ?? val)` pattern
+4. **C++ mesh extraction**: `meshOps.ts` uses `MeshExtractor`/`EdgeMeshExtractor` for all mesh operations (normals, UVs, face groups computed in C++)
+5. **Virtual filesystem**: File I/O uses Emscripten virtual filesystem, not real disk paths
+6. **Degree conversion**: `rotate()` takes degrees, converts internally to radians
+7. **withKernel is sync-only**: The kernel override is restored in `finally`, so async functions would observe the wrong kernel after `await`

--- a/src/kernel/manifold/README.md
+++ b/src/kernel/manifold/README.md
@@ -6,7 +6,7 @@ boolean CSG, transforms, measurement, and tessellation, all computed natively on
 triangle meshes. It is not a B-rep kernel: it has no exact curves, surfaces, or
 topological sub-shapes of its own. Exact answers (STEP/IGES/BREP export, NURBS
 curve/surface queries, topological introspection) come from **replaying the
-recorded op-graph onto OCCT** — every constructive operation records an
+recorded op-graph onto OCCT**. Every constructive operation records an
 `OpNode` (see [`opGraph.ts`](./opGraph.ts)) capturing its exact parameters, and
 the replay engine ([`replay.ts`](./replay.ts)) rebuilds a true B-rep on the
 registered `occt` kernel on demand. Shapes whose history is tainted by a raw
@@ -15,33 +15,33 @@ B-rep export degrades to a **faceted approximation with a `console.warn`**.
 
 ## Op-support matrix
 
-| Category | Strategy | Notes |
-| --- | --- | --- |
-| Primitives (box, cylinder, sphere, cone, torus, ellipsoid) | NATIVE | Built directly on `manifold-3d`. |
-| Booleans (fuse, cut, common) | NATIVE | Exact mesh CSG; recorded as replayable ops. |
-| Transforms (translate, rotate, scale, mirror, general, grid) | NATIVE | Matrix transforms applied to the mesh. |
-| Measure (volume, area, center of mass, bbox, inertia) | NATIVE | Derived from the manifold solid. |
-| Mesh tessellation | NATIVE | The kernel's native representation. |
-| Fillet, chamfer, shell, thicken, loft, sweep, offset, draft, defeature, simplify | MESH APPROX (preview) / EXACT via OCCT replay (export) | Mesh-level approximation for fast preview; the recorded op-graph replays onto OCCT for exact results on B-rep export. |
-| STEP / IGES / BREP / XCAF export | REPLAY → OCCT | Replays the op-graph to a true B-rep, then delegates to OCCT. Non-replayable origins export a faceted approximation with a `console.warn`. |
-| NURBS curve queries (type, params, tangent, knot/degree ops, adaptor, NURBS data) | REPLAY → OCCT | Lazily replays the shape and answers from the real B-rep (memoized per op-node). |
-| NURBS surface queries (type, UV bounds, normal, classification, untrim, cylinder data, NURBS data, features, projectEdges) | REPLAY → OCCT | As above. |
-| Curve/surface constructors (interpolatePoints, approximatePoints, approximateSurfaceLspia, reverseSurfaceU) | DELEGATED → OCCT | No mesh-solid input to replay; delegated straight to OCCT (result is an OCCT shape). |
-| Topology introspection (shapeType, hashCode, edgeToFaceMap, adjacentFaces, sharedEdges, iterShapeList) | REPLAY → OCCT | `hashCode` and `shapeType` cache their replayed B-rep / result on the op-node. |
-| STL / OBJ / PLY export & import | NATIVE | Encoded/decoded directly from the mesh. Imports are raw-mesh origins. |
-| GLB export & import | NATIVE | Minimal glTF 2.0 binary (one mesh, one primitive: POSITION + indices). Imports are raw-mesh origins. |
-| 3MF export & import | UNSUPPORTED (throws) | 3MF is an OPC (ZIP) container; no zip dependency is available. Export GLB/STL/OBJ or use a B-rep kernel. |
-| 2D ops | DELEGATED → OCCT | Replays onto OCCT; throws when no OCCT kernel is registered. |
-| Constraint sketch | UNSUPPORTED (throws) | No mesh semantics. |
-| Projection | UNSUPPORTED (throws) | No mesh semantics. |
-| B-rep builders (makeEdge, makeWire, makeFace, makeVertex) | UNSUPPORTED (throws) | No mesh equivalent for sub-solid topology. |
-| `sew` | UNSUPPORTED (throws) | Builds B-rep topology from faces — no mesh semantics. |
-| Arena checkpoint / executeBatch | NO-OP / UNSUPPORTED | manifold has no arena; nothing to checkpoint or batch. |
+| Category                                                                                                                   | Strategy                                               | Notes                                                                                                                                      |
+| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Primitives (box, cylinder, sphere, cone, torus, ellipsoid)                                                                 | NATIVE                                                 | Built directly on `manifold-3d`.                                                                                                           |
+| Booleans (fuse, cut, common)                                                                                               | NATIVE                                                 | Exact mesh CSG; recorded as replayable ops.                                                                                                |
+| Transforms (translate, rotate, scale, mirror, general, grid)                                                               | NATIVE                                                 | Matrix transforms applied to the mesh.                                                                                                     |
+| Measure (volume, area, center of mass, bbox, inertia)                                                                      | NATIVE                                                 | Derived from the manifold solid.                                                                                                           |
+| Mesh tessellation                                                                                                          | NATIVE                                                 | The kernel's native representation.                                                                                                        |
+| Fillet, chamfer, shell, thicken, loft, sweep, offset, draft, defeature, simplify                                           | MESH APPROX (preview) / EXACT via OCCT replay (export) | Mesh-level approximation for fast preview; the recorded op-graph replays onto OCCT for exact results on B-rep export.                      |
+| STEP / IGES / BREP / XCAF export                                                                                           | REPLAY → OCCT                                          | Replays the op-graph to a true B-rep, then delegates to OCCT. Non-replayable origins export a faceted approximation with a `console.warn`. |
+| NURBS curve queries (type, params, tangent, knot/degree ops, adaptor, NURBS data)                                          | REPLAY → OCCT                                          | Lazily replays the shape and answers from the real B-rep (memoized per op-node).                                                           |
+| NURBS surface queries (type, UV bounds, normal, classification, untrim, cylinder data, NURBS data, features, projectEdges) | REPLAY → OCCT                                          | As above.                                                                                                                                  |
+| Curve/surface constructors (interpolatePoints, approximatePoints, approximateSurfaceLspia, reverseSurfaceU)                | DELEGATED → OCCT                                       | No mesh-solid input to replay; delegated straight to OCCT (result is an OCCT shape).                                                       |
+| Topology introspection (shapeType, hashCode, edgeToFaceMap, adjacentFaces, sharedEdges, iterShapeList)                     | REPLAY → OCCT                                          | `hashCode` and `shapeType` cache their replayed B-rep / result on the op-node.                                                             |
+| STL / OBJ / PLY export & import                                                                                            | NATIVE                                                 | Encoded/decoded directly from the mesh. Imports are raw-mesh origins.                                                                      |
+| GLB export & import                                                                                                        | NATIVE                                                 | Minimal glTF 2.0 binary (one mesh, one primitive: POSITION + indices). Imports are raw-mesh origins.                                       |
+| 3MF export & import                                                                                                        | UNSUPPORTED (throws)                                   | 3MF is an OPC (ZIP) container; no zip dependency is available. Export GLB/STL/OBJ or use a B-rep kernel.                                   |
+| 2D ops                                                                                                                     | DELEGATED → OCCT                                       | Replays onto OCCT; throws when no OCCT kernel is registered.                                                                               |
+| Constraint sketch                                                                                                          | UNSUPPORTED (throws)                                   | No mesh semantics.                                                                                                                         |
+| Projection                                                                                                                 | UNSUPPORTED (throws)                                   | No mesh semantics.                                                                                                                         |
+| B-rep builders (makeEdge, makeWire, makeFace, makeVertex)                                                                  | UNSUPPORTED (throws)                                   | No mesh equivalent for sub-solid topology.                                                                                                 |
+| `sew`                                                                                                                      | UNSUPPORTED (throws)                                   | Builds B-rep topology from faces; no mesh semantics.                                                                                       |
+| Arena checkpoint / executeBatch                                                                                            | NO-OP / UNSUPPORTED                                    | manifold has no arena; nothing to checkpoint or batch.                                                                                     |
 
 ## Replayability
 
 A shape's op-node is **replayable** only when every op in its history is a
-constructive op (primitive, boolean, transform, sweep, modifier, or builder — see
+constructive op (primitive, boolean, transform, sweep, modifier, or builder, see
 `REPLAYABLE_OPS` in [`helpers.ts`](./helpers.ts)) and all of its inputs are
 themselves replayable.
 

--- a/src/measurement/README.md
+++ b/src/measurement/README.md
@@ -1,6 +1,6 @@
 # Measurement
 
-**Layer 2** — Volume, area, length, and distance measurement.
+**Layer 2**: Volume, area, length, and distance measurement.
 
 ## Key Files
 
@@ -10,7 +10,7 @@
 
 ## API (`measureFns.ts`)
 
-All functions return plain numbers or objects — no memory management needed.
+All functions return plain numbers or objects; no memory management needed.
 
 | Function                  | Input                | Output                       | Use Case                  |
 | ------------------------- | -------------------- | ---------------------------- | ------------------------- |
@@ -46,9 +46,9 @@ query.dispose(); // Clean up
 
 ## Gotchas
 
-1. **Stateless** — No `.delete()` required; all cleanup happens internally
-2. **Reusable queries are faster** — `createDistanceQuery()` loads reference shape once, then measures against many targets efficiently
-3. **"Mass" is not mass** — The `mass` field represents geometric properties (volume/area/length), not actual mass. Multiply by density if needed.
-4. **Center of mass from geometry** — Computed from shape geometry, not physical distribution
-5. **Face vs Shape3D for area** — `measureArea()` accepts both faces (single surface) and 3D shapes (total surface area)
-6. **AnyShape for length** — `measureLength()` works on edges, wires, and any shape (computes total edge length)
+1. **Stateless**: No `.delete()` required; all cleanup happens internally
+2. **Reusable queries are faster**: `createDistanceQuery()` loads reference shape once, then measures against many targets efficiently
+3. **"Mass" is not mass**: The `mass` field represents geometric properties (volume/area/length), not actual mass. Multiply by density if needed.
+4. **Center of mass from geometry**: Computed from shape geometry, not physical distribution
+5. **Face vs Shape3D for area**: `measureArea()` accepts both faces (single surface) and 3D shapes (total surface area)
+6. **AnyShape for length**: `measureLength()` works on edges, wires, and any shape (computes total edge length)

--- a/src/operations/README.md
+++ b/src/operations/README.md
@@ -29,10 +29,10 @@ graph TD
 
 ## Gotchas
 
-1. **Dual API surface** — Each operation exists in OO form (`extrude.ts`, `loft.ts`, `exporters.ts`) using Point/Vector objects AND functional form (`*Fns.ts`) using Vec3 tuples `[x, y, z]`. Prefer functional API for new code.
-2. **OrientedFace required** — `extrude()`, `revolve()`, and `complexExtrude()` in the functional API require `OrientedFace` (not plain `Face`). Use `face(closedWire)` or the `polygon()` convenience to get one.
-3. **Sweep shellMode overload** — `genericSweep(wire, spine, config, true)` returns `Result<[Shape3D, Wire, Wire]>` tuple (shape + start/end wires) instead of just `Result<Shape3D>` when shellMode is true.
-4. **Complex extrude profiles** — `complexExtrude` with `profile: 's-curve'` uses BSpline law for smooth tapering, `profile: 'linear'` uses linear scaling. `endFactor` controls final scale (0.5 = 50% taper).
-5. **XCAF metadata preservation** — `createAssembly` + `exportSTEP` preserves shape colors/names/layers via XCAF document. Plain topology exports lose this metadata.
-6. **Loft ruled default** — `loft` defaults to `ruled: true` for straight-ruled surface. Set `ruled: false` for smooth interpolated surface through wire sections.
-7. **Unit case sensitivity** — `SupportedUnit` accepts both uppercase ('M', 'MM') and lowercase ('m', 'mm') for backward compatibility.
+1. **Dual API surface**: Each operation exists in OO form (`extrude.ts`, `loft.ts`, `exporters.ts`) using Point/Vector objects AND functional form (`*Fns.ts`) using Vec3 tuples `[x, y, z]`. Prefer functional API for new code.
+2. **OrientedFace required**: `extrude()`, `revolve()`, and `complexExtrude()` in the functional API require `OrientedFace` (not plain `Face`). Use `face(closedWire)` or the `polygon()` convenience to get one.
+3. **Sweep shellMode overload**: `genericSweep(wire, spine, config, true)` returns `Result<[Shape3D, Wire, Wire]>` tuple (shape + start/end wires) instead of just `Result<Shape3D>` when shellMode is true.
+4. **Complex extrude profiles**: `complexExtrude` with `profile: 's-curve'` uses BSpline law for smooth tapering, `profile: 'linear'` uses linear scaling. `endFactor` controls final scale (0.5 = 50% taper).
+5. **XCAF metadata preservation**: `createAssembly` + `exportSTEP` preserves shape colors/names/layers via XCAF document. Plain topology exports lose this metadata.
+6. **Loft ruled default**: `loft` defaults to `ruled: true` for straight-ruled surface. Set `ruled: false` for smooth interpolated surface through wire sections.
+7. **Unit case sensitivity**: `SupportedUnit` accepts both uppercase ('M', 'MM') and lowercase ('m', 'mm') for backward compatibility.

--- a/src/projection/README.md
+++ b/src/projection/README.md
@@ -12,7 +12,7 @@ Layer 3 camera definitions and 3D-to-2D edge projection with hidden line removal
 
 ## Gotchas
 
-1. **Hidden line performance**: The kernel's hidden line removal can be slow on complex geometry — use `withHiddenLines: false` if only visible edges needed.
+1. **Hidden line performance**: The kernel's hidden line removal can be slow on complex geometry. Use `withHiddenLines: false` if only visible edges needed.
 2. **Separate edge arrays**: Returns visible edges (solid lines) and hidden edges (dashed lines) separately for rendering control.
 3. **Standard view names**: Supports `'front'`, `'back'`, `'top'`, `'bottom'`, `'left'`, `'right'` plus plane names (`'XY'`, `'XZ'`, `'YZ'`, `'YX'`, `'ZX'`, `'ZY'`).
 4. **Plain objects**: `Camera` is a plain immutable object (no `.delete()` needed). Uses same underlying `makeProjectedEdges()` implementation.

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -1,6 +1,6 @@
 # Query
 
-**Layer 2** — Functional immutable finders for edges, faces, and corners.
+**Layer 2**: Functional immutable finders for edges, faces, and corners.
 
 ```mermaid
 graph TB
@@ -58,9 +58,9 @@ finder
 
 ## Gotchas
 
-1. **Immutable finders** — Each filter call returns a new finder instance; chain calls or save intermediate results
-2. **Unique mode errors** — `findUnique(shape)` returns `Result<T>` and errors if 0 or >1 match found
-3. **cornerFinder operates on 2D** — Works on `BlueprintLike` objects (2D sketches), not 3D shapes
-4. **Direction shortcuts** — Accepts `'X' | 'Y' | 'Z'` strings or `Vec3` tuples like `[1, 0, 0]`
-5. **Angle tolerance** — Direction/plane filters use 1e-6 radian tolerance for floating-point safety
-6. **Edge tangents may fail** — Degenerate edges lack valid tangents; filters receive `normal: null` and should handle gracefully
+1. **Immutable finders**: Each filter call returns a new finder instance; chain calls or save intermediate results
+2. **Unique mode errors**: `findUnique(shape)` returns `Result<T>` and errors if 0 or >1 match found
+3. **cornerFinder operates on 2D**: Works on `BlueprintLike` objects (2D sketches), not 3D shapes
+4. **Direction shortcuts**: Accepts `'X' | 'Y' | 'Z'` strings or `Vec3` tuples like `[1, 0, 0]`
+5. **Angle tolerance**: Direction/plane filters use 1e-6 radian tolerance for floating-point safety
+6. **Edge tangents may fail**: Degenerate edges lack valid tangents; filters receive `normal: null` and should handle gracefully

--- a/src/sketching/README.md
+++ b/src/sketching/README.md
@@ -29,8 +29,8 @@ graph LR
 
 ## Gotchas
 
-1. **Sketch consumption**: Sketch operations (`extrude()`, `revolve()`, etc.) "consume" the sketch by calling `.delete()` internally — the sketch instance cannot be reused after.
-2. **Drawing immutability**: Drawings are non-destructive — operations return new Drawing instances.
+1. **Sketch consumption**: Sketch operations (`extrude()`, `revolve()`, etc.) "consume" the sketch by calling `.delete()` internally. The sketch instance cannot be reused after.
+2. **Drawing immutability**: Drawings are non-destructive; operations return new Drawing instances.
 3. **Relative vs absolute coordinates**: Use `.line(dx, dy)` for relative movement, `.lineTo([x, y])` for absolute positioning.
 4. **Mirror symmetry**: `closeWithMirror()` mirrors the drawn path around the start-to-end axis to create symmetric shapes.
 5. **UV coordinates**: `FaceSketcher` works on curved 3D surfaces using UV parametric coordinates, not Cartesian.

--- a/src/text/README.md
+++ b/src/text/README.md
@@ -11,6 +11,6 @@ Layer 3 font loading and text-to-blueprint conversion.
 ## Gotchas
 
 1. **Font loading required**: Must call `loadFont()` before using text functions, otherwise throws error.
-2. **Font registry**: Fonts are keyed by family name — calling `loadFont()` with same family overwrites previous font unless `force: false` is passed.
+2. **Font registry**: Fonts are keyed by family name. Calling `loadFont()` with same family overwrites previous font unless `force: false` is passed.
 3. **Coordinate flipping**: Text Y-axis is flipped for CAD conventions (mirror transformation applied internally).
-4. **2D output**: `textBlueprints()` returns 2D Blueprints — use `.sketchOnPlane()` or `sketchText()` to create 3D sketches, then `.extrude()` for 3D text.
+4. **2D output**: `textBlueprints()` returns 2D Blueprints. Use `.sketchOnPlane()` or `sketchText()` to create 3D sketches, then `.extrude()` for 3D text.

--- a/src/topology/README.md
+++ b/src/topology/README.md
@@ -1,6 +1,6 @@
 # Topology
 
-Layer 2 — Casting, primitives, transforms, booleans, modifiers, and the public functional API for shape manipulation.
+Layer 2: Casting, primitives, transforms, booleans, modifiers, and the public functional API for shape manipulation.
 
 Shapes are **branded handles**, not class instances. Each shape (`Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `CompSolid`, `Compound`) is a typed `ShapeHandle` defined in `core/shapeTypes.ts` carrying a phantom `D extends Dimension` parameter. Validity brands (`ClosedWire`, `OrientedFace`, `ManifoldShell`, `ValidSolid`) layer on top to encode topological invariants at compile time.
 
@@ -21,7 +21,7 @@ graph TD
 | Group              | Files                                                                                          | Purpose                                                                                                |
 | ------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | Public API         | `api.ts`, `apiTypes.ts`                                                                        | Short-named, options-object functions accepting `Shapeable<T>`. The canonical surface for callers.     |
-| Fluent facade      | `wrapperFns.ts`                                                                                | `shape(x)` returns `Wrapped<T>` — chainable, auto-unwraps `Result` by throwing `BrepWrapperError`.     |
+| Fluent facade      | `wrapperFns.ts`                                                                                | `shape(x)` returns `Wrapped<T>`, chainable, auto-unwraps `Result` by throwing `BrepWrapperError`.      |
 | Casting & topology | `cast.ts`                                                                                      | `cast`, `downcast`, `shapeType`, `iterTopo`, `asTopo`, `isCompSolid`, `fromBREP`.                      |
 | Primitives         | `primitiveFns.ts`, `curveBuilders.ts`, `surfaceBuilders.ts`, `solidBuilders.ts`                | `box`, `cylinder`, `sphere`, `cone`, `torus`, `ellipsoid`, `wire`, `wireLoop`, `face`, `polygon`, etc. |
 | Transforms         | `transformFns.ts`                                                                              | `translate`, `rotate`, `mirror`, `scale`, `applyMatrix`, `transformCopy`, `composeTransforms`.         |
@@ -41,9 +41,9 @@ graph TD
 
 `primitiveFns.ts` uses validity-branded return types to encode invariants at compile time:
 
-- **`ValidSolid`** — `box()`, `cylinder()`, `sphere()`, `cone()`, `torus()`, `ellipsoid()`, `solid()`
-- **`ClosedWire`** — `wireLoop()` (assembles edges and verifies closure)
-- **`OrientedFace`** — `face()`, `filledFace()`, `polygon()`, `subFace()`, `addHoles()`
+- **`ValidSolid`**: `box()`, `cylinder()`, `sphere()`, `cone()`, `torus()`, `ellipsoid()`, `solid()`
+- **`ClosedWire`**: `wireLoop()` (assembles edges and verifies closure)
+- **`OrientedFace`**: `face()`, `filledFace()`, `polygon()`, `subFace()`, `addHoles()`
 
 Functions that need stronger guarantees require these branded types:
 
@@ -55,13 +55,13 @@ extrude(f: OrientedFace, h: number): ...      // Won't accept a plain Face
 ## Two API styles
 
 ```typescript
-// Functional (canonical) — explicit Result handling
+// Functional (canonical) - explicit Result handling
 const boxR = box(30, 20, 10);
 const filleted = fillet(boxR, (e) => e.inDirection('Z'), 2);
 if (isErr(filleted)) throw filleted.error;
 const moved = translate(filleted.value, [0, 0, 5]);
 
-// Fluent facade — auto-unwraps, throws BrepWrapperError on failure
+// Fluent facade - auto-unwraps, throws BrepWrapperError on failure
 const bracket = shape(box(30, 20, 10))
   .cut(cylinder(5, 15, { at: [15, 10, -1] }))
   .fillet((e) => e.inDirection('Z'), 2)
@@ -72,9 +72,9 @@ Prefer the functional API for library code where explicit error handling matters
 
 ## Gotchas
 
-1. **`.wrapped` is read-only data** — Layer 2+ code reads `shape.wrapped` to pass the kernel handle to `getKernel().method(...)` but **never calls methods on `.wrapped` directly**. ESLint's `no-restricted-syntax` enforces this.
-2. **`iterTopo` does not deduplicate** — it delegates straight to `getKernel().iterShapes`. If you need unique sub-shapes, dedupe via `getHashCode()` at the call site.
-3. **Fluent facade throws, functional API doesn't** — `shape(x).fillet(...)` throws `BrepWrapperError` on kernel failure; `fillet(x, ...)` returns `Result<T>`. Pick one style per call chain.
-4. **Flat mesh data** — `mesh()` returns `ShapeMesh` with flat `Float32Array` / `Uint32Array` buffers, not nested objects. See `meshFns.ts`.
-5. **Validity brands must round-trip carefully** — applying a transform to a `ValidSolid` does not preserve the brand at the type level; re-validate or use `validSolid()` to re-brand if needed downstream.
-6. **All new functionality goes in `*Fns.ts` files** — surface it via `api.ts` for the functional public API, and (if appropriate) add a method on `Wrapped<T>` in `wrapperFns.ts` to expose it through the fluent facade.
+1. **`.wrapped` is read-only data**: Layer 2+ code reads `shape.wrapped` to pass the kernel handle to `getKernel().method(...)` but **never calls methods on `.wrapped` directly**. ESLint's `no-restricted-syntax` enforces this.
+2. **`iterTopo` does not deduplicate**: it delegates straight to `getKernel().iterShapes`. If you need unique sub-shapes, dedupe via `getHashCode()` at the call site.
+3. **Fluent facade throws, functional API doesn't**: `shape(x).fillet(...)` throws `BrepWrapperError` on kernel failure; `fillet(x, ...)` returns `Result<T>`. Pick one style per call chain.
+4. **Flat mesh data**: `mesh()` returns `ShapeMesh` with flat `Float32Array` / `Uint32Array` buffers, not nested objects. See `meshFns.ts`.
+5. **Validity brands must round-trip carefully**: applying a transform to a `ValidSolid` does not preserve the brand at the type level; re-validate or use `validSolid()` to re-brand if needed downstream.
+6. **All new functionality goes in `*Fns.ts` files**: surface it via `api.ts` for the functional public API, and (if appropriate) add a method on `Wrapped<T>` in `wrapperFns.ts` to expose it through the fluent facade.

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -14,6 +14,6 @@ Low-level helper functions with no internal imports (Layer 0 foundation).
 
 ## Gotchas
 
-1. **Never catch bug()** — `bug()` should never be caught, it signals programmer errors (invariant violations), not recoverable failures
-2. **Single dependency** — `zip` imports from `range.js` (only inter-file dependency in utils)
-3. **Export patterns** — All files use default exports except `bug.ts` and `uuid.ts` which use named exports. `precisionRound.ts` has both a default export and named `round2`/`round5` exports
+1. **Never catch bug()**: `bug()` should never be caught, it signals programmer errors (invariant violations), not recoverable failures
+2. **Single dependency**: `zip` imports from `range.js` (only inter-file dependency in utils)
+3. **Export patterns**: All files use default exports except `bug.ts` and `uuid.ts` which use named exports. `precisionRound.ts` has both a default export and named `round2`/`round5` exports

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,4 +1,4 @@
-# `tests/parity/` — brepjs behavioral spec
+# `tests/parity/`: brepjs behavioral spec
 
 These tests are the **kernel-agnostic specification** that brepjs's geometric
 operations must satisfy. They exist because brepjs supports two kernels
@@ -26,8 +26,8 @@ a fixed target to implement against.
 
 | Suite                            | What runs            | Required-to-merge? |
 | -------------------------------- | -------------------- | ------------------ |
-| `npm test` / `npm run test:full` | OCCT project only    | yes — CI gate      |
-| `npm run test:brepkit`           | brepkit project only | no — informational |
+| `npm test` / `npm run test:full` | OCCT project only    | yes: CI gate       |
+| `npm run test:brepkit`           | brepkit project only | no: informational  |
 
 Failures in the brepkit project on these files are **expected** during the
 cleanroom rewrite and represent the parity gap. They do not block PRs.
@@ -36,25 +36,25 @@ cleanroom rewrite and represent the parity gap. They do not block PRs.
 
 1. Identify the failing assertion's _mathematical claim_ (e.g.
    `vol(cylinder r=2 h=5) === π·4·5`).
-2. Run the same op on OCCT (`npm test`) — should pass.
+2. Run the same op on OCCT (`npm test`), should pass.
 3. Run on brepkit (`TEST_KERNEL=brepkit npx vitest run tests/parity/...`).
 4. The numerical delta is the parity gap. File or fix in `src/kernel/brepkit/`
    or, if the issue is in the brepkit WASM kernel itself, in the brepkit repo.
 
 ## Tolerance policy
 
-- **Unit-scale closed-form values**: `toBeCloseTo(expected, 0)` — within 0.5
+- **Unit-scale closed-form values**: `toBeCloseTo(expected, 0)`, within 0.5
   absolute units. OCCT and a correct brepkit both clear this comfortably.
 - **fast-check invariants**: relative tolerance, default `1e-6` of the
   expected sum. Property tests run with `numRuns: 50`.
-- **Round-trip serialization**: `toBeCloseTo(original, 6)` — six decimals.
+- **Round-trip serialization**: `toBeCloseTo(original, 6)`, six decimals.
 
 ## Input generators
 
 `fcDim` excludes near-zero/huge dimensions; `fcOffset` is **quantized to a
 0.05 mm grid**. Sub-micron, non-zero offsets put solids in near-coincident
 configurations OCCT booleans resolve unstably (volumes up to ~98% wrong), and
-fast-check shrinks straight toward them — a nondeterministic CI red. Use
+fast-check shrinks straight toward them, a nondeterministic CI red. Use
 `fcOffset` for positional offsets rather than a raw `fc.double`, or the
 degeneracy returns.
 

--- a/tests/parity/voxel/README.md
+++ b/tests/parity/voxel/README.md
@@ -1,8 +1,8 @@
-# `tests/parity/voxel/` — voxel-domain behavioral spec
+# `tests/parity/voxel/`: voxel-domain behavioral spec
 
 The kernel-agnostic spec for the **voxel / SDF domain** (ADR-0013). It is the
 voxel analog of [`../README.md`](../README.md), but the voxel domain is a
-parallel domain — **not** a `KernelAdapter` — so the kernel-swap harness in
+parallel domain, **not** a `KernelAdapter`, so the kernel-swap harness in
 `../*.ts` does not apply, and the rules differ.
 
 ## Why a separate suite
@@ -13,7 +13,7 @@ mesh; they never touch `getKernel`/`ShapeHandle`. So:
 - **References are still closed-form math**, not kernel output (volume of a
   10mm cube is `1000` because `w·d·h = 1000`).
 - **But results are resolution-bound and lossy by construction.** Tolerances are
-  coarse and resolution-dependent, computed from the output mesh — `compareMetrics`
+  coarse and resolution-dependent, computed from the output mesh. `compareMetrics`
   (which measures B-rep shapes) cannot be used; `helpers.ts` provides
   `meshVolume`/`meshArea`/`meshBbox`/`meshTopology` instead.
 - **Invariants are the real guard** (ADR-0013 §11). A single volume number can
@@ -42,7 +42,7 @@ cylinder ~0.4%, box-union ~0.8%; area inflated ~5%.
 ## Documented divergences (these are properties of voxel v1, not bugs)
 
 1. **Not strictly 2-manifold.** Surface Nets v1 output is always **closed** (no
-   boundary edges — asserted), but emits non-manifold edges + degenerate/sliver
+   boundary edges, asserted), but emits non-manifold edges + degenerate/sliver
    triangles except on grid-aligned geometry (e.g. a cube at res 32 is clean; at
    res 24/48 it is not). The suite bounds the bad-triangle fraction (`badTriFraction`,
    ~8%) as a regression guard, **not** a 2-manifold guarantee. The manifold
@@ -52,7 +52,7 @@ cylinder ~0.4%, box-union ~0.8%; area inflated ~5%.
 3. **Cost scales with input triangle count, not just resolution.** The FWN sign
    pass is O(grid · inputTriangles), so a finely-tessellated input (e.g.
    `sphere()` floors at ~8000 triangles → ~12s) dominates runtime. Spec inputs
-   are low-poly (boxes; cylinders tessellated coarsely) — fidelity comes from the
+   are low-poly (boxes; cylinders tessellated coarsely). Fidelity comes from the
    grid resolution, not input density. **Avoid high-poly inputs in this suite.**
 
 ## Running
@@ -102,5 +102,5 @@ describe.skipIf(!RUN_VOXEL_PARITY)('SPEC: …', () => {
 });
 ```
 
-Build op outputs in `beforeAll` (never at collection time — the kernel/engine
+Build op outputs in `beforeAll` (never at collection time: the kernel/engine
 are not ready yet); keep `describe`/`it` names static.


### PR DESCRIPTION
Repo-wide punctuation sweep removing every em dash from authored markdown, following the verify-docs scrub in #1317.

## Scope
87 files: `apps/docs/**`, `docs/decisions/**` (ADRs), `docs/*.md`, package READMEs, `src/**/README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `.claude/commands/*.md`.

## What changed
Punctuation-only. Each em dash became the grammatically appropriate ASCII punctuation:
- label/term → definition: colon
- joined independent clauses: semicolon or sentence split
- parenthetical aside: parentheses or comma pair
- code-comment dashes: hyphen

No prose was reworded and no content was added or removed (per-file diffs are balanced). Em dashes inside fenced code that carry meaning were handled as comments.

## Excluded
Generated/vendored files: `CHANGELOG.md`, `node_modules`, benchmark output, `.serena` memories.

Swept with parallel agents over file batches, then verified `grep -P '—'` is empty across all authored markdown.