### PR TITLE
feat(sheetmetal): flat-pattern 2D overlay in the playground

### DIFF
--- a/apps/playground/src/components/playground/DesktopLayout.tsx
+++ b/apps/playground/src/components/playground/DesktopLayout.tsx
@@ -6,6 +6,7 @@ import ViewerPanel from './ViewerPanelLazy';
 import OutputPanel from './OutputPanel';
 import CollapsedConsoleBar from './CollapsedConsoleBar';
 import BimTreePanel from './BimTreePanel';
+import FlatPatternPanel from './FlatPatternPanel';
 
 interface Props {
   panels: PlaygroundPanels;
@@ -95,8 +96,10 @@ export default function DesktopLayout({
         {isViewerCollapsed ? null : (
           <div className="relative h-full w-full">
             <ViewerPanel />
-            {/* Overlay: renders only when the current example exposes a BIM tree. */}
+            {/* Overlays: each renders only when the current example exposes its
+                data (BIM tree / sheet-metal flat pattern), so they never co-occur. */}
             <BimTreePanel />
+            <FlatPatternPanel />
           </div>
         )}
       </Panel>

--- a/apps/playground/src/components/playground/FlatPatternPanel.tsx
+++ b/apps/playground/src/components/playground/FlatPatternPanel.tsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from 'react';
+import type { Pt2 } from 'brepjs-sheetmetal';
+import { usePlaygroundStore } from '../../stores/playgroundStore';
+
+const UP_COLOR = '#4acecc';
+const DOWN_COLOR = '#f59e0b';
+
+/**
+ * Read-only 2D overlay showing a sheet-metal flat pattern (the developed blank):
+ * the outline, any cutouts, and the bend lines coloured by fold direction.
+ * Renders only when the current example exposed one via
+ * `present(shape, { overlay2d })`.
+ */
+export default function FlatPatternPanel() {
+  const flat = usePlaygroundStore((s) => s.flatPattern);
+  const [collapsed, setCollapsed] = useState(false);
+
+  const view = useMemo(() => {
+    if (!flat || flat.outline.length < 3) return null;
+    const all: Pt2[] = [
+      ...flat.outline,
+      ...flat.holes.flat(),
+      ...flat.bendLines.flatMap((b) => [b.from, b.to]),
+    ];
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const [x, y] of all) {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    const w = Math.max(maxX - minX, 1);
+    const h = Math.max(maxY - minY, 1);
+    const span = Math.max(w, h);
+    // SVG y grows downward; flip so the developed pattern reads upright.
+    const fy = (y: number) => minY + maxY - y;
+    const points = (poly: Pt2[]) => poly.map(([x, y]) => `${x},${fy(y)}`).join(' ');
+    return { minX, minY, w, h, span, fy, points };
+  }, [flat]);
+
+  if (!flat || !view) return null;
+  const pad = view.span * 0.06;
+  const stroke = view.span * 0.006;
+  const dash = `${view.span * 0.022} ${view.span * 0.014}`;
+
+  return (
+    <div className="absolute right-3 top-3 z-10 flex w-64 flex-col overflow-hidden rounded-md border border-border-subtle bg-surface/95 shadow-lg backdrop-blur">
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center justify-between border-b border-border-subtle px-3 py-1.5 text-left text-xs font-medium text-gray-300 hover:text-white"
+        title={collapsed ? 'Expand flat pattern' : 'Collapse flat pattern'}
+        aria-expanded={!collapsed}
+      >
+        <span>Flat Pattern</span>
+        <span className="text-[10px] text-gray-500">
+          {flat.bendLines.length} bend{flat.bendLines.length === 1 ? '' : 's'}{' '}
+          {collapsed ? '▸' : '▾'}
+        </span>
+      </button>
+      {!collapsed && (
+        <div className="p-2">
+          <svg
+            viewBox={`${view.minX - pad} ${view.minY - pad} ${view.w + 2 * pad} ${view.h + 2 * pad}`}
+            className="w-full"
+            style={{ maxHeight: 220 }}
+          >
+            <polygon
+              points={view.points(flat.outline)}
+              fill="#3a3a44"
+              stroke="#9ca3af"
+              strokeWidth={stroke}
+            />
+            {flat.holes.map((hole, i) => (
+              <polygon
+                key={i}
+                points={view.points(hole)}
+                fill="#0f0f14"
+                stroke="#9ca3af"
+                strokeWidth={stroke}
+              />
+            ))}
+            {flat.bendLines.map((bend, i) => (
+              <line
+                key={i}
+                x1={bend.from[0]}
+                y1={view.fy(bend.from[1])}
+                x2={bend.to[0]}
+                y2={view.fy(bend.to[1])}
+                stroke={bend.direction === 'up' ? UP_COLOR : DOWN_COLOR}
+                strokeWidth={stroke}
+                strokeDasharray={dash}
+              />
+            ))}
+          </svg>
+          {flat.bendLines.length > 0 && (
+            <div className="mt-1 flex gap-3 px-1 text-[10px] text-gray-500">
+              <span style={{ color: UP_COLOR }}>--- bend up</span>
+              <span style={{ color: DOWN_COLOR }}>--- bend down</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/playground/src/components/playground/FlatPatternPanel.tsx
+++ b/apps/playground/src/components/playground/FlatPatternPanel.tsx
@@ -37,8 +37,11 @@ export default function FlatPatternPanel() {
     const span = Math.max(w, h);
     // SVG y grows downward; flip so the developed pattern reads upright.
     const fy = (y: number) => minY + maxY - y;
-    const points = (poly: Pt2[]) => poly.map(([x, y]) => `${x},${fy(y)}`).join(' ');
-    return { minX, minY, w, h, span, fy, points };
+    // Outline + holes as one even-odd path so cutouts are genuinely transparent
+    // (the 3D viewer shows through), not opaque polygons stacked on the outline.
+    const subpath = (poly: Pt2[]) => `M${poly.map(([x, y]) => `${x} ${fy(y)}`).join(' L ')} Z`;
+    const fillPath = [flat.outline, ...flat.holes].map(subpath).join(' ');
+    return { minX, minY, w, h, span, fy, fillPath };
   }, [flat]);
 
   if (!flat || !view) return null;
@@ -47,7 +50,7 @@ export default function FlatPatternPanel() {
   const dash = `${view.span * 0.022} ${view.span * 0.014}`;
 
   return (
-    <div className="absolute right-3 top-3 z-10 flex w-64 flex-col overflow-hidden rounded-md border border-border-subtle bg-surface/95 shadow-lg backdrop-blur">
+    <div className="absolute bottom-3 left-3 z-10 flex w-64 flex-col overflow-hidden rounded-md border border-border-subtle bg-surface/95 shadow-lg backdrop-blur">
       <button
         onClick={() => setCollapsed((c) => !c)}
         className="flex items-center justify-between border-b border-border-subtle px-3 py-1.5 text-left text-xs font-medium text-gray-300 hover:text-white"
@@ -67,21 +70,13 @@ export default function FlatPatternPanel() {
             className="w-full"
             style={{ maxHeight: 220 }}
           >
-            <polygon
-              points={view.points(flat.outline)}
+            <path
+              d={view.fillPath}
+              fillRule="evenodd"
               fill="#3a3a44"
               stroke="#9ca3af"
               strokeWidth={stroke}
             />
-            {flat.holes.map((hole, i) => (
-              <polygon
-                key={i}
-                points={view.points(hole)}
-                fill="#0f0f14"
-                stroke="#9ca3af"
-                strokeWidth={stroke}
-              />
-            ))}
             {flat.bendLines.map((bend, i) => (
               <line
                 key={i}

--- a/apps/playground/src/hooks/useCodeExecution.ts
+++ b/apps/playground/src/hooks/useCodeExecution.ts
@@ -1,5 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react';
 import type { BimTreeSummary } from 'brepjs-bim';
+import type { FlatPatternPolylines } from 'brepjs-sheetmetal';
 import type { FromWorker, ToWorker } from '../workers/workerProtocol';
 import { usePlaygroundStore } from '../stores/playgroundStore';
 import { useEngineStore } from '../stores/engineStore';
@@ -53,6 +54,7 @@ export function useCodeExecution() {
     store.setMeshes([]);
     store.setAvailableArtifacts([]);
     store.setBimTree(null);
+    store.setFlatPattern(null);
     postMessageRef.current({ type: 'eval', id, code });
     return id;
   }, []);
@@ -78,6 +80,7 @@ export function useCodeExecution() {
           // The worker forwards present({ bimTree }) verbatim; it's the
           // serializable BimModel.toTreeSummary() shape.
           store.setBimTree((msg.bimTree as BimTreeSummary | undefined) ?? null);
+          store.setFlatPattern((msg.overlay2d as FlatPatternPolylines | undefined) ?? null);
           store.setConsoleOutput(msg.console);
           store.setTimeMs(msg.timeMs);
           store.setIsRunning(false);

--- a/apps/playground/src/lib/ambientModule.ts
+++ b/apps/playground/src/lib/ambientModule.ts
@@ -70,6 +70,8 @@ const PLAYGROUND_MODULE_DTS = `declare module 'brepjs/playground' {
     ifc?: Uint8Array;
     /** A serializable BIM tree summary (BimModel.toTreeSummary()) for the domain panel. */
     bimTree?: unknown;
+    /** Serializable flat-pattern polylines (flatPatternToPolylines()) for the 2D overlay. */
+    overlay2d?: unknown;
   }
   /** Attach downloadable artifacts to the shown shape; enables the matching toolbar download. */
   export function present<T>(shape: T, artifacts: PresentArtifacts): T;

--- a/apps/playground/src/lib/examples/sheetMetal.ts
+++ b/apps/playground/src/lib/examples/sheetMetal.ts
@@ -11,7 +11,7 @@ export const SHEET_METAL_EXAMPLES: readonly Example[] = [
     label: 'Mitered L-Bracket',
     description:
       'A folded sheet-metal L-bracket with two mitered flanges, unfolded to a flat pattern. Use the DXF button in the toolbar to download the fabrication-ready flat pattern.',
-    code: `import { author, miterCorner, unfold, toDXF } from 'brepjs-sheetmetal';
+    code: `import { author, miterCorner, unfold, toDXF, flatPatternToPolylines } from 'brepjs-sheetmetal';
 import { present } from 'brepjs/playground';
 
 // A folded sheet-metal L-bracket. Two 90° flanges come off adjacent edges of a
@@ -43,7 +43,11 @@ if (!unfolded.ok) throw unfolded.error;
 const dxf = toDXF(unfolded.value.pattern);
 if (!dxf.ok) throw dxf.error;
 
-export default present(solid, { dxf: dxf.value });
+// Attach the DXF for download and the 2D polylines for the flat-pattern overlay.
+export default present(solid, {
+  dxf: dxf.value,
+  overlay2d: flatPatternToPolylines(unfolded.value.pattern),
+});
 `,
   },
   {

--- a/apps/playground/src/stores/playgroundStore.ts
+++ b/apps/playground/src/stores/playgroundStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { BimTreeSummary } from 'brepjs-bim';
+import type { FlatPatternPolylines } from 'brepjs-sheetmetal';
 import { DEFAULT_CODE } from '../lib/constants';
 import type { FaceInfo, EdgeInfo } from '../workers/workerProtocol';
 import type { SharedSelection } from '../lib/urlCodec';
@@ -32,6 +33,9 @@ interface PlaygroundState {
   // A BIM tree summary the current model exposes via present({ bimTree }),
   // rendered in the domain panel; null when the model isn't a BIM model.
   bimTree: BimTreeSummary | null;
+  // Flat-pattern polylines the current model exposes via present({ overlay2d }),
+  // rendered as a 2D overlay; null when the model isn't a sheet-metal flat pattern.
+  flatPattern: FlatPatternPolylines | null;
   isConsoleCollapsed: boolean;
   isViewerCollapsed: boolean;
   isEditorCollapsed: boolean;
@@ -48,6 +52,7 @@ interface PlaygroundState {
   setMeshes: (meshes: MeshData[]) => void;
   setAvailableArtifacts: (artifacts: string[]) => void;
   setBimTree: (tree: BimTreeSummary | null) => void;
+  setFlatPattern: (pattern: FlatPatternPolylines | null) => void;
   setError: (error: string | null, line?: number | null) => void;
   setConsoleOutput: (output: string[]) => void;
   setTimeMs: (ms: number) => void;
@@ -82,6 +87,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   isRunning: false,
   availableArtifacts: [],
   bimTree: null,
+  flatPattern: null,
   isConsoleCollapsed: false,
   isViewerCollapsed: false,
   isEditorCollapsed: false,
@@ -105,6 +111,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
     }),
   setAvailableArtifacts: (availableArtifacts) => set({ availableArtifacts }),
   setBimTree: (bimTree) => set({ bimTree }),
+  setFlatPattern: (flatPattern) => set({ flatPattern }),
   setError: (error, line) => set({ error, errorLine: line ?? null }),
   setConsoleOutput: (consoleOutput) => set({ consoleOutput }),
   setTimeMs: (timeMs) => set({ timeMs }),
@@ -133,6 +140,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
       meshes: [],
       availableArtifacts: [],
       bimTree: null,
+      flatPattern: null,
       error: null,
       errorLine: null,
       consoleOutput: [],

--- a/apps/playground/src/types/brepjs-sheetmetal-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-sheetmetal-ambient.d.ts
@@ -717,6 +717,32 @@ type Polygon = Pt2[];
  */
 declare function wireToPolygon(outline: Wire): Result<Polygon>;
 
+/** A bend line in the developed plane: a segment plus its fold direction. */
+interface FlatPatternBendLine {
+    from: Pt2;
+    to: Pt2;
+    direction: 'up' | 'down';
+}
+
+/** A flat pattern reduced to serializable 2D polylines for a developed-view overlay. */
+interface FlatPatternPolylines {
+    /** Closed outer boundary as an ordered, non-closing vertex loop. */
+    outline: Polygon;
+    /** Interior cutout loops (holes / slots / polygon cutouts). */
+    holes: Polygon[];
+    /** Bend lines, each with its fold direction. */
+    bendLines: FlatPatternBendLine[];
+}
+
+/**
+ * Reduce a {@link FlatPattern} to serializable 2D polylines (outline, holes, bend
+ * lines) for a developed-pattern overlay. Best-effort: a wire that fails to read
+ * is dropped rather than throwing, so a partial pattern still yields what it can.
+ * Arc edges are approximated by endpoints, the same assumption {@link wireToPolygon}
+ * and the DXF writer make.
+ */
+declare function flatPatternToPolylines(pattern: FlatPattern): FlatPatternPolylines;
+
 /** Signed area (CCW positive) — used to normalise orientation and reject degenerates. */
 declare function signedArea(poly: Polygon): number;
 

--- a/apps/playground/src/workers/cad.worker.ts
+++ b/apps/playground/src/workers/cad.worker.ts
@@ -37,6 +37,7 @@ interface CachedEval {
   timeMs: number;
   artifacts: string[];
   bimTree: unknown;
+  overlay2d: unknown;
 }
 
 const codeCache = new Map<string, CachedEval>();
@@ -81,6 +82,8 @@ interface PresentArtifacts {
   ifc?: Uint8Array;
   // A serializable BimModel.toTreeSummary() result, rendered in the domain panel.
   bimTree?: unknown;
+  // A serializable flatPatternToPolylines() result, rendered as a 2D overlay.
+  overlay2d?: unknown;
 }
 interface PresentWrapper {
   [PLAYGROUND_PRESENT_TAG]: PresentArtifacts;
@@ -339,6 +342,7 @@ async function handleEval(id: string, code: string) {
         timeMs: cached.timeMs,
         artifacts: [...cached.artifacts],
         bimTree: cached.bimTree,
+        overlay2d: cached.overlay2d,
       },
       transferablesFor(meshes)
     );
@@ -397,6 +401,7 @@ async function handleEval(id: string, code: string) {
     const { shape: presented, artifacts } = unwrapPresent(userModule.default);
     const artifactKeys = DOWNLOAD_ARTIFACT_KEYS.filter((k) => artifacts[k] != null);
     const bimTree = artifacts.bimTree;
+    const overlay2d = artifacts.overlay2d;
     const exported = presented;
     if (exported == null) {
       post({
@@ -407,6 +412,7 @@ async function handleEval(id: string, code: string) {
         timeMs: performance.now() - startTime,
         artifacts: artifactKeys,
         bimTree,
+        overlay2d,
       });
       return;
     }
@@ -490,6 +496,7 @@ async function handleEval(id: string, code: string) {
       timeMs,
       artifacts: artifactKeys,
       bimTree,
+      overlay2d,
     });
 
     post(
@@ -501,6 +508,7 @@ async function handleEval(id: string, code: string) {
         timeMs,
         artifacts: artifactKeys,
         bimTree,
+        overlay2d,
       },
       transferablesFor(meshes)
     );

--- a/apps/playground/src/workers/workerProtocol.ts
+++ b/apps/playground/src/workers/workerProtocol.ts
@@ -56,6 +56,8 @@ export type FromWorker =
       artifacts?: string[];
       // A serializable BIM tree summary attached via present({ bimTree }), if any.
       bimTree?: unknown;
+      // Serializable flat-pattern polylines attached via present({ overlay2d }), if any.
+      overlay2d?: unknown;
     }
   | { type: 'eval-error'; id: string; error: string; line?: number }
   | { type: 'eval-cancelled'; id: string }

--- a/packages/brepjs-sheetmetal/src/index.ts
+++ b/packages/brepjs-sheetmetal/src/index.ts
@@ -76,6 +76,7 @@ export type {
 
 export {
   wireToPolygon,
+  flatPatternToPolylines,
   polygonsOverlap,
   polygonsOverlapWithClearance,
   segmentsIntersect,
@@ -84,7 +85,12 @@ export {
   polygonBounds,
   signedArea,
 } from './polygonFns.js';
-export type { Polygon, Pt2 } from './polygonFns.js';
+export type {
+  Polygon,
+  Pt2,
+  FlatPatternPolylines,
+  FlatPatternBendLine,
+} from './polygonFns.js';
 
 export { buildReport, reportFromUnfold, reportToJSON } from './reportFns.js';
 

--- a/packages/brepjs-sheetmetal/src/polygonFns.ts
+++ b/packages/brepjs-sheetmetal/src/polygonFns.ts
@@ -11,8 +11,18 @@
  * assumption the DXF/SVG writers and the bbox nester make.
  */
 
-import { type Result, ok, err, validationError, getEdges, curveStartPoint } from 'brepjs';
+import {
+  type Result,
+  ok,
+  err,
+  isOk,
+  validationError,
+  getEdges,
+  curveStartPoint,
+  curveEndPoint,
+} from 'brepjs';
 import type { Wire } from 'brepjs';
+import type { FlatPattern } from './types.js';
 
 export type Pt2 = [number, number];
 
@@ -41,6 +51,50 @@ export function wireToPolygon(outline: Wire): Result<Polygon> {
     return err(validationError('EMPTY_OUTLINE', 'outline polygon has fewer than 3 vertices'));
   }
   return ok(poly);
+}
+
+/** A bend line in the developed plane: a segment plus its fold direction. */
+export interface FlatPatternBendLine {
+  from: Pt2;
+  to: Pt2;
+  direction: 'up' | 'down';
+}
+
+/** A flat pattern reduced to serializable 2D polylines for a developed-view overlay. */
+export interface FlatPatternPolylines {
+  /** Closed outer boundary as an ordered, non-closing vertex loop. */
+  outline: Polygon;
+  /** Interior cutout loops (holes / slots / polygon cutouts). */
+  holes: Polygon[];
+  /** Bend lines, each with its fold direction. */
+  bendLines: FlatPatternBendLine[];
+}
+
+/**
+ * Reduce a {@link FlatPattern} to serializable 2D polylines (outline, holes, bend
+ * lines) for a developed-pattern overlay. Best-effort: a wire that fails to read
+ * is dropped rather than throwing, so a partial pattern still yields what it can.
+ * Arc edges are approximated by endpoints, the same assumption {@link wireToPolygon}
+ * and the DXF writer make.
+ */
+export function flatPatternToPolylines(pattern: FlatPattern): FlatPatternPolylines {
+  const outlineResult = wireToPolygon(pattern.outline);
+  const outline = isOk(outlineResult) ? outlineResult.value : [];
+  const holes: Polygon[] = [];
+  for (const hole of pattern.holes) {
+    const holeResult = wireToPolygon(hole);
+    if (isOk(holeResult)) holes.push(holeResult.value);
+  }
+  const bendLines: FlatPatternBendLine[] = pattern.bendLines.map((bend) => {
+    const start = curveStartPoint(bend.line);
+    const end = curveEndPoint(bend.line);
+    return {
+      from: [start[0], start[1]],
+      to: [end[0], end[1]],
+      direction: bend.direction,
+    };
+  });
+  return { outline, holes, bendLines };
 }
 
 /** Signed area (CCW positive) — used to normalise orientation and reject degenerates. */

--- a/packages/brepjs-sheetmetal/tests/flatPatternPolylines.test.ts
+++ b/packages/brepjs-sheetmetal/tests/flatPatternPolylines.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { isErr } from 'brepjs';
+import { author, unfold } from '../src/api.js';
+import { flatPatternToPolylines } from '../src/polygonFns.js';
+import type { BendRule } from '../src/types.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const rule: BendRule = { innerRadius: 2, kFactor: 0.44 };
+
+describe('flatPatternToPolylines', () => {
+  it('reduces an unfolded L-bracket to outline + bend lines', () => {
+    const part = author({
+      thickness: 1.5,
+      base: { length: 60, width: 40 },
+      flanges: [
+        { id: 'side', length: 25, angleDeg: 90, side: 'xmax', rule },
+        { id: 'front', length: 25, angleDeg: 90, side: 'ymax', rule },
+      ],
+    });
+    if (isErr(part)) throw new Error(part.error.message);
+    const unfolded = unfold(part.value);
+    if (isErr(unfolded)) throw new Error(unfolded.error.message);
+
+    const poly = flatPatternToPolylines(unfolded.value.pattern);
+
+    // The developed outline is a closed loop with at least a few [x, y] vertices.
+    expect(poly.outline.length).toBeGreaterThanOrEqual(4);
+    expect(poly.outline.every((p) => p.length === 2)).toBe(true);
+
+    // Two flanges → two bend lines, each a nonzero-length segment with a fold dir.
+    expect(poly.bendLines).toHaveLength(2);
+    for (const bend of poly.bendLines) {
+      expect(bend.from).toHaveLength(2);
+      expect(bend.to).toHaveLength(2);
+      expect(['up', 'down']).toContain(bend.direction);
+      expect(Math.hypot(bend.to[0] - bend.from[0], bend.to[1] - bend.from[1])).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Phase 5b — the sheet-metal **flat-pattern 2D overlay**, the companion to the BIM tree panel (#1459). Completes the Phase 5 domain views.

## What this adds
- `flatPatternToPolylines()` (brepjs-sheetmetal) — reduces a `FlatPattern` to serializable 2D polylines (outline, holes, bend lines + fold direction) via `wireToPolygon` + edge endpoints. Unit-tested.
- The playground carries it via `present(shape, { overlay2d })`, the worker forwards it on `eval-result`, and a new `FlatPatternPanel` renders it as an SVG card over the viewer — the developed blank with the outline, any cutouts, and bend lines coloured by up/down. Reuses the domain-overlay infra from #1459 (the two panels are mutually exclusive — BIM vs sheet metal).
- The mitered **L-bracket** example now exposes both its DXF download *and* the 2D overlay.

Verified end-to-end via puppeteer (panel appears; SVG has the outline polygon + 2 bend lines) — screenshot in the thread.

This is the last Phase-5 follow-up. The only remaining deferred item is the **IFC download** (needs web-ifc's WASM in the worker — a separate integration).