### PR TITLE
feat(playground): make truss, I-beam, and enclosure examples true to life

### DIFF
--- a/apps/playground/src/lib/examples/bim.ts
+++ b/apps/playground/src/lib/examples/bim.ts
@@ -11,13 +11,12 @@ export const BIM_EXAMPLES: readonly Example[] = [
     id: 'bim-steel-beam',
     label: 'Steel I-Beam',
     description:
-      'A parametric structural-steel wide-flange (I-beam) authored through a BimModel. The element carries a brepjs solid for display and the model serializes to IFC.',
+      'A parametric structural-steel wide-flange (I-beam) authored through a BimModel, complete with the rolled root fillets where the web meets the flanges. The element carries a brepjs solid for display and the model serializes to IFC.',
     code: `import { BimModel } from 'brepjs-bim';
 
-// A parametric structural-steel I-beam (wide-flange section), authored through
-// the BIM model rather than as raw geometry. The element carries a brepjs solid
-// (shown here); the same model serializes to a real IFC file via toIfc(model).
-// Tune the length and the I_BEAM section dimensions.
+// A parametric structural-steel I-beam authored through the BIM model (it also
+// serializes to IFC via toIfc(model)). filletRadius adds the rolled root fillets
+// real wide-flange sections carry where the web meets the flanges.
 const model = new BimModel();
 model.init({ name: 'Beam example' });
 
@@ -29,6 +28,7 @@ const beam = model.addBeam({
     overallDepth: 300,
     flangeThickness: 12,
     webThickness: 8,
+    filletRadius: 14,
   },
   origin: [0, 0, 0],
   axisX: [1, 0, 0],

--- a/apps/playground/src/lib/examples/mechanical.ts
+++ b/apps/playground/src/lib/examples/mechanical.ts
@@ -880,68 +880,73 @@ export default knuckleHinge();`,
     id: 'cube-truss-frame',
     label: 'Cube-Truss Frame',
     description:
-      'Modular open-framed cube-truss beam: hollow box-section cubes with octagonal windows and diagonal X cross-braces, tiled into a structural run.',
-    code: `import {
-  box,
-  cut,
-  cutAll,
-  fuse,
-  rotate,
-  sketchPolysides,
-  translate,
-  unwrap,
-} from 'brepjs/quick';
+      'A square-section tubular space frame — round chord tubes, a Warren zig-zag of round web braces, and spherical gusset nodes — the way real stage rigging and lattice booms are actually built.',
+    code: `import { cylinder, sphere } from 'brepjs/quick';
 
-// Modular cube-truss frame: a chain of open-framed structural cubes (think
-// stage rigging / 3D-printed lattice beam). Each cube is \`cube\` mm on a side
-// with \`strut\` mm box-section walls, an octagonal lightening window punched
-// through all six faces, and an internal diagonal X cross-brace per cube for
-// stiffness. Cubes tile along the run sharing one strut wall (pitch = cube -
-// strut), so \`segments\` grows the beam end to end.
-function cubeTrussFrame({ segments = 3, cube = 30, strut = 4, bracing = true } = {}) {
-  const inner = cube - 2 * strut; // clear span inside the box-section walls
-  const pitch = cube - strut; // cubes overlap by one strut wall
-  const braceW = strut / Math.SQRT2; // square brace, same cross-section as struts
-  const span = inner * Math.SQRT2; // face-diagonal length the brace must cover
+// Square-section tubular space frame (like real stage rigging): round chord
+// tubes, a Warren zig-zag of web braces, and spherical gusset nodes at each joint.
+function cubeTrussFrame({
+  segments = 4,
+  cube = 30,
+  rod = 1.8, // chord + ring tube radius (mm)
+  brace = 1.3, // diagonal web-brace radius (mm)
+  node = 3, // spherical gusset-node radius (mm)
+  bracing = true,
+} = {}) {
+  const h = cube / 2;
+  const y0 = -(segments * cube) / 2; // centre the run about the origin
+  const yAt = (j: number) => y0 + j * cube;
 
-  // Octagonal window cutter, sized so its flats sit just inside the walls.
-  // Built as a Z-axis octagonal prism, then turned onto whichever axis it cuts.
-  const octR = inner / 2 / Math.cos(Math.PI / 8);
-  const octZ = () =>
-    translate(sketchPolysides(octR, 8, 0, 'XY').extrude(cube + 2), [0, 0, -(cube + 2) / 2]);
+  // The four chord corners [x, z] of the cross-section and the edges joining them.
+  const c00: [number, number] = [-h, -h];
+  const c10: [number, number] = [h, -h];
+  const c11: [number, number] = [h, h];
+  const c01: [number, number] = [-h, h];
+  const corners: [number, number][] = [c00, c10, c11, c01];
+  const edges: [[number, number], [number, number]][] = [
+    [c00, c10],
+    [c10, c11],
+    [c11, c01],
+    [c01, c00],
+  ];
+  const at = (xz: [number, number], j: number): [number, number, number] => [xz[0], yAt(j), xz[1]];
 
-  // One open-framed cube centred on the origin: hollow box, then three
-  // through-windows, then (optionally) a pair of crossed diagonal braces.
-  function oneCube() {
-    const hollow = unwrap(
-      cut(box(cube, cube, cube, { centered: true }), box(inner, inner, inner, { centered: true })),
-    );
-    const windows = [
-      octZ(), // vertical window (Z)
-      rotate(octZ(), 90, { axis: [1, 0, 0] }), // window through Y
-      rotate(octZ(), 90, { axis: [0, 1, 0] }), // window through X
-    ];
-    const frame = unwrap(cutAll(hollow, windows));
-    if (!bracing) return frame;
+  // A round member from a to b: a cylinder oriented along a→b (axis option, no rotate).
+  const strut = (a: [number, number, number], b: [number, number, number], r: number) => {
+    const d: [number, number, number] = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    const len = Math.hypot(d[0], d[1], d[2]);
+    return cylinder(r, len, { at: a, axis: [d[0] / len, d[1] / len, d[2] / len] });
+  };
 
-    // Two flat diagonal braces filling the vertical (XZ) window, crossed into
-    // an X. Each is a thin slab spun 45 deg about Y; their overlap fuses solid.
-    const slab = box(braceW, inner, span, { centered: true });
-    const braceA = rotate(slab, 45, { axis: [0, 1, 0] });
-    const braceB = rotate(slab, -45, { axis: [0, 1, 0] });
-    const cross = unwrap(fuse(braceA, braceB));
-    return unwrap(fuse(frame, cross));
+  const members = [];
+
+  // Chords along each corner line, then a ring of transverse tubes at every station.
+  for (let j = 0; j < segments; j++) {
+    for (const c of corners) members.push(strut(at(c, j), at(c, j + 1), rod));
+  }
+  for (let j = 0; j <= segments; j++) {
+    for (const [a, b] of edges) members.push(strut(at(a, j), at(b, j), rod));
   }
 
-  const base = oneCube();
-  const run = [base];
-  for (let i = 1; i < segments; i++) {
-    run.push(translate(oneCube(), [0, i * pitch, 0]));
+  // One web brace per side face per bay, flipped each bay so they zig-zag (Warren).
+  if (bracing) {
+    for (let j = 0; j < segments; j++) {
+      const up = j % 2 === 0;
+      for (const [a, b] of edges) {
+        const p1 = up ? at(a, j) : at(a, j + 1);
+        const p2 = up ? at(b, j + 1) : at(b, j);
+        members.push(strut(p1, p2, brace));
+      }
+    }
   }
-  // Re-centre the whole beam about the origin along its run (Y).
-  // Pairwise fuse the overlapping cubes (fuseAll leaves them as separate bodies).
-  const beam = run.reduce((a, b) => unwrap(fuse(a, b)));
-  return translate(beam, [0, -((segments - 1) * pitch) / 2, 0]);
+
+  // Gusset nodes at every joint.
+  const nodes = [];
+  for (let j = 0; j <= segments; j++) {
+    for (const c of corners) nodes.push(sphere(node, { at: at(c, j) }));
+  }
+
+  return [...members, ...nodes];
 }
 
 export default cubeTrussFrame();`,
@@ -1109,7 +1114,7 @@ export default dovetailJoint();`,
     id: 'project-enclosure',
     label: 'Two-Part Project Enclosure',
     description:
-      'A PCB project box: rounded base tray with corner standoffs and a ridge lip, plus a matching lid that nests over it.',
+      'A PCB project box with a real fastening system: a hollow base tray whose four corner bosses are tapped with a modelled M3 thread, and a hollow lid with matching counterbored-free clearance holes that line up so the halves actually screw together.',
     code: `import {
   box,
   cut,
@@ -1118,17 +1123,15 @@ export default dovetailJoint();`,
   edgeFinder,
   fillet,
   fuse,
+  thread,
   translate,
   unwrap,
 } from 'brepjs/quick';
 
-// Two-part project enclosure (base + lid) sized around a PCB footprint.
-// Outer shell = PCB + 2 mm padding on every side, 2 mm walls, rounded vertical
-// edges (r = 3). The base is a 25 mm-deep tray with four corner standoffs
-// (7 mm posts, 2.4 mm pin holes); its top wall carries a 5 mm ridge lip, inset
-// by a slack gap. The lid is a 23 mm-deep inverted tray whose inner groove
-// drops over that ridge so the halves register. Shown side by side along Y,
-// exactly how the print plate would lay them out.
+// Two-part PCB box that actually screws together: a hollow base tray whose four
+// corner bosses are tapped with a modelled thread, and a hollow lid with
+// clearance holes that line up over them. A base ridge + lid groove register the
+// halves. Laid out open-face-up along Y, print-plate style.
 function projectEnclosure({
   pcbLength = 150, // PCB extent along X (mm)
   pcbWidth = 100, // PCB extent along Y (mm)
@@ -1140,82 +1143,84 @@ function projectEnclosure({
   ridge = 5, // overlap ridge height (mm)
   slack = 0.3, // ridge-to-lid radial clearance (mm)
   round = 3, // rounded vertical-edge radius (mm)
-  standoffD = 7, // standoff post diameter (mm)
-  pinD = 2.4, // standoff pin-hole diameter (mm)
-  standoffH = 12, // standoff post height above the floor (mm)
+  bossD = 8, // screw-boss / standoff diameter (mm)
+  bossH = 14, // boss height above the floor (mm)
+  threadR = 1.5, // tapped-thread nominal radius (mm)
+  threadPitch = 1.2, // tapped-thread pitch (coarse, so it reads + stays cheap)
+  threadDepth = 5, // tapped length down each boss (mm)
+  clearR = 1.7, // lid clearance-hole radius for an M3 shank (mm)
 } = {}) {
-  // Inner cavity footprint, then the full outer footprint (cavity + two walls).
   const innerX = pcbLength + 2 * padding;
   const innerY = pcbWidth + 2 * padding;
   const outerX = innerX + 2 * wall;
   const outerY = innerY + 2 * wall;
+  const innerR = Math.max(round - wall, 0.5);
 
-  // A rounded-corner rectangular prism: a centred box with its four vertical
-  // (Z-running) edges filleted. Used for every outer wall and every cavity.
+  // Centred box with its four vertical edges filleted — every wall and cavity.
   const roundedPrism = (w: number, d: number, h: number, z: number, r: number) => {
     const blk = box(w, d, h, { at: [0, 0, z + h / 2] });
     if (r <= 0) return blk;
     return unwrap(fillet(blk, edgeFinder().inDirection('Z'), r));
   };
 
-  // --- BASE: a tray, floor at z = 0, opening upward. --------------------------
+  // Four boss/hole centres, inset from the corners.
+  const sx = innerX / 2 - bossD / 2 - 1;
+  const sy = innerY / 2 - bossD / 2 - 1;
+  const bossCenters: [number, number][] = [
+    [-sx, -sy],
+    [sx, -sy],
+    [sx, sy],
+    [-sx, sy],
+  ];
+
+  // BASE: a hollow tray — cap at z = 0, opening upward.
   const baseOuter = roundedPrism(outerX, outerY, floor + baseWall, 0, round);
-  const baseCavity = roundedPrism(innerX, innerY, baseWall + round, floor, Math.max(round - wall, 0.5));
+  const baseCavity = roundedPrism(innerX, innerY, baseWall + round, floor, innerR);
   let base = unwrap(cut(baseOuter, baseCavity));
 
-  // Ridge lip: a thin perimeter wall rising from the top of the base wall,
-  // pulled in by \`slack\` so the lid's inner face clears it on assembly.
+  // Ridge lip on the top rim, inset by \`slack\` so the lid groove clears it.
   const ridgeTop = floor + baseWall;
   const ridgeOuterW = innerX + 2 * wall - 2 * slack;
   const ridgeOuterD = innerY + 2 * wall - 2 * slack;
   const ridgeBand = unwrap(
     cut(
       roundedPrism(ridgeOuterW, ridgeOuterD, ridge, ridgeTop, Math.max(round - slack, 0.5)),
-      roundedPrism(innerX, innerY, ridge + 1, ridgeTop - 0.5, Math.max(round - wall, 0.5)),
+      roundedPrism(innerX, innerY, ridge + 1, ridgeTop - 0.5, innerR),
     ),
   );
   base = unwrap(fuse(base, ridgeBand));
 
-  // Four corner standoffs with pin holes — PCB sits on the post tops.
-  // Each post is grown down from z = 0 through the whole \`floor\` slab so it
-  // overlaps the tray solid (a post that merely kissed the floor plane at
-  // z = floor stays a separate, floating solid — fuse needs real overlap), then
-  // rises \`standoffH\` above the floor's top face to seat the board.
-  const sx = innerX / 2 - standoffD / 2 - 1;
-  const sy = innerY / 2 - standoffD / 2 - 1;
-  const posts = [];
-  const pins = [];
-  for (const cx of [-sx, sx]) {
-    for (const cy of [-sy, sy]) {
-      posts.push(cylinder(standoffD / 2, floor + standoffH, { at: [cx, cy, 0] }));
-      // Pin hole punches clean through both ends (z below the floor, z above the
-      // post top) so cutAll leaves an open through-hole, not a thin skin.
-      pins.push(cylinder(pinD / 2, floor + standoffH + 2, { at: [cx, cy, -1] }));
-    }
+  // Tapped corner bosses (also PCB standoffs). Tapping one standalone boss —
+  // bore, then cut the inward thread ridge — is far cheaper than carving the
+  // helix out of the whole enclosure, so the four copies are just fused on.
+  const tapTop = floor + bossH;
+  const ridgeSolid = unwrap(
+    thread({ radius: threadR, pitch: threadPitch, height: threadDepth, inward: true, sectionsPerTurn: 10 }),
+  );
+  let boss = cylinder(bossD / 2, floor + bossH, { at: [0, 0, 0] });
+  boss = unwrap(cut(boss, cylinder(threadR, threadDepth + 1, { at: [0, 0, tapTop - threadDepth] })));
+  boss = unwrap(cut(boss, translate(ridgeSolid, [0, 0, tapTop - threadDepth])));
+  for (const [cx, cy] of bossCenters) {
+    base = unwrap(fuse(base, translate(boss, [cx, cy, 0])));
   }
-  // Weld posts in one at a time with the 2-way \`fuse\` (the same op that merged
-  // the ridge): the N-way \`fuseAll\` glues via BuilderAlgo and leaves each post
-  // a separate solid in a compound, so the tray would ship with four floating
-  // pegs. Pairwise fuse unifies overlapping solids into one body.
-  for (const post of posts) {
-    base = unwrap(fuse(base, post));
-  }
-  base = unwrap(cutAll(base, pins));
 
-  // --- LID: an inverted tray that caps the base, placed beside it in Y. -------
+  // LID: hollow shell, cavity starting at z = floor so a floor-thick cap remains
+  // (flipped onto the base on assembly). Printed open-face-up beside the base.
   const lidOuter = roundedPrism(outerX, outerY, floor + lidWall, 0, round);
-  const lidCavity = roundedPrism(innerX, innerY, lidWall + round, 0, Math.max(round - wall, 0.5));
+  const lidCavity = roundedPrism(innerX, innerY, lidWall + 1, floor, innerR);
   let lid = unwrap(cut(lidOuter, lidCavity));
 
-  // Groove that swallows the base ridge: widen the cavity near the rim by the
-  // ridge band thickness so the two halves nest with the slack gap.
+  // Groove in the top rim that swallows the base ridge.
   const grooveW = ridgeOuterW + 2 * slack;
   const grooveD = ridgeOuterD + 2 * slack;
   const groove = roundedPrism(grooveW, grooveD, ridge, lidWall - ridge + floor, Math.max(round - slack, 0.5));
   lid = unwrap(cut(lid, groove));
 
-  // Lay the lid alongside the base (open faces both up) with a small print gap.
-  const gap = 10;
+  // Clearance holes through the lid cap, on the same centres as the bosses.
+  const lidHoles = bossCenters.map(([cx, cy]) => cylinder(clearR, floor + 2, { at: [cx, cy, -1] }));
+  lid = unwrap(cutAll(lid, lidHoles));
+
+  const gap = 10; // print gap between the two parts
   const placedLid = translate(lid, [0, outerY + gap, 0]);
 
   return [base, placedLid];
@@ -1227,7 +1232,7 @@ export default projectEnclosure();`,
     id: 'tx-enclosure',
     label: 'Two-part RF enclosure (side connectors)',
     description:
-      'A snap-fit transmitter/receiver project box: shelled base + lid, PCB standoffs, and side I/O connector ports, drawn exploded.',
+      'A screw-together transmitter/receiver project box: shelled base + lid, PCB standoffs cored as self-tapping screw bosses, matching clearance holes in the lid, and side I/O connector ports, drawn exploded.',
     code: `import {
   box,
   cut,
@@ -1371,9 +1376,15 @@ function txEnclosure({
   const lidCavity = roundedPrism(innerL, innerW, lidWall + 1, -1, innerR);
   const lidTray = unwrap(cut(lidOuter, lidCavity));
 
+  // Clearance holes through the lid cap, aligned to the standoff bores, so a
+  // self-tapping screw passes through the lid and bites the boss below.
+  const lidClearR = 1.5;
+  const lidHoles = postCenters.map(([x, y]) => cylinder(lidClearR, lidH + 2, { at: [x, y, -1] }));
+  const lidBored = unwrap(cutAll(lidTray, lidHoles));
+
   // Lift the lid clear of the base for the exploded gallery view: its skirt rim
   // floats \`explode\` mm above the base's top edge.
-  const lid = translate(lidTray, [0, 0, baseHeight + explode]);
+  const lid = translate(lidBored, [0, 0, baseHeight + explode]);
 
   return [base, lid];
 }

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -505,6 +505,7 @@ type IShapeProfile = {
     readonly overallDepth: number;
     readonly flangeThickness: number;
     readonly webThickness: number;
+    readonly filletRadius?: number | undefined;
 };
 
 type CoreProfile = RectangularProfile | CircularProfile | IShapeProfile;

--- a/packages/brepjs-bim/src/elementFns/profileFns.ts
+++ b/packages/brepjs-bim/src/elementFns/profileFns.ts
@@ -22,9 +22,51 @@ export function profileCrossSectionArea(profile: Profile): number {
       const flangeArea = 2 * profile.overallWidth * profile.flangeThickness;
       const webHeight = profile.overallDepth - 2 * profile.flangeThickness;
       const webArea = webHeight * profile.webThickness;
-      return flangeArea + webArea;
+      // Each of the four root fillets fills a corner notch: the r×r square corner
+      // minus the quarter disc it sweeps out, i.e. r²(1 - π/4) of added material.
+      const r = profile.filletRadius ?? 0;
+      const filletArea = 4 * r * r * (1 - Math.PI / 4);
+      return flangeArea + webArea + filletArea;
     }
   }
+}
+
+// Arc points (minor sweep) rounding the corner at `v` between its neighbours
+// `prev`/`next` with radius `r`. Returns the tessellated fillet from the tangent
+// point on the incoming edge to the tangent point on the outgoing edge; the
+// caller drops the original sharp vertex. Used for I-beam root fillets.
+const FILLET_SEGMENTS = 8;
+function filletArc(
+  prev: readonly [number, number],
+  v: readonly [number, number],
+  next: readonly [number, number],
+  r: number
+): Array<[number, number]> {
+  const aLen = Math.hypot(prev[0] - v[0], prev[1] - v[1]);
+  const bLen = Math.hypot(next[0] - v[0], next[1] - v[1]);
+  const a: [number, number] = [(prev[0] - v[0]) / aLen, (prev[1] - v[1]) / aLen];
+  const b: [number, number] = [(next[0] - v[0]) / bLen, (next[1] - v[1]) / bLen];
+  const alpha = Math.acos(Math.max(-1, Math.min(1, a[0] * b[0] + a[1] * b[1])));
+  const setback = r / Math.tan(alpha / 2); // distance from v to each tangent point
+  const center = r / Math.sin(alpha / 2); // distance from v to the arc centre
+  const bisLen = Math.hypot(a[0] + b[0], a[1] + b[1]);
+  const bis: [number, number] = [(a[0] + b[0]) / bisLen, (a[1] + b[1]) / bisLen];
+  const cx = v[0] + bis[0] * center;
+  const cy = v[1] + bis[1] * center;
+  const p1: [number, number] = [v[0] + a[0] * setback, v[1] + a[1] * setback];
+  const p2: [number, number] = [v[0] + b[0] * setback, v[1] + b[1] * setback];
+  const a1 = Math.atan2(p1[1] - cy, p1[0] - cx);
+  const a2 = Math.atan2(p2[1] - cy, p2[0] - cx);
+  // Normalise to the minor arc (|Δ| ≤ π), which always bulges toward the corner.
+  let delta = a2 - a1;
+  while (delta <= -Math.PI) delta += 2 * Math.PI;
+  while (delta > Math.PI) delta -= 2 * Math.PI;
+  const out: Array<[number, number]> = [];
+  for (let i = 0; i <= FILLET_SEGMENTS; i++) {
+    const ang = a1 + (delta * i) / FILLET_SEGMENTS;
+    out.push([cx + r * Math.cos(ang), cy + r * Math.sin(ang)]);
+  }
+  return out;
 }
 
 // Returns 3D polygon vertices (z = 0) approximating the profile outline.
@@ -81,21 +123,41 @@ export function profileToPolygon(
       const halfD = profile.overallDepth / 2;
       const halfWeb = profile.webThickness / 2;
       const flangeInnerY = halfD - profile.flangeThickness;
-      // Trace the I outline clockwise starting from bottom-left flange corner.
-      const pts: Array<[number, number, number]> = [
-        [-halfW, -halfD, 0],
-        [halfW, -halfD, 0],
-        [halfW, -flangeInnerY, 0],
-        [halfWeb, -flangeInnerY, 0],
-        [halfWeb, flangeInnerY, 0],
-        [halfW, flangeInnerY, 0],
-        [halfW, halfD, 0],
-        [-halfW, halfD, 0],
-        [-halfW, flangeInnerY, 0],
-        [-halfWeb, flangeInnerY, 0],
-        [-halfWeb, -flangeInnerY, 0],
-        [-halfW, -flangeInnerY, 0],
+      // Outline vertices traced clockwise from the bottom-left flange corner.
+      // The four web-to-flange junctions (indices 3, 4, 9, 10) are the concave
+      // root corners; with a fillet radius they become tessellated arcs.
+      const v: Array<[number, number]> = [
+        [-halfW, -halfD],
+        [halfW, -halfD],
+        [halfW, -flangeInnerY],
+        [halfWeb, -flangeInnerY],
+        [halfWeb, flangeInnerY],
+        [halfW, flangeInnerY],
+        [halfW, halfD],
+        [-halfW, halfD],
+        [-halfW, flangeInnerY],
+        [-halfWeb, flangeInnerY],
+        [-halfWeb, -flangeInnerY],
+        [-halfW, -flangeInnerY],
       ];
+      const r = profile.filletRadius ?? 0;
+      const rootCorners = new Set([3, 4, 9, 10]);
+      const pts: Array<[number, number, number]> = [];
+      for (let i = 0; i < v.length; i++) {
+        const cur = v[i];
+        if (cur === undefined) continue;
+        if (r > 0 && rootCorners.has(i)) {
+          const prev = v[(i - 1 + v.length) % v.length];
+          const next = v[(i + 1) % v.length];
+          if (prev !== undefined && next !== undefined) {
+            for (const [ax, ay] of filletArc(prev, cur, next, r)) {
+              pts.push([ax, ay, 0]);
+            }
+            continue;
+          }
+        }
+        pts.push([cur[0], cur[1], 0]);
+      }
       return ok(pts);
     }
   }

--- a/packages/brepjs-bim/src/elementFns/profileFns.ts
+++ b/packages/brepjs-bim/src/elementFns/profileFns.ts
@@ -34,8 +34,12 @@ export function profileCrossSectionArea(profile: Profile): number {
 // Arc points (minor sweep) rounding the corner at `v` between its neighbours
 // `prev`/`next` with radius `r`. Returns the tessellated fillet from the tangent
 // point on the incoming edge to the tangent point on the outgoing edge; the
-// caller drops the original sharp vertex. Used for I-beam root fillets.
+// caller drops the original sharp vertex. Used for I-beam root fillets (always
+// 90°). A near-collinear (≈0) or near-straight (≈π) corner has no well-defined
+// finite fillet — `tan(α/2)`/`sin(α/2)` or the bisector would blow up to NaN —
+// so those degenerate cases fall back to the original sharp vertex.
 const FILLET_SEGMENTS = 8;
+const FILLET_MIN_ANGLE = 1e-3; // radians; below this (or above π − this) skip the fillet
 function filletArc(
   prev: readonly [number, number],
   v: readonly [number, number],
@@ -47,6 +51,9 @@ function filletArc(
   const a: [number, number] = [(prev[0] - v[0]) / aLen, (prev[1] - v[1]) / aLen];
   const b: [number, number] = [(next[0] - v[0]) / bLen, (next[1] - v[1]) / bLen];
   const alpha = Math.acos(Math.max(-1, Math.min(1, a[0] * b[0] + a[1] * b[1])));
+  if (alpha < FILLET_MIN_ANGLE || alpha > Math.PI - FILLET_MIN_ANGLE) {
+    return [[v[0], v[1]]];
+  }
   const setback = r / Math.tan(alpha / 2); // distance from v to each tangent point
   const center = r / Math.sin(alpha / 2); // distance from v to the arc centre
   const bisLen = Math.hypot(a[0] + b[0], a[1] + b[1]);

--- a/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
@@ -288,10 +288,7 @@ function writeAxis2Placement2D(w: IfcWriter): number {
   w.writeLine({
     expressID: originId,
     type: WebIFC.IFCCARTESIANPOINT,
-    Coordinates: [
-      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
-      w.mkType(WebIFC.IFCLENGTHMEASURE, 0),
-    ],
+    Coordinates: [w.mkType(WebIFC.IFCLENGTHMEASURE, 0), w.mkType(WebIFC.IFCLENGTHMEASURE, 0)],
   });
   const id = w.nextId();
   w.writeLine({
@@ -344,8 +341,14 @@ export function writeProfile(w: IfcWriter, profile: Profile): number {
         OverallWidth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.overallWidth)),
         OverallDepth: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.overallDepth)),
         WebThickness: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.webThickness)),
-        FlangeThickness: w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.flangeThickness)),
-        FilletRadius: null,
+        FlangeThickness: w.mkType(
+          WebIFC.IFCPOSITIVELENGTHMEASURE,
+          toIfcLengthM(profile.flangeThickness)
+        ),
+        FilletRadius:
+          profile.filletRadius === undefined
+            ? null
+            : w.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, toIfcLengthM(profile.filletRadius)),
         FlangeEdgeRadius: null,
         FlangeSlope: null,
       });
@@ -359,11 +362,7 @@ function crossUnit(
   a: [number, number, number],
   b: [number, number, number]
 ): [number, number, number] {
-  return [
-    a[1] * b[2] - a[2] * b[1],
-    a[2] * b[0] - a[0] * b[2],
-    a[0] * b[1] - a[1] * b[0],
-  ];
+  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
 }
 
 // Emits IfcLocalPlacement + IfcExtrudedAreaSolid + IfcProductDefinitionShape

--- a/packages/brepjs-bim/src/specs/profile.ts
+++ b/packages/brepjs-bim/src/specs/profile.ts
@@ -12,8 +12,8 @@ import { extendedProfileToFace } from './profilesExtended.js';
 
 export type RectangularProfile = {
   readonly kind: 'RECTANGULAR';
-  readonly width: number;   // X extent
-  readonly height: number;  // Y extent
+  readonly width: number; // X extent
+  readonly height: number; // Y extent
 };
 
 export type CircularProfile = {
@@ -26,12 +26,15 @@ export type CircularProfile = {
 //   overallDepth: outer Y extent (total height)
 //   flangeThickness: top and bottom flange thickness
 //   webThickness: vertical web thickness (centered)
+//   filletRadius: root radius at the four web-to-flange junctions (optional). Hot-
+//     rolled wide-flange sections always carry one; omit it for a sharp section.
 export type IShapeProfile = {
   readonly kind: 'I_BEAM';
   readonly overallWidth: number;
   readonly overallDepth: number;
   readonly flangeThickness: number;
   readonly webThickness: number;
+  readonly filletRadius?: number | undefined;
 };
 
 // Core parametric profiles handled directly by profileToPolygon (brepjs solids)
@@ -83,6 +86,7 @@ const IShapeProfileSchema = z.object({
   overallDepth: z.number().positive(),
   flangeThickness: z.number().positive(),
   webThickness: z.number().positive(),
+  filletRadius: z.number().positive().optional(),
 });
 
 const CoreProfileSchema = z.discriminatedUnion('kind', [
@@ -185,7 +189,10 @@ function validateExtendedProfile(profile: ExtendedProfile): BimError | null {
   switch (profile.kind) {
     case 'L_SHAPE':
       if (profile.legThickness >= profile.width || profile.legThickness >= profile.depth) {
-        return specError('INVALID_PROFILE', 'L_SHAPE legThickness must be smaller than width and depth');
+        return specError(
+          'INVALID_PROFILE',
+          'L_SHAPE legThickness must be smaller than width and depth'
+        );
       }
       return null;
     case 'T_SHAPE':
@@ -199,31 +206,58 @@ function validateExtendedProfile(profile: ExtendedProfile): BimError | null {
     case 'U_SHAPE':
     case 'Z_SHAPE':
       if (2 * profile.flangeThickness >= profile.depth) {
-        return specError('INVALID_PROFILE', `${profile.kind} flangeThickness × 2 must be less than depth`);
+        return specError(
+          'INVALID_PROFILE',
+          `${profile.kind} flangeThickness × 2 must be less than depth`
+        );
       }
       if (profile.webThickness >= profile.flangeWidth) {
-        return specError('INVALID_PROFILE', `${profile.kind} webThickness must be less than flangeWidth`);
+        return specError(
+          'INVALID_PROFILE',
+          `${profile.kind} webThickness must be less than flangeWidth`
+        );
       }
       return null;
     case 'C_SHAPE':
-      if (2 * profile.wallThickness >= profile.width || 2 * profile.wallThickness >= profile.depth) {
-        return specError('INVALID_PROFILE', 'C_SHAPE wallThickness × 2 must be less than width and depth');
+      if (
+        2 * profile.wallThickness >= profile.width ||
+        2 * profile.wallThickness >= profile.depth
+      ) {
+        return specError(
+          'INVALID_PROFILE',
+          'C_SHAPE wallThickness × 2 must be less than width and depth'
+        );
       }
       if (profile.girth >= profile.depth / 2 || profile.girth <= profile.wallThickness) {
-        return specError('INVALID_PROFILE', 'C_SHAPE girth must exceed wallThickness and be less than depth/2');
+        return specError(
+          'INVALID_PROFILE',
+          'C_SHAPE girth must exceed wallThickness and be less than depth/2'
+        );
       }
       return null;
     case 'ASYMMETRIC_I':
       if (profile.topFlangeThickness + profile.bottomFlangeThickness >= profile.overallDepth) {
-        return specError('INVALID_PROFILE', 'ASYMMETRIC_I flange thicknesses must sum to less than overallDepth');
+        return specError(
+          'INVALID_PROFILE',
+          'ASYMMETRIC_I flange thicknesses must sum to less than overallDepth'
+        );
       }
-      if (profile.webThickness >= profile.topFlangeWidth || profile.webThickness >= profile.bottomFlangeWidth) {
-        return specError('INVALID_PROFILE', 'ASYMMETRIC_I webThickness must be less than both flange widths');
+      if (
+        profile.webThickness >= profile.topFlangeWidth ||
+        profile.webThickness >= profile.bottomFlangeWidth
+      ) {
+        return specError(
+          'INVALID_PROFILE',
+          'ASYMMETRIC_I webThickness must be less than both flange widths'
+        );
       }
       return null;
     case 'RECTANGLE_HOLLOW':
       if (2 * profile.wallThickness >= profile.xDim || 2 * profile.wallThickness >= profile.yDim) {
-        return specError('INVALID_PROFILE', 'RECTANGLE_HOLLOW wallThickness × 2 must be less than xDim and yDim');
+        return specError(
+          'INVALID_PROFILE',
+          'RECTANGLE_HOLLOW wallThickness × 2 must be less than xDim and yDim'
+        );
       }
       return null;
     case 'CIRCLE_HOLLOW':
@@ -252,16 +286,28 @@ export function parseProfile(input: unknown): Result<Profile, BimError> {
   }
   if (profile.kind === 'I_BEAM') {
     if (2 * profile.flangeThickness >= profile.overallDepth) {
-      return err(specError(
-        'INVALID_PROFILE',
-        'I-beam flangeThickness × 2 must be less than overallDepth'
-      ));
+      return err(
+        specError('INVALID_PROFILE', 'I-beam flangeThickness × 2 must be less than overallDepth')
+      );
     }
     if (profile.webThickness >= profile.overallWidth) {
-      return err(specError(
-        'INVALID_PROFILE',
-        'I-beam webThickness must be less than overallWidth'
-      ));
+      return err(
+        specError('INVALID_PROFILE', 'I-beam webThickness must be less than overallWidth')
+      );
+    }
+    if (profile.filletRadius !== undefined) {
+      // The root fillet sits in the notch beside the web and above the flange;
+      // it must fit both the clear half-web-height and the clear half-span.
+      const clearHeight = profile.overallDepth / 2 - profile.flangeThickness;
+      const clearSpan = (profile.overallWidth - profile.webThickness) / 2;
+      if (profile.filletRadius >= clearHeight || profile.filletRadius >= clearSpan) {
+        return err(
+          specError(
+            'INVALID_PROFILE',
+            'I-beam filletRadius must be smaller than the clear web height and the clear span beside the web'
+          )
+        );
+      }
     }
   }
   return ok(profile);

--- a/packages/brepjs-bim/tests/beamFns.test.ts
+++ b/packages/brepjs-bim/tests/beamFns.test.ts
@@ -62,6 +62,32 @@ describe('beamToSolid', () => {
     expect(vol.value).toBeCloseTo(5000 * 9700, -2);
   });
 
+  it('I-beam with root fillets adds material at the web junctions', () => {
+    const r = 12;
+    const result = beamToSolid({
+      ...BASE,
+      profile: {
+        kind: 'I_BEAM',
+        overallWidth: 200,
+        overallDepth: 400,
+        flangeThickness: 15,
+        webThickness: 10,
+        filletRadius: r,
+      },
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    using solid = result.value;
+    const vol = measureVolume(solid);
+    if (!vol.ok) throw new Error(vol.error.message);
+    // Sharp section (9700) plus four root fills of r²(1 − π/4), times length.
+    // The fillet arcs are tessellated, so accept the analytic target within 1%;
+    // it must still exceed the sharp section's volume (material was added).
+    const area = 9700 + 4 * r * r * (1 - Math.PI / 4);
+    expect(vol.value).toBeGreaterThan(5000 * 9700);
+    expect(vol.value).toBeGreaterThan(5000 * area * 0.99);
+    expect(vol.value).toBeLessThan(5000 * area * 1.01);
+  });
+
   it('rejects zero length', () => {
     const result = beamToSolid({ ...BASE, length: 0 });
     expect(result.ok).toBe(false);

--- a/packages/brepjs-bim/tests/profile.test.ts
+++ b/packages/brepjs-bim/tests/profile.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseProfile } from '../src/specs/profile.js';
-import {
-  profileCrossSectionArea,
-  profileToPolygon,
-} from '../src/elementFns/profileFns.js';
+import { profileCrossSectionArea, profileToPolygon } from '../src/elementFns/profileFns.js';
 import type { Profile } from '../src/specs/profile.js';
 
 describe('parseProfile', () => {
@@ -83,6 +80,21 @@ describe('profileCrossSectionArea', () => {
     // 2 × (200 × 15) + (400 - 30) × 10 = 6000 + 3700 = 9700
     expect(profileCrossSectionArea(profile)).toBe(9700);
   });
+
+  it('I-beam root fillets add material at the four web junctions', () => {
+    const r = 12;
+    const profile: Profile = {
+      kind: 'I_BEAM',
+      overallWidth: 200,
+      overallDepth: 400,
+      flangeThickness: 15,
+      webThickness: 10,
+      filletRadius: r,
+    };
+    // Sharp area (9700) plus four corner fills of r²(1 − π/4) each.
+    const expected = 9700 + 4 * r * r * (1 - Math.PI / 4);
+    expect(profileCrossSectionArea(profile)).toBeCloseTo(expected, 6);
+  });
 });
 
 describe('profileToPolygon', () => {
@@ -132,5 +144,28 @@ describe('profileToPolygon', () => {
     expect(pts[0]).toEqual([-100, -200, 0]);
     // Top-right flange corner
     expect(pts[6]).toEqual([100, 200, 0]);
+  });
+
+  it('I-beam with a fillet radius tessellates the four root corners into arcs', () => {
+    const r = 12;
+    const result = profileToPolygon({
+      kind: 'I_BEAM',
+      overallWidth: 200,
+      overallDepth: 400,
+      flangeThickness: 15,
+      webThickness: 10,
+      filletRadius: r,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const pts = result.value;
+    // Eight sharp vertices remain; each of the four root corners becomes an arc
+    // of FILLET_SEGMENTS + 1 = 9 points.
+    expect(pts).toHaveLength(8 + 4 * 9);
+    // The eight outer flange corners are untouched.
+    expect(pts[0]).toEqual([-100, -200, 0]);
+    // No tessellated point lands exactly on a sharp root corner (5, 185).
+    const onSharpRoot = pts.some(([x, y]) => Math.abs(x) === 5 && Math.abs(y) === 185);
+    expect(onSharpRoot).toBe(false);
   });
 });


### PR DESCRIPTION
Reworks three mechanical/BIM playground examples that read as obviously synthetic, plus the small `brepjs-bim` feature one of them needs.

## Changes

### `feat(bim)`: optional root fillets on I-beam profiles
Hot-rolled wide-flange sections always carry a **root fillet** where the web meets the flanges (and `IfcIShapeProfileDef` stores it as `FilletRadius`). Added an optional `filletRadius` to the `I_BEAM` profile:
- tessellate the four root corners into arcs in `profileToPolygon`
- account for the added material in `profileCrossSectionArea` (`4·r²(1−π/4)`)
- emit it to IFC (the `FilletRadius` slot was previously hard-`null`)
- tests in `profile.test.ts` + `beamFns.test.ts`

### `feat(playground)`: three examples made true-to-life
- **Cube-truss frame** — was a blocky stack of box-section cubes with flat slab braces. Now a square-section **tubular space frame**: round chord tubes, a Warren zig-zag of round web braces, and spherical gusset nodes (returned as an array of solids, like the curtain-wall example — no fragile N-way fusing).
- **Steel I-beam** — now passes `filletRadius` so the web/flange junctions show the rolled root fillets; ambient types regenerated.
- **Project enclosure** — fixed a latent bug where the lid cavity removed the entire cap (a capless frame); it's now a proper hollow shell. Added tapped corner bosses (modelled thread) + aligned lid clearance holes so the halves actually screw together. Tapping a standalone boss then fusing copies brought the build from ~17s down to ~3s.
- **RF enclosure** — added lid clearance holes aligned to the standoff bores so the self-tapping screws mate the two halves.

## Verification
- `brepjs-bim` suite: 575 passing; package typecheck clean
- `check:examples`: all 40 snippets type-check
- A temporary kernel-backed smoke test confirmed all three reworked builders produce valid solids (since removed)

## Notes
- Comments in the example `code` strings were kept terse per feedback (read in a small Monaco pane).
- The modelled enclosure threads sit inside ~1.5 mm bores (near-invisible at enclosure scale) but were kept since they were explicitly requested; build time is back to ~3s.