### PR TITLE
chore(vercel): skip preview deploys for brepjs-verify release branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "framework": "vitepress",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in *components--brepjs-verify) exit 0 ;; *) exit 1 ;; esac",
   "installCommand": "npm install --legacy-peer-deps",
   "buildCommand": "npm run build && npm run build --workspace=apps/playground && npm run build --workspace=apps/docs && mkdir -p apps/docs/.vitepress/dist/playground && cp -r apps/playground/dist/. apps/docs/.vitepress/dist/playground/",
   "outputDirectory": "apps/docs/.vitepress/dist",


### PR DESCRIPTION
## Why

The Vercel preview deploy for the `brepjs-verify` release-please PR (e.g. #1337) only ever fails — the docs/playground site doesn't depend on the (unpublished) `brepjs-verify` package, so building a site preview for its release is pointless and just adds a red check.

## What

Adds a Vercel **Ignored Build Step** (`ignoreCommand` in `vercel.json`):

```sh
case "$VERCEL_GIT_COMMIT_REF" in *components--brepjs-verify) exit 0 ;; *) exit 1 ;; esac
```

Vercel skips the deploy when the command exits 0 and proceeds when it exits 1, so this skips previews on any release-please branch for the `brepjs-verify` component and builds normally for every other branch.

Takes effect once release-please next regenerates its branch from `main` (it rebases on merge), so future `brepjs-verify` releases won't trigger a failing preview. Easily extended to other package-only release components by adding more patterns to the `case`.