### PR TITLE
ci(publish): publish workflows + LICENSE/README for brepjs-bim and brepjs-sheetmetal

### DIFF
--- a/.github/workflows/publish-brepjs-bim.yml
+++ b/.github/workflows/publish-brepjs-bim.yml
@@ -1,0 +1,45 @@
+name: Publish brepjs-bim
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, skip publish)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+
+      # Build the root brepjs first: brepjs-bim externalizes `brepjs` at runtime,
+      # but vite-plugin-dts needs brepjs's emitted types to resolve `import type`s
+      # when generating brepjs-bim's declarations.
+      - name: Build brepjs-bim (root brepjs prerequisite)
+        run: |
+          npm run build
+          npm run build --workspace=brepjs-bim
+
+      # Authenticates via OIDC trusted publisher (configured for this exact
+      # workflow filename on npmjs.com -> brepjs-bim -> Trusted Publisher Mgmt).
+      - name: Publish brepjs-bim
+        if: ${{ inputs.dry_run != true }}
+        run: npm publish -w brepjs-bim --provenance

--- a/.github/workflows/publish-brepjs-sheetmetal.yml
+++ b/.github/workflows/publish-brepjs-sheetmetal.yml
@@ -1,0 +1,45 @@
+name: Publish brepjs-sheetmetal
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, skip publish)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+
+      # Build the root brepjs first: brepjs-sheetmetal externalizes `brepjs` at
+      # runtime, but vite-plugin-dts needs brepjs's emitted types to resolve
+      # `import type`s when generating brepjs-sheetmetal's declarations.
+      - name: Build brepjs-sheetmetal (root brepjs prerequisite)
+        run: |
+          npm run build
+          npm run build --workspace=brepjs-sheetmetal
+
+      # Authenticates via OIDC trusted publisher (configured for this exact
+      # workflow filename on npmjs.com -> brepjs-sheetmetal -> Trusted Publisher Mgmt).
+      - name: Publish brepjs-sheetmetal
+        if: ${{ inputs.dry_run != true }}
+        run: npm publish -w brepjs-sheetmetal --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ Monorepo packages:
 
 - `brepjs` (root): Core library (published)
 - `packages/brepjs-opencascade`: OpenCascade WASM build (published)
-- `packages/brepjs-bim`: IFC/BIM helpers (experimental, unpublished)
+- `packages/brepjs-bim`: IFC/BIM parametric building elements + IFC import/export (experimental, published)
+- `packages/brepjs-sheetmetal`: Sheet-metal authoring + unfold/flat-pattern + DXF (experimental, published)
 - `packages/brepjs-manifold`: Manifold mesh/CSG preview kernel (experimental, unpublished)
 - `packages/brepjs-viewer`: Shared React/R3F renderer (consumed by the playground and brepjs-verify; not yet published)
 - `packages/brepjs-verify`: Agent skill + verify/preview CLI + WASM viewer (not yet published; skill ships via the repo Claude-plugin marketplace)

--- a/packages/brepjs-bim/LICENSE
+++ b/packages/brepjs-bim/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Andy Aragon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -1,6 +1,10 @@
 # brepjs-bim
 
