### PR TITLE
fix(brepjs-cad): make blind-judge reference adaptation render multi-body parts at scale

### DIFF
--- a/packages/brepjs-cad/bench/adaptReference.ts
+++ b/packages/brepjs-cad/bench/adaptReference.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Adapt a playground example's `code` into a `brep`-renderable `.brep.ts` for the blind design judge
+// (bench/blind-judge.md). The reference is the known-good playground part; this turns it into a part
+// the CLI can run + snapshot so the judge can compare it against the clean-room author's render.
+//
+// Two divergences between the playground runtime and the `brep` CLI are reconciled here:
+//   1. Multi-body examples return a shape ARRAY (`return [a, b, c]` / `export default [x, y]`). The
+//      playground renderer accepts an array; the CLI's runChecks calls isSolid() on the default
+//      export, and a bare array has no kernel handle → "expected an OcctWasmHandle … got undefined".
+//      Wrap an array return in `compound(...)` so the CLI sees one shape. (A single-shape default
+//      passes straight through.)
+//   2. The example imports from `brepjs/quick`, which auto-inits the kernel via a top-level await.
+//      KEEP that import — rewriting it to `brepjs` drops the import-time init that examples with
+//      module-level geometry rely on (the same "got undefined" surfaces a different way).
+//
+// Render the result WITHOUT `--check`: playground `code` is type-checked against the looser Monaco
+// ambient surface, so strict-CLI type gaps (e.g. `sketchOnPlane('XY')`) are expected and irrelevant
+// to the image the judge needs.
+
+const QUICK = 'brepjs/quick';
+
+/** Pure transform: playground example `code` → CLI-renderable reference part source. */
+export function adaptReferenceCode(code: string): string {
+  // Keep whatever brepjs entry the example already uses; default to the kernel-auto-init `quick`.
+  const usesPlain = /from ['"]brepjs['"]/.test(code) && !/from ['"]brepjs\/quick['"]/.test(code);
+  const src = usesPlain ? 'brepjs' : QUICK;
+
+  // The default export is a single expression — a call (`fn()`), a variable, or an array literal.
+  const m = code.match(/export default\s+([\s\S]+?);[ \t]*\r?\n?$/m);
+  if (!m || m.index === undefined || m[1] === undefined) {
+    throw new Error('adaptReference: no `export default <expr>;` found');
+  }
+  const expr = m[1].trim();
+
+  // `await` makes the wrapper tolerate both sync and async (loadFont/importSTEP) defaults.
+  const wrapper =
+    `export default async () => {\n` +
+    `  const __ref = await (${expr});\n` +
+    `  return Array.isArray(__ref) ? __refCompound(__ref) : __ref;\n` +
+    `};`;
+  const body = code.slice(0, m.index) + wrapper + code.slice(m.index + m[0].length);
+  return `import { compound as __refCompound } from '${src}';\n${body}`;
+}
+
+interface Example {
+  id: string;
+  label: string;
+  description: string;
+  code: string;
+}
+interface Category {
+  id: string;
+  label: string;
+  examples: readonly Example[];
+}
+
+const SCOPE = new Set(['basics', 'mechanical']); // plain brepjs; bim/sheet-metal need other skills
+
+/**
+ * Load the plain-brepjs playground examples. A runtime (variable-path) import so the bench tsconfig
+ * takes no compile-time dependency on the playground app (same approach as bench/syncDataset.ts).
+ */
+async function loadReferenceCorpus(): Promise<Example[]> {
+  const registry = '../../../apps/playground/src/lib/examples/index.ts';
+  const mod = (await import(registry)) as { CATEGORIES: readonly Category[] };
+  return mod.CATEGORIES.filter((c) => SCOPE.has(c.id)).flatMap((c) => c.examples);
+}
+
+// CLI: write adapted reference parts for the blind judge to render.
+//   tsx bench/adaptReference.ts <outDir> [id...]   (no ids → the whole basics+mechanical corpus)
+async function main(): Promise<void> {
+  const [outDir, ...ids] = process.argv.slice(2);
+  if (!outDir) {
+    process.stderr.write('usage: tsx bench/adaptReference.ts <outDir> [id...]\n');
+    process.exitCode = 1;
+    return;
+  }
+  mkdirSync(outDir, { recursive: true });
+  const wanted = new Set(ids);
+  const examples = (await loadReferenceCorpus()).filter((e) => !ids.length || wanted.has(e.id));
+  for (const e of examples) {
+    const out = join(outDir, `${e.id}.ref.brep.ts`);
+    try {
+      writeFileSync(out, adaptReferenceCode(e.code));
+      process.stdout.write(`${e.id} -> ${out}\n`);
+    } catch (err) {
+      process.stderr.write(`${e.id}: SKIP (${(err as Error).message})\n`);
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/packages/brepjs-cad/bench/adaptReference.ts
+++ b/packages/brepjs-cad/bench/adaptReference.ts
@@ -28,8 +28,12 @@ export function adaptReferenceCode(code: string): string {
   const usesPlain = /from ['"]brepjs['"]/.test(code) && !/from ['"]brepjs\/quick['"]/.test(code);
   const src = usesPlain ? 'brepjs' : QUICK;
 
-  // The default export is a single expression — a call (`fn()`), a variable, or an array literal.
-  const m = code.match(/export default\s+([\s\S]+?);[ \t]*\r?\n?$/m);
+  // The default export is a single expression — a call (`fn()`), a variable, or an array literal,
+  // possibly spanning lines. Anchor `$` to end-of-string (no `m` flag) so the non-greedy capture runs
+  // to the expression's terminating `;` (the last one before trailing whitespace), not the first `;`
+  // that merely happens to end an inner line of a multi-line default. `export default` is always the
+  // module's final statement in the corpus, so the trailing `;\s*$` is unambiguous.
+  const m = code.match(/export default\s+([\s\S]+?);\s*$/);
   if (!m || m.index === undefined || m[1] === undefined) {
     throw new Error('adaptReference: no `export default <expr>;` found');
   }

--- a/packages/brepjs-cad/bench/blind-judge.md
+++ b/packages/brepjs-cad/bench/blind-judge.md
@@ -34,8 +34,13 @@ Ignore color, lighting, camera, and exact dimensions you can't read from the ima
 
 Per auto-valid part, **serially** (the render server is a singleton on :7373):
 
-1. Render the **author** `<id>.brep.ts` and the **reference** (adapt the playground `code`:
-   `brepjs/quick`→`brepjs`, `export default X`→`export default () => X`) to snapshots.
+1. Render the **author** `<id>.brep.ts` (`--check --snapshot`) and the **reference** to snapshots.
+   Generate the reference part with **`tsx bench/adaptReference.ts <dir> <id>`** — do **not** hand-edit
+   the playground `code`. The adapter keeps the `brepjs/quick` import (it auto-inits the kernel) and
+   wraps a multi-body **array** return in `compound(...)` (the CLI's runChecks needs one shape; a bare
+   array reports `expected an OcctWasmHandle … got undefined`). Render the reference **without
+   `--check`** — playground `code` is typed against the looser Monaco surface, so strict-CLI type gaps
+   (e.g. `sketchOnPlane('XY')`) are expected and don't affect the image. (Rendering is still serial.)
 2. **Strip the labels.** Copy both renders to **neutral filenames** — `<id>-A-iso.png` /
    `<id>-B-iso.png` (+ a detail view) — and **coin-flip** which of {author, reference} is A vs B,
    varied per part. Record the mapping privately. _If a path says `author`/`ref`, the judge isn't

--- a/packages/brepjs-cad/tests/adaptReference.test.ts
+++ b/packages/brepjs-cad/tests/adaptReference.test.ts
@@ -27,6 +27,23 @@ describe('adaptReferenceCode (blind-judge reference adaptation)', () => {
     expect(out).toContain('__refCompound(__ref)');
   });
 
+  it('captures a multi-line default with inner semicolons (end-anchored, not first-`;`)', () => {
+    const code = [
+      "import { box, cylinder } from 'brepjs/quick';",
+      'export default (() => {',
+      '  const a = box(1, 1, 1);',
+      '  const b = cylinder(1, 1);',
+      '  return [a, b];',
+      '})();',
+    ].join('\n');
+    const out = adaptReferenceCode(code);
+    // The whole IIFE must be captured — not truncated at the inner `const a = …;`.
+    expect(out).toContain('const a = box(1, 1, 1);');
+    expect(out).toContain('return [a, b];');
+    expect(out).toContain('})());');
+    expect(out).not.toContain('const __ref = await (box(1, 1, 1));');
+  });
+
   it('passes a single-shape default through the same wrapper', () => {
     const code = ["import { box } from 'brepjs/quick';", 'export default box(2, 3, 4);'].join('\n');
     const out = adaptReferenceCode(code);

--- a/packages/brepjs-cad/tests/adaptReference.test.ts
+++ b/packages/brepjs-cad/tests/adaptReference.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { adaptReferenceCode } from '../bench/adaptReference.js';
+
+describe('adaptReferenceCode (blind-judge reference adaptation)', () => {
+  it('wraps an array-returning call in compound so the CLI sees one shape', () => {
+    const code = [
+      "import { box, cylinder } from 'brepjs/quick';",
+      'function asm() { return [box(1, 1, 1), cylinder(1, 1)]; }',
+      'export default asm();',
+    ].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).toContain("import { compound as __refCompound } from 'brepjs/quick';");
+    expect(out).toContain('const __ref = await (asm());');
+    expect(out).toContain('Array.isArray(__ref) ? __refCompound(__ref) : __ref');
+    // The single-body branch is preserved for non-array defaults.
+    expect(out).toContain('export default async () =>');
+  });
+
+  it('handles a bare array-literal default (multi-body basics examples)', () => {
+    const code = [
+      "import { sphere, box } from 'brepjs/quick';",
+      'const s = sphere(1); const b = box(1, 1, 1);',
+      'export default [s, b];',
+    ].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).toContain('const __ref = await ([s, b]);');
+    expect(out).toContain('__refCompound(__ref)');
+  });
+
+  it('passes a single-shape default through the same wrapper', () => {
+    const code = ["import { box } from 'brepjs/quick';", 'export default box(2, 3, 4);'].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).toContain('const __ref = await (box(2, 3, 4));');
+  });
+
+  it('keeps brepjs/quick — does NOT rewrite the kernel-auto-init import to brepjs', () => {
+    const code = ["import { box } from 'brepjs/quick';", 'export default box(1, 1, 1);'].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).toContain("from 'brepjs/quick'");
+    // The compound import must come from quick too, not bare brepjs.
+    expect(out).toContain("compound as __refCompound } from 'brepjs/quick'");
+  });
+
+  it('uses the plain brepjs entry when the example imports from brepjs (not quick)', () => {
+    const code = ["import { box } from 'brepjs';", 'export default box(1, 1, 1);'].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).toContain("compound as __refCompound } from 'brepjs';");
+  });
+
+  it('throws on a module with no `export default <expr>;`', () => {
+    expect(() =>
+      adaptReferenceCode("import { box } from 'brepjs/quick';\nconst x = box(1,1,1);")
+    ).toThrow(/no .export default/);
+  });
+});


### PR DESCRIPTION
## What

Fixes the blind design judge (`bench/blind-judge.md`) so it can render the **whole** playground corpus, not just single-solid parts. Follow-up to the implement heal in #1529, where the design judge collapsed to 1 of 14 parts because most references wouldn't render.

## Root cause

The judge renders each playground **reference** next to the clean-room author's part. The prescribed manual adaptation — `brepjs/quick`→`brepjs` + `export default X`→`export default () => X` — silently failed for most of the corpus:

- **Multi-body examples return a shape *array*** (`return [a, b, c]`, or a bare `export default [x, y]`). The playground renderer accepts arrays; the `brep` CLI's `runChecks` calls `isSolid()` on the default export, and a bare array has no kernel handle → **`expected an OcctWasmHandle … got undefined`**.
- The `brepjs/quick`→`brepjs` rewrite was a **red herring** — it strips the import-time kernel auto-init, surfacing the *same* error a different way. The geometry builds fine when `quick` is kept.
- d-sub-style parts additionally tripped `--check` on a quick-vs-strict type gap (`sketchOnPlane('XY')` vs `PlaneConfig`) — irrelevant to the image.

Net effect: only single-fused-solid parts (e.g. axial-fan) rendered, so a hardest-corpus design judge reported one real verdict and the rest as `judge:—` coverage gaps.

## Fix

`bench/adaptReference.ts`:
- `adaptReferenceCode(code)` — pure transform that **keeps `brepjs/quick`** (auto-inits the kernel) and **wraps an array return in `compound(...)`** so the CLI sees one shape (single-shape defaults pass through unchanged; `await` tolerates async defaults).
- A CLI writer (`tsx bench/adaptReference.ts <dir> [id...]`) that emits adapted `.ref.brep.ts` over the basics + mechanical corpus.

`bench/blind-judge.md` step 1 now points to the helper and says to render the reference **without `--check`** (instead of the hand-edit).

## Verification

- `tests/adaptReference.test.ts` (6 cases, no kernel) locks the transform: array-call wrap, bare-array-literal wrap, single-shape passthrough, `brepjs/quick` preserved, plain-`brepjs` honored, throws on no default.
- End-to-end: the 5 references that previously failed — `knuckle-hinge`, `d-sub-connector`, `planetary-gear-reducer` (all `got undefined`), `primitives`, `mortise-tenon` (array literals) — now run `ok:true` and snapshot to 4 PNGs each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)