### PR TITLE
fix(occt): don't coerce an open pipe shell into an invalid solid

### DIFF
--- a/src/kernel/occt/sweepOps.ts
+++ b/src/kernel/occt/sweepOps.ts
@@ -142,7 +142,18 @@ export function simplePipe(
     solidMaker.Build(solidProgress);
     solidProgress.delete();
 
-    const result = solidMaker.IsDone() ? solidMaker.Solid() : pipeShape;
+    // MakeSolid.IsDone() is true even for an OPEN shell (a tube swept from a
+    // wire profile is open at both ends), yielding an invalid zero-volume
+    // solid. Keep the solid only if it actually validates; otherwise return the
+    // open shell — an open lateral surface has no solid form — matching the
+    // occt-wasm build, which returns the shell.
+    let result: KernelShape = pipeShape;
+    if (solidMaker.IsDone()) {
+      const solid = solidMaker.Solid();
+      const analyzer = new oc.BRepCheck_Analyzer(solid, true, false, false);
+      if (analyzer.IsValid_2()) result = solid;
+      analyzer.delete();
+    }
 
     shellDowncast.delete();
     solidMaker.delete();

--- a/tests/sweepFns.test.ts
+++ b/tests/sweepFns.test.ts
@@ -11,7 +11,9 @@ import {
   unwrap,
   isSolid,
   isShape3D,
+  isValid,
   measureVolume,
+  measureArea,
   box,
   getFaces,
   getKernel,
@@ -96,6 +98,20 @@ describe('sweepFns', () => {
     const result = sweep(profile, helix(40, 40, 10), { frenet: true });
     expect(isOk(result)).toBe(true);
     expect(unwrap(measureVolume(unwrap(result)))).toBeGreaterThan(0);
+  });
+
+  it('simple-mode helix sweep produces a valid (non-degenerate) shape', () => {
+    // Regression: occt's simplePipe coerced the open tube (a wire profile swept
+    // along a helix has no caps) into an INVALID zero-volume solid. It now
+    // returns the valid open shell, matching occt-wasm. (Volume of an open shell
+    // is kernel-dependent, so assert validity + surface area, not volume.)
+    const profile = castShape(sketchCircle(2).wire.wrapped) as Wire;
+    const result = sweep(profile, helix(40, 40, 10), { mode: 'simple' });
+    expect(isOk(result)).toBe(true);
+    const shape = unwrap(result);
+    expect(isShape3D(shape)).toBe(true);
+    expect(isValid(shape)).toBe(true);
+    expect(unwrap(measureArea(shape))).toBeGreaterThan(0);
   });
 
   describe('kernel.helicalSweep', () => {


### PR DESCRIPTION
Closes the opencascade.js half of the helix-sweep gap (follow-up to #1353/#1354).

## The gap

`sweep(circleWire, helix, { mode: 'simple' })` (the `simplePipe` / `BRepOffsetAPI_MakePipe` fast path) diverged between kernels:

| | shape | valid | area |
|--|-------|-------|------|
| occt (before) | **solid** | **false** ❌ | 781.30 |
| occt-wasm | shell | true | 781.32 |

A circle *wire* swept along a helix produces an **open tube shell** (no end caps). occt's adapter ran it through `BRepBuilderAPI_MakeSolid`, whose `IsDone()` returns `true` even for an open shell — so it returned an **invalid, zero-volume solid**. This wasn't helix-specific: a straight-line simple pipe hit the same invalid-solid path. No existing test exercised `mode: 'simple'` with a validity/volume assertion, so it slipped through.

## Fix

Validate the candidate solid with `BRepCheck_Analyzer`; keep it only if it actually validates, otherwise return the open shell — matching the occt-wasm build (an open lateral surface has no solid form).

| | shape | valid |
|--|-------|-------|
| occt (after) | **shell** | **true** ✅ |
| occt-wasm | shell | true |

## Tests

Regression test in `sweepFns.test.ts`: the simple-mode helix sweep is a valid `Shape3D` with positive surface area. Verified on occt, occt-wasm, and brepkit; the 2 manifold failures are pre-existing (transition-mode + helicalSweep), unrelated.

## Note

One intentional residual: `measureVolume` of the resulting *open* shell returns `0` on occt vs `~466` on occt-wasm. That's an open-shell *measurement* question (0 is defensible for a surface with no enclosed volume — occt-wasm's value is a divergence-theorem artifact), separate from the sweep, so it's left as-is. Filing/fixing that can follow if you want kernel parity there too.