### PR TITLE
fix(deps): point brepjs-verify's brepjs-viewer devDep at the workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5614,8 +5614,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.83.1"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -13414,7 +13413,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "brepjs": "^18.83.1",
+        "brepjs": "^18.0.0",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0",
         "typescript": "^6.0.3"
@@ -13432,7 +13431,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^6.0.2",
-        "brepjs-viewer": "0.2.1",
+        "brepjs-viewer": "*",
         "eslint": "^10.4.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -13512,7 +13511,7 @@
       }
     },
     "packages/brepjs-viewer": {
-      "version": "0.2.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "*",

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -70,7 +70,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^6.0.2",
-    "brepjs-viewer": "0.2.1",
+    "brepjs-viewer": "*",
     "eslint": "^10.4.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",


### PR DESCRIPTION
## Summary

**Unblocks `main` CI.** Every job has been failing at `npm ci` with:
```
npm error notarget No matching version found for brepjs-viewer@0.2.1
```

`packages/brepjs-verify` pinned `brepjs-viewer@0.2.1` (devDependency), but the workspace `brepjs-viewer` is `0.2.0` and only `0.1.0` is published — so npm couldn't satisfy the exact `0.2.1` from the workspace and fell back to the registry, which 404s. A release-please version desync from the recent auto-publish-viewer work.

## Fix

Point the **devDependency** at the workspace (`"*"`, exactly as `apps/playground` already does), so it resolves to the local `packages/brepjs-viewer` instead of the registry. It's dev-only, so the loose range never reaches published consumers of `brepjs-verify`.

## Verification

- `npm ci --dry-run` resolves cleanly (was ETARGET).
- Lockfile regenerated; `brepjs-viewer@0.2.1` reference removed; `@emnapi` entries preserved (npm 11.15).
- Pre-commit green (typecheck + occt-wasm changed suite: 4188 passed).