### PR TITLE
feat(assembly): non-plane coincident and distance mates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ For adding a new operation or kernel method, see `.claude/commands/`.
 
 - OCCT Emscripten returns enum objects with `.value`; extract with: `typeof val === 'number' ? val : Number(val?.value ?? val)`
 - `autoHeal` short-circuits valid shapes: `report.alreadyValid=true`, no sew/heal diagnostics run
-- Assembly solver composes constraints down a chain: each positioning mate reads the referenced part's _solved_ pose and resolves in topological order (a `fixed` node anchors the chain). `concentric`/`angle` and non-plane entity pairs are still unsupported (report `ASSEMBLY_NOT_CONVERGED`).
+- Assembly solver composes constraints down a chain: each positioning mate reads the referenced part's _solved_ pose and resolves in topological order (a `fixed` node anchors the chain). Solved mates: `fixed`, `concentric` (axis-axis), `angle` (plane-plane), and `coincident`/`distance` for plane-plane, plane-point, point-point, axis-axis, and axis-point pairs (`TRANSLATIONAL_PAIRS` in `solverAdapter.ts`). Unsupported pairs (e.g. axis-plane) report `ASSEMBLY_NOT_CONVERGED` with the offending `type(a-b)` and DOF count.
 - `Uint32Array` WASM interop: always convert to regular `Array` before passing to kernel methods
 - `DisposalScope` disposes in LIFO order; register dependencies after their dependees
 - `noUncheckedIndexedAccess` is enabled: array indexing returns `T | undefined`, add bounds checks or use `!` with eslint-disable

--- a/src/kernel/solverAdapter.ts
+++ b/src/kernel/solverAdapter.ts
@@ -135,15 +135,136 @@ function solveAngle(ref: SolverEntity, dep: SolverEntity, angleRad: number): Pos
   return { position: [0, 0, 0], rotation: quatFromAxisAngle(axis, phi - angleRad) };
 }
 
-/** Entity types each positioning constraint requires of (entityA, entityB). */
+/**
+ * Point-point coincident/distance: place the dependent point on the reference
+ * point (`extra` = 0) or at `extra` along the original separation direction.
+ * If the points already coincide the direction is arbitrary (+X).
+ */
+function solvePointPair(refOrigin: Vec3, depOrigin: Vec3, extra: number): Pose {
+  const sep = sub(depOrigin, refOrigin);
+  const len = Math.hypot(sep[0], sep[1], sep[2]);
+  const dir: Vec3 = len < 1e-9 ? [1, 0, 0] : scale(sep, 1 / len);
+  const target = add(refOrigin, scale(dir, extra));
+  return { position: sub(target, depOrigin), rotation: IDENTITY_ROTATION };
+}
+
+/**
+ * Move the dependent plane (normal `depNormal`, at the origin) so its signed
+ * distance from the reference point equals `extra` (the mirror of `solvePlanePair`
+ * for a point reference and a plane dependent).
+ */
+function solvePlaneToPoint(depNormal: Vec3, refOrigin: Vec3, depOrigin: Vec3, extra: number): Pose {
+  const n = normalize(depNormal);
+  const t = dot(n, sub(refOrigin, depOrigin)) - extra;
+  return { position: scale(n, t), rotation: IDENTITY_ROTATION };
+}
+
+/**
+ * Reference axis, dependent point: drop the point onto the axis line
+ * (`extra` = 0) or place it at radial distance `extra` from the line, keeping
+ * its along-axis position. A point already on the axis gets an arbitrary radial.
+ */
+function solveAxisToPoint(ref: SolverEntity, depOrigin: Vec3, extra: number): Pose {
+  const d = normalize(ref.direction ?? [0, 0, 1]);
+  const foot = add(ref.origin, scale(d, dot(d, sub(depOrigin, ref.origin))));
+  if (extra === 0) return { position: sub(foot, depOrigin), rotation: IDENTITY_ROTATION };
+  const radial = sub(depOrigin, foot);
+  const rlen = Math.hypot(radial[0], radial[1], radial[2]);
+  const rdir = rlen < 1e-9 ? anyPerpendicular(d) : scale(radial, 1 / rlen);
+  return { position: sub(add(foot, scale(rdir, extra)), depOrigin), rotation: IDENTITY_ROTATION };
+}
+
+/**
+ * Reference point, dependent axis: translate the axis line so it passes through
+ * the point (`extra` = 0) or lies at perpendicular distance `extra` from it.
+ * Translation is purely perpendicular to the axis, so the line's direction and
+ * along-axis parameterization are preserved.
+ */
+function solvePointToAxis(refOrigin: Vec3, dep: SolverEntity, extra: number): Pose {
+  const d = normalize(dep.direction ?? [0, 0, 1]);
+  const w = sub(dep.origin, refOrigin);
+  const perp = sub(w, scale(d, dot(d, w)));
+  const plen = Math.hypot(perp[0], perp[1], perp[2]);
+  if (extra === 0) return { position: scale(perp, -1), rotation: IDENTITY_ROTATION };
+  const pdir = plen < 1e-9 ? anyPerpendicular(d) : scale(perp, 1 / plen);
+  return { position: sub(scale(pdir, extra), perp), rotation: IDENTITY_ROTATION };
+}
+
+/**
+ * Axis-axis distance: align the dependent axis parallel to the reference, then
+ * offset it to perpendicular distance `extra` (parallel pin-and-spacer). With
+ * `extra` = 0 the axes become collinear, matching `concentric`.
+ */
+function solveAxisAxisDistance(ref: SolverEntity, dep: SolverEntity, extra: number): Pose {
+  const dRef = normalize(ref.direction ?? [0, 0, 1]);
+  const dDep = normalize(dep.direction ?? [0, 0, 1]);
+  const rotation = quatFromTo(dDep, dRef);
+  const depO = quatRotate(rotation, dep.origin);
+  const w = sub(depO, ref.origin);
+  const perp = sub(w, scale(dRef, dot(dRef, w)));
+  const plen = Math.hypot(perp[0], perp[1], perp[2]);
+  const pdir = plen < 1e-9 ? anyPerpendicular(dRef) : scale(perp, 1 / plen);
+  return { position: sub(scale(pdir, extra), perp), rotation };
+}
+
+/**
+ * Supported entity-type pairs for the translational mates (`coincident` /
+ * `distance`), keyed `${entityA}-${entityB}`. Both orders are listed where the
+ * solver handles them, so a user need not pre-order the entities.
+ */
+const TRANSLATIONAL_PAIRS = new Set([
+  'plane-plane',
+  'plane-point',
+  'point-plane',
+  'point-point',
+  'axis-axis',
+  'axis-point',
+  'point-axis',
+]);
+
+/** Entity types the orientation/axis mates require of (entityA, entityB). */
 const REQUIRED_ENTITIES: Readonly<Record<string, SolverEntity['type']>> = {
-  coincident: 'plane',
-  distance: 'plane',
   angle: 'plane',
   concentric: 'axis',
 };
 
 const POSITIONING_TYPES = new Set(['coincident', 'distance', 'angle', 'concentric']);
