### PR TITLE
fix(2d): make stretch2D directional affinity consistent across kernels

### DIFF
--- a/src/2d/curves.ts
+++ b/src/2d/curves.ts
@@ -63,7 +63,16 @@ export const stretchTransform2d = (
   direction: Point2D,
   origin: Point2D = [0, 0]
 ): Transformation2D => {
-  return getKernel().createAffinityGTrsf2d(origin[0], origin[1], direction[0], direction[1], ratio);
+  // `createAffinityGTrsf2d` follows OCCT `gp_GTrsf2d::SetAffinity`: it scales the
+  // component perpendicular to its axis. To stretch *along* `direction`, pass the
+  // axis perpendicular to it (rotate 90°: (dx, dy) -> (-dy, dx)).
+  return getKernel().createAffinityGTrsf2d(
+    origin[0],
+    origin[1],
+    -direction[1],
+    direction[0],
+    ratio
+  );
 };
 
 /** Create a 2D translation transformation. */
@@ -151,7 +160,8 @@ export function curvesAsEdgesOnFace(
     if (!cylData.isDirect) {
       geomSurf = kernel.reverseSurfaceU(geomSurf);
     }
-    transformation = stretchTransform2d(1 / cylData.radius, [0, 1]);
+    // Scale the u (circumferential, X) coordinate from arc length to angle.
+    transformation = stretchTransform2d(1 / cylData.radius, [1, 0]);
   }
 
   if (scale === 'bounds') {

--- a/src/kernel/occtWasm/kernel2dOps.ts
+++ b/src/kernel/occtWasm/kernel2dOps.ts
@@ -337,9 +337,52 @@ export function mirrorCurve2dAcrossAxis(
   return c2dWrap(ow2d.mirrorAcrossAxis(c2d(curve), originX, originY, dirX, dirY));
 }
 
-export function affinityTransform2d(curve: Curve2dHandle): Curve2dHandle {
-  // Affinity transform not yet supported — pass curve through unchanged.
-  return curve;
+/**
+ * Directional affinity matching OCCT `gp_GTrsf2d::SetAffinity`: scales the
+ * component perpendicular to the axis `(dx, dy)` through `(ox, oy)` by `ratio`,
+ * leaving the parallel component fixed. Applied by sampling and refitting as a
+ * Bezier, since occt-wasm has no native Geom2d transform.
+ */
+export function affinityCurve2d(
+  curve: Curve2dHandle,
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  ratio: number
+): Curve2dHandle {
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 1e-15) return curve;
+  const px = -dy / len,
+    py = dx / len; // perpendicular to axis
+  const k = ratio - 1;
+  const a = 1 + k * px * px,
+    b = k * px * py,
+    d = k * py * px,
+    e = 1 + k * py * py;
+  const tx = ox - a * ox - b * oy;
+  const ty = oy - d * ox - e * oy;
+  const c = c2d(curve);
+  const bounds = ow2d.curveBounds(c);
+  const N = 20;
+  const pts: [number, number][] = [];
+  for (let i = 0; i <= N; i++) {
+    const t = bounds.first + ((bounds.last - bounds.first) * i) / N;
+    const [qx, qy] = ow2d.evaluateCurve2d(c, t);
+    pts.push([a * qx + b * qy + tx, d * qx + e * qy + ty]);
+  }
+  return c2dWrap(ow2d.makeBezier2d(pts));
+}
+
+export function affinityTransform2d(
+  curve: Curve2dHandle,
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  ratio: number
+): Curve2dHandle {
+  return affinityCurve2d(curve, ox, oy, dx, dy, ratio);
 }
 
 // ─── 2D general transforms (GTrsf) ──────────────────────────────────────────
@@ -444,11 +487,13 @@ export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType)
     return mirrorCurve2dAtPoint(curve, Number(t['ox']) || 0, Number(t['oy']) || 0);
   }
   if (t['type'] === 'affinity2d') {
-    return scaleCurve2d(
+    return affinityCurve2d(
       curve,
-      Number(t['ratio']) || 1,
       Number(t['axOriginX']) || 0,
-      Number(t['axOriginY']) || 0
+      Number(t['axOriginY']) || 0,
+      Number(t['axDirX']) || 0,
+      Number(t['axDirY']) || 0,
+      Number(t['ratio']) || 1
     );
   }
   if (Number(t['dx']) || Number(t['dy'])) {

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1742,13 +1742,20 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
   affinityTransform2d(
     curve: Curve2dHandle,
-    _axisOriginX: number,
-    _axisOriginY: number,
-    _axisDirX: number,
-    _axisDirY: number,
-    _ratio: number
+    axisOriginX: number,
+    axisOriginY: number,
+    axisDirX: number,
+    axisDirY: number,
+    ratio: number
   ): Curve2dHandle {
-    return kernel2dOps.affinityTransform2d(curve);
+    return kernel2dOps.affinityTransform2d(
+      curve,
+      axisOriginX,
+      axisOriginY,
+      axisDirX,
+      axisDirY,
+      ratio
+    );
   }
   createIdentityGTrsf2d(): KernelType {
     return kernel2dOps.createIdentityGTrsf2d();

--- a/tests/blueprintFns.test.ts
+++ b/tests/blueprintFns.test.ts
@@ -228,8 +228,18 @@ describe('blueprint sketching + stretch', () => {
   it('stretch2D scales the blueprint along a direction', () => {
     const bp = stretch2D(rect(10, 10), 2, [1, 0]);
     const bounds = getBounds2D(bp);
-    // Stretching x2 along X widens the 10-unit width to ~20.
-    expect(bounds.width).toBeGreaterThan(15);
+    // Stretching x2 along X doubles the 10-unit width and leaves height unchanged.
+    // The height check rejects a uniform-scale approximation that would double both.
+    expect(bounds.width).toBeCloseTo(20, 4);
+    expect(bounds.height).toBeCloseTo(10, 4);
+    bp.delete();
+  });
+
+  it('stretch2D along Y scales only the perpendicular axis', () => {
+    const bp = stretch2D(rect(10, 10), 3, [0, 1]);
+    const bounds = getBounds2D(bp);
+    expect(bounds.width).toBeCloseTo(10, 4);
+    expect(bounds.height).toBeCloseTo(30, 4);
     bp.delete();
   });
 


### PR DESCRIPTION
## Summary

`stretch2D` (2D directional affinity) only gave the correct result under the occt-wasm adapter; brepkit and occt (opencascade.js) scaled the wrong axis. Closes #1373.

## Root cause

`stretchTransform2d` passed the stretch direction straight to `createAffinityGTrsf2d`, which faithfully implements OCCT `gp_GTrsf2d::SetAffinity` — that scales the component **perpendicular** to its axis. So stretching a rect along X scaled Y instead under brepkit/occt. occt-wasm only passed the loose `width > 15` assertion because its `affinity2d` branch fell back to a **uniform** scale (doubling both dimensions).

It was a convention collision, not a broken matrix: the kernel primitive is OCCT-axis semantics; `stretchTransform2d` ("stretch along a direction") wanted parallel semantics.

## Fix

- `stretchTransform2d`: pass the perpendicular of the stretch direction `(dx,dy) -> (-dy,dx)` as the affinity axis, so all three adapters scale the intended (parallel) axis. The kernel primitive stays faithful to OCCT.
- occt-wasm: implement a true directional affinity (sample + refit), replacing both the uniform-scale shortcut in `transformCurve2dGeneral` and the no-op `affinityTransform2d` stub (which ignored its axis args entirely).
- `curvesAsEdgesOnFace` cylinder `native` mapping: pass `[1,0]` so it keeps scaling the u (circumferential) coordinate under the corrected convention. This also fixes a latent occt-wasm bug where the uniform fallback was squashing the v coordinate too.
- Tighten the test to assert **both** the stretched and unstretched dimensions, plus a stretch-along-Y case, so a uniform-scale approximation can no longer pass.

## Verification

`tests/blueprintFns.test.ts` stretch cases pass under all three kernel projects (occt-wasm, brepkit, occt). Full `tests/2d.test.ts` + `tests/blueprintFns.test.ts` green across occt-wasm/brepkit/occt (106 each). typecheck, lint, format, boundaries, knip clean. The 20 pattern-checker violations on this branch are pre-existing baseline drift from #1372 (all in untouched `manifold/` files).
