### PR TITLE
feat(brepjs-cad): aimed section cut for the design judge (Phase 3)

### DIFF
--- a/packages/brepjs-cad/bench/blind-judge.md
+++ b/packages/brepjs-cad/bench/blind-judge.md
@@ -16,7 +16,8 @@ One judge subagent (general-purpose — it must `Read` the PNGs) per part. Its *
 part's NL `description` + two rendered images each — **iso + one detail view, the SAME view pair for
 both renders** so the A/B comparison is fair (pick the detail view — front/top/right, or **`iso-xray`
 for any part with internal features** like bores/cavities/shelled walls, since it shows them through a
-translucent body — that best exposes the features the description names) — labeled only **A** and
+translucent body — that best exposes the features the description names; for a bored part the `section` cut is the cleanest read of
+the bore + wall thickness) — labeled only **A** and
 **B**, **a one-line "measured
 facts" string per render** (body count + interference relations — the ground truth the render can't
 show; see step 1b), + the rubric below. It is told NOTHING about which render is the skill's clean-room

--- a/packages/brepjs-cad/bench/judge.ts
+++ b/packages/brepjs-cad/bench/judge.ts
@@ -8,7 +8,7 @@ import { formatDigest, type MetricsDigest } from './metrics.js';
 // request + rubric, decide whether the geometry matches. Verdict is a structured
 // output (messages.parse + Zod) so the score is a clean boolean, not parsed prose.
 
-const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered views (iso / front / top / right, plus an xray pass that shows internal features — bores, cavities, shelled walls — through a translucent body) of a 3D part a model produced from a natural-language request, along with the request and a rubric describing what a correct part must show. Use the xray to confirm internal features the opaque views can't show.
+const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered views (iso / front / top / right, an xray pass that shows internal features — bores, cavities, shelled walls — through a translucent body, and when the part has a bore an aimed section cut that opens it as a clean cross-section) of a 3D part a model produced from a natural-language request, along with the request and a rubric describing what a correct part must show. Use the xray and the section to confirm internal features and wall thickness the opaque views can't show.
 
 Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.
 

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -14,6 +14,7 @@ import { exportPart } from './exportPart.js';
 import { openBrowser, shouldAutoOpen } from './openBrowser.js';
 import { disposeShape } from '../disposeShape.js';
 import type { shoot as ShootFn } from '../snapshot/shoot.js';
+import { aimedSection } from '../snapshot/aiming.js';
 
 // OCCT's WASM STEP writer emits a "Statistics on Transfer" banner via console.log
 // (Emscripten's default stdout sink). The CLI owns stdout for machine-readable JSON,
@@ -60,7 +61,10 @@ program
     '--expect-code <code>',
     'exit 0 only if the report emits this error code (for fixtures/eval recall)'
   )
