### PR TITLE
ci: serialize release-please runs and stop coverage gating docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,9 +234,12 @@ jobs:
     # out of ci-pass). The full instrumented suite can't shard (see `test`), so
     # it runs on one runner with maxWorkers=2 and a raised per-test timeout to
     # ride out any residual swap stall rather than red on the 90s default.
+    # continue-on-error so an informational threshold dip doesn't flip the whole
+    # CI run to failure — that conclusion gates the Deploy API Docs workflow_run.
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name == 'push'
     runs-on: ubuntu-24.04
+    continue-on-error: true
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,15 @@ on:
 permissions:
   contents: read
 
+# Serialize release runs on main. Without this, rapid back-to-back merges (or a
+# dependency-bump release loop) spawn concurrent runs that race on the shared
+# `autorelease:*` labels — one run removes a label another expects, failing with
+# "Label does not exist", which skips the gated publish jobs. Queue, never
+# cancel: cancelling mid-publish would leave a tagged-but-unpublished release.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Why

Two stability fixes surfaced while recovering `main` after the recent release-loop incident (#1425) and the `npm ci` break (#1426).

### 1. release-please races on labels → publishes silently skipped

`release-please.yml` had **no concurrency group**. When runs overlap (rapid back-to-back merges, or the dependency-bump release loop), they race on the shared `autorelease:*` labels — one run removes a label another expects, failing with `Label does not exist`. That fails the `release-please` job, so its `*_release_created` outputs never set, and the **gated publish jobs are skipped**.

This is the confirmed root cause of the version drift: **brepjs 18.83.2** (and several verify/viewer versions) bumped in-repo but never reached npm.

**Fix:** add a `concurrency` group keyed on `github.ref` with `cancel-in-progress: false` (queue, never abort a publish mid-flight).

### 2. Informational coverage failure silently blocked docs deploys

The `coverage` job is documented as *"informational, not a PR gate"* and is kept out of `ci-pass` — but it lacked `continue-on-error`, so a threshold dip flips the **whole CI run** to `failure`. `Deploy API Docs` triggers only on a successful CI `workflow_run`, so an informational coverage miss was silently skipping docs deploys.

**Fix:** mark `coverage` `continue-on-error: true` — it still runs and reports, but no longer flips the run conclusion.

## Verification
- Both workflow files validated as YAML.
- No untrusted input used (concurrency key is `github.ref`).