### PR TITLE
fix(topology): generated boolean faces inherit parent origin

### DIFF
--- a/src/topology/metadata/originTrackingFns.ts
+++ b/src/topology/metadata/originTrackingFns.ts
@@ -76,7 +76,14 @@ export function propagateOriginsFromEvolution(
     if (generatedHashes) {
       for (const genHash of generatedHashes) {
         if (!resultMap.has(genHash)) {
-          resultMap.set(genHash, 0);
+          // Generated faces (new geometry created at a boolean seam) inherit
+          // the origin of the input face that generated them, rather than
+          // defaulting to 0 (body). Without this the surface where a feature
+          // tool meets the body — e.g. a scoop ramp's top edge against the
+          // wall — loses its tag and renders in the body color in multi-color
+          // consumers (gridfinity-layout-tool GH #1654). first-writer-wins via
+          // the `has` guard keeps it deterministic when a seam is shared.
+          resultMap.set(genHash, origin);
         }
       }
     }

--- a/tests/metadataPropagation.test.ts
+++ b/tests/metadataPropagation.test.ts
@@ -126,6 +126,28 @@ describe('metadata propagation pipeline', () => {
       // No face should have leaked to origin 0 (the pre-fix bug).
       expect([...(origins?.values() ?? [])].every((v) => v === 7)).toBe(true);
     });
+
+    it('keeps a tagged tool feature on seam faces when fused into an untagged body', () => {
+      // Mirrors the gridfinity case: the body carries no origin, a feature tool
+      // does. Generated seam faces derived from the tool must keep the tool's
+      // origin (2), not fall back to 0 (body). Guards both the fix and the
+      // first-writer-wins ordering (untagged body contributes no origins).
+      const body = box(10, 10, 10); // intentionally NOT tagged
+      const tool = box(10, 10, 10);
+      setShapeOrigin(tool, 2);
+      const movedTool = translate(tool, [5, 5, 0]); // overlaps body
+
+      const result = fuse(body, movedTool);
+      expect(isOk(result)).toBe(true);
+      const fused = unwrap(result);
+      const origins = getFaceOrigins(fused);
+      expect(origins).toBeDefined();
+      // Only the tool's origin is in play; nothing should read as 0 (body leak).
+      const values = [...(origins?.values() ?? [])];
+      expect(values.length).toBeGreaterThan(0);
+      expect(values).toContain(2);
+      expect(values.every((v) => v === 2)).toBe(true);
+    });
   });
 
   describe('full metadata propagation through modifiers', () => {

--- a/tests/metadataPropagation.test.ts
+++ b/tests/metadataPropagation.test.ts
@@ -105,6 +105,27 @@ describe('metadata propagation pipeline', () => {
       expect(origins).toBeDefined();
       expect(origins?.size).toBeGreaterThan(0);
     });
+
+    it('gives boolean-generated seam faces the origin of their parent face', () => {
+      // Two OVERLAPPING boxes sharing one origin: the union regenerates faces
+      // at the intersection seam. Those generated faces must inherit the
+      // origin (7), not default to 0 (body) — otherwise a feature tool's seam
+      // with the body renders body-colored downstream (GH #1654).
+      const b1 = box(10, 10, 10);
+      setShapeOrigin(b1, 7);
+      const b2 = box(10, 10, 10);
+      setShapeOrigin(b2, 7);
+      const moved = translate(b2, [5, 5, 0]); // overlaps b1
+
+      const result = fuse(b1, moved);
+      expect(isOk(result)).toBe(true);
+      const fused = unwrap(result);
+      const origins = getFaceOrigins(fused);
+      expect(origins).toBeDefined();
+      expect(origins?.size).toBeGreaterThan(0);
+      // No face should have leaked to origin 0 (the pre-fix bug).
+      expect([...(origins?.values() ?? [])].every((v) => v === 7)).toBe(true);
+    });
   });
 
   describe('full metadata propagation through modifiers', () => {


### PR DESCRIPTION
## Problem
`propagateOriginsFromEvolution` assigns **origin 0 (body)** to every face that a boolean *generates* — new geometry created at the seam where a tool meets the body. So when a downstream consumer tags features by origin, the seam surfaces lose their tag.

In gridfinity-layout-tool (#1654) this made the **top of a finger-scoop ramp** (where it meets the bin wall) render in the body color instead of the scoop color in multi-color mode. The same class of bug affects any feature whose tool intersects the body and produces seam faces.

## Fix
Generated faces now inherit the origin of the **input face that produced them**, instead of defaulting to 0:

```ts
// before: resultMap.set(genHash, 0);
resultMap.set(genHash, origin);
```

`first-writer-wins` (the existing `!resultMap.has(genHash)` guard) keeps shared seams deterministic. Faces generated from a body face (origin 0) still read as body; faces generated from a tagged feature face now keep that tag.

## Test
Adds `metadataPropagation.test.ts > gives boolean-generated seam faces the origin of their parent face`: fuses two **overlapping** boxes that share origin `7` and asserts every result-face origin is `7` (no leak to `0`). Verified it **fails on the old code** and passes with the fix. Full `metadataPropagation` suite green (8/8).

Once released, gridfinity-layout-tool bumps to pick this up and the scoop-top color is fixed end-to-end.