### PR TITLE
docs(boolean): document strategy:pairwise as the #1126 STEP-export workaround

### DIFF
--- a/apps/docs/tasks/booleans.md
+++ b/apps/docs/tasks/booleans.md
@@ -63,6 +63,8 @@ export default drilled;
 
 `cutAll(base, tools)` cuts every tool from base in one operation. `fuseAll(shapes)` fuses everything in the list.
 
+If a fused result passes validity checks but fails to export STEP (a rare BOPAlgo corruption on some disjoint inputs, [#1126](https://github.com/andymai/brepjs/issues/1126)), retry with `fuseAll(shapes, { strategy: 'pairwise' })`. The pairwise path uses a different OCCT algorithm that is not affected.
+
 ## With the fluent wrapper
 
 ```typescript

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -431,7 +431,15 @@ function fuseAllPairwise(
  * Fuse all shapes in a single boolean operation.
  *
  * With `strategy: 'native'` (default), uses N-way BRepAlgoAPI_BuilderAlgo.
- * With `strategy: 'pairwise'`, uses recursive divide-and-conquer.
+ * With `strategy: 'pairwise'`, uses recursive divide-and-conquer over
+ * BRepAlgoAPI_Fuse.
+ *
+ * `strategy: 'pairwise'` is the workaround for #1126: the native N-way builder
+ * can silently corrupt the topology of certain disjoint inputs (e.g. an
+ * annular-sector tread fused with a frenet-swept rail) so the result passes all
+ * in-memory checks but traps the STEP writer. The pairwise path uses a different
+ * OCCT algorithm that is not affected. Tracked upstream at
+ * andymai/opencascade.js#3.
  *
  * @param shapes - Array of 3D shapes to fuse (at least one required).
  * @param options - Boolean operation options.

--- a/tests/stepExportDegenerate.test.ts
+++ b/tests/stepExportDegenerate.test.ts
@@ -15,6 +15,7 @@ import {
   unwrap,
   unwrapErr,
   type AnyShape,
+  type Shape3D,
   type Result,
 } from '@/index.js';
 
@@ -33,7 +34,7 @@ const deg = (d: number) => (d * Math.PI) / 180;
  * algorithm) does not. `fuseAll(..., { strategy: 'pairwise' })` is the supported
  * workaround until the upstream OCCT fix lands (andymai/opencascade.js#3).
  */
-function buildTreadAndRail(): [AnyShape, AnyShape] {
+function buildTreadAndRail(): [Shape3D, Shape3D] {
   const TREAD_T = 4,
     TREAD_INNER_R = 10,
     TREAD_OUTER_R = 62,

--- a/tests/stepExportDegenerate.test.ts
+++ b/tests/stepExportDegenerate.test.ts
@@ -28,10 +28,12 @@ const deg = (d: number) => (d * Math.PI) / 180;
  * `isValid`/`validSolid`/`mesh`/`getBounds`/`measureArea` but OOB-trap the STEP/BREP
  * writer. Each input serializes fine on its own; only this specific pairing triggers it.
  *
- * Note: the list-builder `fuseAll` path reproduces this deterministically; the
- * pairwise `fuse` path (a different OCCT algorithm) does not, so this must use `fuseAll`.
+ * Note: the list-builder `fuseAll` path (native N-way BRepAlgoAPI_BuilderAlgo)
+ * reproduces this deterministically; the pairwise path (a different OCCT
+ * algorithm) does not. `fuseAll(..., { strategy: 'pairwise' })` is the supported
+ * workaround until the upstream OCCT fix lands (andymai/opencascade.js#3).
  */
-function buildCorruptingFuse(): AnyShape {
+function buildTreadAndRail(): [AnyShape, AnyShape] {
   const TREAD_T = 4,
     TREAD_INNER_R = 10,
     TREAD_OUTER_R = 62,
@@ -64,7 +66,11 @@ function buildCorruptingFuse(): AnyShape {
   const railProfile = sketchCircle(RAIL_DIA / 2, { plane: railPlane }).wire;
   const rail = unwrap(sweep(railProfile, railPath, { frenet: true }));
 
-  return unwrap(fuseAll([tread0, rail]));
+  return [tread0, rail];
+}
+
+function buildCorruptingFuse(): AnyShape {
+  return unwrap(fuseAll(buildTreadAndRail()));
 }
 
 // Isolated in its own file: a successful trap poisons the kernel's writer for the
@@ -81,6 +87,17 @@ describe.skipIf(currentKernel !== 'occt')(
     it('exports a healthy box before the poisoning call', () => {
       // Proves the kernel is alive, so a later failure is attributable to the shape.
       expect(isOk(exportSTEP(box(5, 5, 5)))).toBe(true);
+    });
+
+    it('strategy: "pairwise" produces a STEP-exportable shape (the #1126 workaround)', () => {
+      // The pairwise reduction uses BRepAlgoAPI_Fuse rather than the N-way
+      // BuilderAlgo, sidestepping the BOPAlgo corruption. Same inputs that
+      // corrupt under the native path export cleanly here. Runs before the
+      // poisoning call below, which would otherwise leave the writer unusable.
+      const pairwise = fuseAll(buildTreadAndRail(), { strategy: 'pairwise' });
+      expect(isOk(pairwise)).toBe(true);
+      const result = exportSTEP(unwrap(pairwise));
+      expect(isOk(result)).toBe(true);
     });
 
     it('returns a clean Err (never throws, never a phantom file-read error)', () => {


### PR DESCRIPTION
Addresses #1126 with a documented, tested escape hatch.

## Background
`fuseAll` defaults to the native N-way fuse (`BRepAlgoAPI_BuilderAlgo`), which on certain disjoint inputs (the spiral-staircase tread + frenet-swept rail in #1126) silently corrupts the result's topology: it passes `isValid` / `validSolid` / `mesh` / `getBounds` / `measureArea` but traps the STEP writer. The root cause is upstream OCCT BOPAlgo, filed at andymai/opencascade.js#3; no in-memory check detects it.

## The workaround
The bisection in #1126 showed pairwise `fuse` (a different OCCT algorithm, `BRepAlgoAPI_Fuse`) is unaffected. That path already exists: `fuseAll(shapes, { strategy: 'pairwise' })`. This PR makes it discoverable and locks it in:

- **JSDoc** on `fuseAll` and a note in `apps/docs/tasks/booleans.md` point to `strategy: 'pairwise'` as the #1126 workaround.
- **Regression test** (`tests/stepExportDegenerate.test.ts`): the exact tread+rail inputs that corrupt under the native path now export cleanly under `strategy: 'pairwise'` (`exportSTEP` → Ok). Gated to occt, where the frenet sweep that builds the repro is supported.

No default behavior changes: native stays the default fast path; pairwise is opt-in. The existing "native path traps are caught and classified, never a phantom file-read error" guarantee is unchanged.

Verified: `tests/stepExportDegenerate.test.ts` 3/3 on occt.