### PR TITLE
fix(occt): delete the rejected solid in simplePipe to avoid a WASM leak

### DIFF
--- a/src/kernel/occt/sweepOps.ts
+++ b/src/kernel/occt/sweepOps.ts
@@ -151,7 +151,11 @@ export function simplePipe(
     if (solidMaker.IsDone()) {
       const solid = solidMaker.Solid();
       const analyzer = new oc.BRepCheck_Analyzer(solid, true, false, false);
-      if (analyzer.IsValid_2()) result = solid;
+      if (analyzer.IsValid_2()) {
+        result = solid;
+      } else {
+        solid.delete(); // rejected: free the WASM-owned TopoDS_Solid
+      }
       analyzer.delete();
     }
 


### PR DESCRIPTION
Follow-up to #1357: that PR auto-merged on its pre-review tip before the Greptile fix push landed (the branch was deleted out from under the push), so this addresses the review comment as a separate PR.

## Issue (Greptile, #1357)

In `simplePipe`, when the candidate solid fails `BRepCheck_Analyzer` validation, `solidMaker.Solid()` had allocated a WASM-owned `TopoDS_Solid` that was then abandoned without `.delete()` — leaking WASM heap on every open-shell pipe call (the now-common path after #1357).

## Fix

Free the rejected solid in the invalid branch:

```ts
if (analyzer.IsValid_2()) {
  result = solid;
} else {
  solid.delete(); // rejected: free the WASM-owned TopoDS_Solid
}
```

One-line follow-up; no behavior change beyond reclaiming the leaked handle. Typecheck + occt sweep suite green.