### PR TITLE
chore: ignore generated example outputs and nested agent memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Claude Code agent memory (user-specific, not shared)
-.claude/agent-memory-local/
+# Claude Code agent memory (user-specific, not shared) — any package, any depth
+**/.claude/agent-memory-local/
 .claude/scheduled_tasks.lock
 
 # Superpowers brainstorming/spec/plan docs (local working artifacts, not shared)
@@ -58,3 +58,7 @@ apps/playground/dist/
 # Scratch: OpenSCAD reference clone, example screenshots, candidate scratch, etc.
 tmp/
 **/tmp/
+
+# Generated example/render outputs (SVG/HTML produced by running examples)
+examples/output/
+docs/images/examples/


### PR DESCRIPTION
## Summary

Generated example/render artifacts and package-level Claude agent memory were showing up as untracked in `git status`. This adds gitignore rules so they stay out of the way, and generalizes the existing agent-memory rule so it also matches nested packages.

## What changes

- **Ignore generated outputs** — `examples/output/` and `docs/images/examples/` (SVG/HTML produced by running examples) are now ignored.
- **Generalize agent-memory rule** — `.claude/agent-memory-local/` → `**/.claude/agent-memory-local/`, so it covers package-level agent memory (e.g. `packages/brepjs-bim/.claude/`), not just the repo-root `.claude/`. The previous middle-slash pattern anchored to the repo root and missed nested packages.

## What does *not* change

- No source files, tracked content, or build config moved.
- The parent `examples/` and `docs/images/` directories stay **un-ignored**, so real source committed there later won't be silently swallowed.

## Test plan

- [x] Pre-commit hooks green (typecheck, layer boundaries, changed-file tests)
- [x] `git check-ignore -v` confirms all three paths now match the new rules
- [x] `git status` clean after the change
