### PR TITLE
feat(brepjs-verify): blind LLM-as-judge for the eval design signal

### DIFF
--- a/.claude/commands/eval-skill.md
+++ b/.claude/commands/eval-skill.md
@@ -67,7 +67,7 @@ Author parts into a scratch ESM dir so `import 'brepjs'` resolves and the kernel
    `A`/`B` filenames (coin-flipped so neither role is fixed), and dispatch a judge never told
    which is whose: it returns which render better realizes the description as a **designed
    object** (right features, present and legible) or whether both are blobs. One judge,
-   escalate to 3 on `tie`/low-confidence; decode against your private map, then record the `judge.pass` verdict with its reason.
+   escalate to 3 on `tie-good`/low-confidence; decode against your private map, then record the `judge.pass` verdict with its reason.
    Full protocol: `bench/blind-judge.md`.
 6. **Repair + polish.** If `auto.pass` is false, fix the smallest responsible section from
    the report `hints`. If valid but blobby, do the **polish pass** (SKILL.md step 8). ≤ 4

--- a/.claude/commands/eval-skill.md
+++ b/.claude/commands/eval-skill.md
@@ -6,8 +6,9 @@ argument-hint: '[basics | mechanical | <example-id> | all]   (default: all plain
 # brepjs-verify skill eval (manual loop)
 
 Measure the deployed `SKILL.md` by re-authoring the **playground examples** — the quality
-bar — from their descriptions through **this** Claude Code session, where you are both the
-author and the visual judge. No API key, no billing. The point of this loop is not the
+bar — from their descriptions through **this** Claude Code session: you author each part, and a
+**blind judge subagent** grades it (you never grade your own output — see `bench/blind-judge.md`).
+No API key, no billing. The point of this loop is not the
 score — it's the **findings**: each playground part the skill can't reproduce _as a
 designed object_ (not just a valid blob) is a concrete SKILL.md gap to close. (`npm run
 eval:live` is the billed SDK counterpart; it still uses the legacy `bench/prompts.ts`.)
@@ -60,11 +61,14 @@ Author parts into a scratch ESM dir so `import 'brepjs'` resolves and the kernel
 4. **Auto signal** (objective): `auto.pass` is `ok === true` (a valid manifold solid /
    assembly). Playground descriptions rarely pin dims; if one does, check the bbox by
    **span/extent**, not absolute position (matches `checkAuto`).
-5. **Judge signal** (the quality bar): render the **reference** once — adapt the example's
-   `code` (`brepjs/quick`→`brepjs`, `export default X`→`export default () => X`) and
-   `--snapshot` it — then grade the author's render against it + the description: does it
-   read as a **designed object as polished as the reference** (the right features, present
-   and legible), or a valid blob? Record `judge.pass` + a one-line reason.
+5. **Judge signal** (the quality bar): grade with a **blind judge subagent**, not yourself.
+   Render the **reference** (adapt the example's `code`: `brepjs/quick`→`brepjs`,
+   `export default X`→`export default () => X`) and the author part, copy both to neutral
+   `A`/`B` filenames (coin-flipped so neither role is fixed), and dispatch a judge never told
+   which is whose: it returns which render better realizes the description as a **designed
+   object** (right features, present and legible) or whether both are blobs. One judge,
+   escalate to 3 on `tie`/low-confidence; decode against your private map, then record the `judge.pass` verdict with its reason.
+   Full protocol: `bench/blind-judge.md`.
 6. **Repair + polish.** If `auto.pass` is false, fix the smallest responsible section from
    the report `hints`. If valid but blobby, do the **polish pass** (SKILL.md step 8). ≤ 4
    attempts; track the first attempt vs the eventual (the lift signal).

--- a/.claude/commands/heal-skill.md
+++ b/.claude/commands/heal-skill.md
@@ -48,14 +48,16 @@ One **general-purpose subagent per example**, dispatched in parallel batches. Ea
   error, `EVENTUAL_OK`, `ATTEMPTS`, a **causal field** (what tripped it; did the skill's prose
   carry or fail it), `SKILL_GAP` (did a rule mislead/omit/contradict — name it), and `FINAL_CODE`.
 
-## 2. Judge — main session (the design signal)
+## 2. Judge — blind subagent (the design signal)
 
