### PR TITLE
feat(bim): export and download BIM models as IFC from the playground

### DIFF
--- a/apps/playground/src/components/playground/PlaygroundPage.tsx
+++ b/apps/playground/src/components/playground/PlaygroundPage.tsx
@@ -97,6 +97,7 @@ export default function PlaygroundPage() {
         onExportSTL={actions.handleExportSTL}
         onExportSTEP={actions.handleExportSTEP}
         onExportDXF={actions.handleExportDXF}
+        onExportIFC={actions.handleExportIFC}
         onShare={actions.handleShare}
         onOpenCommandPalette={openCommandPalette}
         onOpenHelp={openShortcutHelp}

--- a/apps/playground/src/components/playground/Toolbar.tsx
+++ b/apps/playground/src/components/playground/Toolbar.tsx
@@ -8,6 +8,7 @@ interface ToolbarProps {
   onExportSTL: () => void;
   onExportSTEP: () => void;
   onExportDXF: () => void;
+  onExportIFC: () => void;
   onShare: () => void;
   onOpenCommandPalette: () => void;
   onOpenHelp: () => void;
@@ -23,6 +24,7 @@ export default function Toolbar({
   onExportSTL,
   onExportSTEP,
   onExportDXF,
+  onExportIFC,
   onShare,
   onOpenCommandPalette,
   onOpenHelp,
@@ -33,9 +35,10 @@ export default function Toolbar({
   const engineReady = useEngineStore((s) => s.status === 'ready');
   const selectionCount = usePlaygroundStore((s) => s.selections.length);
   const clearSelections = usePlaygroundStore((s) => s.clearSelections);
-  // DXF is a domain artifact only some models produce (sheet-metal flat
-  // patterns); show the button only when the current model exposes one.
+  // DXF / IFC are domain artifacts only some models produce (sheet-metal flat
+  // patterns / BIM models); show each button only when the model exposes it.
   const canExportDXF = usePlaygroundStore((s) => s.availableArtifacts.includes('dxf'));
+  const canExportIFC = usePlaygroundStore((s) => s.availableArtifacts.includes('ifc'));
 
   return (
     <div className="flex h-11 items-center justify-between border-b border-border-subtle bg-surface px-3">
@@ -118,6 +121,16 @@ export default function Toolbar({
                 className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
               >
                 DXF
+              </button>
+            )}
+            {canExportIFC && (
+              <button
+                onClick={onExportIFC}
+                disabled={!engineReady || isRunning}
+                title="Export the BIM model as IFC"
+                className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+              >
+                IFC
               </button>
             )}
             <div className="mx-1 h-4 w-px bg-border-subtle" />

--- a/apps/playground/src/hooks/useCodeExecution.ts
+++ b/apps/playground/src/hooks/useCodeExecution.ts
@@ -32,6 +32,7 @@ export function useCodeExecution() {
   const latestStlIdRef = useRef<string>('');
   const latestStepIdRef = useRef<string>('');
   const latestDxfIdRef = useRef<string>('');
+  const latestIfcIdRef = useRef<string>('');
   const isRecoveringRef = useRef(false);
   // Snapshot the code submitted under each eval id so eval-result records
   // what actually ran, not whatever the user has typed since.
@@ -121,6 +122,10 @@ export function useCodeExecution() {
         case 'export-dxf-result':
           if (msg.id !== latestDxfIdRef.current) return;
           downloadBlob(msg.dxf, 'flat-pattern.dxf', 'image/vnd.dxf');
+          break;
+        case 'export-ifc-result':
+          if (msg.id !== latestIfcIdRef.current) return;
+          downloadBlob(msg.ifc, 'model.ifc', 'application/x-step');
           break;
         case 'export-error':
           store.setError(msg.error);
@@ -225,6 +230,16 @@ export function useCodeExecution() {
     [engineStatus, postMessage]
   );
 
+  const exportIFC = useCallback(
+    (code: string) => {
+      if (engineStatus !== 'ready') return;
+      const id = `ifc-${++evalCounter}`;
+      latestIfcIdRef.current = id;
+      postMessage({ type: 'export-ifc', id, code });
+    },
+    [engineStatus, postMessage]
+  );
+
   const debouncedRun = useCallback(
     (code: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -241,5 +256,5 @@ export function useCodeExecution() {
     };
   }, []);
 
-  return { runCode, exportSTL, exportSTEP, exportDXF, debouncedRun };
+  return { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, debouncedRun };
 }

--- a/apps/playground/src/hooks/useCodeExecution.ts
+++ b/apps/playground/src/hooks/useCodeExecution.ts
@@ -125,7 +125,7 @@ export function useCodeExecution() {
           break;
         case 'export-ifc-result':
           if (msg.id !== latestIfcIdRef.current) return;
-          downloadBlob(msg.ifc, 'model.ifc', 'application/x-step');
+          downloadBlob(msg.ifc, 'model.ifc', 'application/x-ifc');
           break;
         case 'export-error':
           store.setError(msg.error);

--- a/apps/playground/src/hooks/usePlaygroundActions.ts
+++ b/apps/playground/src/hooks/usePlaygroundActions.ts
@@ -19,6 +19,7 @@ export interface PlaygroundActions {
   handleExportSTL: () => void;
   handleExportSTEP: () => void;
   handleExportDXF: () => void;
+  handleExportIFC: () => void;
   handleCopyCode: () => void;
   handleResetToDefault: () => void;
   handleResetViewer: () => void;
@@ -29,7 +30,7 @@ export interface PlaygroundActions {
 export function usePlaygroundActions(): PlaygroundActions {
   const code = usePlaygroundStore((s) => s.code);
   const addToast = useToastStore((s) => s.addToast);
-  const { runCode, exportSTL, exportSTEP, exportDXF, debouncedRun } = useCodeExecution();
+  const { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, debouncedRun } = useCodeExecution();
   const { updateUrl, copyShareUrl } = useUrlState();
   const handleScreenshot = useScreenshot();
   const resetViewerDefaults = useViewerStore((s) => s.resetViewerDefaults);
@@ -72,6 +73,13 @@ export function usePlaygroundActions(): PlaygroundActions {
     track('playground_export', { format: 'dxf' });
     captureEvent('playground_export', { format: 'dxf' });
   }, [exportDXF, code, addToast]);
+
+  const handleExportIFC = useCallback(() => {
+    exportIFC(code);
+    addToast('Exporting IFC...');
+    track('playground_export', { format: 'ifc' });
+    captureEvent('playground_export', { format: 'ifc' });
+  }, [exportIFC, code, addToast]);
 
   const handleShare = useCallback(() => {
     void copyShareUrl(code);
@@ -120,6 +128,7 @@ export function usePlaygroundActions(): PlaygroundActions {
       handleExportSTL,
       handleExportSTEP,
       handleExportDXF,
+      handleExportIFC,
       handleCopyCode,
       handleResetToDefault,
       handleResetViewer,
@@ -133,6 +142,7 @@ export function usePlaygroundActions(): PlaygroundActions {
       handleExportSTL,
       handleExportSTEP,
       handleExportDXF,
+      handleExportIFC,
       handleCopyCode,
       handleResetToDefault,
       handleResetViewer,

--- a/apps/playground/src/lib/ambientModule.ts
+++ b/apps/playground/src/lib/ambientModule.ts
@@ -66,8 +66,8 @@ const PLAYGROUND_MODULE_DTS = `declare module 'brepjs/playground' {
   export interface PresentArtifacts {
     /** A DXF document (e.g. a sheet-metal flat pattern) offered for download. */
     dxf?: string;
-    /** An IFC-SPF byte buffer offered for download. */
-    ifc?: Uint8Array;
+    /** IFC-SPF bytes offered for download, or a thunk producing them (deferred to the download click). */
+    ifc?: Uint8Array | (() => Uint8Array | Promise<Uint8Array>);
     /** A serializable BIM tree summary (BimModel.toTreeSummary()) for the domain panel. */
     bimTree?: unknown;
     /** Serializable flat-pattern polylines (flatPatternToPolylines()) for the 2D overlay. */

--- a/apps/playground/src/lib/examples/bim.ts
+++ b/apps/playground/src/lib/examples/bim.ts
@@ -45,12 +45,13 @@ export default model.getBeams()[0].geometry;
     label: 'Wall with Openings',
     description:
       'A parametric wall hosting a door and a window, placed in a project → site → building → storey spatial structure. The BIM panel shows the live IFC model tree.',
-    code: `import { BimModel } from 'brepjs-bim';
+    code: `import { BimModel, toIfc } from 'brepjs-bim';
 import { present } from 'brepjs/playground';
 
 // A parametric wall hosting a door and a window, organised into a real IFC
 // spatial structure (project → site → building → storey). Each opening is a void
-// boolean-cut into the wall solid. The BIM panel (top-right) shows the model tree.
+// boolean-cut into the wall solid. The BIM panel (top-right) shows the model
+// tree; the IFC button exports the model as a real IFC-SPF file.
 const model = new BimModel();
 model.init({ name: 'Wall example' });
 
@@ -97,8 +98,20 @@ const win = model.addWindow({
 if (!win.ok) throw win.error;
 model.placeIn(win.value, storeyId);
 
-// Show the wall solid (with its openings) and attach the IFC tree for the panel.
-export default present(model.getWalls()[0].geometry, { bimTree: model.toTreeSummary() });
+// Show the wall solid (with its openings), the IFC tree for the panel, and an
+// IFC export. The ifc thunk runs only when you click the IFC button — serializing
+// IFC re-initializes web-ifc, so it's deferred from every render.
+export default present(model.getWalls()[0].geometry, {
+  bimTree: model.toTreeSummary(),
+  ifc: async () => {
+    const result = await toIfc(model, {
+      applicationName: 'brepjs playground',
+      applicationVersion: '1.0',
+    });
+    if (!result.ok) throw result.error;
+    return result.value;
+  },
+});
 `,
   },
   {

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -182,9 +182,10 @@ interface ValidatedIfcResult {
 declare function toIfcValidated(model: BimModel, meta: BimModelMeta): Promise<Result<ValidatedIfcResult, BimError>>;
 
 /**
- * Override how web-ifc finds its `.wasm` file, used by {@link IfcWriter.create}
- * (and therefore `toIfc`/`fromIfc`). Required when brepjs-bim is bundled into a
- * worker that serves the wasm itself; not needed in Node.
+ * Override how web-ifc finds its `.wasm` file. Applied by every web-ifc entry
+ * point in this package — IFC export ({@link toIfc}), import ({@link fromIfc})
+ * and validation. Required when brepjs-bim is bundled into a worker that serves
+ * the wasm itself; not needed in Node.
  */
 declare function setIfcWasmLocateFile(locate: ((path: string, prefix: string) => string) | undefined): void;
 

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -160,7 +160,7 @@ interface BimTreeNode {
 interface BimTreeSummary {
     /** The project node and its nested spatial structure + contained elements. */
     readonly root: BimTreeNode | null;
-    /** Total number of elements in the model. */
+    /** Number of nodes in the tree (the project and everything reachable from it). */
     readonly elementCount: number;
 }
 
@@ -180,6 +180,13 @@ interface ValidatedIfcResult {
  * which serializes unconditionally).
  */
 declare function toIfcValidated(model: BimModel, meta: BimModelMeta): Promise<Result<ValidatedIfcResult, BimError>>;
+
+/**
+ * Override how web-ifc finds its `.wasm` file, used by {@link IfcWriter.create}
+ * (and therefore `toIfc`/`fromIfc`). Required when brepjs-bim is bundled into a
+ * worker that serves the wasm itself; not needed in Node.
+ */
+declare function setIfcWasmLocateFile(locate: ((path: string, prefix: string) => string) | undefined): void;
 
 interface FromIfcOptions {
     /** Activate web-ifc's large-coordinate recentering on open. Default false. */

--- a/apps/playground/src/workers/cad.worker.ts
+++ b/apps/playground/src/workers/cad.worker.ts
@@ -79,7 +79,9 @@ const PLAYGROUND_PRESENT_TAG = '__brepjsPlaygroundPresent';
 const DOWNLOAD_ARTIFACT_KEYS = ['dxf', 'ifc'] as const;
 interface PresentArtifacts {
   dxf?: string;
-  ifc?: Uint8Array;
+  // IFC bytes, or a thunk that produces them — toIfc re-inits web-ifc on every
+  // call, so examples pass a thunk to defer that work to the download click.
+  ifc?: Uint8Array | (() => Uint8Array | Promise<Uint8Array>);
   // A serializable BimModel.toTreeSummary() result, rendered in the domain panel.
   bimTree?: unknown;
   // A serializable flatPatternToPolylines() result, rendered as a 2D overlay.
@@ -259,6 +261,11 @@ function ensureBimLoaded(): Promise<void> {
   bimLoading ??= (async () => {
     bim = await import('brepjs-bim');
     (self as unknown as { __brepjs_bim: unknown }).__brepjs_bim = bim;
+    // Point web-ifc (used by toIfc) at the wasm the playground serves: its
+    // default "fetch relative to my module" can't find the file in the bundled
+    // worker. Mirrors loadOcctWasmModule's locateFile.
+    const webIfcWasm = `${import.meta.env.BASE_URL}wasm/web-ifc.wasm`;
+    bim.setIfcWasmLocateFile((path: string) => (path.endsWith('.wasm') ? webIfcWasm : path));
     bimBlobUrl = buildWrapperUrl(bim, '__brepjs_bim', false);
   })().catch((e: unknown) => {
     bimLoading = null;
@@ -724,6 +731,39 @@ async function handleExportDXF(id: string, code: string) {
   }
 }
 
+// Return the IFC an example attached via present(shape, { ifc }). `ifc` is a
+// thunk (so toIfc, which re-inits web-ifc, runs only on the download click); it
+// resolves to the IFC-SPF bytes. Computed here on demand, not on every render.
+async function handleExportIFC(id: string, code: string) {
+  try {
+    const { ifc } = await evalArtifacts(code);
+    let bytes: Uint8Array | undefined;
+    if (typeof ifc === 'function') {
+      const produced = await ifc();
+      if (produced instanceof Uint8Array) bytes = produced;
+    } else if (ifc instanceof Uint8Array) {
+      bytes = ifc;
+    }
+    if (!bytes || bytes.length === 0) {
+      post({
+        type: 'export-error',
+        id,
+        error: 'This model has no IFC to export — attach one with present(shape, { ifc }).',
+      });
+      return;
+    }
+    // web-ifc returns a Uint8Array over a plain ArrayBuffer; copy out just its
+    // bytes as a transferable ArrayBuffer.
+    const buf = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength
+    ) as ArrayBuffer;
+    post({ type: 'export-ifc-result', id, ifc: buf }, [buf]);
+  } catch (e) {
+    post({ type: 'export-error', id, error: e instanceof Error ? e.message : String(e) });
+  }
+}
+
 addEventListener('message', (e: MessageEvent<ToWorker>) => {
   const msg = e.data;
   switch (msg.type) {
@@ -748,6 +788,9 @@ addEventListener('message', (e: MessageEvent<ToWorker>) => {
       break;
     case 'export-dxf':
       void handleExportDXF(msg.id, msg.code);
+      break;
+    case 'export-ifc':
+      void handleExportIFC(msg.id, msg.code);
       break;
   }
 });

--- a/apps/playground/src/workers/workerProtocol.ts
+++ b/apps/playground/src/workers/workerProtocol.ts
@@ -38,7 +38,8 @@ export type ToWorker =
   | { type: 'cancel'; id: string }
   | { type: 'export-stl'; id: string; code: string }
   | { type: 'export-step'; id: string; code: string }
-  | { type: 'export-dxf'; id: string; code: string };
+  | { type: 'export-dxf'; id: string; code: string }
+  | { type: 'export-ifc'; id: string; code: string };
 
 // -- Worker -> Main --
 
@@ -64,4 +65,5 @@ export type FromWorker =
   | { type: 'export-result'; id: string; stl: ArrayBuffer }
   | { type: 'export-step-result'; id: string; step: ArrayBuffer }
   | { type: 'export-dxf-result'; id: string; dxf: string }
+  | { type: 'export-ifc-result'; id: string; ifc: ArrayBuffer }
   | { type: 'export-error'; id: string; error: string };

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -17,19 +17,28 @@ const brepjsPkgPath = fileURLToPath(new URL('../../package.json', import.meta.ur
 const brepjsPkg = JSON.parse(readFileSync(brepjsPkgPath, 'utf8')) as PackageJson;
 const BREPJS_VERSION = brepjsPkg.version ?? '0.0.0-dev';
 
-const WASM_FILES = ['occt-wasm.js', 'occt-wasm.wasm'];
-
 const BASE = '/playground/';
 
-function occtWasm(): Plugin {
-  // Resolve the occt-wasm dist dir (the package's exports map exposes
-  // ./dist/occt-wasm.js and ./dist/occt-wasm.wasm).
-  const wasmDir = dirname(reactRequire.resolve('occt-wasm/dist/occt-wasm.js'));
+// WASM assets the playground worker fetches from `${base}wasm/<file>`: the OCCT
+// kernel (occt-wasm) and web-ifc (used by brepjs-bim's IFC export). Each maps a
+// served filename to its source in node_modules.
+function wasmFileMap(): Record<string, string> {
+  const occtDir = dirname(reactRequire.resolve('occt-wasm/dist/occt-wasm.js'));
+  // web-ifc's main entry sits alongside its .wasm files in the package root.
+  const webIfcDir = dirname(reactRequire.resolve('web-ifc'));
+  return {
+    'occt-wasm.js': resolve(occtDir, 'occt-wasm.js'),
+    'occt-wasm.wasm': resolve(occtDir, 'occt-wasm.wasm'),
+    'web-ifc.wasm': resolve(webIfcDir, 'web-ifc.wasm'),
+  };
+}
 
+function wasmAssets(): Plugin {
+  const files = wasmFileMap();
   let base = BASE;
 
   return {
-    name: 'occt-wasm',
+    name: 'wasm-assets',
     configResolved(config) {
       base = config.base;
     },
@@ -38,9 +47,8 @@ function occtWasm(): Plugin {
       const wasmPath = `${base.replace(/\/$/, '')}/wasm`;
       server.middlewares.use(wasmPath, (req, res, next) => {
         const file = req.url?.slice(1) ?? '';
-        if (!WASM_FILES.includes(file)) return next();
-        const filePath = resolve(wasmDir, file);
-        if (!existsSync(filePath)) return next();
+        const filePath = files[file];
+        if (filePath === undefined || !existsSync(filePath)) return next();
 
         // Set COEP/COOP headers required for SharedArrayBuffer
         res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
@@ -56,8 +64,8 @@ function occtWasm(): Plugin {
       if (!dir) return;
       const out = resolve(dir, 'wasm');
       mkdirSync(out, { recursive: true });
-      for (const f of WASM_FILES) {
-        copyFileSync(resolve(wasmDir, f), resolve(out, f));
+      for (const [file, src] of Object.entries(files)) {
+        if (existsSync(src)) copyFileSync(src, resolve(out, file));
       }
     },
   };
@@ -70,7 +78,7 @@ export default defineConfig({
     // brepjs version in bug reports without needing devtools.
     __BREPJS_VERSION__: JSON.stringify(BREPJS_VERSION),
   },
-  plugins: [react(), tailwindcss(), occtWasm()],
+  plugins: [react(), tailwindcss(), wasmAssets()],
   server: {
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
@@ -78,7 +86,9 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    exclude: ['occt-wasm'],
+    // Both are Emscripten glue: running them through esbuild's dep optimizer
+    // corrupts the WASM import object, so serve them as native ESM instead.
+    exclude: ['occt-wasm', 'web-ifc'],
   },
   resolve: {
     // Pin react/react-dom to a single physical copy so vite 8 + rolldown's stricter

--- a/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
@@ -15,6 +15,24 @@ export const DEFAULT_MVD_VIEW_DEFINITION = 'ReferenceView_v1.2';
 // FILE_DESCRIPTION; we rewrite whatever is between the brackets with our MVD.
 const VIEW_DEFINITION_RE = /ViewDefinition \[[^\]]*\]/;
 
+// Optional override for how web-ifc locates its `.wasm`. When brepjs-bim is
+// bundled into a Web Worker, web-ifc's default (fetch the wasm relative to its
+// own bundled module URL) can't find the file; a host sets this to point Init at
+// a served copy. Undefined falls back to web-ifc's own resolution (works in Node
+// and when web-ifc is loaded from a real package URL).
+let wasmLocateFile: ((path: string, prefix: string) => string) | undefined;
+
+/**
+ * Override how web-ifc finds its `.wasm` file, used by {@link IfcWriter.create}
+ * (and therefore `toIfc`/`fromIfc`). Required when brepjs-bim is bundled into a
+ * worker that serves the wasm itself; not needed in Node.
+ */
+export function setIfcWasmLocateFile(
+  locate: ((path: string, prefix: string) => string) | undefined
+): void {
+  wasmLocateFile = locate;
+}
+
 export class IfcWriter {
   readonly #api: IfcAPI;
   readonly #modelId: number;
@@ -37,7 +55,11 @@ export class IfcWriter {
   ): Promise<Result<IfcWriter, BimError>> {
     try {
       const api = new IfcAPI();
-      await api.Init();
+      // Force single-threaded: in a cross-origin-isolated context web-ifc would
+      // load its pthread build and spawn a sub-Worker, which fails when brepjs-bim
+      // is itself bundled inside a Web Worker. Multithreading only speeds up
+      // parsing/geometry anyway, not the one-shot serialization the writer does.
+      await api.Init(wasmLocateFile, true);
       const modelId = api.CreateModel({ schema: fileSchemaString(ifcSchema) });
       return ok(new IfcWriter(api, modelId, mvdViewDefinition));
     } catch (e) {

--- a/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
@@ -5,6 +5,7 @@ import type { IfcGuid } from '../identity/ifcGuid.js';
 import { deriveIfcGuidSync, makeLineKey } from '../identity/guidDerivation.js';
 import type { IfcSchema } from './schemaVersion.js';
 import { DEFAULT_IFC_SCHEMA, fileSchemaString } from './schemaVersion.js';
+import { initIfcApi } from '../ifcRuntime.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 
@@ -14,24 +15,6 @@ export const DEFAULT_MVD_VIEW_DEFINITION = 'ReferenceView_v1.2';
 // web-ifc emits a default ViewDefinition (e.g. "[CoordinationView]") in the STEP
 // FILE_DESCRIPTION; we rewrite whatever is between the brackets with our MVD.
 const VIEW_DEFINITION_RE = /ViewDefinition \[[^\]]*\]/;
-
-// Optional override for how web-ifc locates its `.wasm`. When brepjs-bim is
-// bundled into a Web Worker, web-ifc's default (fetch the wasm relative to its
-// own bundled module URL) can't find the file; a host sets this to point Init at
-// a served copy. Undefined falls back to web-ifc's own resolution (works in Node
-// and when web-ifc is loaded from a real package URL).
-let wasmLocateFile: ((path: string, prefix: string) => string) | undefined;
-
-/**
- * Override how web-ifc finds its `.wasm` file, used by {@link IfcWriter.create}
- * (and therefore `toIfc`/`fromIfc`). Required when brepjs-bim is bundled into a
- * worker that serves the wasm itself; not needed in Node.
- */
-export function setIfcWasmLocateFile(
-  locate: ((path: string, prefix: string) => string) | undefined
-): void {
-  wasmLocateFile = locate;
-}
 
 export class IfcWriter {
   readonly #api: IfcAPI;
@@ -55,11 +38,7 @@ export class IfcWriter {
   ): Promise<Result<IfcWriter, BimError>> {
     try {
       const api = new IfcAPI();
-      // Force single-threaded: in a cross-origin-isolated context web-ifc would
-      // load its pthread build and spawn a sub-Worker, which fails when brepjs-bim
-      // is itself bundled inside a Web Worker. Multithreading only speeds up
-      // parsing/geometry anyway, not the one-shot serialization the writer does.
-      await api.Init(wasmLocateFile, true);
+      await initIfcApi(api);
       const modelId = api.CreateModel({ schema: fileSchemaString(ifcSchema) });
       return ok(new IfcWriter(api, modelId, mvdViewDefinition));
     } catch (e) {

--- a/packages/brepjs-bim/src/ifcRuntime.ts
+++ b/packages/brepjs-bim/src/ifcRuntime.ts
@@ -1,0 +1,35 @@
+import type { IfcAPI } from 'web-ifc';
+
+// Optional override for how web-ifc locates its `.wasm`. When brepjs-bim is
+// bundled into a Web Worker, web-ifc's default (fetch the wasm relative to its
+// own bundled module URL) can't find the file; a host sets this to point Init at
+// a served copy. Undefined falls back to web-ifc's own resolution (works in Node
+// and when web-ifc is loaded from a real package URL).
+let wasmLocateFile: ((path: string, prefix: string) => string) | undefined;
+
+/**
+ * Override how web-ifc finds its `.wasm` file. Applied by every web-ifc entry
+ * point in this package — IFC export ({@link toIfc}), import ({@link fromIfc})
+ * and validation. Required when brepjs-bim is bundled into a worker that serves
+ * the wasm itself; not needed in Node.
+ */
+export function setIfcWasmLocateFile(
+  locate: ((path: string, prefix: string) => string) | undefined
+): void {
+  wasmLocateFile = locate;
+}
+
+/**
+ * Initialize a web-ifc API instance the way this package always wants it: with
+ * the host-provided wasm locator and forced single-threaded.
+ *
+ * Single-threaded matters in a cross-origin-isolated context (e.g. a page that
+ * sets COOP/COEP for another WASM kernel): web-ifc would otherwise load its
+ * pthread build and spawn a sub-Worker, which fails when brepjs-bim is itself
+ * bundled inside a Web Worker. In Node the flag is a no-op (web-ifc is already
+ * single-threaded there), and multithreading only speeds up parsing/geometry,
+ * not the one-shot serialize/read this package does.
+ */
+export async function initIfcApi(api: IfcAPI): Promise<void> {
+  await api.Init(wasmLocateFile, true);
+}

--- a/packages/brepjs-bim/src/import/spfReader.ts
+++ b/packages/brepjs-bim/src/import/spfReader.ts
@@ -2,6 +2,7 @@ import { IfcAPI } from 'web-ifc';
 import type { FlatMesh, IfcGeometry } from 'web-ifc';
 import type { BimError } from '../errors/bimError.js';
 import { importError } from '../errors/bimError.js';
+import { initIfcApi } from '../ifcRuntime.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 
@@ -56,7 +57,7 @@ export class SpfReader {
     let api: IfcAPI;
     try {
       api = new IfcAPI();
-      await api.Init();
+      await initIfcApi(api);
     } catch (e) {
       return err(importError('OPEN_MODEL_FAILED', 'Failed to initialize web-ifc', e));
     }

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -2,6 +2,7 @@ export { BimModel } from './model/bimModel.js';
 export type { BimTreeNode, BimTreeSummary } from './model/treeSummary.js';
 export { toIfc, toIfcValidated } from './serialize/toIfc.js';
 export type { ValidatedIfcResult } from './serialize/toIfc.js';
+export { setIfcWasmLocateFile } from './ifc-writer/ifcWriter.js';
 export { fromIfc } from './import/fromIfc.js';
 export { disposeImportedModel } from './import/importedModel.js';
 export type { FromIfcOptions } from './import/fromIfc.js';

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -2,7 +2,7 @@ export { BimModel } from './model/bimModel.js';
 export type { BimTreeNode, BimTreeSummary } from './model/treeSummary.js';
 export { toIfc, toIfcValidated } from './serialize/toIfc.js';
 export type { ValidatedIfcResult } from './serialize/toIfc.js';
-export { setIfcWasmLocateFile } from './ifc-writer/ifcWriter.js';
+export { setIfcWasmLocateFile } from './ifcRuntime.js';
 export { fromIfc } from './import/fromIfc.js';
 export { disposeImportedModel } from './import/importedModel.js';
 export type { FromIfcOptions } from './import/fromIfc.js';

--- a/packages/brepjs-bim/src/validation/roundTrip.ts
+++ b/packages/brepjs-bim/src/validation/roundTrip.ts
@@ -2,6 +2,7 @@ import { IfcAPI } from 'web-ifc';
 import * as WebIFC from 'web-ifc';
 import type { ValidationIssue, ValidationReport } from './severity.js';
 import { issue, emptyReport, appendIssues } from './severity.js';
+import { initIfcApi } from '../ifcRuntime.js';
 
 /**
  * Human-readable names of the key entities whose per-type counts are compared
@@ -51,7 +52,7 @@ export interface RoundTripReport extends ValidationReport {
  */
 export async function firstPassCounts(bytes: Uint8Array): Promise<EntityCounts> {
   const api = new IfcAPI();
-  await api.Init();
+  await initIfcApi(api);
   const modelId = api.OpenModel(bytes);
   try {
     return collectCounts(api, modelId);
@@ -66,7 +67,7 @@ export async function firstPassCounts(bytes: Uint8Array): Promise<EntityCounts> 
  */
 async function secondPassCounts(bytes: Uint8Array): Promise<EntityCounts> {
   const api = new IfcAPI();
-  await api.Init();
+  await initIfcApi(api);
   const sourceModelId = api.OpenModel(bytes);
   let resaved: Uint8Array;
   try {

--- a/packages/brepjs-bim/src/validation/schemaCheck.ts
+++ b/packages/brepjs-bim/src/validation/schemaCheck.ts
@@ -1,5 +1,6 @@
 import * as WebIFC from 'web-ifc';
 import { isValidIfcGuid } from '../identity/ifcGuid.js';
+import { initIfcApi } from '../ifcRuntime.js';
 import {
   appendIssue,
   appendIssues,
@@ -30,7 +31,7 @@ export async function checkSchema(bytes: Uint8Array): Promise<ValidationReport> 
   }
 
   const api = new WebIFC.IfcAPI();
-  await api.Init();
+  await initIfcApi(api);
 
   let modelId: number | undefined;
   try {

--- a/tests/helpers/playgroundExampleEval.ts
+++ b/tests/helpers/playgroundExampleEval.ts
@@ -22,11 +22,12 @@ import * as brepjs from '@/index.js';
 import * as sheetmetal from 'brepjs-sheetmetal';
 import * as bim from 'brepjs-bim';
 
-// Mirrors scripts/extract-doc-tests.ts — a synchronous body suffices since the
-// playground eval surface (and `mesh`) is synchronous.
-const BodyFunction = Object.getPrototypeOf(function () {}).constructor as new (
+// An AsyncFunction so example bodies can use top-level await — e.g. a BIM
+// example that does `await toIfc(...)` before its default export. The worker
+// runs examples via `await import(blobUrl)`, which supports the same.
+const AsyncBodyFunction = Object.getPrototypeOf(async function () {}).constructor as new (
   ...args: string[]
-) => (...args: unknown[]) => unknown;
+) => (...args: unknown[]) => Promise<unknown>;
 
 const PLAYGROUND_COLOR_TAG = '__brepjsPlaygroundColor';
 const PLAYGROUND_PRESENT_TAG = '__brepjsPlaygroundPresent';
@@ -101,12 +102,12 @@ function unwrapResultShape(shape: unknown): unknown {
 }
 
 /** Run an example's source and return the exported shape(s) as an array. */
-export function runExample(code: string): unknown[] {
+export async function runExample(code: string): Promise<unknown[]> {
   const body = transpileExample(code);
-  const fn = new BodyFunction('__brepjs', '__pg', '__sheetmetal', '__bim', body);
+  const fn = new AsyncBodyFunction('__brepjs', '__pg', '__sheetmetal', '__bim', body);
   // A present() wrapper carries downloadable artifacts alongside the shown
   // shape; mesh the shape, ignore the artifacts here.
-  const raw = fn(brepjs, playgroundModule, sheetmetal, bim);
+  const raw = await fn(brepjs, playgroundModule, sheetmetal, bim);
   const exported = isPresentWrapper(raw) ? raw.shape : raw;
   if (exported === null || exported === undefined) return [];
   return Array.isArray(exported) ? exported : [exported];
@@ -123,8 +124,8 @@ export interface MeshCheck {
  * nothing or if any shape produces an empty mesh — the two failure modes a
  * blank playground viewer would show.
  */
-export function evalAndMeshExample(code: string): MeshCheck {
-  const shapes = runExample(code);
+export async function evalAndMeshExample(code: string): Promise<MeshCheck> {
+  const shapes = await runExample(code);
   if (shapes.length === 0) {
     throw new Error('example exported no shapes (default export was null/undefined)');
   }

--- a/tests/playgroundExamples.test.ts
+++ b/tests/playgroundExamples.test.ts
@@ -25,8 +25,8 @@ describe('playground examples', () => {
   });
 
   for (const example of EXAMPLES) {
-    it(`evaluates and meshes: ${example.id}`, () => {
-      const { shapeCount, totalVertices } = evalAndMeshExample(example.code);
+    it(`evaluates and meshes: ${example.id}`, async () => {
+      const { shapeCount, totalVertices } = await evalAndMeshExample(example.code);
       expect(shapeCount).toBeGreaterThan(0);
       expect(totalVertices).toBeGreaterThan(0);
     });

--- a/tests/validateCandidate.test.ts
+++ b/tests/validateCandidate.test.ts
@@ -21,9 +21,9 @@ beforeAll(async () => {
 }, 60000);
 
 describe.skipIf(!candidateFile)('candidate playground example', () => {
-  it('evaluates and meshes', () => {
+  it('evaluates and meshes', async () => {
     const code = readFileSync(candidateFile as string, 'utf-8');
-    const { shapeCount, totalVertices } = evalAndMeshExample(code);
+    const { shapeCount, totalVertices } = await evalAndMeshExample(code);
     expect(shapeCount).toBeGreaterThan(0);
     expect(totalVertices).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## What

Adds an **IFC download** button to the playground, wired to `brepjs-bim`'s
`toIfc` serializer running inside the eval worker. The *Wall with Openings*
BIM example now carries an `ifc` artifact thunk; clicking **IFC** serializes
the live `BimModel` (project → site → building → storey, wall + door + window)
to a real IFC-SPF file and downloads `model.ifc`.

The thunk is computed **only on click** (`ifc: async () => …`), so web-ifc is
never initialized on render — geometry-only BIM examples never pull in the IFC
WASM.

## Why two infra fixes were needed

Running web-ifc's Emscripten WASM inside the Vite-bundled worker hit two walls:

1. **Dep-optimizer corruption** — esbuild's dep pre-bundling mangled web-ifc's
   glue, leaving the WASM import object's `env` undefined
   (`WebAssembly.instantiate(): Import #0 "env": module is not an object`).
   Fix: serve `web-ifc.wasm` from the `wasm-assets` plugin and add `web-ifc` to
   `optimizeDeps.exclude` (same treatment occt-wasm already gets).

2. **Pthread build in a nested worker** — the COOP/COEP headers OCCT needs make
   the worker cross-origin-isolated, so web-ifc auto-selected its multithreaded
   build and tried to spawn a pthread sub-Worker (`Cannot use import statement
   outside a module`). Fix: force single-threaded (`Init(locate, true)`) in
   `IfcWriter.create` — multithreading only speeds up parsing/geometry, not the
   one-shot serialization the writer does.

## Public API

- `brepjs-bim` now exports **`setIfcWasmLocateFile(locate)`** so a host (the
  worker) can point `Init` at a served `.wasm`. No-op/unneeded in Node.

## Notes

- The shared example eval harness (`tests/helpers/playgroundExampleEval.ts`)
  becomes async to support the top-level-await IFC thunk; `runExample`/
  `evalAndMeshExample` now return promises.

## Verification

- Playground build: `tsc -b` + `check:examples` **40/40** + vite ✓
- `tests/playgroundExamples.test.ts` (Node mesh, occt-wasm): **79 passed** ✓
- `brepjs-bim` typecheck / lint / test: **0 / 0 / 572 passed** ✓
- root typecheck: **0** ✓
- **E2E (puppeteer):** loaded the wall example, clicked **IFC**, verified the
  downloaded file is valid IFC-SPF (7849 bytes; `ISO-10303-21` header,
  `IFCWALL`/`IFCDOOR`/`IFCWINDOW` entities, `END-ISO-10303-21;` terminator).