### PR TITLE
feat(brepjs-cad): xray internal-reveal shot for the design judge (Phase 2a)

### DIFF
--- a/packages/brepjs-cad/bench/blind-judge.md
+++ b/packages/brepjs-cad/bench/blind-judge.md
@@ -14,8 +14,10 @@ is _pairwise_ (author vs reference) and _blind_ (labels stripped), and costs not
 
 One judge subagent (general-purpose — it must `Read` the PNGs) per part. Its **entire input**: the
 part's NL `description` + two rendered images each — **iso + one detail view, the SAME view pair for
-both renders** so the A/B comparison is fair (pick the detail view — front/top/right — that best
-exposes the features the description names) — labeled only **A** and **B**, **a one-line "measured
+both renders** so the A/B comparison is fair (pick the detail view — front/top/right, or **`iso-xray`
+for any part with internal features** like bores/cavities/shelled walls, since it shows them through a
+translucent body — that best exposes the features the description names) — labeled only **A** and
+**B**, **a one-line "measured
 facts" string per render** (body count + interference relations — the ground truth the render can't
 show; see step 1b), + the rubric below. It is told NOTHING about which render is the skill's clean-room
 output vs the playground reference, and never reads any `.brep.ts`, the heal, the orchestration, or

--- a/packages/brepjs-cad/bench/judge.ts
+++ b/packages/brepjs-cad/bench/judge.ts
@@ -8,7 +8,7 @@ import { formatDigest, type MetricsDigest } from './metrics.js';
 // request + rubric, decide whether the geometry matches. Verdict is a structured
 // output (messages.parse + Zod) so the score is a clean boolean, not parsed prose.
 
-const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered views (iso / front / top / right) of a 3D part a model produced from a natural-language request, along with the request and a rubric describing what a correct part must show.
+const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered views (iso / front / top / right, plus an xray pass that shows internal features — bores, cavities, shelled walls — through a translucent body) of a 3D part a model produced from a natural-language request, along with the request and a rubric describing what a correct part must show. Use the xray to confirm internal features the opaque views can't show.
 
 Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.
 
