### PR TITLE
fix(brepjs-cad): heal implement + polish skills from clean-room eval

### DIFF
--- a/packages/brepjs-cad/skills/implement/SKILL.md
+++ b/packages/brepjs-cad/skills/implement/SKILL.md
@@ -30,9 +30,13 @@ advanced; `chamfer` is the fragile exception (prefer `fillet`).
 ## Declare intent — the `expected` block
 
 Add `export const expected = { … }` from the brief; the CLI asserts it, catching valid-but-wrong
-sizing. Any of `volume`, `area`, `bounds` are optional; `tolerancePct` sets the match window. Bounds
+sizing. The **only** authorable keys are `volume`, `area`, `bounds`, `tolerancePct` (each optional;
+`tolerancePct` sets the match window) — `TOP_LEVEL_KEYS` in `src/verify/expected.ts:45`. Bounds
 shape is exactly `{ xMin, xMax, yMin, yMax, zMin, zMax }` (any subset) — **not** `{ min, max }` or
-`{ x, y, z }` (a wrong shape reports `EXPECTED_UNKNOWN_KEY`).
+`{ x, y, z }` (a wrong shape reports `EXPECTED_UNKNOWN_KEY`). **`shapeType` is report-only, not
+authorable**: the report tells you whether the part measured as a `solid`/`compound`/etc., but
+putting `shapeType` (or any other field) in `expected` also reports `EXPECTED_UNKNOWN_KEY` — assert
+the body count or shape via `volume`/`bounds`, never a `shapeType` key.
 
 **Prefer `bounds`** over a hand-computed `volume` (a wrong number fails a _correct_ part). Predict
 only extents you **place directly** — a footprint, a stack height, where each body sits — these read
