### PR TITLE
fix(occt-wasm): build 3D curves on helix wires so they can be swept

### DIFF
--- a/src/kernel/occtWasm/constructionOps.ts
+++ b/src/kernel/occtWasm/constructionOps.ts
@@ -216,7 +216,13 @@ export function makeHelixWire(
   const dx = direction ? direction[0] : 0;
   const dy = direction ? direction[1] : 0;
   const dz = direction ? direction[2] : 1;
-  return handle('wire', k.makeHelixWire(px, py, pz, dx, dy, dz, pitch, height, radius));
+  const wireId = k.makeHelixWire(px, py, pz, dx, dy, dz, pitch, height, radius);
+  // The helix edge is built as a 2D curve on a cylindrical surface with no 3D
+  // curve. BRepOffsetAPI_MakePipe/MakePipeShell require a 3D curve on the spine,
+  // so without this they throw on a helix spine (#1353). Build the 3D curves so
+  // the helix is sweepable, matching the opencascade.js build.
+  k.buildCurves3d(wireId);
+  return handle('wire', wireId);
 }
 
 export function makeCompound(

--- a/tests/sweepFns.test.ts
+++ b/tests/sweepFns.test.ts
@@ -6,6 +6,7 @@ import {
   wire,
   castShape,
   sweep,
+  helix,
   isOk,
   unwrap,
   isSolid,
@@ -76,6 +77,25 @@ describe('sweepFns', () => {
     const actual = unwrap(measureVolume(shape));
     expect(actual).toBeGreaterThan(expected * 0.99);
     expect(actual).toBeLessThan(expected * 1.01);
+  });
+
+  it('sweeps a circle along a helix spine (#1353)', () => {
+    // Regression: occt-wasm built the helix edge with only a pcurve (no 3D
+    // curve), so MakePipe/MakePipeShell threw on a helix spine. makeHelixWire
+    // now builds the 3D curves, matching the opencascade.js build.
+    const profile = castShape(sketchCircle(2).wire.wrapped) as Wire;
+    const result = sweep(profile, helix(40, 40, 10));
+    expect(isOk(result)).toBe(true);
+    const shape = unwrap(result);
+    expect(isShape3D(shape)).toBe(true);
+    expect(unwrap(measureVolume(shape))).toBeGreaterThan(0);
+  });
+
+  it('sweeps a circle along a helix spine with frenet (#1353)', () => {
+    const profile = castShape(sketchCircle(2).wire.wrapped) as Wire;
+    const result = sweep(profile, helix(40, 40, 10), { frenet: true });
+    expect(isOk(result)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(result)))).toBeGreaterThan(0);
   });
 
   describe('kernel.helicalSweep', () => {


### PR DESCRIPTION
Closes #1353.

## Root cause

I traced it by comparing spine shapes across kernels:

| spine | occt-wasm (before) | occt (opencascade.js) |
|-------|--------------------|------------------------|
| straight line | ok | ok |
| planar arc | ok | ok |
| generic 3D bspline | **ok** | ok |
| **helix** | **throws `sweepPipeShell:` / `pipe:`** | ok |

So occt-wasm sweeps non-planar spines fine in general — the defect was specific to the **helix wire**. occt-wasm's `makeHelixWire` builds the helix edge as a 2D pcurve on a cylindrical surface with **no 3D curve**, and `BRepOffsetAPI_MakePipe`/`MakePipeShell` require a 3D curve (`BRep_Tool::Curve`) on the spine. The opencascade.js build creates that 3D curve, which is why it worked there.

## Fix

Call `k.buildCurves3d` (OCCT `BRepLib::BuildCurves3d`) on the helix wire in `makeHelixWire` so its edges get 3D curves. This is the targeted fix at the defect site, brings occt-wasm to parity with opencascade.js, and benefits any consumer of a helix wire (not just sweep).

## Verification

Helix sweep now succeeds on occt-wasm with volumes **matching opencascade.js**: default `526.0`, frenet `502.7`. Confirmed working on occt-wasm, occt, and brepkit. Regression tests added to `sweepFns.test.ts` (default + frenet helix sweep, asserting a positive-volume 3D solid).

This also unblocks reconstructing the #1126 staircase repro (frenet handrail sweep along a helix) on the default kernel.