### PR TITLE
build(playground): rebuild workspace deps before dev/build

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -4,7 +4,10 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "build:deps": "npm -C ../../packages/brepjs-bim run build && npm -C ../../packages/brepjs-sheetmetal run build && npm -C ../../packages/brepjs-viewer run build",
+    "predev": "npm run build:deps",
     "dev": "vite",
+    "prebuild": "npm run build:deps",
     "build": "tsc -b && npm run check:examples && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b",


### PR DESCRIPTION
## Problem

The playground imports the symlinked `dist/` of `brepjs-bim`, `brepjs-sheetmetal`, and `brepjs-viewer`, but neither `dev` nor `build` rebuilt those packages. A source change to a companion package that wasn't followed by a manual `npm run build` left the playground silently running **stale** code.

The failure is invisible to the type gate: `check:examples` validates against the ambient `.d.ts` (regenerated from source), while the worker actually runs the built `dist`. So when source gained an export the stale dist lacked, the type check stayed green while the worker threw at runtime — e.g. `placedSolids` missing, breaking all the BIM `placedSolids()` examples.

## Fix

Add a `build:deps` script wired as `predev`/`prebuild`, so the companion packages are always current before the playground runs or builds. ~5s, using the repo's existing `npm -C <dir>` idiom.

Scoped to the companion packages a playground-focused dev won't think to rebuild. Core `brepjs` is left out of the hot path — its build is the heaviest and core staleness is obvious (it breaks everything, not one example) and already part of every core dev's loop.

Also closes a latent gap: `build:site` never explicitly rebuilt `brepjs-viewer` before the playground.

## Context

Found while fixing the BIM `placedSolids` worker errors. The viewer-side fix from that same investigation is #1534.