### PR TITLE
docs(readme): add Vercel OSS Program badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ The command exits non-zero unless the report is `ok` (valid **and** every declar
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
 
+## Acknowledgements
+
+brepjs.dev and the playground are hosted on [Vercel](https://vercel.com) through its Open Source Program.
+
+<div align="center">
+  <a href="https://vercel.com/open-source-program">
+    <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
+  </a>
+</div>
+
 ## License
 
 [Apache-2.0](./LICENSE)


### PR DESCRIPTION
Adds the Vercel OSS Program badge to the README in a dedicated centered **Acknowledgements** section (between Contributing and License), with a one-line note that brepjs.dev and the playground are hosted on Vercel through its Open Source Program.

## Why here?
- The Vercel asset is the large official `program-badge-2026.svg`, which would visually clash with the small flat shields in the top badge row and disrupt the curated hero block.
- Sponsor/program recognition badges conventionally live in a footer Acknowledgements/Sponsors section — that's where readers expect "backed by" attribution.

## Notes
- Badge kept at native size (official brand asset; no documented resize guidance).
- Markup is Vercel's exact link + `alt`-tagged `img`, wrapped in a centered `<div>` to match the README's other centered blocks.