### PR TITLE
test(1126): correct kernel attribution in STEP-trap regression comment

### DIFF
--- a/tests/stepExportDegenerate.test.ts
+++ b/tests/stepExportDegenerate.test.ts
@@ -76,10 +76,14 @@ function buildCorruptingFuse(): AnyShape {
 
 // Isolated in its own file: a successful trap poisons the kernel's writer for the
 // rest of the worker, so this must not share a process with other export tests.
-// Gated to occt — the BOPAlgo corruption is specific to the occt-wasm build (the
-// manifold mesh kernel doesn't export STEP at all).
+// Gated to the `occt` project (brepjs-opencascade / opencascade.js): the BOPAlgo
+// corruption is specific to that build. The default occt-wasm kernel does not
+// reproduce it (upstream triage exported the same BREP-loaded inputs cleanly on
+// occt-wasm; note the frenet sweep that *builds* this repro is itself an occt-wasm
+// gap, so the repro can only be constructed on `occt`). The manifold mesh kernel
+// doesn't export STEP at all. Tracked upstream: andymai/opencascade.js#3.
 describe.skipIf(currentKernel !== 'occt')(
-  'STEP export of BOPAlgo-corrupted geometry (#1126)',
+  'STEP export of BOPAlgo-corrupted geometry (#1126, opencascade.js fallback)',
   () => {
     beforeAll(async () => {
       await initKernel();


### PR DESCRIPTION
While closing the loop on #1126's upstream dependency, I found the regression test's comment misattributes the bug.

The comment said the BOPAlgo / STEP-writer corruption is "specific to the occt-wasm build." The upstream triage (andymai/opencascade.js#3) shows the opposite:

| Build | `exportSTEP(fuseAll([tread0, rail]))` |
|-------|----------------------------------------|
| opencascade.js / brepjs-opencascade (the gated `occt` project) | **traps** (OOB) |
| occt-wasm (default kernel) | **OK** — valid STEP from the same BREP-loaded inputs |

So the trap is specific to the **opencascade.js** build, which is now only a fallback; the default `occt-wasm` kernel is unaffected. Also noted: the frenet `sweep` that *constructs* this repro throws on occt-wasm, so the repro can only be built on the `occt` project (which is why the test stays gated there).

Comment-only change — no behavior or assertion change.