### PR TITLE
ci(release): manage + auto-publish brepjs-bim and brepjs-sheetmetal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,24 @@ jobs:
       - run: npm run test --workspace=brepjs-sheetmetal
       - run: npm run build --workspace=brepjs-sheetmetal
 
+  packages-bim:
+    # Experimental BIM (IFC4) domain satellite. Build root brepjs first so the
+    # package typecheck/build resolve `brepjs` via package exports → dist/; tests
+    # resolve `brepjs` to source through the vitest alias and need the OCCT WASM
+    # the setup composite restores (web-ifc is a devDep, installed by npm ci).
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+      - run: npm run build
+      - run: npm run typecheck --workspace=brepjs-bim
+      - run: npm run lint --workspace=brepjs-bim
+      - run: npm run test --workspace=brepjs-bim
+      - run: npm run build --workspace=brepjs-bim
+
   voxel-wasm-rust:
     # The brepjs-voxel-wasm crate's correctness — the BVH/FWN/narrow-band/sparse
     # parity gates (incl. the seam-free tiled-vs-dense contour proof) — lives in
@@ -272,7 +290,7 @@ jobs:
       - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          build_script: "build"
+          build_script: 'build'
 
   benchmark:
     needs: changes
@@ -402,7 +420,23 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, typecheck, lint, quality, build, playground-build, packages-viewer, packages-verify, packages-sheetmetal, voxel-wasm-rust, test, size, benchmark]
+    needs:
+      [
+        changes,
+        typecheck,
+        lint,
+        quality,
+        build,
+        playground-build,
+        packages-viewer,
+        packages-verify,
+        packages-sheetmetal,
+        packages-bim,
+        voxel-wasm-rust,
+        test,
+        size,
+        benchmark,
+      ]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       republish:
-        description: "Republish current main package.json version (skip release-please, run publish-brepjs only)"
+        description: 'Republish current main package.json version (skip release-please, run publish-brepjs only)'
         required: false
         type: boolean
         default: false
@@ -34,6 +34,10 @@ jobs:
       brepjs_opencascade_release_created: ${{ steps.release.outputs['packages/brepjs-opencascade--release_created'] }}
       brepjs_verify_release_created: ${{ steps.release.outputs['packages/brepjs-verify--release_created'] }}
       brepjs_verify_tag_name: ${{ steps.release.outputs['packages/brepjs-verify--tag_name'] }}
+      brepjs_bim_release_created: ${{ steps.release.outputs['packages/brepjs-bim--release_created'] }}
+      brepjs_bim_tag_name: ${{ steps.release.outputs['packages/brepjs-bim--tag_name'] }}
+      brepjs_sheetmetal_release_created: ${{ steps.release.outputs['packages/brepjs-sheetmetal--release_created'] }}
+      brepjs_sheetmetal_tag_name: ${{ steps.release.outputs['packages/brepjs-sheetmetal--tag_name'] }}
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
       prs: ${{ steps.release.outputs.prs }}
@@ -100,7 +104,7 @@ jobs:
             # release pipeline across linked workspace packages). Only the root
             # brepjs release PR auto-merges.
             case "$pr_title" in
-              *brepjs-opencascade* | *brepjs-verify* | *brepjs-viewer*)
+              *brepjs-opencascade* | *brepjs-verify* | *brepjs-viewer* | *brepjs-bim* | *brepjs-sheetmetal*)
                 echo "Holding auto-merge for PR #$pr_number ($pr_title) — manual merge"
                 continue
                 ;;
@@ -168,6 +172,48 @@ jobs:
           # commit if another push lands on main during the dispatch window.
           GH_REF: ${{ needs.release-please.outputs.brepjs_verify_tag_name }}
         run: gh workflow run publish-brepjs-verify.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
+
+  # Auto-publish brepjs-bim by dispatching its own publish workflow (the npm OIDC
+  # trusted publisher is bound to the publish-brepjs-bim.yml filename, so the
+  # publish must run from that workflow). Fires on the post-merge release-please
+  # run that cuts the brepjs-bim release.
+  publish-brepjs-bim:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.brepjs_bim_release_created == 'true' }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
+          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
+      - name: Dispatch publish-brepjs-bim (real publish)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          # Dispatch against the immutable release tag, not main (see verify above).
+          GH_REF: ${{ needs.release-please.outputs.brepjs_bim_tag_name }}
+        run: gh workflow run publish-brepjs-bim.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
+
+  # Auto-publish brepjs-sheetmetal — same pattern as brepjs-bim above.
+  publish-brepjs-sheetmetal:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.brepjs_sheetmetal_release_created == 'true' }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
+          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
+      - name: Dispatch publish-brepjs-sheetmetal (real publish)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_REF: ${{ needs.release-please.outputs.brepjs_sheetmetal_tag_name }}
+        run: gh workflow run publish-brepjs-sheetmetal.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
 
   # brepjs-viewer is NOT managed by release-please (removed from
   # release-please-config.json): node-workspace was re-pinning brepjs-verify's

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,7 @@
   ".": "18.85.0",
   "packages/brepjs-opencascade": "0.16.0",
   "packages/brepjs-voxel-wasm": "0.7.0",
-  "packages/brepjs-verify": "0.24.3"
+  "packages/brepjs-verify": "0.24.3",
+  "packages/brepjs-bim": "0.1.0",
+  "packages/brepjs-sheetmetal": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,6 +36,18 @@
       "changelog-path": "CHANGELOG.md",
       "component": "brepjs-verify",
       "bump-minor-pre-major": true
+    },
+    "packages/brepjs-bim": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "component": "brepjs-bim",
+      "bump-minor-pre-major": true
+    },
+    "packages/brepjs-sheetmetal": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "component": "brepjs-sheetmetal",
+      "bump-minor-pre-major": true
     }
   },
   "plugins": ["node-workspace"],


### PR DESCRIPTION
Follow-up to #1451. Now that `brepjs-bim@0.1.0` and `brepjs-sheetmetal@0.1.0` are on npm with OIDC trusted publishers configured against their workflow filenames, bring both under release-please automation.

## What this does
- Adds both packages to `release-please-config.json` + `.release-please-manifest.json` (at the published `0.1.0`).
- Holds their release PRs from auto-merge (node-workspace linkage would otherwise loop), mirroring opencascade/verify.
- Adds `publish-brepjs-bim` / `publish-brepjs-sheetmetal` jobs that dispatch the standalone publish workflows on release (the OIDC trusted publisher is bound to each workflow filename), mirroring `publish-brepjs-verify`.
- Adds a `packages-bim` CI job — bim was published but had no CI gate — and wires it into `ci-pass`.

## After merge
The next release-please run opens **held** release PRs for the two packages (first pipeline release will be the next version after the manual `0.1.0` bootstrap). Merging a held PR fires its auto-publish. The playground (which depends on these as workspace packages) is unaffected — it's `private` and not release-please-tracked, so node-workspace doesn't re-pin it.