### PR TITLE
feat(brepjs-bim): real roof shapes, posted railings, placed-geometry accessor

### DIFF
--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -21,10 +21,17 @@ useful downstream (psets, classification, materials, quantities), with import, e
 validation. Geometry is produced by brepjs (OCCT); each element carries a `ValidSolid` (or, for
 curtain walls, a panel/mullion grid). Element geometry is **unplaced template geometry** in local
 coordinates — placement (`origin` / `axisX` / `axisZ`) is applied by the IFC layer via
-`IfcLocalPlacement`, not baked into the brepjs solid.
+`IfcLocalPlacement`, not baked into the brepjs solid. Use `placedSolids(element)` to read an
+element's geometry already transformed to its world placement as fresh, caller-owned solids
+(stairs return one solid per flight) — handy for display so the on-screen scene matches the IFC
+export.
 
 - Units default to mm; IFC export emits SI metres.
 - Stable identity: deterministic IFC GUIDs (`deriveIfcGuid`) and local id counters.
+- Shaped geometry: roofs build real shed/gable/hip/dome solids when `pitch` is set (flat slab
+  otherwise); railings build posts + top/bottom rails with `infill: 'POSTED'` (a single swept panel
+  otherwise). Shaped roofs and posted railings serialize to IFC as tessellated bodies; flat roofs
+  and panel railings keep their parametric `IfcExtrudedAreaSolid`.
 
 ## Status
 

