### PR TITLE
chore: add repository metadata to bim/sheetmetal for npm provenance

### DIFF
--- a/packages/brepjs-bim/package.json
+++ b/packages/brepjs-bim/package.json
@@ -5,6 +5,7 @@
   "keywords": ["bim", "ifc", "cad", "brep"],
   "author": "Andy Aragon",
   "license": "Apache-2.0",
+  "repository": { "type": "git", "url": "https://github.com/andymai/brepjs", "directory": "packages/brepjs-bim" },
   "type": "module",
   "sideEffects": false,
   "engines": { "node": ">=24" },

--- a/packages/brepjs-sheetmetal/package.json
+++ b/packages/brepjs-sheetmetal/package.json
@@ -12,6 +12,11 @@
   ],
   "author": "Andy Aragon",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/andymai/brepjs",
+    "directory": "packages/brepjs-sheetmetal"
+  },
   "type": "module",
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
## Why

The `brepjs-sheetmetal` **0.2.0** publish (auto-dispatched from its release) **failed**:

```
npm error 422 - Error verifying sigstore provenance bundle: Failed to validate
repository information: package.json: "repository.url" is "", expected to match
"https://github.com/andymai/brepjs" from provenance
```

CI publishes with `--provenance` (OIDC trusted publishing); npm cross-checks that
`package.json`'s `repository.url` matches the repo the sigstore attestation came from.
Both satellite manifests were **missing the `repository` field entirely**, so the check
fails. (The manual `0.1.0` publishes only succeeded because they used `--provenance=false`.)

## Fix

Add the same `repository` block `brepjs-verify` already ships (it publishes via OIDC
fine), with each package's `directory`. No version bump (`chore`), so this doesn't
spawn another release cycle.

## Unblocks

- Re-dispatching the **brepjs-sheetmetal 0.2.0** publish (the release/tag already exist;
  only the npm publish failed).
- The pending **brepjs-bim 0.2.0** release (#1455), whose publish would fail identically
  without this. Merging this also triggers release-please to refresh #1455 (currently
  conflicted on the shared manifest).