### PR TITLE
feat(brepjs-cad): deterministic body/interference metrics for the design judge (Phase 1)

### DIFF
--- a/packages/brepjs-cad/bench/blind-judge.md
+++ b/packages/brepjs-cad/bench/blind-judge.md
@@ -15,12 +15,15 @@ is _pairwise_ (author vs reference) and _blind_ (labels stripped), and costs not
 One judge subagent (general-purpose — it must `Read` the PNGs) per part. Its **entire input**: the
 part's NL `description` + two rendered images each — **iso + one detail view, the SAME view pair for
 both renders** so the A/B comparison is fair (pick the detail view — front/top/right — that best
-exposes the features the description names) — labeled only **A** and **B** + the rubric below. It is told NOTHING about which render is the skill's clean-room output vs
-the playground reference, and never reads any `.brep.ts`, the heal, the orchestration, or
+exposes the features the description names) — labeled only **A** and **B**, **a one-line "measured
+facts" string per render** (body count + interference relations — the ground truth the render can't
+show; see step 1b), + the rubric below. It is told NOTHING about which render is the skill's clean-room
+output vs the playground reference, and never reads any `.brep.ts`, the heal, the orchestration, or
 `apps/playground/**`. Structured return:
 
 - per label (`A`, `B`): `designed | partial | blob` + one-line reason (are the described features
-  present, legible, proportioned — or a lumpy primitive stack?),
+  present, legible, proportioned — or a lumpy primitive stack? do the measured body count + relations
+  match what the description implies?),
 - pairwise: `A-better | B-better | tie-good | tie-blob`,
 - `confidence`: `high | low`.
 
@@ -41,6 +44,13 @@ Per auto-valid part, **serially** (the render server is a singleton on :7373):
    array reports `expected an OcctWasmHandle … got undefined`). Render the reference **without
    `--check`** — playground `code` is typed against the looser Monaco surface, so strict-CLI type gaps
    (e.g. `sketchOnPlane('XY')`) are expected and don't affect the image. (Rendering is still serial.)
+   1b. **Capture measured facts.** Run `brep verify <part> --metrics --json` for the author AND the
+   reference, and from each report build a one-line digest of `bodies` (count) + `bodyRelations`
+   (which bodies sit apart vs touch/overlap) + any `manufacturability.violations`. Give the judge the
+   digest for **A** and for **B** as ground truth — **symmetric and label-free** (each render gets its
+   own line; the digest must not reveal which is author vs reference). The judge reconciles the facts
+   with the image (does it see the stated body count?) and decides whether a reported interference is
+   an intended assembly or an accidental collision from the description.
 2. **Strip the labels.** Copy both renders to **neutral filenames** — `<id>-A-iso.png` /
    `<id>-B-iso.png` (+ a detail view) — and **coin-flip** which of {author, reference} is A vs B,
    varied per part. Record the mapping privately. _If a path says `author`/`ref`, the judge isn't

--- a/packages/brepjs-cad/bench/judge.ts
+++ b/packages/brepjs-cad/bench/judge.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import type Anthropic from '@anthropic-ai/sdk';
 import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
 import { z } from 'zod';
+import { formatDigest, type MetricsDigest } from './metrics.js';
 
 // Multimodal judge: given the rendered views of a generated part plus the original
 // request + rubric, decide whether the geometry matches. Verdict is a structured
@@ -9,10 +10,18 @@ import { z } from 'zod';
 
 const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered views (iso / front / top / right) of a 3D part a model produced from a natural-language request, along with the request and a rubric describing what a correct part must show.
 
-Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.`;
+Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.
+
+You may also be given "Measured facts" computed deterministically from the kernel (exact body count, and which bodies sit apart vs touch/overlap). Treat these as ground truth the render cannot show, and reconcile them with what you see — if the facts report N bodies, confirm you see N. A reported interference is ambiguous on its own: decide from the request and image whether it is an intended assembly (e.g. an exploded view or a part that legitimately overlaps another) or an accidental collision. Also judge manufacturability: whether the part reads as a producible object (no zero-thickness walls, stray disconnected bodies, or self-colliding geometry the request did not ask for).`;
 
 const VERDICT = z.object({
   pass: z.boolean().describe('true only if the rendered part matches the request and rubric'),
+  manufacturable: z
+    .boolean()
+    .describe('true if the part reads as producible; false for zero-thickness walls, stray/colliding bodies, or other unmanufacturable geometry the request did not ask for'),
+  usedMetrics: z
+    .boolean()
+    .describe('true if the measured facts (body count / relations) changed your verdict versus the images alone'),
   reason: z.string().describe('one sentence citing the deciding feature(s)'),
 });
 export type Verdict = z.infer<typeof VERDICT>;