-  .option('--expect-invalid', 'exit 0 only if the part is invalid (ok:false) — for known-bad fixtures')
+  .option(
+    '--expect-invalid',
+    'exit 0 only if the part is invalid (ok:false) — for known-bad fixtures'
+  )
   .option(
     '--metrics',
     'compute deterministic manufacturability metrics (per-body breakdown + interference matrix) for the design judge — slower; off by default'
@@ -97,8 +101,17 @@ program
 
       if (targets.length > 1) {
         // Batch: validity-only JSON array. The single-file artifact flags don't apply.
-        if (opts.step || opts.serve || opts.snapshot || opts.glb || opts.expectCode || opts.expectInvalid) {
-          process.stderr.write('batch mode: --step/--glb/--serve/--snapshot/--expect-code/--expect-invalid ignored (single-file only)\n');
+        if (
+          opts.step ||
+          opts.serve ||
+          opts.snapshot ||
+          opts.glb ||
+          opts.expectCode ||
+          opts.expectInvalid
+        ) {
+          process.stderr.write(
+            'batch mode: --step/--glb/--serve/--snapshot/--expect-code/--expect-invalid ignored (single-file only)\n'
+          );
         }
         const results: { file: string; ok: boolean; report: VerifyReport }[] = [];
         for (const f of targets) {
@@ -124,7 +137,8 @@ program
         step: wantStep,
         glb: Boolean(opts.glb),
         check: Boolean(opts.check),
-        metrics: Boolean(opts.metrics),
+        // A snapshot feeds the design judge, so compute metrics too (bores → an aimed section shot).
+        metrics: Boolean(opts.metrics) || Boolean(opts.snapshot),
       });
       let stepPath: string | undefined = opts.step;
       try {
@@ -137,7 +151,15 @@ program
         if (opts.snapshot && stepPath) {
           const shoot = await loadSnapshotShoot(); // lazy: keeps puppeteer off the default path
           if (shoot) {
-            const { pngs } = await shoot({ file: stepPath, outDir: opts.snapshot });
+            const section = aimedSection(
+              report.manufacturability?.bores ?? [],
+              report.measurements.bounds
+            );
+            const { pngs } = await shoot({
+              file: stepPath,
+              outDir: opts.snapshot,
+              ...(section ? { section } : {}),
+            });
             // Diagnostic paths go to stderr — stdout stays a single clean JSON document.
             for (const p of pngs) process.stderr.write(`snapshot: ${p}\n`);
           }
@@ -219,7 +241,10 @@ program
 
 program
   .command('snapshot')
-  .argument('<file>', 'path to a .brep.ts module; renders iso/front/top/right PNGs (no report assertions)')
+  .argument(
+    '<file>',
+    'path to a .brep.ts module; renders iso/front/top/right PNGs (no report assertions)'
+  )
   .option('--out <dir>', 'output directory for the PNGs (default <file>-shots)')
   .option('--label <tag>', 'subfolder for this render set (e.g. pre, post) for A/B pairing')
   .action(async (file: string, opts: { out?: string; label?: string }) => {
@@ -244,7 +269,16 @@ program
         return;
       }
       // fresh: a private ephemeral render server so parallel snapshots don't contend on :7373.
-      const { pngs } = await shoot({ file: stepPath, outDir, fresh: true });
+      const section = aimedSection(
+        report.manufacturability?.bores ?? [],
+        report.measurements.bounds
+      );
+      const { pngs } = await shoot({
+        file: stepPath,
+        outDir,
+        fresh: true,
+        ...(section ? { section } : {}),
+      });
       for (const p of pngs) process.stdout.write(`${p}\n`);
     } finally {
       disposeShape(shape);

--- a/packages/brepjs-cad/src/snapshot/aiming.ts
+++ b/packages/brepjs-cad/src/snapshot/aiming.ts
@@ -1,0 +1,47 @@
+// Pure section-aiming logic, kept free of the puppeteer import in shoot.ts so the CLI can import it
+// on the default (no-render) path without pulling in puppeteer.
+
+type SectionAxis = 'x' | 'y' | 'z';
+
+/** A clipping section: cut perpendicular to `axis` at `frac` (0..1) of that axis's bbox span. */
+export interface SectionSpec {
+  axis: SectionAxis;
+  frac: number;
+}
+
+interface AimBore {
+  radius: number;
+  axisOrigin: readonly [number, number, number];
+  axisDir: readonly [number, number, number];
+}
+interface AimBounds {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  zMin: number;
+  zMax: number;
+}
+
+/**
+ * Aim a section cut through the dominant (largest-radius) bore: cut on the basis axis MOST
+ * perpendicular to the bore axis, positioned to pass THROUGH the bore origin — so the bore opens as
+ * a clean cross-section (reads wall thickness, where the xray is cluttered). Returns null when there
+ * are no bores or no bounds. Plain structural inputs keep this decoupled from the verify report.
+ */
+export function aimedSection(
+  bores: readonly AimBore[],
+  bounds: AimBounds | undefined
+): SectionSpec | null {
+  if (bores.length === 0 || !bounds) return null;
+  const bore = bores.reduce((a, b) => (b.radius > a.radius ? b : a));
+  const d = bore.axisDir;
+  const perp = { x: Math.abs(d[0]), y: Math.abs(d[1]), z: Math.abs(d[2]) };
+  const axis = (['x', 'y', 'z'] as const).reduce((a, b) => (perp[b] < perp[a] ? b : a));
+  const i = axis === 'x' ? 0 : axis === 'y' ? 1 : 2;
+  const min = axis === 'x' ? bounds.xMin : axis === 'y' ? bounds.yMin : bounds.zMin;
+  const max = axis === 'x' ? bounds.xMax : axis === 'y' ? bounds.yMax : bounds.zMax;
+  const span = max - min || 1;
+  const frac = Math.min(1, Math.max(0, (bore.axisOrigin[i] - min) / span));
+  return { axis, frac };
+}

--- a/packages/brepjs-cad/src/snapshot/shoot.ts
+++ b/packages/brepjs-cad/src/snapshot/shoot.ts
@@ -4,14 +4,16 @@ import puppeteer from 'puppeteer';
 import { mkdir } from 'node:fs/promises';
 import { resolve, basename, dirname } from 'node:path';
 import { acquireServer, type AcquireOptions } from './registry.js';
+import type { SectionSpec } from './aiming.js';
 
 export type ViewName = 'iso' | 'front' | 'top' | 'right';
 type ViewMode = 'solid' | 'wireframe' | 'xray';
-/** One capture: a camera view + render mode, written to `<name>.png`. */
+/** One capture: a camera view + render mode (+ optional section), written to `<name>.png`. */
 export interface Shot {
   name: string;
   view: ViewName;
   viewMode?: ViewMode;
+  section?: SectionSpec;
 }
 // The default recipe: the four orthographic-ish views plus an xray pass that reveals internal
 // features (bores, shelled walls, internal teeth) an opaque exterior render is blind to — the
@@ -31,6 +33,8 @@ export interface ShootOptions extends AcquireOptions {
   outDir: string;
   /** Capture recipe; defaults to the four views + an xray internal pass. */
   shots?: readonly Shot[];
+  /** When set (and no explicit `shots`), append an aimed cross-section capture to the default recipe. */
+  section?: SectionSpec;
   /** Wall-clock ms to let the camera settle before each capture (default 400; raise on slow CI). */
   settleMs?: number;
   /** Burn the model's bbox dimensions into each PNG so the agent can read scale (default true). */
@@ -45,7 +49,11 @@ export async function shoot(opts: ShootOptions): Promise<ShootResult> {
   const absFile = resolve(opts.file);
   const dir = dirname(absFile);
   const rel = basename(absFile);
-  const shots = opts.shots ?? DEFAULT_SHOTS;
+  const shots =
+    opts.shots ??
+    (opts.section
+      ? [...DEFAULT_SHOTS, { name: 'section', view: 'iso' as const, section: opts.section }]
+      : DEFAULT_SHOTS);
 
   await mkdir(opts.outDir, { recursive: true });
   const server = await acquireServer(opts);

--- a/packages/brepjs-cad/src/snapshot/shoot.ts
+++ b/packages/brepjs-cad/src/snapshot/shoot.ts
@@ -25,6 +25,14 @@ const DEFAULT_SHOTS: readonly Shot[] = [
   { name: 'right', view: 'right' },
   { name: 'iso-xray', view: 'iso', viewMode: 'xray' },
 ];
+// The section is shot from iso, not flat-on along the cut axis. Render-tested both: looking ALONG the
+// cut axis shows the *closed* far half (the clip keeps the side away from the camera, so its cut face
+// points away), whereas the iso 3/4 angle looks INTO the opened cavity and legibly shows the bore +
+// walls — more informative for the judge than a foreshortened-but-flat profile.
+function sectionShots(section: SectionSpec | undefined): Shot[] {
+  return section ? [{ name: 'section', view: 'iso', section }] : [];
+}
+
 // The viewer boots WASM in-browser, so __ready arrives far later than a plain GLB load.
 const READY_TIMEOUT_MS = 90_000;
 
@@ -49,11 +57,7 @@ export async function shoot(opts: ShootOptions): Promise<ShootResult> {
   const absFile = resolve(opts.file);
   const dir = dirname(absFile);
   const rel = basename(absFile);
-  const shots =
-    opts.shots ??
-    (opts.section
-      ? [...DEFAULT_SHOTS, { name: 'section', view: 'iso' as const, section: opts.section }]
-      : DEFAULT_SHOTS);
+  const shots = opts.shots ?? [...DEFAULT_SHOTS, ...sectionShots(opts.section)];
 
   await mkdir(opts.outDir, { recursive: true });
   const server = await acquireServer(opts);

--- a/packages/brepjs-cad/tests/aiming.test.ts
+++ b/packages/brepjs-cad/tests/aiming.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { aimedSection } from '@/snapshot/aiming.js';
+
+const bounds = { xMin: -20, xMax: 20, yMin: -20, yMax: 20, zMin: 0, zMax: 30 };
+
+describe('aimedSection', () => {
+  it('returns null with no bores or no bounds', () => {
+    expect(aimedSection([], bounds)).toBeNull();
+    expect(
+      aimedSection([{ radius: 4, axisOrigin: [0, 0, 0], axisDir: [0, 0, 1] }], undefined)
+    ).toBeNull();
+  });
+
+  it('cuts on a basis axis perpendicular to a Z-aligned bore, through its origin', () => {
+    const s = aimedSection([{ radius: 4, axisOrigin: [0, 0, 15], axisDir: [0, 0, 1] }], bounds);
+    // Z bore → cut on x or y (both perpendicular); the plane must pass through the bore at x=0.
+    expect(s?.axis === 'x' || s?.axis === 'y').toBe(true);
+    expect(s?.frac).toBeCloseTo(0.5, 5); // origin 0 within x span [-20,20]
+  });
+
+  it('cuts perpendicular to an X-aligned bore (not along it)', () => {
+    const s = aimedSection([{ radius: 4, axisOrigin: [0, 0, 15], axisDir: [1, 0, 0] }], bounds);
+    expect(s?.axis).not.toBe('x'); // never cut along the bore axis
+  });
+
+  it('aims at the DOMINANT (largest-radius) bore and positions through it', () => {
+    const s = aimedSection(
+      [
+        { radius: 2, axisOrigin: [10, 0, 15], axisDir: [0, 0, 1] },
+        { radius: 8, axisOrigin: [-10, 0, 15], axisDir: [0, 0, 1] },
+      ],
+      bounds
+    );
+    // dominant bore is the r8 at x=-10 → frac = (-10 - -20)/40 = 0.25
+    expect(s?.frac).toBeCloseTo(0.25, 5);
+  });
+
+  it('clamps frac into [0,1] for an out-of-bounds origin', () => {
+    const s = aimedSection([{ radius: 4, axisOrigin: [999, 0, 15], axisDir: [0, 0, 1] }], bounds);
+    expect(s?.frac).toBe(1);
+  });
+});

--- a/packages/brepjs-cad/viewer/main.tsx
+++ b/packages/brepjs-cad/viewer/main.tsx
@@ -54,15 +54,6 @@ function App() {
   const [sectionAxis, setSectionAxis] = useState<SectionAxis>('x');
   const [sectionPos, setSectionPos] = useState(0);
   const [sectionFlip, setSectionFlip] = useState(false);
-  // bridge window.__renderView / __setScene -> camera + view mode
-  useEffect(
-    () =>
-      onScene((c) => {
-        setView(c.view);
-        setViewMode(c.viewMode ?? 'solid');
-      }),
-    []
-  );
   const handleFit = useCallback(() => {
     setFitSignal((n) => n + 1);
   }, []);
@@ -73,6 +64,24 @@ function App() {
     setHoverFaceId(info ? info.faceId : null);
   }, []);
   const bounds = useMemo(() => (state.status === 'ready' ? meshBounds(state.data) : null), [state]);
+  // bridge window.__renderView / __setScene -> camera + view mode + section. Depends on `bounds`
+  // so a section `frac` maps to an absolute position on the model.
+  useEffect(
+    () =>
+      onScene((c) => {
+        setView(c.view);
+        setViewMode(c.viewMode ?? 'solid');
+        if (c.section && bounds) {
+          const i = c.section.axis === 'x' ? 0 : c.section.axis === 'y' ? 1 : 2;
+          setSectionAxis(c.section.axis);
+          setSectionPos(bounds.min[i] + c.section.frac * (bounds.max[i] - bounds.min[i]));
+          setSectionOn(true);
+        } else {
+          setSectionOn(false);
+        }
+      }),
+    [bounds]
+  );
   const axisIndex = sectionAxis === 'x' ? 0 : sectionAxis === 'y' ? 1 : 2;
   const sectionMin = bounds ? bounds.min[axisIndex] : 0;
   const sectionMax = bounds ? bounds.max[axisIndex] : 1;

--- a/packages/brepjs-cad/viewer/src/screenshotApi.ts
+++ b/packages/brepjs-cad/viewer/src/screenshotApi.ts
@@ -1,13 +1,21 @@
-import type { ViewMode } from 'brepjs-viewer';
+import type { SectionAxis, ViewMode } from 'brepjs-viewer';
 
 export const VIEWS = ['iso', 'front', 'top', 'right'] as const;
 export type ViewName = (typeof VIEWS)[number];
+
+/** A clipping section: cut perpendicular to `axis` at `frac` of that axis's bbox span (0..1). */
+export interface SectionSpec {
+  axis: SectionAxis;
+  frac: number;
+}
 
 /** A scene the snapshot pipeline asks the page to render before a capture. */
 export interface SceneControl {
   view: ViewName;
   /** solid | wireframe | xray. Default solid. `xray` reveals internal features through the body. */
   viewMode?: ViewMode;
+  /** A section cut to apply (e.g. aimed through a bore). Absent/null = no section. */
+  section?: SectionSpec | null;
 }
 
 type SceneListener = (c: SceneControl) => void;


### PR DESCRIPTION
## What

Builds on the keystone bore detection (#1542): when a part has a bore, the judge now also gets a **section capture that cuts through the dominant bore axis**, opening it as a clean cross-section. The xray (Phase 2a) reveals internals translucently but is cluttered for *reading wall thickness* — an aimed cut is the clean read.

## How it aims (the keystone pays off)

`aimedSection(bores, bounds)` uses the bore axes from #1542: it picks the basis axis **most perpendicular** to the largest-radius bore and positions the plane to pass **through** the bore origin — so the plane *contains* the bore axis and the bore opens as a cross-section. Dominant-bore selection + clamped frac.

## Changes

- **`snapshot/aiming.ts`** (new, puppeteer-free so the CLI imports it on the default path): the pure aiming helper.
- **`viewer/screenshotApi.ts` / `main.tsx`**: `SceneControl` gains `section`; the bridge maps `frac` → absolute position via the model bounds and drives the existing section state (absent section → off, so non-section shots reset cleanly).
- **`shoot.ts`**: `Shot.section` + a `ShootOptions.section` that appends one aimed `section` capture to the default recipe.
- **`cli/main.ts`**: a snapshot now implies `--metrics` (so bores exist to aim from) and passes the aimed section to `shoot`.
- **`judge.ts` / `blind-judge.md`**: the judge is told about the section view and to use it for bore + wall-thickness reads.

## Render-verified

On a shelled, bored box, the `section` cut slices through the bore, showing the cavity walls + bore as a clean cross-section (reads wall thickness, where the xray is cluttered).

## Verification

- `tests/aiming.test.ts` (5 cases): perpendicular-to-Z-bore, never-along-the-bore, dominant-bore selection, frac-through-origin, out-of-bounds clamp.
- Full package suite **176/176**; typecheck/eslint/prettier/knip/boundaries clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)