### PR TITLE
fix(playground): disambiguate viewer mesh keys for repeated bodies

### DIFF
--- a/apps/playground/src/components/playground/ViewerPanel.tsx
+++ b/apps/playground/src/components/playground/ViewerPanel.tsx
@@ -27,7 +27,11 @@ function meshKey(m: MeshData, fallback: number): string {
   const p = m.position;
   if (!p || p.length === 0) return `empty-${fallback}`;
   const mid = ((p.length / 6) | 0) * 3;
-  return `${p.length}-${p[0]}-${p[mid] ?? 0}-${p[p.length - 1] ?? 0}`;
+  // Sampling three buffer values keeps the key stable across re-runs for an
+  // unchanged body, but symmetric/repeated bodies in an assembly (e.g. a truss
+  // of identical struts) collide on those samples — so disambiguate with the
+  // positional index, which is unique per rendered child.
+  return `${p.length}-${p[0]}-${p[mid] ?? 0}-${p[p.length - 1] ?? 0}-${fallback}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

Several multi-body playground examples spammed React's *"Encountered two children with the same key"* error in the console — `cube-truss-frame`, `project-enclosure`, `tx-enclosure`, `green-terminal-block`, and the multi-body BIM assemblies. React may **omit** children with duplicate keys, so this is a correctness risk (bodies can silently vanish from the viewer), not just console noise.

## Root cause

`ViewerPanel.tsx`'s `meshKey` derived each `<group>` key from only three sampled buffer values (`length-first-mid-last`). Repeated or symmetric bodies in an assembly — a truss of identical struts, a grid of identical I-beams — collide on those samples and produce identical keys.

## Fix

Append the positional index (already passed as `fallback`) to the key. This guarantees uniqueness per rendered child while preserving the geometry-hash prefix, so an unchanged body at a given slot keeps its identity/material/selection state across re-runs.

## Verification

Ran every example headless through the real worker/eval pipeline. Duplicate-key console errors: **21+ → 0**. Typecheck passes.

> Found while investigating worker errors in the playground. A separate, non-committed issue surfaced in the same pass: a stale local `brepjs-bim` `dist/` (gitignored) was missing the `placedSolids` export, breaking 5 BIM examples in the worker — fixed locally by rebuilding the package.