### PR TITLE
fix(brepjs-cad): correct spur-gear example flanks + add root fillet

### DIFF
--- a/packages/brepjs-cad/skills/implement/examples/spur-gear.brep.ts
+++ b/packages/brepjs-cad/skills/implement/examples/spur-gear.brep.ts
@@ -1,20 +1,25 @@
-// gear.brep.ts — involute spur gear (math ported from BOSL2 gears.scad for parity)
-// One closed polygon of all teeth -> extrude. Avoids per-tooth booleans (robust on occt-wasm).
+// spur-gear.brep.ts — involute spur gear that MESHES (math ported from BOSL2 gears.scad).
+// One closed polygon of all teeth -> extrude (robust on occt-wasm; no per-tooth booleans).
+// Two correctness points a "looks like a gear" build gets wrong:
+//   1. the +angle flank must use the MIRRORED involute (offset = halfTooth + phiPitch) so the
+//      tooth NARROWS to the tip; an un-mirrored flank diverges -> a dovetail that jams, not meshes.
+//   2. where the root dips below the base circle, a circular root FILLET (not a sharp radial root)
+//      clears the mating tooth tip. Validate meshing with intersect+measureVolume, not single-gear validity.
 import { polygon, extrude, unwrap } from 'brepjs';
 
 const MODULE = 2.0; // m = pitch dia / teeth
 const TEETH = 20;
 const PA = (20 * Math.PI) / 180; // pressure angle (20° standard)
+const BACKLASH = 0.1; // tooth-thinning clearance at the pitch circle (mm)
 const THICK = 6.0;
-const STEPS = 8; // involute samples per flank
+const STEPS = 12; // involute samples per flank/fillet
 
 const pr = (MODULE * TEETH) / 2; // pitch radius
 const br = pr * Math.cos(PA); // base radius
 const ra = pr + MODULE; // addendum (outer) radius
 const rr = pr - 1.25 * MODULE; // dedendum (root) radius  (clearance = m/4)
-const halfToothPitch = Math.PI / (2 * TEETH); // half tooth angular width at pitch circle
+const halfTooth = Math.PI / (2 * TEETH) - BACKLASH / 2 / pr; // half tooth angle at pitch, less backlash
 
