### PR TITLE
fix(docs): quote home-page feature detail with a colon

### DIFF
--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -25,7 +25,7 @@ features:
     details: Shapes are mathematical boundaries (faces, edges, vertices), so booleans are precise, measurements are real, and you can export to STEP.
   - icon: 🛡️
     title: If it compiles, it's valid
-    details: Branded types and validity brands (ClosedWire, OrientedFace, ValidSolid) prove topological invariants at compile time. Not just type-safe: geometry-safe.
+    details: 'Branded types and validity brands (ClosedWire, OrientedFace, ValidSolid) prove topological invariants at compile time. Not just type-safe: geometry-safe.'
   - icon: ⚡
     title: Two kernels, one API
     details: occt-wasm (OpenCascade compiled to WebAssembly) is the default kernel and ships today. brepkit (Rust-based) is a faster drop-in replacement under active development. Switching is one line.


### PR DESCRIPTION
## Root cause of the failing Vercel preview deploys

Every Vercel preview deploy has been failing at the **vitepress docs build** step:

```
[vitepress] incomplete explicit mapping pair; a key node is missed; or
followed by a non-tabulated empty line at line 28, column 151
file: apps/docs/index.md
```

`apps/docs/index.md` line 28 had an **unquoted** YAML frontmatter value containing a colon-space:

```yaml
details: Branded types ... Not just type-safe: geometry-safe.
```

YAML reads `type-safe: geometry-safe` as a nested mapping inside the scalar, which is invalid here — so the frontmatter fails to parse and `vitepress build` exits 1, taking the whole Vercel deployment down with it. (The lib/playground builds were fine; only the docs step failed.)

## Fix

Single-quote the value. Verified locally: `npm run build --workspace=apps/docs` now completes (`build complete in 14s`, all pages rendered), and the full build renders every page so no other frontmatter has the same issue.

This is independent of the recently-merged kinematics work; the homepage frontmatter has been malformed since that feature card was added.