### PR TITLE
fix(verify): unpin brepjs-viewer devDep to workspace wildcard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5614,8 +5614,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.83.1"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -13414,7 +13413,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "brepjs": "^18.83.1",
+        "brepjs": "^18.0.0",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0",
         "typescript": "^6.0.3"
@@ -13432,7 +13431,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^6.0.2",
-        "brepjs-viewer": "0.2.1",
+        "brepjs-viewer": "*",
         "eslint": "^10.4.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -13512,7 +13511,7 @@
       }
     },
     "packages/brepjs-viewer": {
-      "version": "0.2.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "*",

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -70,7 +70,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^6.0.2",
-    "brepjs-viewer": "0.2.1",
+    "brepjs-viewer": "*",
     "eslint": "^10.4.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",


### PR DESCRIPTION
## What

Change `brepjs-verify`'s `brepjs-viewer` devDependency from the exact pin `0.2.1` to `*`.

## Why

`brepjs-verify` devDepended on `brepjs-viewer@0.2.1`, but the workspace package is `0.2.0` and `0.2.1` was never published. So `npm ci` (in CI and in the publish workflows) fails:

```
npm error code ETARGET
npm error notarget No matching version found for brepjs-viewer@0.2.1.
```

The exact pin is an orphaned release-please artifact — the manifest records viewer at `0.2.0`, and `0.2.1` doesn't exist anywhere. `apps/playground` already uses `*` for the same internal dep, which always resolves to the local workspace package and is immune to version skew. This matches that convention.

Lockfile updated surgically via `npm install --package-lock-only` (no full regen).

## Unblocks

`npm ci` on main, which currently fails — including the `publish-brepjs-viewer` workflow. After this merges, viewer 0.2.0 can publish from `main`.