### PR TITLE
refactor(kinematics): address review feedback on joints and mates

### DIFF
--- a/src/kernel/solverAdapter.ts
+++ b/src/kernel/solverAdapter.ts
@@ -273,10 +273,20 @@ function solveMate(c: SolverConstraint, ref: SolverEntity, dep: SolverEntity): P
       return solveConcentric(ref, dep);
     case 'angle':
       return solveAngle(ref, dep, ((c.value ?? 0) * Math.PI) / 180);
-    case 'distance':
-      return solveTranslational(ref, dep, c.value ?? 0) ?? solvePlanePair(ref, dep, c.value ?? 0);
-    default:
-      return solveTranslational(ref, dep, 0) ?? solvePlanePair(ref, dep, 0);
+    default: {
+      // coincident (extra = 0) / distance (extra = value). isSupportedPair has
+      // already filtered out unsupported pairs upstream, so a null here means
+      // TRANSLATIONAL_PAIRS and solveTranslational drifted out of sync — surface
+      // that invariant violation loudly rather than guessing with plane logic.
+      const extra = c.type === 'distance' ? (c.value ?? 0) : 0;
+      const pose = solveTranslational(ref, dep, extra);
+      if (!pose) {
+        throw new Error(
+          `solveMate: unsupported entity pair escaped filter: ${ref.type}-${dep.type}`
+        );
+      }
+      return pose;
+    }
   }
 }
 

--- a/src/operations/jointFns.ts
+++ b/src/operations/jointFns.ts
@@ -81,7 +81,12 @@ export interface JointOptions {
 export interface CylindricalOptions {
   /** Rotation DOF (degrees). Default range -180..180. */
   rotation?: JointOptions;
-  /** Translation DOF (length). Default range 0..100. */
+  /**
+   * Translation DOF (length). Default range 0..100, matching `prismaticJoint`
+   * (both model a slide along an axis). This is deliberately asymmetric with
+   * `planarJoint`'s in-plane translations, which default to -100..100 because
+   * an unanchored in-plane slide is naturally bidirectional.
+   */
   translation?: JointOptions;
 }
 
@@ -302,6 +307,7 @@ export function setJointValue(joint: Joint, value: number): Joint {
 /** The local rigid transform contributed by a single DOF at `value`. */
 function dofPose(origin: Vec3, dof: JointDOF, value: number): JointPose {
   if (dof.kind === 'translation') {
+    // `origin` is intentionally unused: a pure translation has no pivot.
     return {
       position: [dof.axis[0] * value, dof.axis[1] * value, dof.axis[2] * value],
       rotation: [1, 0, 0, 0],

--- a/tests/jointFns.test.ts
+++ b/tests/jointFns.test.ts
@@ -259,6 +259,23 @@ describe('jointFns — multi-DOF kinematics', () => {
     expectVecClose(applyPose(pose, [0, 0, 0]), [3, 4, 0]);
   });
 
+  it('planar rotates about the normal through an offset plane origin', () => {
+    const j = setJointValues(
+      planarJoint(
+        'base',
+        'slide',
+        { origin: [5, 0, 0], direction: [0, 0, 1] },
+        { uDirection: [1, 0, 0] }
+      ),
+      [0, 0, 90] // rotation only, no in-plane translation
+    );
+    const pose = jointTransform(j);
+    // 90° about the Z line through (5,0,0): a point 1 unit out at (6,0,0) → (5,1,0).
+    expectVecClose(applyPose(pose, [6, 0, 0]), [5, 1, 0]);
+    // The plane origin is the pivot and stays fixed.
+    expectVecClose(applyPose(pose, [5, 0, 0]), [5, 0, 0]);
+  });
+
   it('spherical drives each axis and composes Rx·Ry·Rz about the pivot', () => {
     const pivot: [number, number, number] = [0, 0, 0];
     // Single-axis: +90 about X sends +Y to +Z.

--- a/tests/mateFns.test.ts
+++ b/tests/mateFns.test.ts
@@ -150,7 +150,7 @@ describe('assembly mates', () => {
     expect(upperTransform?.position[2]).toBeCloseTo(15, 0);
   });
 
-  it('point-plane coincident mate drops a part point onto a reference face', () => {
+  it('plane-point coincident mate drops a part point onto a reference face', () => {
     const base = box(10, 10, 10);
     let assembly = createAssemblyNode('root');
     assembly = addChild(assembly, createAssemblyNode('base', { shape: base }));


### PR DESCRIPTION
Addresses Greptile review comments left on the already-merged #1335 (multi-DOF joints) and #1332 (non-plane mates).

## Changes

- **`solveMate` fallback → throw** (`solverAdapter.ts`): the `?? solvePlanePair` fallback was dead code (`isSupportedPair` filters unsupported pairs before `solveMate` runs). If `TRANSLATIONAL_PAIRS` and the `solveTranslational` switch ever drift, the old fallback would silently apply plane logic to non-plane entities. Now it throws an invariant-violation error instead.
- **Document the translation-range asymmetry**: `cylindricalJoint`'s slide defaults to `0..100` (matching `prismaticJoint` — both slide along an axis), while `planarJoint`'s in-plane translations default to `-100..100` (bidirectional). Clarified in `CylindricalOptions`.
- **`dofPose` origin note**: a comment makes explicit that `origin` is intentionally ignored for translation DOFs (no pivot).
- **Planar offset-pivot test**: adds coverage for planar rotation about a non-zero plane origin (previously only `origin=[0,0,0]` was exercised).
- **Test rename**: the mislabeled `point-plane` mate test is now `plane-point` (entityA is the reference face/plane, entityB the dependent point).

No public API or behavior change for valid inputs; the throw only fires on an internal invariant violation that's currently unreachable.