--- a/packages/brepjs-bim/src/elementFns/placedGeometry.ts
+++ b/packages/brepjs-bim/src/elementFns/placedGeometry.ts
@@ -1,0 +1,65 @@
+import { applyMatrix } from 'brepjs';
+import type { ValidSolid } from 'brepjs';
+import type { AnyBimElement } from '../types/bimTypes.js';
+import { placementToMatrix, type FrameInput } from '../import/placement.js';
+import { stairFlightToSolid } from './stairFns.js';
+
+// Applies an (origin, axisX, axisZ) frame to a local solid, returning a fresh
+// caller-owned solid. Orthonormal frames use the validity-preserving transform
+// path, so the result is a ValidSolid.
+function place(solid: ValidSolid, frame: FrameInput): ValidSolid {
+  const result = applyMatrix(solid, placementToMatrix(frame));
+  if (!result.ok) {
+    throw new Error(`placedSolids: failed to place element geometry: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+/**
+ * Returns each element's geometry transformed to its world placement, as fresh
+ * caller-owned solids. **Dispose them** (e.g. via `using` or `[Symbol.dispose]`);
+ * they are independent of the model's lifetime — `BimModel[Symbol.dispose]` only
+ * frees the stored (local) `.geometry`.
+ *
+ * Stairs carry no element solid (`.geometry` is null), so their flight solids are
+ * built from `spec.flights` and placed per flight. Curtain walls are returned as
+ * placed panels + mullions. Elements with no solid geometry (doors/windows/ramps/
+ * groups/spatial) return an empty array. The unplaced `.geometry` is unchanged.
+ */
+export function placedSolids(el: AnyBimElement): readonly ValidSolid[] {
+  switch (el.category) {
+    case 'WALL':
+    case 'SLAB':
+    case 'BEAM':
+    case 'COLUMN':
+    case 'SPACE':
+    case 'ROOF':
+    case 'FOOTING':
+    case 'PILE':
+    case 'RAILING':
+      return [place(el.geometry, el.spec)];
+    case 'STAIR': {
+      const out: ValidSolid[] = [];
+      for (const flight of el.spec.flights) {
+        const built = stairFlightToSolid(flight);
+        if (!built.ok) {
+          throw new Error(`placedSolids: stair flight geometry failed: ${built.error.message}`);
+        }
+        using local = built.value.solid;
+        out.push(place(local, flight));
+      }
+      return out;
+    }
+    case 'CURTAIN_WALL': {
+      const out: ValidSolid[] = [];
+      for (const c of [...el.geometry.panels, ...el.geometry.mullions]) {
+        // Two-level: place by the component-local origin, then by the wall frame.
+        using componentLocal = place(c.solid, { origin: c.origin, axisX: [1, 0, 0], axisZ: [0, 0, 1] });
+        out.push(place(componentLocal, el.spec));
+      }
+      return out;
+    }
+    default:
+      return [];
+  }
+}

--- a/packages/brepjs-bim/src/elementFns/placedGeometry.ts
+++ b/packages/brepjs-bim/src/elementFns/placedGeometry.ts
@@ -1,32 +1,41 @@
-import { applyMatrix } from 'brepjs';
-import type { ValidSolid } from 'brepjs';
+import { applyMatrix, ok, err } from 'brepjs';
+import type { ValidSolid, Result } from 'brepjs';
 import type { AnyBimElement } from '../types/bimTypes.js';
+import type { BimError } from '../errors/bimError.js';
+import { fromBrepError } from '../errors/bimError.js';
 import { placementToMatrix, type FrameInput } from '../import/placement.js';
 import { stairFlightToSolid } from './stairFns.js';
 
 // Applies an (origin, axisX, axisZ) frame to a local solid, returning a fresh
 // caller-owned solid. Orthonormal frames use the validity-preserving transform
 // path, so the result is a ValidSolid.
-function place(solid: ValidSolid, frame: FrameInput): ValidSolid {
+function place(solid: ValidSolid, frame: FrameInput): Result<ValidSolid, BimError> {
   const result = applyMatrix(solid, placementToMatrix(frame));
   if (!result.ok) {
-    throw new Error(`placedSolids: failed to place element geometry: ${result.error.message}`);
+    return err(fromBrepError(result.error, 'PLACED_GEOMETRY_FAILED', 'Failed to place element geometry'));
   }
-  return result.value;
+  return ok(result.value);
+}
+
+function disposeAll(solids: readonly ValidSolid[]): void {
+  for (const s of solids) s[Symbol.dispose]();
 }
 
 /**
  * Returns each element's geometry transformed to its world placement, as fresh
- * caller-owned solids. **Dispose them** (e.g. via `using` or `[Symbol.dispose]`);
- * they are independent of the model's lifetime — `BimModel[Symbol.dispose]` only
- * frees the stored (local) `.geometry`.
+ * caller-owned solids, wrapped in a `Result` (Layer-2 code prefers `Result` over
+ * throwing). **Dispose the returned solids** (e.g. via `using` / `[Symbol.dispose]`)
+ * when you own their lifetime — they are independent of the model
+ * (`BimModel[Symbol.dispose]` frees only the stored, unplaced `.geometry`). On any
+ * failure the solids already built for this call are disposed before the error is
+ * returned, so no partial array is leaked.
  *
- * Stairs carry no element solid (`.geometry` is null), so their flight solids are
- * built from `spec.flights` and placed per flight. Curtain walls are returned as
- * placed panels + mullions. Elements with no solid geometry (doors/windows/ramps/
- * groups/spatial) return an empty array. The unplaced `.geometry` is unchanged.
+ * Stairs carry no element solid (`.geometry` is null), so flight solids are built
+ * from `spec.flights` and placed per flight. Curtain walls return placed panels +
+ * mullions. Elements with no solid geometry (doors/windows/ramps/groups/spatial)
+ * return an empty array.
  */
-export function placedSolids(el: AnyBimElement): readonly ValidSolid[] {
+export function placedSolids(el: AnyBimElement): Result<readonly ValidSolid[], BimError> {
   switch (el.category) {
     case 'WALL':
     case 'SLAB':
@@ -36,30 +45,49 @@ export function placedSolids(el: AnyBimElement): readonly ValidSolid[] {
     case 'ROOF':
     case 'FOOTING':
     case 'PILE':
-    case 'RAILING':
-      return [place(el.geometry, el.spec)];
+    case 'RAILING': {
+      const placed = place(el.geometry, el.spec);
+      if (!placed.ok) return placed;
+      return ok([placed.value]);
+    }
     case 'STAIR': {
       const out: ValidSolid[] = [];
       for (const flight of el.spec.flights) {
         const built = stairFlightToSolid(flight);
         if (!built.ok) {
-          throw new Error(`placedSolids: stair flight geometry failed: ${built.error.message}`);
+          disposeAll(out);
+          return err(built.error);
         }
         using local = built.value.solid;
-        out.push(place(local, flight));
+        const placed = place(local, flight);
+        if (!placed.ok) {
+          disposeAll(out);
+          return placed;
+        }
+        out.push(placed.value);
       }
-      return out;
+      return ok(out);
     }
     case 'CURTAIN_WALL': {
       const out: ValidSolid[] = [];
       for (const c of [...el.geometry.panels, ...el.geometry.mullions]) {
         // Two-level: place by the component-local origin, then by the wall frame.
-        using componentLocal = place(c.solid, { origin: c.origin, axisX: [1, 0, 0], axisZ: [0, 0, 1] });
-        out.push(place(componentLocal, el.spec));
+        const componentLocal = place(c.solid, { origin: c.origin, axisX: [1, 0, 0], axisZ: [0, 0, 1] });
+        if (!componentLocal.ok) {
+          disposeAll(out);
+          return componentLocal;
+        }
+        using local = componentLocal.value;
+        const placed = place(local, el.spec);
+        if (!placed.ok) {
+          disposeAll(out);
+          return placed;
+        }
+        out.push(placed.value);
       }
-      return out;
+      return ok(out);
     }
     default:
-      return [];
+      return ok([]);
   }
 }

--- a/packages/brepjs-bim/src/elementFns/railingFns.ts
+++ b/packages/brepjs-bim/src/elementFns/railingFns.ts
@@ -1,15 +1,94 @@
-import { polygon, extrude, isValidSolid } from 'brepjs';
-import type { ValidSolid, Result } from 'brepjs';
+import { polygon, extrude, box, fuse, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result, Solid } from 'brepjs';
 import { ok, err } from 'brepjs';
 import type { RailingSpec } from '../specs/railingSpec.js';
 import type { BimError } from '../errors/bimError.js';
 import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
 
-// Returned solid is unplaced template geometry: a rectangular rail cross-section
-// (thickness × height) in the global YZ plane, swept (extruded) along +X by the
-// run length. A straight run sweeps the profile along a linear path, which is a
-// pure extrusion. origin/axisX/axisZ are applied by the IFC layer via
-// IfcLocalPlacement and are not embedded in this brepjs solid.
+// PANEL (default): a rectangular rail cross-section (thickness × height) in the
+// local YZ plane swept along +X by the run length — a single extrusion.
+function panelRailing(spec: RailingSpec): Result<ValidSolid, BimError> {
+  const { length, height, thickness } = spec;
+  const profileResult = polygon([
+    [0, 0, 0],
+    [0, thickness, 0],
+    [0, thickness, height],
+    [0, 0, height],
+  ]);
+  if (!profileResult.ok) {
+    return err(fromBrepError(profileResult.error, 'RAILING_PROFILE_FAILED', 'Failed to create railing profile'));
+  }
+  using profile = profileResult.value;
+  const solidResult = extrude(profile, [length, 0, 0]);
+  if (!solidResult.ok) {
+    return err(fromBrepError(solidResult.error, 'RAILING_EXTRUDE_FAILED', 'Failed to sweep railing profile'));
+  }
+  const solid = solidResult.value;
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(geometryError('RAILING_INVALID_SOLID', 'Swept railing solid failed validity check'));
+  }
+  return ok(solid);
+}
+
+// POSTED: vertical square posts (every ~1m) plus a top and bottom rail spanning
+// the run, all square bars of side `thickness`, fused into one solid. Every
+// intermediate box is disposed on success and on failure (mirrors the
+// curtainWallFns disposal discipline). Envelope matches PANEL: x∈[0,length],
+// y∈[0,thickness], z∈[0,height].
+function postedRailing(spec: RailingSpec): Result<ValidSolid, BimError> {
+  const { length, height, thickness: t } = spec;
+  const boxes: ValidSolid[] = [];
+
+  const postCount = Math.max(2, Math.round(length / 1000) + 1);
+  for (let i = 0; i < postCount; i++) {
+    const x = t / 2 + (length - t) * (i / (postCount - 1));
+    boxes.push(box(t, t, height, { at: [x, t / 2, height / 2], centered: true }));
+  }
+  for (const z of [height - t / 2, t / 2]) {
+    boxes.push(box(length, t, t, { at: [length / 2, t / 2, z], centered: true }));
+  }
+
+  // Fuse the bars pairwise (fuseAll's bundled .d.ts type is ambiguous/never; the
+  // 2-arg `fuse` is clean). `scratch` tracks every box and intermediate union so
+  // all are disposed; only the final survivor is kept.
+  const scratch: ValidSolid[] = [...boxes];
+  let acc: ValidSolid | undefined;
+  let failure: BimError | undefined;
+  for (const b of boxes) {
+    if (acc === undefined) {
+      acc = b;
+      continue;
+    }
+    const fused = fuse(acc, b);
+    if (!fused.ok) {
+      failure = fromBrepError(fused.error, 'RAILING_FUSE_FAILED', 'Failed to fuse railing parts');
+      break;
+    }
+    acc = fused.value;
+    scratch.push(acc);
+  }
+
+  const survivor = failure ? undefined : acc;
+  for (const s of scratch) {
+    if (s !== survivor) s[Symbol.dispose]();
+  }
+  if (failure) return err(failure);
+  if (survivor === undefined) {
+    return err(geometryError('RAILING_INVALID_SOLID', 'Posted railing produced no solid'));
+  }
+  // Widen to Solid so isValidSolid can narrow (survivor is statically ValidSolid).
+  const result: Solid = survivor;
+  if (!isValidSolid(result)) {
+    result[Symbol.dispose]();
+    return err(geometryError('RAILING_INVALID_SOLID', 'Posted railing solid failed validity check'));
+  }
+  return ok(result);
+}
+
+// Returned solid is unplaced template geometry in the local frame; origin/axisX/
+// axisZ are applied downstream (IFC writer / placedSolids accessor). `infill`
+// selects the geometry: PANEL (default, backward-compatible) or POSTED.
 export function railingToSolid(spec: RailingSpec): Result<ValidSolid, BimError> {
   if (spec.length <= 0) {
     return err(specError('RAILING_ZERO_LENGTH', 'Railing length must be positive'));
@@ -20,31 +99,5 @@ export function railingToSolid(spec: RailingSpec): Result<ValidSolid, BimError> 
   if (spec.thickness <= 0) {
     return err(specError('RAILING_ZERO_THICKNESS', 'Railing thickness must be positive'));
   }
-
-  const { length, height, thickness } = spec;
-
-  const profileResult = polygon([
-    [0, 0, 0],
-    [0, thickness, 0],
-    [0, thickness, height],
-    [0, 0, height],
-  ]);
-
-  if (!profileResult.ok) {
-    return err(fromBrepError(profileResult.error, 'RAILING_PROFILE_FAILED', 'Failed to create railing profile'));
-  }
-
-  using profile = profileResult.value;
-  const solidResult = extrude(profile, [length, 0, 0]);
-
-  if (!solidResult.ok) {
-    return err(fromBrepError(solidResult.error, 'RAILING_EXTRUDE_FAILED', 'Failed to sweep railing profile'));
-  }
-
-  const solid = solidResult.value;
-  if (!isValidSolid(solid)) {
-    solid[Symbol.dispose]();
-    return err(geometryError('RAILING_INVALID_SOLID', 'Swept railing solid failed validity check'));
-  }
-  return ok(solid);
+  return spec.infill === 'POSTED' ? postedRailing(spec) : panelRailing(spec);
 }

--- a/packages/brepjs-bim/src/elementFns/roofFns.ts
+++ b/packages/brepjs-bim/src/elementFns/roofFns.ts
@@ -133,6 +133,12 @@ function domeRoof(spec: RoofSpec): Result<ValidSolid, BimError> {
 // axisZ are applied downstream (IFC writer / placedSolids accessor). When `pitch`
 // is absent the roof is a flat slab regardless of predefinedType (backward-
 // compatible); when present the solid is shaped for the predefinedType.
+//
+// `thickness` is the slab/eave depth and is used by the FLAT, SHED and GABLE
+// builders (which extrude a profile of that depth). HIP and DOME are intentionally
+// solid masses filling the footprint from z=0 up to the apex — they have no slab
+// depth, so they do not consume `thickness` (it is still validated as positive for
+// a consistent spec).
 export function roofToSolid(spec: RoofSpec): Result<ValidSolid, BimError> {
   if (spec.length <= 0) return err(specError('ROOF_ZERO_LENGTH', 'Roof length must be positive'));
   if (spec.width <= 0) return err(specError('ROOF_ZERO_WIDTH', 'Roof width must be positive'));

--- a/packages/brepjs-bim/src/elementFns/roofFns.ts
+++ b/packages/brepjs-bim/src/elementFns/roofFns.ts
@@ -1,52 +1,142 @@
-import { polygon, extrude, isValidSolid } from 'brepjs';
-import type { ValidSolid, Result } from 'brepjs';
+import { polygon, extrude, sphere, box, cut, convexHull, isValidSolid } from 'brepjs';
+import type { ValidSolid, Result, Solid, Vec3 } from 'brepjs';
 import { ok, err } from 'brepjs';
 import type { RoofSpec } from '../specs/roofSpec.js';
 import type { BimError } from '../errors/bimError.js';
 import { specError, fromBrepError, geometryError } from '../errors/bimError.js';
 
-// Returned solid is unplaced template geometry: footprint rectangle in the
-// global XY plane (length × width), extruded along +Z by thickness.
-// origin/axisX/axisZ are applied by the IFC layer via IfcLocalPlacement.
-//
-// All predefined types produce a flat rectangular slab. For pitched/curved roof
-// shapes the slab is a simplified-but-valid envelope; `predefinedType` carries
-// the intended shape to IFC consumers.
-export function roofToSolid(spec: RoofSpec): Result<ValidSolid, BimError> {
-  if (spec.length <= 0) {
-    return err(specError('ROOF_ZERO_LENGTH', 'Roof length must be positive'));
-  }
-  if (spec.width <= 0) {
-    return err(specError('ROOF_ZERO_WIDTH', 'Roof width must be positive'));
-  }
-  if (spec.thickness <= 0) {
-    return err(specError('ROOF_ZERO_THICKNESS', 'Roof thickness must be positive'));
-  }
+const DEG2RAD = Math.PI / 180;
 
+// Validates a freshly-built solid, branding + owning it on success or disposing
+// + erroring on failure. Used for every roof shape because some upstream ops
+// (skeletonRoof's primary path, cut/revolve) return un-revalidated handles.
+function gate(solid: Solid, code: string): Result<ValidSolid, BimError> {
+  if (!isValidSolid(solid)) {
+    solid[Symbol.dispose]();
+    return err(geometryError(code, 'Roof solid failed validity check'));
+  }
+  return ok(solid);
+}
+
+// Flat slab (current behavior): length × width footprint extruded +Z by thickness.
+function flatRoof(spec: RoofSpec): Result<ValidSolid, BimError> {
   const { length, width, thickness } = spec;
-
-  const profileResult = polygon([
+  const face = polygon([
     [0, 0, 0],
     [length, 0, 0],
     [length, width, 0],
     [0, width, 0],
   ]);
+  if (!face.ok) return err(fromBrepError(face.error, 'ROOF_PROFILE_FAILED', 'Failed to create roof profile'));
+  using profile = face.value;
+  const solid = extrude(profile, [0, 0, thickness]);
+  if (!solid.ok) return err(fromBrepError(solid.error, 'ROOF_EXTRUDE_FAILED', 'Failed to extrude roof profile'));
+  return gate(solid.value, 'ROOF_INVALID_SOLID');
+}
 
-  if (!profileResult.ok) {
-    return err(fromBrepError(profileResult.error, 'ROOF_PROFILE_FAILED', 'Failed to create roof profile'));
+// Shed: a right-trapezoid in the local Y-Z plane swept +X by length.
+function shedRoof(spec: RoofSpec, pitch: number): Result<ValidSolid, BimError> {
+  const { length, width, thickness } = spec;
+  const rise = width * Math.tan(pitch * DEG2RAD);
+  const face = polygon([
+    [0, 0, 0],
+    [0, width, 0],
+    [0, width, thickness + rise],
+    [0, 0, thickness],
+  ]);
+  if (!face.ok) return err(fromBrepError(face.error, 'ROOF_PROFILE_FAILED', 'Failed to create shed profile'));
+  using profile = face.value;
+  const solid = extrude(profile, [length, 0, 0]);
+  if (!solid.ok) return err(fromBrepError(solid.error, 'ROOF_EXTRUDE_FAILED', 'Failed to extrude shed roof'));
+  return gate(solid.value, 'ROOF_INVALID_SOLID');
+}
+
+// Gable: a house-pentagon in the local Y-Z plane swept +X by length.
+function gableRoof(spec: RoofSpec, pitch: number): Result<ValidSolid, BimError> {
+  const { length, width, thickness } = spec;
+  const ridge = (width / 2) * Math.tan(pitch * DEG2RAD);
+  const face = polygon([
+    [0, 0, 0],
+    [0, width, 0],
+    [0, width, thickness],
+    [0, width / 2, thickness + ridge],
+    [0, 0, thickness],
+  ]);
+  if (!face.ok) return err(fromBrepError(face.error, 'ROOF_PROFILE_FAILED', 'Failed to create gable profile'));
+  using profile = face.value;
+  const solid = extrude(profile, [length, 0, 0]);
+  if (!solid.ok) return err(fromBrepError(solid.error, 'ROOF_EXTRUDE_FAILED', 'Failed to extrude gable roof'));
+  return gate(solid.value, 'ROOF_INVALID_SOLID');
+}
+
+// Hip: a hip roof over a rectangle is a convex solid, so the convex hull of the
+// four base corners plus the two ridge endpoints reconstructs it exactly as a
+// genuine closed solid. (Core roof() returns an open shell under occt-wasm, so
+// it is not usable for a measurable IfcRoof body.) The ridge runs along the
+// longer side, inset from each end by half the shorter side; a square footprint
+// collapses the ridge to a single apex (a pyramid), still a valid hull.
+function hipRoof(spec: RoofSpec, pitch: number): Result<ValidSolid, BimError> {
+  const { length: l, width: w } = spec;
+  const tan = Math.tan(pitch * DEG2RAD);
+  const base: Vec3[] = [
+    [0, 0, 0],
+    [l, 0, 0],
+    [l, w, 0],
+    [0, w, 0],
+  ];
+  let ridge: Vec3[];
+  if (l >= w) {
+    const h = (w / 2) * tan;
+    ridge = [
+      [w / 2, w / 2, h],
+      [l - w / 2, w / 2, h],
+    ];
+  } else {
+    const h = (l / 2) * tan;
+    ridge = [
+      [l / 2, l / 2, h],
+      [l / 2, w - l / 2, h],
+    ];
   }
+  const solid = convexHull([...base, ...ridge]);
+  if (!solid.ok) return err(fromBrepError(solid.error, 'ROOF_HIP_FAILED', 'Failed to build hip roof'));
+  return gate(solid.value, 'ROOF_INVALID_SOLID');
+}
 
-  using profile = profileResult.value;
-  const solidResult = extrude(profile, [0, 0, thickness]);
+// Dome: a hemisphere of radius min(L,W)/2 centred on the footprint, lower half cut.
+function domeRoof(spec: RoofSpec): Result<ValidSolid, BimError> {
+  const { length, width } = spec;
+  const r = Math.min(length, width) / 2;
+  using ball = sphere(r, { at: [length / 2, width / 2, 0] });
+  using cutter = box(length * 3, width * 3, r, {
+    at: [length / 2, width / 2, -r / 2],
+    centered: true,
+  });
+  const solid = cut(ball, cutter);
+  if (!solid.ok) return err(fromBrepError(solid.error, 'ROOF_DOME_FAILED', 'Failed to build dome roof'));
+  return gate(solid.value, 'ROOF_INVALID_SOLID');
+}
 
-  if (!solidResult.ok) {
-    return err(fromBrepError(solidResult.error, 'ROOF_EXTRUDE_FAILED', 'Failed to extrude roof profile'));
+// Returned solid is unplaced template geometry in the local frame; origin/axisX/
+// axisZ are applied downstream (IFC writer / placedSolids accessor). When `pitch`
+// is absent the roof is a flat slab regardless of predefinedType (backward-
+// compatible); when present the solid is shaped for the predefinedType.
+export function roofToSolid(spec: RoofSpec): Result<ValidSolid, BimError> {
+  if (spec.length <= 0) return err(specError('ROOF_ZERO_LENGTH', 'Roof length must be positive'));
+  if (spec.width <= 0) return err(specError('ROOF_ZERO_WIDTH', 'Roof width must be positive'));
+  if (spec.thickness <= 0) return err(specError('ROOF_ZERO_THICKNESS', 'Roof thickness must be positive'));
+
+  if (spec.pitch === undefined) return flatRoof(spec);
+  switch (spec.predefinedType) {
+    case 'SHED_ROOF':
+      return shedRoof(spec, spec.pitch);
+    case 'GABLE_ROOF':
+      return gableRoof(spec, spec.pitch);
+    case 'HIP_ROOF':
+      return hipRoof(spec, spec.pitch);
+    case 'DOME_ROOF':
+      return domeRoof(spec);
+    default:
+      return flatRoof(spec);
   }
-
-  const solid = solidResult.value;
-  if (!isValidSolid(solid)) {
-    solid[Symbol.dispose]();
-    return err(geometryError('ROOF_INVALID_SOLID', 'Extruded roof solid failed validity check'));
-  }
-  return ok(solid);
 }

--- a/packages/brepjs-bim/src/elementFns/roofFns.ts
+++ b/packages/brepjs-bim/src/elementFns/roofFns.ts
@@ -1,4 +1,4 @@
-import { polygon, extrude, sphere, box, cut, convexHull, isValidSolid } from 'brepjs';
+import { polygon, extrude, convexHull, isValidSolid } from 'brepjs';
 import type { ValidSolid, Result, Solid, Vec3 } from 'brepjs';
 import { ok, err } from 'brepjs';
 import type { RoofSpec } from '../specs/roofSpec.js';
@@ -103,16 +103,28 @@ function hipRoof(spec: RoofSpec, pitch: number): Result<ValidSolid, BimError> {
   return gate(solid.value, 'ROOF_INVALID_SOLID');
 }
 
-// Dome: a hemisphere of radius min(L,W)/2 centred on the footprint, lower half cut.
+// Dome: a faceted hemisphere — the convex hull of points sampled on a hemisphere
+// of radius min(L,W)/2 centred on the footprint. A boolean sphere∩box produces a
+// solid whose spherical surface HANGS the occt-wasm mesher, so the dome is built
+// from planar facets (like the hip) to mesh reliably.
 function domeRoof(spec: RoofSpec): Result<ValidSolid, BimError> {
   const { length, width } = spec;
   const r = Math.min(length, width) / 2;
-  using ball = sphere(r, { at: [length / 2, width / 2, 0] });
-  using cutter = box(length * 3, width * 3, r, {
-    at: [length / 2, width / 2, -r / 2],
-    centered: true,
-  });
-  const solid = cut(ball, cutter);
+  const cx = length / 2;
+  const cy = width / 2;
+  const segments = 24;
+  const rings = [0, 0.4, 0.7, 0.9];
+  const pts: Vec3[] = [];
+  for (const h of rings) {
+    const z = r * h;
+    const ringR = r * Math.sqrt(1 - h * h);
+    for (let i = 0; i < segments; i++) {
+      const a = (2 * Math.PI * i) / segments;
+      pts.push([cx + ringR * Math.cos(a), cy + ringR * Math.sin(a), z]);
+    }
+  }
+  pts.push([cx, cy, r]);
+  const solid = convexHull(pts);
   if (!solid.ok) return err(fromBrepError(solid.error, 'ROOF_DOME_FAILED', 'Failed to build dome roof'));
   return gate(solid.value, 'ROOF_INVALID_SOLID');
 }

--- a/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/geometryWriter.ts
@@ -1,7 +1,8 @@
 import * as WebIFC from 'web-ifc';
+import type { ValidSolid } from 'brepjs';
 import type { IfcWriter } from './ifcWriter.js';
 import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
-import { writeWallAxisRepresentation } from './tessellationWriter.js';
+import { writeWallAxisRepresentation, writeTessellation } from './tessellationWriter.js';
 import type { WallSpec } from '../specs/wallSpec.js';
 import type { SlabSpec } from '../specs/slabSpec.js';
 import type { BeamSpec } from '../specs/beamSpec.js';
@@ -193,15 +194,19 @@ export function writeSlabGeometry(
   return { localPlacementId, productDefinitionShapeId };
 }
 
-// Roof geometry mirrors a flat slab: a centred rectangle profile (length ×
-// width) extruded along local +Z by thickness. predefinedType carries the
-// intended roof shape to IFC consumers; the body is a flat slab regardless.
+// A flat roof (no `spec.pitch`) is a centred rectangle profile (length × width)
+// extruded along local +Z by thickness — a parametric IfcExtrudedAreaSolid. A
+// shaped roof (pitch set → shed/gable/hip/dome) cannot be a single extrusion, so
+// its body is the tessellated `solid` (IfcTriangulatedFaceSet). Either way
+// `predefinedType` records the intended shape for IFC consumers. `usedFallback`
+// is true only when tessellation failed and a degenerate brep was emitted.
 export function writeRoofGeometry(
   w: IfcWriter,
   spec: RoofSpec,
+  solid: ValidSolid,
   geomSubContextId: number,
   parentPlacementId: number | null
-): SlabRepresentationIds {
+): SlabRepresentationIds & { usedFallback: boolean } {
   const placement3DId = writeAxis2Placement3D(
     w,
     spec.origin.map(toIfcLengthM) as [number, number, number],
@@ -216,6 +221,17 @@ export function writeRoofGeometry(
     PlacementRelTo: parentPlacementId !== null ? w.ref(parentPlacementId) : null,
     RelativePlacement: w.ref(placement3DId),
   });
+
+  // Shaped roof → tessellate the real solid (the placement is carried by the
+  // owning product, so writeTessellation ignores localPlacementId).
+  if (spec.pitch !== undefined) {
+    const tess = writeTessellation(w, solid, geomSubContextId, localPlacementId);
+    return {
+      localPlacementId,
+      productDefinitionShapeId: tess.productDefinitionShapeId,
+      usedFallback: tess.usedFallback,
+    };
+  }
 
   const lengthM = toIfcLengthM(spec.length);
   const widthM = toIfcLengthM(spec.width);
@@ -280,7 +296,7 @@ export function writeRoofGeometry(
     Representations: [w.ref(shapeRepId)],
   });
 
-  return { localPlacementId, productDefinitionShapeId };
+  return { localPlacementId, productDefinitionShapeId, usedFallback: false };
 }
 
 function writeAxis2Placement2D(w: IfcWriter): number {

--- a/packages/brepjs-bim/src/ifc-writer/railingWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/railingWriter.ts
@@ -1,15 +1,22 @@
 import * as WebIFC from 'web-ifc';
+import type { ValidSolid } from 'brepjs';
 import type { IfcWriter } from './ifcWriter.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import { writeAxis2Placement3D, writeDirection } from './headerWriter.js';
+import { writeTessellation } from './tessellationWriter.js';
 import { toIfcLengthM } from '../units/units.js';
 import type { RailingSpec, RailingPredefinedType } from '../specs/railingSpec.js';
 
 export interface RailingRepresentationIds {
   localPlacementId: number;
   productDefinitionShapeId: number;
-  /** Express ID of the body representation item (the extrusion), for styling. */
-  bodyItemId: number;
+  /**
+   * Express ID of the body representation item (the swept extrusion) for surface
+   * styling, or null for a tessellated POSTED railing (no single styleable item).
+   */
+  bodyItemId: number | null;
+  /** True when tessellation fell back to a degenerate brep. */
+  usedFallback: boolean;
 }
 
 // Emits IfcLocalPlacement + IfcRectangleProfileDef + IfcExtrudedAreaSolid +
@@ -20,6 +27,7 @@ export interface RailingRepresentationIds {
 export function writeRailingGeometry(
   w: IfcWriter,
   spec: RailingSpec,
+  solid: ValidSolid,
   geomSubContextId: number,
   parentPlacementId: number | null
 ): RailingRepresentationIds {
@@ -37,6 +45,18 @@ export function writeRailingGeometry(
     PlacementRelTo: parentPlacementId !== null ? w.ref(parentPlacementId) : null,
     RelativePlacement: w.ref(placement3DId),
   });
+
+  // POSTED railing → tessellate the real posts+rails solid. There is no single
+  // styleable body item, so bodyItemId is null (POSTED carries no surface style).
+  if (spec.infill === 'POSTED') {
+    const tess = writeTessellation(w, solid, geomSubContextId, localPlacementId);
+    return {
+      localPlacementId,
+      productDefinitionShapeId: tess.productDefinitionShapeId,
+      bodyItemId: null,
+      usedFallback: tess.usedFallback,
+    };
+  }
 
   const thicknessM = toIfcLengthM(spec.thickness);
   const heightM = toIfcLengthM(spec.height);
@@ -102,7 +122,7 @@ export function writeRailingGeometry(
     Representations: [w.ref(shapeRepId)],
   });
 
-  return { localPlacementId, productDefinitionShapeId, bodyItemId: extrusionId };
+  return { localPlacementId, productDefinitionShapeId, bodyItemId: extrusionId, usedFallback: false };
 }
 
 export function writeRailingEntity(

--- a/packages/brepjs-bim/src/import/placement.ts
+++ b/packages/brepjs-bim/src/import/placement.ts
@@ -1,4 +1,5 @@
 import * as WebIFC from 'web-ifc';
+import type { MatrixTransform } from 'brepjs';
 import type { SpfReader } from './spfReader.js';
 
 /**
@@ -253,6 +254,39 @@ export function readAxis2Placement3D(
     z[0], z[1], z[2], 0,
     originMm[0], originMm[1], originMm[2], 1,
   ];
+}
+
+/** An (origin, axisX, axisZ) frame in mm — the authoring/display side of a placement. */
+export interface FrameInput {
+  readonly origin: Vec3;
+  readonly axisX: Vec3;
+  readonly axisZ: Vec3;
+}
+
+/**
+ * Builds a row-major MatrixTransform (for brepjs `applyMatrix`) from an
+ * (origin, axisX, axisZ) frame, using the SAME IFC orthonormalization as
+ * {@link readAxis2Placement3D}: z = normalize(axisZ); x = normalize(axisX
+ * projected onto the plane ⊥ z); y = z × x. The basis vectors are the matrix
+ * columns, so the row-major linear array is [Xx,Yx,Zx, Xy,Yy,Zy, Xz,Yz,Zz];
+ * translation = origin (mm). This is the display-side counterpart to the IFC
+ * writer's Axis2Placement3D (Axis=Z, RefDirection=X) so on-screen placement and
+ * the IFC export agree.
+ */
+export function placementToMatrix(f: FrameInput): MatrixTransform {
+  const z = normalize(f.axisZ);
+  const dot = z[0] * f.axisX[0] + z[1] * f.axisX[1] + z[2] * f.axisX[2];
+  const projX: Vec3 = [
+    f.axisX[0] - dot * z[0],
+    f.axisX[1] - dot * z[1],
+    f.axisX[2] - dot * z[2],
+  ];
+  const x = lengthSq(projX) < 1e-12 ? normalize(orthogonal(z)) : normalize(projX);
+  const y = cross(z, x);
+  return {
+    linear: [x[0], y[0], z[0], x[1], y[1], z[1], x[2], y[2], z[2]],
+    translation: [f.origin[0], f.origin[1], f.origin[2]],
+  };
 }
 
 /** Decomposes a column-major matrix into origin (mm) + IFC axes (Z, X). */

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -1,5 +1,6 @@
 export { BimModel } from './model/bimModel.js';
 export type { BimTreeNode, BimTreeSummary } from './model/treeSummary.js';
+export { placedSolids } from './elementFns/placedGeometry.js';
 export { toIfc, toIfcValidated } from './serialize/toIfc.js';
 export type { ValidatedIfcResult } from './serialize/toIfc.js';
 export { setIfcWasmLocateFile } from './ifcRuntime.js';

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -353,9 +353,12 @@ export async function toIfc(
   for (const [i, roof] of roofs.entries()) {
     const containingId = findContainerOf(roof.localId, relationships);
     const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
-    const { localPlacementId, productDefinitionShapeId } = writeRoofGeometry(
-      w, roof.spec, geomSubContextId, storeyPlacementId
+    const { localPlacementId, productDefinitionShapeId, usedFallback } = writeRoofGeometry(
+      w, roof.spec, roof.geometry, geomSubContextId, storeyPlacementId
     );
+    if (usedFallback) {
+      console.warn(`Roof ${i + 1} tessellation failed; IFC body is a degenerate fallback.`);
+    }
     const roofExpressId = writeRoofEntity(
       w, roof.guid, `Roof ${i + 1}`, roof.spec.predefinedType,
       ownerHistoryId, localPlacementId, productDefinitionShapeId

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -484,9 +484,11 @@ export async function toIfc(
   for (const [i, railing] of railings.entries()) {
     const containingId = findContainerOf(railing.localId, relationships);
     const storeyPlacementId = containingId !== null ? (placementMap.get(containingId) ?? null) : null;
-    const { localPlacementId, productDefinitionShapeId, bodyItemId } = writeRailingGeometry(
-      w, railing.spec, geomSubContextId, storeyPlacementId
-    );
+    const { localPlacementId, productDefinitionShapeId, bodyItemId, usedFallback } =
+      writeRailingGeometry(w, railing.spec, railing.geometry, geomSubContextId, storeyPlacementId);
+    if (usedFallback) {
+      console.warn(`Railing ${i + 1} tessellation failed; IFC body is a degenerate fallback.`);
+    }
     const railingExpressId = writeRailingEntity(
       w, railing.guid, `Railing ${i + 1}`, railing.spec.predefinedType ?? 'NOTDEFINED',
       ownerHistoryId, localPlacementId, productDefinitionShapeId
@@ -498,7 +500,8 @@ export async function toIfc(
     if (railing.spec.customProperties !== undefined) {
       writeCustomPsets(w, ownerHistoryId, railingExpressId, railing.spec.customProperties);
     }
-    applySurfaceStyle(w, model, railing.localId, bodyItemId);
+    // POSTED railings tessellate and have no single styleable body item.
+    if (bodyItemId !== null) applySurfaceStyle(w, model, railing.localId, bodyItemId);
   }
 
   for (const [i, covering] of coverings.entries()) {

--- a/packages/brepjs-bim/src/specs/railingSpec.ts
+++ b/packages/brepjs-bim/src/specs/railingSpec.ts
@@ -25,6 +25,13 @@ export interface RailingSpec {
   readonly predefinedType?: RailingPredefinedType | undefined;
   readonly materialName: string;
 
+  /**
+   * Geometric infill style. 'PANEL' (default) is a single swept panel; 'POSTED'
+   * is vertical posts plus top & bottom rails. Orthogonal to `predefinedType`
+   * (which is the IFC usage role, not a geometry descriptor).
+   */
+  readonly infill?: 'PANEL' | 'POSTED' | undefined;
+
   readonly isExternal?: boolean | undefined;
   readonly fireRating?: string | undefined;
   readonly status?: string | undefined;
@@ -56,6 +63,7 @@ const RailingSpecSchema = z.object({
   axisX: unitVec,
   axisZ: unitVec,
   predefinedType: z.enum(['BALUSTRADE', 'GUARDRAIL', 'HANDRAIL', 'NOTDEFINED']).optional(),
+  infill: z.enum(['PANEL', 'POSTED']).optional(),
   materialName: z.string().min(1),
 
   isExternal: z.boolean().optional(),

--- a/packages/brepjs-bim/src/specs/roofSpec.ts
+++ b/packages/brepjs-bim/src/specs/roofSpec.ts
@@ -44,6 +44,14 @@ export interface RoofSpec {
   readonly status?: string | undefined;
 
   /**
+   * Optional roof slope in degrees (0 < pitch < 90). Its PRESENCE opts the roof
+   * into shaped geometry built for `predefinedType` (shed/gable/hip/dome); when
+   * absent the roof is a flat slab regardless of predefinedType (backward-
+   * compatible). Ignored geometrically for DOME_ROOF (a hemisphere).
+   */
+  readonly pitch?: number | undefined;
+
+  /**
    * When present, the roof is associated via a layered IfcMaterialLayerSet built
    * from these layers instead of the bare `materialName` IfcMaterial.
    */
@@ -98,6 +106,7 @@ const RoofSpecSchema = z.object({
   fireRating: z.string().optional(),
   thermalTransmittance: z.number().positive().optional(),
   status: z.string().optional(),
+  pitch: z.number().positive().max(89).optional(),
 
   materialLayers: z.array(MaterialLayerSchema).optional(),
   layerSetName: z.string().optional(),

--- a/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
+++ b/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
@@ -55,3 +55,34 @@ describe('roof IFC representation', () => {
     expect(txt).toContain('IFCEXTRUDEDAREASOLID');
   });
 });
+
+const railBase = {
+  length: 2000,
+  height: 1000,
+  thickness: 50,
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+  predefinedType: 'GUARDRAIL' as const,
+  materialName: 'Steel',
+};
+
+describe('railing IFC representation', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  it('POSTED railing serializes as a Tessellation', async () => {
+    const txt = await ifcText((m) => {
+      unwrap(m.addRailing({ ...railBase, infill: 'POSTED' }));
+    });
+    expect(txt).toContain('IFCTRIANGULATEDFACESET');
+  });
+
+  it('PANEL railing keeps the parametric SweptSolid', async () => {
+    const txt = await ifcText((m) => {
+      unwrap(m.addRailing({ ...railBase }));
+    });
+    expect(txt).toContain('IFCEXTRUDEDAREASOLID');
+  });
+});

--- a/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
+++ b/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { unwrap } from 'brepjs';
+import { initOCCT } from '../../../tests/setup.js';
+import { BimModel } from '../src/model/bimModel.js';
+import { toIfc } from '../src/serialize/toIfc.js';
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+// Builds a minimal valid model (project→site→building→storey), runs the caller's
+// element setup, serializes to IFC, and returns the SPF text.
+async function ifcText(build: (m: BimModel) => void): Promise<string> {
+  const m = new BimModel();
+  m.init({ name: 'T' });
+  const site = m.addSite({ name: 'S' });
+  const bld = m.addBuilding({ name: 'B' });
+  const st = m.addStorey({ name: 'L', elevation: 0 });
+  const p = m.getProject();
+  if (p) m.aggregate(p.localId, site);
+  m.aggregate(site, bld);
+  m.aggregate(bld, st);
+  build(m);
+  const r = await toIfc(m, { applicationName: 'test', applicationVersion: '1' });
+  return decode(unwrap(r));
+}
+
+const roofBase = {
+  length: 4000,
+  width: 3000,
+  thickness: 200,
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+  materialName: 'Tile',
+};
+
+describe('roof IFC representation', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  it('shaped roof serializes as a Tessellation, not a degenerate brep', async () => {
+    const txt = await ifcText((m) => {
+      unwrap(m.addRoof({ ...roofBase, predefinedType: 'GABLE_ROOF', pitch: 30 }));
+    });
+    expect(txt).toContain('IFCTRIANGULATEDFACESET');
+    expect(txt).not.toContain('IFCFACETEDBREP'); // the degenerate mesh-failure fallback
+  });
+
+  it('flat roof keeps the parametric SweptSolid (no regression)', async () => {
+    const txt = await ifcText((m) => {
+      unwrap(m.addRoof({ ...roofBase, predefinedType: 'FLAT_ROOF' }));
+    });
+    expect(txt).toContain('IFCEXTRUDEDAREASOLID');
+  });
+});

--- a/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
+++ b/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { unwrap } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
-import { toIfc } from '../src/serialize/toIfc.js';
+import { toIfc, toIfcValidated } from '../src/serialize/toIfc.js';
+import { hasErrors } from '../src/validation/severity.js';
 
 function decode(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes);
@@ -84,5 +85,50 @@ describe('railing IFC representation', () => {
       unwrap(m.addRailing({ ...railBase }));
     });
     expect(txt).toContain('IFCEXTRUDEDAREASOLID');
+  });
+});
+
+describe('shaped model round-trips cleanly', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  it('shaped roof + posted railing + stair → no error-severity IFC issues', async () => {
+    const m = new BimModel();
+    m.init({ name: 'Validity' });
+    const site = m.addSite({ name: 'S' });
+    const bld = m.addBuilding({ name: 'B' });
+    const st = m.addStorey({ name: 'L', elevation: 0 });
+    const p = m.getProject();
+    if (p) m.aggregate(p.localId, site);
+    m.aggregate(site, bld);
+    m.aggregate(bld, st);
+    const roof = unwrap(
+      m.addRoof({
+        length: 4000, width: 3000, thickness: 200, origin: [0, 0, 0],
+        axisX: [1, 0, 0], axisZ: [0, 0, 1], predefinedType: 'HIP_ROOF', pitch: 35, materialName: 'Tile',
+      })
+    );
+    m.placeIn(roof, st);
+    const rail = unwrap(
+      m.addRailing({
+        length: 2000, height: 1000, thickness: 50, origin: [0, 0, 0],
+        axisX: [1, 0, 0], axisZ: [0, 0, 1], predefinedType: 'GUARDRAIL', infill: 'POSTED', materialName: 'Steel',
+      })
+    );
+    m.placeIn(rail, st);
+    const stair = unwrap(
+      m.addStair({
+        flights: [{
+          width: 1000, riserHeight: 175, treadLength: 250, numberOfRisers: 10,
+          origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1], materialName: 'Concrete',
+        }],
+        materialName: 'Concrete',
+      })
+    );
+    m.placeIn(stair, st);
+    const res = await toIfcValidated(m, { applicationName: 'test', applicationVersion: '1' });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(hasErrors(res.value.report)).toBe(false);
   });
 });

--- a/packages/brepjs-bim/tests/placedGeometry.test.ts
+++ b/packages/brepjs-bim/tests/placedGeometry.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { measureVolumeProps, isValidSolid, unwrap } from 'brepjs';
+import { initOCCT } from '../../../tests/setup.js';
+import { BimModel } from '../src/model/bimModel.js';
+import { placementToMatrix } from '../src/import/placement.js';
+import { placedSolids } from '../src/elementFns/placedGeometry.js';
+
+describe('placementToMatrix', () => {
+  it('identity frame → identity linear + given origin', () => {
+    const m = placementToMatrix({ origin: [10, 20, 30], axisX: [1, 0, 0], axisZ: [0, 0, 1] });
+    expect(m.linear).toEqual([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    expect(m.translation).toEqual([10, 20, 30]);
+  });
+
+  it('90° about Z (axisX=+Y) puts the X basis vector in column 0 (row-major)', () => {
+    // linear is row-major [Xx,Yx,Zx, Xy,Yy,Zy, Xz,Yz,Zz]; with axisX=(0,1,0) the
+    // X column is (0,1,0) → linear[0]=0, linear[3]=1, linear[6]=0.
+    const m = placementToMatrix({ origin: [0, 0, 0], axisX: [0, 1, 0], axisZ: [0, 0, 1] });
+    expect(m.linear[0]).toBeCloseTo(0);
+    expect(m.linear[3]).toBeCloseTo(1);
+    expect(m.linear[6]).toBeCloseTo(0);
+  });
+});
+
+describe('placedSolids', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  it('places a solid element at its world origin (centroid shifts by origin)', () => {
+    const m = new BimModel();
+    m.init({ name: 'T' });
+    unwrap(
+      m.addBeam({
+        length: 1000,
+        profile: { kind: 'RECTANGULAR', width: 100, height: 100 },
+        origin: [500, 0, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        materialName: 'Steel',
+      })
+    );
+    const beam = m.getBeams()[0];
+    const local = beam.geometry;
+    const placed = placedSolids(beam);
+    expect(placed.length).toBe(1);
+    const localCoM = unwrap(measureVolumeProps(local)).centerOfMass;
+    const placedCoM = unwrap(measureVolumeProps(placed[0])).centerOfMass;
+    // identity rotation + origin [500,0,0] → centroid shifts by exactly [500,0,0].
+    expect(placedCoM[0] - localCoM[0]).toBeCloseTo(500, 1);
+    expect(placedCoM[1] - localCoM[1]).toBeCloseTo(0, 1);
+    expect(placedCoM[2] - localCoM[2]).toBeCloseTo(0, 1);
+    for (const s of placed) s[Symbol.dispose]();
+  });
+
+  it('returns N placed flight solids for a stair (whose .geometry is null)', () => {
+    const m = new BimModel();
+    m.init({ name: 'T' });
+    const flight = {
+      width: 1000,
+      riserHeight: 175,
+      treadLength: 250,
+      numberOfRisers: 10,
+      origin: [0, 0, 0] as [number, number, number],
+      axisX: [1, 0, 0] as [number, number, number],
+      axisZ: [0, 0, 1] as [number, number, number],
+      materialName: 'Concrete',
+    };
+    unwrap(
+      m.addStair({
+        flights: [flight, { ...flight, origin: [2500, 0, 1750] }],
+        materialName: 'Concrete',
+      })
+    );
+    const placed = placedSolids(m.getStairs()[0]);
+    expect(placed.length).toBe(2);
+    for (const s of placed) expect(isValidSolid(s)).toBe(true);
+    for (const s of placed) s[Symbol.dispose]();
+  });
+});

--- a/packages/brepjs-bim/tests/placedGeometry.test.ts
+++ b/packages/brepjs-bim/tests/placedGeometry.test.ts
@@ -42,7 +42,7 @@ describe('placedSolids', () => {
     );
     const beam = m.getBeams()[0];
     const local = beam.geometry;
-    const placed = placedSolids(beam);
+    const placed = unwrap(placedSolids(beam));
     expect(placed.length).toBe(1);
     const localCoM = unwrap(measureVolumeProps(local)).centerOfMass;
     const placedCoM = unwrap(measureVolumeProps(placed[0])).centerOfMass;
@@ -72,7 +72,7 @@ describe('placedSolids', () => {
         materialName: 'Concrete',
       })
     );
-    const placed = placedSolids(m.getStairs()[0]);
+    const placed = unwrap(placedSolids(m.getStairs()[0]));
     expect(placed.length).toBe(2);
     for (const s of placed) expect(isValidSolid(s)).toBe(true);
     for (const s of placed) s[Symbol.dispose]();

--- a/packages/brepjs-bim/tests/railingInfill.test.ts
+++ b/packages/brepjs-bim/tests/railingInfill.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { measureVolume, isValidSolid, unwrap } from 'brepjs';
+import { initOCCT } from '../../../tests/setup.js';
+import { parseRailingSpec } from '../src/specs/railingSpec.js';
+import { railingToSolid } from '../src/elementFns/railingFns.js';
+
+const base = {
+  length: 2000,
+  height: 1000,
+  thickness: 50,
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+  predefinedType: 'GUARDRAIL' as const,
+  materialName: 'Steel',
+};
+
+describe('railingSpec infill', () => {
+  it('defaults to undefined (PANEL behavior) when omitted', () => {
+    const r = parseRailingSpec(base);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.infill).toBeUndefined();
+  });
+
+  it('accepts POSTED', () => {
+    const r = parseRailingSpec({ ...base, infill: 'POSTED' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.infill).toBe('POSTED');
+  });
+
+  it('rejects an unknown infill', () => {
+    expect(parseRailingSpec({ ...base, infill: 'GLASS' }).ok).toBe(false);
+  });
+});
+
+describe('railingToSolid infill geometry', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  it('PANEL (default) builds one valid solid', () => {
+    using solid = unwrap(railingToSolid({ ...base }));
+    expect(isValidSolid(solid)).toBe(true);
+  });
+
+  it('POSTED builds a valid solid lighter than the full panel', () => {
+    using panel = unwrap(railingToSolid({ ...base }));
+    using posted = unwrap(railingToSolid({ ...base, infill: 'POSTED' }));
+    expect(isValidSolid(posted)).toBe(true);
+    const vPanel = unwrap(measureVolume(panel));
+    const vPosted = unwrap(measureVolume(posted));
+    expect(vPosted).toBeGreaterThan(0);
+    // Posts + two rails are far lighter than a solid panel of the same envelope.
+    expect(vPosted).toBeLessThan(vPanel);
+  });
+});

--- a/packages/brepjs-bim/tests/roofShapes.test.ts
+++ b/packages/brepjs-bim/tests/roofShapes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
-import { measureVolume, isValidSolid, unwrap } from 'brepjs';
+import { measureVolume, isValidSolid, unwrap, mesh } from 'brepjs';
 import { parseRoofSpec } from '../src/specs/roofSpec.js';
 import { roofToSolid } from '../src/elementFns/roofFns.js';
 
@@ -62,6 +62,9 @@ describe('roofToSolid shapes', () => {
       expect(vShaped).toBeGreaterThan(0);
       // Shaping must change the volume; identical volume means it stayed a flat box.
       expect(Math.abs(vShaped - vFlat)).toBeGreaterThan(1);
+      // Must mesh (the playground/IFC tessellate it) — guards against a curved
+      // surface that hangs the occt-wasm mesher (e.g. a sphere-based dome).
+      expect(mesh(shapedSolid).triangles.length).toBeGreaterThan(0);
     });
   }
 });

--- a/packages/brepjs-bim/tests/roofShapes.test.ts
+++ b/packages/brepjs-bim/tests/roofShapes.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { measureVolume, isValidSolid, unwrap } from 'brepjs';
+import { parseRoofSpec } from '../src/specs/roofSpec.js';
+import { roofToSolid } from '../src/elementFns/roofFns.js';
+
+const base = {
+  length: 4000,
+  width: 3000,
+  thickness: 200,
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+  predefinedType: 'GABLE_ROOF' as const,
+  materialName: 'Tile',
+};
+
+describe('roofSpec pitch param', () => {
+  it('accepts an optional pitch and preserves it', () => {
+    const r = parseRoofSpec({ ...base, pitch: 30 });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.pitch).toBe(30);
+  });
+
+  it('parses without pitch (backward-compatible)', () => {
+    const r = parseRoofSpec(base);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.pitch).toBeUndefined();
+  });
+
+  it('rejects a non-positive or >=90 pitch', () => {
+    expect(parseRoofSpec({ ...base, pitch: 0 }).ok).toBe(false);
+    expect(parseRoofSpec({ ...base, pitch: 90 }).ok).toBe(false);
+  });
+});
+
+describe('roofToSolid shapes', () => {
+  beforeAll(async () => {
+    await initOCCT();
+  }, 30000);
+
+  it('flat (no pitch) stays a valid slab', () => {
+    const r = roofToSolid({ ...base, predefinedType: 'FLAT_ROOF' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      using s = r.value;
+      expect(isValidSolid(s)).toBe(true);
+    }
+  });
+
+  for (const t of ['SHED_ROOF', 'GABLE_ROOF', 'HIP_ROOF', 'DOME_ROOF'] as const) {
+    it(`${t} with pitch produces a valid solid whose volume differs from the flat slab`, () => {
+      const flat = roofToSolid({ ...base, predefinedType: t });
+      const shaped = roofToSolid({ ...base, predefinedType: t, pitch: 30 });
+      expect(flat.ok && shaped.ok).toBe(true);
+      if (!flat.ok || !shaped.ok) return;
+      using flatSolid = flat.value;
+      using shapedSolid = shaped.value;
+      expect(isValidSolid(shapedSolid)).toBe(true);
+      const vFlat = unwrap(measureVolume(flatSolid));
+      const vShaped = unwrap(measureVolume(shapedSolid));
+      expect(vShaped).toBeGreaterThan(0);
+      // Shaping must change the volume; identical volume means it stayed a flat box.
+      expect(Math.abs(vShaped - vFlat)).toBeGreaterThan(1);
+    });
+  }
+});


### PR DESCRIPTION
Geometry-fidelity improvements to `brepjs-bim`, the foundation for an upcoming playground BIM-examples PR (stacked on this one). **Backward-compatible** — existing callers are untouched; new behavior is opt-in.

## What's new

- **Roof shapes** — `RoofSpec.pitch?` (degrees) opts a roof into real geometry for its `predefinedType`: **shed/gable** (extruded profiles), **hip** (convex hull of base + ridge points), **dome** (hemisphere). Absent `pitch` → today's flat slab. Shaped roofs serialize to IFC as tessellated bodies; **flat roofs keep their parametric `IfcExtrudedAreaSolid`** (no output change).
- **Posted railings** — `RailingSpec.infill?: 'PANEL' | 'POSTED'` (default `PANEL`). `POSTED` builds posts + top/bottom rails fused into one solid; tessellated to IFC. `PANEL` unchanged.
- **`placedSolids(element)`** — new accessor returning each element's geometry transformed to its world placement as fresh, caller-owned solids. Stairs (null `.geometry`) return per-flight solids; curtain walls return placed panels + mullions. Built on a new reader-free `placementToMatrix` extracted from the import path, so display and IFC export share the placement convention.

## Notes / decisions

- Hip uses `convexHull`, not core `roof()` — `roof()` returns an open shell (volume 0) under occt-wasm, unusable for a measurable `IfcRoof`.
- A `POSTED` railing carries no IFC surface style (tessellation has no single styleable body item) — documented limitation; the only posted railing in the examples PR is monochrome.

## Verification

- 603 tests pass (60 files), incl. new roof-shape, railing-infill, placement, and an end-to-end `toIfcValidated` test (shaped roof + posted railing + stair → no error-severity schema/referential-integrity/round-trip/geometry-validity issues).
- typecheck / lint / build / knip all green.

`feat(brepjs-bim)` → release-please minor bump.