@@ -57,6 +61,13 @@ measure-first (run once, copy the report's measured value).
   `.extrude()`/`.revolve()` (or `loft`/`sweep`) is typed `Shape3D`; passing it to these ops is
   `TS2345`. Lift in two steps: `if (!isSolid(x)) throw …; const solid = unwrap(validSolid(x));`. Or
   build the prism from a primitive when you know you'll `fillet`/`shell` it. (`references/modifiers.md`.)
+- **A loose-`Compound` boolean can't be lifted to `ValidSolid` — fix the boolean, don't lift.** When
+  `fuse`/`fuseAll` only touch (don't overlap) they return a `Compound` (`ok:true`), and `isSolid`
+  returns `false` on it (`shapeType()==='compound'`, not `'solid'` — `src/core/shapeTypes.ts:248`).
+  There is **no lift** from a multi-body `Compound` to a `ValidSolid`: `validSolid()` needs one
+  `Solid`, so `if (!isSolid(x)) throw …` just throws, and feeding the Compound onward
+  `KERNEL_FAILED`s. Make the operands actually overlap and `fuseAll(shapes, { unsafe: true })` so the
+  weld yields a single solid **first**, then `fillet`/`shell`. (`references/booleans.md`.)
 - **Select edges/faces; don't fillet/chamfer everything.** `fillet(solid, radius)` with no edge
   list rounds EVERY edge and frequently `FILLET_FAILED`s. Pass `edgeFinder().inDirection('Z').findAll(solid)`.
   `inDirection` matches BOTH ± orientations; discriminate by position with

--- a/packages/brepjs-cad/skills/implement/references/modifiers.md
+++ b/packages/brepjs-cad/skills/implement/references/modifiers.md
@@ -43,6 +43,7 @@ Finder vocabulary: `edgeFinder()` / `faceFinder()` then `.inDirection(dir)`, `.o
 - **`fillet(solid, radius)` rounds ALL edges and often fails:** a uniform radius rarely fits every edge (e.g. it can't exceed a thin wall). Select the edges you mean with `edgeFinder()`. A failed fillet/chamfer surfaces as `FILLET_FAILED` / `CHAMFER_FAILED`.
 - **`inDirection('Z')` matches BOTH orientations** (+Z and −Z): it tests the axis, not the sign. To single out one face/edge add `.when(f => getBounds(f).zMax > threshold)` or `.atDistance(...)`.
 - A radius/distance larger than the local geometry makes the kernel fail; keep it well below the smallest adjacent edge length.
+- **`shell` thickness must be positive.** A `0` or negative `thickness` returns `INVALID_THICKNESS` ("Shell thickness must be positive") before the kernel runs (`src/topology/modifierFns.ts:416`); the sign does **not** flip the wall inward — pass a positive wall thickness (shell hollows inward by default). Likewise an empty face list returns `NO_FACES`.
 - **`fillet`/`chamfer`/`shell`/`offset` only accept a `ValidSolid`** — otherwise `TS2345: not assignable to Shapeable<ValidSolid>`. The trigger is **not** a boolean (`cut`/`fuse` keep whatever validity they were handed); it's a shape born from a **2D-sketch `.extrude()`/`.revolve()`** (or `loft`/`sweep`), which is typed `Shape3D`. `validSolid(...)` takes a concrete `Solid`, so the union won't go straight in — narrow with `isSolid`, then lift:
 
   ```ts

--- a/packages/brepjs-cad/skills/implement/references/sketching-2d.md
+++ b/packages/brepjs-cad/skills/implement/references/sketching-2d.md
@@ -25,7 +25,7 @@ export default () => {
 };
 ```
 
-**Obround / slot:** a corner radius of half the width gives fully-rounded (stadium) ends — `drawRoundedRectangle(length, width, width / 2)` — extrude and `cut` it through a plate for a rounded-end slot.
+**Obround / slot:** a corner radius approaching half the width gives fully-rounded (stadium) ends — extrude and `cut` it through a plate for a rounded-end slot. **Keep the radius _below_ `width / 2`, not exactly equal.** At `r === width / 2` the straight side segments collapse to zero length (`drawRoundedRectangle` only emits the `width - 2*r` side when `r < width / 2` — `src/2d/blueprints/cannedBlueprints.ts:84`); the degenerate profile then `KERNEL_FAILED`s when you extrude/`cut` it. Use a hair under, e.g. `drawRoundedRectangle(length, width, width / 2 - 0.01)` (or `width * 0.499`), for a stadium slot that builds.
 
 ## Revolving a profile
 
@@ -57,6 +57,7 @@ export default () => {
 ## Pitfalls
 
 - A `Drawing` is purely 2D; you must `.sketchOnPlane(...)` before `.extrude`.
+- **A non-XY sketch plane extrudes along its _signed_ normal, not toward the positive axis** (`src/core/planeOps.ts`): `XY`→+Z, `YZ`→+X, `ZX`→+Y, but **`XZ`→−Y**, `YX`→−Z, `ZY`→−X. So `draw(...).sketchOnPlane('XZ').extrude(L)` seats the body in `y ∈ [−L, 0]`, not `[0, L]` — then every +Y feature placement and `expected.bounds` misses by `L`. `translate(s, [0, L, 0])` to land it on a `y ∈ [0, L]` datum (or sketch on `ZX` for +Y), or measure-first and bound generously.
 - `.sketchOnPlane(...)` returns `SketchInterface | Sketches`. `.extrude(...)` works on the union, but `.face()` / `.sweepSketch()` do not; for a single profile that needs a face (revolve), use `polygon(points3D)` instead (see above) to stay `--check`-clean.
 - Low-level `circle`/`ellipse`/`line` (primitives) return **edges**, not faces; use the `draw*` factories when you need a closed profile to extrude.
 - **For an extruded regular polygon (hex prism, nut, etc.) use `drawPolysides(radius, sides).sketchOnPlane('XY', origin?).extrude(h)`.** Do **not** reach for `polygon(points3D).extrude(...)`: `polygon()` returns an `OrientedFace` (for `revolve`/a face), which has **no `.extrude()`** — `tsc` rejects it with `TS2339: Property 'extrude' does not exist on type '… face … oriented … planar'`.

--- a/packages/brepjs-cad/skills/implement/references/sketching-2d.md
+++ b/packages/brepjs-cad/skills/implement/references/sketching-2d.md
@@ -25,7 +25,7 @@ export default () => {
 };
 ```
 
-**Obround / slot:** a corner radius approaching half the width gives fully-rounded (stadium) ends — extrude and `cut` it through a plate for a rounded-end slot. **Keep the radius _below_ `width / 2`, not exactly equal.** At `r === width / 2` the straight side segments collapse to zero length (`drawRoundedRectangle` only emits the `width - 2*r` side when `r < width / 2` — `src/2d/blueprints/cannedBlueprints.ts:84`); the degenerate profile then `KERNEL_FAILED`s when you extrude/`cut` it. Use a hair under, e.g. `drawRoundedRectangle(length, width, width / 2 - 0.01)` (or `width * 0.499`), for a stadium slot that builds.
+**Obround / slot:** a corner radius of half the **shorter** side gives fully-rounded (stadium) ends — `drawRoundedRectangle(length, width, width / 2)` with `length > width` extrudes and `cut`s cleanly (the long-axis straight survives; only the short-side straight collapses, which _is_ the rounded end). The one degenerate case is a **square** obround: when `width === height` and `r === width / 2`, _both_ straight pairs collapse to zero and the all-arc profile `KERNEL_FAILED`s on extrude/`cut` (`drawRoundedRectangle` emits each straight side only while `r < that side / 2` — `src/2d/blueprints/cannedBlueprints.ts:84`). For a square rounded end nudge under: `width / 2 - 0.01`. Also keep `r` below half of **each** side — a radius past a half-dimension over-rounds and fails too.
 
 ## Revolving a profile
 

--- a/packages/brepjs-cad/skills/polish/SKILL.md
+++ b/packages/brepjs-cad/skills/polish/SKILL.md
@@ -23,6 +23,12 @@ Prefer **additive** detail — fins, gussets, lightening holes, grooves, a flush
 the failure-prone `fillet`/`chamfer` ops. Re-verify (`ok` stays true), re-render, repeat on the next
 worst offender. Detail and rationale: **`references/design-polish.md`**.
 
+A no-op is a valid outcome. If the part already reads as manufactured, the worst remaining offender
+is minor, or the only available edit is marginal, make NO edit, report the part as already-designed,
+and proceed to export. A marginal addition usually ties or loses against the un-touched render (it
+reads as decoration noise) — do not edit just to satisfy the loop. Only edit when the offender is a
+clear primitive-blob, mismatched cap, raw rim, or missing functional feature a human would notice.
+
 A polish edit must never break validity: if a round/blend pushes the part to `ok:false`, revert it
 and choose an additive alternative.
 

--- a/packages/brepjs-cad/skills/polish/references/design-polish.md
+++ b/packages/brepjs-cad/skills/polish/references/design-polish.md
@@ -21,7 +21,11 @@ primitives glued together?"** Specifically:
 - **Mismatched cap** — an oversized `sphere` knob on a thin shaft reads as a club. Size an end
   cap to ≈ the shaft radius.
 - **Raw rims everywhere** — every box/cylinder edge left sharp looks like a CAD primitive.
-- **Decoration noise** — detail that implies no function. Engineered ≠ busy.
+- **Decoration noise / invented blemish** — detail that implies no function, OR a fabricated
+  manufacturing defect (parting-line flash, mold seams, tooling marks, weld spatter). A designed
+  part looks CLEAN; adding a defect to make it look real reads worse than the primitive and loses
+  to the un-touched render. Engineered ≠ busy and ≠ flawed. Add functional features (grooves that
+  seat, holes that fasten, gussets that carry load), never simulated imperfections.
 - **Girdling band** — a feature (mounting ear, rib, deck) modelled as a slab that passes through
   the WHOLE body instead of protruding from one face. Build the protrusion as a discrete boss/tab
   fused to the surface, not a band wrapping the part.
@@ -61,3 +65,8 @@ Render iso + a close detail view. Critique against the bar above. Fix the worst 
 a blob or a raw edge — re-verify (`ok` must stay true), re-render. Polish is **qualitative**: you
 cannot convert "looks like a club" into a `bounds` assertion, so the snapshot review _is_ the check
 here. Stop when it reads as a designed part, not a pile of primitives.
+
+Before keeping an edit, compare the post render against the pre render and ask: would a blind judge
+prefer post? If post only ties — or the edit is a small feature on an already-clean part — discard
+it and keep pre. The goal is a clearly better render, not merely a different one. A tie means the
+edit was unnecessary; revert to the simpler form.


### PR DESCRIPTION
## What

Self-healed the three geometry-producing **brepjs-cad** pipeline skills from their own evals, run as one multi-agent workflow over the 38-part playground corpus (5 `basics` + 34 `mechanical`):

- **implement** — clean-room author fan-out (one subagent per part, reads *only* the implement skill + references; forbidden from the playground answer key), signal = `verify --check` valid + declared dims.
- **verify** — precision over the good corpus + recall over the known-bad `mutate.ts` fixtures.
- **polish** — blind pre/post design judge (render pre → polish → render post → validity-gate → A/B judge with panel escalation).

Every claimed gap was **ground-truthed against `src/` before editing** (clean-room agents misattribute citations — phantoms rejected, not healed) and **RED→GREEN re-verified** against the patched skill, with each pass causally attributable to the new rule.

## Heals

### implement — 29/38 → 38/38 first-try; 5 confirmed gaps, 0 phantoms
| Code | Class | Rule added | Cite |
|---|---|---|---|
| `EXPECTED_UNKNOWN_KEY` | contradiction | `shapeType` is report-only, not an authorable `expected` key | `expected.ts:45` |
| `KERNEL_FAILED` | omission | a loose-`Compound` boolean can't be lifted to `ValidSolid` — fix the boolean, don't lift | `shapeTypes.ts:248` |
| `INVALID_THICKNESS` | omission | `shell` thickness must be positive | `modifierFns.ts:416` |
| `KERNEL_FAILED` | contradiction | obround corner radius must stay **below** `width/2` or the profile degenerates | `cannedBlueprints.ts:84` |
| `EXPECTED_ASSERTION_FAILED` | omission | a non-XY sketch plane extrudes along its **signed** normal (`XZ`→−Y, `YX`→−Z, `ZY`→−X) | `planeOps.ts:79` |

The last rule was surfaced by the one remaining still-red part (`tripod-rc2-plate`): its original `KERNEL_FAILED` *was* fixed by the obround rule, but attempt #1 then missed because `sketchOnPlane('XZ').extrude(L)` seats the body in `y ∈ [−L, 0]`. Verified against `planeOps.ts` (XZ normal `[0,−1,0]`) and added here. (The other still-red part, `panel-fuse-holder`, was author error against an already-correct rule — correctly **not** healed.)

### verify — clean, no heal
Precision **15/15**, recall **5/5**. The verifier already catches every fixture class with the right code. (Recall is a lower bound — only the `mutate.ts` codes.)

### polish — 7/12 judge-preferred; 3 confirmed gaps (all omissions)
- **A no-op is a valid outcome** — don't force a marginal edit onto an already-designed part; it ties or loses against the un-touched render (4 corpus ties came from this).
- **Invented blemishes read worse, not realer** — a fabricated parting-line flash / mold seam dressed up as "detail" lost to the clean primitive (the one pre-preferred case, `o-ring`).
- **Weigh post vs pre before keeping an edit** — the snapshot check only gated validity, never asked whether the edit beat the prior render.

RED→GREEN: re-running the 5 polish misses against the patched skill flipped 3 to post-preferred & attributable; the other 2 are the no-op rule working as intended (a correct no-op renders identically → judged a tie, not a regression).

## Scope & cost
Markdown-only (5 skill files, +32/−4). No code, types, or tests changed; `verify` needed no `HINT_TABLE` edit. Sub-only / $0 incremental — no billed `eval:live` or Langfuse push.
