### PR TITLE
fix(verify): reap orphaned sandbox processes on timeout and host shutdown

### DIFF
--- a/packages/brepjs-verify/src/mcp/server.ts
+++ b/packages/brepjs-verify/src/mcp/server.ts
@@ -24,6 +24,11 @@ import {
   runProgramTool,
   type ExportPartToolArgs,
 } from './tools.js';
+import { installSandboxShutdownHandlers } from '../sandbox/runProgram.js';
+
+// Reap any in-flight sandbox process groups if this server is stopped mid-build (the agent
+// disconnecting), so a runaway part can't outlive the server and burn a core indefinitely.
+installSandboxShutdownHandlers();
 
 // Read the version from package.json at runtime so it tracks the package (this module sits two
 // levels below the package root in both src/ and dist/). NB: don't use

--- a/packages/brepjs-verify/src/sandbox/runProgram.ts
+++ b/packages/brepjs-verify/src/sandbox/runProgram.ts
@@ -8,16 +8,13 @@
  * live WASM handles), and the temp program directory is always cleaned up.
  */
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn } from 'node:child_process';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { VerifyReport } from '../verify/report.js';
-
-const execFileAsync = promisify(execFile);
 
 /** The verify report as serialized by the CLI (the report plus the top-level `ok` verdict). */
 export type SerializedReport = VerifyReport & { ok: boolean };
@@ -109,41 +106,96 @@ async function runVerifyCli(
     const cliArgs = makeArgs(partPath);
     const cmd = useTsx ? 'npx' : process.execPath;
     const args = useTsx ? ['tsx', cliEntry, ...cliArgs] : [cliEntry, ...cliArgs];
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      // Append rather than replace, so an existing NODE_OPTIONS (flags, other limits) survives.
+      NODE_OPTIONS: [process.env['NODE_OPTIONS'], `--max-old-space-size=${maxMemoryMb}`]
+        .filter(Boolean)
+        .join(' '),
+    };
 
