### PR TITLE
chore(release): unmanage brepjs-viewer from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,6 @@ jobs:
       brepjs_opencascade_release_created: ${{ steps.release.outputs['packages/brepjs-opencascade--release_created'] }}
       brepjs_verify_release_created: ${{ steps.release.outputs['packages/brepjs-verify--release_created'] }}
       brepjs_verify_tag_name: ${{ steps.release.outputs['packages/brepjs-verify--tag_name'] }}
-      brepjs_viewer_release_created: ${{ steps.release.outputs['packages/brepjs-viewer--release_created'] }}
-      brepjs_viewer_tag_name: ${{ steps.release.outputs['packages/brepjs-viewer--tag_name'] }}
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
       prs: ${{ steps.release.outputs.prs }}
@@ -171,30 +169,8 @@ jobs:
           GH_REF: ${{ needs.release-please.outputs.brepjs_verify_tag_name }}
         run: gh workflow run publish-brepjs-verify.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
 
-  # Auto-publish brepjs-viewer by dispatching its own publish workflow, mirroring
-  # publish-brepjs-verify above. The npm OIDC trusted publisher for brepjs-viewer
-  # is bound to the publish-brepjs-viewer.yml filename, so the publish must run
-  # from that workflow to authenticate. Dispatching also keeps the manual
-  # workflow_dispatch path working as the recovery route.
-  # Fires on the post-merge release-please run that cuts the brepjs-viewer release.
-  publish-brepjs-viewer:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    needs: [release-please]
-    if: ${{ needs.release-please.outputs.brepjs_viewer_release_created == 'true' }}
-    steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
-          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
-      - name: Dispatch publish-brepjs-viewer (real publish)
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          # Dispatch against the release tag release-please just created, not the
-          # `main` branch: the workflow_dispatch API accepts a tag (immutable) but
-          # rejects a raw SHA, and pinning the tag avoids publishing the wrong
-          # commit if another push lands on main during the dispatch window.
-          GH_REF: ${{ needs.release-please.outputs.brepjs_viewer_tag_name }}
-        run: gh workflow run publish-brepjs-viewer.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
+  # brepjs-viewer is NOT managed by release-please (removed from
+  # release-please-config.json): node-workspace was re-pinning brepjs-verify's
+  # build-time `brepjs-viewer` devDep to viewer's pending, unpublished version on
+  # every verify release, repeatedly breaking the monorepo `npm ci`. Viewer is
+  # versioned and published manually via publish-brepjs-viewer.yml dispatch.

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,5 @@
   ".": "18.83.3",
   "packages/brepjs-opencascade": "0.16.0",
   "packages/brepjs-voxel-wasm": "0.7.0",
-  "packages/brepjs-verify": "0.24.0",
-  "packages/brepjs-viewer": "0.2.0"
+  "packages/brepjs-verify": "0.24.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,12 +36,6 @@
       "changelog-path": "CHANGELOG.md",
       "component": "brepjs-verify",
       "bump-minor-pre-major": true
-    },
-    "packages/brepjs-viewer": {
-      "release-type": "node",
-      "changelog-path": "CHANGELOG.md",
-      "component": "brepjs-viewer",
-      "bump-minor-pre-major": true
     }
   },
   "plugins": ["node-workspace"],


### PR DESCRIPTION
## Why

`brepjs-viewer` is a **build-time-only `devDependency`** of `brepjs-verify` — consumed solely by verify's bundled `viewer/` sub-app (mostly `import type`). It is **not** in verify's runtime `dependencies`, so consumers of the published `brepjs-verify` never install it.

release-please's `node-workspace` plugin kept rewriting that devDep from the workspace wildcard (`*`) to viewer's **pending, unpublished** version (`0.2.1`) on every `brepjs-verify` release. Since that version isn't on npm and the local workspace package is a different version, `npm ci` fails with `ETARGET` — repeatedly breaking the monorepo (fixed and re-broken in #1320, #1408, #1426).

## What

- Remove `packages/brepjs-viewer` from `release-please-config.json` and `.release-please-manifest.json`.
- Drop the now-dead `brepjs_viewer_*` workflow outputs and the `publish-brepjs-viewer` auto-dispatch job in `release-please.yml`.

node-workspace no longer rewrites verify's viewer devDep, so it stays a stable workspace `*` — **the recurring `npm ci` break is eliminated for good**. Viewer remains a workspace package (built/linked locally) and is versioned + published manually via the existing `publish-brepjs-viewer.yml` dispatch.

## Follow-ups (this session)
- `brepjs-verify` release PR #1427 will regenerate **without** the viewer re-pin → safe to merge → publishes verify 0.24.1.
- Viewer release PR #1397 becomes obsolete → will be closed.
- Viewer published manually to catch npm up.