### PR TITLE
docs(landing): show finished hero state on mobile, hide Replay

### DIFF
--- a/apps/docs/.vitepress/theme/components/CodeCadHero.vue
+++ b/apps/docs/.vitepress/theme/components/CodeCadHero.vue
@@ -281,10 +281,15 @@ function onLeave(): void {
 onMounted(async () => {
   const canvas = canvasEl.value;
   if (!canvas) return;
-  const reduceMotion =
+  const mq = (q: string): boolean =>
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.matchMedia(q).matches;
+  const reduceMotion = mq('(prefers-reduced-motion: reduce)');
+  // On phones the IDE collapses to a single cramped column (the 760px
+  // breakpoint in the styles below), where a one-char-at-a-time build is hard
+  // to follow — show the finished program and bin straight away instead.
+  const staticView = reduceMotion || mq('(max-width: 760px)');
 
   let data: HeroFramesData;
   try {
@@ -297,14 +302,14 @@ onMounted(async () => {
 
   try {
     const { mountCodeCad } = await import('./codeCadRenderer');
-    handle = mountCodeCad(canvas, data, { dark: true, reduceMotion });
+    handle = mountCodeCad(canvas, data, { dark: true, reduceMotion: staticView });
   } catch {
     failed.value = true; // no WebGL — the code panel still tells the story
     return;
   }
   ready.value = true;
 
-  if (reduceMotion) {
+  if (staticView) {
     // No typing/playback: show the whole program and the finished bin.
     typedLine.value = LINES.length;
     typedChars.value = 0;
@@ -729,6 +734,15 @@ onBeforeUnmount(() => {
   }
   .codecol {
     border-right: none;
+  }
+  /* The build plays through once to its finished state on mobile (see the
+     staticView gate in script) — Replay would restart a typing run that's hard
+     to follow on a phone, so drop it and let the link own the right edge. */
+  .bar-btn {
+    display: none;
+  }
+  .run-link {
+    margin-left: auto;
   }
 }
 </style>


### PR DESCRIPTION
## What

On mobile, the code-as-CAD hero now skips the type-it-out build sequence and lands directly on the **finished program + bin**, and the **Replay** button is hidden there.

## Why

Below the component's existing 760px breakpoint the IDE collapses to a single cramped column. The one-character-at-a-time typing build is hard to follow on a phone, and Replay only restarts that same hard-to-follow run. Desktop is unchanged — the full animation still plays.

## How

`apps/docs/.vitepress/theme/components/CodeCadHero.vue`:

- Introduced an `mq()` matchMedia helper and a `staticView = reduceMotion || mq('(max-width: 760px)')` flag, reusing the **existing reduced-motion fast-path** rather than adding a parallel one. Mobile inherits its known-good "show the whole program + final frame" behavior, and the renderer is mounted with `reduceMotion: staticView` so it also skips the continuous rAF loop (battery-friendly, still orbit/zoom-able).
- Hid `.bar-btn` (Replay) under the same 760px media query — chosen as CSS, not the JS flag, so it tracks the live layout state on resize. Moved the bar's right-aligning `margin-left: auto` from the button onto `.run-link` so "Open in Playground" stays pinned right.

## Verification

- `vitepress build` passes clean.
- Headless-browser probe (swiftshader WebGL) at two viewports, sampled ~1.1s after load:
  - **mobile 390×844** → finished immediately: full program shown, all 4 rail stages lit, `✓ default export ready`, bin rendered (`vol 14,043.4 mm³`); Replay `display: none`.
  - **desktop 1280×800** → unchanged: still mid-typing (line 3/17, "authoring…"); Replay visible.