-Render the auto-valid parts **serially** (`--snapshot`, singleton server) and vision-judge each
-iso/detail render against the description + the playground reference `code` (adapt it:
-`brepjs/quick`→`brepjs`, `export default X`→`export default () => X`): a **designed object as
-polished as the reference**, or a valid blob? Note: clean-room authors stop at `ok:true` without
-the polish pass (SKILL.md's authoring loop, step 8), so this measures _first-valid_ design
-quality — call that out.
+**Don't grade your own loop's output** — you authored the heal, so you're a conflicted judge. Hand
+the design signal to a **blind judge subagent** (full protocol: `bench/blind-judge.md`): render the
+author part AND the playground reference serially, strip the labels to neutral `A`/`B` filenames
+(coin-flipped per part), and a judge that never saw the heal or which render is whose returns the
+verdict — you only render, shuffle, decode, aggregate. One judge per part, escalate to a panel of 3
+on `tie`/`confidence:low`. Note: clean-room authors stop at `ok:true` with no `--snapshot`, skipping
+the polish pass (SKILL.md authoring step 8), so this measures _first-valid_ design quality — call
+that out.
 
 ## 3. Diagnose — verify before healing
 

--- a/.claude/commands/heal-skill.md
+++ b/.claude/commands/heal-skill.md
@@ -55,7 +55,7 @@ the design signal to a **blind judge subagent** (full protocol: `bench/blind-jud
 author part AND the playground reference serially, strip the labels to neutral `A`/`B` filenames
 (coin-flipped per part), and a judge that never saw the heal or which render is whose returns the
 verdict — you only render, shuffle, decode, aggregate. One judge per part, escalate to a panel of 3
-on `tie`/`confidence:low`. Note: clean-room authors stop at `ok:true` with no `--snapshot`, skipping
+on `tie-good`/`confidence:low` (`tie-blob` re-renders instead — see `bench/blind-judge.md`). Note: clean-room authors stop at `ok:true` with no `--snapshot`, skipping
 the polish pass (SKILL.md authoring step 8), so this measures _first-valid_ design quality — call
 that out.
 

--- a/packages/brepjs-verify/bench/blind-judge.md
+++ b/packages/brepjs-verify/bench/blind-judge.md
@@ -13,8 +13,9 @@ is _pairwise_ (author vs reference) and _blind_ (labels stripped), and costs not
 ## The judge unit
 
 One judge subagent (general-purpose — it must `Read` the PNGs) per part. Its **entire input**: the
-part's NL `description` + two rendered images (**iso + one detail view each**) labeled only **A** and
-**B** + the rubric below. It is told NOTHING about which render is the skill's clean-room output vs
+part's NL `description` + two rendered images each — **iso + one detail view, the SAME view pair for
+both renders** so the A/B comparison is fair (pick the detail view — front/top/right — that best
+exposes the features the description names) — labeled only **A** and **B** + the rubric below. It is told NOTHING about which render is the skill's clean-room output vs
 the playground reference, and never reads any `.brep.ts`, the heal, the orchestration, or
 `apps/playground/**`. Structured return:
 
@@ -40,8 +41,10 @@ Per auto-valid part, **serially** (the render server is a singleton on :7373):
    varied per part. Record the mapping privately. _If a path says `author`/`ref`, the judge isn't
    blind — rename first._
 3. Dispatch ONE blind judge → verdict.
-4. **Escalate only on `tie-*` or `confidence:low`:** two more blind judges (labels re-shuffled per
-   judge), take the majority.
+4. **Escalate only on `tie-good` or `confidence:low`:** two more blind judges (labels re-shuffled
+   per judge), take the majority. `tie-blob` is _not_ an escalation — it means both renders read
+   blobby (usually a bad camera angle); re-render per the verdict map below and re-judge rather than
+   burning panel calls on the same images.
 5. **Decode** the verdict against your private A/B map → author-vs-reference result.
 
 ## Verdict → scorecard (the bar: author ≥ reference, _and_ actually designed)

--- a/packages/brepjs-verify/bench/blind-judge.md
+++ b/packages/brepjs-verify/bench/blind-judge.md
@@ -41,8 +41,9 @@ Per auto-valid part, **serially** (the render server is a singleton on :7373):
    varied per part. Record the mapping privately. _If a path says `author`/`ref`, the judge isn't
    blind — rename first._
 3. Dispatch ONE blind judge → verdict.
-4. **Escalate only on `tie-good` or `confidence:low`:** two more blind judges (labels re-shuffled
-   per judge), then vote **each signal the verdict map consumes independently** — the author's
+4. **Escalate only on `tie-good` or `confidence:low`:** two more blind judges on the **same per-part
+   A/B map** (independent subagents — no need to re-shuffle; the step-2 coin-flip already blinds
+   each), then vote **each signal the verdict map consumes independently** — the author's
    per-label class (`designed` vs `partial`/`blob`) and the pairwise call (author ≥ reference?) —
    taking the majority of each across the three judges (a 3-way split with no majority on _either_
    → `judge:⚠`, inconclusive — report it, don't guess). `tie-blob` is _not_ an escalation — it means both renders read

--- a/packages/brepjs-verify/bench/blind-judge.md
+++ b/packages/brepjs-verify/bench/blind-judge.md
@@ -42,7 +42,10 @@ Per auto-valid part, **serially** (the render server is a singleton on :7373):
    blind — rename first._
 3. Dispatch ONE blind judge → verdict.
 4. **Escalate only on `tie-good` or `confidence:low`:** two more blind judges (labels re-shuffled
-   per judge), take the majority pairwise verdict (a 3-way split with no majority → `judge:⚠`, inconclusive — report it, don't guess). `tie-blob` is _not_ an escalation — it means both renders read
+   per judge), then vote **each signal the verdict map consumes independently** — the author's
+   per-label class (`designed` vs `partial`/`blob`) and the pairwise call (author ≥ reference?) —
+   taking the majority of each across the three judges (a 3-way split with no majority on _either_
+   → `judge:⚠`, inconclusive — report it, don't guess). `tie-blob` is _not_ an escalation — it means both renders read
    blobby (usually a bad camera angle); re-render per the verdict map below and re-judge rather than
    burning panel calls on the same images.
 5. **Decode** the verdict against your private A/B map → author-vs-reference result.

--- a/packages/brepjs-verify/bench/blind-judge.md
+++ b/packages/brepjs-verify/bench/blind-judge.md
@@ -1,0 +1,61 @@
+# Blind LLM-as-judge — the design signal (sub-only)
+
+The eval's **design signal** — _does the skill reproduce the part as a designed object, not a valid
+blob?_ — is graded by a **blind judge subagent**, not by the session driving the loop. The
+orchestrator authored (and, in `/heal-skill`, _healed_) the thing under test, so it is a conflicted
+judge; an isolated judge that never saw the heal, the code, or which render is whose removes the
+bias. Sub-only, **$0** (judge subagents are flat-rate).
+
+This is the sub-loop counterpart to `bench/judge.ts` (the billed SDK judge used by `eval:live`).
+`judge.ts` is _absolute_ (one part's renders vs the request + rubric) and _not_ blind; this protocol
+is _pairwise_ (author vs reference) and _blind_ (labels stripped), and costs nothing.
+
+## The judge unit
+
+One judge subagent (general-purpose — it must `Read` the PNGs) per part. Its **entire input**: the
+part's NL `description` + two rendered images (**iso + one detail view each**) labeled only **A** and
+**B** + the rubric below. It is told NOTHING about which render is the skill's clean-room output vs
+the playground reference, and never reads any `.brep.ts`, the heal, the orchestration, or
+`apps/playground/**`. Structured return:
+
+- per label (`A`, `B`): `designed | partial | blob` + one-line reason (are the described features
+  present, legible, proportioned — or a lumpy primitive stack?),
+- pairwise: `A-better | B-better | tie-good | tie-blob`,
+- `confidence`: `high | low`.
+
+**Rubric (put in the judge prompt):** grade each render against the **description** as the absolute
+bar — the named features present and legible, the thing reads as manufactured/designed. Use the
+other render only to calibrate _how polished is achievable_, never to reward mere similarity. A part
+that differs from the other render but realizes the description as a designed object is `designed`.
+Ignore color, lighting, camera, and exact dimensions you can't read from the image.
+
+## The blind protocol (orchestrator: renders + shuffles + decodes — never grades)
+
+Per auto-valid part, **serially** (the render server is a singleton on :7373):
+
+1. Render the **author** `<id>.brep.ts` and the **reference** (adapt the playground `code`:
+   `brepjs/quick`→`brepjs`, `export default X`→`export default () => X`) to snapshots.
+2. **Strip the labels.** Copy both renders to **neutral filenames** — `<id>-A-iso.png` /
+   `<id>-B-iso.png` (+ a detail view) — and **coin-flip** which of {author, reference} is A vs B,
+   varied per part. Record the mapping privately. _If a path says `author`/`ref`, the judge isn't
+   blind — rename first._
+3. Dispatch ONE blind judge → verdict.
+4. **Escalate only on `tie-*` or `confidence:low`:** two more blind judges (labels re-shuffled per
+   judge), take the majority.
+5. **Decode** the verdict against your private A/B map → author-vs-reference result.
+
+## Verdict → scorecard (the bar: author ≥ reference, _and_ actually designed)
+
+- author `designed` AND (author-preferred OR `tie-good`) → **`judge:✓`**
+- author `partial`/`blob`, OR reference clearly preferred → **`judge:✗`** + the judge's reason
+- `tie-blob` (even the reference rendered blobby — usually a bad camera angle) → **`judge:⚠`**:
+  re-render from a better view and re-judge; don't score it as a pass.
+
+Record the verdict + reason + whether it escalated in the scorecard's judge column. **No silent
+caps:** an unrendered-but-valid part stays `judge:—` (a coverage gap, not a pass).
+
+## Caveat it can't see past
+
+Clean-room authors in `/heal-skill` stop at `ok:true` with no `--snapshot`, so they skip the polish
+pass (SKILL.md authoring step 8). The blind judge therefore measures _first-valid_ design quality,
+not the skill's ceiling — note that in the findings.

--- a/packages/brepjs-verify/bench/blind-judge.md
+++ b/packages/brepjs-verify/bench/blind-judge.md
@@ -42,7 +42,7 @@ Per auto-valid part, **serially** (the render server is a singleton on :7373):
    blind — rename first._
 3. Dispatch ONE blind judge → verdict.
 4. **Escalate only on `tie-good` or `confidence:low`:** two more blind judges (labels re-shuffled
-   per judge), take the majority. `tie-blob` is _not_ an escalation — it means both renders read
+   per judge), take the majority pairwise verdict (a 3-way split with no majority → `judge:⚠`, inconclusive — report it, don't guess). `tie-blob` is _not_ an escalation — it means both renders read
    blobby (usually a bad camera angle); re-render per the verdict map below and re-judge rather than
    burning panel calls on the same images.
 5. **Decode** the verdict against your private A/B map → author-vs-reference result.
@@ -51,8 +51,9 @@ Per auto-valid part, **serially** (the render server is a singleton on :7373):
 
 - author `designed` AND (author-preferred OR `tie-good`) → **`judge:✓`**
 - author `partial`/`blob`, OR reference clearly preferred → **`judge:✗`** + the judge's reason
-- `tie-blob` (even the reference rendered blobby — usually a bad camera angle) → **`judge:⚠`**:
-  re-render from a better view and re-judge; don't score it as a pass.
+- `tie-blob` (both renders read blobby — usually a bad camera angle) → re-render **once** from a
+  better view and re-judge; if it's still `tie-blob`, record **`judge:⚠`** and move on (don't loop).
+  Never score it as a pass.
 
 Record the verdict + reason + whether it escalated in the scorecard's judge column. **No silent
 caps:** an unrendered-but-valid part stays `judge:—` (a coverage gap, not a pass).


### PR DESCRIPTION
## Problem

The eval's **design signal** (does the skill reproduce the part *as a designed object*, not a valid blob?) was graded by the session running the loop — which authored the parts and, in `/heal-skill`, *wrote the heal under test*. That's a conflicted judge: it has every incentive to see its own output as designed.

## Change

Move the design signal to a **blind judge subagent** (`$0`, sub-only — flat-rate):

- **Pairwise + blind.** Render the author part *and* the playground reference, strip the labels to neutral `A`/`B` filenames (coin-flipped per part so neither role is fixed), and dispatch a judge that never saw the heal, any `.brep.ts`, or which render is whose. It returns, per label, `designed | partial | blob` + reason, then the pairwise call and a confidence.
- **Single, escalate on doubt.** One judge per part; only a `tie-*` or `confidence:low` verdict spins up a panel of 3 for a majority. Cheap common case, robust tail.
- **Orchestrator never grades** — it only renders, shuffles, decodes against its private A/B map, and aggregates.
- **Bar:** `judge:✓` iff the author render is *designed* AND ≥ the reference; else `judge:✗` + the judge's reason.

## Why this design
- A **separate subagent** (same model, fresh context) removes the *context* bias — the judge can't favor a heal it never saw — while honoring the `$0` sub-only rule. (Model-diversity via a different billed model was considered and rejected as cost.)
- **Blind pairwise** additionally removes *role* bias ("grade the skill's output harder/softer").
- Grades against the **description as the absolute bar**, using the reference only to calibrate — so a part isn't dinged merely for differing from the reference, only for being *less designed*.

## Files
- `packages/brepjs-verify/bench/blind-judge.md` — the protocol. The sub-loop counterpart to the billed `bench/judge.ts` (which is *absolute*, *not* blind, *not* pairwise, used by `eval:live`).
- `.claude/commands/heal-skill.md` §2 and `.claude/commands/eval-skill.md` §5 now delegate to it; `eval-skill` no longer claims the session is "the visual judge."

Doc/command-only change — no source or runtime behavior. Follow-up to #1507 (the worked heal) and #1511 (`/heal-skill`).