### PR TITLE
ci: auto-merge and auto-publish brepjs-verify release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
       brepjs_release_created: ${{ steps.release.outputs.release_created }}
       brepjs_opencascade_release_created: ${{ steps.release.outputs['packages/brepjs-opencascade--release_created'] }}
       brepjs_verify_release_created: ${{ steps.release.outputs['packages/brepjs-verify--release_created'] }}
+      brepjs_verify_tag_name: ${{ steps.release.outputs['packages/brepjs-verify--tag_name'] }}
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
       prs: ${{ steps.release.outputs.prs }}
@@ -53,7 +54,7 @@ jobs:
         with:
           app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
           private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
-      - name: Enable auto-merge for the root brepjs PR only
+      - name: Enable auto-merge for brepjs and brepjs-verify PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # Prefer the plural `prs` array (separate-pull-requests: true emits
@@ -145,5 +146,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          GH_REF: ${{ github.ref_name }}
+          # Dispatch against the release tag release-please just created, not the
+          # `main` branch: the workflow_dispatch API accepts a tag (immutable) but
+          # rejects a raw SHA, and pinning the tag avoids publishing the wrong
+          # commit if another push lands on main during the dispatch window.
+          GH_REF: ${{ needs.release-please.outputs.brepjs_verify_tag_name }}
         run: gh workflow run publish-brepjs-verify.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,8 +40,8 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Only auto-merge the root brepjs PR. brepjs-opencascade (expensive WASM
-  # build) and brepjs-verify (publish HELD: Andy merges manually) are skipped.
+  # Auto-merge the root brepjs and brepjs-verify PRs. brepjs-opencascade
+  # (expensive WASM build) is skipped and merged manually.
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -81,15 +81,10 @@ jobs:
               echo "PR with no number, skipping"
               continue
             fi
-            # Skip brepjs-opencascade (manual review: expensive WASM build) and
-            # brepjs-verify (publish HELD: Andy merges manually).
+            # Skip brepjs-opencascade only (manual review: expensive WASM build).
             case "$pr_title" in
               *brepjs-opencascade*)
                 echo "Skipping auto-merge for brepjs-opencascade PR #$pr_number (requires manual review)"
-                continue
-                ;;
-              *brepjs-verify*)
-                echo "Skipping auto-merge for brepjs-verify PR #$pr_number (publish held, manual merge)"
                 continue
                 ;;
             esac
@@ -97,8 +92,8 @@ jobs:
             gh pr merge "$pr_number" --auto --squash --repo "$GH_REPO"
           done
 
-  # brepjs-opencascade is published via publish-opencascade.yml and brepjs-verify
-  # via publish-brepjs-verify.yml — both manual workflow_dispatch (publish held).
+  # brepjs-opencascade is published via publish-opencascade.yml — manual
+  # workflow_dispatch (expensive WASM build, publish held).
 
   publish-brepjs:
     runs-on: ubuntu-24.04
@@ -128,3 +123,27 @@ jobs:
       # workflow filename on npmjs.com -> brepjs -> Trusted Publisher Mgmt).
       - name: Publish brepjs
         run: npm publish --provenance
+
+  # Auto-publish brepjs-verify by dispatching its own publish workflow rather
+  # than inlining `npm publish` here. The npm OIDC trusted publisher for
+  # brepjs-verify is bound to the publish-brepjs-verify.yml filename, so the
+  # publish must run from that workflow to authenticate. Dispatching also keeps
+  # the manual workflow_dispatch path working as the recovery route.
+  # Fires on the post-merge release-please run that cuts the brepjs-verify release.
+  publish-brepjs-verify:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.brepjs_verify_release_created == 'true' }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
+          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
+      - name: Dispatch publish-brepjs-verify (real publish)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_REF: ${{ github.ref_name }}
+        run: gh workflow run publish-brepjs-verify.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"


### PR DESCRIPTION
Enables release-please `brepjs-verify` PRs to auto-merge (drops the skip case from the auto-merge job) and auto-publish (new `publish-brepjs-verify` job gated on `brepjs_verify_release_created`), matching root brepjs.

Dispatches `publish-brepjs-verify.yml` rather than inlining `npm publish` because the npm OIDC trusted publisher is bound to that workflow filename; this also keeps the manual dispatch as the recovery path.