-    try {
-      const { stdout, stderr } = await execFileAsync(cmd, args, {
-        timeout: timeoutMs,
-        killSignal: 'SIGKILL',
-        maxBuffer: MAX_OUTPUT_BYTES,
-        env: {
-          ...process.env,
-          // Append rather than replace, so an existing NODE_OPTIONS (flags, other limits) survives.
-          NODE_OPTIONS: [process.env['NODE_OPTIONS'], `--max-old-space-size=${maxMemoryMb}`]
-            .filter(Boolean)
-            .join(' '),
-        },
-      });
-      return { stdout, stderr, timedOut: false, outputTooLarge: false, exitCode: 0 };
-    } catch (err) {
-      const e = err as {
-        stdout?: string;
-        stderr?: string;
-        killed?: boolean;
-        code?: number | string | null;
-      };
-      // The CLI prints its JSON document and exits 1 for a not-ok part — that is not a crash; the
-      // caller inspects stdout. We only classify timeout / output-cap here.
-      return {
-        stdout: e.stdout ?? '',
-        stderr: e.stderr ?? (err instanceof Error ? err.message : String(err)),
-        timedOut: Boolean(e.killed) && e.code !== 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
-        outputTooLarge: e.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
-        exitCode: typeof e.code === 'number' ? e.code : null,
-      };
-    }
+    return await spawnCliOutcome(cmd, args, env, timeoutMs);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Spawn the verify CLI in its OWN process group and enforce the wall-clock budget by SIGKILLing the
+ * WHOLE group on timeout — not just the direct child.
+ *
+ * Why a process group rather than Node's built-in `execFile` timeout: in dev/test the CLI runs as
+ * `npx tsx <main.ts>`, so the process that actually executes the part (and can spin on a CPU-bound
+ * OCCT op) is a *grandchild* behind npx+tsx. `child_process`' `timeout`/`killSignal` signals only
+ * the direct child, so a fired timeout SIGKILLs `npx` and orphans the still-spinning grandchild
+ * forever (it reparents to init and keeps burning a core). Spawning `detached` makes the child a
+ * process-group leader that npx's descendants inherit, so `process.kill(-pid, …)` reaps the entire
+ * tree. The production path (`node dist/cli/main.js`) has no intermediary, but the group kill is
+ * equally correct there.
+ */
+function spawnCliOutcome(
+  cmd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number
+): Promise<CliOutcome> {
+  return new Promise<CliOutcome>((resolve) => {
+    const child = spawn(cmd, args, { env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    let stdout = '';
+    let stderr = '';
+    let stdoutBytes = 0;
+    let timedOut = false;
+    let outputTooLarge = false;
+    let settled = false;
+
+    const killTree = (signal: NodeJS.Signals): void => {
+      const pid = child.pid;
+      if (pid === undefined) return;
+      try {
+        // Negative pid → the whole process GROUP (POSIX). On win32 (no POSIX groups) fall back to
+        // the root process — best effort; the dev CLI targets POSIX.
+        process.kill(process.platform === 'win32' ? pid : -pid, signal);
+      } catch {
+        // The group is already gone (child exited between the check and the signal).
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killTree('SIGKILL');
+    }, timeoutMs);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes > MAX_OUTPUT_BYTES) {
+        // Mirror execFile's maxBuffer: a runaway writer is killed and classified as output-too-large.
+        outputTooLarge = true;
+        killTree('SIGKILL');
+        return;
+      }
+      stdout += chunk.toString();
+    });
+    // stderr is diagnostic only; cap it so a chatty failure can't exhaust memory.
+    child.stderr?.on('data', (chunk: Buffer) => {
+      if (stderr.length < MAX_OUTPUT_BYTES) stderr += chunk.toString();
+    });
+
+    const finish = (exitCode: number | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, timedOut, outputTooLarge, exitCode });
+    };
+
+    // The command itself could not be spawned (e.g. ENOENT) — surface as a crash (no JSON report).
+    child.on('error', (err: Error) => {
+      if (!stderr) stderr = err.message;
+      finish(null);
+    });
+    // 'close' fires once stdio is fully drained; a signal-kill reports a null exit code.
+    child.on('close', (code: number | null) => finish(code));
+  });
 }
 
 function tryParse<T>(out: string): T | null {

--- a/packages/brepjs-verify/src/sandbox/runProgram.ts
+++ b/packages/brepjs-verify/src/sandbox/runProgram.ts
@@ -179,6 +179,8 @@ function spawnCliOutcome(
     }, timeoutMs);
 
     child.stdout?.on('data', (chunk: Buffer) => {
+      // Already over the cap and condemned — don't re-fire the kill on every buffered chunk.
+      if (outputTooLarge) return;
       stdoutBytes += chunk.length;
       if (stdoutBytes > MAX_OUTPUT_BYTES) {
         // Mirror execFile's maxBuffer: a runaway writer is killed and classified as output-too-large.
@@ -188,9 +190,12 @@ function spawnCliOutcome(
       }
       stdout += chunk.toString();
     });
-    // stderr is diagnostic only; cap it so a chatty failure can't exhaust memory.
+    // stderr is diagnostic only; cap it by byte count (matching stdout — `.length` would count
+    // UTF-16 code units, undercounting multi-byte output) so a chatty failure can't exhaust memory.
+    let stderrBytes = 0;
     child.stderr?.on('data', (chunk: Buffer) => {
-      if (stderr.length < MAX_OUTPUT_BYTES) stderr += chunk.toString();
+      stderrBytes += chunk.length;
+      if (stderrBytes <= MAX_OUTPUT_BYTES) stderr += chunk.toString();
     });
 
     const finish = (exitCode: number | null): void => {

--- a/packages/brepjs-verify/src/sandbox/runProgram.ts
+++ b/packages/brepjs-verify/src/sandbox/runProgram.ts
@@ -56,6 +56,24 @@ const DEFAULT_MAX_MEMORY_MB = 2048;
 const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 /**
+ * In-flight sandbox process *groups*, keyed by group-leader pid. Tracked so a dying host can reap
+ * its runs (see installSandboxShutdownHandlers) — the per-run timeout can't, since its timer dies
+ * with the host.
+ */
+const activeGroups = new Set<number>();
+
+/** SIGKILL (or `signal`) an entire detached process group by its leader pid; ignore if already gone. */
+function killGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    // Negative pid → the whole process GROUP (POSIX). On win32 (no POSIX groups) fall back to the
+    // root process — best effort; the dev CLI targets POSIX.
+    process.kill(process.platform === 'win32' ? pid : -pid, signal);
+  } catch {
+    // The group is already gone (the leader exited between the check and the signal).
+  }
+}
+
+/**
  * Clamp a caller-supplied limit to a positive, finite value, falling back to the default otherwise.
  * Critical for the timeout: Node's `execFile` treats `timeout: 0` (and it ignores negatives) as
  * "no timeout", which would silently disable the sandbox's only runaway protection.
@@ -141,6 +159,8 @@ function spawnCliOutcome(
 ): Promise<CliOutcome> {
   return new Promise<CliOutcome>((resolve) => {
     const child = spawn(cmd, args, { env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    // Track the group so a host shutdown can reap it even if this run's timer never fires.
+    if (child.pid !== undefined) activeGroups.add(child.pid);
 
     let stdout = '';
     let stderr = '';
@@ -150,15 +170,7 @@ function spawnCliOutcome(
     let settled = false;
 
     const killTree = (signal: NodeJS.Signals): void => {
-      const pid = child.pid;
-      if (pid === undefined) return;
-      try {
-        // Negative pid → the whole process GROUP (POSIX). On win32 (no POSIX groups) fall back to
-        // the root process — best effort; the dev CLI targets POSIX.
-        process.kill(process.platform === 'win32' ? pid : -pid, signal);
-      } catch {
-        // The group is already gone (child exited between the check and the signal).
-      }
+      if (child.pid !== undefined) killGroup(child.pid, signal);
     };
 
     const timer = setTimeout(() => {
@@ -185,6 +197,7 @@ function spawnCliOutcome(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (child.pid !== undefined) activeGroups.delete(child.pid);
       resolve({ stdout, stderr, timedOut, outputTooLarge, exitCode });
     };
 
@@ -195,6 +208,42 @@ function spawnCliOutcome(
     });
     // 'close' fires once stdio is fully drained; a signal-kill reports a null exit code.
     child.on('close', (code: number | null) => finish(code));
+  });
+}
+
+/** SIGKILL every in-flight sandbox process group now. Exported so a host can reap explicitly. */
+export function killActiveSandboxes(signal: NodeJS.Signals = 'SIGKILL'): void {
+  for (const pid of activeGroups) killGroup(pid, signal);
+  activeGroups.clear();
+}
+
+let shutdownHandlersInstalled = false;
+
+/**
+ * Install process-shutdown hooks that reap any in-flight sandbox process groups when THIS process
+ * (the host — e.g. the MCP server) terminates. Idempotent; call once at startup from an entrypoint.
+ *
+ * Rationale: the per-run timeout (`spawnCliOutcome`) only protects a run while the host is alive —
+ * its timer dies with the host. If the host is stopped (the agent disconnects) before a run's
+ * budget elapses, the `detached` sandbox group is in its own session and survives, burning a core
+ * indefinitely. These hooks SIGKILL every tracked group on the way down so a dying host doesn't
+ * leak its children. (A hard SIGKILL of the host can't be trapped — that residual needs the kernel's
+ * PR_SET_PDEATHSIG, which Node doesn't expose.)
+ */
+export function installSandboxShutdownHandlers(): void {
+  if (shutdownHandlersInstalled) return;
+  shutdownHandlersInstalled = true;
+  // Normal or explicit exit: reap synchronously (process.kill is sync and valid in an 'exit' handler).
+  process.on('exit', () => killActiveSandboxes('SIGKILL'));
+  // Signal-initiated stop (the agent terminating the server): reap, then keep terminating with the
+  // conventional 128+signal exit code so the host still exits promptly.
+  process.once('SIGTERM', () => {
+    killActiveSandboxes('SIGKILL');
+    process.exit(143);
+  });
+  process.once('SIGINT', () => {
+    killActiveSandboxes('SIGKILL');
+    process.exit(130);
   });
 }
 

