### PR TITLE
fix(brepjs-verify): heal polygon().extrude() gap — point to drawPolysides

### DIFF
--- a/packages/brepjs-verify/skill/references/sketching-2d.md
+++ b/packages/brepjs-verify/skill/references/sketching-2d.md
@@ -9,6 +9,7 @@ Build a 2D profile with the `draw` pen or a `draw*` factory, place it with `.ske
 | `drawRectangle`        | `drawRectangle(width, height)`                   | `Drawing`                                 |
 | `drawRoundedRectangle` | `drawRoundedRectangle(width, height, r?)`        | `Drawing`                                 |
 | `drawEllipse`          | `drawEllipse(majorRadius, minorRadius)`          | `Drawing`                                 |
+| `drawPolysides`        | `drawPolysides(radius, sidesCount, sagitta?)`    | `Drawing` (regular polygon: hex, etc.)    |
 | `.sketchOnPlane`       | `.sketchOnPlane('XY', origin?)`                  | `SketchInterface \| Sketches` (see below) |
 | `.extrude`             | `sketch.extrude(distance, { twistAngle?, ... })` | `Shape3D`                                 |
 | `revolve`              | `revolve(face, { axis?, at?, angle? })`          | `Result<Shape3D>`                         |
@@ -58,6 +59,7 @@ export default () => {
 - A `Drawing` is purely 2D; you must `.sketchOnPlane(...)` before `.extrude`.
 - `.sketchOnPlane(...)` returns `SketchInterface | Sketches`. `.extrude(...)` works on the union, but `.face()` / `.sweepSketch()` do not; for a single profile that needs a face (revolve), use `polygon(points3D)` instead (see above) to stay `--check`-clean.
 - Low-level `circle`/`ellipse`/`line` (primitives) return **edges**, not faces; use the `draw*` factories when you need a closed profile to extrude.
+- **For an extruded regular polygon (hex prism, nut, etc.) use `drawPolysides(radius, sides).sketchOnPlane('XY', origin?).extrude(h)`.** Do **not** reach for `polygon(points3D).extrude(...)`: `polygon()` returns an `OrientedFace` (for `revolve`/a face), which has **no `.extrude()`** — `tsc` rejects it with `TS2339: Property 'extrude' does not exist on type '… face … oriented … planar'`.
 - **`polygon(points)` needs distinct points** — two coincident/duplicate points make a zero-length edge and crash (`makeLineEdge: construction failed`). Dedupe before building, especially in computed tooth/gear profiles where a land and a groove point can land on the same coordinate.
 
 See also: docs/function-lookup.md → brepjs/sketching.


### PR DESCRIPTION
## What

Second heal from the same clean-room author sweep (sibling of #1515). A `TS2339` first-try failure: an author building a honeycomb hex-vent floor reaches for `polygon(points3D).extrude(...)`, but `polygon()` returns an `OrientedFace` (for `revolve`/a face) which has **no `.extrude()`**. The extrudable regular-polygon factory — `drawPolysides` — was absent from `sketching-2d.md`.

Ground truth (shipped `dist/**/*.d.ts`):
```
dist/topology/primitiveFns.d.ts:200  polygon(points: Vec3[]): Result<OrientedFace & PlanarFace>   // no .extrude
dist/sketching/drawingFactories.d.ts:57  drawPolysides(radius, sidesCount, sagitta?): Drawing     // exported from 'brepjs'
```

### Change (prose only)
- **sketching-2d.md**: add `drawPolysides` to the factory table; add a pitfall steering away from `polygon().extrude()` (naming the `TS2339`) toward `drawPolysides(r, sides).sketchOnPlane('XY', origin?).extrude(h)`.

## Verification — RED→GREEN
- **Micro-test:** `polygon([...]).extrude(6)` → `ok:false, TS2339: Property 'extrude' does not exist on type '… face … oriented … planar'`. `drawPolysides(10, 6).sketchOnPlane('XY').extrude(6)` → `ok:true, shapeType: Solid`.
- **Causal re-author:** a fresh clean-room author reproduced `vented-louvre-case` (the part that originally hit this), **quoted the new pitfall verbatim**, used `drawPolysides(HEX_R, 6).sketchOnPlane('XY', [x,y]).extrude(...)`, and passed **first-try** (was: first-try `TS2339`, 3 attempts).

This closes the single-incident finding deferred in #1515.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (`/heal-skill`)
