### PR TITLE
feat(brepjs-verify): fan out the eval across sharded CI runners

### DIFF
--- a/.github/workflows/eval-on-demand.yml
+++ b/.github/workflows/eval-on-demand.yml
@@ -2,9 +2,9 @@ name: eval-on-demand
 
 # On-demand brepjs-verify skill eval against the playground quality bar. Authors + judges each
 # example with Claude (BILLED — uses ANTHROPIC_API_KEY) and records the run to Langfuse: aggregate
-# scores on one trace + a brepjs-playground dataset experiment (per-part scores linked to each
-# dataset item). Deliberately NOT scheduled — trigger from the Actions tab or
-# `gh workflow run eval-on-demand -f only=basics` when you want a fresh trend point.
+# scores on one trace + a brepjs-playground dataset experiment. Fanned out — the corpus is sharded
+# across 5 parallel runners (map), then a combine job merges + pushes the single run (reduce).
+# Deliberately NOT scheduled — `gh workflow run eval-on-demand -f only=mechanical`.
 on:
   workflow_dispatch:
     inputs:
@@ -25,9 +25,17 @@ on:
         type: string
 
 jobs:
-  eval:
+  shard:
+    # Map: each runner authors + judges a round-robin 1/5 slice of the corpus and uploads its
+    # scorecard. Shards do NOT push to Langfuse (no keys here) — the combine job does the one push,
+    # so there's a single aggregate trace + dataset run, not five partials. Each runner gets its own
+    # snapshot server, sidestepping the port-7373 singleton that blocks in-process parallelism.
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -35,8 +43,6 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      # The sandbox imports 'brepjs' and snapshots render through the viewers, so build the library,
-      # the shared renderer, and the verify package (its CLI + local viewer/dist) before evaluating.
       - name: Build library + viewers + verify
         run: |
           npm run build
@@ -45,20 +51,52 @@ jobs:
       - name: Install Chrome for snapshots
         run: npx puppeteer browsers install chrome
         working-directory: packages/brepjs-verify
-      - name: Run eval (author + judge + push to Langfuse)
-        # Inputs are passed via env (never interpolated into the run script) so a crafted dispatch
-        # value can't inject shell commands; each is quoted on use.
+      - name: Run shard (author + judge, write scorecard)
+        # Inputs via env (never interpolated into the run script) to avoid shell injection.
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
-          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
           ONLY: ${{ inputs.only }}
           MODEL: ${{ inputs.model }}
           MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+          SHARD: ${{ matrix.shard }}
         run: |
           npm run eval:live -w brepjs-verify -- \
             --corpus playground \
             --only "$ONLY" \
             --model "$MODEL" \
-            --max-attempts "$MAX_ATTEMPTS"
+            --max-attempts "$MAX_ATTEMPTS" \
+            --shard "$SHARD/5" \
+            --out "$GITHUB_WORKSPACE/shard-$SHARD.json"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-${{ matrix.shard }}
+          path: shard-${{ matrix.shard }}.json
+
+  combine:
+    # Reduce: merge the shard scorecards and push the SINGLE Langfuse run (aggregate trend trace + the
+    # brepjs-playground dataset experiment). No model calls here — Langfuse keys only, no build/Chrome
+    # (the combine runs from source via tsx and never touches the kernel). Runs even if a shard failed
+    # so a single bad part can't sink the whole run.
+    needs: shard
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: scorecard-*
+          merge-multiple: true
+          path: shards
+      - name: Merge shards + push to Langfuse
+        env:
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+        run: |
+          npm run eval:combine -w brepjs-verify -- "$GITHUB_WORKSPACE"/shards/shard-*.json

