### PR TITLE
fix(ci): unbreak main — unpin viewer devDep and clear OSV vulns

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,14 @@
+# OSV-Scanner suppressions. Auto-discovered next to package-lock.json by the
+# OSV Scan workflow (.github/workflows/osv-scan.yml). Each entry must carry a
+# reason and a review date so exceptions don't outlive their justification.
+
+[[IgnoredVulns]]
+id = "GHSA-gv7w-rqvm-qjhr"
+ignoreUntil = 2026-09-15
+# esbuild 0.25.10 reaches the tree only via vitepress -> vite@6.4.x, a dev-only
+# docs-site build dependency. The advisory is the Deno install path trusting a
+# malicious NPM_CONFIG_REGISTRY; not reachable from our Node-only trusted CI
+# build. The fix (esbuild 0.28.1) drops destructuring->es2020 transform support
+# and breaks the vitepress build, and vitepress' stable line still pins vite
+# 6.x. Re-evaluate once vitepress 2.x (newer vite/esbuild) ships.
+reason = "esbuild dev-only via vitepress; Deno/NPM_CONFIG_REGISTRY vector not reachable in Node CI; fix breaks docs build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4456,6 +4456,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -5614,8 +5615,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.83.2"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -6942,15 +6942,6 @@
       "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
       "devOptional": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -8443,10 +8434,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8959,10 +8960,20 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -9260,15 +9271,25 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -9396,6 +9417,16 @@
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
@@ -9636,7 +9667,7 @@
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "^3.4.10",
         "marked": "14.0.0"
       }
     },
@@ -12745,9 +12776,9 @@
       }
     },
     "node_modules/vitepress/node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13432,7 +13463,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^6.0.2",
-        "brepjs-viewer": "0.2.1",
+        "brepjs-viewer": "*",
         "eslint": "^10.4.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -13512,7 +13543,7 @@
       }
     },
     "packages/brepjs-viewer": {
-      "version": "0.2.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "*",

--- a/package.json
+++ b/package.json
@@ -306,8 +306,8 @@
     "brace-expansion": "^5.0.6",
     "esbuild@<0.25.0": "^0.25.0",
     "esbuild@>=0.26.0 <0.28.1": "^0.28.1",
-    "js-yaml": "4.2.0",
-    "markdown-it": "14.2.0",
+    "js-yaml": "^4.2.0",
+    "markdown-it": "^14.2.0",
     "vitepress": {
       "vite": "6.4.3"
     }

--- a/package.json
+++ b/package.json
@@ -302,12 +302,14 @@
     "opentype.js": "1.3.4"
   },
   "overrides": {
-    "dompurify": "^3.4.5",
+    "dompurify": "^3.4.10",
     "brace-expansion": "^5.0.6",
     "esbuild@<0.25.0": "^0.25.0",
     "esbuild@>=0.26.0 <0.28.1": "^0.28.1",
+    "js-yaml": "4.2.0",
+    "markdown-it": "14.2.0",
     "vitepress": {
-      "vite": "6.4.2"
+      "vite": "6.4.3"
     }
   }
 }

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -70,7 +70,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^6.0.2",
-    "brepjs-viewer": "0.2.1",
+    "brepjs-viewer": "*",
     "eslint": "^10.4.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",


### PR DESCRIPTION
## What

Fixes the two checks failing on `main`:

| Failing check | Root cause | Fix |
|---|---|---|
| **Deploy API Docs** | `npm ci` → `ETARGET brepjs-viewer@0.2.1` | unpin `brepjs-verify`'s `brepjs-viewer` devDep `0.2.1 → *` |
| **OSV Scan (blocking)** | 12 known vulns in `package-lock.json` | override-bump 11 fixable; suppress 1 unfixable |

## Deploy API Docs

The `node-workspace` release-please plugin re-pins `brepjs-verify`'s workspace
devDep on `brepjs-viewer` to the **pending** viewer version (`0.2.1`, from the
still-open release PR #1397). That version is never published, and the local
workspace package is `0.2.0`, so `npm ci` can satisfy it from neither the
workspace nor the registry. Unpinning to `*` (the same fix as #1408) lets npm
link the local workspace package.

> Note: this recurs on every `brepjs-verify` release (re-pinned in #1398 and
> again in #1415 after #1408 fixed it). A durable fix — publishing
> `brepjs-viewer` or reconfiguring the node-workspace linkage — is worth a
> follow-up, but is a release-policy decision out of scope here.

## OSV Scan

Fixable advisories bumped via root `overrides` (surgical, `--package-lock-only`;
`@emnapi` peer-dep entries preserved):

- **dompurify** `→ ^3.4.10` — clears 7 advisories (via `mermaid` / `monaco-editor` in the docs + playground apps)
- **js-yaml** `→ 4.2.0`, **markdown-it** `→ 14.2.0` (supersedes Dependabot #1417)
- **vitepress**'s **vite** `→ 6.4.3` — clears 2 advisories

### The one suppressed advisory

`GHSA-gv7w-rqvm-qjhr` (esbuild) is **not remediable here**:

- esbuild reaches the tree only via `vitepress → vite@6.4.x` — a **dev-only** docs-site build dependency.
- The advisory is esbuild's **Deno** install path trusting a malicious `NPM_CONFIG_REGISTRY`; not reachable from our Node-only trusted CI build.
- The fix version (esbuild `0.28.1`) drops the destructuring→`es2020`/`safari14` transform and **breaks `npm run docs:build`**. The original overrides deliberately carve out the `[0.25, 0.26)` range to keep vitepress working.
- vitepress's stable line (1.6.4) still pins vite 6.x; the real fix is **vitepress 2.x** (alpha-only today).

Suppressed in `osv-scanner.toml` with a **2026-09-15** review date.

## Verification

- ✅ `npm run typecheck`, `npm run build`, `npm run docs:build` all pass
- ✅ Lockfile changes surgical; `@emnapi` entries preserved (36)
- ✅ `osv-scanner:v2.3.8` (exact CI image) → *"GHSA-gv7w-rqvm-qjhr filtered out... No issues found"* (exit 0)
- ✅ Pre-push full `test:ci` + `knip` passed