--- a/packages/brepjs-verify/tests/fixtures/sandboxHost.ts
+++ b/packages/brepjs-verify/tests/fixtures/sandboxHost.ts
@@ -1,0 +1,32 @@
+/**
+ * Test host for the sandbox shutdown reaper (Mode B: host-death).
+ *
+ * Starts a long-budget runaway sandbox run — so the per-run timeout will NOT fire during the test —
+ * and installs the same shutdown handlers the MCP server uses. The runaway records its leaf pid (the
+ * `node` process actually executing the part) to the file given as argv[2] before spinning. A test
+ * SIGTERMs this process and asserts the leaf is reaped rather than orphaned.
+ */
+import { fileURLToPath } from 'node:url';
+import { installSandboxShutdownHandlers, runProgram } from '../../src/sandbox/runProgram.js';
+
+const pidFile = process.argv[2];
+if (!pidFile) process.exit(2);
+
+installSandboxShutdownHandlers();
+
+const tsEntry = fileURLToPath(new URL('../../src/cli/main.ts', import.meta.url));
+const runaway = [
+  `import { writeFileSync } from 'node:fs';`,
+  `export default () => {`,
+  `  writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+  `  // eslint-disable-next-line`,
+  `  while (true) {}`,
+  `};`,
+  ``,
+].join('\n');
+
+// Fire-and-forget with a long budget: we are exercising shutdown reaping, not the per-run timeout.
+void runProgram(runaway, { timeoutMs: 120000, cliEntry: tsEntry });
+
+// Keep the host alive until the test terminates it.
+setInterval(() => undefined, 1 << 30);