--- a/packages/brepjs-verify/bench/combineShards.ts
+++ b/packages/brepjs-verify/bench/combineShards.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { mergeScorecards, formatScorecard, type Scorecard } from './score.js';
+import { createTelemetry } from './langfuse.js';
+
+// Combine (reduce) step of the fan-out eval: read the per-shard scorecard JSONs written by
+// `eval:live --shard i/N --out shard-i.json`, merge them into one scorecard, print it, and push the
+// SINGLE Langfuse record set — the aggregate trend trace + the brepjs-playground dataset run (one
+// run-item per part). Shards deliberately don't push, so this is the only place trends are written.
+// No-op push without the LANGFUSE_* keys.
+//   npm run eval:combine -w brepjs-verify -- shard-0.json shard-1.json ...
+async function main(): Promise<void> {
+  const paths = process.argv.slice(2);
+  if (paths.length === 0) {
+    console.error('usage: combineShards <shard-0.json> <shard-1.json> ...');
+    process.exit(2);
+  }
+  const cards = paths.map((p) => JSON.parse(readFileSync(p, 'utf8')) as Scorecard);
+  const card = mergeScorecards(cards);
+  console.log('\n' + formatScorecard(card));
+
+  const telemetry = createTelemetry();
+  await telemetry.pushScorecard(card);
+  const linked = await telemetry.pushDatasetRun(card);
+  await telemetry.shutdown();
+  const hasKeys = process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY'];
+  console.log(
+    hasKeys
+      ? `langfuse: pushed merged run "${card.skillVersion ?? card.model}" — ${card.results.length} parts (${linked} dataset items linked).`
+      : 'langfuse: no LANGFUSE_* keys — merged scorecard printed, not pushed.'
+  );
+}
+
+await main();

