### PR TITLE
feat(brepjs-cad): decomposed, cross-checked design-judge rubric (Phase 1.5)

### DIFF
--- a/packages/brepjs-cad/bench/blind-judge.md
+++ b/packages/brepjs-cad/bench/blind-judge.md
@@ -28,10 +28,15 @@ output vs the playground reference, and never reads any `.brep.ts`, the heal, th
 - `confidence`: `high | low`.
 
 **Rubric (put in the judge prompt):** grade each render against the **description** as the absolute
-bar — the named features present and legible, the thing reads as manufactured/designed. Use the
-other render only to calibrate _how polished is achievable_, never to reward mere similarity. A part
-that differs from the other render but realizes the description as a designed object is `designed`.
-Ignore color, lighting, camera, and exact dimensions you can't read from the image.
+bar. **First decompose** the description into its named features (the holes, bores, walls, bodies,
+blades, teeth, slots it implies); for each render, check each feature `present` (legible) and
+`correct` (right count/form/proportion), **reconciling counts against that render's measured-facts
+line** (if the facts say N bodies, confirm you see N; treat a reported interference as intended vs
+accidental per the description). Base the `designed | partial | blob` class on that per-feature pass —
+`designed` only when the described features are present and correct, `partial`/`blob` when features
+are missing, miscounted, or faked. Use the other render only to calibrate _how polished is
+achievable_, never to reward mere similarity. Ignore color, lighting, camera, and exact dimensions
+you can't read from the image.
 
 ## The blind protocol (orchestrator: renders + shuffles + decodes — never grades)
 

--- a/packages/brepjs-cad/bench/judge.ts
+++ b/packages/brepjs-cad/bench/judge.ts
@@ -12,19 +12,51 @@ const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered 
 
 Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.
 
-You may also be given "Measured facts" computed deterministically from the kernel (exact body count, and which bodies sit apart vs touch/overlap). Treat these as ground truth the render cannot show, and reconcile them with what you see — if the facts report N bodies, confirm you see N. A reported interference is ambiguous on its own: decide from the request and image whether it is an intended assembly (e.g. an exploded view or a part that legitimately overlaps another) or an accidental collision. Also judge manufacturability: whether the part reads as a producible object (no zero-thickness walls, stray disconnected bodies, or self-colliding geometry the request did not ask for).`;
+You may also be given "Measured facts" computed deterministically from the kernel (exact body count, and which bodies sit apart vs touch/overlap). Treat these as ground truth the render cannot show, and reconcile them with what you see — if the facts report N bodies, confirm you see N. A reported interference is ambiguous on its own: decide from the request and image whether it is an intended assembly (e.g. an exploded view or a part that legitimately overlaps another) or an accidental collision. Also judge manufacturability: whether the part reads as a producible object (no zero-thickness walls, stray disconnected bodies, or self-colliding geometry the request did not ask for).
+
+Work in this order. FIRST decompose the request into its named features — the holes, bores, walls, bodies, blades, teeth, slots, fillets, etc. it implies — and grade EACH one for \`present\` (legible in the render) and \`correct\` (right count / form / proportion, not faked or distorted), reconciling any count against the measured facts. THEN set \`pass\` true only if every feature the request requires is present and correct; base \`reason\` on the decisive feature(s), naming any that are missing or wrong. Decomposing first guards against a "looks roughly right" pass and against hallucinating features that aren't there.`;
 
 const VERDICT = z.object({
-  pass: z.boolean().describe('true only if the rendered part matches the request and rubric'),
+  features: z
+    .array(
+      z.object({
+        name: z
+          .string()
+          .describe(
+            'a feature the request implies, e.g. "motor bore", "ring of twisted blades", "4 corner holes"'
+          ),
+        present: z.boolean().describe('present and legible in the render'),
+        correct: z
+          .boolean()
+          .describe('right count / form / proportion — false if wrong-count, distorted, or faked'),
+      })
+    )
+    .describe(
+      'decompose the request into its named features and grade EACH before the overall verdict'
+    ),
+  pass: z
+    .boolean()
+    .describe('true only if every feature the request requires is present and correct'),
   manufacturable: z
     .boolean()
-    .describe('true if the part reads as producible; false for zero-thickness walls, stray/colliding bodies, or other unmanufacturable geometry the request did not ask for'),
+    .describe(
+      'true if the part reads as producible; false for zero-thickness walls, stray/colliding bodies, or other unmanufacturable geometry the request did not ask for'
+    ),
   usedMetrics: z
     .boolean()
-    .describe('true if the measured facts (body count / relations) changed your verdict versus the images alone'),
-  reason: z.string().describe('one sentence citing the deciding feature(s)'),
+    .describe(
+      'true if the measured facts (body count / relations) changed your verdict versus the images alone'
+    ),
+  reason: z
+    .string()
+    .describe('one sentence citing the deciding feature(s), naming any missing or wrong'),
 });
 export type Verdict = z.infer<typeof VERDICT>;
