### PR TITLE
fix(kinematics): bound-aware IK Jacobian probe

### DIFF
--- a/src/operations/ikFns.ts
+++ b/src/operations/ikFns.ts
@@ -244,12 +244,20 @@ function residualTwist(
   return Math.sqrt(s);
 }
 
-/** Finite-difference Jacobian: column `j` is the end-effector twist from δq[j]. */
+/**
+ * Finite-difference Jacobian: column `j` is the end-effector twist from δq[j].
+ * The probe steps *inward* from a bound — `forwardKinematics` clamps each DOF to
+ * its range, so a forward `+eps` at the upper limit would yield a zero column and
+ * trap the solver at the ceiling. Stepping `-eps` there (and dividing by the
+ * signed step) keeps every column a true one-sided derivative.
+ */
 function fillJacobian(
   J: Float64Array,
   q: Float64Array,
   n: number,
   m: number,
+  lo: Float64Array,
+  hi: Float64Array,
   base: JointPose,
   tip: Vec3,
   eps: number,
@@ -258,18 +266,21 @@ function fillJacobian(
   const basePos = applyPose(base, tip);
   for (let j = 0; j < n; j++) {
     const saved = el(q, j);
-    q[j] = saved + eps;
+    // Step away from whichever bound we're against so the perturbation isn't
+    // clamped to a no-op; default forward.
+    const h = saved + eps > el(hi, j) && saved - eps >= el(lo, j) ? -eps : eps;
+    q[j] = saved + h;
     const p2 = tipPose(q);
     q[j] = saved;
     const pos2 = applyPose(p2, tip);
-    J[j] = (pos2[0] - basePos[0]) / eps;
-    J[n + j] = (pos2[1] - basePos[1]) / eps;
-    J[2 * n + j] = (pos2[2] - basePos[2]) / eps;
+    J[j] = (pos2[0] - basePos[0]) / h;
+    J[n + j] = (pos2[1] - basePos[1]) / h;
+    J[2 * n + j] = (pos2[2] - basePos[2]) / h;
     if (m === 6) {
       const dr = rotationError(base.rotation, p2.rotation);
-      J[3 * n + j] = dr[0] / eps;
-      J[4 * n + j] = dr[1] / eps;
-      J[5 * n + j] = dr[2] / eps;
+      J[3 * n + j] = dr[0] / h;
+      J[4 * n + j] = dr[1] / h;
+      J[5 * n + j] = dr[2] / h;
     }
   }
 }
@@ -339,7 +350,7 @@ export function inverseKinematics(
   let iter = 0;
 
   for (; iter < maxIterations && n > 0 && err > tolerance; iter++) {
-    fillJacobian(J, q, n, m, pose, tip, eps, tipPose);
+    fillJacobian(J, q, n, m, lo, hi, pose, tip, eps, tipPose);
     const dq = dlsStep(J, e, n, m, lambda);
     if (!dq) break;
     for (let j = 0; j < n; j++) {

--- a/tests/ikFns.test.ts
+++ b/tests/ikFns.test.ts
@@ -128,7 +128,35 @@ describe('inverseKinematics — planar 2R', () => {
       expect(angle).toBeLessThanOrEqual(20 + 1e-9);
     }
   });
+
+  it('escapes a DOF seeded at its upper bound (bound-aware Jacobian probe)', () => {
+    // Single revolute about +Z, tip 10 out on +X, seeded at the max (180°).
+    let asm = createAssemblyNode('root');
+    asm = addChild(asm, createAssemblyNode('base'));
+    asm = addChild(asm, createAssemblyNode('arm'));
+    asm = addJoint(
+      asm,
+      revoluteJoint(
+        'base',
+        'arm',
+        { origin: [0, 0, 0], direction: [0, 0, 1] },
+        { min: 0, max: 180 }
+      )
+    );
+    const tip: [number, number, number] = [10, 0, 0];
+    // Target at 30° — requires pulling the joint *down* from the 180° ceiling.
+    const target = tipAt30();
+    const result = inverseKinematics(asm, 'arm', { position: target }, { tip, seed: { arm: 180 } });
+    expect(result.converged).toBe(true);
+    expect(result.values.arm?.[0]).toBeCloseTo(30, 2);
+  });
 });
+
+/** Tip of a 10-unit +X link rotated 30° about +Z. */
+function tipAt30(): [number, number, number] {
+  const r = (30 * Math.PI) / 180;
+  return [10 * Math.cos(r), 10 * Math.sin(r), 0];
+}
 
 describe('inverseKinematics — prismatic and multi-DOF', () => {
   it('solves a prismatic slide to a target distance', () => {


### PR DESCRIPTION
Greptile follow-up on #1333 (inverse kinematics).

## Bug

`fillJacobian` always probed with `q[j] = saved + eps`. When a DOF is already at its upper bound, `forwardKinematics` clamps `saved + eps` back to `max`, so the probed pose equals the base pose and that Jacobian **column is zero**. A zero column makes the DLS step assign `dq[j] = 0`, so the solver can never pull the DOF back down — any iterate that overshoots and gets clamped to the ceiling stays pinned there, reporting `converged: false` for a geometrically reachable target.

## Fix

Step *inward* from a bound: use `-eps` when `saved + eps` would exceed the upper limit (and there's room below), dividing the difference by the signed step so each column stays a true one-sided derivative.

## Test

New regression: a single revolute joint (range 0..180) **seeded at 180°** solving for a 30° target — requires pulling the DOF down from the ceiling. Fails before the fix (stuck at 180), converges to 30° after. Full IK suite green.

(Greptile also noted `chainTo` returns an empty chain for an end-effector that drives no joint; that path already returns `converged: false` with the residual in `error`, which is the correct outcome for a 0-DOF/unknown end-effector, so it's left as-is.)