### PR TITLE
fix: mobile example-gallery scroll and landing hero line breaks

### DIFF
--- a/apps/docs/.vitepress/theme/components/Landing.vue
+++ b/apps/docs/.vitepress/theme/components/Landing.vue
@@ -119,7 +119,7 @@ onBeforeUnmount(() => observer?.disconnect());
       <section class="hero">
         <div class="wrap hero-top">
           <p class="eyebrow">Exact B-Rep · TypeScript · Browser-native</p>
-          <h1>Exact CAD geometry,<br /><span class="grad">written in TypeScript.</span></h1>
+          <h1>Exact CAD geometry,<br class="h1-break" /><span class="grad">written in TypeScript.</span></h1>
           <p class="subhead">
             A real B-Rep kernel in your browser via WASM. A type system that makes invalid geometry
             uncompilable. And a verification loop so AI agents author parts that are provably
@@ -701,10 +701,11 @@ pre code {
   margin-top: 44px;
 }
 h1 {
-  font-size: clamp(2.5rem, 5vw, 3.9rem);
-  line-height: 1.04;
+  font-size: clamp(2rem, 7.4vw, 3.9rem);
+  line-height: 1.06;
   letter-spacing: -0.022em;
   margin: 16px 0 0;
+  text-wrap: balance;
 }
 h1 .grad {
   background: var(--grad-name);
@@ -1321,6 +1322,13 @@ pre.term {
   }
   .hero {
     padding: 56px 0 40px;
+  }
+}
+@media (max-width: 600px) {
+  /* Drop the deliberate two-clause break on phones: the headline scales down
+     and balances on its own, so the hard <br> would only force ragged lines. */
+  h1 .h1-break {
+    display: none;
   }
 }
 @media (max-width: 460px) {

--- a/apps/playground/src/components/playground/ExampleGallery.tsx
+++ b/apps/playground/src/components/playground/ExampleGallery.tsx
@@ -131,7 +131,7 @@ export default function ExampleGallery({
     >
       <div
         ref={panelRef}
-        className="flex h-full max-h-[94vh] w-full max-w-[110rem] flex-col overflow-hidden rounded-xl border border-border-subtle bg-surface shadow-2xl sm:flex-row"
+        className="flex h-full max-h-[94dvh] w-full max-w-[110rem] flex-col overflow-hidden rounded-xl border border-border-subtle bg-surface shadow-2xl sm:flex-row"
         onClick={(e) => {
           e.stopPropagation();
         }}
@@ -170,7 +170,7 @@ export default function ExampleGallery({
         </nav>
 
         {/* Main: search header + card grid */}
-        <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <div className="flex items-center gap-2 border-b border-border-subtle px-3 py-2.5">
             <svg viewBox="0 0 16 16" className="h-4 w-4 shrink-0 text-gray-500" aria-hidden="true">
               <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" fill="none" />


### PR DESCRIPTION
## What

Two mobile-web fixes reported on the playground/landing.

### 1. Example gallery modal not scrollable on mobile
`apps/playground/src/components/playground/ExampleGallery.tsx`

- Added `min-h-0` to the main content column. On mobile the panel is `flex-col overflow-hidden`, and the column had `flex-1` without `min-h-0`. A flex item's default `min-height: auto` won't shrink below its content height, so the column grew to fit the whole grid and was clipped by `overflow-hidden` — the inner `overflow-y-auto` never engaged. (Desktop is `flex-row`, so the column was on the cross-axis with a definite height — which is why it scrolled there but not on mobile.)
- Switched the panel cap `max-h-[94vh]` → `max-h-[94dvh]`. Static `vh` on mobile is the *large* (toolbar-hidden) viewport, so the modal could exceed the visible area and clip the header/close button. `dvh` tracks the visible height.

### 2. Landing hero headline wraps raggedly on mobile
`apps/docs/.vitepress/theme/components/Landing.vue`

- `clamp(2.5rem, 5vw, 3.9rem)` → `clamp(2rem, 7.4vw, 3.9rem)`: the old `5vw` slope bottomed out at the `2.5rem` floor under ~800px, pinning every phone to a 40px headline that overflowed.
- Added `text-wrap: balance` for even line lengths.
- Made the deliberate `<br>` responsive (hidden under 600px) so on phones the balanced natural flow controls wrapping instead of the hard break compounding into 4–5 ragged lines. The intended two-line composition is preserved at ≥601px.

## Verification

Both verified with Puppeteer at mobile widths:

- **Gallery (360/390px):** scroll container reports `scrollable: true` (scrollHeight 5877 vs clientHeight 581), `scrollTop` moves 0 → max, panel sits at 94dvh, last card reachable without clipping.
- **Hero (320–768px):** phones render a clean balanced headline; ≥601px restores the designed two-line break.

Changes are CSS/markup only — no logic, type, or test surface affected.