--- a/packages/brepjs-verify/tests/runProgram.test.ts
+++ b/packages/brepjs-verify/tests/runProgram.test.ts
@@ -73,8 +73,9 @@ describe('runProgram (sandbox executor)', () => {
       leafPid = Number(readFileSync(pidFile, 'utf8'));
       expect(Number.isInteger(leafPid)).toBe(true);
 
-      // Give the OS a beat to deliver signals, then assert the leaf is gone — not orphaned.
-      await delay(1000);
+      // Poll (don't fix-wait) for the leaf to be reaped — avoids flakiness from the brief
+      // dead-but-not-yet-reaped window on loaded machines.
+      for (let i = 0; i < 80 && isAlive(leafPid); i++) await delay(100);
       expect(isAlive(leafPid)).toBe(false);
     } finally {
       if (leafPid !== undefined && isAlive(leafPid)) {

--- a/packages/brepjs-verify/tests/runProgram.test.ts
+++ b/packages/brepjs-verify/tests/runProgram.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -86,6 +87,53 @@ describe('runProgram (sandbox executor)', () => {
       if (existsSync(pidFile)) rmSync(pidFile, { force: true });
     }
   }, 45000);
+
+  it('reaps an in-flight sandbox when the host process is terminated (host-death)', async () => {
+    // The per-run timeout protects a run only while the host's timer is alive. If the host (the MCP
+    // server) is stopped mid-build, its detached sandbox group must still be reaped — not orphaned
+    // to spin forever. This is the failure that left 13h-old runaways burning cores.
+    const pidFile = join(tmpdir(), `brepjs-orphan-host-${process.pid}-${Date.now()}.pid`);
+    const hostScript = fileURLToPath(new URL('./fixtures/sandboxHost.ts', import.meta.url));
+    // Run the host as a direct `node` child (mirrors the production `node dist/mcp/server.js`), so
+    // the SIGTERM lands on the process that installed the handlers — not on an `npx` wrapper.
+    const host = spawn(process.execPath, ['--import', 'tsx', hostScript, pidFile], {
+      stdio: 'ignore',
+    });
+
+    let leafPid = -1;
+    try {
+      // Wait until the sandbox leaf is actually executing the part.
+      const deadline = Date.now() + 45000;
+      while (!existsSync(pidFile)) {
+        if (Date.now() > deadline) throw new Error('sandbox leaf never started');
+        await delay(150);
+      }
+      leafPid = Number(readFileSync(pidFile, 'utf8'));
+      expect(Number.isInteger(leafPid)).toBe(true);
+      expect(isAlive(leafPid)).toBe(true);
+
+      // Simulate the agent stopping the MCP server while a build is in flight.
+      host.kill('SIGTERM');
+
+      // The shutdown reaper must SIGKILL the whole sandbox tree, not orphan the spinning leaf.
+      for (let i = 0; i < 80 && isAlive(leafPid); i++) await delay(100);
+      expect(isAlive(leafPid)).toBe(false);
+    } finally {
+      if (leafPid > 0 && isAlive(leafPid)) {
+        try {
+          process.kill(leafPid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      try {
+        host.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      if (existsSync(pidFile)) rmSync(pidFile, { force: true });
+    }
+  }, 70000);
 
   it('reports crashed when the runner produces no report (bad CLI entry)', async () => {
     // A non-existent .js entry runs under `node` and exits non-zero with no JSON on stdout —

--- a/packages/brepjs-verify/tests/runProgram.test.ts
+++ b/packages/brepjs-verify/tests/runProgram.test.ts
@@ -1,10 +1,31 @@
 import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runProgram, positiveOrDefault } from '@/sandbox/runProgram.js';
 
 const VALID_PART = `import { box } from 'brepjs';\nexport default () => box(10, 10, 10);\n`;
 // A synchronous infinite loop blocks the child's event loop — only an out-of-process
 // timeout/kill can stop it, which is exactly what the sandbox must guarantee.
 const RUNAWAY_PART = `export default () => {\n  // eslint-disable-next-line\n  while (true) {}\n};\n`;
+
+// The dev/test sandbox runs the CLI via `npx tsx <main.ts>`, which spawns the part-executing
+// `node` as a GRANDCHILD behind npx+tsx. Pinning the `.ts` entry forces that grandchild chain
+// (rather than a built `dist/.../main.js`, which would run as a single direct child).
+const TS_CLI_ENTRY = fileURLToPath(new URL('../src/cli/main.ts', import.meta.url));
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM = the process exists but we don't own it (still "alive"); ESRCH = gone.
+    return (e as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe('runProgram (sandbox executor)', () => {
   it('runs a valid part in a child process and returns a completed report', async () => {
@@ -21,6 +42,50 @@ describe('runProgram (sandbox executor)', () => {
     expect(res.outcome).toBe('timeout');
     if (res.outcome === 'timeout') expect(res.timeoutMs).toBe(8000);
   }, 30000);
+
+  it('kills the whole process tree (leaf included), not just the direct child, on timeout', async () => {
+    // The runaway records the LEAF pid — the `node` process actually running the part — to a file
+    // before spinning. If the timeout only SIGKILLs the direct child (npx), this leaf is orphaned
+    // and keeps burning a core indefinitely. The sandbox must reap the whole tree.
+    const pidFile = join(tmpdir(), `brepjs-orphan-leaf-${process.pid}-${Date.now()}.pid`);
+    const PID_RECORDING_RUNAWAY = [
+      `import { writeFileSync } from 'node:fs';`,
+      `export default () => {`,
+      `  writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+      `  // eslint-disable-next-line`,
+      `  while (true) {}`,
+      `};`,
+      ``,
+    ].join('\n');
+
+    let leafPid: number | undefined;
+    try {
+      const res = await runProgram(PID_RECORDING_RUNAWAY, {
+        timeoutMs: 10000,
+        cliEntry: TS_CLI_ENTRY,
+      });
+      expect(res.outcome).toBe('timeout');
+
+      // The leaf actually started executing the part before the kill (otherwise the test below
+      // would be vacuous — it'd "pass" only because the part never ran).
+      expect(existsSync(pidFile)).toBe(true);
+      leafPid = Number(readFileSync(pidFile, 'utf8'));
+      expect(Number.isInteger(leafPid)).toBe(true);
+
+      // Give the OS a beat to deliver signals, then assert the leaf is gone — not orphaned.
+      await delay(1000);
+      expect(isAlive(leafPid)).toBe(false);
+    } finally {
+      if (leafPid !== undefined && isAlive(leafPid)) {
+        try {
+          process.kill(leafPid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+      if (existsSync(pidFile)) rmSync(pidFile, { force: true });
+    }
+  }, 45000);
 
   it('reports crashed when the runner produces no report (bad CLI entry)', async () => {
     // A non-existent .js entry runs under `node` and exits non-zero with no JSON on stdout —


### PR DESCRIPTION
## Problem

Sandboxed `run_program` / `export_part` verify runs could leak `node` processes that spin a CPU core indefinitely. Observed in the wild: dozens of orphaned `brepjs-verify … --check` processes up to 13h old, saturating every core.

## Root cause

The sandbox's only runaway protection is the per-run wall-clock timeout (`runProgram.ts`), enforced via `child_process`' `timeout` + `killSignal`. Two ways it failed to actually kill the work:

- **Mode A — timeout signals the wrong process.** In dev/test the CLI runs as `npx tsx <main.ts>`, so the process that executes the part (and spins on a CPU-bound OCCT op) is a *grandchild* behind npx+tsx. `child_process` signals only the **direct child** (`npx`), so a fired timeout SIGKILLed npx and orphaned the still-spinning grandchild, which reparented to init and kept burning a core.
- **Mode B — the timer dies with the host.** The timeout lives in the host process (the MCP server). If the server is stopped — the agent disconnecting — before a run's budget elapses, the timer never fires and the whole `detached` sandbox group is orphaned. This is what produced the 13h-old runaways.

## Fix

- **Process-group isolation + group kill.** Spawn the CLI `detached` (its own process group) and SIGKILL the **whole group** (`process.kill(-pid)`) on timeout/output-cap, so the entire `npx → tsx → node` tree is reaped. `CliOutcome` semantics (stdout/stderr/timedOut/outputTooLarge/exitCode) are unchanged.
- **Host-shutdown reaping.** Track each run's group in a registry; install `exit`/`SIGTERM`/`SIGINT` hooks (`installSandboxShutdownHandlers`, wired into the MCP server entrypoint) that SIGKILL every in-flight group on the way down. Exposes `killActiveSandboxes()` for explicit reaping.

### Known residual
A hard `SIGKILL` of the host can't be trapped (no handler runs); that case needs the kernel's `PR_SET_PDEATHSIG`, which Node doesn't expose without a native addon. Documented in the `installSandboxShutdownHandlers` docstring.

## Tests (TDD — each watched fail first, for the right reason)

- Mode A: records the **leaf** PID inside the runaway, asserts it's dead after the timeout (the existing timeout test only checked the return value, which `execFile` reported correctly even while leaking).
- Mode B: spawns a host fixture (direct `node`, mirroring the built server), lets it start a runaway, SIGTERMs it, asserts the sandbox leaf is reaped rather than orphaned.

Full `runProgram` suite + adjacent sandbox/entrypoint/cli tests green; typecheck + lint clean; full `test:ci` (4116 tests) green on push.