### PR TITLE
test(coverage): restore functions floor + drop full suite from pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Running comprehensive checks before push..."
+echo "Running pre-push checks..."
 
-# Full suite without coverage — mirrors the CI gate (the sharded `test` job runs
-# test:ci). Coverage is main-only and non-blocking in CI (the `coverage` job is
-# excluded from ci-pass), so gating pushes on it is stricter than CI and pays the
-# v8 instrumentation + report cost on every push. Set VITEST_MAX_WORKERS to trade
-# RAM for wall-time if you have the headroom (default 4; each fork caps at 6 GB).
-npm run test:ci
+# The full test suite runs in CI (the sharded `test` job runs test:ci), so it is
+# not re-run here — pre-commit already gates changed-file tests, and re-running
+# the whole suite on every push was the slow path. Push relies on CI for the full
+# gate.
 
 # Detect unused code
 npm run knip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Monorepo packages:
 ## Git hooks
 
 - **Pre-commit**: lint-staged (ESLint + Prettier + pattern checker) + typecheck + boundary check (parallel), then changed-file tests (no coverage thresholds). Set `FULL_TESTS=1` for full coverage run
-- **Pre-push**: Full `test:ci` (no coverage, mirrors the CI gate) + `knip`. Coverage is main-only/non-blocking in CI, so it's not run here. Set `VITEST_MAX_WORKERS` to use more cores locally (default 4)
+- **Pre-push**: `knip` (unused-code detection) only. The full test suite is **not** run on push — CI's sharded `test` job (`test:ci`) is the full gate, and pre-commit already runs changed-file tests
 - Bypass: `--no-verify` (not recommended)
 
 ## Key patterns

--- a/tests/implicitCore.test.ts
+++ b/tests/implicitCore.test.ts
@@ -6,10 +6,17 @@ import {
   sdfSphere,
   sdfBox,
   sdfCone,
+  sdfRoundedBox,
+  sdfCylinder,
+  sdfCapsule,
+  sdfTorus,
+  sdfPlane,
   sdfSweep,
   sdfLattice,
   sdfStrutLattice,
   sdfFieldAxialRamp,
+  sdfFieldRadialRamp,
+  sdfFieldFromSdf,
   sdfFieldConst,
   sdfFieldClamp,
 } from '@/index.js';
@@ -166,6 +173,65 @@ describe('implicit SDF builder (field-first authoring against the real wasm engi
       -(min[1] as number)
     );
     expect(radial).toBeGreaterThan(2.1);
+  });
+});
+
+describe('implicit SDF primitives and scalar fields (analytic builders)', () => {
+  it.each([
+    ['roundedBox', () => sdfRoundedBox(1, 1, 1, 0.2)],
+    ['cylinder', () => sdfCylinder(0.8, 2)],
+    ['capsule', () => sdfCapsule([0, 0, -1], [0, 0, 1], 0.4)],
+    ['torus', () => sdfTorus(1.2, 0.3)],
+  ])('rasterizes %s into a non-empty contour', (_name, make) => {
+    using s = unwrap(make());
+    using field = unwrap(s.rasterize({ resolution: 24, padding: 2 }));
+    const mesh = field.contour();
+    expect(mesh.vertices.length).toBeGreaterThan(0);
+    expect(mesh.triangles.length % 3).toBe(0);
+  });
+
+  it('clips an unbounded plane half-space via explicit rasterizeIn bounds', () => {
+    using half = unwrap(sdfPlane([0, 0, 1], 0));
+    using region = unwrap(sdfBox(1, 1, 1));
+    // The plane is unbounded; intersect with a finite box so it frames a grid.
+    using clipped = half.intersection(region);
+    using field = unwrap(
+      clipped.rasterizeIn(
+        { min: [-1.5, -1.5, -1.5], max: [1.5, 1.5, 1.5] },
+        { resolution: 24, padding: 2 }
+      )
+    );
+    const mesh = field.contour();
+    expect(mesh.vertices.length).toBeGreaterThan(0);
+  });
+
+  it('rejects degenerate rasterizeIn bounds as a Result error', () => {
+    using s = unwrap(sdfSphere(1));
+    // max <= min on an axis.
+    expect(isErr(s.rasterizeIn({ min: [0, 0, 0], max: [1, 1, 0] }))).toBe(true);
+    // A non-finite bound.
+    expect(isErr(s.rasterizeIn({ min: [0, 0, 0], max: [1, 1, Number.NaN] }))).toBe(true);
+  });
+
+  it('grades a shell thickness with a radial-ramp field', () => {
+    using cyl = unwrap(sdfCylinder(1, 2));
+    using thickness = unwrap(sdfFieldRadialRamp([0, 0, 0], 2, 0, 1, 0.1, 0.3));
+    using walled = cyl.shellField(thickness);
+    using field = unwrap(walled.rasterize({ resolution: 28, padding: 2 }));
+    const mesh = field.contour();
+    expect(mesh.vertices.length).toBeGreaterThan(0);
+  });
+
+  it('drives an offset from another SDF via fieldFromSdf (clamped)', () => {
+    using base = unwrap(sdfSphere(1));
+    using driver = unwrap(sdfBox(2, 2, 2));
+    using raw = unwrap(sdfFieldFromSdf(driver, 0.2, 0.1));
+    // fieldFromSdf is unbounded; clamp before driving a bounds-affecting op.
+    using bounded = unwrap(sdfFieldClamp(raw, -0.5, 0.5));
+    using grown = base.offsetField(bounded);
+    using field = unwrap(grown.rasterize({ resolution: 24, padding: 3 }));
+    const mesh = field.contour();
+    expect(mesh.vertices.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Why

The default-kernel `coverage` CI job has been failing on `main`: functions coverage dropped to **90.96%**, just under the **91%** floor (all other metrics pass). The job is `continue-on-error`, so overall CI stayed green, but the gate itself was genuinely red.

The floor is set to occt-wasm's *measured* numbers rounded down — recent suite changes shifted the denominator and tipped functions below it. Rather than shave the threshold, this restores real coverage.

## What

- **Cover untested analytic SDF builders** in `src/implicit/sdfFns.ts` — `roundedBox`, `cylinder`, `capsule`, `torus`, `plane`, plus `rasterizeIn` (valid + degenerate bounds → `validateBounds` both branches) and the `fieldRadialRamp` / `fieldFromSdf` scalar fields. Each builder + its make-closure is two functions, so this is high-ROI: **+19 functions covered**.
- Functions: **90.96% → 91.44%** (3605 → 3624 / 3963). Tests-only; no `src` changes.

```
Statements   : 86.27%
Branches     : 72.74%
Functions    : 91.44%  (floor 91)
Lines        : 89.38%
```

- **Pre-push hook**: stop running the full `test:ci` suite on every push (CI's sharded `test` job is the full gate; pre-commit already runs changed-file tests). Keeps `knip`. Docs updated to match.

## Test plan

- `npm run test:full` passes the coverage gate locally (exit 0, no threshold error).