+
+/** The features the judge marked missing or incorrect — actionable specifics for the retry/heal loop. */
+export function missingFeatures(v: Verdict): string[] {
+  return v.features.filter((f) => !f.present || !f.correct).map((f) => f.name);
+}
 
 export interface JudgeInput {
   prompt: string;
@@ -73,6 +105,7 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
 
   return (
     response.parsed_output ?? {
+      features: [],
       pass: false,
       manufacturable: false,
       usedMetrics: false,

--- a/packages/brepjs-cad/bench/live.ts
+++ b/packages/brepjs-cad/bench/live.ts
@@ -8,7 +8,7 @@ import { PROMPTS, type EvalPrompt } from './prompts.js';
 import { playgroundPrompts } from './playgroundCorpus.js';
 import { formatScorecard, type EvalResult, type Scorecard } from './score.js';
 import { runAttemptLoop, type ChatMessage, type LoopDeps } from './loop.js';
-import { judge } from './judge.js';
+import { judge, missingFeatures } from './judge.js';
 import { createTelemetry } from './langfuse.js';
 import { skillVersion } from './skillVersion.js';
 
@@ -169,7 +169,13 @@ async function evalPrompt(
           model: args.judgeModel,
           ...(metrics ? { metrics } : {}),
         });
-        return { pass: v.pass, reason: v.reason, manufacturable: v.manufacturable };
+        // Surface the per-feature decomposition's misses in the reason so the retry/heal feedback
+        // bundle gets actionable specifics ("missing: motor bore") rather than a vague sentence.
+        const missing = missingFeatures(v);
+        const reason = missing.length
+          ? `${v.reason} [missing/wrong: ${missing.join(', ')}]`
+          : v.reason;
+        return { pass: v.pass, reason, manufacturable: v.manufacturable };
       } catch (e) {
         console.warn(`  judge failed (${(e as Error).message.split('\n')[0]})`);
         return null;
@@ -263,7 +269,9 @@ async function main(): Promise<void> {
     // Shard mode: write the scorecard for the combine step, which merges all shards and does the
     // single Langfuse push — shards don't push (avoids N partial aggregate traces + run pushes).
     writeFileSync(args.out, JSON.stringify(card, null, 2));
-    console.log(`wrote ${results.length}-part scorecard to ${args.out} (shard — combine step pushes)`);
+    console.log(
+      `wrote ${results.length}-part scorecard to ${args.out} (shard — combine step pushes)`
+    );
   } else {
     // Record the run for Langfuse trends: aggregate scores on one trace, plus — for the playground
     // corpus — a dataset experiment on brepjs-playground (per-part scores linked to each dataset
@@ -272,7 +280,9 @@ async function main(): Promise<void> {
     if (args.corpus === 'playground') {
       const linked = await telemetry.pushDatasetRun(card);
       if (process.env['LANGFUSE_PUBLIC_KEY'] && process.env['LANGFUSE_SECRET_KEY'])
-        console.log(`langfuse: dataset run "${skillVer}" — ${linked}/${results.length} items linked`);
+        console.log(
+          `langfuse: dataset run "${skillVer}" — ${linked}/${results.length} items linked`
+        );
     }
   }
   await telemetry.shutdown();

--- a/packages/brepjs-cad/tests/manufacturability.test.ts
+++ b/packages/brepjs-cad/tests/manufacturability.test.ts
@@ -5,6 +5,7 @@ import { runChecks } from '@/verify/checks.js';
 import { emptyReport } from '@/verify/report.js';
 import { digestMetrics, formatDigest } from '../bench/metrics.js';
 import { formatScorecard, type Scorecard } from '../bench/score.js';
+import { missingFeatures, type Verdict } from '../bench/judge.js';
 
 beforeAll(async () => {
   await init();
@@ -100,5 +101,29 @@ describe('formatScorecard manufacturability axis', () => {
     expect(out).toContain('risky');
     expect(out).toContain('mfg:⚠');
     expect(out).toContain('manufacturable 50%');
+  });
+});
+
+describe('missingFeatures (decomposed rubric)', () => {
+  const verdict = (features: Verdict['features']): Verdict => ({
+    features,
+    pass: false,
+    manufacturable: true,
+    usedMetrics: false,
+    reason: 'x',
+  });
+
+  it('lists features that are absent or incorrect', () => {
+    const v = verdict([
+      { name: 'motor bore', present: true, correct: true },
+      { name: 'twisted blades', present: true, correct: false }, // wrong form
+      { name: 'mounting holes', present: false, correct: false }, // absent
+    ]);
+    expect(missingFeatures(v)).toEqual(['twisted blades', 'mounting holes']);
+  });
+
+  it('returns empty when every feature is present and correct', () => {
+    const v = verdict([{ name: 'hub', present: true, correct: true }]);
+    expect(missingFeatures(v)).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Phase 1.5 of the [design-judge upgrade](https://github.com/andymai/brepjs/pull/1531). Phase 1 gave the judge deterministic facts; this makes it **use them rigorously**. Both judges now **decompose the brief into its named features and grade each** (`present` / `correct`) before the overall verdict, reconciling counts against the Phase-1 measured facts.

Decomposition-first is the strongest lever against the two dominant LLM-judge failure modes: a vague "looks roughly right → pass", and hallucinating features that aren't actually rendered. No renderer or kernel changes.

## Changes

- **`judge.ts`**: `VERDICT` gains a `features[]` array (per-feature `present`/`correct`), placed **first** in the schema so the model decomposes before it concludes. `JUDGE_SYSTEM` directs: decompose → grade each → reconcile counts against the measured facts → `pass` only if every required feature is present and correct. New pure **`missingFeatures()`** helper.
- **`live.ts`**: folds the missing/wrong features into the judge `reason`, so the retry/heal feedback bundle gets actionable specifics (`[missing/wrong: motor bore]`) rather than one vague sentence — directly improving the heal loop's next-attempt hint.
- **`blind-judge.md`** (the $0 sub-agent path the heal/eval loop uses): the rubric now decomposes per-feature and reconciles with each render's measured-facts line as the basis for `designed`/`partial`/`blob`.

## Verification

- `tests/manufacturability.test.ts`: `missingFeatures` cases (absent + wrong-form flagged; all-correct → empty).
- Full package suite **166/166**; typecheck/eslint/prettier/knip clean.
- The LLM judge's behavior itself isn't unit-testable; the structured `features[]` schema is the reasoning scaffold, and the pure helper + plumbing are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)