### PR TITLE
fix(playground): serve favicons in dev and fix manifest icon paths

### DIFF
--- a/apps/playground/public/site.webmanifest
+++ b/apps/playground/public/site.webmanifest
@@ -2,11 +2,11 @@
   "name": "brepjs",
   "short_name": "brepjs",
   "icons": [
-    { "src": "/icon-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512x512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "icon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icon-512x512.png", "sizes": "512x512", "type": "image/png" }
   ],
   "theme_color": "#4ACECC",
   "background_color": "#0f0f14",
   "display": "standalone",
-  "start_url": "/"
+  "start_url": "."
 }

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -71,18 +71,23 @@ function wasmAssets(): Plugin {
   };
 }
 
-// index.html references its favicons/manifest with root-absolute paths
-// (`/favicon.ico`). Vite rewrites those to `${base}favicon.ico` at build time —
-// correct for production, including deep `/playground/examples/<id>` permalinks —
-// but the dev server doesn't rewrite them, so they 404 at `/favicon.ico` in dev.
-// Serve those few public files at root during dev to match production's behaviour.
+// index.html references its favicons with root-absolute paths (`/favicon.ico`).
+// Vite rewrites those to `${base}favicon.ico` at build time — correct for
+// production, including deep `/playground/examples/<id>` permalinks — but the dev
+// server doesn't rewrite them, and browsers also probe `/favicon.ico` at the
+// origin root regardless. Serve those image files at root during dev to match
+// production's behaviour.
+//
+// site.webmanifest is deliberately NOT served here: it's reached via the
+// base-rewritten `<link rel="manifest">` (`/playground/site.webmanifest`), and
+// its icon `src`s are relative to the manifest URL — serving it from root would
+// make those resolve to `/icon-*.png` (404) instead of `/playground/icon-*.png`.
 function devRootIcons(): Plugin {
   const publicDir = fileURLToPath(new URL('./public', import.meta.url));
   const types: Record<string, string> = {
     '/favicon.ico': 'image/x-icon',
     '/favicon.svg': 'image/svg+xml',
     '/apple-touch-icon.png': 'image/png',
-    '/site.webmanifest': 'application/manifest+json',
   };
   return {
     name: 'dev-root-icons',

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -71,6 +71,34 @@ function wasmAssets(): Plugin {
   };
 }
 
+// index.html references its favicons/manifest with root-absolute paths
+// (`/favicon.ico`). Vite rewrites those to `${base}favicon.ico` at build time —
+// correct for production, including deep `/playground/examples/<id>` permalinks —
+// but the dev server doesn't rewrite them, so they 404 at `/favicon.ico` in dev.
+// Serve those few public files at root during dev to match production's behaviour.
+function devRootIcons(): Plugin {
+  const publicDir = fileURLToPath(new URL('./public', import.meta.url));
+  const types: Record<string, string> = {
+    '/favicon.ico': 'image/x-icon',
+    '/favicon.svg': 'image/svg+xml',
+    '/apple-touch-icon.png': 'image/png',
+    '/site.webmanifest': 'application/manifest+json',
+  };
+  return {
+    name: 'dev-root-icons',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const type = req.url && types[req.url];
+        const filePath = req.url && resolve(publicDir, req.url.slice(1));
+        if (!type || !filePath || !existsSync(filePath)) return next();
+        res.setHeader('Content-Type', type);
+        createReadStream(filePath).pipe(res);
+      });
+    },
+  };
+}
+
 export default defineConfig({
   base: BASE,
   define: {
@@ -78,7 +106,7 @@ export default defineConfig({
     // brepjs version in bug reports without needing devtools.
     __BREPJS_VERSION__: JSON.stringify(BREPJS_VERSION),
   },
-  plugins: [react(), tailwindcss(), wasmAssets()],
+  plugins: [react(), tailwindcss(), wasmAssets(), devRootIcons()],
   server: {
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',


### PR DESCRIPTION
## Problem

Every playground page logged a 404 in the dev console for `/favicon.ico` (and the other icons / manifest). `index.html` references them with root-absolute paths (`/favicon.ico`); Vite rewrites those to `/playground/...` at **build** time — correct for production, including deep `/playground/examples/<id>` permalinks — but the **dev server** doesn't rewrite them, so they 404 at the root in dev.

Separately, `site.webmanifest` listed root-absolute icon `src`s and `start_url`. The manifest is a static `public/` file that Vite never rewrites, so those 404 in **both** dev and prod (`/icon-192x192.png` → wrong origin), and `start_url: "/"` pointed PWA installs at the marketing site instead of the playground.

## Fix

- **Dev favicons:** a `serve`-only Vite plugin maps the handful of root icon/manifest requests to their `public/` files, matching production. (Alternatives rejected: relative paths fix dev but 404 the favicon on deep `/examples/<id>` permalinks in prod; `%BASE_URL%` double-prefixes to `/playground/playground/...` in the dev server.)
- **Manifest:** make icon `src`s and `start_url` relative to the manifest URL per the manifest spec, so they resolve under `/playground/` regardless of host or route — fixing a real prod bug too.

`index.html` is unchanged (its root-absolute paths are already correct for the production build).

## Verification

- Dev (headless, networkidle): **0** icon/favicon 404s on both `/playground/` and the deep permalink `/playground/examples/gridfinity-bin` (was 4–5 each).
- `vite build`: `index.html` links emit `/playground/favicon.*` (base-rewritten, robust on all routes); built manifest ships relative icon paths. No prod regression.
- `tsc -b` passes.

Follow-up from the playground worker-errors investigation (#1534, #1535).