### PR TITLE
fix(occt): derive cylinder data via embind downcast, not GeomAdaptor_Surface

### DIFF
--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -442,24 +442,21 @@ export function createCurveAdaptor(oc: KernelInstance, shape: KernelShape): Kern
 
 /** Extract cylinder data from a surface handle. Returns null if not a cylinder. */
 export function getSurfaceCylinderData(
-  oc: KernelInstance,
+  _oc: KernelInstance,
   surface: KernelType
 ): { radius: number; isDirect: boolean } | null {
-  const adaptor = new oc.GeomAdaptor_Surface_2(surface);
-  const typeVal = adaptor.GetType();
-  const typeIdx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
-  // 1 = GeomAbs_Cylinder
-  if (typeIdx !== 1) {
-    adaptor.delete();
-    return null;
-  }
-  const cyl = adaptor.Cylinder();
+  // GeomAdaptor_Surface is not bound in this WASM build (#1312). embind
+  // auto-downcasts the handle's payload to its most-derived registered type, so a
+  // cylindrical surface exposes gp_Cylinder accessors directly; non-cylinders lack
+  // Cylinder().
+  const geom = surface.get();
+  if (typeof geom.Cylinder !== 'function') return null;
+  const cyl = geom.Cylinder();
   const result = {
     radius: cyl.Radius(),
     isDirect: cyl.Direct(),
   };
   cyl.delete();
-  adaptor.delete();
   return result;
 }
 

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -60,8 +60,7 @@ export const divergences: DivergenceMap = {
     'curves.cylinderUnwrapOriginal': {
       kind: 'not-implemented',
       reason:
-        'manifold proxies getSurfaceCylinderData to occt, which throws ' +
-        '(oc.GeomAdaptor_Surface_2 is not a constructor in the brepjs-opencascade WASM build; see #1312)',
+        'manifold is a mesh kernel: a cylinder tessellates to planar facets, so surfaceType never reports a cylindrical face to unwrap onto',
     },
     'mateFns.coneAxis': {
       kind: 'not-implemented',
@@ -437,12 +436,6 @@ export const divergences: DivergenceMap = {
       kind: 'skip',
       reason:
         'Sampled B-spline approximation of ellipse arcs has lower precision than native OCCT Geom2d',
-    },
-    'curves.cylinderUnwrapOriginal': {
-      kind: 'not-implemented',
-      reason:
-        'getSurfaceCylinderData throws on occt: oc.GeomAdaptor_Surface_2 is not a constructor ' +
-        'in the brepjs-opencascade WASM build (see #1312)',
     },
     'mateFns.coneAxis': {
       kind: 'not-implemented',


### PR DESCRIPTION
## Summary

Fixes #1312. `getSurfaceCylinderData` threw `oc.GeomAdaptor_Surface_2 is not a constructor` on the **occt** kernel because that adaptor isn't bound in the `brepjs-opencascade` WASM build. This broke `sketchOnFace` / `curvesAsEdgesOnFace(..., 'original')` onto cylindrical faces on occt (and manifold, which proxies to it).

## Fix

embind auto-downcasts a `Geom_Surface` handle's payload to its most-derived registered type, so a cylindrical surface exposes `gp_Cylinder` accessors directly (verified by probing the live build). Replaced the unavailable adaptor with `surface.get().Cylinder()`, guarding non-cylinders on the absence of `Cylinder()`. This mirrors the existing `reverseSurfaceU` pattern (`surface.get().UReversed()`).

## Divergences

- **occt**: removed `curves.cylinderUnwrapOriginal` — now passes, assertion runs.
- **manifold**: kept, but corrected the reason. Manifold is a mesh kernel: `cylinder()` tessellates to planar facets, so `surfaceType` never reports a cylindrical face to unwrap onto (same root cause as the existing `mateFns.coneAxis` manifold divergence). The original "proxies to occt which throws" reason was a misdiagnosis.

## Verification

- `tests/curves.test.ts` cylinder-unwrap test passes on **occt**, **occt-wasm**, **brepkit**; correctly skipped on **manifold**.
- typecheck + lint clean; pre-commit changed-file suite green (3670 passed).