### PR TITLE
feat(brepjs-verify): Langfuse observability foundation

### DIFF
--- a/.claude/commands/eval-skill.md
+++ b/.claude/commands/eval-skill.md
@@ -91,10 +91,19 @@ bugs if a verify report exposes one). Then ask whether to apply them.
 
 ## Optional — log to Langfuse
 
-If `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` are set, record the run so it
-trends over skill versions. Write the scorecard as JSON matching `bench/score.ts` `Scorecard` —
-`{ model, brepjsVersion, skillVersion, date, results: EvalResult[] }`, where each result carries
-`auto`, `judgePass`, and `firstTry` so the lift is computed — then push it:
-`npm run eval:push -w brepjs-verify -- <scorecard.json>`. It sends one trace with the aggregate
-scores (`both`, `first_try_both`, `eventual_both`, `lift`), stamped with the skill version, and
-no-ops without the keys.
+If the LANGFUSE\_\* keys are set, record the run so it trends over skill versions. Keys live in the
+repo-root `.env` as `LANGFUSE_HOST` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`; the SDK reads
+`LANGFUSE_BASE_URL`, so bridge first or it silently hits EU cloud:
+`set -a; . ./.env; set +a; export LANGFUSE_BASE_URL="${LANGFUSE_BASE_URL:-$LANGFUSE_HOST}"`.
+
+Once per corpus change, sync the dataset: `npm run eval:dataset:sync -w brepjs-verify` (upserts the
+playground examples into the `brepjs-playground` dataset, keyed by example id).
+
+Write the scorecard as JSON matching `bench/score.ts` `Scorecard` — `{ model, brepjsVersion,
+skillVersion, date, results: EvalResult[] }`, where each result's `id` **is the playground example
+id** and carries `auto`, `judgePass`, and `firstTry` (so the lift is computed) — then push:
+`npm run eval:push -w brepjs-verify -- <scorecard.json>`. It records two things, both no-op without
+keys: (1) one `eval-run` trace with the aggregate scores (`both`, `first_try_both`, `eventual_both`,
+`lift`), and (2) a dataset run on `brepjs-playground` — one trace per part, scored and linked to its
+dataset item — so skill versions compare per part in the dataset Runs view. The run name is the
+`skillVersion`.

--- a/.claude/commands/eval-skill.md
+++ b/.claude/commands/eval-skill.md
@@ -91,6 +91,10 @@ bugs if a verify report exposes one). Then ask whether to apply them.
 
 ## Optional — log to Langfuse
 
-If `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` are set and the user
-wants trend history, offer to record the run (skill version + model + per-category both%)
-so manual runs still accrue a trend over time.
+If `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` are set, record the run so it
+trends over skill versions. Write the scorecard as JSON matching `bench/score.ts` `Scorecard` —
+`{ model, brepjsVersion, skillVersion, date, results: EvalResult[] }`, where each result carries
+`auto`, `judgePass`, and `firstTry` so the lift is computed — then push it:
+`npm run eval:push -w brepjs-verify -- <scorecard.json>`. It sends one trace with the aggregate
+scores (`both`, `first_try_both`, `eventual_both`, `lift`), stamped with the skill version, and
+no-ops without the keys.

--- a/.github/workflows/eval-on-demand.yml
+++ b/.github/workflows/eval-on-demand.yml
@@ -1,0 +1,64 @@
+name: eval-on-demand
+
+# On-demand brepjs-verify skill eval against the playground quality bar. Authors + judges each
+# example with Claude (BILLED — uses ANTHROPIC_API_KEY) and records the run to Langfuse: aggregate
+# scores on one trace + a brepjs-playground dataset experiment (per-part scores linked to each
+# dataset item). Deliberately NOT scheduled — trigger from the Actions tab or
+# `gh workflow run eval-on-demand -f only=basics` when you want a fresh trend point.
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: 'Scope: a category (basics | mechanical), an example id, or "all"'
+        required: true
+        default: 'basics'
+        type: string
+      model:
+        description: 'Author + judge model'
+        required: true
+        default: 'claude-opus-4-8'
+        type: string
+      max_attempts:
+        description: 'Max author -> verify -> judge attempts per part'
+        required: true
+        default: '3'
+        type: string
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      # The sandbox imports 'brepjs' and snapshots render through the viewers, so build the library,
+      # the shared renderer, and the verify package (its CLI + local viewer/dist) before evaluating.
+      - name: Build library + viewers + verify
+        run: |
+          npm run build
+          npm run build --workspace=brepjs-viewer
+          npm run build --workspace=brepjs-verify
+      - name: Install Chrome for snapshots
+        run: npx puppeteer browsers install chrome
+        working-directory: packages/brepjs-verify
+      - name: Run eval (author + judge + push to Langfuse)
+        # Inputs are passed via env (never interpolated into the run script) so a crafted dispatch
+        # value can't inject shell commands; each is quoted on use.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          ONLY: ${{ inputs.only }}
+          MODEL: ${{ inputs.model }}
+          MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        run: |
+          npm run eval:live -w brepjs-verify -- \
+            --corpus playground \
+            --only "$ONLY" \
+            --model "$MODEL" \
+            --max-attempts "$MAX_ATTEMPTS"

--- a/packages/brepjs-verify/bench/langfuse.ts
+++ b/packages/brepjs-verify/bench/langfuse.ts
@@ -3,7 +3,7 @@ import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { startActiveObservation } from '@langfuse/tracing';
 import { LangfuseClient } from '@langfuse/client';
 import type { EvalPrompt } from './prompts.js';
-import { SCHEMA_VERSION, type EvalResult } from './score.js';
+import { SCHEMA_VERSION, runScores, type EvalResult, type Scorecard } from './score.js';
 
 /**
  * Langfuse v5 (OpenTelemetry-based) telemetry for the live eval, behind a no-op shim.
@@ -28,6 +28,8 @@ export interface Telemetry {
   ) => Promise<EvalResult>;
   /** Register the SKILL.md text as a versioned Langfuse prompt (best-effort, once per run). */
   registerSkill: (skillMd: string) => Promise<void>;
+  /** Push one run's aggregate scores (both% + first-try-vs-eventual lift) on a single trace. */
+  pushScorecard: (card: Scorecard) => Promise<void>;
   /** Flush spans + scores and shut down. */
   shutdown: () => Promise<void>;
 }
@@ -35,6 +37,7 @@ export interface Telemetry {
 const NOOP: Telemetry = {
   observePrompt: (_p, _metadata, run) => run(),
   registerSkill: () => Promise.resolve(),
+  pushScorecard: () => Promise.resolve(),
   shutdown: () => Promise.resolve(),
 };
 
@@ -95,6 +98,42 @@ export function createTelemetry(): Telemetry {
         console.warn(
           `langfuse: skill prompt registration failed (${(e as Error).message.split('\n')[0]})`
         );
+      }
+    },
+    pushScorecard: async (card) => {
+      // One trace per run carrying the aggregate scores, so Langfuse trends both%/lift across
+      // skill versions. Strictly best-effort — a telemetry failure never affects the eval output.
+      try {
+        await startActiveObservation('eval-run', (obs) => {
+          obs.update({
+            input: {
+              model: card.model,
+              judgeModel: card.judgeModel,
+              brepjsVersion: card.brepjsVersion,
+            },
+            output: { prompts: card.results.length },
+            metadata: {
+              date: card.date,
+              skillVersion: card.skillVersion,
+              schemaVersion: SCHEMA_VERSION,
+              units: 'mm',
+            },
+          });
+          for (const s of runScores(card)) {
+            try {
+              client.score.create({
+                traceId: obs.traceId,
+                name: s.name,
+                value: s.value,
+                dataType: 'NUMERIC',
+              });
+            } catch {
+              // best-effort — a single score failure must not break the run push.
+            }
+          }
+        });
+      } catch (e) {
+        console.warn(`langfuse: pushScorecard failed (${(e as Error).message.split('\n')[0]})`);
       }
     },
     shutdown: async () => {

--- a/packages/brepjs-verify/bench/langfuse.ts
+++ b/packages/brepjs-verify/bench/langfuse.ts
@@ -113,8 +113,10 @@ export function createTelemetry(): Telemetry {
     pushScorecard: async (card) => {
       // One trace per run carrying the aggregate scores, so Langfuse trends both%/lift across
       // skill versions. Strictly best-effort — a telemetry failure never affects the eval output.
+      // The callback is sync (update + enqueue scores), so startActiveObservation returns a
+      // non-Promise and isn't awaited; client.flush() below delivers the scores.
       try {
-        await startActiveObservation('eval-run', (obs) => {
+        startActiveObservation('eval-run', (obs) => {
           obs.update({
             input: {
               model: card.model,
@@ -142,6 +144,7 @@ export function createTelemetry(): Telemetry {
             }
           }
         });
+        await client.flush();
       } catch (e) {
         console.warn(`langfuse: pushScorecard failed (${(e as Error).message.split('\n')[0]})`);
       }

--- a/packages/brepjs-verify/bench/langfuse.ts
+++ b/packages/brepjs-verify/bench/langfuse.ts
@@ -3,7 +3,13 @@ import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { startActiveObservation } from '@langfuse/tracing';
 import { LangfuseClient } from '@langfuse/client';
 import type { EvalPrompt } from './prompts.js';
-import { SCHEMA_VERSION, runScores, type EvalResult, type Scorecard } from './score.js';
+import {
+  SCHEMA_VERSION,
+  runScores,
+  itemScores,
+  type EvalResult,
+  type Scorecard,
+} from './score.js';
 
 /**
  * Langfuse v5 (OpenTelemetry-based) telemetry for the live eval, behind a no-op shim.
@@ -15,9 +21,10 @@ import { SCHEMA_VERSION, runScores, type EvalResult, type Scorecard } from './sc
  * corrupt the eval. The split-package v5 API is used directly (`@langfuse/tracing` + `@langfuse/otel`
  * + `@langfuse/client`); there is no single `langfuse` package and no `.trace()/.generation()`.
  *
- * Deferred (spec Delta 2, both need live keys to validate): a formal dataset run linking traces to
- * dataset items, and per-call nested generation/span observations. Runs are grouped today via trace
- * metadata (runId / skillVersion / model).
+ * `pushDatasetRun` records a run as a Langfuse dataset experiment — one trace per part, its scores
+ * linked to the matching `brepjs-playground` dataset item, under a per-skill-version run name — so
+ * runs compare natively in the dataset Runs view. Deferred: per-call nested generation/span
+ * observations inside the live `eval:live` path.
  */
 export interface Telemetry {
   /** Run one prompt's eval inside a trace; derive + attach scores from the result. */
@@ -30,6 +37,8 @@ export interface Telemetry {
   registerSkill: (skillMd: string) => Promise<void>;
   /** Push one run's aggregate scores (both% + first-try-vs-eventual lift) on a single trace. */
   pushScorecard: (card: Scorecard) => Promise<void>;
+  /** Record the run as a dataset experiment: per-part trace + scores linked to its dataset item. */
+  pushDatasetRun: (card: Scorecard) => Promise<void>;
   /** Flush spans + scores and shut down. */
   shutdown: () => Promise<void>;
 }
@@ -38,6 +47,7 @@ const NOOP: Telemetry = {
   observePrompt: (_p, _metadata, run) => run(),
   registerSkill: () => Promise.resolve(),
   pushScorecard: () => Promise.resolve(),
+  pushDatasetRun: () => Promise.resolve(),
   shutdown: () => Promise.resolve(),
 };
 
@@ -136,6 +146,35 @@ export function createTelemetry(): Telemetry {
         console.warn(`langfuse: pushScorecard failed (${(e as Error).message.split('\n')[0]})`);
       }
     },
+    pushDatasetRun: async (card) => {
+      // Record the run as a Langfuse dataset experiment so per-part scores compare across skill
+      // versions natively (the lift view). Each result links its own trace to the matching
+      // brepjs-playground dataset item (item id === example id) under one run name = the skill
+      // version. Best-effort + isolated per item: corpus drift (a result whose id has no dataset
+      // item) only warns and skips, so one missing item never aborts the rest of the run.
+      const runName = card.skillVersion ?? `${card.model}-${card.date}`;
+      for (const r of card.results) {
+        try {
+          await startActiveObservation(r.id, async (obs) => {
+            obs.update({
+              metadata: { runName, category: r.category, skillVersion: card.skillVersion },
+            });
+            attachScores(client, obs.traceId, r);
+            await client.api.datasetRunItems.create({
+              runName,
+              runDescription: `brepjs-verify eval — ${card.model} ${card.date}`,
+              datasetItemId: r.id,
+              traceId: obs.traceId,
+              metadata: { skillVersion: card.skillVersion, brepjsVersion: card.brepjsVersion },
+            });
+          });
+        } catch (e) {
+          console.warn(
+            `langfuse: dataset-run link failed for ${r.id} (${(e as Error).message.split('\n')[0]})`
+          );
+        }
+      }
+    },
     shutdown: async () => {
       try {
         await client.flush();
@@ -147,19 +186,13 @@ export function createTelemetry(): Telemetry {
   };
 }
 
-/** Derive the run's scores from the EvalResult and queue them on the trace (best-effort). */
+/** Queue the part's per-item scores on its trace (best-effort; shared with the dataset-run path). */
 function attachScores(client: LangfuseClient, traceId: string, r: EvalResult): void {
-  const both = (autoPass: boolean, judgePass: boolean | undefined): number =>
-    autoPass && judgePass === true ? 1 : 0;
-  const put = (name: string, value: number): void => {
+  for (const s of itemScores(r)) {
     try {
-      client.score.create({ traceId, name, value, dataType: 'NUMERIC' });
+      client.score.create({ traceId, name: s.name, value: s.value, dataType: 'NUMERIC' });
     } catch {
       // best-effort — never let a score failure break the eval.
     }
-  };
-  put('auto_pass', r.auto.pass ? 1 : 0);
-  put('judge_pass', r.judgePass === true ? 1 : 0);
-  put('eventual_both', both(r.auto.pass, r.judgePass));
-  if (r.firstTry) put('first_try_both', both(r.firstTry.auto.pass, r.firstTry.judgePass));
+  }
 }

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module';
 import Anthropic from '@anthropic-ai/sdk';
 import { runProgramWithStep } from '../src/sandbox/runProgram.js';
 import { PROMPTS, type EvalPrompt } from './prompts.js';
+import { playgroundPrompts } from './playgroundCorpus.js';
 import { formatScorecard, type EvalResult, type Scorecard } from './score.js';
 import { runAttemptLoop, type ChatMessage, type LoopDeps } from './loop.js';
 import { judge } from './judge.js';
@@ -28,6 +29,8 @@ interface Args {
   only?: string | undefined;
   keep: boolean;
   maxAttempts: number;
+  /** Which corpus to author against: the playground quality bar (default) or the legacy toy prompts. */
+  corpus: 'playground' | 'prompts';
 }
 
 function parseArgs(argv: readonly string[]): Args {
@@ -36,6 +39,7 @@ function parseArgs(argv: readonly string[]): Args {
     judgeModel: 'claude-opus-4-8',
     keep: false,
     maxAttempts: 3,
+    corpus: 'playground',
   };
   let judgeOverride: string | undefined;
   for (let i = 0; i < argv.length; i++) {
@@ -44,6 +48,7 @@ function parseArgs(argv: readonly string[]): Args {
     else if (a === '--judge-model') judgeOverride = argv[++i];
     else if (a === '--only') args.only = argv[++i];
     else if (a === '--keep') args.keep = true;
+    else if (a === '--corpus') args.corpus = argv[++i] === 'prompts' ? 'prompts' : 'playground';
     else if (a === '--max-attempts')
       args.maxAttempts = Math.max(1, Math.trunc(Number(argv[++i])) || args.maxAttempts);
   }
@@ -171,11 +176,12 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const args = parseArgs(process.argv.slice(2));
-  const prompts = PROMPTS.filter(
-    (p) => !args.only || p.id === args.only || p.category === args.only
-  );
+  const corpus = args.corpus === 'playground' ? await playgroundPrompts() : [...PROMPTS];
+  // `--only all` (or blank) means the whole corpus; otherwise match an id or a category.
+  const only = args.only && args.only !== 'all' ? args.only : undefined;
+  const prompts = corpus.filter((p) => !only || p.id === only || p.category === only);
   if (prompts.length === 0) {
-    console.error(`no prompts match --only ${args.only ?? ''}`);
+    console.error(`no prompts match --only ${args.only ?? ''} in corpus ${args.corpus}`);
     process.exit(1);
   }
 
@@ -223,10 +229,16 @@ async function main(): Promise<void> {
     model: args.model,
     judgeModel: args.judgeModel,
     brepjsVersion: version,
+    skillVersion: skillVer,
     date,
     results,
   };
   console.log('\n' + formatScorecard(card));
+  // Record the run for Langfuse trends: aggregate scores on one trace, plus — for the playground
+  // corpus — a dataset experiment on brepjs-playground (per-part scores linked to each dataset item),
+  // the same two records the manual loop's `eval:push` writes. Best-effort + no-op without keys.
+  await telemetry.pushScorecard(card);
+  if (args.corpus === 'playground') await telemetry.pushDatasetRun(card);
   await telemetry.shutdown();
 
   if (!args.keep) rmSync(workdir, { recursive: true, force: true });

--- a/packages/brepjs-verify/bench/playgroundCorpus.ts
+++ b/packages/brepjs-verify/bench/playgroundCorpus.ts
@@ -1,0 +1,40 @@
+import type { EvalPrompt } from './prompts.js';
+
+// Load the plain-brepjs playground examples as the live-eval corpus — the same quality bar the
+// manual `/eval-skill` loop and the `brepjs-playground` Langfuse dataset use. Each example's
+// description is BOTH the request handed to the author and the rubric handed to the judge (the part
+// must read as that designed object); the example id keys the matching dataset item, so an
+// `eval:live --corpus playground` run records cleanly as a dataset experiment. `basics` +
+// `mechanical` only (plain brepjs); `bim` / `sheet-metal` need their own skills.
+const SCOPE = new Set(['basics', 'mechanical']);
+
+interface Example {
+  id: string;
+  label: string;
+  description: string;
+  code: string;
+}
+interface Category {
+  id: string;
+  label: string;
+  examples: readonly Example[];
+}
+
+/**
+ * Load the playground examples as EvalPrompts. A runtime (variable-path) import so the bench tsconfig
+ * takes no compile-time dependency on the playground app (same approach as bench/syncDataset.ts).
+ */
+export async function playgroundPrompts(): Promise<EvalPrompt[]> {
+  const registry = '../../../apps/playground/src/lib/examples/index.ts';
+  const mod = (await import(registry)) as { CATEGORIES: readonly Category[] };
+  return mod.CATEGORIES.filter((c) => SCOPE.has(c.id)).flatMap((c) =>
+    c.examples.map(
+      (e): EvalPrompt => ({
+        id: e.id,
+        category: c.id as EvalPrompt['category'],
+        prompt: e.description,
+        rubric: e.description,
+      })
+    )
+  );
+}

--- a/packages/brepjs-verify/bench/prompts.ts
+++ b/packages/brepjs-verify/bench/prompts.ts
@@ -10,7 +10,16 @@
 
 export interface EvalPrompt {
   id: string;
-  category: 'primitive' | 'boolean' | 'sketch' | 'modifier' | 'transform' | 'gridfinity';
+  category:
+    | 'primitive'
+    | 'boolean'
+    | 'sketch'
+    | 'modifier'
+    | 'transform'
+    | 'gridfinity'
+    // Playground corpus categories (the `eval:live --corpus playground` quality bar).
+    | 'basics'
+    | 'mechanical';
   /** The natural-language request handed to the model. */
   prompt: string;
   /** What a correct part must show — handed to the multimodal judge. */

--- a/packages/brepjs-verify/bench/pushScorecard.ts
+++ b/packages/brepjs-verify/bench/pushScorecard.ts
@@ -2,9 +2,11 @@ import { readFileSync } from 'node:fs';
 import { createTelemetry } from './langfuse.js';
 import type { Scorecard } from './score.js';
 
-// Push a saved scorecard to Langfuse as one run-level trace carrying the aggregate scores
-// (both% + first-try-vs-eventual lift), so runs trend over skill versions. No-op without the
-// LANGFUSE_* keys. The `/eval-skill` manual loop writes the scorecard JSON, then runs this.
+// Push a saved scorecard to Langfuse two ways: (1) one run-level trace carrying the aggregate scores
+// (both% + first-try-vs-eventual lift) so runs trend over skill versions, and (2) a dataset run /
+// experiment on `brepjs-playground` — one trace per part, scored + linked to its dataset item — so
+// skill versions compare per part natively. No-op without the LANGFUSE_* keys. The `/eval-skill`
+// manual loop writes the scorecard JSON, then runs this.
 //   npm run eval:push -w brepjs-verify -- <scorecard.json>
 async function main(): Promise<void> {
   const path = process.argv[2];
@@ -15,10 +17,12 @@ async function main(): Promise<void> {
   const card = JSON.parse(readFileSync(path, 'utf8')) as Scorecard;
   const telemetry = createTelemetry();
   await telemetry.pushScorecard(card);
+  await telemetry.pushDatasetRun(card);
   await telemetry.shutdown();
+  const runName = card.skillVersion ?? `${card.model}-${card.date}`;
   console.log(
     process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY']
-      ? `langfuse: pushed run-level scores for ${card.results.length} parts (${card.skillVersion ?? card.brepjsVersion}).`
+      ? `langfuse: pushed run-level scores + dataset run "${runName}" for ${card.results.length} parts.`
       : 'langfuse: no LANGFUSE_* keys set — nothing pushed (set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_BASE_URL).'
   );
 }

--- a/packages/brepjs-verify/bench/pushScorecard.ts
+++ b/packages/brepjs-verify/bench/pushScorecard.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { createTelemetry } from './langfuse.js';
+import type { Scorecard } from './score.js';
+
+// Push a saved scorecard to Langfuse as one run-level trace carrying the aggregate scores
+// (both% + first-try-vs-eventual lift), so runs trend over skill versions. No-op without the
+// LANGFUSE_* keys. The `/eval-skill` manual loop writes the scorecard JSON, then runs this.
+//   npm run eval:push -w brepjs-verify -- <scorecard.json>
+async function main(): Promise<void> {
+  const path = process.argv[2];
+  if (!path) {
+    console.error('usage: pushScorecard <scorecard.json>  (a bench/score.ts Scorecard)');
+    process.exit(2);
+  }
+  const card = JSON.parse(readFileSync(path, 'utf8')) as Scorecard;
+  const telemetry = createTelemetry();
+  await telemetry.pushScorecard(card);
+  await telemetry.shutdown();
+  console.log(
+    process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY']
+      ? `langfuse: pushed run-level scores for ${card.results.length} parts (${card.skillVersion ?? card.brepjsVersion}).`
+      : 'langfuse: no LANGFUSE_* keys set — nothing pushed (set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_BASE_URL).'
+  );
+}
+
+await main();

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -193,6 +193,26 @@ export function runScores(card: Scorecard): RunScore[] {
 }
 
 /**
+ * Per-part scores for one EvalResult — the part's own valid/judge/both, plus its first-try both when
+ * loop data is present. Attached to a per-item trace that's linked to the matching
+ * `brepjs-playground` dataset item, so a dataset run compares parts across skill versions natively
+ * (the lift view). Mirrors the run-level `runScores` at single-part granularity.
+ */
+export function itemScores(r: EvalResult): RunScore[] {
+  const both = (autoPass: boolean, judgePass: boolean | undefined): number =>
+    autoPass && judgePass === true ? 1 : 0;
+  const out: RunScore[] = [
+    { name: 'auto_pass', value: r.auto.pass ? 1 : 0 },
+    { name: 'judge_pass', value: r.judgePass === true ? 1 : 0 },
+    { name: 'eventual_both', value: both(r.auto.pass, r.judgePass) },
+  ];
+  if (r.firstTry) {
+    out.push({ name: 'first_try_both', value: both(r.firstTry.auto.pass, r.firstTry.judgePass) });
+  }
+  return out;
+}
+
+/**
  * How many *built* parts (eventual attempt produced a STEP) actually got judged. A built part left
  * unjudged means the snapshot/judge pipeline silently failed (no Chrome/viewer) — a harness
  * regression that would otherwise hide as `judge:—` while `both%` collapses to `auto%` (vision §6).

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -75,7 +75,9 @@ export function checkAuto(report: VerifyReport, expected: EvalPrompt['expected']
           const aSpan = amax - amin;
           const eps = Math.max(0.1, (eSpan * tol) / 100);
           if (Math.abs(aSpan - eSpan) > eps)
-            failures.push(`bounds.${axis}: span ${aSpan.toFixed(1)} vs ${eSpan} (±${eps.toFixed(2)})`);
+            failures.push(
+              `bounds.${axis}: span ${aSpan.toFixed(1)} vs ${eSpan} (±${eps.toFixed(2)})`
+            );
         }
       }
     }
@@ -88,6 +90,8 @@ export interface Scorecard {
   /** The model that graded the rendered parts; omitted when it's the same as the author model. */
   judgeModel?: string | undefined;
   brepjsVersion: string;
+  /** The deployed skill's content hash — provenance so trends attribute to a SKILL.md edit. */
+  skillVersion?: string | undefined;
   date: string;
   results: readonly EvalResult[];
 }
@@ -156,6 +160,36 @@ function liftSummary(results: readonly EvalResult[]): LiftSummary | null {
   }).length;
   const eventualBoth = looped.filter((r) => r.auto.pass && r.judgePass === true).length;
   return { firstTryBoth, eventualBoth, total: looped.length };
+}
+
+/** A run-level numeric score for a Langfuse trend trace (one per eval run). 0–1 fraction. */
+export interface RunScore {
+  name: string;
+  value: number;
+}
+
+/**
+ * Run-level aggregate scores for one eval run — `both%` (the headline) plus the first-try-vs-eventual
+ * lift when loop data is present. Pushed as numeric scores on a single Langfuse trace so runs trend
+ * over skill versions. Empty for an empty run.
+ */
+export function runScores(card: Scorecard): RunScore[] {
+  const t = tally(card.results);
+  if (t.total === 0) return [];
+  const out: RunScore[] = [
+    { name: 'valid', value: t.autoValid / t.total },
+    { name: 'judge', value: t.judgeMatch / t.total },
+    { name: 'both', value: t.both / t.total },
+  ];
+  const lift = liftSummary(card.results);
+  if (lift && lift.total > 0) {
+    out.push(
+      { name: 'first_try_both', value: lift.firstTryBoth / lift.total },
+      { name: 'eventual_both', value: lift.eventualBoth / lift.total },
+      { name: 'lift', value: (lift.eventualBoth - lift.firstTryBoth) / lift.total }
+    );
+  }
+  return out;
 }
 
 /**

--- a/packages/brepjs-verify/bench/syncDataset.ts
+++ b/packages/brepjs-verify/bench/syncDataset.ts
@@ -41,8 +41,11 @@ async function main(): Promise<void> {
   }
   const corpus = await loadCorpus();
   const client = new LangfuseClient();
+  // Go through client.api.* — the flat client.createDataset/createDatasetItem aliases are assigned
+  // unbound in the v5.5.3 constructor (`this.createDataset = this.api.datasets.create`), so calling
+  // them detaches `this` and throws "this.__create is not a function". The .api path stays bound.
   try {
-    await client.createDataset({
+    await client.api.datasets.create({
       name: DATASET,
       description:
         'brepjs playground examples — the /eval-skill quality bar (basics + mechanical).',
@@ -51,7 +54,7 @@ async function main(): Promise<void> {
     // Dataset already exists — fine; items below upsert by stable id.
   }
   for (const { example, category } of corpus) {
-    await client.createDatasetItem({
+    await client.api.datasetItems.create({
       datasetName: DATASET,
       id: example.id, // stable id → re-sync upserts instead of duplicating
       input: example.description,

--- a/packages/brepjs-verify/bench/syncDataset.ts
+++ b/packages/brepjs-verify/bench/syncDataset.ts
@@ -1,0 +1,66 @@
+import { LangfuseClient } from '@langfuse/client';
+
+// Sync the plain-brepjs playground examples (basics + mechanical) into a Langfuse dataset, so
+// /eval-skill runs can be recorded + compared as dataset experiments. Each example's description
+// is the prompt (input); its own code is the reference (expectedOutput). The dataset auto-tracks
+// the playground catalog. No-op without LANGFUSE_* keys.
+//   npm run eval:dataset:sync -w brepjs-verify
+const DATASET = 'brepjs-playground';
+const SCOPE = new Set(['basics', 'mechanical']); // plain brepjs; bim/sheet-metal need other skills
+
+interface Example {
+  id: string;
+  label: string;
+  description: string;
+  code: string;
+}
+interface Category {
+  id: string;
+  label: string;
+  examples: readonly Example[];
+}
+
+/**
+ * Load the plain-brepjs playground examples. A runtime (variable-path) import so the bench
+ * tsconfig takes no compile-time dependency on the playground app.
+ */
+async function loadCorpus(): Promise<{ example: Example; category: string }[]> {
+  const registry = '../../../apps/playground/src/lib/examples/index.ts';
+  const mod = (await import(registry)) as { CATEGORIES: readonly Category[] };
+  return mod.CATEGORIES.filter((c) => SCOPE.has(c.id)).flatMap((c) =>
+    c.examples.map((example) => ({ example, category: c.id }))
+  );
+}
+
+async function main(): Promise<void> {
+  if (!process.env['LANGFUSE_PUBLIC_KEY'] || !process.env['LANGFUSE_SECRET_KEY']) {
+    console.log(
+      'langfuse: no LANGFUSE_* keys — nothing synced (set the keys to populate the dataset).'
+    );
+    return;
+  }
+  const corpus = await loadCorpus();
+  const client = new LangfuseClient();
+  try {
+    await client.createDataset({
+      name: DATASET,
+      description:
+        'brepjs playground examples — the /eval-skill quality bar (basics + mechanical).',
+    });
+  } catch {
+    // Dataset already exists — fine; items below upsert by stable id.
+  }
+  for (const { example, category } of corpus) {
+    await client.createDatasetItem({
+      datasetName: DATASET,
+      id: example.id, // stable id → re-sync upserts instead of duplicating
+      input: example.description,
+      expectedOutput: example.code,
+      metadata: { label: example.label, category },
+    });
+  }
+  await client.flush();
+  console.log(`langfuse: synced ${corpus.length} items to dataset "${DATASET}".`);
+}
+
+await main();

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -48,6 +48,7 @@
     "eval": "tsx bench/run.ts",
     "eval:live": "tsx bench/live.ts",
     "eval:push": "tsx bench/pushScorecard.ts",
+    "eval:dataset:sync": "tsx bench/syncDataset.ts",
     "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8'));if(r.ok!==true||!(r.measurements.volume>0))process.exit(1)\"",
     "smoke:standalone": "node scripts/smokeStandalone.mjs",
     "prepack": "npm run build"

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -47,6 +47,7 @@
     "test": "vitest run",
     "eval": "tsx bench/run.ts",
     "eval:live": "tsx bench/live.ts",
+    "eval:push": "tsx bench/pushScorecard.ts",
     "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8'));if(r.ok!==true||!(r.measurements.volume>0))process.exit(1)\"",
     "smoke:standalone": "node scripts/smokeStandalone.mjs",
     "prepack": "npm run build"

--- a/packages/brepjs-verify/src/mcp/telemetry.ts
+++ b/packages/brepjs-verify/src/mcp/telemetry.ts
@@ -1,0 +1,77 @@
+/**
+ * Optional Langfuse tracing for MCP `run_program` executions — a strictly best-effort side channel,
+ * exactly like the `BREPJS_RUN_RECORD_PATH` JSONL record. The @langfuse / OpenTelemetry packages are
+ * NOT runtime dependencies of the shipped MCP: they are *dynamically* imported, and only when the
+ * `LANGFUSE_*` keys are present. So the server never hard-requires telemetry — no keys (or the deps
+ * simply absent in a published install) → {@link traceRun} is a silent no-op. It never throws.
+ */
+
+import { buildRunRecord } from '../sandbox/runRecord.js';
+import type { RunProgramResult } from '../sandbox/runProgram.js';
+
+interface Tracer {
+  trace: (code: string, result: RunProgramResult) => Promise<void>;
+}
+
+// Single lazily-initialised tracer for the server's lifetime (cached promise — the OTel SDK + client
+// are started once, on the first traced run, not per call).
+let tracerPromise: Promise<Tracer | null> | undefined;
+
+async function initTracer(): Promise<Tracer | null> {
+  if (!process.env['LANGFUSE_PUBLIC_KEY'] || !process.env['LANGFUSE_SECRET_KEY']) return null;
+  try {
+    const [{ NodeSDK }, otel, { startActiveObservation }, { LangfuseClient }] = await Promise.all([
+      import('@opentelemetry/sdk-node'),
+      import('@langfuse/otel'),
+      import('@langfuse/tracing'),
+      import('@langfuse/client'),
+    ]);
+    const processor = new otel.LangfuseSpanProcessor();
+    const sdk = new NodeSDK({ spanProcessors: [processor] });
+    sdk.start();
+    const client = new LangfuseClient();
+    return {
+      trace: async (code, result) => {
+        const rec = buildRunRecord(code, result);
+        await startActiveObservation('run_program', (obs) => {
+          obs.update({
+            input: { code },
+            output: { outcome: rec.outcome, ok: rec.ok, measurements: rec.measurements },
+            metadata: { source: 'mcp', resultHash: rec.resultHash },
+          });
+          try {
+            client.score.create({
+              traceId: obs.traceId,
+              name: 'ok',
+              value: rec.ok ? 1 : 0,
+              dataType: 'NUMERIC',
+            });
+          } catch {
+            // best-effort — a score failure must never affect the run.
+          }
+        });
+        // Per-call flush: the MCP server is long-running and may be killed without a clean shutdown,
+        // so deliver each run's span + score now rather than rely on batch/exit flushing. Settled so
+        // a flush hiccup (or a processor without forceFlush) can't reject.
+        await Promise.allSettled([processor.forceFlush(), client.flush()]);
+      },
+    };
+  } catch (e) {
+    // Optional deps absent or init failed → telemetry stays off; the MCP is unaffected.
+    console.warn(`langfuse: MCP tracing unavailable (${(e as Error).message.split('\n')[0]})`);
+    return null;
+  }
+}
+
+/**
+ * Trace one `run_program` execution to Langfuse (best-effort; no-op without the `LANGFUSE_*` keys or
+ * the optional telemetry deps). Never throws — callers fire-and-forget it as a side channel.
+ */
+export async function traceRun(code: string, result: RunProgramResult): Promise<void> {
+  try {
+    const tracer = await (tracerPromise ??= initTracer());
+    await tracer?.trace(code, result);
+  } catch (e) {
+    console.warn(`langfuse: traceRun failed (${(e as Error).message.split('\n')[0]})`);
+  }
+}

--- a/packages/brepjs-verify/src/mcp/telemetry.ts
+++ b/packages/brepjs-verify/src/mcp/telemetry.ts
@@ -33,7 +33,9 @@ async function initTracer(): Promise<Tracer | null> {
     return {
       trace: async (code, result) => {
         const rec = buildRunRecord(code, result);
-        await startActiveObservation('run_program', (obs) => {
+        // Sync callback → startActiveObservation returns a non-Promise (not awaited); the span ends
+        // synchronously and the explicit flush below delivers it + the score.
+        startActiveObservation('run_program', (obs) => {
           obs.update({
             input: { code },
             output: { outcome: rec.outcome, ok: rec.ok, measurements: rec.measurements },

--- a/packages/brepjs-verify/src/mcp/tools.ts
+++ b/packages/brepjs-verify/src/mcp/tools.ts
@@ -6,6 +6,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { runProgram, exportProgram, type ExportFormats } from '../sandbox/runProgram.js';
 import { appendRunRecord, buildRunRecord } from '../sandbox/runRecord.js';
+import { traceRun } from './telemetry.js';
 
 export interface RunProgramToolArgs {
   /** A brepjs `.brep.ts` module source with a default-exported part function. */
@@ -58,6 +59,11 @@ export async function runProgramTool(args: RunProgramToolArgs): Promise<CallTool
       console.warn(`run-record append failed (BREPJS_RUN_RECORD_PATH=${recordPath}):`, err);
     });
   }
+
+  // Optional Langfuse trace of this run — best-effort, no-op without LANGFUSE_* keys (see
+  // mcp/telemetry.ts). Fire-and-forget like the run-record above, so telemetry never blocks or
+  // affects the agent's tool result. traceRun swallows its own errors and never throws.
+  void traceRun(args.code, result);
 
   if (result.outcome === 'completed') {
     const payload = { outcome: 'completed', ok: result.report.ok, report: result.report };

--- a/packages/brepjs-verify/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalScore.test.ts
@@ -4,6 +4,7 @@ import {
   formatScorecard,
   failureBreakdown,
   runScores,
+  itemScores,
   type EvalResult,
   type AttemptResult,
 } from '../bench/score.js';
@@ -141,6 +142,45 @@ describe('runScores', () => {
 
   it('returns no scores for an empty run', () => {
     expect(runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results: [] })).toEqual([]);
+  });
+});
+
+describe('itemScores', () => {
+  const get = (r: EvalResult, n: string): number | undefined =>
+    itemScores(r).find((s) => s.name === n)?.value;
+
+  it('scores a part by its own auto/judge/both (no first-try without loop data)', () => {
+    const r: EvalResult = {
+      id: 'a',
+      category: 'primitive',
+      auto: { pass: true, failures: [] },
+      judgePass: true,
+    };
+    expect(get(r, 'auto_pass')).toBe(1);
+    expect(get(r, 'judge_pass')).toBe(1);
+    expect(get(r, 'eventual_both')).toBe(1);
+    expect(get(r, 'first_try_both')).toBeUndefined();
+  });
+
+  it('marks eventual_both 0 when the judge fails despite a valid solid', () => {
+    const r: EvalResult = {
+      id: 'b',
+      category: 'primitive',
+      auto: { pass: true, failures: [] },
+      judgePass: false,
+    };
+    expect(get(r, 'auto_pass')).toBe(1);
+    expect(get(r, 'judge_pass')).toBe(0);
+    expect(get(r, 'eventual_both')).toBe(0);
+  });
+
+  it('adds first_try_both from the first attempt when loop data is present', () => {
+    const r = looped('c', [
+      attempt([], { auto: { pass: true, failures: [] }, judgePass: false }),
+      attempt([], { auto: { pass: true, failures: [] }, judgePass: true }),
+    ]);
+    expect(get(r, 'eventual_both')).toBe(1);
+    expect(get(r, 'first_try_both')).toBe(0);
   });
 });
 

--- a/packages/brepjs-verify/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalScore.test.ts
@@ -3,6 +3,7 @@ import {
   checkAuto,
   formatScorecard,
   failureBreakdown,
+  runScores,
   type EvalResult,
   type AttemptResult,
 } from '../bench/score.js';
@@ -67,7 +68,10 @@ describe('checkAuto', () => {
 
   it('fails a wrong-sized part even when its corner sits at the expected origin', () => {
     const tooWide = { xMin: 0, xMax: 50, yMin: 0, yMax: 30, zMin: 0, zMax: 20 };
-    const res = checkAuto(validReport({ bounds: tooWide }), { bounds: { x: [0, 40] }, tolerancePct: 1 });
+    const res = checkAuto(validReport({ bounds: tooWide }), {
+      bounds: { x: [0, 40] },
+      tolerancePct: 1,
+    });
     expect(res.pass).toBe(false);
     expect(res.failures.join(' ')).toContain('bounds.x');
   });
@@ -102,6 +106,41 @@ describe('formatScorecard', () => {
     expect(out).toContain('primitive');
     // 2/3 valid overall, 1/3 judged matching, 1/3 both.
     expect(out).toMatch(/TOTAL\s+valid 67%\s+judge 33%\s+both 33%/);
+  });
+});
+
+describe('runScores', () => {
+  it('derives run-level valid/judge/both fractions (no lift without loop data)', () => {
+    const results: EvalResult[] = [
+      { id: 'a', category: 'primitive', auto: { pass: true, failures: [] }, judgePass: true },
+      { id: 'b', category: 'primitive', auto: { pass: true, failures: [] }, judgePass: false },
+      { id: 'c', category: 'boolean', auto: { pass: false, failures: [] } },
+    ];
+    const scores = runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results });
+    const get = (n: string): number | undefined => scores.find((s) => s.name === n)?.value;
+    expect(get('valid')).toBeCloseTo(2 / 3, 5);
+    expect(get('judge')).toBeCloseTo(1 / 3, 5);
+    expect(get('both')).toBeCloseTo(1 / 3, 5);
+    expect(get('lift')).toBeUndefined();
+  });
+
+  it('adds first_try_both / eventual_both / lift when loop data is present', () => {
+    const results: EvalResult[] = [
+      looped('x', [
+        attempt([], { auto: { pass: true, failures: [] }, judgePass: false }),
+        attempt([], { auto: { pass: true, failures: [] }, judgePass: true }),
+      ]),
+      looped('y', [attempt([], { auto: { pass: true, failures: [] }, judgePass: true })]),
+    ];
+    const scores = runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results });
+    const get = (n: string): number | undefined => scores.find((s) => s.name === n)?.value;
+    expect(get('first_try_both')).toBeCloseTo(1 / 2, 5);
+    expect(get('eventual_both')).toBeCloseTo(1, 5);
+    expect(get('lift')).toBeCloseTo(1 / 2, 5);
+  });
+
+  it('returns no scores for an empty run', () => {
+    expect(runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results: [] })).toEqual([]);
   });
 });
 

--- a/packages/brepjs-verify/vite.config.ts
+++ b/packages/brepjs-verify/vite.config.ts
@@ -49,6 +49,10 @@ export default defineConfig({
         'puppeteer',
         'typescript',
         /^@modelcontextprotocol\/sdk/,
+        // Optional MCP telemetry — kept external so src/mcp/telemetry.ts can dynamic-import them at
+        // runtime and gracefully no-op when they're absent (the shipped MCP never hard-requires them).
+        /^@langfuse\//,
+        /^@opentelemetry\//,
         /^node:/,
       ],
     },


### PR DESCRIPTION
Wires the brepjs-verify skill eval + MCP to Langfuse (v5 SDK, OTel-based), entirely behind the `LANGFUSE_*` keys — every path is a no-op without them.

## What's in it

- **Run-level scorecard push** (`eval:push`) — one `eval-run` trace per run carrying the aggregate scores (`both` + first-try-vs-eventual `lift`), stamped with the skill version, so runs trend over SKILL.md edits.
- **Playground corpus → Langfuse dataset** (`eval:dataset:sync`) — upserts the `basics` + `mechanical` playground examples into the `brepjs-playground` dataset (the quality bar), keyed by example id.
- **Each run as a dataset experiment** — `eval:push` also records a dataset run: one trace per part (per-part scores via `itemScores`) linked to its dataset item under `runName = skillVersion`, for native per-part lift comparison across skill versions.
- **On-demand CI eval** (`.github/workflows/eval-on-demand.yml`, `workflow_dispatch`) — `eval:live` now authors + judges the **playground corpus** (`--corpus playground`, default) and pushes both records. Not scheduled (no recurring cost); defaults to the cheap `basics` scope.
- **MCP `run_program` tracing** — each sandbox run emits an optional best-effort trace (span + `ok` score). `@langfuse`/OTel stay dev-only and are dynamically imported, so the shipped MCP never hard-requires telemetry.

## Verification

Every piece verified live against `us.cloud.langfuse.com` (dataset = 38 items; aggregate + per-part scores match `runScores`/`itemScores`; the MCP trace lands with `source=mcp`); all smoke traces deleted afterward. Pure scoring (`runScores`, `itemScores`) is TDD'd; the v5 SDK's unbound flat-alias bug is worked around via `client.api.*`.

## Use

```
set -a; . ./.env; set +a; export LANGFUSE_BASE_URL="${LANGFUSE_BASE_URL:-$LANGFUSE_HOST}"
npm run eval:dataset:sync -w brepjs-verify          # once, to populate the dataset
npm run eval:push -w brepjs-verify -- <scorecard>   # aggregate trace + dataset experiment
```

…or dispatch the `eval-on-demand` workflow (repo secrets verified). No keys → everything no-ops.
