### PR TITLE
feat(docs): extend Signifier + landing palette to the docs site

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -102,6 +102,19 @@ export default withMermaid(
       ['meta', { property: 'og:image:width', content: '1200' }],
       ['meta', { property: 'og:image:height', content: '630' }],
       ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+      // DM Mono is the code face across the whole site (docs + landing); load
+      // it globally. Signifier (the display face) is self-hosted via @font-face
+      // in theme/custom.css and lazy-loaded on docs headings (swap, no preload);
+      // the landing additionally preloads it below for a no-flash hero.
+      ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+      ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+      [
+        'link',
+        {
+          rel: 'stylesheet',
+          href: 'https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap',
+        },
+      ],
     ],
     transformPageData(pageData, ctx) {
       // Per-page meta. `frontmatter.description` wins over the global default
@@ -121,7 +134,9 @@ export default withMermaid(
         ? `${siteUrl}/${ogRelPath}`
         : defaultOgImage;
       const ogAlt =
-        title === 'brepjs' ? 'brepjs — Exact CAD geometry, written in TypeScript' : `${title} — brepjs`;
+        title === 'brepjs'
+          ? 'brepjs — Exact CAD geometry, written in TypeScript'
+          : `${title} — brepjs`;
 
       // VitePress emits `<meta name="description">` natively from
       // `frontmatter.description`, so we don't push one here — that would
@@ -163,9 +178,9 @@ export default withMermaid(
         ]);
       }
 
