### PR TITLE
test(manifold): gate analytic measurement tests as mesh-kernel divergences

### DIFF
--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -67,6 +67,30 @@ export const divergences: DivergenceMap = {
       reason:
         'manifold is a mesh kernel: a cone tessellates to planar facets, so there is no analytic cone face to extract an axis from',
     },
+
+    // -----------------------------------------------------------------------
+    // measureFns.test.ts — null-shape helpers and analytic-surface measurement
+    // -----------------------------------------------------------------------
+    'measureFns.nullShapeValidation': {
+      kind: 'not-implemented',
+      reason:
+        'Tests construct null shapes via raw OCCT API (oc.TopoDS_Solid/oc.TopoDS_Face), unavailable in the manifold kernel.',
+    },
+    'measureFns.analyticFaceMeasurement': {
+      kind: 'not-implemented',
+      reason:
+        'manifold is a mesh kernel: a sketched rectangle / sphere / cylinder tessellates to planar facets, so there is no single analytic face to extract for area, surface centroid, or principal-curvature measurement.',
+    },
+    'measurement.faceMeasurement': {
+      kind: 'not-implemented',
+      reason:
+        'manifold is a mesh kernel: a sketched-rectangle face does not round-trip to a single analytic face for area / surface-property measurement.',
+    },
+    'measurement.wireLength': {
+      kind: 'not-implemented',
+      reason:
+        'manifold does not implement length() for curved wires (e.g. a circle wire) — only straight edges measure.',
+    },
   },
   brepkit: {
     // -----------------------------------------------------------------------

--- a/tests/measureFns.test.ts
+++ b/tests/measureFns.test.ts
@@ -65,7 +65,7 @@ describe('measureFns', () => {
       expect(unwrap(measureArea(castShape(b.wrapped)))).toBeCloseTo(2200, 0);
     });
 
-    it('face area', () => {
+    it.skipIf(shouldSkipSuite('measureFns.analyticFaceMeasurement'))('face area', () => {
       const rect = sketchRectangle(10, 20);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- getFaces always returns at least one face for a rectangle
       const f = getFaces(castShape(rect.face().wrapped))[0]!;
@@ -229,21 +229,24 @@ describe('measureFns', () => {
       throw new Error('no cylindrical face found');
     }
 
-    it('surfaceCenterOfMass: cylinder lateral face is on the axis', () => {
-      const c = cylinder(5, 10);
-      const lateral = pickLateralFace(getFaces(castShape(c.wrapped)));
-      const center = getKernel().surfaceCenterOfMass(lateral.wrapped);
-      // Cylinder is at origin with axis along +Z, height 10 → centroid at (0, 0, 5).
-      // 0.1% of the bounding-box diagonal (~12) is ~0.012; we use 0.05 absolute.
-      expect(center[0]).toBeCloseTo(0, 1);
-      expect(center[1]).toBeCloseTo(0, 1);
-      expect(center[2]).toBeCloseTo(5, 1);
-    });
+    it.skipIf(shouldSkipSuite('measureFns.analyticFaceMeasurement'))(
+      'surfaceCenterOfMass: cylinder lateral face is on the axis',
+      () => {
+        const c = cylinder(5, 10);
+        const lateral = pickLateralFace(getFaces(castShape(c.wrapped)));
+        const center = getKernel().surfaceCenterOfMass(lateral.wrapped);
+        // Cylinder is at origin with axis along +Z, height 10 → centroid at (0, 0, 5).
+        // 0.1% of the bounding-box diagonal (~12) is ~0.012; we use 0.05 absolute.
+        expect(center[0]).toBeCloseTo(0, 1);
+        expect(center[1]).toBeCloseTo(0, 1);
+        expect(center[2]).toBeCloseTo(5, 1);
+      }
+    );
 
     // brepkit's existing tessellateFace(face, 0.1) returns an asymmetric mesh
     // around the seam that biases the centroid; tracked separately, not part
     // of this measurement-quality work.
-    it.skipIf(isBrepkit)(
+    it.skipIf(isBrepkit || shouldSkipSuite('measureFns.analyticFaceMeasurement'))(
       'surfaceCenterOfMass: sphere face centroid is at the sphere center',
       () => {
         const s = sphere(7);
@@ -256,43 +259,52 @@ describe('measureFns', () => {
       }
     );
 
-    it('surfaceCurvature: sphere principal curvatures equal 1/R', () => {
-      const R = 4;
-      const s = sphere(R);
-      const f = getFaces(castShape(s.wrapped))[0];
-      if (!f) throw new Error('expected one face on a sphere');
-      const result = unwrap(measureCurvatureAtMid(f));
-      // Both principal curvatures should be ±1/R (sign depends on orientation).
-      expect(Math.abs(result.maxCurvature)).toBeCloseTo(1 / R, 2);
-      expect(Math.abs(result.minCurvature)).toBeCloseTo(1 / R, 2);
-      // Each principal direction must be a unit vector tangent to the sphere
-      // at the sample point — i.e. perpendicular to the surface normal.
-      const dot = (a: readonly [number, number, number], b: readonly [number, number, number]) =>
-        a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-      const lenMax = Math.sqrt(dot(result.maxDirection, result.maxDirection));
-      const lenMin = Math.sqrt(dot(result.minDirection, result.minDirection));
-      expect(lenMax).toBeCloseTo(1, 2);
-      expect(lenMin).toBeCloseTo(1, 2);
-    });
+    it.skipIf(shouldSkipSuite('measureFns.analyticFaceMeasurement'))(
+      'surfaceCurvature: sphere principal curvatures equal 1/R',
+      () => {
+        const R = 4;
+        const s = sphere(R);
+        const f = getFaces(castShape(s.wrapped))[0];
+        if (!f) throw new Error('expected one face on a sphere');
+        const result = unwrap(measureCurvatureAtMid(f));
+        // Both principal curvatures should be ±1/R (sign depends on orientation).
+        expect(Math.abs(result.maxCurvature)).toBeCloseTo(1 / R, 2);
+        expect(Math.abs(result.minCurvature)).toBeCloseTo(1 / R, 2);
+        // Each principal direction must be a unit vector tangent to the sphere
+        // at the sample point — i.e. perpendicular to the surface normal.
+        const dot = (a: readonly [number, number, number], b: readonly [number, number, number]) =>
+          a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+        const lenMax = Math.sqrt(dot(result.maxDirection, result.maxDirection));
+        const lenMin = Math.sqrt(dot(result.minDirection, result.minDirection));
+        expect(lenMax).toBeCloseTo(1, 2);
+        expect(lenMin).toBeCloseTo(1, 2);
+      }
+    );
 
-    it('surfaceCurvature: planar face has zero principal curvatures', () => {
-      const rect = sketchRectangle(10, 8);
-      const f = getFaces(castShape(rect.face().wrapped))[0];
-      if (!f) throw new Error('expected one face on a rectangle');
-      const result = unwrap(measureCurvatureAtMid(f));
-      expect(result.maxCurvature).toBeCloseTo(0, 4);
-      expect(result.minCurvature).toBeCloseTo(0, 4);
-    });
+    it.skipIf(shouldSkipSuite('measureFns.analyticFaceMeasurement'))(
+      'surfaceCurvature: planar face has zero principal curvatures',
+      () => {
+        const rect = sketchRectangle(10, 8);
+        const f = getFaces(castShape(rect.face().wrapped))[0];
+        if (!f) throw new Error('expected one face on a rectangle');
+        const result = unwrap(measureCurvatureAtMid(f));
+        expect(result.maxCurvature).toBeCloseTo(0, 4);
+        expect(result.minCurvature).toBeCloseTo(0, 4);
+      }
+    );
 
-    it('surfaceCurvature: cylinder lateral face — one curvature is 1/R, the other 0', () => {
-      const R = 3;
-      const c = cylinder(R, 10);
-      const lateral = pickLateralFace(getFaces(castShape(c.wrapped)));
-      const result = unwrap(measureCurvatureAtMid(lateral));
-      const ks = [result.maxCurvature, result.minCurvature].map(Math.abs).sort((a, b) => b - a);
-      expect(ks[0]).toBeCloseTo(1 / R, 2);
-      expect(ks[1]).toBeCloseTo(0, 2);
-    });
+    it.skipIf(shouldSkipSuite('measureFns.analyticFaceMeasurement'))(
+      'surfaceCurvature: cylinder lateral face — one curvature is 1/R, the other 0',
+      () => {
+        const R = 3;
+        const c = cylinder(R, 10);
+        const lateral = pickLateralFace(getFaces(castShape(c.wrapped)));
+        const result = unwrap(measureCurvatureAtMid(lateral));
+        const ks = [result.maxCurvature, result.minCurvature].map(Math.abs).sort((a, b) => b - a);
+        expect(ks[0]).toBeCloseTo(1 / R, 2);
+        expect(ks[1]).toBeCloseTo(0, 2);
+      }
+    );
 
     it('measureDistance: witness points lie on (or near) the connecting line for two boxes', () => {
       const b1 = castShape(box(2, 2, 2).wrapped);

--- a/tests/measurement.test.ts
+++ b/tests/measurement.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { shouldSkipSuite } from './helpers/kernelDivergences.js';
 import {
   box,
   sphere,
@@ -43,7 +44,7 @@ describe('measureArea', () => {
     expect(unwrap(measureArea(cyl))).toBeCloseTo(2 * Math.PI * 5 * 10 + 2 * Math.PI * 25, 0);
   });
 
-  it('face area of a rectangle', () => {
+  it.skipIf(shouldSkipSuite('measurement.faceMeasurement'))('face area of a rectangle', () => {
     const sketch = sketchRectangle(10, 20);
     const f = sketch.face();
     expect(unwrap(measureArea(f))).toBeCloseTo(200, 0);
@@ -61,7 +62,7 @@ describe('measureLength', () => {
     expect(unwrap(measureLength(edge))).toBeCloseTo(5, 2);
   });
 
-  it('circle wire', () => {
+  it.skipIf(shouldSkipSuite('measurement.wireLength'))('circle wire', () => {
     const c = sketchCircle(10);
     expect(unwrap(measureLength(c.wire))).toBeCloseTo(2 * Math.PI * 10, 0);
   });
@@ -104,7 +105,7 @@ describe('measureSurfaceProps (functional)', () => {
     expect(com[2]).toBeCloseTo(5, 0);
   });
 
-  it('works on a face', () => {
+  it.skipIf(shouldSkipSuite('measurement.faceMeasurement'))('works on a face', () => {
     const sketch = sketchRectangle(10, 20);
     const faces = getFaces(castShape(sketch.face().wrapped));
     const f = faces[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
@@ -123,7 +124,7 @@ describe('measureLinearProps (functional)', () => {
     expect(com[0]).toBeCloseTo(5, 0);
   });
 
-  it('returns mass (length) for wire', () => {
+  it.skipIf(shouldSkipSuite('measurement.wireLength'))('returns mass (length) for wire', () => {
     const c = sketchCircle(5);
     const w = castShape(c.wire.wrapped);
     const props = unwrap(measureLinearProps(w));


### PR DESCRIPTION
The manifold measurement suites had 22 failures — all because the tests assume B-rep capabilities a mesh kernel doesn't have, not because of measurement-code bugs. Surfaced while fixing #1361.

## Failure classes (all on manifold only)

1. **Null-shape validation** — the test helpers build shapes via raw OCCT (`oc.TopoDS_Solid` / `oc.TopoDS_Face`), which don't exist on manifold (`oc.TopoDS_Solid is not a constructor`). **brepkit is already gated** for the identical reason.
2. **Analytic face/surface measurement** — a sketched rectangle / sphere / cylinder tessellates to facets, so there's no single analytic face to extract for area, surface centroid, or principal curvature.
3. **Curved-wire length** — manifold doesn't implement `length()` for curved wires (`circle wire`).

## Fix

Register these as **manifold divergences** in the kernel-divergence registry and gate the affected tests via `shouldSkipSuite(...)`, exactly matching how brepkit divergences are handled. Each entry carries a documented reason.

## Result

| kernel | before | after |
|--------|--------|-------|
| manifold (measureFns) | 18 failed | 16 passed, 18 skipped, **0 failed** |
| manifold (measurement) | 4 failed | 16 passed, 4 skipped, **0 failed** |
| occt / occt-wasm | pass | pass (run every test — registry entries are manifold-only) |
| brepkit | pass | pass (unchanged) |

Test-only change; no production code touched. occt-wasm gate green.