-> Experimental, unpublished satellite package.
+> Experimental satellite package, published to npm. Early-stage — the API may change.
+
+```bash
+npm install brepjs-bim
+```
 
 A BIM (Building Information Modeling) layer for [brepjs](https://github.com/andymai/brepjs). It
 authors IFC4-aligned parametric building elements (walls, slabs, beams, columns, roofs, curtain

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -1,0 +1,100 @@
+# brepjs-bim
+
+> Experimental, unpublished satellite package.
+
+A BIM (Building Information Modeling) layer for [brepjs](https://github.com/andymai/brepjs). It
+authors IFC4-aligned parametric building elements (walls, slabs, beams, columns, roofs, curtain
+walls, stairs, …), assembles them into a spatial structure (project → site → building → storey),
+and serializes the result to a valid **IFC-SPF** file — with a matching importer to read IFC back in.
+
+Pipeline: **author spec → `BimModel` (typed element + brepjs geometry) → spatial structure +
+property sets + classification → export IFC / COBie, validate, round-trip.**
+
+## Scope
+
+Parametric authoring of the common IFC4 building elements plus the data layers that make a model
+useful downstream (psets, classification, materials, quantities), with import, export, and
+validation. Geometry is produced by brepjs (OCCT); each element carries a `ValidSolid` (or, for
+curtain walls, a panel/mullion grid). Element geometry is **unplaced template geometry** in local
+coordinates — placement (`origin` / `axisX` / `axisZ`) is applied by the IFC layer via
+`IfcLocalPlacement`, not baked into the brepjs solid.
+
+- Units default to mm; IFC export emits SI metres.
+- Stable identity: deterministic IFC GUIDs (`deriveIfcGuid`) and local id counters.
+
+## Status
+
+| Area              | State                                                                                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
+| Elements          | wall, slab, beam, column, roof, curtain wall, space, footing/pile, stair, ramp, railing, covering, proxy |
+| Profiles          | rectangular / circular / I-shape cores + extended L/T/U/Z/C, hollow, ellipse, arbitrary-with-voids       |
+| Openings          | door / window / slab openings cut as boolean voids; `FillsOpening` / `Voids*` relationships              |
+| Spatial structure | project → site → building → storey aggregation; `placeIn` to assign elements to a storey                 |
+| Property sets     | IFC pset templates + measure types; quantity sets for takeoff                                            |
+| Data layers       | materials (layer/profile/simple sets), classification refs, surface styles, zones/systems                |
+| IFC export        | `toIfc` → IFC-SPF (`Uint8Array`); IFC2X3 / IFC4 schema selection; owner history                          |
+| IFC import        | `fromIfc` / `SpfReader` → `ImportedModel` (elements, geometry, psets, materials, spatial tree)           |
+| Validation        | referential integrity, schema check, geometry validity, IFC round-trip report                            |
+| Interop           | COBie 2.4 export (CSV/JSON), IDS 1.0 checking, BCF 3.0 read/write                                        |
+
+## Usage
+
+Author a small model and export IFC:
+
+```ts
+import { BimModel, toIfc } from 'brepjs-bim';
+
+const model = new BimModel();
+model.init({ name: 'Example' });
+
+// Spatial structure: project → site → building → storey.
+const project = model.getProject();
+const siteId = model.addSite({ name: 'Site' });
+const buildingId = model.addBuilding({ name: 'Building' });
+const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+if (project) model.aggregate(project.localId, siteId);
+model.aggregate(siteId, buildingId);
+model.aggregate(buildingId, storeyId);
+
+// A parametric wall, placed on the storey. Dimensions in mm; axisX is the wall's
+// length direction and axisZ its up direction.
+const wall = model.addWall({
+  length: 4000,
+  height: 3000,
+  thickness: 200,
+  origin: [0, 0, 0],
+  axisX: [1, 0, 0],
+  axisZ: [0, 0, 1],
+  materialName: 'Concrete',
+});
+if (wall.ok) model.placeIn(wall.value, storeyId);
+
+// Renderable geometry (a brepjs ValidSolid, unplaced/local coords):
+const solid = model.getWalls()[0]?.geometry;
+
+// Serialize to an IFC-SPF byte buffer.
+const ifc = await toIfc(model, { name: 'Example', author: 'brepjs-bim' });
+// ifc.ok && ifc.value instanceof Uint8Array
+```
+
+Reading element geometry requires only the core brepjs kernel; `toIfc` / `fromIfc` additionally load
+the `web-ifc` peer dependency.
+
+All public operations return `Result<T, BimError>` (from `brepjs`); validation issues and non-fatal
+warnings travel inside the payload rather than throwing.
+
+## Design
+
+Each `add*` call parses and validates the spec (the `parse*Spec` functions are also exported for
+standalone use), builds the brepjs solid analytically from the spec, and stores a typed `BimElement`
+keyed by a `LocalId`. The IFC writer walks the model, applies placement, and emits schema-correct
+IFC entities; the importer is the inverse. No kernel/WASM changes are required.
+
+## Development
+
+```bash
+npm run typecheck --workspace=brepjs-bim
+npm run lint --workspace=brepjs-bim
+npm run build --workspace=brepjs-bim
+npm run test --workspace=brepjs-bim
+```

--- a/packages/brepjs-sheetmetal/LICENSE
+++ b/packages/brepjs-sheetmetal/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Andy Aragon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/brepjs-sheetmetal/README.md
+++ b/packages/brepjs-sheetmetal/README.md
@@ -1,6 +1,10 @@
 # brepjs-sheetmetal
 
-> Experimental, unpublished satellite package.
+> Experimental satellite package, published to npm. Early-stage — the API may change.
+
+```bash
+npm install brepjs-sheetmetal
+```
 
 A sheet-metal CAD domain for [brepjs](https://github.com/andymai/brepjs). It authors parametric
 sheet-metal parts (flange/bend features), auto-miters corners, folds to 3D, and unfolds to a flat


### PR DESCRIPTION
First step of making `brepjs-bim` and `brepjs-sheetmetal` publishable, part of the playground BIM/sheet-metal showcase work.

## What this does
- **Readiness:** adds the Apache-2.0 `LICENSE` to both packages (already referenced in their `files` field) and a `README` for `brepjs-bim`, so the published tarballs are complete.
- **Publish workflows:** `publish-brepjs-bim.yml` + `publish-brepjs-sheetmetal.yml`, mirroring `publish-brepjs-verify.yml` — `workflow_dispatch` with a `dry_run` input, OIDC trusted publishing (`id-token: write`) bound to each workflow filename, building the root `brepjs` first so `vite-plugin-dts` can resolve cross-package types.

## Status
- `brepjs-bim@0.1.0` and `brepjs-sheetmetal@0.1.0` are already published manually (the first publish has to be manual so an OIDC trusted publisher can be configured against an existing package name).
- Tarballs verified clean via `npm pack --dry-run` (LICENSE + README + dist bundles, no `src` leak).

## Follow-up (separate PR)
release-please management (config + manifest @ 0.1.0) + auto-publish-on-release jobs + hold-from-auto-merge — deferred until after the first publish + OIDC setup.

## Note
Commit type is `ci` (non-bumping): these paths are not yet release-please components, so they currently attribute to the root `brepjs` package; `ci` avoids bumping the core library version.