### PR TITLE
feat(mates): concentric axis extraction for cones, tori, and surfaces of revolution

### DIFF
--- a/src/kernel/brepkit/geometryOps.ts
+++ b/src/kernel/brepkit/geometryOps.ts
@@ -399,9 +399,16 @@ export function getSurfaceAxis(
   face: KernelShape
 ): { origin: [number, number, number]; direction: [number, number, number] } | null {
   const params = JSON.parse(bk.getAnalyticSurfaceParams(unwrap(face, 'face')));
-  if (params.type !== 'cylinder') return null;
-  const [ox, oy, oz] = params.origin;
-  const [ax, ay, az] = params.axis;
+  // Cylinder params expose origin+axis; cone params expose apex+axis (the apex
+  // is a point on the axis). Torus params carry only a center, no axis vector,
+  // so a toroidal axis is not recoverable here.
+  // params is `any` from JSON.parse; cylinder exposes origin, cone exposes apex.
+
+  const point =
+    params.type === 'cylinder' ? params.origin : params.type === 'cone' ? params.apex : null;
+  if (!point || !params.axis) return null;
+  const [ox, oy, oz] = point as [number, number, number];
+  const [ax, ay, az] = params.axis as [number, number, number];
   const len = Math.hypot(ax, ay, az);
   if (len < 1e-12) return null;
   return {

--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -463,7 +463,34 @@ export function getSurfaceCylinderData(
   return result;
 }
 
-/** Get a cylindrical face's axis (point on axis + unit direction). Null otherwise. */
+/**
+ * Extract the `gp_Ax1` axis of an analytic surface adaptor by type index, or
+ * null. GeomAbs_SurfaceType: 1 = Cylinder, 2 = Cone, 4 = Torus, 7 =
+ * SurfaceOfRevolution. gp_Cone / gp_Torus are not bound in the shipped
+ * opencascade.js build, so their accessors throw; that is treated as "no axis".
+ */
+function surfaceAxisAx1(adaptor: KernelType, typeIdx: number): KernelType | null {
+  let prim: KernelType = null;
+  try {
+    if (typeIdx === 7) return adaptor.AxeOfRevolution();
+    if (typeIdx === 1) prim = adaptor.Cylinder();
+    else if (typeIdx === 2) prim = adaptor.Cone();
+    else if (typeIdx === 4) prim = adaptor.Torus();
+    else return null;
+    const axis = prim.Axis();
+    prim.delete();
+    return axis;
+  } catch {
+    prim?.delete?.();
+    return null;
+  }
+}
+
+/**
+ * Get the axis of symmetry (point on axis + unit direction) for an analytic
+ * face that has one: cylinder, cone, torus, or surface of revolution. Null
+ * otherwise (plane, sphere, free-form).
+ */
 export function getSurfaceAxis(
   oc: KernelInstance,
   face: KernelShape
@@ -472,10 +499,8 @@ export function getSurfaceAxis(
   try {
     const typeVal = adaptor.GetType();
     const typeIdx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
-    // 1 = GeomAbs_Cylinder
-    if (typeIdx !== 1) return null;
-    const cyl = adaptor.Cylinder();
-    const axis = cyl.Axis();
+    const axis = surfaceAxisAx1(adaptor, typeIdx);
+    if (!axis) return null;
     const loc = axis.Location();
     const dir = axis.Direction();
     const result = {
@@ -485,7 +510,6 @@ export function getSurfaceAxis(
     loc.delete();
     dir.delete();
     axis.delete();
-    cyl.delete();
     return result;
   } finally {
     adaptor.delete();

--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -501,16 +501,20 @@ export function getSurfaceAxis(
     const typeIdx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
     const axis = surfaceAxisAx1(adaptor, typeIdx);
     if (!axis) return null;
-    const loc = axis.Location();
-    const dir = axis.Direction();
-    const result = {
-      origin: [loc.X(), loc.Y(), loc.Z()] as [number, number, number],
-      direction: [dir.X(), dir.Y(), dir.Z()] as [number, number, number],
-    };
-    loc.delete();
-    dir.delete();
-    axis.delete();
-    return result;
+    let loc: KernelType = null;
+    let dir: KernelType = null;
+    try {
+      loc = axis.Location();
+      dir = axis.Direction();
+      return {
+        origin: [loc.X(), loc.Y(), loc.Z()] as [number, number, number],
+        direction: [dir.X(), dir.Y(), dir.Z()] as [number, number, number],
+      };
+    } finally {
+      loc?.delete?.();
+      dir?.delete?.();
+      axis.delete();
+    }
   } finally {
     adaptor.delete();
   }

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -126,13 +126,82 @@ function deriveCylinder(
   return { origin, direction, radius, isDirect };
 }
 
-/** Cylindrical face axis (point on axis + unit direction). Null for non-cylinders. */
+/** Circumcenter of three points (the center of the unique circle through them). */
+function circumcenter(a: V3, p: V3, q: V3): V3 | null {
+  const ab = subV(p, a);
+  const ac = subV(q, a);
+  const m = crossV(ab, ac);
+  const mSq = dotV(m, m);
+  if (mSq < 1e-18) return null; // collinear samples
+  const abSq = dotV(ab, ab);
+  const acSq = dotV(ac, ac);
+  const d: V3 = [
+    abSq * ac[0] - acSq * ab[0],
+    abSq * ac[1] - acSq * ab[1],
+    abSq * ac[2] - acSq * ab[2],
+  ];
+  const dxm = crossV(d, m);
+  const inv = 1 / (2 * mSq);
+  return [a[0] + dxm[0] * inv, a[1] + dxm[1] * inv, a[2] + dxm[2] * inv];
+}
+
+/** Center of the iso-v circle at height v (three u-samples → circumcenter). */
+function isoCircleCenter(
+  k: OcctKernelWasm,
+  face: KernelShape,
+  uMin: number,
+  uMax: number,
+  v: number
+): V3 | null {
+  return circumcenter(
+    pointOnSurface(k, face, uMin + 0.1 * (uMax - uMin), v),
+    pointOnSurface(k, face, uMin + 0.45 * (uMax - uMin), v),
+    pointOnSurface(k, face, uMin + 0.8 * (uMax - uMin), v)
+  );
+}
+
+/**
+ * Axis of a surface of revolution (cone, torus, general revolution) by sampling.
+ * occt-wasm exposes no analytic accessor for these. Their U parameter is the
+ * angle of revolution, so the iso-v curve at a fixed v is a circle centered on
+ * the axis; two such centers at different heights span the axis. Avoids v
+ * extremes so a cone apex (a degenerate zero-radius circle) is not sampled.
+ */
+function deriveAxisBySampling(
+  k: OcctKernelWasm,
+  face: KernelShape
+): {
+  origin: V3;
+  direction: V3;
+} | null {
+  const b = uvBounds(k, face);
+  const c1 = isoCircleCenter(k, face, b.uMin, b.uMax, b.vMin + 0.25 * (b.vMax - b.vMin));
+  const c2 = isoCircleCenter(k, face, b.uMin, b.uMax, b.vMin + 0.75 * (b.vMax - b.vMin));
+  if (!c1 || !c2) return null;
+  const d = subV(c2, c1);
+  const len = lenV(d);
+  if (len < 1e-9) return null; // centers coincide; axis not resolvable
+  return { origin: c1, direction: [d[0] / len, d[1] / len, d[2] / len] };
+}
+
+/**
+ * Axis of symmetry (point on axis + unit direction) for an analytic face that
+ * has one. Cylinders use the exact normal-cross derivation; cones, tori, and
+ * surfaces of revolution fall back to circle-center sampling. Null otherwise.
+ */
 export function getSurfaceAxis(
   k: OcctKernelWasm,
   face: KernelShape
 ): { origin: V3; direction: V3 } | null {
-  const cyl = deriveCylinder(k, face);
-  return cyl ? { origin: cyl.origin, direction: cyl.direction } : null;
+  const type = surfaceType(k, face);
+  if (type === 'cylinder') {
+    const cyl = deriveCylinder(k, face);
+    return cyl ? { origin: cyl.origin, direction: cyl.direction } : null;
+  }
+  if (type === 'cone' || type === 'torus' || type === 'revolution') {
+    return deriveAxisBySampling(k, face);
+  }
+  return null;
 }
 
 /** Cylinder radius + handedness for a cylindrical surface. Null for non-cylinders. */

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -164,7 +164,13 @@ function isoCircleCenter(
  * Axis of a surface of revolution (cone, torus, general revolution) by sampling.
  * occt-wasm exposes no analytic accessor for these. Their U parameter is the
  * angle of revolution, so the iso-v curve at a fixed v is a circle centered on
- * the axis; two such centers at different heights span the axis. Avoids v
+ * the axis; two such centers at different heights span the axis.
+ *
+ * Samples three v-levels and uses the farthest-apart pair of centers. Two levels
+ * suffice for a cone or general revolution (v is monotonic along the axis), but
+ * a torus parameterizes v as the tube angle: on a v-symmetric partial torus (a
+ * half-torus, v in [0, pi]) two symmetric samples land at equal heights and
+ * their centers coincide. A third level breaks that symmetry. Avoids the v
  * extremes so a cone apex (a degenerate zero-radius circle) is not sampled.
  */
 function deriveAxisBySampling(
@@ -175,13 +181,27 @@ function deriveAxisBySampling(
   direction: V3;
 } | null {
   const b = uvBounds(k, face);
-  const c1 = isoCircleCenter(k, face, b.uMin, b.uMax, b.vMin + 0.25 * (b.vMax - b.vMin));
-  const c2 = isoCircleCenter(k, face, b.uMin, b.uMax, b.vMin + 0.75 * (b.vMax - b.vMin));
-  if (!c1 || !c2) return null;
-  const d = subV(c2, c1);
-  const len = lenV(d);
-  if (len < 1e-9) return null; // centers coincide; axis not resolvable
-  return { origin: c1, direction: [d[0] / len, d[1] / len, d[2] / len] };
+  const centers = [0.2, 0.5, 0.8]
+    .map((f) => isoCircleCenter(k, face, b.uMin, b.uMax, b.vMin + f * (b.vMax - b.vMin)))
+    .filter((c): c is V3 => c !== null);
+  if (centers.length < 2) return null;
+
+  let best: { origin: V3; direction: V3 } | null = null;
+  let bestLen = 1e-9; // require a resolvable separation between centers
+  for (let i = 0; i < centers.length; i++) {
+    for (let j = i + 1; j < centers.length; j++) {
+      const ci = centers[i];
+      const cj = centers[j];
+      if (!ci || !cj) continue;
+      const d = subV(cj, ci);
+      const len = lenV(d);
+      if (len > bestLen) {
+        bestLen = len;
+        best = { origin: ci, direction: [d[0] / len, d[1] / len, d[2] / len] };
+      }
+    }
+  }
+  return best;
 }
 
 /**

--- a/tests/curveFns.test.ts
+++ b/tests/curveFns.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { skipIfDiverges } from './helpers/kernelDivergences.js';
+import { getKernel } from '@/kernel/index.js';
 import {
   line,
   circle,
@@ -56,6 +58,21 @@ describe('curveAxis', () => {
   it('returns null for a non-circular (line) edge', () => {
     const edge = line([0, 0, 0], [10, 0, 0]);
     expect(curveAxis(castShape(edge.wrapped))).toBeNull();
+  });
+
+  it('resolves the same axis from a partial arc as from the full circle', (ctx) => {
+    skipIfDiverges(ctx, 'curveFns.circleArcType');
+    // A 90-degree arc samples three points spanning a quarter turn, a much
+    // thinner triangle than a full circle; the circumcenter must still land on
+    // the true center. Arc: radius 4, center (2, 3, 5), in a plane normal to Z.
+    const arcShape = getKernel().makeCircleArc([2, 3, 5], [0, 0, 1], 4, 0, Math.PI / 2);
+    const axis = curveAxis(castShape(arcShape));
+    expect(axis).not.toBeNull();
+    if (!axis) return;
+    expect(axis.origin[0]).toBeCloseTo(2, 5);
+    expect(axis.origin[1]).toBeCloseTo(3, 5);
+    expect(axis.origin[2]).toBeCloseTo(5, 5);
+    expect(Math.abs(axis.direction[2])).toBeCloseTo(1, 5);
   });
 });
 

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -63,6 +63,11 @@ export const divergences: DivergenceMap = {
         'manifold proxies getSurfaceCylinderData to occt, which throws ' +
         '(oc.GeomAdaptor_Surface_2 is not a constructor in the brepjs-opencascade WASM build; see #1312)',
     },
+    'mateFns.coneAxis': {
+      kind: 'not-implemented',
+      reason:
+        'manifold is a mesh kernel: a cone tessellates to planar facets, so there is no analytic cone face to extract an axis from',
+    },
   },
   brepkit: {
     // -----------------------------------------------------------------------
@@ -295,6 +300,11 @@ export const divergences: DivergenceMap = {
       kind: 'not-implemented',
       reason: 'Shape evolution tracking not implemented in brepkit kernel',
     },
+    'curveFns.circleArcType': {
+      kind: 'not-implemented',
+      reason:
+        'brepkit represents a circular arc as a BSPLINE_CURVE, not CIRCLE, so curveAxis (which keys on the CIRCLE type) returns null for arc edges',
+    },
 
     // -----------------------------------------------------------------------
     // meshFns.test.ts
@@ -433,6 +443,11 @@ export const divergences: DivergenceMap = {
       reason:
         'getSurfaceCylinderData throws on occt: oc.GeomAdaptor_Surface_2 is not a constructor ' +
         'in the brepjs-opencascade WASM build (see #1312)',
+    },
+    'mateFns.coneAxis': {
+      kind: 'not-implemented',
+      reason:
+        'gp_Cone is not bound in the brepjs-opencascade WASM build, so getSurfaceAxis returns null for cone faces on occt',
     },
   },
 

--- a/tests/mateFns.test.ts
+++ b/tests/mateFns.test.ts
@@ -4,6 +4,7 @@ import { shouldSkipSuite } from './helpers/kernelDivergences.js';
 import {
   box,
   cylinder,
+  cone,
   createAssemblyNode,
   addChild,
   addMate,
@@ -333,6 +334,39 @@ describe('solveAssembly — concentric mate', () => {
     expect(sleeve?.position[1]).toBeCloseTo(0, 4);
     expect(Math.abs(sleeve?.rotation[0] ?? 0)).toBeCloseTo(1, 4);
   });
+
+  it.skipIf(shouldSkipSuite('mateFns.coneAxis'))(
+    'concentric mate aligns two conical faces (tapered pin-in-hole)',
+    () => {
+      // Two coaxial cones along +Z; concentric on their conical faces converges.
+      const cone1 = cone(5, 2, 20);
+      const cone2 = cone(4, 1.5, 15);
+      const coneFace = (shape: Parameters<typeof getFaces>[0]) => {
+        const f = getFaces(shape).find((face) => faceAxis(face) !== null);
+        if (!f) throw new Error('no conical face with an axis found');
+        return f;
+      };
+
+      let assembly = createAssemblyNode('root');
+      assembly = addChild(assembly, createAssemblyNode('shaft', { shape: cone1 }));
+      assembly = addChild(assembly, createAssemblyNode('sleeve', { shape: cone2 }));
+      assembly = addMate(assembly, { type: 'fixed', entity: { node: 'shaft' } });
+      assembly = addMate(assembly, {
+        type: 'concentric',
+        axisA: { node: 'shaft', face: coneFace(cone1) },
+        axisB: { node: 'sleeve', face: coneFace(cone2) },
+      });
+
+      const result = solveAssembly(assembly);
+      expect(isOk(result)).toBe(true);
+      const solved = unwrap(result);
+      expect(solved.converged).toBe(true);
+      const sleeve = solved.transforms.get('sleeve');
+      expect(sleeve?.position[0]).toBeCloseTo(0, 4);
+      expect(sleeve?.position[1]).toBeCloseTo(0, 4);
+      expect(Math.abs(sleeve?.rotation[0] ?? 0)).toBeCloseTo(1, 4);
+    }
+  );
 
   it('concentric mate with no geometry returns error', () => {
     let assembly = createAssemblyNode('root');


### PR DESCRIPTION
Completes #1299 (circular edges landed in #1325). `getSurfaceAxis` now resolves an axis for conical, toroidal, and surface-of-revolution faces, so a `concentric` mate solves against tapered pins/holes, not just cylinders and circular edges.

## Per-kernel implementation
- **occt-wasm (default):** derive the axis by sampling. The iso-v curve of a revolved surface is a circle centered on the axis, so two circle centers at different heights span it. Handles cone, torus, and general revolution. Verified exact for all three.
- **occt:** read the analytic axis where bound (cylinder, surface of revolution). `gp_Cone`/`gp_Torus` are not bound in the shipped opencascade.js WASM build, so those accessors throw; that is caught and returns null rather than failing. Refactored to a small `surfaceAxisAx1` helper.
- **brepkit:** read cone apex + axis from `getAnalyticSurfaceParams`. Torus params carry only a center (no axis vector), so a toroidal axis is not recoverable there.
- **manifold:** mesh kernel, so cones tessellate to planar facets with no analytic cone face (N/A).

## Verification
- New concentric mate test on two conical faces: passes on occt-wasm and brepkit; skipped on occt (`gp_Cone` unbound) and manifold (no analytic face) via divergences.
- New `curveAxis` arc test (addresses Greptile's note on #1325): a 90-degree arc resolves the same center as the full circle. Skipped on brepkit, which types arcs as NURBS rather than CIRCLE.
- `mateFns.test.ts` + `curveFns.test.ts`: occt-wasm 44/44, brepkit 43/44 (1 skip), occt 43/44 (1 skip).

Closes #1299.