--- a/packages/brepjs-verify/bench/combineShards.ts
+++ b/packages/brepjs-verify/bench/combineShards.ts
@@ -20,7 +20,9 @@ async function main(): Promise<void> {
 
   const telemetry = createTelemetry();
   await telemetry.pushScorecard(card);
-  const linked = await telemetry.pushDatasetRun(card);
+  // Push the dataset run only for the playground corpus (the same guard live.ts uses) — its ids
+  // match brepjs-playground items; legacy-prompts ids would just warn + skip per item.
+  const linked = card.corpus === 'playground' ? await telemetry.pushDatasetRun(card) : 0;
   await telemetry.shutdown();
   const hasKeys = process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY'];
   console.log(

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -54,10 +54,16 @@ function parseArgs(argv: readonly string[]): Args {
     else if (a === '--max-attempts')
       args.maxAttempts = Math.max(1, Math.trunc(Number(argv[++i])) || args.maxAttempts);
     else if (a === '--shard') {
-      const [idxStr, cntStr] = (argv[++i] ?? '').split('/');
+      const spec = argv[++i] ?? '';
+      const [idxStr, cntStr] = spec.split('/');
       const idx = Math.trunc(Number(idxStr));
       const cnt = Math.trunc(Number(cntStr));
       if (cnt >= 1 && idx >= 0 && idx < cnt) args.shard = { i: idx, n: cnt };
+      else {
+        // Don't silently fall back to the full corpus — a bad shard spec in CI would duplicate work.
+        console.error(`invalid --shard "${spec}" — expected i/N with 0 <= i < N`);
+        process.exit(2);
+      }
     } else if (a === '--out') args.out = argv[++i];
   }
   // The judge defaults to the author model; decoupling lets a cheaper, independent model grade the
@@ -245,6 +251,7 @@ async function main(): Promise<void> {
     judgeModel: args.judgeModel,
     brepjsVersion: version,
     skillVersion: skillVer,
+    corpus: args.corpus,
     date,
     results,
   };

--- a/packages/brepjs-verify/bench/live.ts
+++ b/packages/brepjs-verify/bench/live.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -29,6 +29,10 @@ interface Args {
   maxAttempts: number;
   /** Which corpus to author against: the playground quality bar (default) or the legacy toy prompts. */
   corpus: 'playground' | 'prompts';
+  /** Fan-out: evaluate only this shard's round-robin slice of the corpus (`--shard i/N`). */
+  shard?: { i: number; n: number } | undefined;
+  /** Write the scorecard JSON here (a shard) instead of pushing to Langfuse — the combine step pushes. */
+  out?: string | undefined;
 }
 
 function parseArgs(argv: readonly string[]): Args {
@@ -49,6 +53,12 @@ function parseArgs(argv: readonly string[]): Args {
     else if (a === '--corpus') args.corpus = argv[++i] === 'prompts' ? 'prompts' : 'playground';
     else if (a === '--max-attempts')
       args.maxAttempts = Math.max(1, Math.trunc(Number(argv[++i])) || args.maxAttempts);
+    else if (a === '--shard') {
+      const [idxStr, cntStr] = (argv[++i] ?? '').split('/');
+      const idx = Math.trunc(Number(idxStr));
+      const cnt = Math.trunc(Number(cntStr));
+      if (cnt >= 1 && idx >= 0 && idx < cnt) args.shard = { i: idx, n: cnt };
+    } else if (a === '--out') args.out = argv[++i];
   }
   // The judge defaults to the author model; decoupling lets a cheaper, independent model grade the
   // renders (e.g. Sonnet) while a stronger model authors the CAD.
@@ -180,11 +190,15 @@ async function main(): Promise<void> {
   const corpus = args.corpus === 'playground' ? await playgroundPrompts() : [...PROMPTS];
   // `--only all` (or blank) means the whole corpus; otherwise match an id or a category.
   const only = args.only && args.only !== 'all' ? args.only : undefined;
-  const prompts = corpus.filter((p) => !only || p.id === only || p.category === only);
-  if (prompts.length === 0) {
+  const filtered = corpus.filter((p) => !only || p.id === only || p.category === only);
+  if (filtered.length === 0) {
     console.error(`no prompts match --only ${args.only ?? ''} in corpus ${args.corpus}`);
     process.exit(1);
   }
+  // Fan-out: evaluate only this shard's round-robin slice (`--shard i/N`). An empty slice (more
+  // shards than parts) is fine — it produces an empty scorecard for the combine step to merge.
+  const shard = args.shard;
+  const prompts = shard ? filtered.filter((_, idx) => idx % shard.n === shard.i) : filtered;
 
   const client = new Anthropic();
   const system = authorSystem();
@@ -235,14 +249,21 @@ async function main(): Promise<void> {
     results,
   };
   console.log('\n' + formatScorecard(card));
-  // Record the run for Langfuse trends: aggregate scores on one trace, plus — for the playground
-  // corpus — a dataset experiment on brepjs-playground (per-part scores linked to each dataset item),
-  // the same two records the manual loop's `eval:push` writes. Best-effort + no-op without keys.
-  await telemetry.pushScorecard(card);
-  if (args.corpus === 'playground') {
-    const linked = await telemetry.pushDatasetRun(card);
-    if (process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY'])
-      console.log(`langfuse: dataset run "${skillVer}" — ${linked}/${results.length} items linked`);
+  if (args.out) {
+    // Shard mode: write the scorecard for the combine step, which merges all shards and does the
+    // single Langfuse push — shards don't push (avoids N partial aggregate traces + run pushes).
+    writeFileSync(args.out, JSON.stringify(card, null, 2));
+    console.log(`wrote ${results.length}-part scorecard to ${args.out} (shard — combine step pushes)`);
+  } else {
+    // Record the run for Langfuse trends: aggregate scores on one trace, plus — for the playground
+    // corpus — a dataset experiment on brepjs-playground (per-part scores linked to each dataset
+    // item). Best-effort + no-op without keys.
+    await telemetry.pushScorecard(card);
+    if (args.corpus === 'playground') {
+      const linked = await telemetry.pushDatasetRun(card);
+      if (process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY'])
+        console.log(`langfuse: dataset run "${skillVer}" — ${linked}/${results.length} items linked`);
+    }
   }
   await telemetry.shutdown();
 

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -96,6 +96,8 @@ export interface Scorecard {
   brepjsVersion: string;
   /** The deployed skill's content hash — provenance so trends attribute to a SKILL.md edit. */
   skillVersion?: string | undefined;
+  /** The corpus evaluated — lets the combine step guard the dataset push the way the live run does. */
+  corpus?: 'playground' | 'prompts' | undefined;
   date: string;
   results: readonly EvalResult[];
 }
@@ -113,6 +115,7 @@ export function mergeScorecards(cards: readonly Scorecard[]): Scorecard {
     ...(first?.judgeModel !== undefined ? { judgeModel: first.judgeModel } : {}),
     brepjsVersion: first?.brepjsVersion ?? 'unknown',
     ...(first?.skillVersion !== undefined ? { skillVersion: first.skillVersion } : {}),
+    ...(first?.corpus !== undefined ? { corpus: first.corpus } : {}),
     date: first?.date ?? '',
     results: cards.flatMap((c) => [...c.results]),
   };

--- a/packages/brepjs-verify/bench/score.ts
+++ b/packages/brepjs-verify/bench/score.ts
@@ -100,6 +100,24 @@ export interface Scorecard {
   results: readonly EvalResult[];
 }
 
+/**
+ * Merge per-shard scorecards into one — for the fan-out eval, where each CI shard scores a slice of
+ * the corpus and the combine step concatenates their results under the first shard's header, then
+ * pushes the single dataset run + aggregate trend trace. Header (model/version/date) comes from the
+ * first shard; empty for no cards.
+ */
+export function mergeScorecards(cards: readonly Scorecard[]): Scorecard {
+  const first = cards[0];
+  return {
+    model: first?.model ?? 'unknown',
+    ...(first?.judgeModel !== undefined ? { judgeModel: first.judgeModel } : {}),
+    brepjsVersion: first?.brepjsVersion ?? 'unknown',
+    ...(first?.skillVersion !== undefined ? { skillVersion: first.skillVersion } : {}),
+    date: first?.date ?? '',
+    results: cards.flatMap((c) => [...c.results]),
+  };
+}
+
 interface Tally {
   total: number;
   autoValid: number;

--- a/packages/brepjs-verify/package.json
+++ b/packages/brepjs-verify/package.json
@@ -48,6 +48,7 @@
     "eval": "tsx bench/run.ts",
     "eval:live": "tsx bench/live.ts",
     "eval:push": "tsx bench/pushScorecard.ts",
+    "eval:combine": "tsx bench/combineShards.ts",
     "eval:dataset:sync": "tsx bench/syncDataset.ts",
     "smoke": "node dist/cli/main.js verify tests/fixtures/validBox.brep.ts | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8'));if(r.ok!==true||!(r.measurements.volume>0))process.exit(1)\"",
     "smoke:standalone": "node scripts/smokeStandalone.mjs",

--- a/packages/brepjs-verify/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalScore.test.ts
@@ -5,6 +5,7 @@ import {
   failureBreakdown,
   runScores,
   itemScores,
+  mergeScorecards,
   type EvalResult,
   type AttemptResult,
 } from '../bench/score.js';
@@ -160,6 +161,30 @@ describe('runScores', () => {
 
   it('returns no scores for an empty run', () => {
     expect(runScores({ model: 'm', brepjsVersion: 'v', date: 'd', results: [] })).toEqual([]);
+  });
+});
+
+describe('mergeScorecards', () => {
+  const mk = (results: EvalResult[]): Parameters<typeof mergeScorecards>[0][number] => ({
+    model: 'm',
+    brepjsVersion: 'v',
+    skillVersion: 's',
+    date: 'd',
+    results,
+  });
+
+  it('concatenates shard results under the first shard header', () => {
+    const merged = mergeScorecards([
+      mk([{ id: 'p1', category: 'primitive', auto: { pass: true, failures: [] } }]),
+      mk([{ id: 'p2', category: 'boolean', auto: { pass: false, failures: [] } }]),
+    ]);
+    expect(merged.results.map((r) => r.id)).toEqual(['p1', 'p2']);
+    expect(merged.skillVersion).toBe('s');
+    expect(merged.model).toBe('m');
+  });
+
+  it('returns an empty run when there are no cards', () => {
+    expect(mergeScorecards([]).results).toEqual([]);
   });
 });
 

--- a/packages/brepjs-verify/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-verify/tests/liveEvalScore.test.ts
@@ -169,6 +169,7 @@ describe('mergeScorecards', () => {
     model: 'm',
     brepjsVersion: 'v',
     skillVersion: 's',
+    corpus: 'playground',
     date: 'd',
     results,
   });
@@ -180,6 +181,7 @@ describe('mergeScorecards', () => {
     ]);
     expect(merged.results.map((r) => r.id)).toEqual(['p1', 'p2']);
     expect(merged.skillVersion).toBe('s');
+    expect(merged.corpus).toBe('playground');
     expect(merged.model).toBe('m');
   });
 


### PR DESCRIPTION
The `eval-on-demand` workflow ran the whole corpus **sequentially in one runner** — 33 mechanical parts took >90 min and hit the CI cap. This shards it into a **map-reduce**:

- **Map (5-way matrix):** `eval:live --shard i/N` evaluates a round-robin 1/5 slice, writes its scorecard (`--out`) as an artifact, and does **not** push to Langfuse. Each runner gets its own snapshot server (sidesteps the port-7373 singleton).
- **Reduce (combine job):** `eval:combine` merges the shard scorecards (new pure `mergeScorecards`) and does the **single** Langfuse push — one aggregate trend trace + one `brepjs-playground` dataset run, not five partials.

~5x faster wall-clock. `fail-fast: false` + combine `if: !cancelled()` tolerate a single failed shard; an empty slice (more shards than parts) is handled. `mergeScorecards` is TDD'd; combine verified locally on synthetic shards. Full `packages-verify` suite green (lint, typecheck, 149 tests, eval 15/15, smoke).