-// involute: param theta from base circle; returns [x,y] and polar angle
 const invPt = (th: number): [number, number] => [
   br * (Math.cos(th) + th * Math.sin(th)),
   br * (Math.sin(th) - th * Math.cos(th)),
@@ -27,24 +32,45 @@ const rot = (p: [number, number], a: number): [number, number] => [
 
 export default () => {
   const thMax = thetaAt(ra);
-  const thPitch = thetaAt(pr);
-  const phiPitch = Math.atan2(...([invPt(thPitch)[1], invPt(thPitch)[0]] as [number, number])); // atan2(y,x)
-  const offset = halfToothPitch - phiPitch; // rotate so the pitch point lands at the half-tooth angle
+  const phiPitch = Math.atan2(invPt(thetaAt(pr))[1], invPt(thetaAt(pr))[0]);
+  const offset = halfTooth + phiPitch; // +phiPitch: the +angle flank uses the mirrored involute
 
-  // one tooth's outer boundary, centred at angle 0, traced low->high angle (CCW)
-  const tooth: [number, number][] = [];
-  // left flank: root -> tip (mirror of the right flank)
-  tooth.push(rot([rr, 0], -offset)); // left root (radial below base)
-  for (let i = 0; i <= STEPS; i++) {
-    const p = invPt((thMax * i) / STEPS);
-    tooth.push(rot([p[0], -p[1]], -offset)); // mirror across X, then -offset
-  }
-  // right flank: tip -> root
+  // +angle side of one tooth, tip -> base (mirrored involute curves back toward centre).
+  const side: [number, number][] = [];
   for (let i = STEPS; i >= 0; i--) {
     const p = invPt((thMax * i) / STEPS);
-    tooth.push(rot(p, offset));
+    side.push(rot([p[0], -p[1]], offset));
   }
-  tooth.push(rot([rr, 0], offset)); // right root
+
+  // root: a circular fillet (tangent to the flank at the base circle) run to the shared
+  // space-centre point, so adjacent fillets meet there and it undercuts to clear the mating tip.
+  const rSpace = rot([rr, 0], Math.PI / TEETH);
+  if (rr < br) {
+    const pb = rot([br, 0], offset);
+    const nHat: [number, number] = [-Math.sin(offset), Math.cos(offset)]; // perp to flank, toward the space
+    const dx = pb[0] - rSpace[0];
+    const dy = pb[1] - rSpace[1];
+    const rf = -(dx * dx + dy * dy) / (2 * (dx * nHat[0] + dy * nHat[1]));
+    const cf: [number, number] = [pb[0] + rf * nHat[0], pb[1] + rf * nHat[1]];
+    const a0 = Math.atan2(pb[1] - cf[1], pb[0] - cf[0]);
+    const a1 = Math.atan2(rSpace[1] - cf[1], rSpace[0] - cf[0]);
+    let dA = a1 - a0;
+    while (dA > Math.PI) dA -= 2 * Math.PI;
+    while (dA < -Math.PI) dA += 2 * Math.PI;
+    for (let i = 1; i <= STEPS; i++) {
+      const a = a0 + (dA * i) / STEPS;
+      side.push([cf[0] + Math.abs(rf) * Math.cos(a), cf[1] + Math.abs(rf) * Math.sin(a)]);
+    }
+  } else {
+    side.push(rSpace); // root above the base circle: straight root land
+  }
+
+  // mirror the +angle side across X for the -angle side; drop the trailing space-centre
+  // point (it is the next tooth's leading point) to avoid a duplicate vertex.
+  const tooth = [
+    ...side.map(([x, y]) => [x, -y] as [number, number]).reverse(),
+    ...side.slice(0, -1),
+  ];
 
   // replicate around the gear into one closed loop
   const pts3: [number, number, number][] = [];
@@ -61,7 +87,7 @@ export default () => {
 };
 
 export const expected = {
-  // outer Ø = 2*ra = 2*(pr+m); for m2 N20 -> 44; root-to-root etc. inside
+  // outer Ø = 2*ra = 2*(pr+m); for m2 N20 -> 44
   bounds: { xMin: -22, xMax: 22, yMin: -22, yMax: 22, zMin: 0, zMax: 6 },
   tolerancePct: 4,
 };

--- a/packages/brepjs-cad/skills/implement/examples/spur-gear.expected.json
+++ b/packages/brepjs-cad/skills/implement/examples/spur-gear.expected.json
@@ -1,7 +1,7 @@
 {
   "ok": true,
   "shapeType": "Solid",
-  "volume": 7446.012,
-  "area": 4680.214,
+  "volume": 7383.983,
+  "area": 3911.354,
   "tolerancePct": 0.5
 }

--- a/packages/brepjs-cad/skills/implement/references/gears.md
+++ b/packages/brepjs-cad/skills/implement/references/gears.md
@@ -19,6 +19,14 @@ the centre and add a hub/keyway with `cut` afterward.
 - involute point at roll angle θ: `x = br·(cosθ + θ·sinθ)`, `y = br·(sinθ − θ·cosθ)`; θ runs 0 (base)
   → `θmax = √((ra/br)² − 1)` (tip). Half-tooth angular width at the pitch circle = `π/(2N)`; rotate
   each flank so its pitch point lands there.
+- **The +angle flank must use the MIRRORED involute** (`[x, −y]`) with `offset = halfTooth + φpitch`,
+  so the tooth NARROWS to its tip. The un-mirrored flank diverges → teeth wider at the tip (a
+  **dovetail**) that jam instead of meshing — and a single such gear still passes `isValidSolid`.
+- **Add a root fillet where `rr < br`** (i.e. `N` below ~42). A sharp radial root lets the mating
+  tooth tip interfere below the base circle (~tens of mm³ even at the right phase). Use a circular
+  fillet tangent to the flank at the base point, run to the shared space-centre point
+  `rot([rr,0], π/N)` — adjacent fillets meet there (dedupe that vertex) and it undercuts to clear
+  the tip. See `examples/spur-gear.brep.ts`.
 
 ## Meshing rules (get these wrong and the gears jam or skip)
 


### PR DESCRIPTION
## What

Re-homes the spur-gear meshing fix from **#1524** onto the `brepjs-cad` skill path. #1524 targeted `packages/brepjs-verify/skill/…`, which **PR #1520 deleted** in the `brepjs-verify → brepjs-cad` rename — so it went stale and `CONFLICTING`, while the renamed tree still carried the **buggy** gear. This applies the same fix to the live path.

Supersedes #1524 (close it in favor of this).

## The bug

The `spur-gear.brep.ts` example built a valid solid with **inverted flanks**: the `+angle` flank used the un-mirrored involute (`offset = halfTooth − phiPitch`), so teeth *widened* toward the tip (a dovetail). A dovetail tooth can't roll through a mating space, so two gears jam. A single gear still passes `isValidSolid` with the correct OD, so it slipped through single-part validity.

## The fix

- **Mirrored involute** for the `+angle` flank (`offset = halfTooth + phiPitch`) → the tooth **narrows** to the tip and can mesh.
- **Circular root fillet** where the root dips below the base circle, to clear the mating tooth tip.
- **Pitch-line backlash** (`0.1 mm`) for running clearance.
- Updated `references/gears.md`; `spur-gear.expected.json` re-baselined.

## Verification

- `brep verify spur-gear.brep.ts --check` → `ok:true`, volume `7383.98 mm³` / area `3911.35 mm²`, matching the re-baselined `expected.json` (so it stays clean in the verify-skill precision corpus).
- Meshing correctness was established in #1524 (intersect + `measureVolume` across phases); this PR is a faithful re-home of that fix, not a re-derivation.

## Scope

Three files under `packages/brepjs-cad/skills/implement/` (example + fixture + reference doc). No library code.
