### PR TITLE
fix(brepjs-verify): three deferred Langfuse-eval follow-ups

### DIFF
--- a/packages/brepjs-verify/bench/langfuse.ts
+++ b/packages/brepjs-verify/bench/langfuse.ts
@@ -37,8 +37,9 @@ export interface Telemetry {
   registerSkill: (skillMd: string) => Promise<void>;
   /** Push one run's aggregate scores (both% + first-try-vs-eventual lift) on a single trace. */
   pushScorecard: (card: Scorecard) => Promise<void>;
-  /** Record the run as a dataset experiment: per-part trace + scores linked to its dataset item. */
-  pushDatasetRun: (card: Scorecard) => Promise<void>;
+  /** Record the run as a dataset experiment (per-part trace + scores linked to its dataset item);
+   *  resolves with the number of items successfully linked. */
+  pushDatasetRun: (card: Scorecard) => Promise<number>;
   /** Flush spans + scores and shut down. */
   shutdown: () => Promise<void>;
 }
@@ -47,7 +48,7 @@ const NOOP: Telemetry = {
   observePrompt: (_p, _metadata, run) => run(),
   registerSkill: () => Promise.resolve(),
   pushScorecard: () => Promise.resolve(),
-  pushDatasetRun: () => Promise.resolve(),
+  pushDatasetRun: () => Promise.resolve(0),
   shutdown: () => Promise.resolve(),
 };
 
@@ -156,6 +157,7 @@ export function createTelemetry(): Telemetry {
       // version. Best-effort + isolated per item: corpus drift (a result whose id has no dataset
       // item) only warns and skips, so one missing item never aborts the rest of the run.
       const runName = card.skillVersion ?? `${card.model}-${card.date}`;
+      let linked = 0;
       for (const r of card.results) {
         try {
           await startActiveObservation(r.id, async (obs) => {
@@ -171,12 +173,14 @@ export function createTelemetry(): Telemetry {
               metadata: { skillVersion: card.skillVersion, brepjsVersion: card.brepjsVersion },
             });
           });
+          linked++;
         } catch (e) {
           console.warn(
             `langfuse: dataset-run link failed for ${r.id} (${(e as Error).message.split('\n')[0]})`
           );
         }
       }
