### PR TITLE
docs: fix brepkit-wasm init pattern in kernel docs

### DIFF
--- a/apps/docs/concepts/kernels.md
+++ b/apps/docs/concepts/kernels.md
@@ -31,11 +31,10 @@ For brepkit explicitly:
 <!-- @no-test -->
 
 ```typescript
-import init, { Brepkit } from 'brepkit-wasm';
+import { BrepKernel } from 'brepkit-wasm';
 import { registerKernel, BrepkitAdapter, withKernel } from 'brepjs';
 
-await init();
-const bk = new Brepkit();
+const bk = new BrepKernel();
 registerKernel('brepkit', new BrepkitAdapter(bk));
 
 withKernel('brepkit', () => {

--- a/apps/docs/reference/errors.md
+++ b/apps/docs/reference/errors.md
@@ -43,7 +43,7 @@ You called a brepjs function before any kernel was registered. Either you forgot
 
 You called `withKernel('name', ...)` for a kernel that hasn't been registered. Either the import is missing or `registerKernel('name', adapter)` wasn't called.
 
-**Fix**: Verify the kernel package is installed and registered. For brepkit: `import init, { Brepkit } from 'brepkit-wasm'; ...; registerKernel('brepkit', new BrepkitAdapter(bk));`.
+**Fix**: Verify the kernel package is installed and registered. For brepkit: `import { BrepKernel } from 'brepkit-wasm'; const bk = new BrepKernel(); registerKernel('brepkit', new BrepkitAdapter(bk));`.
 
 ## Boolean operations
 

--- a/docs/kernel-swap.md
+++ b/docs/kernel-swap.md
@@ -28,8 +28,7 @@ const kernel = await OcctKernel.init();
 registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
 
 // Register the brepkit kernel as an alternative (external brepkit-wasm package)
-import bkInit, { BrepKernel } from 'brepkit-wasm';
-await bkInit();
+import { BrepKernel } from 'brepkit-wasm';
 registerKernel('brepkit', new BrepkitAdapter(new BrepKernel()));
 
 // Register the legacy brepjs-opencascade kernel as an alternative

--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -88,8 +88,7 @@ initFromOC(oc);
 
 // brepkit WASM (external brepkit-wasm package)
 import { BrepkitAdapter } from 'brepjs';
-import bkInit, { BrepKernel } from 'brepkit-wasm';
-await bkInit();
+import { BrepKernel } from 'brepkit-wasm';
 registerKernel('brepkit', new BrepkitAdapter(new BrepKernel()));
 
 // Custom kernel

--- a/src/kernel/brepkit/brepkitAdapter.ts
+++ b/src/kernel/brepkit/brepkitAdapter.ts
@@ -16,11 +16,10 @@
  * ## Lifecycle
  *
  * ```ts
- * import init, { BrepKernel } from 'brepkit-wasm';
+ * import { BrepKernel } from 'brepkit-wasm';
  * import { BrepkitAdapter } from './brepkitAdapter.js';
  * import { registerKernel } from './index.js';
  *
- * await init();
  * const kernel = new BrepKernel();
  * registerKernel('brepkit', new BrepkitAdapter(kernel));
  * ```


### PR DESCRIPTION
## Summary

Follow-up to the brepkit README fix (andymai/brepkit#853). The `brepkit-wasm` package is built for the **bundler** target — it auto-initializes on import and exposes **no default `init` export**. The brepkit kernel examples here still showed `import init … await init()` (and one used `bkInit`), which would throw `TypeError: init is not a function` if copied. Two examples also used a nonexistent export name `Brepkit` instead of `BrepKernel`.

## Changes (docs/JSDoc only)

Corrected the five brepkit-kernel snippets:

| File | Fix |
|------|-----|
| `apps/docs/concepts/kernels.md` | drop `init`/`await init()`, `Brepkit` → `BrepKernel` |
| `apps/docs/reference/errors.md` | drop `init`, `Brepkit` → `BrepKernel`, add `bk` construction |
| `docs/kernel-swap.md` | drop `bkInit`/`await bkInit()` |
| `src/kernel/README.md` | drop `bkInit`/`await bkInit()` |
| `src/kernel/brepkit/brepkitAdapter.ts` | JSDoc: drop `init`/`await init()` |

**Not touched:** brepjs's own auto-detect `init()` function (a real, correct API) and its many usages — only the snippets that import a default/init **from `'brepkit-wasm'`** were wrong.

## Verification
- `rg "from 'brepkit-wasm'"` → all imports now named-only (`import { BrepKernel }`)
- Confirmed `brepkit-wasm` exports `BrepKernel` (not `Brepkit`) via the installed `.d.ts`
- Pre-commit hooks passed (full vitest suite: 3701 passed)