### PR TITLE
perf(brepkit): use binary grouped tessellation (no JSON marshaling)

### DIFF
--- a/scripts/sync-brepkit-types.ts
+++ b/scripts/sync-brepkit-types.ts
@@ -37,9 +37,12 @@ function snakeToCamel(s: string): string {
 function convertParams(raw: string): string {
   let result = raw;
   // Convert param names from snake_case to camelCase
-  result = result.replace(/\b([a-z][a-z0-9_]*)\s*([\?]?\s*:)/g, (_, name: string, colon: string) => {
-    return snakeToCamel(name) + colon;
-  });
+  result = result.replace(
+    /\b([a-z][a-z0-9_]*)\s*([\?]?\s*:)/g,
+    (_, name: string, colon: string) => {
+      return snakeToCamel(name) + colon;
+    }
+  );
   // Widen typed array params to also accept plain number[]:
   // Float64Array → Float64Array | number[]
   // Uint32Array → Uint32Array | number[]
@@ -180,56 +183,98 @@ const METHOD_SECTIONS: Section[] = [
   {
     label: 'Primitives',
     methods: [
-      'makeBox', 'makeCylinder', 'makeSphere', 'makeCone', 'makeTorus',
-      'makeEllipsoid', 'makeRectangle', 'makePolygon', 'makeCircle',
+      'makeBox',
+      'makeCylinder',
+      'makeSphere',
+      'makeCone',
+      'makeTorus',
+      'makeEllipsoid',
+      'makeRectangle',
+      'makePolygon',
+      'makeCircle',
       'makeCircleFace',
     ],
   },
   {
     label: 'Shape construction',
     methods: [
-      'makeVertex', 'makeLineEdge', 'makeCircleArc3d', 'makeTangentArc3d',
-      'makeNurbsEdge', 'makeWire', 'makePolygonWire', 'makeRegularPolygonWire',
-      'makeFaceFromWire', 'makeCompound', 'makeSolid', 'solidFromShell',
-      'addHolesToFace', 'removeHolesFromFace', 'reverseShape',
+      'makeVertex',
+      'makeLineEdge',
+      'makeCircleArc3d',
+      'makeTangentArc3d',
+      'makeNurbsEdge',
+      'makeWire',
+      'makePolygonWire',
+      'makeRegularPolygonWire',
+      'makeFaceFromWire',
+      'makeCompound',
+      'makeSolid',
+      'solidFromShell',
+      'addHolesToFace',
+      'removeHolesFromFace',
+      'reverseShape',
     ],
   },
   {
     label: 'Boolean ops',
-    methods: [
-      'fuse', 'cut', 'intersect', 'compoundCut', 'convexHull',
-      'section', 'split',
-    ],
+    methods: ['fuse', 'cut', 'intersect', 'compoundCut', 'convexHull', 'section', 'split'],
   },
   {
     label: 'Evolution tracking',
-    methods: [
-      'fuseWithEvolution', 'cutWithEvolution', 'intersectWithEvolution',
-    ],
+    methods: ['fuseWithEvolution', 'cutWithEvolution', 'intersectWithEvolution'],
   },
   {
     label: 'Sweep / Loft',
     methods: [
-      'extrude', 'revolve', 'sweep', 'sweepSmooth', 'sweepAlongEdges',
-      'sweepWithOptions', 'pipe', 'loft', 'loftSmooth', 'loftWithOptions',
+      'extrude',
+      'revolve',
+      'sweep',
+      'sweepSmooth',
+      'sweepAlongEdges',
+      'sweepWithOptions',
+      'pipe',
+      'loft',
+      'loftSmooth',
+      'loftWithOptions',
       'helicalSweep',
     ],
   },
   {
     label: 'Modifiers',
     methods: [
-      'fillet', 'filletV2', 'filletVariable', 'chamfer', 'chamferV2',
-      'chamferDistanceAngle', 'shell', 'offsetSolid', 'offsetSolidV2',
-      'offsetFace', 'offsetWire', 'offsetWireWithJoinType', 'thicken', 'draft',
-      'defeature', 'detectSmallFeatures', 'recognizeFeatures', 'unifyFaces',
+      'fillet',
+      'filletV2',
+      'filletVariable',
+      'chamfer',
+      'chamferV2',
+      'chamferDistanceAngle',
+      'shell',
+      'offsetSolid',
+      'offsetSolidV2',
+      'offsetFace',
+      'offsetWire',
+      'offsetWireWithJoinType',
+      'thicken',
+      'draft',
+      'defeature',
+      'detectSmallFeatures',
+      'recognizeFeatures',
+      'unifyFaces',
     ],
   },
   {
     label: 'Transform',
     methods: [
-      'transformSolid', 'transformWire', 'copySolid', 'copyWire',
-      'copyAndTransformSolid', 'mirror', 'linearPattern', 'circularPattern',
-      'gridPattern', 'composeTransforms',
+      'transformSolid',
+      'transformWire',
+      'copySolid',
+      'copyWire',
+      'copyAndTransformSolid',
+      'mirror',
+      'linearPattern',
+      'circularPattern',
+      'gridPattern',
+      'composeTransforms',
     ],
   },
   {
@@ -239,102 +284,172 @@ const METHOD_SECTIONS: Section[] = [
   {
     label: 'Topology',
     methods: [
-      'getSolidFaces', 'getSolidEdges', 'getSolidVertices', 'getFaceEdges',
-      'getFaceVertices', 'getFaceNormal', 'getFaceOuterWire', 'getFaceWires',
-      'faceWires', 'getWireEdges', 'getEdgeVertices', 'getEdgeVertexHandles',
-      'getVertexPosition', 'getEntityCounts', 'getShellFaces',
-      'getShapeOrientation', 'adjacentFaces', 'sharedEdges', 'edgeToFaceMap',
-      'isEdgeForwardInWire', 'isWireClosed', 'getCompoundSolids',
+      'getSolidFaces',
+      'getSolidEdges',
+      'getSolidVertices',
+      'getFaceEdges',
+      'getFaceVertices',
+      'getFaceNormal',
+      'getFaceOuterWire',
+      'getFaceWires',
+      'faceWires',
+      'getWireEdges',
+      'getEdgeVertices',
+      'getEdgeVertexHandles',
+      'getVertexPosition',
+      'getEntityCounts',
+      'getShellFaces',
+      'getShapeOrientation',
+      'adjacentFaces',
+      'sharedEdges',
+      'edgeToFaceMap',
+      'isEdgeForwardInWire',
+      'isWireClosed',
+      'getCompoundSolids',
     ],
   },
   {
     label: 'Geometry',
     methods: [
-      'getSurfaceType', 'getSurfaceDomain', 'getAnalyticSurfaceParams',
-      'getEdgeCurveType', 'getEdgeCurveParameters', 'getEdgeNurbsData',
-      'evaluateEdgeCurve', 'evaluateEdgeCurveD1', 'evaluateSurface',
-      'evaluateSurfaceNormal', 'projectPointOnSurface',
+      'getSurfaceType',
+      'getSurfaceDomain',
+      'getAnalyticSurfaceParams',
+      'getEdgeCurveType',
+      'getEdgeCurveParameters',
+      'getEdgeNurbsData',
+      'evaluateEdgeCurve',
+      'evaluateEdgeCurveD1',
+      'evaluateSurface',
+      'evaluateSurfaceNormal',
+      'projectPointOnSurface',
       'liftCurve2dToPlane',
     ],
   },
   {
     label: 'Measurement',
     methods: [
-      'boundingBox', 'volume', 'surfaceArea', 'faceArea', 'facePerimeter',
-      'edgeLength', 'wireLength', 'centerOfMass',
-      'measureCurvatureAtEdge', 'measureCurvatureAtSurface',
-      'pointToSolidDistance', 'pointToFaceDistance', 'pointToEdgeDistance',
+      'boundingBox',
+      'volume',
+      'surfaceArea',
+      'faceArea',
+      'facePerimeter',
+      'edgeLength',
+      'wireLength',
+      'centerOfMass',
+      'measureCurvatureAtEdge',
+      'measureCurvatureAtSurface',
+      'pointToSolidDistance',
+      'pointToFaceDistance',
+      'pointToEdgeDistance',
       'solidToSolidDistance',
     ],
   },
   {
     label: 'Classification',
-    methods: [
-      'classifyPoint', 'classifyPointWinding', 'classifyPointRobust',
-    ],
+    methods: ['classifyPoint', 'classifyPointWinding', 'classifyPointRobust'],
   },
   {
     label: 'Validation & repair',
     methods: [
-      'validateSolid', 'validateSolidRelaxed', 'validateSolidWithOptions',
-      'healSolid', 'repairSolid', 'fixFaceOrientations',
-      'mergeCoincidentVertices', 'removeDegenerateEdges',
+      'validateSolid',
+      'validateSolidRelaxed',
+      'validateSolidWithOptions',
+      'healSolid',
+      'repairSolid',
+      'fixFaceOrientations',
+      'mergeCoincidentVertices',
+      'removeDegenerateEdges',
     ],
   },
   {
     label: 'Tessellation',
     methods: [
-      'tessellateFace', 'tessellateSolid', 'tessellateSolidGrouped',
-      'tessellateSolidUV', 'tessellateEdge', 'meshEdges', 'meshEdgesAll',
+      'tessellateFace',
+      'tessellateSolid',
+      'tessellateSolidGrouped',
+      'tessellateSolidGroupedBinary',
+      'tessellateSolidUV',
+      'tessellateEdge',
+      'meshEdges',
+      'meshEdgesAll',
       'meshBoolean',
     ],
   },
   {
     label: 'Export',
     methods: [
-      'exportStep', 'exportStl', 'exportStlAscii', 'exportIges',
-      'export3mf', 'exportObj', 'exportGlb', 'exportPly',
+      'exportStep',
+      'exportStl',
+      'exportStlAscii',
+      'exportIges',
+      'export3mf',
+      'exportObj',
+      'exportGlb',
+      'exportPly',
     ],
   },
   {
     label: 'Import',
     methods: [
-      'importStep', 'importStl', 'importIges', 'import3mf',
-      'importObj', 'importGlb', 'importIndexedMesh',
+      'importStep',
+      'importStl',
+      'importIges',
+      'import3mf',
+      'importObj',
+      'importGlb',
+      'importIndexedMesh',
     ],
   },
   {
     label: 'NURBS curves & surfaces',
     methods: [
-      'interpolatePoints', 'approximateCurve', 'approximateCurveLspia',
-      'curveKnotInsert', 'curveKnotRemove', 'curveSplit', 'curveDegreeElevate',
-      'interpolateSurface', 'approximateSurfaceLspia',
+      'interpolatePoints',
+      'approximateCurve',
+      'approximateCurveLspia',
+      'curveKnotInsert',
+      'curveKnotRemove',
+      'curveSplit',
+      'curveDegreeElevate',
+      'interpolateSurface',
+      'approximateSurfaceLspia',
     ],
   },
   {
     label: 'Sketch',
     methods: [
-      'sketchNew', 'sketchAddPoint', 'sketchAddArc', 'sketchAddConstraint',
-      'sketchSolve', 'sketchDof',
+      'sketchNew',
+      'sketchAddPoint',
+      'sketchAddArc',
+      'sketchAddConstraint',
+      'sketchSolve',
+      'sketchDof',
     ],
   },
   {
     label: '2D polygon ops',
     methods: [
-      'offsetPolygon2d', 'chamfer2d', 'fillet2d', 'polygonsIntersect2d',
-      'intersectPolygons2d', 'commonSegment2d', 'pointInPolygon2d',
+      'offsetPolygon2d',
+      'chamfer2d',
+      'fillet2d',
+      'polygonsIntersect2d',
+      'intersectPolygons2d',
+      'commonSegment2d',
+      'pointInPolygon2d',
     ],
   },
   {
     label: 'Batch & checkpoint',
-    methods: [
-      'executeBatch', 'checkpoint', 'checkpointCount', 'restore',
-      'discardCheckpoint',
-    ],
+    methods: ['executeBatch', 'checkpoint', 'checkpointCount', 'restore', 'discardCheckpoint'],
   },
   {
     label: 'Assembly',
-    methods: ['assemblyNew', 'assemblyAddRoot', 'assemblyAddChild', 'assemblyFlatten', 'assemblyBom'],
+    methods: [
+      'assemblyNew',
+      'assemblyAddRoot',
+      'assemblyAddChild',
+      'assemblyFlatten',
+      'assemblyBom',
+    ],
   },
   {
     label: 'BREP serialization',
@@ -344,10 +459,7 @@ const METHOD_SECTIONS: Section[] = [
 
 // ── Generate output ────────────────────────────────────────────
 
-function formatMethodSignature(
-  method: ParsedMethod,
-  isWired: boolean
-): string {
+function formatMethodSignature(method: ParsedMethod, isWired: boolean): string {
   const tag = isWired ? '' : '  /** @unwired */\n';
   const params = convertParams(method.params);
   const ret = mapReturnType(method.returnType, method.name);
@@ -425,7 +537,7 @@ function generate(): void {
   lines.push('// ── Main kernel interface ────────────────────────────────────────');
   lines.push('');
   lines.push('/**');
-  lines.push(' * Type-safe view of brepkit\'s WASM `BrepKernel` class.');
+  lines.push(" * Type-safe view of brepkit's WASM `BrepKernel` class.");
   lines.push(' *');
   lines.push(' * All handle parameters and return values are `number` (u32 arena indices).');
   lines.push(' * Coordinate arrays are flat `number[]` (`[x,y,z, ...]`).');
@@ -477,14 +589,14 @@ function generate(): void {
     validateSolidDetails: 'validateSolidDetails?(solid: number): string;',
   };
 
-  const futureToEmit = [...missingGuarded]
-    .sort()
-    .filter((name) => FUTURE_STUBS[name]);
+  const futureToEmit = [...missingGuarded].sort().filter((name) => FUTURE_STUBS[name]);
   if (futureToEmit.length > 0) {
     lines.push('  // ── Feature-guarded stubs (not in current WASM) ─────────────────');
     lines.push('');
     for (const name of futureToEmit) {
-      lines.push(`  /** @future Not in brepkit-wasm ${upstreamVersion}. Referenced with feature detection in adapter. */`);
+      lines.push(
+        `  /** @future Not in brepkit-wasm ${upstreamVersion}. Referenced with feature detection in adapter. */`
+      );
       lines.push(`  ${FUTURE_STUBS[name]}`);
       lines.push('');
     }
@@ -495,7 +607,7 @@ function generate(): void {
   if (unhandled.length > 0) {
     console.warn(
       `⚠ Feature-guarded methods missing from FUTURE_STUBS: ${unhandled.join(', ')}\n` +
-      '  Add typed signatures to FUTURE_STUBS in sync-brepkit-types.ts'
+        '  Add typed signatures to FUTURE_STUBS in sync-brepkit-types.ts'
     );
   }
 
@@ -513,8 +625,8 @@ function generate(): void {
   const totalCount = methods.length;
   console.log(
     `✓ Generated ${OUTPUT_FILE}\n` +
-    `  ${totalCount} methods from brepkit-wasm@${upstreamVersion}\n` +
-    `  ${wiredCount} wired, ${totalCount - wiredCount} @unwired`
+      `  ${totalCount} methods from brepkit-wasm@${upstreamVersion}\n` +
+      `  ${wiredCount} wired, ${totalCount - wiredCount} @unwired`
   );
 }
 

--- a/src/kernel/brepkit/brepkitWasmTypes.ts
+++ b/src/kernel/brepkit/brepkitWasmTypes.ts
@@ -27,7 +27,14 @@ export interface BrepkitMesh {
   packedBuffer(): Uint8Array;
 }
 
-/** Per-face-grouped mesh returned by `tessellateSolidGroupedBinary` (packed). */
+/**
+ * Per-face-grouped mesh returned by `tessellateSolidGroupedBinary` (packed).
+ *
+ * Hand-added forward-declaration: the binary binding ships in a brepkit-wasm
+ * release newer than the one this file is synced against. Once the dependency
+ * is bumped, `npm run sync:brepkit-types` regenerates this from the upstream
+ * `.d.ts` (the method is already in the sync script's Tessellation list).
+ */
 export interface BrepkitGroupedMesh {
   /** Flattened vertex positions `[x, y, z, ...]`. */
   readonly positions: Float32Array;
@@ -555,7 +562,12 @@ export interface BrepkitKernel {
     angularTolerance?: number | null
   ): string;
 
-  /** Binary counterpart of `tessellateSolidGrouped` — packed typed arrays, no JSON. */
+  /**
+   * Binary counterpart of `tessellateSolidGrouped` — packed typed arrays, no JSON.
+   *
+   * Optional (and hand-added) so the adapter's `typeof`-based feature detection
+   * typechecks while the pinned brepkit-wasm release may not yet expose it.
+   */
   tessellateSolidGroupedBinary?(
     solid: number,
     deflection: number,

--- a/src/kernel/brepkit/brepkitWasmTypes.ts
+++ b/src/kernel/brepkit/brepkitWasmTypes.ts
@@ -27,6 +27,18 @@ export interface BrepkitMesh {
   packedBuffer(): Uint8Array;
 }
 
+/** Per-face-grouped mesh returned by `tessellateSolidGroupedBinary` (packed). */
+export interface BrepkitGroupedMesh {
+  /** Flattened vertex positions `[x, y, z, ...]`. */
+  readonly positions: Float32Array;
+  /** Flattened per-vertex normals `[nx, ny, nz, ...]`. */
+  readonly normals: Float32Array;
+  /** Triangle indices (groups of 3). */
+  readonly indices: Uint32Array;
+  /** Per-face start offsets into `indices`; last element equals `indices.length`. */
+  readonly faceOffsets: Uint32Array;
+}
+
 /** Edge polylines returned by `meshEdges`. */
 export interface BrepkitEdgeLines {
   /** Flattened vertex positions `[x, y, z, ...]`. */
@@ -542,6 +554,13 @@ export interface BrepkitKernel {
     deflection: number,
     angularTolerance?: number | null
   ): string;
+
+  /** Binary counterpart of `tessellateSolidGrouped` — packed typed arrays, no JSON. */
+  tessellateSolidGroupedBinary?(
+    solid: number,
+    deflection: number,
+    angularTolerance?: number | null
+  ): BrepkitGroupedMesh;
 
   tessellateSolidUV(solid: number, deflection: number, angularTolerance?: number | null): string;
 

--- a/src/kernel/brepkit/meshOps.ts
+++ b/src/kernel/brepkit/meshOps.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import type { BrepkitKernel } from './brepkitWasmTypes.js';
+import type { BrepkitKernel, BrepkitGroupedMesh } from './brepkitWasmTypes.js';
 import type {
   KernelShape,
   KernelMeshResult,
@@ -120,10 +120,88 @@ function meshSolid(
  * Batch tessellation via `tessellateSolidGrouped` -- single WASM call for
  * all faces. Falls back to `meshSolidPerFace` on error.
  *
+ * Prefers the binary `tessellateSolidGroupedBinary` (packed typed arrays) when
+ * the kernel exposes it; the mesh then crosses the WASM boundary as bulk memory
+ * copies instead of a multi-megabyte JSON string round-trip (the JSON variant
+ * was ~2x slower on large meshes). Falls back to the JSON path on older kernels.
+ *
  * When `includeUVs` is true, makes an additional `tessellateSolidUV` call
  * to populate real surface parametrization coordinates.
  */
 function meshSolidGrouped(
+  bk: BrepkitKernel,
+  solidId: number,
+  deflection: number,
+  includeUVs: boolean,
+  angularTolerance?: number
+): KernelMeshResult {
+  if (typeof bk.tessellateSolidGroupedBinary === 'function') {
+    // Call here, inside the `typeof` guard, so the call site is a direct method
+    // invocation (TS narrows the optional method; no unbound method reference).
+    const m = bk.tessellateSolidGroupedBinary(solidId, deflection, angularTolerance);
+    return meshSolidGroupedBinary(bk, solidId, deflection, includeUVs, angularTolerance, m);
+  }
+  return meshSolidGroupedJson(bk, solidId, deflection, includeUVs, angularTolerance);
+}
+
+/**
+ * Binary grouped tessellation: positions/normals are packed `Float32Array`s and
+ * indices/`faceOffsets` are `Uint32Array`s straight from the kernel — no JSON.
+ */
+function meshSolidGroupedBinary(
+  bk: BrepkitKernel,
+  solidId: number,
+  deflection: number,
+  includeUVs: boolean,
+  angularTolerance: number | undefined,
+  m: BrepkitGroupedMesh
+): KernelMeshResult {
+  const positions = m.positions;
+  const normals = m.normals;
+  const indices = m.indices;
+  const faceOffsets = m.faceOffsets;
+
+  const faceIds = toArray(bk.getSolidFaces(solidId));
+  const groupCount = faceOffsets.length - 1;
+  if (groupCount !== faceIds.length) {
+    throw new Error(
+      `faceOffsets/faceIds length mismatch: ${groupCount} groups vs ${faceIds.length} faces`
+    );
+  }
+  const faceGroups: Array<{ start: number; count: number; faceHash: number }> = [];
+  for (let i = 0; i < faceOffsets.length - 1; i++) {
+    const start = wasmIndex(faceOffsets, i);
+    const count = wasmIndex(faceOffsets, i + 1) - start;
+    if (count === 0) continue; // degenerate face -- skip
+    faceGroups.push({ start, count, faceHash: faceIds[i] ?? 0 });
+  }
+
+  let uvs = new Float32Array(0);
+  if (includeUVs) {
+    const expectedUvLen = (positions.length / 3) * 2;
+    try {
+      const uvJson = bk.tessellateSolidUV(solidId, deflection, angularTolerance);
+      const uvData: { uvs: number[] } = JSON.parse(uvJson);
+      uvs =
+        uvData.uvs.length === expectedUvLen
+          ? new Float32Array(uvData.uvs)
+          : new Float32Array(expectedUvLen);
+    } catch {
+      uvs = new Float32Array(expectedUvLen);
+    }
+  }
+
+  return {
+    vertices: positions,
+    normals,
+    triangles: indices,
+    uvs,
+    faceGroups,
+  };
+}
+
+/** JSON grouped tessellation (fallback for kernels without the binary API). */
+function meshSolidGroupedJson(
   bk: BrepkitKernel,
   solidId: number,
   deflection: number,


### PR DESCRIPTION
## Summary

The brepkit mesh adapter round-tripped every mesh through a **JSON string**. `tessellateSolidGrouped` returned JSON; we `JSON.parse`d it and re-packed the number arrays into typed arrays (`new Float32Array(numberArray)`). For a sphere at tol 0.01 (56k triangles → a **4.2 MB JSON string**) that added **~46 ms** on top of the ~35 ms of actual tessellation — roughly doubling meshing cost.

This prefers the kernel's binary `tessellateSolidGroupedBinary` when present: it returns packed `Float32Array`/`Uint32Array` buffers directly, so the mesh crosses the WASM boundary as bulk memory copies — no JSON. Falls back to the JSON path (`meshSolidGroupedJson`) on kernels without the binary API.

## Measured (kernel-comparison suite)

| op | before | after |
|---|---|---|
| mesh sphere (56k tris) | 81 ms | **33 ms** |
| cut(box,cyl) ×10 | 106 ms | **62 ms** |
| multi-boolean (16 ops) | 13 ms | **7 ms** |

## Compatibility

- The binary method is **feature-detected** (`typeof bk.tessellateSolidGroupedBinary === 'function'`). Older kernels keep working via the JSON fallback, so this is safe to merge ahead of the brepkit-wasm release.
- Activates the fast path once the brepkit-wasm dependency is bumped to a release containing `tessellateSolidGroupedBinary` (brepkit PR andymai/brepkit#817).

Full pre-commit suite green locally: typecheck, layer boundaries, eslint/prettier, **3701 tests pass**.