### PR TITLE
fix(brepjs-verify): heal pen .fillet/.chamfer gap — name customCorner

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -204,7 +204,7 @@ DrawingPen methods:
 - `quadraticBezierCurveTo(end, control)` — Quadratic Bezier
 - `cubicBezierCurveTo(end, c1, c2)` — Cubic Bezier
 - `smoothSplineTo(end, config?)`, `smoothSpline(dx, dy, config?)` — Smooth splines
-- `fillet(radius)`, `chamfer(radius)` — Corner treatments (call before next segment)
+- `customCorner(radius, mode?)` — Round/bevel the corner at the current vertex (call before the next segment). `mode`: `'fillet'` (default) or `'chamfer'`. (The pen has no bare `.fillet`/`.chamfer`; those are Drawing methods, after `.close()`/`.done()`.)
 - `close()` — Close the path and return a Drawing
 - `closeWithMirror()` — Close by mirroring the path
 - `closeWithCustomCorner(radius, mode?)` — Close with a fillet or chamfer at the join. `mode`: `'fillet'` (default) or `'chamfer'`

--- a/llms.txt
+++ b/llms.txt
@@ -204,7 +204,7 @@ DrawingPen methods:
 - `quadraticBezierCurveTo(end, control)` — Quadratic Bezier
 - `cubicBezierCurveTo(end, c1, c2)` — Cubic Bezier
 - `smoothSplineTo(end, config?)`, `smoothSpline(dx, dy, config?)` — Smooth splines
-- `fillet(radius)`, `chamfer(radius)` — Corner treatments (call before next segment)
+- `customCorner(radius, mode?)` — Round/bevel the corner at the current vertex (call before the next segment). `mode`: `'fillet'` (default) or `'chamfer'`. (The pen has no bare `.fillet`/`.chamfer`; those are Drawing methods, after `.close()`/`.done()`.)
 - `close()` — Close the path and return a Drawing
 - `closeWithMirror()` — Close by mirroring the path
 - `closeWithCustomCorner(radius, mode?)` — Close with a fillet or chamfer at the join. `mode`: `'fillet'` (default) or `'chamfer'`

--- a/packages/brepjs-verify/skill/references/sketching-2d.md
+++ b/packages/brepjs-verify/skill/references/sketching-2d.md
@@ -61,5 +61,6 @@ export default () => {
 - Low-level `circle`/`ellipse`/`line` (primitives) return **edges**, not faces; use the `draw*` factories when you need a closed profile to extrude.
 - **For an extruded regular polygon (hex prism, nut, etc.) use `drawPolysides(radius, sides).sketchOnPlane('XY', origin?).extrude(h)`.** Do **not** reach for `polygon(points3D).extrude(...)`: `polygon()` returns an `OrientedFace` (for `revolve`/a face), which has **no `.extrude()`** — `tsc` rejects it with `TS2339: Property 'extrude' does not exist on type '… face … oriented … planar'`.
 - **`polygon(points)` needs distinct points** — two coincident/duplicate points make a zero-length edge and crash (`makeLineEdge: construction failed`). Dedupe before building, especially in computed tooth/gear profiles where a land and a groove point can land on the same coordinate.
+- **Round/bevel a corner mid-pen with `customCorner(radius, mode?)`** (`mode`: `'fillet'` default or `'chamfer'`), called before the next segment — e.g. `draw([0,0]).lineTo([20,0]).customCorner(3, 'chamfer').lineTo([20,20])`. The pen (`DrawingPen`) has **no bare `.fillet`/`.chamfer`** (`TS2339`); those exist only on a `Drawing` (after `.close()`/`.done()`), as `.fillet(radius, filter?)` / `.chamfer(radius, filter?)`.
 
 See also: docs/function-lookup.md → brepjs/sketching.


### PR DESCRIPTION
## What

Final heal from the clean-room sweep (sibling of #1515, #1516). A `TS2339`: an author treats a corner mid-pen with `draw(...).chamfer(r)` — as the bundled `llms` reference advertised — but `DrawingPen` has **no bare `.fillet`/`.chamfer`** → `TS2339: Property 'chamfer' does not exist on type 'DrawingPen'`.

Ground truth (shipped `dist/**/*.d.ts`):
```
dist/2d/blueprints/baseSketcher2d.d.ts:100  customCorner(radius, mode?: 'fillet'|'chamfer'): this   // the pen's mid-chain corner method
dist/sketching/drawing.d.ts:81/88           fillet(radius, filter?) / chamfer(radius, filter?): Drawing  // only on a Drawing, post-.close()
```
`llms.txt`/`llms-full.txt:207` mislabeled `fillet(radius)`/`chamfer(radius)` as **pen** methods.

### Changes (prose only)
- **llms.txt + llms-full.txt** (the root pair — source of truth; the package's `reference/` copies regenerate from it at build via `copyReference.mjs`, and are gitignored): correct line 207 to `customCorner(radius, mode?)` and note bare `.fillet`/`.chamfer` are Drawing methods.
- **sketching-2d.md**: add a matching pitfall.

## Verification — RED→GREEN
- **Micro-test:** `draw(...).chamfer(3)` → `TS2339` on `DrawingPen`; `draw(...).customCorner(3, 'chamfer')` → `ok:true, Solid`.
- **Causal re-author:** a fresh clean-room author rebuilt `tripod-rc2-plate` (the part that surfaced this), **quoted the new pitfall verbatim**, used `.customCorner(CORNER_CHAMFER, 'chamfer')`, and passed **first-try** (was: first-try `TS2339`).

Closes the last deferred finding from the `/heal-skill` run (after #1515, #1516).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (`/heal-skill`)