@@ -22,6 +31,8 @@ export interface JudgeInput {
   rubric: string;
   pngPaths: readonly string[];
   model: string;
+  /** Deterministic metrics the render can't show; rendered into the user message as ground truth. */
+  metrics?: MetricsDigest;
 }
 
 export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdict> {
@@ -47,7 +58,10 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
             ...images,
             {
               type: 'text',
-              text: `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\nDoes the rendered part satisfy the request and rubric?`,
+              text:
+                `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\n` +
+                (input.metrics ? `${formatDigest(input.metrics)}\n\n` : '') +
+                `Does the rendered part satisfy the request and rubric?`,
             },
           ],
         },
@@ -57,5 +71,12 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
     { signal: AbortSignal.timeout(120_000) }
   );
 
-  return response.parsed_output ?? { pass: false, reason: 'judge returned no parseable verdict' };
+  return (
+    response.parsed_output ?? {
+      pass: false,
+      manufacturable: false,
+      usedMetrics: false,
+      reason: 'judge returned no parseable verdict',
+    }
+  );
 }

--- a/packages/brepjs-cad/bench/live.ts
+++ b/packages/brepjs-cad/bench/live.ts
@@ -154,19 +154,22 @@ async function evalPrompt(
   const deps: LoopDeps = {
     author: (messages) => authorPart(client, system, messages, args.model),
     execute: (code, attempt) =>
-      runProgramWithStep(code, join(workdir, `${p.id}-a${attempt}.step`), {}),
+      // --metrics so the report carries body/interference facts for the judge (this path already
+      // pays for the STEP export, so the extra metric pass is proportionate).
+      runProgramWithStep(code, join(workdir, `${p.id}-a${attempt}.step`), { metrics: true }),
     snapshot: (stepPath) => snapshot(stepPath, `${stepPath}-shots`),
     // The judge is a secondary signal — swallow its errors and return null so a judge timeout/API
     // blip leaves judgePass undefined (scorecard shows judge:—) instead of failing the attempt.
-    judge: async (pngPaths) => {
+    judge: async (pngPaths, metrics) => {
       try {
         const v = await judge(client, {
           prompt: p.prompt,
           rubric: p.rubric,
           pngPaths: [...pngPaths],
           model: args.judgeModel,
+          ...(metrics ? { metrics } : {}),
         });
-        return { pass: v.pass, reason: v.reason };
+        return { pass: v.pass, reason: v.reason, manufacturable: v.manufacturable };
       } catch (e) {
         console.warn(`  judge failed (${(e as Error).message.split('\n')[0]})`);
         return null;

--- a/packages/brepjs-cad/bench/loop.ts
+++ b/packages/brepjs-cad/bench/loop.ts
@@ -1,4 +1,5 @@
 import { checkAuto, type AttemptResult, type AutoResult, type EvalResult } from './score.js';
+import { digestMetrics, type MetricsDigest } from './metrics.js';
 import type { EvalPrompt } from './prompts.js';
 import type { RunProgramWithStepResult } from '../src/sandbox/runProgram.js';
 
@@ -21,8 +22,12 @@ export interface LoopDeps {
   execute: (code: string, attempt: number) => Promise<RunProgramWithStepResult>;
   /** Render multi-view snapshots of a STEP; returns [] when unavailable (no Chrome/viewer). */
   snapshot: (stepPath: string) => Promise<readonly string[]>;
-  /** Multimodal judge over the rendered views; null = no verdict (e.g. judge errored — a soft skip). */
-  judge: (pngPaths: readonly string[]) => Promise<{ pass: boolean; reason: string } | null>;
+  /** Multimodal judge over the rendered views; null = no verdict (e.g. judge errored — a soft skip).
+   * `metrics` carries the deterministic facts the render can't show (body count/interference). */
+  judge: (
+    pngPaths: readonly string[],
+    metrics?: MetricsDigest
+  ) => Promise<{ pass: boolean; reason: string; manufacturable?: boolean } | null>;
 }
 
 export interface LoopOptions {
@@ -100,13 +105,16 @@ export async function runAttemptLoop(
     const wantJudge = attempt === 1 || auto.pass || isFinal;
     let judgePass: boolean | undefined;
     let judgeReason: string | undefined;
+    let manufacturable: boolean | undefined;
     if (wantJudge && outcome.outcome === 'completed' && outcome.stepPath) {
       const pngs = await deps.snapshot(outcome.stepPath);
       if (pngs.length > 0) {
-        const v = await deps.judge(pngs);
+        const metrics = digestMetrics(outcome.report);
+        const v = await deps.judge(pngs, metrics);
         if (v) {
           judgePass = v.pass;
           judgeReason = v.reason;
+          manufacturable = v.manufacturable;
         }
       }
     }
@@ -119,6 +127,7 @@ export async function runAttemptLoop(
     };
     if (judgePass !== undefined) result.judgePass = judgePass;
     if (judgeReason !== undefined) result.judgeReason = judgeReason;
+    if (manufacturable !== undefined) result.manufacturable = manufacturable;
     attempts.push(result);
 
     // An absent judge does not block convergence (judge:— is a legitimate skip, not a fail).
@@ -150,5 +159,6 @@ export async function runAttemptLoop(
   if (firstTry) out.firstTry = firstTry;
   if (eventual?.judgePass !== undefined) out.judgePass = eventual.judgePass;
   if (eventual?.judgeReason !== undefined) out.judgeReason = eventual.judgeReason;
+  if (eventual?.manufacturable !== undefined) out.manufacturable = eventual.manufacturable;
   return out;
 }

--- a/packages/brepjs-cad/bench/metrics.ts
+++ b/packages/brepjs-cad/bench/metrics.ts
@@ -1,0 +1,43 @@
+import type { VerifyReport } from '../src/verify/report.js';
+
+// Flat, human-legible projection of the deterministic metrics in a VerifyReport (`brep verify
+// --metrics`). Both judges consume this one shape: the SDK judge gets it via JudgeInput.metrics, and
+// the blind sub-agent orchestrator pastes formatDigest() symmetrically per render. Kept out of
+// score.ts so scoring isn't coupled to judge-input shaping.
+
+export interface MetricsDigest {
+  /** Number of distinct solid bodies (1 for a single solid). */
+  bodyCount: number;
+  /** One human-legible line per body pair, e.g. "bodies 0&1: interfering (clearance 0.00mm)". */
+  bodyRelations: string[];
+  /** Conservative deterministic hard violations (e.g. a degenerate zero-volume body). */
+  violations: string[];
+  /** True when the relation matrix was capped (large assembly) — the relations are not exhaustive. */
+  relationsTruncated?: boolean;
+}
+
+/** Project a report's metrics into a digest, or `undefined` if metrics were not computed. */
+export function digestMetrics(report: VerifyReport): MetricsDigest | undefined {
+  if (!report.manufacturability && !report.bodies && !report.bodyRelations) return undefined;
+  const relations = (report.bodyRelations ?? []).map((r) => {
+    const clearance = r.clearance === undefined ? '' : ` (clearance ${r.clearance.toFixed(2)}mm)`;
+    return `bodies ${r.a}&${r.b}: ${r.relation}${clearance}`;
+  });
+  return {
+    bodyCount: report.bodies?.length ?? 1,
+    bodyRelations: relations,
+    violations: report.manufacturability?.violations ?? [],
+    ...(report.manufacturability?.relationsTruncated ? { relationsTruncated: true } : {}),
+  };
+}
+
+/** Render a digest as a compact text block for a judge prompt (ground truth the image can't show). */
+export function formatDigest(d: MetricsDigest): string {
+  const lines = [`Measured facts (ground truth the render cannot show — trust these):`];
+  lines.push(`- distinct bodies: ${d.bodyCount}`);
+  if (d.bodyRelations.length) lines.push(`- body relations: ${d.bodyRelations.join('; ')}`);
+  if (d.relationsTruncated)
+    lines.push(`- (relation matrix truncated — large assembly; not exhaustive)`);
+  if (d.violations.length) lines.push(`- violations: ${d.violations.join('; ')}`);
+  return lines.join('\n');
+}

--- a/packages/brepjs-cad/bench/score.ts
+++ b/packages/brepjs-cad/bench/score.ts
@@ -6,7 +6,7 @@ import type { EvalPrompt } from './prompts.js';
 // unit-tested directly (see tests/liveEvalScore.test.ts).
 
 /** Score/scorecard schema version — bump when the score/scorecard shape changes (vision §H). */
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export interface AutoResult {
   /** Objective signal: valid solid (ok=true) AND any pinned dims within tolerance. */
@@ -19,6 +19,8 @@ export interface AttemptResult {
   auto: AutoResult;
   judgePass?: boolean | undefined;
   judgeReason?: string | undefined;
+  /** The judge's manufacturability axis (separate from `pass`/match). Non-gating; recorded only. */
+  manufacturable?: boolean | undefined;
   outcome: 'completed' | 'timeout' | 'crashed';
   /** Whether this attempt produced a STEP (a valid solid the judge could render). */
   hasStep: boolean;
@@ -34,6 +36,8 @@ export interface EvalResult {
   /** The eventual attempt's judge verdict; undefined when the judge couldn't run (snapshots absent). */
   judgePass?: boolean | undefined;
   judgeReason?: string | undefined;
+  /** The eventual attempt's manufacturability axis (non-gating; recorded for the scorecard). */
+  manufacturable?: boolean | undefined;
   /** undefined when generation/build failed before a report existed. */
   error?: string | undefined;
   /** Per-attempt trail from the bounded loop (absent for the legacy single-shot path). */
@@ -269,7 +273,8 @@ export function formatScorecard(card: Scorecard): string {
   for (const r of card.results) {
     const a = r.error ? 'ERR ' : r.auto.pass ? 'valid' : 'INVALID';
     const j = r.judgePass === undefined ? 'judge:—' : r.judgePass ? 'judge:✓' : 'judge:✗';
-    lines.push(`  ${r.id.padEnd(pad)}  ${a.padEnd(7)} ${j}`);
+    const mfg = r.manufacturable === false ? ' mfg:⚠' : '';
+    lines.push(`  ${r.id.padEnd(pad)}  ${a.padEnd(7)} ${j}${mfg}`);
     if (r.error) lines.push(`        ${r.error}`);
     else {
       for (const f of r.auto.failures) lines.push(`        auto: ${f}`);
@@ -290,6 +295,13 @@ export function formatScorecard(card: Scorecard): string {
   lines.push(
     `  TOTAL      valid ${pct(all.autoValid, all.total)}  judge ${pct(all.judgeMatch, all.total)}  both ${pct(all.both, all.total)}  (n=${all.total})`
   );
+
+  // Manufacturability axis (non-gating): share of judged parts the judge read as producible.
+  const mfgJudged = card.results.filter((r) => r.manufacturable !== undefined);
+  if (mfgJudged.length > 0) {
+    const ok = mfgJudged.filter((r) => r.manufacturable === true).length;
+    lines.push(`  manufacturable ${pct(ok, mfgJudged.length)}  (n=${mfgJudged.length})`);
+  }
 
   // The lodestar signal: does iterating beat single-shot? (Omitted for legacy single-shot results.)
   const lift = liftSummary(card.results);

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -61,6 +61,10 @@ program
     'exit 0 only if the report emits this error code (for fixtures/eval recall)'
   )
   .option('--expect-invalid', 'exit 0 only if the part is invalid (ok:false) — for known-bad fixtures')
+  .option(
+    '--metrics',
+    'compute deterministic manufacturability metrics (per-body breakdown + interference matrix) for the design judge — slower; off by default'
+  )
   .action(
     async (
       files: string[],
@@ -73,6 +77,7 @@ program
         serve?: boolean;
         expectCode?: string;
         expectInvalid?: boolean;
+        metrics?: boolean;
         // Commander materializes a negated flag as a concrete boolean: true by
         // default, false when --no-open is passed.
         open: boolean;
@@ -97,7 +102,10 @@ program
         }
         const results: { file: string; ok: boolean; report: VerifyReport }[] = [];
         for (const f of targets) {
-          const { report, shape } = await runPart(f, { check: Boolean(opts.check) });
+          const { report, shape } = await runPart(f, {
+            check: Boolean(opts.check),
+            metrics: Boolean(opts.metrics),
+          });
           disposeShape(shape);
           results.push({ file: f, ok: reportOk(report), report });
         }
@@ -116,6 +124,7 @@ program
         step: wantStep,
         glb: Boolean(opts.glb),
         check: Boolean(opts.check),
+        metrics: Boolean(opts.metrics),
       });
       let stepPath: string | undefined = opts.step;
       try {
@@ -217,7 +226,7 @@ program
     const resolved = resolve(file);
     const base = opts.out ? resolve(opts.out) : `${resolved}-shots`;
     const outDir = opts.label ? join(base, opts.label) : base;
-    const { report, step, shape } = await runPart(resolved, { step: true });
+    const { report, step, shape } = await runPart(resolved, { step: true, metrics: true });
     try {
       if (!step) {
         process.stderr.write('snapshot: part produced no STEP — nothing to render\n');

--- a/packages/brepjs-cad/src/sandbox/runProgram.ts
+++ b/packages/brepjs-cad/src/sandbox/runProgram.ts
@@ -42,6 +42,8 @@ export interface SandboxOptions {
    * inferred from the extension: `.ts` → `npx tsx`, otherwise the current `node`.
    */
   cliEntry?: string;
+  /** Pass `--metrics` so the report carries body/interference metrics for the design judge. */
+  metrics?: boolean;
 }
 
 export type RunProgramOptions = SandboxOptions;
@@ -305,7 +307,13 @@ export async function runProgramWithStep(
   await rm(stepOutPath, { force: true });
   const o = await runVerifyCli(
     code,
-    (partPath) => [partPath, '--check', '--step', stepOutPath],
+    (partPath) => [
+      partPath,
+      '--check',
+      '--step',
+      stepOutPath,
+      ...(opts.metrics ? ['--metrics'] : []),
+    ],
     opts
   );
 

--- a/packages/brepjs-cad/src/verify/checks.ts
+++ b/packages/brepjs-cad/src/verify/checks.ts
@@ -1,5 +1,6 @@
-import type { AnyShape } from 'brepjs';
+import type { AnyShape, Solid } from 'brepjs';
 import type { BrepNs } from './brepjsRuntime.js';
+import { computeMetrics } from './manufacturability.js';
 import {
   buildHints,
   emptyReport,
@@ -8,6 +9,13 @@ import {
   type VerifyCheck,
   type VerifyReport,
 } from './report.js';
+
+export interface RunChecksOptions {
+  /** Compute deterministic manufacturability metrics (bodies/interference). Default false — the
+   * author `--check` loop skips them; only the judge/snapshot path opts in (they are slow on
+   * high-face assemblies). */
+  metrics?: boolean;
+}
 
 function shapeTypeOf(brep: BrepNs, s: AnyShape): string {
   const { isSolid, isFace, isShell, isWire, isEdge, isVertex, isCompound, isCompSolid } = brep;
@@ -22,7 +30,11 @@ function shapeTypeOf(brep: BrepNs, s: AnyShape): string {
   return 'Unknown';
 }
 
-export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
+export function runChecks(
+  brep: BrepNs,
+  shape: AnyShape,
+  opts: RunChecksOptions = {}
+): VerifyReport {
   const {
     isSolid,
     isShape3D,
@@ -43,6 +55,10 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
   const r = emptyReport();
   r.shapeType = shapeTypeOf(brep, shape);
 
+  // The constituent solids, shared by the validity check and the optional metrics pass. A single
+  // Solid is its own one-body list; a Compound/CompSolid yields its contained solids.
+  const solids: Solid[] = isSolid(shape) ? [shape] : getSolids(shape);
+
   // Strongest validity check available: BRepCheck on a single Solid.
   if (isSolid(shape)) {
     const valid = validSolid(shape);
@@ -57,7 +73,6 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
   } else {
     // Multi-body assemblies (Compound/CompSolid): validate each contained solid so the assembly
     // isn't reported ok on volume alone while an invalid body hides inside it.
-    const solids = getSolids(shape);
     if (solids.length > 0) {
       // Keep each failing body's BRepCheck message (which body, and why) rather than just a count.
       const failures: string[] = [];
@@ -135,6 +150,19 @@ export function runChecks(brep: BrepNs, shape: AnyShape): VerifyReport {
       if (shells.length > 0) r.topology.manifold = shells.every((s) => isManifoldShell(s));
     } catch {
       // manifold is informational; leave it absent if the check fails
+    }
+  }
+
+  // Deterministic manufacturability metrics — opt-in (judge/snapshot path), off the author hot path.
+  // Informational: a failure here must never drop the validity report already built above.
+  if (opts.metrics) {
+    try {
+      const m = computeMetrics(brep, shape, solids);
+      if (m.bodies) r.bodies = m.bodies;
+      if (m.bodyRelations) r.bodyRelations = m.bodyRelations;
+      r.manufacturability = m.manufacturability;
+    } catch {
+      // metrics are advisory; leave them absent if computation fails on a degenerate shape
     }
   }
 

--- a/packages/brepjs-cad/src/verify/manufacturability.ts
+++ b/packages/brepjs-cad/src/verify/manufacturability.ts
@@ -1,0 +1,128 @@
+import type { AnyShape, Solid } from 'brepjs';
+import type { BrepNs } from './brepjsRuntime.js';
+import type { BodyInfo, BodyRelation, VerifyManufacturability } from './report.js';
+
+// Deterministic, render-free metrics that inform the design judge (see bench/blind-judge.md). Computed
+// only on demand (CLI `--metrics`) so the author's hot `--check` loop is untouched. The headline signal
+// is the per-body interference matrix: it tells the judge how many distinct bodies a part has and which
+// touch/overlap vs sit apart — the assembly-relationship read that an exterior render is blind to. The
+// kernel's contact primitive (`checkInterference`, which already does AABB pre-rejection) is reused; we
+// drive the pair loop ourselves only to enforce a wall-clock budget (BRepExtrema distance is slow on
+// high-face parts like gears, and the report must never hang).
+
+interface Metrics {
+  bodies?: BodyInfo[];
+  bodyRelations?: BodyRelation[];
+  manufacturability: VerifyManufacturability;
+}
+
+type Bounds = NonNullable<BodyInfo['bounds']>;
+
+const RELATION_BUDGET_MS = 15_000;
+// Above this body count the pair matrix is skipped wholesale (recorded as truncated) — BIM-scale
+// assemblies would otherwise spend minutes in pairwise distance with little judge value.
+const MAX_BODIES = 24;
+// A body below this volume (mm³) is treated as a degenerate sliver — a conservative hard violation.
+const VOL_EPS = 1e-9;
+
+function diagonalOf(boundsList: readonly Bounds[]): number {
+  if (boundsList.length === 0) return 1;
+  const u = {
+    xMin: Math.min(...boundsList.map((b) => b.xMin)),
+    yMin: Math.min(...boundsList.map((b) => b.yMin)),
+    zMin: Math.min(...boundsList.map((b) => b.zMin)),
+    xMax: Math.max(...boundsList.map((b) => b.xMax)),
+    yMax: Math.max(...boundsList.map((b) => b.yMax)),
+    zMax: Math.max(...boundsList.map((b) => b.zMax)),
+  };
+  return Math.hypot(u.xMax - u.xMin, u.yMax - u.yMin, u.zMax - u.zMin) || 1;
+}
+
+function aabbDisjoint(a: Bounds, b: Bounds, eps: number): boolean {
+  return (
+    a.xMax + eps < b.xMin ||
+    b.xMax + eps < a.xMin ||
+    a.yMax + eps < b.yMin ||
+    b.yMax + eps < a.yMin ||
+    a.zMax + eps < b.zMin ||
+    b.zMax + eps < a.zMin
+  );
+}
+
+/** Per-body volume/bounds/validity. Used both for the report and to drive the relation matrix. */
+function computeBodies(brep: BrepNs, solids: readonly Solid[]): BodyInfo[] {
+  const { measureVolume, getBounds, validSolid, isOk } = brep;
+  return solids.map((s, index) => {
+    const v = measureVolume(s);
+    const volume = isOk(v) ? v.value : 0;
+    let bounds: Bounds | undefined;
+    try {
+      bounds = getBounds(s);
+    } catch {
+      // a degenerate body may have no bounds; leave it absent (it still counts as a body)
+    }
+    return { index, volume, ...(bounds ? { bounds } : {}), valid: isOk(validSolid(s)) };
+  });
+}
+
+/**
+ * Pairwise body relationships. `separate` when the bodies are apart (AABB-disjoint, or measured
+ * clearance above eps); `interfering` when they touch or overlap (clearance within eps). `touching`/
+ * `nested` (which need a boolean-volume tier) are reserved for a later phase. eps scales to the
+ * assembly diagonal so it is meaningful from millimetre parts to metre-scale BIM.
+ */
+function computeBodyRelations(
+  brep: BrepNs,
+  solids: readonly Solid[],
+  bodies: readonly BodyInfo[]
+): { relations: BodyRelation[]; truncated: boolean } {
+  const { checkInterference, isOk } = brep;
+  const relations: BodyRelation[] = [];
+  const eps = Math.max(
+    1e-6,
+    1e-4 * diagonalOf(bodies.flatMap((b) => (b.bounds ? [b.bounds] : [])))
+  );
+  const start = Date.now();
+  for (let i = 0; i < solids.length; i++) {
+    for (let j = i + 1; j < solids.length; j++) {
+      if (Date.now() - start > RELATION_BUDGET_MS) return { relations, truncated: true };
+      const bi = bodies[i]?.bounds;
+      const bj = bodies[j]?.bounds;
+      if (bi && bj && aabbDisjoint(bi, bj, eps)) {
+        relations.push({ a: i, b: j, relation: 'separate' });
+        continue;
+      }
+      const si = solids[i];
+      const sj = solids[j];
+      if (!si || !sj) continue;
+      const res = checkInterference(si, sj, eps);
+      if (!isOk(res)) continue;
+      relations.push({
+        a: i,
+        b: j,
+        relation: res.value.hasInterference ? 'interfering' : 'separate',
+        clearance: res.value.minDistance,
+      });
+    }
+  }
+  return { relations, truncated: false };
+}
+
+/** Orchestrate the deterministic metrics for a verified shape. Never throws (caller wraps too). */
+export function computeMetrics(brep: BrepNs, _shape: AnyShape, solids: readonly Solid[]): Metrics {
+  const bodies = computeBodies(brep, solids);
+  const violations: string[] = [];
+  bodies.forEach((b) => {
+    if (b.volume <= VOL_EPS) violations.push(`body ${b.index} has ~zero volume (degenerate)`);
+  });
+  const manufacturability: VerifyManufacturability = { violations };
+
+  if (bodies.length <= 1) return { manufacturability };
+  if (bodies.length > MAX_BODIES) {
+    manufacturability.relationsTruncated = true;
+    return { bodies, manufacturability };
+  }
+  const { relations, truncated } = computeBodyRelations(brep, solids, bodies);
+  if (truncated) manufacturability.relationsTruncated = true;
+  return { bodies, bodyRelations: relations, manufacturability };
+}

--- a/packages/brepjs-cad/src/verify/report.ts
+++ b/packages/brepjs-cad/src/verify/report.ts
@@ -45,6 +45,43 @@ export interface VerifyAssertion {
   passed: boolean;
 }
 
+/** Per-body fingerprint for multi-body / assembly parts. Absent for single-solid parts. */
+export interface BodyInfo {
+  index: number;
+  volume: number;
+  bounds?: VerifyMeasurements['bounds'];
+  /** validSolid(body) — already computed in the allBodiesValid check. */
+  valid: boolean;
+}
+
+/** Pairwise spatial relationship between two bodies. One entry per unordered pair. */
+export interface BodyRelation {
+  a: number;
+  b: number;
+  /** Min surface-surface distance. 0 ≈ touching/overlapping. Absent when not measured (far pair). */
+  clearance?: number;
+  relation: 'separate' | 'touching' | 'interfering' | 'nested';
+  /** Overlap volume — only populated for 'interfering'/'nested'. */
+  interferenceVolume?: number;
+}
+
+/**
+ * Deterministic, render-free manufacturability metrics. Computed only on demand (CLI `--metrics`);
+ * absent otherwise and on degenerate shapes. Informs the judge — never gates a part on its own.
+ */
+export interface VerifyManufacturability {
+  /** Smallest analytic-cylinder radius (bore/pin/pillar). Absent if none found. */
+  minRadius?: number;
+  /** Best-effort min wall thickness; absent when not computable. */
+  minWallThickness?: number;
+  /** Count of internal (concave / enclosed) cylindrical faces — a "has bores" signal. */
+  internalCylinderCount?: number;
+  /** True when the relation matrix was capped by the pair/time budget (not exhaustive). */
+  relationsTruncated?: boolean;
+  /** Conservative deterministic flags no process tolerates (e.g. zero-thickness body). */
+  violations: string[];
+}
+
 export interface VerifyReport {
   shapeType: string | null;
   checks: VerifyCheck[];
@@ -61,6 +98,12 @@ export interface VerifyReport {
    * declares no expectations; when non-empty, `ok` additionally requires every assertion pass.
    */
   assertions: VerifyAssertion[];
+  /** Per-body breakdown for multi-body parts. Absent unless metrics were requested + bodies > 1. */
+  bodies?: BodyInfo[];
+  /** Pairwise body relationships. Absent unless metrics were requested + bodies > 1. */
+  bodyRelations?: BodyRelation[];
+  /** Deterministic manufacturability metrics. Absent unless metrics were requested. */
+  manufacturability?: VerifyManufacturability;
 }
 
 export interface BoundsDelta {

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -119,6 +119,12 @@ export interface RunPartOptions {
    * executing it. Type errors are surfaced as `TYPECHECK` error infos and the part is NOT run.
    */
   check?: boolean;
+  /**
+   * Compute deterministic manufacturability metrics (per-body breakdown + interference matrix) for
+   * the design judge. Off by default — these are slow on high-face assemblies, so only the
+   * judge/snapshot path opts in; the author `--check` loop stays fast.
+   */
+  metrics?: boolean;
 }
 
 export interface RunPartResult {
@@ -198,7 +204,7 @@ export async function runPart(
   }
   // Push export errors into the report we actually return (runChecks's), so a failed export
   // surfaces as ok:false rather than being dropped.
-  const result = runChecks(brep, shape);
+  const result = runChecks(brep, shape, { metrics: Boolean(opts.metrics) });
   // Asserted dims: compare measured volume/area/bounds against the part's `export const expected`.
   // When present, every assertion must pass for `ok` (enforced by reportOk).
   if (isExpectedDims(mod.expected)) {

--- a/packages/brepjs-cad/tests/manufacturability.test.ts
+++ b/packages/brepjs-cad/tests/manufacturability.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as brep from 'brepjs';
+import { init, box, compound } from 'brepjs';
+import { runChecks } from '@/verify/checks.js';
+import { emptyReport } from '@/verify/report.js';
+import { digestMetrics, formatDigest } from '../bench/metrics.js';
+import { formatScorecard, type Scorecard } from '../bench/score.js';
+
+beforeAll(async () => {
+  await init();
+}, 30000);
+
+describe('manufacturability metrics (runChecks --metrics)', () => {
+  it('classifies interfering vs separate body pairs in a compound', () => {
+    const a = box(10, 10, 10); // spans [0,10]^3
+    const b = box(10, 10, 10, { at: [5, 5, 5] }); // centered at (5,5,5) → overlaps a
+    const c = box(10, 10, 10, { at: [40, 0, 0] }); // far from both
+    const r = runChecks(brep, compound([a, b, c]), { metrics: true });
+
+    expect(r.bodies?.length).toBe(3);
+    expect(r.bodies?.every((bd) => bd.valid && bd.volume > 0)).toBe(true);
+    const rel = (i: number, j: number) =>
+      r.bodyRelations?.find((x) => x.a === i && x.b === j)?.relation;
+    expect(rel(0, 1)).toBe('interfering');
+    expect(rel(0, 2)).toBe('separate');
+    expect(rel(1, 2)).toBe('separate');
+    expect(r.manufacturability?.violations).toEqual([]);
+  });
+
+  it('treats coplanar-touching bodies as interfering (the loose-compound signal)', () => {
+    const a = box(10, 10, 10); // x [0,10]
+    const b = box(10, 10, 10, { at: [15, 5, 5] }); // x [10,20] — shares the x=10 face
+    const r = runChecks(brep, compound([a, b]), { metrics: true });
+    expect(r.bodyRelations?.find((x) => x.a === 0 && x.b === 1)?.relation).toBe('interfering');
+  });
+
+  it('omits all metric fields when not requested (author --check hot path)', () => {
+    const r = runChecks(brep, box(10, 10, 10));
+    expect(r.bodies).toBeUndefined();
+    expect(r.bodyRelations).toBeUndefined();
+    expect(r.manufacturability).toBeUndefined();
+  });
+
+  it('a single solid gets manufacturability but no bodies/relations', () => {
+    const r = runChecks(brep, box(10, 10, 10), { metrics: true });
+    expect(r.manufacturability).toBeDefined();
+    expect(r.manufacturability?.violations).toEqual([]);
+    expect(r.bodies).toBeUndefined();
+    expect(r.bodyRelations).toBeUndefined();
+  });
+});
+
+describe('digestMetrics (pure)', () => {
+  it('returns undefined when metrics were not computed', () => {
+    expect(digestMetrics(emptyReport())).toBeUndefined();
+  });
+
+  it('projects bodies + relations into a legible digest', () => {
+    const report = emptyReport();
+    report.bodies = [
+      { index: 0, volume: 1000, valid: true },
+      { index: 1, volume: 1000, valid: true },
+    ];
+    report.bodyRelations = [{ a: 0, b: 1, relation: 'interfering', clearance: 0 }];
+    report.manufacturability = { violations: [] };
+    const d = digestMetrics(report);
+    if (!d) throw new Error('expected a digest');
+    expect(d.bodyCount).toBe(2);
+    expect(d.bodyRelations).toEqual(['bodies 0&1: interfering (clearance 0.00mm)']);
+    const block = formatDigest(d);
+    expect(block).toContain('distinct bodies: 2');
+    expect(block).toContain('bodies 0&1: interfering');
+  });
+});
+
+describe('formatScorecard manufacturability axis', () => {
+  it('flags mfg:⚠ per result and prints a manufacturable tally', () => {
+    const card: Scorecard = {
+      model: 'm',
+      brepjsVersion: '0.0.0',
+      date: '2026-06-20',
+      results: [
+        {
+          id: 'good',
+          category: 'mechanical',
+          auto: { pass: true, failures: [] },
+          judgePass: true,
+          manufacturable: true,
+        },
+        {
+          id: 'risky',
+          category: 'mechanical',
+          auto: { pass: true, failures: [] },
+          judgePass: true,
+          manufacturable: false,
+        },
+      ],
+    };
+    const out = formatScorecard(card);
+    expect(out).toContain('risky');
+    expect(out).toContain('mfg:⚠');
+    expect(out).toContain('manufacturable 50%');
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of the design-judge upgrade ([reviewed spec](https://github.com/andymai/brepjs/pull/1530)): give the judge **deterministic kernel facts** it can't see in a render, so it stops inferring a part's structure from pixels. No renderer changes — this is the cheapest, highest-coverage layer.

## Why

A survey of all 51 playground examples: the mechanical corpus is **91% multi-body, 88% internal-feature**, and **32/51 parts are both** — exactly what an exterior silhouette is blind to (the current judge graded cleanly on only 1 of 14 hardest parts). Determinism is objective, cheap, and works where vision can't.

## What's in it

- **Report fields** (`src/verify/report.ts`): optional `bodies`, `bodyRelations`, `manufacturability` on `VerifyReport` (additive — existing consumers unaffected).
- **Metrics** (`src/verify/manufacturability.ts`): per-body volume/bounds/validity + a pairwise **interference matrix** (`separate` vs touching/overlapping `interfering`). Reuses the kernel's `checkInterference` (which already does AABB pre-rejection) but drives the pair loop itself for a **wall-clock budget** — `BRepExtrema` distance is pathologically slow on high-face gears, so the matrix caps (`MAX_BODIES`, 15s budget) and flags `relationsTruncated` rather than hanging. Verified on the 18-body planetary: budget held, flagged truncation, no hang.
- **Opt-in** (`--metrics`): metrics compute only behind `brep verify --metrics` (the `snapshot` subcommand sets it). Plain `--check` — the clean-room author hot path — is byte-identical to before.
- **Judge fusion**: `bench/metrics.ts` digests the report; the SDK judge (`judge.ts`) takes it via `JudgeInput.metrics` + a new `manufacturable`/`usedMetrics` verdict axis with a guidance paragraph (reconcile body count, decide intended-assembly vs collision); the **$0 blind protocol** (`blind-judge.md`) pastes a **symmetric, label-free** per-render facts line (doesn't de-blind).
- **Scorecard**: `SCHEMA_VERSION`→2, per-result `mfg:⚠` + a `manufacturable %` tally; `loop.ts`/`live.ts` thread the digest + axis.

## Deliberately deferred (honest scope)

- `minRadius` / `internalCylinderCount` — a curvature-sign probe showed the kernel's sign does **not** separate a concave bore from a convex boss (both came back negative on a tube), and fillet faces pollute `minRadius`. Shipping a flaky metric would mislead the heal loop, so deferred until a proper internal-feature test lands.
- `touching`/`nested` sub-classification + overlap-volume (needs a boolean-volume tier), per-body color/exploded render, Set-of-Marks, aimed sections — later phases per the spec.

## Verification

- `tests/manufacturability.test.ts`: interfering-vs-separate classification, coplanar-touching → interfering, **metrics absent without `--metrics`**, single-solid case, pure `digestMetrics`/`formatScorecard`.
- Full package suite **164/164**; typecheck/eslint/prettier/knip/boundaries all clean.
- E2E: `brep verify --metrics --json` populates the fields on a 3-body compound (A&B interfering, C separate) and on the planetary (budget-capped, truncation flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)