+      return linked;
     },
     shutdown: async () => {
       try {

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
 import Anthropic from '@anthropic-ai/sdk';
 import { runProgramWithStep } from '../src/sandbox/runProgram.js';
 import { PROMPTS, type EvalPrompt } from './prompts.js';
@@ -21,7 +20,6 @@ import { skillVersion } from './skillVersion.js';
 // authors + judges in-session, use the `/eval-skill` command instead.
 
 const here = dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 interface Args {
   model: string;
@@ -59,8 +57,11 @@ function parseArgs(argv: readonly string[]): Args {
 }
 
 function brepjsVersion(): string {
+  // The package IS "brepjs"; read the repo-root package.json via a relative path (bench/ is three
+  // levels down). Its `exports` map has no `./package.json`, so require.resolve('brepjs/package.json')
+  // throws — which is why CI scorecards + dataset run names read "unknown".
   try {
-    const pkg = JSON.parse(readFileSync(require.resolve('brepjs/package.json'), 'utf8')) as {
+    const pkg = JSON.parse(readFileSync(resolve(here, '../../../package.json'), 'utf8')) as {
       version?: string;
     };
     return pkg.version ?? 'unknown';
@@ -238,7 +239,11 @@ async function main(): Promise<void> {
   // corpus — a dataset experiment on brepjs-playground (per-part scores linked to each dataset item),
   // the same two records the manual loop's `eval:push` writes. Best-effort + no-op without keys.
   await telemetry.pushScorecard(card);
-  if (args.corpus === 'playground') await telemetry.pushDatasetRun(card);
+  if (args.corpus === 'playground') {
+    const linked = await telemetry.pushDatasetRun(card);
+    if (process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY'])
+      console.log(`langfuse: dataset run "${skillVer}" — ${linked}/${results.length} items linked`);
+  }
   await telemetry.shutdown();
 
   if (!args.keep) rmSync(workdir, { recursive: true, force: true });

--- a/packages/brepjs-verify/bench/pushScorecard.ts
+++ b/packages/brepjs-verify/bench/pushScorecard.ts
@@ -17,12 +17,16 @@ async function main(): Promise<void> {
   const card = JSON.parse(readFileSync(path, 'utf8')) as Scorecard;
   const telemetry = createTelemetry();
   await telemetry.pushScorecard(card);
-  await telemetry.pushDatasetRun(card);
+  const linked = await telemetry.pushDatasetRun(card);
   await telemetry.shutdown();
   const runName = card.skillVersion ?? `${card.model}-${card.date}`;
+  const total = card.results.length;
+  // Report the real link count — a scorecard whose result ids aren't playground example ids links 0
+  // (every datasetRunItems.create warns + skips), so don't claim a clean dataset run when none landed.
+  const linkNote = linked < total ? ' — others had no matching brepjs-playground item' : '';
   console.log(
     process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY']
-      ? `langfuse: pushed run-level scores + dataset run "${runName}" for ${card.results.length} parts.`
+      ? `langfuse: pushed run-level scores + dataset run "${runName}" (${linked}/${total} items linked${linkNote}).`
       : 'langfuse: no LANGFUSE_* keys set — nothing pushed (set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_BASE_URL).'
   );
 }

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -183,10 +183,13 @@ export function runScores(card: Scorecard): RunScore[] {
   ];
   const lift = liftSummary(card.results);
   if (lift && lift.total > 0) {
+    // Normalize by t.total (all items), not lift.total (looped subset), so all six scores share one
+    // denominator and are directly comparable on a Langfuse chart that carries no n annotation. For
+    // the all-looping runs (eval:live / /eval-skill) t.total == lift.total, so this is identity there.
     out.push(
-      { name: 'first_try_both', value: lift.firstTryBoth / lift.total },
-      { name: 'eventual_both', value: lift.eventualBoth / lift.total },
-      { name: 'lift', value: (lift.eventualBoth - lift.firstTryBoth) / lift.total }
+      { name: 'first_try_both', value: lift.firstTryBoth / t.total },
+      { name: 'eventual_both', value: lift.eventualBoth / t.total },
+      { name: 'lift', value: (lift.eventualBoth - lift.firstTryBoth) / t.total }
     );
   }
   return out;

--- a/packages/brepjs-verify/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalScore.test.ts
@@ -140,6 +140,24 @@ describe('runScores', () => {
     expect(get('lift')).toBeCloseTo(1 / 2, 5);
   });
 
+  it('normalizes lift scores by the full run size, not just the looped subset', () => {
+    // A mixed run: one single-shot both-pass item + one looped item (first-try miss, eventual both).
+    // All six scores must share the t.total=2 denominator so they're directly comparable on a chart.
+    const results: EvalResult[] = [
+      { id: 'single', category: 'primitive', auto: { pass: true, failures: [] }, judgePass: true },
+      looped('lp', [
+        attempt([], { auto: { pass: true, failures: [] }, judgePass: false }),
+        attempt([], { auto: { pass: true, failures: [] }, judgePass: true }),
+      ]),
+    ];
+    const scores = runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results });
+    const get = (n: string): number | undefined => scores.find((s) => s.name === n)?.value;
+    expect(get('both')).toBeCloseTo(1, 5); // 2 both-pass / 2
+    expect(get('eventual_both')).toBeCloseTo(1 / 2, 5); // 1 looped-both / 2  (NOT 1/1)
+    expect(get('first_try_both')).toBeCloseTo(0, 5); // 0 looped-first-try-both / 2
+    expect(get('lift')).toBeCloseTo(1 / 2, 5); // (1 - 0) / 2
+  });
+
   it('returns no scores for an empty run', () => {
     expect(runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results: [] })).toEqual([]);
   });


### PR DESCRIPTION
Follow-up to #1498 — addresses the three deferred items (Greptile's two non-blocking notes on that PR + the `brepjs=unknown` the first real CI eval surfaced).

## Fixes

1. **Version resolution** — `brepjsVersion()` used `require.resolve('brepjs/package.json')`, which the package's `exports` map blocks, so CI scorecards + dataset run names read `unknown+skill.<hash>`. Now reads the repo-root `package.json` (the package *is* `brepjs`) by relative path → `<version>+skill.<hash>`.
2. **Lift-score denominators** (Greptile note 1) — `first_try_both`/`eventual_both`/`lift` now divide by `t.total` (all items) like `valid`/`judge`/`both`, so all six Langfuse scores share one denominator and stay comparable on a chart that carries no `n` annotation. Identity for the all-looping runs (`eval:live` / `/eval-skill`); covered by a new mixed-run test.
3. **Dataset-link reporting** (Greptile note 2) — `pushDatasetRun` returns the count of successfully linked items; `eval:push` and `eval:live` report `N/M items linked` instead of unconditionally claiming a clean dataset run when every link silently skipped (a scorecard whose ids aren't playground example ids).

## Verification

Full `packages-verify` suite green locally: lint, typecheck (×3), test (145), `eval` (15/15), smoke, standalone. Version fix confirmed resolving to `18.94.0`.
