### PR TITLE
feat(brepjs-verify): enrich experiment traces with request + code (for Langfuse evaluators)

### DIFF
--- a/packages/brepjs-verify/bench/langfuse.ts
+++ b/packages/brepjs-verify/bench/langfuse.ts
@@ -162,6 +162,10 @@ export function createTelemetry(): Telemetry {
         try {
           await startActiveObservation(r.id, async (obs) => {
             obs.update({
+              // Request + authored module so a Langfuse LLM-as-a-Judge evaluator can review the run
+              // against the dataset item's expectedOutput. Absent for legacy/manual scorecards.
+              ...(r.prompt !== undefined ? { input: r.prompt } : {}),
+              ...(r.code !== undefined ? { output: r.code } : {}),
               metadata: { runName, category: r.category, skillVersion: card.skillVersion },
             });
             attachScores(client, obs.traceId, r);

--- a/packages/brepjs-verify/bench/loop.ts
+++ b/packages/brepjs-verify/bench/loop.ts
@@ -144,8 +144,8 @@ export async function runAttemptLoop(
     attempts,
     iterations: attempts.length,
     termination,
-    prompt: p.prompt,
   };
+  if (p.prompt) out.prompt = p.prompt;
   if (lastCode) out.code = lastCode;
   if (firstTry) out.firstTry = firstTry;
   if (eventual?.judgePass !== undefined) out.judgePass = eventual.judgePass;

--- a/packages/brepjs-verify/bench/loop.ts
+++ b/packages/brepjs-verify/bench/loop.ts
@@ -84,10 +84,12 @@ export async function runAttemptLoop(
 ): Promise<EvalResult> {
   const messages: ChatMessage[] = [{ role: 'user', content: p.prompt }];
   const attempts: AttemptResult[] = [];
+  let lastCode = '';
   let termination: 'CONVERGED' | 'EXHAUSTED' = 'EXHAUSTED';
 
   for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
     const code = await deps.author(messages);
+    lastCode = code;
     const outcome = await deps.execute(code, attempt);
     const auto = autoFromOutcome(outcome, p.expected);
 
@@ -142,7 +144,9 @@ export async function runAttemptLoop(
     attempts,
     iterations: attempts.length,
     termination,
+    prompt: p.prompt,
   };
+  if (lastCode) out.code = lastCode;
   if (firstTry) out.firstTry = firstTry;
   if (eventual?.judgePass !== undefined) out.judgePass = eventual.judgePass;
   if (eventual?.judgeReason !== undefined) out.judgeReason = eventual.judgeReason;

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -42,6 +42,10 @@ export interface EvalResult {
   firstTry?: AttemptResult | undefined;
   iterations?: number | undefined;
   termination?: 'CONVERGED' | 'EXHAUSTED' | undefined;
+  /** The NL request — pushed as the experiment trace `input` so Langfuse evaluators can read it. */
+  prompt?: string | undefined;
+  /** The eventual attempt's authored module source — pushed as the experiment trace `output`. */
+  code?: string | undefined;
 }
 
 /** Objective check: the report is ok (valid solid) and any pinned dims are within tolerance. */

--- a/packages/brepjs-verify/tests/liveEvalLoop.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalLoop.test.ts
@@ -177,4 +177,29 @@ describe('runAttemptLoop', () => {
     expect(res.attempts?.[0]?.codes).toContain('TIMEOUT');
     expect(res.attempts?.[0]?.outcome).toBe('timeout');
   });
+
+  it('captures the request and the eventual authored code on the result', async () => {
+    const res = await runAttemptLoop(
+      PROMPT,
+      deps({ author: () => Promise.resolve('export default () => box(5, 5, 5);') }),
+      { maxAttempts: 3 }
+    );
+    expect(res.prompt).toBe('make a 10mm box');
+    expect(res.code).toBe('export default () => box(5, 5, 5);');
+  });
+
+  it('captures the eventual code after a retry, not the first attempt', async () => {
+    let authorN = 0;
+    let execN = 0;
+    const res = await runAttemptLoop(
+      PROMPT,
+      deps({
+        author: () => Promise.resolve(`// v${++authorN}\nexport default () => box(1, 1, 1);`),
+        execute: () => Promise.resolve(++execN === 1 ? badOutcome() : okOutcome()),
+      }),
+      { maxAttempts: 3 }
+    );
+    expect(res.iterations).toBe(2);
+    expect(res.code).toBe('// v2\nexport default () => box(1, 1, 1);');
+  });
 });


### PR DESCRIPTION
Pushes the NL request (`input`) and the eventual authored brepjs module (`output`) onto each `brepjs-playground` experiment trace, so a server-side Langfuse LLM-as-a-Judge **code-review** evaluator can read the run and compare it to the dataset item's `expectedOutput`. Previously the experiment traces carried only scores + metadata. Additive to the inline vision judge (which never sees code); fields are optional so the manual-loop scorecard degrades cleanly. Validated: full eslint + typecheck (×3) + scoring tests green.