### PR TITLE
feat(kernel): wire brepkit projectEdges to native HLR

### DIFF
--- a/src/kernel/brepkit/brepkitWasmTypes.ts
+++ b/src/kernel/brepkit/brepkitWasmTypes.ts
@@ -857,7 +857,6 @@ export interface BrepkitKernel {
 
   offsetWire2DWithJoin(wire: number, distance: number, joinType: string): number;
 
-  /** @unwired */
   projectEdges(
     solid: number,
     originX: number,

--- a/src/kernel/brepkit/geometryOps.ts
+++ b/src/kernel/brepkit/geometryOps.ts
@@ -18,11 +18,14 @@ import {
   edgeHandle,
   faceHandle,
   wireHandle,
+  compoundHandle,
   unwrap,
   unwrapSolidOrThrow,
   toArray,
   dist3,
   warnOnce,
+  nextSyntheticId,
+  syntheticCompounds,
 } from './helpers.js';
 import { iterShapes } from './topologyOps.js';
 import { extractNurbsFromEdge } from './internalOps.js';
@@ -504,19 +507,75 @@ export function recognizeFeatures(
 export function projectEdges(
   bk: BrepkitKernel,
   shape: KernelShape,
-  _cameraOrigin: [number, number, number],
-  _cameraDirection: [number, number, number],
-  _cameraXAxis?: [number, number, number]
+  cameraOrigin: [number, number, number],
+  cameraDirection: [number, number, number],
+  cameraXAxis?: [number, number, number]
 ): {
   visible: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
   hidden: { outline: KernelShape; smooth: KernelShape; sharp: KernelShape };
 } {
-  // Simplified: return all edges as visible outlines, no hidden line removal
-  const edges = iterShapes(bk, shape, 'edge');
-  const emptyCompound = edges.length > 0 ? edges[0] : shape;
+  const solidId = unwrap(shape);
+  const [ox, oy, oz] = cameraOrigin;
+  const [dx, dy, dz] = cameraDirection;
+  const [xx, xy, xz] = cameraXAxis ?? [1, 0, 0];
+
+  // brepkit returns polyline approximations of the projection, so tie the
+  // tessellation deflection to model scale (1/1000 of the bbox diagonal) to
+  // stay resolution-independent across part sizes.
+  let deflection = 0.1;
+  try {
+    const bb = bk.boundingBox(solidId);
+    const [minX, minY, minZ] = vec3At(bb, 0);
+    const [maxX, maxY, maxZ] = vec3At(bb, 3);
+    const diag = dist3(minX, minY, minZ, maxX, maxY, maxZ);
+    if (diag > 0) deflection = Math.max(diag * 1e-3, 1e-6);
+  } catch {
+    // non-solid input or bbox failure: keep the default deflection
+  }
+
+  const json = bk.projectEdges(solidId, ox, oy, oz, dx, dy, dz, xx, xy, xz, true, deflection);
+  const parsed = JSON.parse(json) as { visible: number[][]; hidden: number[][] };
+
+  // brepkit emits flat [x,y,x,y,…] polylines in view coordinates and, unlike
+  // OCCT's HLR, does not split silhouette/smooth/sharp — rebuild line edges in
+  // the view plane (z=0) and surface them all as the visible/hidden outline.
+  // brepkit's wasm makeCompound only accepts solids; edge collections use the
+  // JS-side synthetic-compound mechanism that iterShapes/getEdges resolves.
+  const polylinesToCompound = (polylines: number[][]): KernelShape => {
+    const edges: BrepkitHandle[] = [];
+    for (const poly of polylines) {
+      for (let i = 0; i + 3 < poly.length; i += 2) {
+        const x1 = poly[i];
+        const y1 = poly[i + 1];
+        const x2 = poly[i + 2];
+        const y2 = poly[i + 3];
+        if (x1 === undefined || y1 === undefined || x2 === undefined || y2 === undefined) break;
+        if (x1 === x2 && y1 === y2) continue;
+        edges.push(edgeHandle(bk.makeLineEdge(x1, y1, 0, x2, y2, 0)));
+      }
+    }
+    const id = nextSyntheticId();
+    syntheticCompounds.set(id, edges);
+    return compoundHandle(id);
+  };
+
+  const emptyCompound = (): KernelShape => {
+    const id = nextSyntheticId();
+    syntheticCompounds.set(id, []);
+    return compoundHandle(id);
+  };
+
   return {
-    visible: { outline: emptyCompound, smooth: emptyCompound, sharp: emptyCompound },
-    hidden: { outline: emptyCompound, smooth: emptyCompound, sharp: emptyCompound },
+    visible: {
+      outline: polylinesToCompound(parsed.visible),
+      smooth: emptyCompound(),
+      sharp: emptyCompound(),
+    },
+    hidden: {
+      outline: polylinesToCompound(parsed.hidden),
+      smooth: emptyCompound(),
+      sharp: emptyCompound(),
+    },
   };
 }
 

--- a/src/kernel/brepkit/geometryOps.ts
+++ b/src/kernel/brepkit/geometryOps.ts
@@ -534,7 +534,12 @@ export function projectEdges(
   }
 
   const json = bk.projectEdges(solidId, ox, oy, oz, dx, dy, dz, xx, xy, xz, true, deflection);
-  const parsed = JSON.parse(json) as { visible: number[][]; hidden: number[][] };
+  let parsed: { visible: number[][]; hidden: number[][] };
+  try {
+    parsed = JSON.parse(json) as { visible: number[][]; hidden: number[][] };
+  } catch {
+    parsed = { visible: [], hidden: [] };
+  }
 
   // brepkit emits flat [x,y,x,y,…] polylines in view coordinates and, unlike
   // OCCT's HLR, does not split silhouette/smooth/sharp — rebuild line edges in
@@ -549,7 +554,9 @@ export function projectEdges(
         const y1 = poly[i + 1];
         const x2 = poly[i + 2];
         const y2 = poly[i + 3];
-        if (x1 === undefined || y1 === undefined || x2 === undefined || y2 === undefined) break;
+        // narrows the four indices to `number` (noUncheckedIndexedAccess); the
+        // loop bound guarantees presence, so this never skips a real segment.
+        if (x1 === undefined || y1 === undefined || x2 === undefined || y2 === undefined) continue;
         if (x1 === x2 && y1 === y2) continue;
         edges.push(edgeHandle(bk.makeLineEdge(x1, y1, 0, x2, y2, 0)));
       }

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1405,6 +1405,11 @@ export class OcctWasmAdapter implements KernelAdapter {
     return curveOps.approximatePoints(this.k, this.Module, points, options);
   }
 
+  // NURBS edit/construct + Bézier pole read are unavailable: occt-wasm exposes
+  // NURBS *read* (getNurbsCurveData) but no Geom_BSplineCurve editing, no
+  // B-spline edge constructor, and no Bézier pole access (getNurbsCurveData
+  // returns null for BEZIER_CURVE). Blocked on the bindings tracked in
+  // andymai/occt-wasm#172; brepkit-wasm implements these natively.
   curveDegreeElevate(_edge: KernelShape, _elevateBy: number): KernelShape {
     notImplemented('curveDegreeElevate');
   }
@@ -1421,12 +1426,14 @@ export class OcctWasmAdapter implements KernelAdapter {
     notImplemented('curveSplit');
   }
 
-  createCurveAdaptor(_shape: KernelShape): KernelType {
-    notImplemented('createCurveAdaptor');
-  }
-
   getBezierPenultimatePole(_edge: KernelShape): [number, number, number] | null {
     notImplemented('getBezierPenultimatePole');
+  }
+
+  // N/A for the id-based API: callers evaluate curves via curvePointAtParam /
+  // curveTangent / curveParameters, so no raw BRepAdaptor object is needed.
+  createCurveAdaptor(_shape: KernelShape): KernelType {
+    notImplemented('createCurveAdaptor');
   }
 
   // =========================================================================

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -45,6 +45,13 @@ export const isBrepkit: boolean = currentKernelId === 'brepkit';
 export const divergences: DivergenceMap = {
   manifold: {
     // -----------------------------------------------------------------------
+    // projection.test.ts — manifold has no HLR
+    // -----------------------------------------------------------------------
+    'projection.makeProjectedEdges': {
+      kind: 'not-implemented',
+      reason: 'manifold is a mesh kernel with no hidden-line-removal projection (projectEdges).',
+    },
+    // -----------------------------------------------------------------------
     // booleans.test.ts — mesh CSG vs exact B-rep
     // -----------------------------------------------------------------------
     'booleans.cutFuseRecombine': {
@@ -93,6 +100,19 @@ export const divergences: DivergenceMap = {
     },
   },
   brepkit: {
+    // -----------------------------------------------------------------------
+    // projection.test.ts — brepkit HLR (projectEdges) is partial
+    // -----------------------------------------------------------------------
+    'projection.hiddenLines': {
+      kind: 'skip',
+      reason:
+        "brepkit's exact point-in-solid occlusion does not flag a box's back-face edges as hidden when they project exactly onto the front silhouette; OCCT's HLR reports them as hidden, so the hidden set is empty here.",
+    },
+    'projection.curvedSilhouette': {
+      kind: 'skip',
+      reason:
+        'brepkit projectEdges projects topological B-rep edges only and does not synthesize view-dependent silhouettes for smooth surfaces, so a sphere yields no projected outline.',
+    },
     // -----------------------------------------------------------------------
     // booleanFns.test.ts
     // -----------------------------------------------------------------------

--- a/tests/projection.test.ts
+++ b/tests/projection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { shouldSkipSuite, skipIfDiverges } from './helpers/kernelDivergences.js';
 import {
   box,
   sphere,
@@ -128,7 +129,7 @@ describe('createCamera', () => {
   });
 });
 
-describe('makeProjectedEdges', () => {
+describe.skipIf(shouldSkipSuite('projection.makeProjectedEdges'))('makeProjectedEdges', () => {
   it('projects a box from front', () => {
     const b = box(10, 10, 10);
     const cam = unwrap(cameraFromPlane('front'));
@@ -153,7 +154,8 @@ describe('makeProjectedEdges', () => {
     expect(result.hidden.length).toBe(0);
   });
 
-  it('with hidden lines', () => {
+  it('with hidden lines', (ctx) => {
+    skipIfDiverges(ctx, 'projection.hiddenLines');
     const b = box(10, 10, 10);
     const cam = unwrap(cameraFromPlane('front'));
     const result = makeProjectedEdges(b, cam, true);
@@ -191,14 +193,16 @@ describe('makeProjectedEdges', () => {
     }
   });
 
-  it('projects a sphere (curved edges)', () => {
+  it('projects a sphere (curved edges)', (ctx) => {
+    skipIfDiverges(ctx, 'projection.curvedSilhouette');
     const s = sphere(10);
     const cam = unwrap(cameraFromPlane('front'));
     const result = makeProjectedEdges(s, cam);
     expect(result.visible.length).toBeGreaterThan(0);
   });
 
-  it('projects a sphere without hidden lines', () => {
+  it('projects a sphere without hidden lines', (ctx) => {
+    skipIfDiverges(ctx, 'projection.curvedSilhouette');
     const s = sphere(10);
     const cam = unwrap(cameraFromPlane('front'));
     const result = makeProjectedEdges(s, cam, false);


### PR DESCRIPTION
## Summary

Wires the brepkit adapter's `projectEdges` to brepkit-wasm's native HLR (landed in 2.109.0; we're on 2.111.1), replacing a degenerate stub that ignored the camera and returned one arbitrary edge in every channel. Also files/links the upstream gap for occt-wasm curve editing.

## What changed

- **brepkit `projectEdges` — wired.** brepkit returns flat 2D polylines `{visible:[[x,y,…]], hidden:[…]}` in view coordinates; the adapter rebuilds them as line edges in the view plane (z=0) and surfaces them as the visible/hidden outline. Edge collections route through the JS-side synthetic-compound mechanism (brepkit's wasm `makeCompound` is solid-only). Dropped the now-inaccurate `@unwired` tag.
- **Honest test gating.** brepkit's HLR is partial vs OCCT — no occlusion of coincident back-face edges (box-from-front → 12 visible / 0 hidden) and no view-dependent silhouettes for smooth surfaces (sphere → 0 / 0). Registered as kernel divergences (`projection.hiddenLines`, `projection.curvedSilhouette`) and gated the affected tests; gated the whole suite off manifold (no HLR). The old stub had masked these as a **false green** by returning non-empty garbage.
- **occt-wasm curve-editing gap documented.** `curveDegreeElevate` / `curveKnotInsert` / `curveKnotRemove` / `curveSplit` / `getBezierPenultimatePole` can't be wired adapter-side: occt-wasm exposes NURBS *read* only — no `Geom_BSplineCurve` editing, no B-spline edge constructor, and `getNurbsCurveData` returns `null` for `BEZIER_CURVE`. Added a tracking comment → **andymai/occt-wasm#172**. `createCurveAdaptor` is N/A for the id-based API.

## Verification

Projection tests green across all four kernels: occt-wasm 20✓, occt 20✓, brepkit 17✓/3 skipped, manifold 12✓/8 skipped. Full pre-push `test:ci` + `knip` passed.

## Notes

None of the curve methods have public-API callers yet — latent kernel infra (tested only in brepkit-only suites), so no behavior change for consumers. This is purely adapter parity.
