### PR TITLE
ci(release): auto-merge brepjs-bim + brepjs-sheetmetal release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,12 +54,14 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Auto-merge ONLY the root brepjs release PR. brepjs-opencascade (expensive
-  # WASM build) and brepjs-verify / brepjs-viewer are held for manual merge:
-  # auto-merging their release-please dependency-bump PRs creates a runaway
-  # release loop across the cross-linked workspace packages (the node-workspace
-  # plugin re-emits a bump release on every linked release). Auto-PUBLISH still
-  # works — it fires when a human merges the held release PR.
+  # Auto-merge the root brepjs release PR plus the leaf packages brepjs-bim and
+  # brepjs-sheetmetal. Those leaves depend only on root brepjs (nothing depends
+  # back on them), so the workspace dep graph stays acyclic and node-workspace
+  # propagation terminates after one root->leaves ripple — no release loop is
+  # possible. brepjs-opencascade (expensive WASM build, manual review) and
+  # brepjs-verify / brepjs-viewer are still held: verify cross-links viewer, the
+  # one pairing that historically re-pinned to an unpublished version and looped
+  # the pipeline. Auto-PUBLISH still works — it fires when the release PR merges.
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -71,7 +73,7 @@ jobs:
         with:
           app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
           private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
-      - name: Enable auto-merge for the root brepjs release PR only
+      - name: Enable auto-merge for root brepjs + leaf package release PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # Prefer the plural `prs` array (separate-pull-requests: true emits
@@ -100,11 +102,12 @@ jobs:
               continue
             fi
             # Hold brepjs-opencascade (expensive WASM build, manual review) and
-            # brepjs-verify / brepjs-viewer (auto-merging their bump PRs loops the
-            # release pipeline across linked workspace packages). Only the root
-            # brepjs release PR auto-merges.
+            # brepjs-verify / brepjs-viewer (verify cross-links viewer — the
+            # pairing that historically looped the pipeline via unpublished
+            # re-pins). The root brepjs PR and the acyclic leaves brepjs-bim /
+            # brepjs-sheetmetal auto-merge.
             case "$pr_title" in
-              *brepjs-opencascade* | *brepjs-verify* | *brepjs-viewer* | *brepjs-bim* | *brepjs-sheetmetal*)
+              *brepjs-opencascade* | *brepjs-verify* | *brepjs-viewer*)
                 echo "Holding auto-merge for PR #$pr_number ($pr_title) — manual merge"
                 continue
                 ;;


### PR DESCRIPTION
## What

Removes `brepjs-bim` and `brepjs-sheetmetal` from the auto-merge hold-list in `release-please.yml`, so their release-please PRs auto-merge (and auto-publish) like the root `brepjs` release PR already does. `brepjs-verify`, `brepjs-viewer`, and `brepjs-opencascade` stay held for manual merge.

## Why this is loop-safe

A never-ending release loop requires a **cycle** in the workspace dependency graph. There isn't one:

- Root `brepjs` depends on no internal package.
- `brepjs-bim` and `brepjs-sheetmetal` are **leaves** — they depend only on root `brepjs`, and nothing depends back on them.

So `node-workspace` propagation is a DAG walk that terminates after one `root → leaves` ripple. On top of that, release-please **ignores its own `chore(main): release` commits**, so a merged release never triggers another release. Auto-merging these leaves can at most cause a patch release of each on a core `brepjs` release (version churn) — never an unbounded loop.

`brepjs-verify` stays held because it cross-links `brepjs-viewer`, the one pairing that historically re-pinned to an unpublished version and looped the pipeline (mitigated separately by unmanaging viewer in #1430, but kept manual here out of caution). `brepjs-opencascade` stays held for its expensive WASM build / manual review.

## Notes

- The existing `concurrency: { cancel-in-progress: false }` group continues to serialize release runs so back-to-back merges don't race on `autorelease:*` labels.
- No change to publish behavior — auto-publish already fires when a release PR merges, by whatever means.