### PR TITLE
chore(brepjs-cad): scrub stale brepjs-verify references

### DIFF
--- a/packages/brepjs-cad/bench/live.ts
+++ b/packages/brepjs-cad/bench/live.ts
@@ -219,7 +219,7 @@ async function main(): Promise<void> {
   await telemetry.registerSkill(skillMd);
   const runId = `${date}-${args.model}`;
 
-  const workdir = mkdtempSync(join(tmpdir(), 'brepjs-verify-eval-'));
+  const workdir = mkdtempSync(join(tmpdir(), 'brepjs-cad-eval-'));
 
   const results: EvalResult[] = [];
   for (const p of prompts) {

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -13,18 +13,18 @@
     "url": "https://github.com/andymai/brepjs",
     "directory": "packages/brepjs-cad"
   },
-  "main": "./dist/brepjs-verify.cjs",
-  "module": "./dist/brepjs-verify.js",
+  "main": "./dist/brepjs-cad.cjs",
+  "module": "./dist/brepjs-cad.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/brepjs-verify.js"
+        "default": "./dist/brepjs-cad.js"
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/brepjs-verify.cjs"
+        "default": "./dist/brepjs-cad.cjs"
       }
     }
   },

--- a/packages/brepjs-cad/src/snapshot/registry.ts
+++ b/packages/brepjs-cad/src/snapshot/registry.ts
@@ -25,7 +25,7 @@ async function probe(port: number): Promise<boolean> {
     if (!res.ok) return false;
     const d = (await res.json()) as Partial<ServerDescriptor>;
     return (
-      d.app === 'brepjs-verify-viewer' &&
+      d.app === 'brepjs-viewer' &&
       d.dynamicRoot === true &&
       typeof d.serverApiVersion === 'number' &&
       d.serverApiVersion >= SERVER_API_VERSION

--- a/packages/brepjs-cad/src/snapshot/static.ts
+++ b/packages/brepjs-cad/src/snapshot/static.ts
@@ -34,7 +34,7 @@ export interface StaticServer {
   close(): Promise<void>;
 }
 export interface ServerDescriptor {
-  app: 'brepjs-verify-viewer';
+  app: 'brepjs-viewer';
   port: number;
   dynamicRoot: true;
   serverApiVersion: number;
@@ -59,7 +59,7 @@ function safeJoin(root: string, rel: string): string | null {
 async function handle(req: IncomingMessage, res: ServerResponse, port: number): Promise<void> {
   const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
   if (url.pathname === '/__cad/server') {
-    const d: ServerDescriptor = { app: 'brepjs-verify-viewer', port, dynamicRoot: true, serverApiVersion: SERVER_API_VERSION };
+    const d: ServerDescriptor = { app: 'brepjs-viewer', port, dynamicRoot: true, serverApiVersion: SERVER_API_VERSION };
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(d));
     return;

--- a/packages/brepjs-cad/tests/cli.test.ts
+++ b/packages/brepjs-cad/tests/cli.test.ts
@@ -34,7 +34,7 @@ describe('init CLI', () => {
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
   it('scaffolds files into --out and prints a clean JSON manifest', () => {
-    dir = mkdtempSync(join(tmpdir(), 'brepjs-verify-cli-init-'));
+    dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-cli-init-'));
     const stdout = execFileSync('npx', ['tsx', cli, 'init', 'gizmo', '--out', dir], {
       encoding: 'utf8', cwd: pkgRoot,
     });
@@ -51,7 +51,7 @@ describe('export CLI', () => {
     if (dir) rmSync(dir, { recursive: true, force: true });
   });
   it('writes requested artifacts for a valid part', () => {
-    dir = mkdtempSync(join(tmpdir(), 'brepjs-verify-cli-export-'));
+    dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-cli-export-'));
     const stdout = execFileSync(
       'npx',
       ['tsx', cli, 'export', fix('validBox.brep.ts'), '--step', '--stl', '--out', dir],
@@ -64,7 +64,7 @@ describe('export CLI', () => {
   }, 60000);
 
   it('exits nonzero and writes nothing for an invalid part', () => {
-    dir = mkdtempSync(join(tmpdir(), 'brepjs-verify-cli-export-bad-'));
+    dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-cli-export-bad-'));
     let exitCode = 0;
     try {
       execFileSync(

--- a/packages/brepjs-cad/tests/exportPart.test.ts
+++ b/packages/brepjs-cad/tests/exportPart.test.ts
@@ -14,7 +14,7 @@ describe('exportPart', () => {
     await init();
   }, 30000);
   beforeEach(() => {
-    out = mkdtempSync(join(tmpdir(), 'brepjs-verify-export-'));
+    out = mkdtempSync(join(tmpdir(), 'brepjs-cad-export-'));
   });
   afterEach(() => {
     rmSync(out, { recursive: true, force: true });

--- a/packages/brepjs-cad/tests/runProgram.test.ts
+++ b/packages/brepjs-cad/tests/runProgram.test.ts
@@ -141,7 +141,7 @@ describe('runProgram (sandbox executor)', () => {
   it('reports crashed when the runner produces no report (bad CLI entry)', async () => {
     // A non-existent .js entry runs under `node` and exits non-zero with no JSON on stdout —
     // exactly the "the child died without a report" path the crashed outcome must catch.
-    const res = await runProgram(VALID_PART, { cliEntry: '/nonexistent/brepjs-verify-cli.js' });
+    const res = await runProgram(VALID_PART, { cliEntry: '/nonexistent/brepjs-cad-cli.js' });
     expect(res.outcome).toBe('crashed');
     if (res.outcome === 'crashed') expect(res.detail.length).toBeGreaterThan(0);
   }, 30000);

--- a/packages/brepjs-cad/tests/scaffold.test.ts
+++ b/packages/brepjs-cad/tests/scaffold.test.ts
@@ -7,7 +7,7 @@ import { scaffoldPart } from '@/cli/scaffold.js';
 describe('scaffoldPart', () => {
   let dir: string;
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'brepjs-verify-init-'));
+    dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-init-'));
   });
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });

--- a/packages/brepjs-cad/tests/snapshot/static.test.ts
+++ b/packages/brepjs-cad/tests/snapshot/static.test.ts
@@ -33,7 +33,7 @@ describe('static server', () => {
     expect(status).toBe(200);
     expect(contentType).toContain('application/json');
     const d = JSON.parse(body) as ServerDescriptor;
-    expect(d.app).toBe('brepjs-verify-viewer');
+    expect(d.app).toBe('brepjs-viewer');
     expect(d.port).toBe(server.port);
     expect(d.dynamicRoot).toBe(true);
     expect(d.serverApiVersion).toBeGreaterThanOrEqual(SERVER_API_VERSION);

--- a/packages/brepjs-cad/vite.config.ts
+++ b/packages/brepjs-cad/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     minify: false,
     lib: {
       entry: {
-        'brepjs-verify': resolve(__dirname, 'src/index.ts'),
+        'brepjs-cad': resolve(__dirname, 'src/index.ts'),
         'cli/main': resolve(__dirname, 'src/cli/main.ts'),
         // Pinned so the CLI's dynamic imports land on stable dist/snapshot/*.js paths
         // (preserves the ../../viewer/dist sibling-depth invariant static.ts relies on).


### PR DESCRIPTION
Removes the dormant `brepjs-verify` identifiers left over from the package rename (brepjs-verify → brepjs-cad). Pure rename + cosmetic; no behavior change.

## Changes
- **Lib output filename**: vite entry `brepjs-verify` → `brepjs-cad`, producing `dist/brepjs-cad.{js,cjs}`; package.json `main`/`module`/`exports` updated to match.
- **Render-server handshake id**: `brepjs-verify-viewer` → `brepjs-viewer` (writer `snapshot/static.ts`, reader `snapshot/registry.ts`, type literal, and the static.test assertion — all in this package, renamed atomically so no handshake skew).
- **Cosmetic**: `mkdtempSync` temp-dir prefixes in tests/bench and a fake CLI path → `brepjs-cad-`.

## Left intentionally
- **CHANGELOGs** (root + package): historical record that the package *was* published as `brepjs-verify`; release-please owns these.

## Verification
- typecheck ✅ · build ✅ (emits `dist/brepjs-cad.*`, no stale `brepjs-verify.*`) · 150/150 package tests ✅ · lint ✅ · pre-commit full changed-file suite 4353 passed ✅

## Related
- npm: `brepjs-cad` un-deprecated; `brepjs-verify` deprecated ("renamed to brepjs-cad"). Hard-deleting `brepjs-verify` from npm is blocked by the registry's 72h unpublish policy (first published 2026-06-04), so deprecation is the terminal state unless npm support removes it.