@@ -68,7 +68,9 @@ export interface JudgeInput {
 }
 
 export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdict> {
-  const images = input.pngPaths.slice(0, 4).map((p) => ({
+  // Up to 6 views — the four orthographic shots plus the xray internal pass (and any extra recipe
+  // shot). The xray reveals bores/cavities the opaque views can't, so it must reach the judge.
+  const images = input.pngPaths.slice(0, 6).map((p) => ({
     type: 'image' as const,
     source: {
       type: 'base64' as const,

--- a/packages/brepjs-cad/src/snapshot/shoot.ts
+++ b/packages/brepjs-cad/src/snapshot/shoot.ts
@@ -6,14 +6,31 @@ import { resolve, basename, dirname } from 'node:path';
 import { acquireServer, type AcquireOptions } from './registry.js';
 
 export type ViewName = 'iso' | 'front' | 'top' | 'right';
-const VIEWS: readonly ViewName[] = ['iso', 'front', 'top', 'right'];
+type ViewMode = 'solid' | 'wireframe' | 'xray';
+/** One capture: a camera view + render mode, written to `<name>.png`. */
+export interface Shot {
+  name: string;
+  view: ViewName;
+  viewMode?: ViewMode;
+}
+// The default recipe: the four orthographic-ish views plus an xray pass that reveals internal
+// features (bores, shelled walls, internal teeth) an opaque exterior render is blind to — the
+// internal-visibility gap that exterior-only shots leave (most of the mechanical corpus has internals).
+const DEFAULT_SHOTS: readonly Shot[] = [
+  { name: 'iso', view: 'iso' },
+  { name: 'front', view: 'front' },
+  { name: 'top', view: 'top' },
+  { name: 'right', view: 'right' },
+  { name: 'iso-xray', view: 'iso', viewMode: 'xray' },
+];
 // The viewer boots WASM in-browser, so __ready arrives far later than a plain GLB load.
 const READY_TIMEOUT_MS = 90_000;
 
 export interface ShootOptions extends AcquireOptions {
   file: string;
   outDir: string;
-  views?: readonly ViewName[];
+  /** Capture recipe; defaults to the four views + an xray internal pass. */
+  shots?: readonly Shot[];
   /** Wall-clock ms to let the camera settle before each capture (default 400; raise on slow CI). */
   settleMs?: number;
   /** Burn the model's bbox dimensions into each PNG so the agent can read scale (default true). */
@@ -28,14 +45,19 @@ export async function shoot(opts: ShootOptions): Promise<ShootResult> {
   const absFile = resolve(opts.file);
   const dir = dirname(absFile);
   const rel = basename(absFile);
-  const views = opts.views ?? VIEWS;
+  const shots = opts.shots ?? DEFAULT_SHOTS;
 
   await mkdir(opts.outDir, { recursive: true });
   const server = await acquireServer(opts);
 
   const browser = await puppeteer.launch({
     headless: true,
-    args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+    args: [
+      '--no-sandbox',
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+    ],
   });
   const pngs: string[] = [];
   try {
@@ -47,12 +69,12 @@ export async function shoot(opts: ShootOptions): Promise<ShootResult> {
     const target = `${server.url}/?dir=${encodeURIComponent(dir)}&file=${encodeURIComponent(rel)}&ui=0${dimsParam}`;
     await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 30_000 });
     await page.waitForFunction('window.__ready === true', { timeout: READY_TIMEOUT_MS });
-    for (const view of views) {
-      await page.evaluate((v: string) => {
-        (globalThis as unknown as { __renderView(s: string): void }).__renderView(v);
-      }, view);
+    for (const shot of shots) {
+      await page.evaluate((s: Shot) => {
+        (globalThis as unknown as { __setScene(c: Shot): void }).__setScene(s);
+      }, shot);
       await new Promise((r) => setTimeout(r, opts.settleMs ?? 400));
-      const path = resolve(opts.outDir, `${view}.png`) as `${string}.png`;
+      const path = resolve(opts.outDir, `${shot.name}.png`) as `${string}.png`;
       await page.screenshot({ path });
       pngs.push(path);
     }

--- a/packages/brepjs-cad/viewer/main.tsx
+++ b/packages/brepjs-cad/viewer/main.tsx
@@ -19,7 +19,7 @@ import {
   type ViewName,
 } from 'brepjs-viewer';
 import { useModel } from './src/useModel.js';
-import { installScreenshotApi, onViewChange, markReady } from './src/screenshotApi.js';
+import { installScreenshotApi, onScene, markReady } from './src/screenshotApi.js';
 
 // The agent snapshot pipeline screenshots this same page, so it loads with ?ui=0 to
 // suppress the toolbar and keep PNGs free of chrome. Human `--serve` links omit it.
@@ -54,7 +54,15 @@ function App() {
   const [sectionAxis, setSectionAxis] = useState<SectionAxis>('x');
   const [sectionPos, setSectionPos] = useState(0);
   const [sectionFlip, setSectionFlip] = useState(false);
-  useEffect(() => onViewChange(setView), []); // bridge window.__renderView -> ViewerCanvas.view
+  // bridge window.__renderView / __setScene -> camera + view mode
+  useEffect(
+    () =>
+      onScene((c) => {
+        setView(c.view);
+        setViewMode(c.viewMode ?? 'solid');
+      }),
+    []
+  );
   const handleFit = useCallback(() => {
     setFitSignal((n) => n + 1);
   }, []);
@@ -64,10 +72,7 @@ function App() {
   const handleFaceHover = useCallback((info: FaceInfo | null) => {
     setHoverFaceId(info ? info.faceId : null);
   }, []);
-  const bounds = useMemo(
-    () => (state.status === 'ready' ? meshBounds(state.data) : null),
-    [state],
-  );
+  const bounds = useMemo(() => (state.status === 'ready' ? meshBounds(state.data) : null), [state]);
   const axisIndex = sectionAxis === 'x' ? 0 : sectionAxis === 'y' ? 1 : 2;
   const sectionMin = bounds ? bounds.min[axisIndex] : 0;
   const sectionMax = bounds ? bounds.max[axisIndex] : 1;
@@ -77,7 +82,7 @@ function App() {
       const i = a === 'x' ? 0 : a === 'y' ? 1 : 2;
       return (bounds.min[i] + bounds.max[i]) / 2;
     },
-    [bounds],
+    [bounds]
   );
   const handleToggleSection = useCallback(() => {
     setSectionOn((on) => {
@@ -90,18 +95,22 @@ function App() {
       setSectionAxis(a);
       setSectionPos(midOfAxis(a));
     },
-    [midOfAxis],
+    [midOfAxis]
   );
   const clippingPlanes = useMemo(
     () => (sectionOn && bounds ? [sectionPlane(sectionAxis, sectionPos, sectionFlip)] : undefined),
-    [sectionOn, bounds, sectionAxis, sectionPos, sectionFlip],
+    [sectionOn, bounds, sectionAxis, sectionPos, sectionFlip]
   );
   if (state.status === 'error')
     return (
-      <div style={{ color: '#e88', padding: 16, fontFamily: 'monospace' }}>error: {state.error}</div>
+      <div style={{ color: '#e88', padding: 16, fontFamily: 'monospace' }}>
+        error: {state.error}
+      </div>
     );
   if (state.status !== 'ready')
-    return <div style={{ color: '#9aa', padding: 16, fontFamily: 'monospace' }}>loading model…</div>;
+    return (
+      <div style={{ color: '#9aa', padding: 16, fontFamily: 'monospace' }}>loading model…</div>
+    );
   return (
     <>
       <ViewerCanvas
@@ -117,15 +126,10 @@ function App() {
           data={state.data}
           viewMode={viewMode}
           {...(clippingPlanes ? { clippingPlanes } : {})}
-          {...(showControls
-            ? { onFacePick: handleFacePick, onFaceHover: handleFaceHover }
-            : {})}
+          {...(showControls ? { onFacePick: handleFacePick, onFaceHover: handleFaceHover } : {})}
         />
         {showEdges && viewMode !== 'wireframe' && state.data.edges.length > 0 && (
-          <EdgeRenderer
-            edges={state.data.edges}
-            {...(clippingPlanes ? { clippingPlanes } : {})}
-          />
+          <EdgeRenderer edges={state.data.edges} {...(clippingPlanes ? { clippingPlanes } : {})} />
         )}
         {showControls && (
           <SelectionHighlight
@@ -204,5 +208,5 @@ if (root)
   createRoot(root).render(
     <StrictMode>
       <App />
-    </StrictMode>,
+    </StrictMode>
   );

--- a/packages/brepjs-cad/viewer/src/screenshotApi.ts
+++ b/packages/brepjs-cad/viewer/src/screenshotApi.ts
@@ -1,22 +1,44 @@
+import type { ViewMode } from 'brepjs-viewer';
+
 export const VIEWS = ['iso', 'front', 'top', 'right'] as const;
 export type ViewName = (typeof VIEWS)[number];
-type ViewListener = (view: ViewName) => void;
-const listeners = new Set<ViewListener>();
+
+/** A scene the snapshot pipeline asks the page to render before a capture. */
+export interface SceneControl {
+  view: ViewName;
+  /** solid | wireframe | xray. Default solid. `xray` reveals internal features through the body. */
+  viewMode?: ViewMode;
+}
+
+type SceneListener = (c: SceneControl) => void;
+const listeners = new Set<SceneListener>();
 function isViewName(v: string): v is ViewName {
   return (VIEWS as readonly string[]).includes(v);
 }
 
-export function onViewChange(cb: ViewListener): () => void {
+export function onScene(cb: SceneListener): () => void {
   listeners.add(cb);
   return () => listeners.delete(cb);
+}
+function emit(c: SceneControl): void {
+  for (const cb of listeners) cb(c);
 }
 export function markReady(): void {
   (globalThis as { __ready?: boolean }).__ready = true;
 }
 export function installScreenshotApi(): void {
-  const g = globalThis as { __ready?: boolean; __renderView?: (view: string) => void };
+  const g = globalThis as {
+    __ready?: boolean;
+    __renderView?: (view: string) => void;
+    __setScene?: (c: SceneControl) => void;
+  };
   g.__ready = false;
+  // Back-compat: a plain camera change (solid). The richer recipe uses __setScene.
   g.__renderView = (view: string) => {
-    if (isViewName(view)) for (const cb of listeners) cb(view);
+    if (isViewName(view)) emit({ view });
+  };
+  // Full scene control for the judge recipe — camera + view mode (e.g. xray for internals).
+  g.__setScene = (c: SceneControl) => {
+    if (c && isViewName(c.view)) emit(c);
   };
 }

--- a/packages/brepjs-cad/viewer/tests/screenshotApi.test.ts
+++ b/packages/brepjs-cad/viewer/tests/screenshotApi.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { installScreenshotApi, onViewChange, VIEWS } from '@viewer/screenshotApi.js';
+import { installScreenshotApi, onScene, VIEWS, type SceneControl } from '@viewer/screenshotApi.js';
 
 beforeEach(() => {
   (globalThis as Record<string, unknown>).__ready = undefined;
   (globalThis as Record<string, unknown>).__renderView = undefined;
+  (globalThis as Record<string, unknown>).__setScene = undefined;
 });
 
 describe('screenshotApi', () => {
@@ -11,19 +12,34 @@ describe('screenshotApi', () => {
     installScreenshotApi();
     expect((globalThis as Record<string, unknown>).__ready).toBe(false);
     expect(typeof (globalThis as Record<string, unknown>).__renderView).toBe('function');
+    expect(typeof (globalThis as Record<string, unknown>).__setScene).toBe('function');
   });
-  it('notifies subscribers for known views', () => {
+  it('__renderView notifies subscribers for known views (solid)', () => {
     installScreenshotApi();
-    const seen: string[] = [];
-    onViewChange((v) => seen.push(v));
+    const seen: SceneControl[] = [];
+    onScene((c) => seen.push(c));
     for (const v of VIEWS) (globalThis as { __renderView?: (s: string) => void }).__renderView?.(v);
-    expect(seen).toEqual(['iso', 'front', 'top', 'right']);
+    expect(seen.map((c) => c.view)).toEqual(['iso', 'front', 'top', 'right']);
+    expect(seen.every((c) => c.viewMode === undefined)).toBe(true);
   });
-  it('ignores unknown view', () => {
+  it('__setScene carries the view mode (e.g. xray)', () => {
+    installScreenshotApi();
+    const seen: SceneControl[] = [];
+    onScene((c) => seen.push(c));
+    (globalThis as { __setScene?: (c: SceneControl) => void }).__setScene?.({
+      view: 'iso',
+      viewMode: 'xray',
+    });
+    expect(seen).toEqual([{ view: 'iso', viewMode: 'xray' }]);
+  });
+  it('ignores an unknown view on both hooks', () => {
     installScreenshotApi();
     const cb = vi.fn();
-    onViewChange(cb);
+    onScene(cb);
     (globalThis as { __renderView?: (s: string) => void }).__renderView?.('sideways');
+    (globalThis as { __setScene?: (c: SceneControl) => void }).__setScene?.({
+      view: 'sideways' as SceneControl['view'],
+    });
     expect(cb).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Phase 2a of the design-judge upgrade — the first **renderer-touching** layer. The judge rendered only opaque exterior views, blind to the internal features that ~88% of the mechanical corpus has (bores, tapped threads, shelled walls, internal teeth). This adds an **xray pass** that shows them through a translucent body. No aiming needed — the highest-value internal-visibility win at the lowest cost (reuses the viewer's existing `xray` view mode; no `brepjs-viewer` change).

## Changes

- **`viewer/screenshotApi.ts`**: generalize the snapshot hook from view-only (`onViewChange`) to a scene channel (`onScene`) + add `window.__setScene({ view, viewMode })`. `__renderView` stays as a solid-view shim on the same channel (back-compat).
- **`viewer/main.tsx`**: bridge `onScene` → `setView` + `setViewMode`.
- **`snapshot/shoot.ts`**: a `Shot` recipe (`view` + `viewMode`); the default recipe now adds an **`iso-xray`** capture alongside the four views, applied via `__setScene`.
- **`judge.ts`**: widen the SDK judge's image set to include the xray + tell it to use the xray to confirm internal features.
- **`blind-judge.md`**: name `iso-xray` as the detail view for internal-feature parts.

## Render-verified

On a shelled, bored box, the solid `iso` hides the interior; the `iso-xray` clearly shows the through-bore and cavity walls:

| iso (solid) | iso-xray |
|---|---|
| internals hidden | through-bore + cavity walls visible |

## Verification

- New `__setScene` test case; existing `screenshotApi` test migrated `onViewChange`→`onScene`.
- Full package suite **167/167**; typecheck/eslint/prettier/knip/boundaries clean.

Follow-ups (later increments): Set-of-Marks (kernel-anchored feature labels), aimed section + back-iso (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)