### PR TITLE
fix(docs): harden font provisioning (Greptile follow-ups)

### DIFF
--- a/scripts/provision-fonts.mjs
+++ b/scripts/provision-fonts.mjs
@@ -18,7 +18,7 @@
  * back to the `Georgia, serif` stack. Drop the licensed woff2 into
  * apps/docs/public/fonts/ locally to preview the real face.
  *
- * Dependency-free: uses Node's global fetch (Node >= 24).
+ * Dependency-free: uses Node's built-in global fetch (stable since Node 18).
  */
 import { mkdir, writeFile } from 'node:fs/promises';
 
@@ -44,7 +44,7 @@ if (urls.length === 0) {
 
 await mkdir(DIR, { recursive: true });
 
-let count = 0;
+const provisioned = new Set();
 for (const url of urls) {
   const parsed = new URL(url);
   const base = decodeURIComponent(parsed.pathname.split('/').pop() ?? '');
@@ -61,7 +61,12 @@ for (const url of urls) {
 
   await writeFile(`${DIR}/${target.out}`, Buffer.from(await res.arrayBuffer()));
   console.log(`[fonts] ✓ ${target.out}`);
-  count++;
+  provisioned.add(target.out);
 }
 
-console.log(`[fonts] provisioned ${count} font(s) into ${DIR}`);
+// Fail loudly on a partial set: a dropped/duplicated URL in FONT_BLOB_URLS would
+// otherwise ship a missing weight as a silently broken @font-face.
+const missing = TARGETS.map((t) => t.out).filter((out) => !provisioned.has(out));
+if (missing.length) throw new Error(`[fonts] incomplete set — missing: ${missing.join(', ')}`);
+
+console.log(`[fonts] provisioned ${provisioned.size} font(s) into ${DIR}`);


### PR DESCRIPTION
Addresses the two non-blocking Greptile P2s from #1486 on `scripts/provision-fonts.mjs`:

- **Fail on an incomplete set.** The script now asserts all three weights (regular/italic/medium) were provisioned. A dropped or duplicated URL in `FONT_BLOB_URLS` previously exited 0 and shipped a missing weight as a silently broken `@font-face`; it now fails the build loudly (`missing: …`).
- **Correct the Node note.** Global `fetch` is stable since Node 18, not 24.

Verified locally: full 3-URL set succeeds, a 2-URL set fails with the missing-weight error, and no env still no-ops to the Georgia fallback.