-      // The bespoke landing page (and only it) uses Signifier (self-hosted,
-      // licensed) for display type, Inter for body, and DM Mono for code. Load
-      // them here so docs pages — which never use these faces — stay lean.
+      // The bespoke landing page additionally loads Inter (its body face) and
+      // preloads Signifier so the hero never flashes the fallback serif. DM Mono
+      // (code) is loaded site-wide in the global head above.
       if (pageData.relativePath === 'index.md') {
         pageData.frontmatter.head.push([
           'script',
@@ -173,27 +188,43 @@ export default withMermaid(
           JSON.stringify(structuredData),
         ]);
         pageData.frontmatter.head.push(
-          ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
-          ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
           // Signifier is self-hosted (Klim, licensed) — preload the three styles
           // the landing uses so the hero doesn't flash the fallback serif.
           [
             'link',
-            { rel: 'preload', href: '/fonts/signifier-regular.woff2', as: 'font', type: 'font/woff2', crossorigin: '' },
+            {
+              rel: 'preload',
+              href: '/fonts/signifier-regular.woff2',
+              as: 'font',
+              type: 'font/woff2',
+              crossorigin: '',
+            },
           ],
           [
             'link',
-            { rel: 'preload', href: '/fonts/signifier-medium.woff2', as: 'font', type: 'font/woff2', crossorigin: '' },
+            {
+              rel: 'preload',
+              href: '/fonts/signifier-medium.woff2',
+              as: 'font',
+              type: 'font/woff2',
+              crossorigin: '',
+            },
           ],
           [
             'link',
-            { rel: 'preload', href: '/fonts/signifier-italic.woff2', as: 'font', type: 'font/woff2', crossorigin: '' },
+            {
+              rel: 'preload',
+              href: '/fonts/signifier-italic.woff2',
+              as: 'font',
+              type: 'font/woff2',
+              crossorigin: '',
+            },
           ],
           [
             'link',
             {
               rel: 'stylesheet',
-              href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=DM+Mono:wght@400;500&display=swap',
+              href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap',
             },
           ],
           // Scroll-reveal on the landing page starts sections at opacity:0 and

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -108,11 +108,16 @@ export default withMermaid(
       // the landing additionally preloads it below for a no-flash hero.
       ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
       ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+      // Load non-render-blocking: a code face tolerates a brief fallback, so
+      // fetch as print media then promote to all once it arrives (no CSP on
+      // docs pages — the playground's strict CSP is a separate route).
       [
         'link',
         {
           rel: 'stylesheet',
           href: 'https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap',
+          media: 'print',
+          onload: "this.media='all'",
         },
       ],
     ],

--- a/apps/docs/.vitepress/theme/components/Landing.vue
+++ b/apps/docs/.vitepress/theme/components/Landing.vue
@@ -119,7 +119,11 @@ onBeforeUnmount(() => observer?.disconnect());
       <section class="hero">
         <div class="wrap hero-top">
           <p class="eyebrow">Exact B-Rep · TypeScript · Browser-native</p>
-          <h1>Exact CAD geometry,<br class="h1-break" /><span class="grad">written in TypeScript.</span></h1>
+          <h1>
+            Exact CAD geometry,<br class="h1-break" /><span class="grad"
+              >written in TypeScript.</span
+            >
+          </h1>
           <p class="subhead">
             A real B-Rep kernel in your browser via WASM. A type system that makes invalid geometry
             uncompilable. And a verification loop so AI agents author parts that are provably
@@ -499,30 +503,8 @@ onBeforeUnmount(() => observer?.disconnect());
 </template>
 
 <style scoped>
-/* Signifier (Klim, licensed) — self-hosted display face, landing only. The
-   woff2 are gitignored and provisioned at build time from Vercel Blob; see
-   apps/docs/public/fonts/README.md. Falls back to Georgia without them. */
-@font-face {
-  font-family: 'Signifier';
-  src: url('/fonts/signifier-regular.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Signifier';
-  src: url('/fonts/signifier-italic.woff2') format('woff2');
-  font-weight: 400;
-  font-style: italic;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Signifier';
-  src: url('/fonts/signifier-medium.woff2') format('woff2');
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
+/* Signifier @font-face declarations live in theme/custom.css — the docs pages
+   now use them for headings too, so they belong in the global stylesheet. */
 
 /* ============================================================
    DESIGN TOKENS — scoped to .landing so the docs theme is untouched

--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -1,3 +1,39 @@
+/* ============================================================
+   FONTS — shared with the bespoke landing (theme/components/Landing.vue)
+   ============================================================ */
+
+/* Signifier (Klim, licensed) — self-hosted display face. The woff2 are
+   gitignored and provisioned at build time from Vercel Blob; see
+   public/fonts/README.md. Falls back to Georgia without them. The landing
+   preloads these for a no-flash hero (config.ts); docs pages let
+   font-display: swap lazy-load them on headings, where a brief fallback is
+   fine and keeps the reading surface from blocking on a third request. */
+@font-face {
+  font-family: 'Signifier';
+  src: url('/fonts/signifier-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Signifier';
+  src: url('/fonts/signifier-italic.woff2') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Signifier';
+  src: url('/fonts/signifier-medium.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ============================================================
+   THEME TOKENS — harmonized with the landing palette
+   ============================================================ */
+
 :root {
   --vp-c-brand-1: #03b0ad;
   --vp-c-brand-2: #4acecc;
@@ -12,9 +48,38 @@
     transparent 75%
   );
   --vp-home-hero-image-filter: blur(72px);
+
+  /* Code in DM Mono, matching the landing. DM Mono is loaded site-wide from
+     Google Fonts (config.ts head). */
+  --vp-font-family-mono: 'DM Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Light mode stays close to VitePress default, faintly cool-tinted so it
+     reads as a relative of the dark theme — the landing is dark-only, so there
+     is no light palette to copy and a heavy bespoke light skin isn't worth it. */
+  --vp-c-bg: #fbfdfd;
+  --vp-c-bg-alt: #f3f7f7;
+  --vp-c-bg-soft: #eef4f4;
+  --vp-c-bg-elv: #ffffff;
+  --vp-c-divider: #e2ecec;
+  --vp-c-border: #d6e2e2;
+  --vp-c-gutter: #eef4f4;
 }
 
 .dark {
+  /* Dark mode mirrors the landing's cool near-black surface ramp (bg-0..bg-3)
+     and its cool ink/borders, so crossing from the landing into the docs reads
+     as the same world rather than a context switch. */
+  --vp-c-bg: #080b0e;
+  --vp-c-bg-alt: #0d1116;
+  --vp-c-bg-soft: #131922;
+  --vp-c-bg-elv: #1a212b;
+  --vp-c-divider: #1c2530;
+  --vp-c-border: #283340;
+  --vp-c-gutter: #05080a;
+  --vp-c-text-1: #f1f6f7;
+  --vp-c-text-2: #aab6bd;
+  --vp-c-text-3: #828d96;
+
   --vp-home-hero-image-background-image: radial-gradient(
     circle at 50% 50%,
     rgba(74, 206, 204, 0.28),
@@ -22,6 +87,48 @@
     transparent 75%
   );
 }
+
+/* ============================================================
+   DISPLAY TYPE — Signifier on the top two heading levels of rendered docs
+   content only. H1 Medium (page-title authority), H2 Regular (calmer section
+   rhythm). Body, H3+, sidebar and nav stay Inter. Scoped to .vp-doc so the
+   bespoke .landing page — which sets its own scaled display type — is
+   untouched. Georgia fallback covers dev clones without the licensed woff2.
+   ============================================================ */
+
+.vp-doc h1 {
+  font-family: 'Signifier', Georgia, 'Times New Roman', serif;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+
+.vp-doc h2 {
+  font-family: 'Signifier', Georgia, 'Times New Roman', serif;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+}
+
+/* Softer corners echoing the landing's radii, applied lightly. */
+.vp-doc div[class*='language-'],
+.vp-doc .custom-block {
+  border-radius: 12px;
+}
+
+/* Faint teal glow anchored to the top-right of the nav band (dark only) — a
+   brand hint carried over from the landing without texturing the reading area
+   below. Absolute radius so the falloff is visible across the bar rather than
+   washing it uniformly. */
+.dark .VPNavBar {
+  background-image: radial-gradient(
+    440px 180px at 88% -10%,
+    rgba(3, 176, 173, 0.16),
+    transparent 70%
+  );
+}
+
+/* ============================================================
+   HOME HERO + CODE BLOCK PLAYGROUND LINK
+   ============================================================ */
 
 .VPHero .image-container {
   width: min(440px, 100%);
@@ -49,7 +156,7 @@ div[class*='language-'] .playground-link {
   font-size: 12px;
   line-height: 1;
   padding: 6px 10px;
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--vp-c-brand-soft);
   color: var(--vp-c-brand-1);
   text-decoration: none;


### PR DESCRIPTION
## What

Carries the landing page's typography and surface treatment into the docs pages so the two read as one site rather than a marketing page bolted onto stock VitePress.

### Typography
- **Signifier** (the licensed Klim display serif) on docs **H1 (Medium 500)** and **H2 (Regular 400)** only — body, H3+, sidebar and nav stay Inter. A display serif is for headings, not 16px body, so this is the deliberate scope.
- Scoped to `.vp-doc`, so the bespoke landing (which sets its own scaled display type) is untouched.
- `@font-face` declarations moved out of `Landing.vue`'s scoped block into `theme/custom.css` — docs now depend on them, so they belong in the global stylesheet.
- **DM Mono** becomes the code face site-wide via `--vp-font-family-mono`, loaded once from the global head. The landing's per-page link drops its now-redundant DM Mono + preconnect entries (DM Mono is global; Inter + Signifier preloads stay landing-only).
- Docs load Signifier **lazily** (`font-display: swap`, no preload). Only the landing preloads it, where a no-flash hero matters; docs headings tolerate a brief fallback and stay off the critical path.

### Color / styling
- **Dark mode** maps the landing's cool near-black surface ramp (`bg-0..bg-3`) and its cool ink/divider tokens onto VitePress's surface vars — dark docs now read as the same world as the landing. The teal brand accent already matched.
- **Light mode** keeps VitePress's default but faintly cool-tints the neutrals (the landing is dark-only, so there's no light palette to copy and a bespoke light skin isn't worth it).
- Light **12px rounding** on code/custom blocks; a **faint top-right teal glow** on the nav in dark mode. Reading area stays clean — no grid/texture behind body copy.

## Decisions
Scope was chosen interactively: headings-only serif (not body), DM Mono everywhere, Google-Fonts delivery matching the landing, lazy swap/no-preload, Medium-H1/Regular-H2, dark surfaces adopted / light cool-tinted / clean reading pages / light rounding.

One thing worth a sanity check before merge: confirm the **Klim Web Font licence tier** covers docs-wide pageviews on `brepjs.dev` (it's almost certainly domain/pageview-scoped, but docs are the highest-traffic surface now using Signifier).

## Verification
- `npm run docs:build` passes (production build, 15s).
- Screenshotted light + dark content pages (headings in Signifier, DM Mono code, cool surfaces) and confirmed the landing renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)