### PR TITLE
chore(analytics): add PostHog to brepjs.dev and playground

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -1,5 +1,9 @@
 # PostHog product analytics (optional). Without these, analytics is disabled.
 # Project API token (phc_...) from PostHog → Project Settings → API Keys.
 # These are inlined at build time, so set them in the Vercel project too.
+#
+# VITE_POSTHOG_HOST: local dev talks to PostHog directly (value below). On
+# Vercel it is set to "/ingest" — a same-origin reverse proxy (vercel.json
+# rewrites) that dodges ad blockers.
 VITE_POSTHOG_PROJECT_TOKEN=
 VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -1,0 +1,5 @@
+# PostHog product analytics (optional). Without these, analytics is disabled.
+# Project API token (phc_...) from PostHog → Project Settings → API Keys.
+# These are inlined at build time, so set them in the Vercel project too.
+VITE_POSTHOG_PROJECT_TOKEN=
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -48,6 +48,29 @@ function registerPreloadErrorRecovery(): void {
   });
 }
 
+/**
+ * Initialize PostHog product analytics on the client.
+ *
+ * Dynamic-imported (like Vercel's analytics below) so `posthog-js` never loads
+ * during VitePress's SSR prerender. The `defaults` preset enables
+ * `capture_pageview: 'history_change'`, so VitePress route changes emit
+ * pageviews without wiring the router by hand. No key set (local dev / forks
+ * without the env var) → skip init entirely.
+ */
+async function initPostHog(): Promise<void> {
+  const key = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN;
+  if (!key) return;
+
+  const { default: posthog } = await import('posthog-js');
+  posthog.init(key, {
+    api_host: import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+    defaults: '2025-05-24',
+    // We never call identify(), so don't mint a person profile per anonymous
+    // visitor — keeps this to pageview/event analytics only.
+    person_profiles: 'identified_only',
+  });
+}
+
 const theme: Theme = {
   extends: DefaultTheme,
   Layout: () => h(Layout),
@@ -57,6 +80,7 @@ const theme: Theme = {
     // emit pageviews automatically once mounted.
     if (typeof window !== 'undefined') {
       void import('@vercel/analytics').then(({ inject }) => inject());
+      void initPostHog();
       registerPreloadErrorRecovery();
     }
   },

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -63,7 +63,10 @@ async function initPostHog(): Promise<void> {
 
   const { default: posthog } = await import('posthog-js');
   posthog.init(key, {
-    api_host: import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+    // Same-origin Vercel reverse proxy (vercel.json rewrites) so ingestion
+    // dodges ad blockers; ui_host keeps toolbar/links on the real app.
+    api_host: import.meta.env.VITE_POSTHOG_HOST ?? '/ingest',
+    ui_host: 'https://us.posthog.com',
     defaults: '2025-05-24',
     // We never call identify(), so don't mint a person profile per anonymous
     // visitor — keeps this to pageview/event analytics only.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "2.0.1",
+    "posthog-js": "1.387.0",
     "three": "0.184.0",
     "three-stdlib": "2.36.1"
   },

--- a/apps/playground/.env.example
+++ b/apps/playground/.env.example
@@ -1,5 +1,9 @@
 # PostHog product analytics (optional). Without these, analytics is disabled.
 # Project API token (phc_...) from PostHog → Project Settings → API Keys.
 # These are inlined at build time, so set them in the Vercel project too.
+#
+# VITE_POSTHOG_HOST: local dev talks to PostHog directly (value below). On
+# Vercel it is set to "/ingest" — a same-origin reverse proxy (vercel.json
+# rewrites) that dodges ad blockers.
 VITE_POSTHOG_PROJECT_TOKEN=
 VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/playground/.env.example
+++ b/apps/playground/.env.example
@@ -1,0 +1,5 @@
+# PostHog product analytics (optional). Without these, analytics is disabled.
+# Project API token (phc_...) from PostHog → Project Settings → API Keys.
+# These are inlined at build time, so set them in the Vercel project too.
+VITE_POSTHOG_PROJECT_TOKEN=
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -24,6 +24,7 @@
     "lz-string": "1.5.0",
     "monaco-editor": "0.55.1",
     "occt-wasm": "*",
+    "posthog-js": "1.387.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-resizable-panels": "4.11.2",

--- a/apps/playground/src/hooks/usePlaygroundActions.ts
+++ b/apps/playground/src/hooks/usePlaygroundActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { track } from '@vercel/analytics';
+import { captureEvent } from '../lib/posthog';
 import { usePlaygroundStore } from '../stores/playgroundStore';
 import { useToastStore } from '../stores/toastStore';
 import { useViewerStore } from '../stores/viewerStore';
@@ -47,24 +48,28 @@ export function usePlaygroundActions(): PlaygroundActions {
     runCode(code);
     updateUrl(code);
     track('playground_run');
+    captureEvent('playground_run');
   }, [runCode, code, updateUrl]);
 
   const handleExportSTL = useCallback(() => {
     exportSTL(code);
     addToast('Exporting STL...');
     track('playground_export', { format: 'stl' });
+    captureEvent('playground_export', { format: 'stl' });
   }, [exportSTL, code, addToast]);
 
   const handleExportSTEP = useCallback(() => {
     exportSTEP(code);
     addToast('Exporting STEP...');
     track('playground_export', { format: 'step' });
+    captureEvent('playground_export', { format: 'step' });
   }, [exportSTEP, code, addToast]);
 
   const handleShare = useCallback(() => {
     void copyShareUrl(code);
     addToast('Link copied to clipboard');
     track('playground_share');
+    captureEvent('playground_share');
   }, [copyShareUrl, code, addToast]);
 
   const handleResetToDefault = useCallback(() => {

--- a/apps/playground/src/lib/posthog.ts
+++ b/apps/playground/src/lib/posthog.ts
@@ -1,7 +1,7 @@
 import posthog from 'posthog-js';
 
 const KEY = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN;
-const HOST = import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+const HOST = import.meta.env.VITE_POSTHOG_HOST ?? '/ingest';
 
 let enabled = false;
 
@@ -11,7 +11,12 @@ export function initPostHog(): void {
   if (!KEY) return;
 
   posthog.init(KEY, {
+    // api_host is a same-origin Vercel reverse proxy (see vercel.json rewrites),
+    // so ingestion dodges the ad blockers that block posthog.com directly —
+    // brepjs's developer audience runs them heavily. ui_host keeps the toolbar
+    // and "view in PostHog" links pointing at the real app.
     api_host: HOST,
+    ui_host: 'https://us.posthog.com',
     defaults: '2025-05-24',
     // We never call identify(), so don't mint a person profile per anonymous
     // visitor — keeps this to pageview/event analytics only.

--- a/apps/playground/src/lib/posthog.ts
+++ b/apps/playground/src/lib/posthog.ts
@@ -1,0 +1,29 @@
+import posthog from 'posthog-js';
+
+const KEY = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN;
+const HOST = import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+
+let enabled = false;
+
+export function initPostHog(): void {
+  // No key (local dev, forks without the env var) → stay disabled so
+  // captureEvent() becomes a no-op instead of warning on every action.
+  if (!KEY) return;
+
+  posthog.init(KEY, {
+    api_host: HOST,
+    defaults: '2025-05-24',
+    // We never call identify(), so don't mint a person profile per anonymous
+    // visitor — keeps this to pageview/event analytics only.
+    person_profiles: 'identified_only',
+  });
+  enabled = true;
+}
+
+export function captureEvent(
+  event: string,
+  props?: Record<string, string | number | boolean>
+): void {
+  if (!enabled) return;
+  posthog.capture(event, props);
+}

--- a/apps/playground/src/main.tsx
+++ b/apps/playground/src/main.tsx
@@ -2,9 +2,11 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { registerPreloadErrorRecovery } from './lib/preloadErrorRecovery';
+import { initPostHog } from './lib/posthog';
 import './styles/globals.css';
 
 registerPreloadErrorRecovery();
+initPostHog();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/playground/src/vite-env.d.ts
+++ b/apps/playground/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_POSTHOG_PROJECT_TOKEN?: string;
+  readonly VITE_POSTHOG_HOST?: string;
+}
+
 declare module '*.d.ts?raw' {
   const content: string;
   export default content;

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vercel/analytics": "2.0.1",
+        "posthog-js": "1.387.0",
         "three": "0.184.0",
         "three-stdlib": "2.36.1"
       },
@@ -107,6 +108,7 @@
         "lz-string": "1.5.0",
         "monaco-editor": "0.55.1",
         "occt-wasm": "*",
+        "posthog-js": "1.387.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-resizable-panels": "4.11.2",
@@ -2995,6 +2997,21 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.33.0.tgz",
+      "integrity": "sha512-Xk5O4g70SlsodD941j5GJTto2DgteKslmuhQ1kH5nR03JVOgdOw7rBesyWGhYkEdkxr8Vhvx33f1NTEZgejL2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.387.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.387.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.387.0.tgz",
+      "integrity": "sha512-XR0B1geABbnUlSNv4RuFWvk19D870B668C/XzcKDctAZ+xCH5gmGM0oltGbA9yj+2ia9Y65nOrDYKN6Whu1oBw==",
+      "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "3.0.4",
@@ -6140,6 +6157,17 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6943,6 +6971,15 @@
       "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
       "devOptional": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -10238,6 +10275,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.387.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.387.0.tgz",
+      "integrity": "sha512-Pv1jUMySMN62zoAxdJBJPV8n62lkHdjuWhpeU7izczc5Dqbx3hhqO2hkrNTI8Yx1ezmWk2qUHZs03FuOBubdFQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "^1.33.0",
+        "@posthog/types": "^1.387.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/potpack": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
@@ -10428,6 +10487,12 @@
           "url": "https://github.com/sponsors/sxzz"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -12999,6 +13064,12 @@
       "integrity": "sha512-VzQ0W/Iiqbidxn1ECUvz6qJ6p2sXBVNcOsUOBCETzy77psAH6yFLKQm74aXabkx3JH4OvFVHe8k1qS6+Z2zl1w==",
       "dev": true,
       "license": "MPL-2.0"
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.2",

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,11 @@
   "outputDirectory": "apps/docs/.vitepress/dist",
   "cleanUrls": true,
   "trailingSlash": false,
+  "rewrites": [
+    { "source": "/ingest/static/:path(.*)", "destination": "https://us-assets.i.posthog.com/static/:path" },
+    { "source": "/ingest/array/:path(.*)", "destination": "https://us-assets.i.posthog.com/array/:path" },
+    { "source": "/ingest/:path(.*)", "destination": "https://us.i.posthog.com/:path" }
+  ],
   "headers": [
     {
       "source": "/playground(/.*)?",

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://va.vercel-scripts.com; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://va.vercel-scripts.com https://us-assets.i.posthog.com; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net" }
       ]
     },
     {


### PR DESCRIPTION
## What

Wires **PostHog product analytics** into both deployed sites, alongside the existing Vercel Analytics (kept):

- **brepjs.dev** (`apps/docs`) — PostHog init in the VitePress theme `enhanceApp()`, dynamic-imported + SSR-guarded so it never loads during prerender. `defaults: '2025-05-24'` auto-captures SPA pageviews (covers the bespoke landing page too).
- **Playground** (`apps/playground`) — singleton init in `main.tsx` + a `captureEvent()` helper; mirrors the existing `track()` events (`playground_run`, `playground_export` {stl/step}, `playground_share`) to PostHog.

## Config

- Reads `VITE_POSTHOG_PROJECT_TOKEN` / `VITE_POSTHOG_HOST` (defaults to US cloud); **no-ops when unset** so local dev / forks without the env var don't error or send events.
- `.env.example` added to both apps documenting the vars.
- **CSP** (`vercel.json` `/playground`) extended to allow the PostHog ingestion + asset hosts (`us.i.posthog.com`, `us-assets.i.posthog.com`) — without this the strict playground CSP silently blocks events.
- Vercel env vars set via CLI for **Production**, **Development**, and **Preview** (this branch).

## Lockfile

`package-lock.json` is a **pure addition** (+71 lines) — only the `posthog-js` closure (`@posthog/*`, `core-js`, `dompurify`, `web-vitals`, `query-selector-shadow-dom`, nested `fflate`); `preact` reused. Grafted onto the existing lockfile to avoid npm's broad re-resolution prune.

## Verification

- Playground `tsc -b` ✓ · `vite build` ✓ · docs `vitepress build` (incl. SSR) ✓
- Token confirmed inlined into both production bundles
- `npm ci` installs clean (no `EUSAGE`)