+
+/** Whether a positioning mate's entity pair is solvable. */
+function isSupportedPair(type: string, a: SolverEntity['type'], b: SolverEntity['type']): boolean {
+  const required = REQUIRED_ENTITIES[type];
+  if (required) return a === required && b === required;
+  // coincident / distance: dispatch by entity-type pair.
+  return TRANSLATIONAL_PAIRS.has(`${a}-${b}`);
+}
+
+/**
+ * Solve a `coincident` (extra = 0) or `distance` (extra = value) mate for any
+ * supported entity-type pair. `ref` is already in world space; the dependent is
+ * at the origin. Returns null only for an unsupported pair (filtered out
+ * upstream by `isSupportedPair`).
+ */
+function solveTranslational(ref: SolverEntity, dep: SolverEntity, extra: number): Pose | null {
+  const key = `${ref.type}-${dep.type}`;
+  switch (key) {
+    case 'plane-plane':
+    case 'plane-point':
+      // Both use the reference plane normal; a point dependent has no normal.
+      return solvePlanePair(ref, dep, extra);
+    case 'point-plane':
+      return solvePlaneToPoint(dep.normal ?? [0, 0, 1], ref.origin, dep.origin, extra);
+    case 'point-point':
+      return solvePointPair(ref.origin, dep.origin, extra);
+    case 'axis-axis':
+      return extra === 0 ? solveConcentric(ref, dep) : solveAxisAxisDistance(ref, dep, extra);
+    case 'axis-point':
+      return solveAxisToPoint(ref, dep.origin, extra);
+    case 'point-axis':
+      return solvePointToAxis(ref.origin, dep, extra);
+    default:
+      return null;
+  }
+}
 
 /** Dispatch a positioning mate to its solver. `ref` is already in world space. */
 function solveMate(c: SolverConstraint, ref: SolverEntity, dep: SolverEntity): Pose {
@@ -153,18 +274,20 @@ function solveMate(c: SolverConstraint, ref: SolverEntity, dep: SolverEntity): P
     case 'angle':
       return solveAngle(ref, dep, ((c.value ?? 0) * Math.PI) / 180);
     case 'distance':
-      return solvePlanePair(ref, dep, c.value ?? 0);
+      return solveTranslational(ref, dep, c.value ?? 0) ?? solvePlanePair(ref, dep, c.value ?? 0);
     default:
-      return solvePlanePair(ref, dep, 0);
+      return solveTranslational(ref, dep, 0) ?? solvePlanePair(ref, dep, 0);
   }
 }
 
 /**
  * Solve assembly constraints analytically.
  *
- * Handles: fixed, coincident/distance (plane-plane), concentric (axis-axis), and
- * angle (plane-plane orientation). For a positioning mate, entityA is the
- * reference and entityB the dependent. Chain roots (nodes never positioned by a
+ * Handles: fixed, concentric (axis-axis), angle (plane-plane orientation), and
+ * coincident/distance for any supported entity-type pair (plane-plane,
+ * plane-point, point-point, axis-axis, axis-point, and both point orders — see
+ * `TRANSLATIONAL_PAIRS`). For a positioning mate, entityA is the reference and
+ * entityB the dependent. Chain roots (nodes never positioned by a
  * mate) and explicit `fixed` nodes anchor at the origin; constraints then resolve
  * in topological order — each places its dependent against the reference's solved
  * pose (rotation included), so multi-body chains compose. Returns
@@ -202,9 +325,10 @@ export function solveConstraints(nodes: string[], constraints: SolverConstraint[
   const pending: SolverConstraint[] = [];
   for (const c of positioning) {
     if (!c.entityA || !c.entityB) continue;
-    const required = REQUIRED_ENTITIES[c.type];
-    if (c.entityA.entity.type !== required || c.entityB.entity.type !== required) {
-      unsupported.push(`${c.type}(${c.entityA.entity.type}-${c.entityB.entity.type})`);
+    const a = c.entityA.entity.type;
+    const b = c.entityB.entity.type;
+    if (!isSupportedPair(c.type, a, b)) {
+      unsupported.push(`${c.type}(${a}-${b})`);
       continue;
     }
     pending.push(c);

--- a/tests/mateFns.test.ts
+++ b/tests/mateFns.test.ts
@@ -12,7 +12,6 @@ import {
   isOk,
   isErr,
   unwrap,
-  unwrapErr,
   getFaces,
   getEdges,
   getCurveType,
@@ -149,6 +148,23 @@ describe('assembly mates', () => {
     // Top of b1 at z=10, bottom of b2 at z=0, distance 5
     // offset = (10-0) + 5 = 15
     expect(upperTransform?.position[2]).toBeCloseTo(15, 0);
+  });
+
+  it('point-plane coincident mate drops a part point onto a reference face', () => {
+    const base = box(10, 10, 10);
+    let assembly = createAssemblyNode('root');
+    assembly = addChild(assembly, createAssemblyNode('base', { shape: base }));
+    assembly = addChild(assembly, createAssemblyNode('peg', { shape: box(2, 2, 2) }));
+    assembly = addMate(assembly, { type: 'fixed', entity: { node: 'base' } });
+    assembly = addMate(assembly, {
+      type: 'coincident',
+      entityA: { node: 'base', face: topFace(base) }, // plane at z=10
+      entityB: { node: 'peg', point: [0, 0, 0] },
+    });
+
+    const solved = unwrap(solveAssembly(assembly));
+    expect(solved.converged).toBe(true);
+    expect(solved.transforms.get('peg')?.position[2]).toBeCloseTo(10, 6);
   });
 
   it('returns error when no mates defined', () => {
@@ -431,23 +447,22 @@ describe('solveAssembly — angle mate', () => {
 });
 
 describe('solveAssembly — coincident with point entity', () => {
-  it('coincident mate using point entities returns error (point-point unsupported)', () => {
+  it('coincident mate using point entities moves the dependent onto the reference point', () => {
     let assembly = createAssemblyNode('root');
     assembly = addChild(assembly, createAssemblyNode('a', { shape: box(10, 10, 10) }));
     assembly = addChild(assembly, createAssemblyNode('b', { shape: box(5, 5, 5) }));
     assembly = addMate(assembly, { type: 'fixed', entity: { node: 'a' } });
     assembly = addMate(assembly, {
       type: 'coincident',
-      // Points are valid MateEntity with type 'point' in extractEntity
       entityA: { node: 'a', point: [0, 0, 10] },
       entityB: { node: 'b', point: [0, 0, 0] },
     });
 
     const result = solveAssembly(assembly);
-    // Point-point coincident is not implemented — solver reports as unsupported
-    expect(isErr(result)).toBe(true);
-    const error = unwrapErr(result);
-    expect(error.message).toContain('coincident(point-point)');
+    expect(isOk(result)).toBe(true);
+    const solved = unwrap(result);
+    expect(solved.converged).toBe(true);
+    expect(solved.transforms.get('b')?.position).toEqual([0, 0, 10]);
   });
 
   it('coincident mate with no geometry returns error', () => {
@@ -631,37 +646,20 @@ describe('solveConstraints — unsupported constraint honesty', () => {
     expect(result.unsupported).toEqual(['concentric(plane-plane)', 'angle(axis-axis)']);
   });
 
-  it('reports non-plane entity combinations as unsupported for coincident', () => {
+  it('reports a genuinely unsupported entity pair (axis-plane) for coincident', () => {
     const result = solveConstraints(
       ['a', 'b'],
       [
         {
           type: 'coincident',
-          entityA: { node: 'a', entity: { type: 'point', origin: [0, 0, 10] } },
-          entityB: { node: 'b', entity: { type: 'point', origin: [0, 0, 0] } },
+          entityA: { node: 'a', entity: { type: 'axis', origin: [0, 0, 0], direction: [0, 0, 1] } },
+          entityB: { node: 'b', entity: { type: 'plane', origin: [0, 0, 0], normal: [0, 0, 1] } },
         },
       ]
     );
     expect(result.converged).toBe(false);
-    expect(result.unsupported).toEqual(['coincident(point-point)']);
+    expect(result.unsupported).toEqual(['coincident(axis-plane)']);
     expect(result.dof).toBe(3);
-  });
-
-  it('reports non-plane entity combinations as unsupported for distance', () => {
-    const result = solveConstraints(
-      ['a', 'b'],
-      [
-        {
-          type: 'distance',
-          entityA: { node: 'a', entity: { type: 'point', origin: [0, 0, 0] } },
-          entityB: { node: 'b', entity: { type: 'axis', origin: [0, 0, 0], direction: [0, 0, 1] } },
-          value: 5,
-        },
-      ]
-    );
-    expect(result.converged).toBe(false);
-    expect(result.unsupported).toEqual(['distance(point-axis)']);
-    expect(result.dof).toBe(1);
   });
 
   it('still solves supported constraints alongside unsupported ones', () => {
@@ -712,5 +710,106 @@ describe('solveConstraints — unsupported constraint honesty', () => {
     );
     expect(result.converged).toBe(false);
     expect(result.unsupported).toEqual(['coincident(unanchored)', 'coincident(unanchored)']);
+  });
+});
+
+describe('solveConstraints — non-plane coincident/distance pairs', () => {
+  const pt = (o: [number, number, number]): SolverEntity => ({ type: 'point', origin: o });
+  const ax = (o: [number, number, number], d: [number, number, number]): SolverEntity => ({
+    type: 'axis',
+    origin: o,
+    direction: d,
+  });
+  const pl = (o: [number, number, number], n: [number, number, number]): SolverEntity => ({
+    type: 'plane',
+    origin: o,
+    normal: n,
+  });
+
+  function solveOne(
+    type: 'coincident' | 'distance',
+    a: SolverEntity,
+    b: SolverEntity,
+    value?: number
+  ) {
+    return solveConstraints(
+      ['a', 'b'],
+      [
+        {
+          type,
+          entityA: { node: 'a', entity: a },
+          entityB: { node: 'b', entity: b },
+          ...(value === undefined ? {} : { value }),
+        },
+      ]
+    );
+  }
+
+  function pos(r: ReturnType<typeof solveConstraints>): [number, number, number] {
+    const p = r.transforms.get('b')?.position;
+    if (!p) throw new Error('no transform for b');
+    return [p[0], p[1], p[2]];
+  }
+
+  function expectPos(r: ReturnType<typeof solveConstraints>, expected: readonly number[]): void {
+    const p = pos(r);
+    for (let i = 0; i < 3; i++) expect(p[i]).toBeCloseTo(expected[i] ?? 0, 9);
+  }
+
+  it('point-point coincident moves the dependent point onto the reference point', () => {
+    const r = solveOne('coincident', pt([0, 0, 10]), pt([0, 0, 0]));
+    expect(r.converged).toBe(true);
+    expectPos(r, [0, 0, 10]);
+  });
+
+  it('point-point distance separates along the original direction', () => {
+    const r = solveOne('distance', pt([0, 0, 0]), pt([3, 0, 0]), 10);
+    expect(r.converged).toBe(true);
+    expectPos(r, [7, 0, 0]); // dep ends at x=10, 10 from ref
+  });
+
+  it('plane-point coincident drops the point onto the reference plane', () => {
+    const r = solveOne('coincident', pl([0, 0, 5], [0, 0, 1]), pt([0, 0, 0]));
+    expect(r.converged).toBe(true);
+    expectPos(r, [0, 0, 5]);
+  });
+
+  it('point-plane coincident moves the dependent plane through the reference point', () => {
+    const r = solveOne('coincident', pt([0, 0, 0]), pl([0, 0, 5], [0, 0, 1]));
+    expect(r.converged).toBe(true);
+    expectPos(r, [0, 0, -5]);
+  });
+
+  it('axis-axis coincident makes the axes collinear', () => {
+    const r = solveOne('coincident', ax([0, 0, 0], [0, 0, 1]), ax([1, 0, 0], [0, 0, 1]));
+    expect(r.converged).toBe(true);
+    expectPos(r, [-1, 0, 0]);
+  });
+
+  it('axis-axis distance offsets the dependent axis to a perpendicular gap', () => {
+    const r = solveOne('distance', ax([0, 0, 0], [0, 0, 1]), ax([0, 0, 0], [0, 0, 1]), 5);
+    expect(r.converged).toBe(true);
+    const p = pos(r);
+    expect(Math.hypot(p[0], p[1])).toBeCloseTo(5, 9); // 5 away from the ref axis
+    expect(p[2]).toBeCloseTo(0, 9);
+  });
+
+  it('axis-point coincident drops the point onto the axis line', () => {
+    const r = solveOne('coincident', ax([0, 0, 0], [0, 0, 1]), pt([3, 0, 0]));
+    expect(r.converged).toBe(true);
+    expectPos(r, [-3, 0, 0]); // point at (3,0,0) → on the z-axis
+  });
+
+  it('axis-point distance places the point at a radial offset', () => {
+    const r = solveOne('distance', ax([0, 0, 0], [0, 0, 1]), pt([3, 0, 0]), 10);
+    expect(r.converged).toBe(true);
+    expectPos(r, [7, 0, 0]); // point at x=10, 10 from the axis
+  });
+
+  it('point-axis distance offsets the axis to a perpendicular gap from the point', () => {
+    const r = solveOne('distance', pt([0, 0, 0]), ax([0, 0, 0], [0, 0, 1]), 5);
+    expect(r.converged).toBe(true);
+    const p = pos(r);
+    expect(Math.hypot(p[0], p[1])).toBeCloseTo(5, 9);
   });
 });


### PR DESCRIPTION
Closes #1332. Follow-up from #1286 (gap A2).

## What

`coincident` and `distance` mates were plane-plane only — any non-plane entity pair reported `ASSEMBLY_NOT_CONVERGED`. This generalizes them to dispatch by the (entityA, entityB) type pair:

| Pair | coincident | distance |
|------|-----------|----------|
| plane-plane | offset to touching | gap by `value` |
| plane-point / point-plane | point onto plane | point at `value` from plane |
| point-point | coincide | separate along original direction |
| axis-axis | collinear (= concentric) | parallel at perpendicular `value` |
| axis-point / point-axis | point onto axis line | point at radial `value` |

`concentric` (axis-axis) and `angle` (plane-plane) keep their fixed required-entity checks. Genuinely unsupported pairs (e.g. axis-plane) still return a clean `ASSEMBLY_NOT_CONVERGED` naming the offending `type(a-b)` and its DOF count.

## How

`extractEntity` (mateFns) already yields `axis`/`point`/`plane` entities, so no input-side change was needed — the work is solver-side DOF math in `solverAdapter.ts`: a `TRANSLATIONAL_PAIRS` set drives the eager unsupported-filter, and `solveTranslational` dispatches each supported pair to a small analytical solver (each derived to keep the dependent's free DOFs untouched, e.g. axis offsets stay perpendicular, radial placements preserve along-axis position).

## Tests

- Pure-solver unit tests (`solveConstraints`, kernel-independent) for every new pair, asserting exact placement.
- End-to-end through `solveAssembly`: point-point coincident (updated the old test that asserted it errored) and a point-plane mate mixing a point with an extracted face.
- Kept an honesty test for a still-unsupported pair (axis-plane).

occt-wasm gate green; occt and brepkit green. The pre-existing manifold failures are the mesh kernel's lack of exact face/axis extraction (ungated, same limitation as the existing box-face mate tests). Also refreshes the stale `CLAUDE.md` solver gotcha.