### PR TITLE
ci: auto-publish brepjs-viewer on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,8 @@ jobs:
       brepjs_opencascade_release_created: ${{ steps.release.outputs['packages/brepjs-opencascade--release_created'] }}
       brepjs_verify_release_created: ${{ steps.release.outputs['packages/brepjs-verify--release_created'] }}
       brepjs_verify_tag_name: ${{ steps.release.outputs['packages/brepjs-verify--tag_name'] }}
+      brepjs_viewer_release_created: ${{ steps.release.outputs['packages/brepjs-viewer--release_created'] }}
+      brepjs_viewer_tag_name: ${{ steps.release.outputs['packages/brepjs-viewer--tag_name'] }}
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
       prs: ${{ steps.release.outputs.prs }}
@@ -41,8 +43,8 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Auto-merge the root brepjs and brepjs-verify PRs. brepjs-opencascade
-  # (expensive WASM build) is skipped and merged manually.
+  # Auto-merge the root brepjs, brepjs-verify, and brepjs-viewer PRs.
+  # brepjs-opencascade (expensive WASM build) is skipped and merged manually.
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -54,7 +56,7 @@ jobs:
         with:
           app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
           private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
-      - name: Enable auto-merge for brepjs and brepjs-verify PRs
+      - name: Enable auto-merge for brepjs, brepjs-verify, and brepjs-viewer PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # Prefer the plural `prs` array (separate-pull-requests: true emits
@@ -152,3 +154,31 @@ jobs:
           # commit if another push lands on main during the dispatch window.
           GH_REF: ${{ needs.release-please.outputs.brepjs_verify_tag_name }}
         run: gh workflow run publish-brepjs-verify.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
+
+  # Auto-publish brepjs-viewer by dispatching its own publish workflow, mirroring
+  # publish-brepjs-verify above. The npm OIDC trusted publisher for brepjs-viewer
+  # is bound to the publish-brepjs-viewer.yml filename, so the publish must run
+  # from that workflow to authenticate. Dispatching also keeps the manual
+  # workflow_dispatch path working as the recovery route.
+  # Fires on the post-merge release-please run that cuts the brepjs-viewer release.
+  publish-brepjs-viewer:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.brepjs_viewer_release_created == 'true' }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
+          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
+      - name: Dispatch publish-brepjs-viewer (real publish)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          # Dispatch against the release tag release-please just created, not the
+          # `main` branch: the workflow_dispatch API accepts a tag (immutable) but
+          # rejects a raw SHA, and pinning the tag avoids publishing the wrong
+          # commit if another push lands on main during the dispatch window.
+          GH_REF: ${{ needs.release-please.outputs.brepjs_viewer_tag_name }}
+        run: gh workflow run publish-brepjs-viewer.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"


### PR DESCRIPTION
## What

Wire `brepjs-viewer` into the same tag-triggered auto-publish flow that #1388 set up for `brepjs-verify`, so it publishes to npm automatically when release-please cuts a release.

Originally this PR also covered `brepjs-verify`, but #1388 landed that mid-flight — this is now **viewer-only**, mirroring the verify wiring exactly so the two are consistent and nothing double-fires.

## Change (single file: `release-please.yml`)

- Add `brepjs_viewer_release_created` + `brepjs_viewer_tag_name` outputs.
- Add a `publish-brepjs-viewer` job (clone of `publish-brepjs-verify`) gated on `brepjs_viewer_release_created`, dispatching `publish-brepjs-viewer.yml -f dry_run=false` pinned to the release tag.

`publish-brepjs-viewer.yml` is unchanged: it stays `workflow_dispatch`-only so npm's OIDC trusted publisher (bound to that filename) authenticates, and manual dispatch remains the recovery path. Auto-merge already covers viewer (skips only `brepjs-opencascade`).

## Rollout note

Fires on **future** viewer releases. viewer `0.2.0` (already tagged) has no pending release PR, so it needs a one-time manual `dry_run=false` dispatch to sync npm now. OIDC trusted publisher for `brepjs-viewer` is confirmed registered.