### PR TITLE
feat(playground): improve mobile web UX

### DIFF
--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -7,7 +7,10 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#4ACECC" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>brepjs Playground — Live TypeScript CAD in the Browser</title>
     <meta
       name="description"
@@ -42,7 +45,7 @@
           display: flex;
           align-items: center;
           justify-content: center;
-          height: 100vh;
+          height: 100dvh;
           background: #0f0f14;
         "
       >

--- a/apps/playground/src/components/playground/EditorPanel.tsx
+++ b/apps/playground/src/components/playground/EditorPanel.tsx
@@ -1,6 +1,7 @@
 import Editor, { type BeforeMount, type OnMount } from '@monaco-editor/react';
 import { useCallback, useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../../stores/playgroundStore';
+import { useIsMobile } from '../../hooks/useIsMobile';
 import { setupMonaco } from '../../lib/monacoSetup';
 
 interface EditorPanelProps {
@@ -14,6 +15,7 @@ export default function EditorPanel({ onCodeChange, onFormat, jumpToLineRef }: E
   const setCode = usePlaygroundStore((s) => s.setCode);
   const error = usePlaygroundStore((s) => s.error);
   const errorLine = usePlaygroundStore((s) => s.errorLine);
+  const isMobile = useIsMobile();
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<Parameters<OnMount>[1] | null>(null);
   // Mirrors the last value we know the model holds. The sync effect and the
@@ -143,8 +145,10 @@ export default function EditorPanel({ onCodeChange, onFormat, jumpToLineRef }: E
       onMount={handleMount}
       theme="brepjs-dark"
       options={{
-        fontSize: 14,
-        lineHeight: 22,
+        // 16px on phones: below 16px, iOS Safari auto-zooms the whole page when
+        // the editor gains focus, which breaks the fixed full-height layout.
+        fontSize: isMobile ? 16 : 14,
+        lineHeight: isMobile ? 24 : 22,
         minimap: { enabled: false },
         scrollBeyondLastLine: false,
         padding: { top: 12, bottom: 12 },

--- a/apps/playground/src/components/playground/ExampleGallery.tsx
+++ b/apps/playground/src/components/playground/ExampleGallery.tsx
@@ -97,7 +97,9 @@ export default function ExampleGallery({
   // Active set = category ∩ query, ranked by fuzzy score when searching.
   const shown = useMemo(() => {
     const inCat =
-      category === ALL ? EXAMPLES : (CATEGORIES.find((c) => c.id === category)?.examples ?? EXAMPLES);
+      category === ALL
+        ? EXAMPLES
+        : (CATEGORIES.find((c) => c.id === category)?.examples ?? EXAMPLES);
     const q = query.trim().toLowerCase();
     if (!q) return [...inCat];
     return inCat
@@ -119,7 +121,10 @@ export default function ExampleGallery({
 
   if (!open) return null;
 
-  const rail = [{ id: ALL, label: 'All' }, ...CATEGORIES.map((c) => ({ id: c.id, label: c.label }))];
+  const rail = [
+    { id: ALL, label: 'All' },
+    ...CATEGORIES.map((c) => ({ id: c.id, label: c.label })),
+  ];
 
   return (
     <div
@@ -151,7 +156,7 @@ export default function ExampleGallery({
                 setCategory(r.id);
               }}
               aria-pressed={category === r.id}
-              className={`flex shrink-0 items-center justify-between gap-2 whitespace-nowrap rounded-md px-3 py-1.5 text-left text-sm font-medium transition-colors ${
+              className={`flex shrink-0 items-center justify-between gap-2 whitespace-nowrap rounded-md px-3 py-2 text-left text-sm font-medium transition-colors sm:py-1.5 ${
                 category === r.id
                   ? 'bg-teal-primary/20 text-teal-light'
                   : 'text-gray-400 hover:bg-surface-overlay hover:text-gray-200'
@@ -174,7 +179,12 @@ export default function ExampleGallery({
           <div className="flex items-center gap-2 border-b border-border-subtle px-3 py-2.5">
             <svg viewBox="0 0 16 16" className="h-4 w-4 shrink-0 text-gray-500" aria-hidden="true">
               <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
-              <path d="M10.5 10.5L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <path
+                d="M10.5 10.5L14 14"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
             </svg>
             <input
               ref={searchRef}
@@ -222,7 +232,7 @@ export default function ExampleGallery({
             // Scroll container kept separate from the grid: a flex-1 element
             // that is itself the grid gives the rows a definite height, which
             // stops aspect-ratio thumbnails from resolving and collapses them.
-            <div ref={gridRef} className="scrollbar-thin min-h-0 flex-1 overflow-y-auto">
+            <div ref={gridRef} className="scrollbar-thin pb-safe min-h-0 flex-1 overflow-y-auto">
               <div className="grid grid-cols-2 content-start gap-3 p-3 sm:grid-cols-3 sm:p-4 lg:grid-cols-4 2xl:grid-cols-5">
                 {shown.map((ex) => (
                   <ExampleCard
@@ -304,7 +314,9 @@ function ExampleCard({ example, focused, failedTurntables, onSelect, onFocus }: 
       </div>
       <div className="flex flex-col gap-0.5 p-2.5">
         <span className="truncate text-sm font-medium text-gray-200">{example.label}</span>
-        <span className="line-clamp-2 text-xs leading-snug text-gray-500">{example.description}</span>
+        <span className="line-clamp-2 text-xs leading-snug text-gray-500">
+          {example.description}
+        </span>
       </div>
     </button>
   );

--- a/apps/playground/src/components/playground/MobileActionSheet.tsx
+++ b/apps/playground/src/components/playground/MobileActionSheet.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from 'react';
+import { useEngineStore } from '../../stores/engineStore';
+import { usePlaygroundStore } from '../../stores/playgroundStore';
+
+interface MobileActionSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onShare: () => void;
+  onExportSTL: () => void;
+  onExportSTEP: () => void;
+  onExportDXF: () => void;
+  onExportIFC: () => void;
+}
+
+interface ActionDef {
+  label: string;
+  hint: string;
+  onSelect: () => void;
+  disabled: boolean;
+}
+
+// Bottom sheet that surfaces the share/export actions hidden from the compact
+// mobile toolbar. Replaces the command palette as the primary way to reach
+// these on a phone, where there's no keyboard to trigger Cmd+K.
+export default function MobileActionSheet({
+  open,
+  onClose,
+  onShare,
+  onExportSTL,
+  onExportSTEP,
+  onExportDXF,
+  onExportIFC,
+}: MobileActionSheetProps) {
+  const engineReady = useEngineStore((s) => s.status === 'ready');
+  const isRunning = usePlaygroundStore((s) => s.isRunning);
+  const canExportDXF = usePlaygroundStore((s) => s.availableArtifacts.includes('dxf'));
+  const canExportIFC = usePlaygroundStore((s) => s.availableArtifacts.includes('ifc'));
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    // Move focus into the sheet so the next Tab stays inside it and screen
+    // readers announce the dialog.
+    sheetRef.current?.focus();
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const exportDisabled = !engineReady || isRunning;
+  const actions: ActionDef[] = [
+    {
+      label: 'Share link',
+      hint: 'Copy or send a permalink',
+      onSelect: onShare,
+      disabled: !engineReady,
+    },
+    {
+      label: 'Export STL',
+      hint: 'Mesh for 3D printing',
+      onSelect: onExportSTL,
+      disabled: exportDisabled,
+    },
+    {
+      label: 'Export STEP',
+      hint: 'B-Rep for CAD',
+      onSelect: onExportSTEP,
+      disabled: exportDisabled,
+    },
+    ...(canExportDXF
+      ? [
+          {
+            label: 'Export DXF',
+            hint: 'Flat-pattern drawing',
+            onSelect: onExportDXF,
+            disabled: exportDisabled,
+          },
+        ]
+      : []),
+    ...(canExportIFC
+      ? [
+          {
+            label: 'Export IFC',
+            hint: 'BIM model',
+            onSelect: onExportIFC,
+            disabled: exportDisabled,
+          },
+        ]
+      : []),
+  ];
+
+  const runAndClose = (fn: () => void) => () => {
+    fn();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col justify-end"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Actions"
+    >
+      <button
+        type="button"
+        aria-label="Close actions"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/50"
+      />
+      <div
+        ref={sheetRef}
+        tabIndex={-1}
+        className="animate-reveal-up pb-safe relative w-full rounded-t-2xl border-t border-border-subtle bg-surface shadow-2xl outline-none"
+      >
+        <div className="flex justify-center pt-2.5">
+          <span className="h-1 w-9 rounded-full bg-gray-600" aria-hidden="true" />
+        </div>
+        <div className="px-3 pb-2 pt-3 text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+          Actions
+        </div>
+        <div className="pb-2">
+          {actions.map((a) => (
+            <button
+              key={a.label}
+              type="button"
+              onClick={runAndClose(a.onSelect)}
+              disabled={a.disabled}
+              className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-overlay active:bg-surface-overlay disabled:opacity-40"
+            >
+              <span className="text-sm font-medium text-gray-100">{a.label}</span>
+              <span className="text-xs text-gray-500">{a.hint}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/components/playground/MobileLayout.tsx
+++ b/apps/playground/src/components/playground/MobileLayout.tsx
@@ -26,6 +26,21 @@ export default function MobileLayout({
   const [tab, setTab] = useState<Tab>('viewer');
   const error = usePlaygroundStore((s) => s.error);
   const hasHadSuccess = usePlaygroundStore((s) => s.lastSuccessfulCode !== null);
+  const runSeq = usePlaygroundStore((s) => s.runSeq);
+
+  // Flag the Viewer tab when a run lands while the user is elsewhere, so they
+  // know their edit took effect without yanking them off the tab they're on.
+  // Switching to Viewer marks the current result seen and clears the flag.
+  const [viewerDirty, setViewerDirty] = useState(false);
+  const seenSeqRef = useRef(runSeq);
+  useEffect(() => {
+    if (tab === 'viewer') {
+      seenSeqRef.current = runSeq;
+      setViewerDirty(false);
+    } else if (runSeq !== seenSeqRef.current) {
+      setViewerDirty(true);
+    }
+  }, [runSeq, tab]);
 
   // Auto-jump to console on the transition into an error so users see the
   // failure without hunting for the tab. Gated on `hasHadSuccess` so the very
@@ -73,32 +88,34 @@ export default function MobileLayout({
       </div>
 
       <nav
-        className="flex h-12 shrink-0 items-stretch border-t border-border-subtle bg-surface"
-        role="tablist"
+        className="pb-safe shrink-0 border-t border-border-subtle bg-surface"
         aria-label="Playground panels"
       >
-        <TabButton
-          label="Editor"
-          active={tab === 'editor'}
-          onClick={() => {
-            setTab('editor');
-          }}
-        />
-        <TabButton
-          label="Viewer"
-          active={tab === 'viewer'}
-          onClick={() => {
-            setTab('viewer');
-          }}
-        />
-        <TabButton
-          label="Console"
-          active={tab === 'console'}
-          onClick={() => {
-            setTab('console');
-          }}
-          badge={error ? '!' : undefined}
-        />
+        <div className="flex h-12 items-stretch" role="tablist">
+          <TabButton
+            label="Editor"
+            active={tab === 'editor'}
+            onClick={() => {
+              setTab('editor');
+            }}
+          />
+          <TabButton
+            label="Viewer"
+            active={tab === 'viewer'}
+            onClick={() => {
+              setTab('viewer');
+            }}
+            dot={viewerDirty}
+          />
+          <TabButton
+            label="Console"
+            active={tab === 'console'}
+            onClick={() => {
+              setTab('console');
+            }}
+            badge={error ? '!' : undefined}
+          />
+        </div>
       </nav>
     </div>
   );
@@ -121,11 +138,13 @@ function TabButton({
   active,
   onClick,
   badge,
+  dot,
 }: {
   label: string;
   active: boolean;
   onClick: () => void;
   badge?: string;
+  dot?: boolean;
 }) {
   return (
     <button
@@ -143,6 +162,12 @@ function TabButton({
         <span className="absolute right-[28%] top-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 text-[9px] font-bold text-white">
           {badge}
         </span>
+      )}
+      {dot && badge === undefined && (
+        <span
+          className="animate-tab-cue absolute right-[30%] top-2 h-2 w-2 rounded-full bg-teal-primary"
+          aria-label="Result updated"
+        />
       )}
     </button>
   );

--- a/apps/playground/src/components/playground/MobileLayout.tsx
+++ b/apps/playground/src/components/playground/MobileLayout.tsx
@@ -25,7 +25,6 @@ export default function MobileLayout({
 }: MobileLayoutProps) {
   const [tab, setTab] = useState<Tab>('viewer');
   const error = usePlaygroundStore((s) => s.error);
-  const hasHadSuccess = usePlaygroundStore((s) => s.lastSuccessfulCode !== null);
   const runSeq = usePlaygroundStore((s) => s.runSeq);
 
   // Flag the Viewer tab when a run lands while the user is elsewhere, so they
@@ -42,18 +41,10 @@ export default function MobileLayout({
     }
   }, [runSeq, tab]);
 
-  // Auto-jump to console on the transition into an error so users see the
-  // failure without hunting for the tab. Gated on `hasHadSuccess` so the very
-  // first eval's error (e.g. a shared link, a stale draft, the seeded default
-  // failing to compile) leaves the user on Viewer — the Console tab's red
-  // badge handles discoverability. Without this gate, mobile silently
-  // teleports docs-link visitors away from the viewport they came to see.
-  const wasErrorRef = useRef(false);
-  useEffect(() => {
-    const isError = !!error;
-    if (isError && !wasErrorRef.current && hasHadSuccess) setTab('console');
-    wasErrorRef.current = isError;
-  }, [error, hasHadSuccess]);
+  // Errors never auto-switch the tab on mobile — the Console tab's red badge
+  // handles discoverability, and yanking the user off Viewer/Editor mid-task
+  // (the debounced auto-run fires an error on every transient typo) is jarring
+  // on a phone. The user opens Console themselves.
 
   const dismissConsole = useCallback(() => {
     setTab('viewer');

--- a/apps/playground/src/components/playground/PlaygroundPage.tsx
+++ b/apps/playground/src/components/playground/PlaygroundPage.tsx
@@ -21,6 +21,7 @@ import LoadingOverlay from './LoadingOverlay';
 import ShortcutHelp from './ShortcutHelp';
 import CommandPalette from './CommandPalette';
 import ExampleGallery from './ExampleGallery';
+import MobileActionSheet from './MobileActionSheet';
 import MobileLayout from './MobileLayout';
 import DesktopLayout from './DesktopLayout';
 import ToastContainer from '../shared/ToastContainer';
@@ -41,6 +42,7 @@ export default function PlaygroundPage() {
 
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
   const exampleRoute = useExampleRoute();
 
   // Loading from the gallery: load the code and leave the friendly permalink.
@@ -54,6 +56,12 @@ export default function PlaygroundPage() {
 
   const openCommandPalette = useCallback(() => {
     setPaletteOpen(true);
+  }, []);
+  const openActions = useCallback(() => {
+    setActionsOpen(true);
+  }, []);
+  const closeActions = useCallback(() => {
+    setActionsOpen(false);
   }, []);
   const openShortcutHelp = useCallback(() => {
     setShortcutHelpOpen(true);
@@ -108,7 +116,7 @@ export default function PlaygroundPage() {
   });
 
   return (
-    <div className="relative flex h-screen flex-col bg-gray-950">
+    <div className="relative flex h-dvh flex-col bg-gray-950">
       <LoadingOverlay />
       <ToastContainer />
 
@@ -122,6 +130,7 @@ export default function PlaygroundPage() {
         onOpenCommandPalette={openCommandPalette}
         onOpenHelp={openShortcutHelp}
         onOpenExamples={exampleRoute.openGallery}
+        onOpenActions={openActions}
         isRunning={isRunning}
         compact={isMobile}
       />
@@ -163,6 +172,15 @@ export default function PlaygroundPage() {
         onClose={exampleRoute.closeGallery}
         onSelect={handleSelectExample}
         onFocusExample={exampleRoute.focusExample}
+      />
+      <MobileActionSheet
+        open={actionsOpen}
+        onClose={closeActions}
+        onShare={actions.handleShare}
+        onExportSTL={actions.handleExportSTL}
+        onExportSTEP={actions.handleExportSTEP}
+        onExportDXF={actions.handleExportDXF}
+        onExportIFC={actions.handleExportIFC}
       />
     </div>
   );

--- a/apps/playground/src/components/playground/Toolbar.tsx
+++ b/apps/playground/src/components/playground/Toolbar.tsx
@@ -13,6 +13,8 @@ interface ToolbarProps {
   onOpenCommandPalette: () => void;
   onOpenHelp: () => void;
   onOpenExamples: () => void;
+  /** Open the mobile action sheet (share/export). Shown only in compact mode. */
+  onOpenActions: () => void;
   isRunning: boolean;
   /** Hide Share/STL/STEP and the help button to fit narrow viewports.
    *  Those actions stay reachable through the command palette. */
@@ -29,6 +31,7 @@ export default function Toolbar({
   onOpenCommandPalette,
   onOpenHelp,
   onOpenExamples,
+  onOpenActions,
   isRunning,
   compact = false,
 }: ToolbarProps) {
@@ -41,122 +44,138 @@ export default function Toolbar({
   const canExportIFC = usePlaygroundStore((s) => s.availableArtifacts.includes('ifc'));
 
   return (
-    <div className="flex h-11 items-center justify-between border-b border-border-subtle bg-surface px-3">
-      <div className="flex items-center gap-2">
-        <a
-          href="/"
-          className="flex items-center gap-1.5 text-sm font-bold"
-          aria-label="Back to brepjs docs"
-        >
-          <Logo className="h-6 w-6" />
-          <span className="text-gray-400">brepjs</span>
-        </a>
-        <button
-          onClick={onOpenExamples}
-          title={`Browse examples (${formatShortcut(SHORTCUTS.examples)})`}
-          className="rounded border border-gray-700 bg-surface-overlay px-2.5 py-1 text-xs font-medium text-gray-200 transition-colors hover:border-gray-500 hover:bg-gray-700 hover:text-white"
-        >
-          Examples
-        </button>
-        {selectionCount > 0 && (
-          <button
-            onClick={clearSelections}
-            title="Click to clear selection"
-            className="flex items-center gap-1 rounded-full border border-teal-primary/30 bg-teal-primary/15 px-2 py-0.5 text-[10px] font-semibold text-teal-light transition-colors hover:bg-teal-primary/25"
+    <div className="pt-safe border-b border-border-subtle bg-surface">
+      <div className="flex h-11 items-center justify-between px-3">
+        <div className="flex items-center gap-2">
+          <a
+            href="/"
+            className="flex items-center gap-1.5 text-sm font-bold"
+            aria-label="Back to brepjs docs"
           >
-            <span>{selectionCount} selected</span>
-            <svg viewBox="0 0 16 16" className="h-2.5 w-2.5 opacity-70" aria-hidden="true">
-              <path
-                d="M3 3l10 10M13 3L3 13"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                fill="none"
-              />
+            <Logo className="h-6 w-6" />
+            <span className="text-gray-400">brepjs</span>
+          </a>
+          <button
+            onClick={onOpenExamples}
+            title={`Browse examples (${formatShortcut(SHORTCUTS.examples)})`}
+            className="rounded border border-gray-700 bg-surface-overlay px-2.5 py-1 text-xs font-medium text-gray-200 transition-colors hover:border-gray-500 hover:bg-gray-700 hover:text-white"
+          >
+            Examples
+          </button>
+          {selectionCount > 0 && (
+            <button
+              onClick={clearSelections}
+              title="Click to clear selection"
+              className="flex items-center gap-1 rounded-full border border-teal-primary/30 bg-teal-primary/15 px-2 py-0.5 text-[10px] font-semibold text-teal-light transition-colors hover:bg-teal-primary/25"
+            >
+              <span>{selectionCount} selected</span>
+              <svg viewBox="0 0 16 16" className="h-2.5 w-2.5 opacity-70" aria-hidden="true">
+                <path
+                  d="M3 3l10 10M13 3L3 13"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                  fill="none"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onRun}
+            disabled={!engineReady || isRunning}
+            title={`Run (${formatShortcut(SHORTCUTS.run)})`}
+            className={`flex items-center gap-1.5 rounded bg-teal-primary px-3 py-1 text-xs font-semibold text-gray-950 transition-colors hover:bg-teal-dark disabled:opacity-40 ${isRunning ? 'animate-pulse' : ''}`}
+          >
+            {isRunning ? 'Running...' : 'Run'}
+          </button>
+          {!compact && (
+            <>
+              <button
+                onClick={onShare}
+                disabled={!engineReady}
+                title={`Share (${formatShortcut(SHORTCUTS.share)})`}
+                className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+              >
+                Share
+              </button>
+              <button
+                onClick={onExportSTL}
+                disabled={!engineReady || isRunning}
+                title={`Export STL (${formatShortcut(SHORTCUTS.exportSTL)})`}
+                className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+              >
+                STL
+              </button>
+              <button
+                onClick={onExportSTEP}
+                disabled={!engineReady || isRunning}
+                title={`Export STEP (${formatShortcut(SHORTCUTS.exportSTEP)})`}
+                className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+              >
+                STEP
+              </button>
+              {canExportDXF && (
+                <button
+                  onClick={onExportDXF}
+                  disabled={!engineReady || isRunning}
+                  title="Export the flat-pattern DXF"
+                  className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+                >
+                  DXF
+                </button>
+              )}
+              {canExportIFC && (
+                <button
+                  onClick={onExportIFC}
+                  disabled={!engineReady || isRunning}
+                  title="Export the BIM model as IFC"
+                  className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+                >
+                  IFC
+                </button>
+              )}
+              <div className="mx-1 h-4 w-px bg-border-subtle" />
+            </>
+          )}
+          {compact && (
+            <button
+              onClick={onOpenActions}
+              title="Share & export"
+              aria-label="Share and export actions"
+              className="rounded px-2 py-1 text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
+            >
+              <svg viewBox="0 0 16 16" className="h-4 w-4" aria-hidden="true">
+                <circle cx="3" cy="8" r="1.4" fill="currentColor" />
+                <circle cx="8" cy="8" r="1.4" fill="currentColor" />
+                <circle cx="13" cy="8" r="1.4" fill="currentColor" />
+              </svg>
+            </button>
+          )}
+          <button
+            onClick={onOpenCommandPalette}
+            title={`Command palette (${formatShortcut(SHORTCUTS.commandPalette)})`}
+            aria-label="Open command palette"
+            className="rounded px-2 py-1 text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
+          >
+            <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+              <circle cx="6" cy="6" r="3.5" stroke="currentColor" strokeWidth="1.4" fill="none" />
+              <path d="M9 9l4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
             </svg>
           </button>
-        )}
-      </div>
-
-      <div className="flex items-center gap-2">
-        <button
-          onClick={onRun}
-          disabled={!engineReady || isRunning}
-          title={`Run (${formatShortcut(SHORTCUTS.run)})`}
-          className={`flex items-center gap-1.5 rounded bg-teal-primary px-3 py-1 text-xs font-semibold text-gray-950 transition-colors hover:bg-teal-dark disabled:opacity-40 ${isRunning ? 'animate-pulse' : ''}`}
-        >
-          {isRunning ? 'Running...' : 'Run'}
-        </button>
-        {!compact && (
-          <>
+          {!compact && (
             <button
-              onClick={onShare}
-              disabled={!engineReady}
-              title={`Share (${formatShortcut(SHORTCUTS.share)})`}
-              className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+              onClick={onOpenHelp}
+              title="Keyboard shortcuts (?)"
+              aria-label="Show keyboard shortcuts"
+              className="rounded px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
             >
-              Share
+              ?
             </button>
-            <button
-              onClick={onExportSTL}
-              disabled={!engineReady || isRunning}
-              title={`Export STL (${formatShortcut(SHORTCUTS.exportSTL)})`}
-              className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-            >
-              STL
-            </button>
-            <button
-              onClick={onExportSTEP}
-              disabled={!engineReady || isRunning}
-              title={`Export STEP (${formatShortcut(SHORTCUTS.exportSTEP)})`}
-              className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-            >
-              STEP
-            </button>
-            {canExportDXF && (
-              <button
-                onClick={onExportDXF}
-                disabled={!engineReady || isRunning}
-                title="Export the flat-pattern DXF"
-                className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-              >
-                DXF
-              </button>
-            )}
-            {canExportIFC && (
-              <button
-                onClick={onExportIFC}
-                disabled={!engineReady || isRunning}
-                title="Export the BIM model as IFC"
-                className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
-              >
-                IFC
-              </button>
-            )}
-            <div className="mx-1 h-4 w-px bg-border-subtle" />
-          </>
-        )}
-        <button
-          onClick={onOpenCommandPalette}
-          title={`Command palette (${formatShortcut(SHORTCUTS.commandPalette)})`}
-          aria-label="Open command palette"
-          className="rounded px-2 py-1 text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
-        >
-          <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
-            <circle cx="6" cy="6" r="3.5" stroke="currentColor" strokeWidth="1.4" fill="none" />
-            <path d="M9 9l4 4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-          </svg>
-        </button>
-        {!compact && (
-          <button
-            onClick={onOpenHelp}
-            title="Keyboard shortcuts (?)"
-            aria-label="Show keyboard shortcuts"
-            className="rounded px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white"
-          >
-            ?
-          </button>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/playground/src/components/playground/ViewerToolbar.tsx
+++ b/apps/playground/src/components/playground/ViewerToolbar.tsx
@@ -1,6 +1,7 @@
 import { ViewerControls, type ViewName } from 'brepjs-viewer';
 import { useViewerStore, type CameraPreset } from '../../stores/viewerStore';
 import { useScreenshot } from '../../hooks/useScreenshot';
+import { useTouchDevice } from '../../hooks/useTouchDevice';
 
 // The shared ViewerControls speaks the canonical ViewName vocabulary (iso/front/top/right);
 // the playground store predates it with equivalent directions under different names.
@@ -30,9 +31,11 @@ export default function ViewerToolbar() {
   const requestFit = useViewerStore((s) => s.requestFit);
   const setCameraPreset = useViewerStore((s) => s.setCameraPreset);
   const handleScreenshot = useScreenshot();
+  const isTouch = useTouchDevice();
 
   return (
     <ViewerControls
+      touch={isTouch}
       viewMode={viewMode}
       onViewModeChange={setViewMode}
       showEdges={showEdges}

--- a/apps/playground/src/hooks/useCodeExecution.ts
+++ b/apps/playground/src/hooks/useCodeExecution.ts
@@ -86,6 +86,7 @@ export function useCodeExecution() {
           store.setTimeMs(msg.timeMs);
           store.setIsRunning(false);
           store.setLastSuccessfulCode(ranCode);
+          store.markRendered();
           engineStore.resetRecoveryAttempts();
           if (isRecoveringRef.current) {
             isRecoveringRef.current = false;

--- a/apps/playground/src/hooks/usePlaygroundActions.ts
+++ b/apps/playground/src/hooks/usePlaygroundActions.ts
@@ -89,15 +89,23 @@ export function usePlaygroundActions(): PlaygroundActions {
     const coarse = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
     if (coarse && typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       const url = buildShareUrl(code);
-      void navigator.share({ title: 'brepjs Playground', url }).catch(() => {
-        /* user dismissed the share sheet */
-      });
+      void navigator
+        .share({ title: 'brepjs Playground', url })
+        // Only count a share once the sheet actually completes — a dismissed
+        // sheet rejects with AbortError and must not inflate the share metric.
+        .then(() => {
+          track('playground_share');
+          captureEvent('playground_share');
+        })
+        .catch(() => {
+          /* user dismissed the share sheet */
+        });
     } else {
       void copyShareUrl(code);
       addToast('Link copied to clipboard');
+      track('playground_share');
+      captureEvent('playground_share');
     }
-    track('playground_share');
-    captureEvent('playground_share');
   }, [buildShareUrl, copyShareUrl, code, addToast]);
 
   const handleResetToDefault = useCallback(() => {

--- a/apps/playground/src/hooks/usePlaygroundActions.ts
+++ b/apps/playground/src/hooks/usePlaygroundActions.ts
@@ -31,7 +31,7 @@ export function usePlaygroundActions(): PlaygroundActions {
   const code = usePlaygroundStore((s) => s.code);
   const addToast = useToastStore((s) => s.addToast);
   const { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, debouncedRun } = useCodeExecution();
-  const { updateUrl, copyShareUrl } = useUrlState();
+  const { updateUrl, copyShareUrl, buildShareUrl } = useUrlState();
   const handleScreenshot = useScreenshot();
   const resetViewerDefaults = useViewerStore((s) => s.resetViewerDefaults);
 
@@ -81,12 +81,24 @@ export function usePlaygroundActions(): PlaygroundActions {
     captureEvent('playground_export', { format: 'ifc' });
   }, [exportIFC, code, addToast]);
 
+  // On touch devices with the Web Share API, hand the permalink to the native
+  // share sheet (Messages / AirDrop / etc.); everywhere else fall back to the
+  // familiar copy-to-clipboard + toast. A dismissed share sheet rejects with
+  // AbortError, which we swallow.
   const handleShare = useCallback(() => {
-    void copyShareUrl(code);
-    addToast('Link copied to clipboard');
+    const coarse = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+    if (coarse && typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      const url = buildShareUrl(code);
+      void navigator.share({ title: 'brepjs Playground', url }).catch(() => {
+        /* user dismissed the share sheet */
+      });
+    } else {
+      void copyShareUrl(code);
+      addToast('Link copied to clipboard');
+    }
     track('playground_share');
     captureEvent('playground_share');
-  }, [copyShareUrl, code, addToast]);
+  }, [buildShareUrl, copyShareUrl, code, addToast]);
 
   const handleResetToDefault = useCallback(() => {
     usePlaygroundStore.getState().setCode(DEFAULT_CODE);

--- a/apps/playground/src/hooks/useUrlState.ts
+++ b/apps/playground/src/hooks/useUrlState.ts
@@ -56,10 +56,17 @@ export function useUrlState() {
     history.replaceState(null, '', `${window.location.pathname}${query}`);
   };
 
-  const copyShareUrl = async (code: string) => {
+  // Build the canonical permalink and sync it into the address bar, returning
+  // the absolute URL so callers can hand it to the native share sheet.
+  const buildShareUrl = (code: string): string => {
     const query = encodeCodeQuery(code, selectionsForUrl());
     const url = `${window.location.origin}${window.location.pathname}${query}`;
     history.replaceState(null, '', `${window.location.pathname}${query}`);
+    return url;
+  };
+
+  const copyShareUrl = async (code: string) => {
+    const url = buildShareUrl(code);
     try {
       await navigator.clipboard.writeText(url);
     } catch {
@@ -75,5 +82,5 @@ export function useUrlState() {
     }
   };
 
-  return { updateUrl, copyShareUrl };
+  return { updateUrl, copyShareUrl, buildShareUrl };
 }

--- a/apps/playground/src/stores/playgroundStore.ts
+++ b/apps/playground/src/stores/playgroundStore.ts
@@ -40,6 +40,10 @@ interface PlaygroundState {
   isViewerCollapsed: boolean;
   isEditorCollapsed: boolean;
   lastSuccessfulCode: string | null;
+  // Monotonic counter bumped on each successful render (setMeshes). The mobile
+  // shell compares it against the value it last showed to flag the Viewer tab
+  // when a result changed while the user was on another tab.
+  runSeq: number;
   selections: Selection[];
   hoverEntity: Selection | null;
   contextMenu: ContextMenuState | null;
@@ -92,6 +96,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   isViewerCollapsed: false,
   isEditorCollapsed: false,
   lastSuccessfulCode: null,
+  runSeq: 0,
   selections: [],
   hoverEntity: null,
   contextMenu: null,
@@ -101,14 +106,15 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   // Drop selections on every new render — they're bound to the mesh by
   // faceId/edgeId and the new mesh likely won't have the same ids.
   setMeshes: (meshes) =>
-    set({
+    set((s) => ({
       meshes,
       error: null,
       errorLine: null,
       selections: [],
       hoverEntity: null,
       contextMenu: null,
-    }),
+      runSeq: s.runSeq + 1,
+    })),
   setAvailableArtifacts: (availableArtifacts) => set({ availableArtifacts }),
   setBimTree: (bimTree) => set({ bimTree }),
   setFlatPattern: (flatPattern) => set({ flatPattern }),

--- a/apps/playground/src/stores/playgroundStore.ts
+++ b/apps/playground/src/stores/playgroundStore.ts
@@ -40,9 +40,11 @@ interface PlaygroundState {
   isViewerCollapsed: boolean;
   isEditorCollapsed: boolean;
   lastSuccessfulCode: string | null;
-  // Monotonic counter bumped on each successful render (setMeshes). The mobile
-  // shell compares it against the value it last showed to flag the Viewer tab
-  // when a result changed while the user was on another tab.
+  // Monotonic counter bumped once per successful render (via markRendered). The
+  // mobile shell compares it against the value it last showed to flag the Viewer
+  // tab when a result changed while the user was on another tab. Deliberately
+  // NOT tied to setMeshes — that also fires with [] at every run start (to drop
+  // stale geometry), which would flag the tab on run-start and on errors too.
   runSeq: number;
   selections: Selection[];
   hoverEntity: Selection | null;
@@ -65,6 +67,7 @@ interface PlaygroundState {
   setViewerCollapsed: (collapsed: boolean) => void;
   setEditorCollapsed: (collapsed: boolean) => void;
   setLastSuccessfulCode: (code: string) => void;
+  markRendered: () => void;
   pickSelection: (selection: Selection, additive: boolean) => void;
   clearSelections: () => void;
   setHoverEntity: (entity: Selection | null) => void;
@@ -106,15 +109,14 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   // Drop selections on every new render — they're bound to the mesh by
   // faceId/edgeId and the new mesh likely won't have the same ids.
   setMeshes: (meshes) =>
-    set((s) => ({
+    set({
       meshes,
       error: null,
       errorLine: null,
       selections: [],
       hoverEntity: null,
       contextMenu: null,
-      runSeq: s.runSeq + 1,
-    })),
+    }),
   setAvailableArtifacts: (availableArtifacts) => set({ availableArtifacts }),
   setBimTree: (bimTree) => set({ bimTree }),
   setFlatPattern: (flatPattern) => set({ flatPattern }),
@@ -126,6 +128,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set) => ({
   setViewerCollapsed: (isViewerCollapsed) => set({ isViewerCollapsed }),
   setEditorCollapsed: (isEditorCollapsed) => set({ isEditorCollapsed }),
   setLastSuccessfulCode: (lastSuccessfulCode) => set({ lastSuccessfulCode }),
+  markRendered: () => set((s) => ({ runSeq: s.runSeq + 1 })),
   pickSelection: (selection, additive) =>
     set((s) => {
       if (!additive) return { selections: [selection] };

--- a/apps/playground/src/styles/globals.css
+++ b/apps/playground/src/styles/globals.css
@@ -151,6 +151,32 @@ body,
   animation: reveal-up 0.25s ease-out both;
 }
 
+/* Subtle "result updated" pulse on the mobile Viewer tab dot — fires when a
+   run succeeds while the user is on the Editor/Console tab. */
+@keyframes tab-cue-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+}
+.animate-tab-cue {
+  animation: tab-cue-pulse 1.5s ease-in-out infinite;
+}
+
+/* --- Safe-area helpers (need viewport-fit=cover; resolve to 0 off notch) --- */
+
+.pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 /* --- Mesh gradient --- */
 
 .mesh-gradient {
@@ -413,6 +439,9 @@ body,
     animation: none !important;
   }
   .animate-toast-in {
+    animation: none !important;
+  }
+  .animate-tab-cue {
     animation: none !important;
   }
   .gen-cube path,

--- a/packages/brepjs-viewer/src/EdgeRenderer.tsx
+++ b/packages/brepjs-viewer/src/EdgeRenderer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { useThree, type ThreeEvent } from '@react-three/fiber';
+import { useTouchLongPress } from './longPress.js';
 import type { EdgeGroup, EdgeInfo, ScreenPos } from './types.js';
 
 export interface EdgeRendererProps {
@@ -38,7 +39,9 @@ export default function EdgeRenderer({
   onEdgeHover,
   onEdgeContextMenu,
 }: EdgeRendererProps) {
-  const pickable = Boolean(edgeGroups && edgeInfos && (onEdgePick || onEdgeHover || onEdgeContextMenu));
+  const pickable = Boolean(
+    edgeGroups && edgeInfos && (onEdgePick || onEdgeHover || onEdgeContextMenu)
+  );
   const viewportHeight = useThree((s) => s.size.height);
   const viewportHeightRef = useRef(viewportHeight);
   viewportHeightRef.current = viewportHeight;
@@ -75,14 +78,17 @@ export default function EdgeRenderer({
     [edgeGroups, edgeInfoById]
   );
 
+  const longPress = useTouchLongPress(resolveEdge, onEdgeContextMenu);
+
   const handleClick = useCallback(
     (event: ThreeEvent<MouseEvent>) => {
+      if (longPress.consumeFired()) return;
       const info = resolveEdge(event);
       if (!info) return;
       event.stopPropagation();
       onEdgePick?.(info, event.shiftKey, { x: event.clientX, y: event.clientY });
     },
-    [resolveEdge, onEdgePick]
+    [resolveEdge, onEdgePick, longPress]
   );
 
   const handleContextMenu = useCallback(
@@ -101,9 +107,10 @@ export default function EdgeRenderer({
   }, []);
   const handlePointerOut = useCallback(() => {
     document.body.style.cursor = '';
+    longPress.cancel();
     onEdgeHover?.(null);
     lastEdgeId.current = null;
-  }, [onEdgeHover]);
+  }, [onEdgeHover, longPress]);
 
   // pointermove updates hover each frame so the tooltip tracks the cursor
   // across the same edge. Stop propagation so the underlying face mesh's
@@ -112,13 +119,14 @@ export default function EdgeRenderer({
   // without this the edge would never win.
   const handlePointerMove = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
+      longPress.trackMove(event);
       const info = resolveEdge(event);
       if (!info) return;
       event.stopPropagation();
       lastEdgeId.current = info.edgeId;
       onEdgeHover?.(info, { x: event.clientX, y: event.clientY });
     },
-    [resolveEdge, onEdgeHover]
+    [resolveEdge, onEdgeHover, longPress]
   );
 
   // R3F doesn't synthesize `pointerout` for an object that gets unmounted
@@ -151,6 +159,9 @@ export default function EdgeRenderer({
     ? {
         onClick: handleClick,
         onContextMenu: handleContextMenu,
+        onPointerDown: longPress.start,
+        onPointerUp: longPress.cancel,
+        onPointerCancel: longPress.cancel,
         onPointerOver: handlePointerOver,
         onPointerOut: handlePointerOut,
         onPointerMove: handlePointerMove,

--- a/packages/brepjs-viewer/src/Renderer.tsx
+++ b/packages/brepjs-viewer/src/Renderer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import { buildGeometry, findFaceGroupAt } from './geometry.js';
+import { useTouchLongPress } from './longPress.js';
 import type { MeshData, FaceInfo, ViewMode, ScreenPos } from './types.js';
 
 export interface RendererProps {
@@ -53,14 +54,19 @@ export function Renderer({
     [data.faceGroups, faceInfoById]
   );
 
+  const longPress = useTouchLongPress(resolveFace, onFaceContextMenu);
+
   const onClick = useCallback(
     (e: ThreeEvent<MouseEvent>) => {
+      // Swallow the tap the browser synthesizes when a touch long-press just
+      // opened the context menu, so it doesn't also select the entity.
+      if (longPress.consumeFired()) return;
       const info = resolveFace(e);
       if (!info) return;
       e.stopPropagation();
       onFacePick?.(info, e.shiftKey, { x: e.clientX, y: e.clientY });
     },
-    [resolveFace, onFacePick]
+    [resolveFace, onFacePick, longPress]
   );
   const onCtx = useCallback(
     (e: ThreeEvent<MouseEvent>) => {
@@ -74,24 +80,29 @@ export function Renderer({
   );
   const onMove = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      longPress.trackMove(e);
       const info = resolveFace(e);
       if (!info) return;
       onFaceHover?.(info, { x: e.clientX, y: e.clientY });
     },
-    [resolveFace, onFaceHover]
+    [resolveFace, onFaceHover, longPress]
   );
   const onOver = useCallback(() => {
     document.body.style.cursor = 'pointer';
   }, []);
   const onOut = useCallback(() => {
     document.body.style.cursor = '';
+    longPress.cancel();
     onFaceHover?.(null);
-  }, [onFaceHover]);
+  }, [onFaceHover, longPress]);
 
   const handlers = pickable
     ? {
         onClick,
         onContextMenu: onCtx,
+        onPointerDown: longPress.start,
+        onPointerUp: longPress.cancel,
+        onPointerCancel: longPress.cancel,
         onPointerOver: onOver,
         onPointerOut: onOut,
         onPointerMove: onMove,

--- a/packages/brepjs-viewer/src/ViewerControls.tsx
+++ b/packages/brepjs-viewer/src/ViewerControls.tsx
@@ -21,6 +21,8 @@ export interface ViewerControlsProps {
   onView?: (view: ViewName) => void;
   onFit?: () => void;
   onScreenshot?: () => void;
+  /** Enlarge buttons and gaps for finger taps on touch devices. */
+  touch?: boolean;
   className?: string;
 }
 
@@ -51,23 +53,28 @@ export function ViewerControls({
   onView,
   onFit,
   onScreenshot,
+  touch = false,
   className,
 }: ViewerControlsProps) {
   return (
-    <div className={className} style={className ? undefined : containerStyle}>
+    <div
+      className={className}
+      style={className ? undefined : { ...containerStyle, gap: touch ? 8 : 6 }}
+    >
       {(onFit || onScreenshot) && (
-        <Group>
-          {onFit && <Btn label="Fit" onClick={onFit} />}
-          {onScreenshot && <Btn label="Snap" onClick={onScreenshot} />}
+        <Group touch={touch}>
+          {onFit && <Btn label="Fit" onClick={onFit} touch={touch} />}
+          {onScreenshot && <Btn label="Snap" onClick={onScreenshot} touch={touch} />}
         </Group>
       )}
       {viewMode && onViewModeChange && (
-        <Group>
+        <Group touch={touch}>
           {(Object.keys(MODE_LABELS) as ViewMode[]).map((mode) => (
             <Btn
               key={mode}
               label={MODE_LABELS[mode]}
               active={viewMode === mode}
+              touch={touch}
               onClick={() => {
                 onViewModeChange(mode);
               }}
@@ -76,30 +83,34 @@ export function ViewerControls({
         </Group>
       )}
       {(onToggleEdges || onToggleGrid || onToggleAutoRotate || onToggleProjection) && (
-        <Group>
+        <Group touch={touch}>
           {onToggleEdges && (
-            <Btn label="Edges" active={showEdges} onClick={onToggleEdges} />
+            <Btn label="Edges" active={showEdges} onClick={onToggleEdges} touch={touch} />
           )}
-          {onToggleGrid && <Btn label="Grid" active={showGrid} onClick={onToggleGrid} />}
+          {onToggleGrid && (
+            <Btn label="Grid" active={showGrid} onClick={onToggleGrid} touch={touch} />
+          )}
           {onToggleAutoRotate && (
-            <Btn label="Spin" active={autoRotate} onClick={onToggleAutoRotate} />
+            <Btn label="Spin" active={autoRotate} onClick={onToggleAutoRotate} touch={touch} />
           )}
           {onToggleProjection && (
             <Btn
               label={projection === 'orthographic' ? 'Ortho' : 'Persp'}
               active={projection === 'orthographic'}
+              touch={touch}
               onClick={onToggleProjection}
             />
           )}
         </Group>
       )}
       {onView && (
-        <Group>
+        <Group touch={touch}>
           {VIEW_NAMES.map((view) => (
             <Btn
               key={view}
               label={VIEW_LABELS[view]}
               active={activeView === view}
+              touch={touch}
               onClick={() => {
                 onView(view);
               }}
@@ -111,18 +122,20 @@ export function ViewerControls({
   );
 }
 
-function Group({ children }: { children: ReactNode }) {
-  return <div style={groupStyle}>{children}</div>;
+function Group({ children, touch }: { children: ReactNode; touch?: boolean }) {
+  return <div style={touch ? groupStyleTouch : groupStyle}>{children}</div>;
 }
 
 function Btn({
   label,
   active,
   onClick,
+  touch,
 }: {
   label: string;
   active?: boolean | undefined;
   onClick: () => void;
+  touch?: boolean;
 }) {
   return (
     <button
@@ -131,7 +144,10 @@ function Btn({
       // Omit aria-pressed for one-shot actions (Fit/Snap, active===undefined); set it only
       // for the toggle buttons so screen readers don't announce actions as unpressed toggles.
       aria-pressed={active}
-      style={{ ...buttonStyle, ...(active ? activeButtonStyle : null) }}
+      style={{
+        ...(touch ? buttonStyleTouch : buttonStyle),
+        ...(active ? activeButtonStyle : null),
+      }}
     >
       {label}
     </button>
@@ -179,4 +195,11 @@ const activeButtonStyle: CSSProperties = {
   color: '#6ee7d7',
   background: 'rgba(45, 212, 191, 0.16)',
   borderColor: 'rgba(45, 212, 191, 0.3)',
+};
+const groupStyleTouch: CSSProperties = { ...groupStyle, gap: 6, padding: 6 };
+const buttonStyleTouch: CSSProperties = {
+  ...buttonStyle,
+  padding: '9px 14px',
+  fontSize: 13,
+  borderRadius: 6,
 };

--- a/packages/brepjs-viewer/src/longPress.ts
+++ b/packages/brepjs-viewer/src/longPress.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { ThreeEvent } from '@react-three/fiber';
+import type { ScreenPos } from './types.js';
+
+const LONG_PRESS_MS = 500;
+const MOVE_TOLERANCE_PX = 10;
+
+// Touch has no right-click, so a stationary finger held on an entity stands in
+// for the desktop context-menu gesture. A press that moves past the tolerance
+// (i.e. an orbit drag) cancels it, and the `consumeFired` flag lets the caller
+// swallow the select-on-release the browser synthesizes after a long press.
+export function useTouchLongPress<T>(
+  resolve: (event: ThreeEvent<PointerEvent>) => T | null,
+  onLongPress: ((info: T, pos: ScreenPos) => void) | undefined
+) {
+  const state = useRef<{
+    timer: ReturnType<typeof setTimeout> | null;
+    x: number;
+    y: number;
+    fired: boolean;
+  }>({ timer: null, x: 0, y: 0, fired: false });
+
+  const cancel = useCallback(() => {
+    if (state.current.timer) {
+      clearTimeout(state.current.timer);
+      state.current.timer = null;
+    }
+  }, []);
+
+  const start = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (event.nativeEvent.pointerType !== 'touch' || !onLongPress) return;
+      const info = resolve(event);
+      if (!info) return;
+      const x = event.clientX;
+      const y = event.clientY;
+      cancel();
+      state.current.x = x;
+      state.current.y = y;
+      state.current.fired = false;
+      state.current.timer = setTimeout(() => {
+        state.current.fired = true;
+        state.current.timer = null;
+        onLongPress(info, { x, y });
+      }, LONG_PRESS_MS);
+    },
+    [resolve, onLongPress, cancel]
+  );
+
+  const trackMove = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      const s = state.current;
+      if (!s.timer) return;
+      if (
+        Math.abs(event.clientX - s.x) > MOVE_TOLERANCE_PX ||
+        Math.abs(event.clientY - s.y) > MOVE_TOLERANCE_PX
+      ) {
+        cancel();
+      }
+    },
+    [cancel]
+  );
+
+  const consumeFired = useCallback(() => {
+    if (state.current.fired) {
+      state.current.fired = false;
+      return true;
+    }
+    return false;
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
+  return { start, cancel, trackMove, consumeFired };
+}


### PR DESCRIPTION
## Mobile web playground UX pass

Improves the playground's mobile experience on the existing tabbed shell (Editor / Viewer / Console). Scope was agreed up front: polish the shell rather than re-architect, surface exports via a bottom sheet, tune Monaco (not replace it), and add safe-area + `dvh` handling. Out of scope: editor replacement, gallery redesign, landscape-specific layout, global touch-target sweep.

### Playground
- **Bottom action sheet** — a new `⋯` toolbar button (compact/mobile only) opens a thumb-reachable sheet with **Share / STL / STEP / DXF / IFC** (DXF/IFC stay conditional on `availableArtifacts`). On mobile these were previously reachable *only* through the command palette, whose canonical trigger is `Cmd+K` — a shortcut a phone has no keyboard for.
- **Native share** — `Share` uses the Web Share API on touch devices (permalink → Messages/AirDrop/etc.), falling back to clipboard-copy + toast everywhere else. Desktop behavior is unchanged.
- **16px Monaco on mobile** — below 16px, iOS Safari auto-zooms the page when the editor focuses, breaking the fixed layout. (Word-wrap was already on.)
- **Safe-area insets** — adds `viewport-fit=cover` and `env(safe-area-inset-*)` to the toolbar, bottom tab bar, and action sheet so they clear the notch / home indicator.
- **Dynamic viewport height** — the shell switches from `100vh`/`h-screen` to `dvh` so the virtual keyboard no longer clips the layout.
- **Viewer "updated" cue** — a subtle, reduced-motion-aware pulse on the Viewer tab when a debounced auto-run lands while the user is on another tab (driven by a new `runSeq` counter), without yanking them off their current tab.
- **Gallery touch-up** — larger category-rail tap targets on mobile and safe-area bottom padding so the last card row clears the home indicator.

### Viewer (`brepjs-viewer`, shared package)
- **Touch long-press → context menu** — touch has no right-click, so a stationary long-press now opens the entity context menu (faces and edges). An orbit drag cancels it; the synthesized release-tap is swallowed so it doesn't also select. Tap-to-select already worked via R3F `onClick`. Gated on `pointerType === 'touch'` and the presence of a context-menu handler, so brepjs-verify is unaffected unless it opts in.
- **`touch` prop on `ViewerControls`** — enlarges button padding/font and group gaps for finger taps; the playground passes it from `useTouchDevice`.

### Verification
- Playground: `tsc -b` ✓, `check:examples` (51 snippets) ✓, full `vite build` ✓
- Viewer: `npm run build` ✓, ESLint ✓
- Puppeteer at 390×844 touch viewport: confirmed `mobile:true / coarse:true`, the action-sheet contents (Share/STL/STEP for the default model), `editor line font-size: 16px`, and the gallery — across the four mobile states (viewer / action sheet / editor / gallery).

### Notes
- `brepjs-viewer` ships as gitignored `dist` built in CI, so its source change is picked up on the CI build (no committed dist).
- The now finger-sized viewer overlay controls stack near the full viewer height on a phone — that's the existing top-right vertical layout, just larger. A future "collapse controls on mobile" pass is possible but was intentionally out of scope.
