### PR TITLE
chore(knip): clear the unused-exports gate

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -2,6 +2,10 @@ import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
   ignoreExportsUsedInFile: true,
+  // Exports tagged `@testOnly` are exercised only by the suite in `tests/`
+  // (outside `src`). knip can't trace those usages here — the tests import via
+  // the `@/…js` alias from a separate tsconfig — so treat the tag as "used".
+  tags: ['-testOnly'],
   rules: {
     // Intentional API-compat aliases (drawRectangle = drawRoundedRectangle, etc.)
     duplicates: 'off',

--- a/src/2d/lib/definitions.ts
+++ b/src/2d/lib/definitions.ts
@@ -16,7 +16,10 @@ export function isPoint2D(point: unknown): point is Point2D {
 /** A 2x2 matrix represented as two row tuples. */
 export type Matrix2X2 = [[number, number], [number, number]];
 
-/** Type guard that checks whether a value is a `Matrix2X2`. */
+/**
+ * Type guard that checks whether a value is a `Matrix2X2`.
+ * @testOnly Exercised by tests/definitions.test.ts.
+ */
 export function isMatrix2X2(matrix: unknown): matrix is Matrix2X2 {
   return (
     Array.isArray(matrix) &&

--- a/src/core/kernelBoundary.ts
+++ b/src/core/kernelBoundary.ts
@@ -87,12 +87,18 @@ export function withKernelDir<T>(v: Vec3, fn: (ocDir: KernelType) => T): T {
 // Axis construction helpers
 // ---------------------------------------------------------------------------
 
-/** Create a kernel 3D axis-1 from point and direction. Caller must delete. */
+/**
+ * Create a kernel 3D axis-1 from point and direction. Caller must delete.
+ * @testOnly Exercised by tests/occtBoundary.test.ts.
+ */
 export function makeKernelAx1(center: Vec3, dir: Vec3): KernelType {
   return getKernel().createAxis1(center[0], center[1], center[2], dir[0], dir[1], dir[2]);
 }
 
-/** Create a kernel 3D axis-2 from origin and z direction (+optional x direction). Caller must delete. */
+/**
+ * Create a kernel 3D axis-2 from origin and z direction (+optional x direction). Caller must delete.
+ * @testOnly Exercised by tests/occtBoundary.test.ts.
+ */
 export function makeKernelAx2(origin: Vec3, zDir: Vec3, xDir?: Vec3): KernelType {
   if (xDir) {
     return getKernel().createAxis2(
@@ -110,7 +116,10 @@ export function makeKernelAx2(origin: Vec3, zDir: Vec3, xDir?: Vec3): KernelType
   return getKernel().createAxis2(origin[0], origin[1], origin[2], zDir[0], zDir[1], zDir[2]);
 }
 
-/** Create a kernel 3D axis-3 from origin, z direction, and optional x direction. Caller must delete. */
+/**
+ * Create a kernel 3D axis-3 from origin, z direction, and optional x direction. Caller must delete.
+ * @testOnly Exercised by tests/occtBoundary.test.ts.
+ */
 export function makeKernelAx3(origin: Vec3, zDir: Vec3, xDir?: Vec3): KernelType {
   if (xDir) {
     return getKernel().createAxis3(

--- a/src/core/planeOps.ts
+++ b/src/core/planeOps.ts
@@ -163,7 +163,10 @@ export function planeToWorld(plane: Plane, local: Vec2): Vec3 {
   return vecAdd(vecAdd(plane.origin, vecScale(plane.xDir, u)), vecScale(plane.yDir, v));
 }
 
-/** Convert 3D world coordinates to 2D local coordinates on the plane. */
+/**
+ * Convert 3D world coordinates to 2D local coordinates on the plane.
+ * @testOnly Exercised by tests/planeOps.test.ts.
+ */
 export function planeToLocal(plane: Plane, world: Vec3): Vec2 {
   const relative = vecSub(world, plane.origin);
   return [vecDot(relative, plane.xDir), vecDot(relative, plane.yDir)];

--- a/src/core/shapeTypeCache.ts
+++ b/src/core/shapeTypeCache.ts
@@ -14,7 +14,10 @@ import type { KernelAdapter } from '@/kernel/interfaces/index.js';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelShape is typed as `any`; WeakMap requires object keys
 const cache = new WeakMap<any, ShapeType>();
 
-/** Get the cached type for a shape, or undefined if not cached. */
+/**
+ * Get the cached type for a shape, or undefined if not cached.
+ * @testOnly Exercised by tests/shapeTypeCache.test.ts.
+ */
 export function getCachedType(shape: KernelShape): ShapeType | undefined {
   return cache.get(shape);
 }
@@ -24,7 +27,10 @@ export function setCachedType(shape: KernelShape, type: ShapeType): void {
   cache.set(shape, type);
 }
 
-/** Check if a shape has a cached type. */
+/**
+ * Check if a shape has a cached type.
+ * @testOnly Exercised by tests/shapeTypeCache.test.ts.
+ */
 export function hasCachedType(shape: KernelShape): boolean {
   return cache.has(shape);
 }

--- a/src/core/typeDiscriminants.ts
+++ b/src/core/typeDiscriminants.ts
@@ -52,6 +52,7 @@ const CURVE_TYPE_BY_INT: CurveType[] = [
  * Map a kernel curve type enum value to its string discriminant.
  *
  * @returns `Ok<CurveType>` on success, or `Err` if the enum value is unrecognised.
+ * @testOnly Exercised by tests/typeDiscriminants.test.ts.
  */
 export const findCurveType = (type: number | { value: number }): Result<CurveType> => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- WASM enum .value may be boxed; Number() ensures plain number

--- a/src/measurement/measureCache.ts
+++ b/src/measurement/measureCache.ts
@@ -40,6 +40,7 @@ export function setCachedMeasurement<K extends MeasurementKey>(
   map.set(key, value);
 }
 
+/** @testOnly Exercised by tests/measureCache.test.ts. */
 export function clearMeasurementCache(shape?: object): void {
   if (shape) {
     cache.delete(shape);

--- a/src/operations/exporters.ts
+++ b/src/operations/exporters.ts
@@ -77,6 +77,7 @@ export function createAssembly(shapes: ShapeOptions[] = []): AssemblyExporter {
  * ```
  *
  * @see {@link exporterFns!exportAssemblySTEP | exportAssemblySTEP} for the functional API equivalent.
+ * @testOnly Exercised by tests/operations-exporters.test.ts.
  */
 export function exportSTEP(
   shapes: ShapeOptions[] = [],

--- a/src/utils/vec2d.ts
+++ b/src/utils/vec2d.ts
@@ -71,7 +71,10 @@ export function crossProduct2d([x0, y0]: Point2D, [x1, y1]: Point2D): number {
   return x0 * y1 - y0 * x1;
 }
 
-/** Compute the dot product of two 2D vectors. */
+/**
+ * Compute the dot product of two 2D vectors.
+ * @testOnly Exercised by tests/vectorOperations.test.ts.
+ */
 export function dotProduct2d([x0, y0]: Point2D, [x1, y1]: Point2D): number {
   return x0 * x1 + y0 * y1;
 }


### PR DESCRIPTION
## Problem
`npm run knip` (pre-push **and** the CI gate) reports **11 unused exports**, so `main` is red and no PR can merge.

## Root cause
They are **not dead code** — all 11 are live utilities exercised only by the suite in `tests/`. knip's project is `src`-only and its Vitest plugin can't statically read this repo's test list (`vitest.config.ts` builds it at runtime), so it never sees those usages and mis-flags the exports. Verified with `knip --debug`: it discovers + resolves the test modules but won't credit named imports from the entry test files. (Notably `exportSTEP` in `operations/exporters.ts` is imported by `tests/operations-exporters.test.ts` as `exportAssemblySTEPOop` — the pre-commit test suite caught an attempt to remove it as 'dead'.)

## Fix
Mark each with a dedicated, self-documenting `@testOnly` JSDoc tag and configure `tags: ['-testOnly']` so knip treats them as used. Each tag cites its covering test. A targeted tag (not `@public`/`@internal` — no overload, no `.d.ts`/build impact):

| export | test |
|---|---|
| isMatrix2X2 | definitions.test.ts |
| makeKernelAx1/2/3 | occtBoundary.test.ts |
| planeToLocal | planeOps.test.ts |
| getCachedType, hasCachedType | shapeTypeCache.test.ts |
| findCurveType | typeDiscriminants.test.ts |
| clearMeasurementCache | measureCache.test.ts |
| dotProduct2d | vectorOperations.test.ts |
| exportSTEP (exporters.ts) | operations-exporters.test.ts |

## Verification
`npm run knip` clean; `tsc --noEmit` + ESLint pass; pre-commit ran the full occt suite (**3712 passed**). No code removed — all 11 stay exported (tests need them).

Unblocks every PR currently stuck on the red knip gate (including the ellipse-arc adapter fix).