### PR TITLE
fix(viewer): add repository field for provenance publishing

### DIFF
--- a/packages/brepjs-viewer/package.json
+++ b/packages/brepjs-viewer/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "Shared React/R3F renderer for brepjs meshes (used by the playground and the brepjs-agent viewer)",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/andymai/brepjs",
+    "directory": "packages/brepjs-viewer"
+  },
   "type": "module",
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
## What

Add a `repository` field to `packages/brepjs-viewer/package.json`.

## Why

The auto-publish workflow runs `npm publish --provenance`, which validates that `package.json`'s `repository.url` matches the OIDC provenance source. brepjs-viewer had no `repository` field, so the publish fails:

```
npm error code E422
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/andymai/brepjs" from provenance
```

The OIDC trusted publisher itself works (provenance signed fine) — this is purely the missing metadata. Field mirrors `brepjs-verify`'s.

## After merge

Publish viewer 0.2.0 from `main` (the `brepjs-viewer-v0.2.0` tag has a stale lockfile; main is in sync).