### PR TITLE
fix(brepjs-cad): teach worm-wheel and rack tooth recipes; fix gear-build contradiction

### DIFF
--- a/packages/brepjs-cad/skills/implement/references/gears.md
+++ b/packages/brepjs-cad/skills/implement/references/gears.md
@@ -101,7 +101,9 @@ A rack is the involute of an infinite-radius gear, so its flanks **degenerate to
    and doesn't jam. For multi-body drives, also assert the **frame never intersects a moving part**.
    - **gear ↔ gear:** centre distance `m·(N1+N2)/2`; rotate both at the conjugate ratio `−N1/N2`.
    - **rack ↔ pinion:** pinion axis one pitch radius (`m·N/2`) above the rack pitch line; rotate the
-     pinion by θ and translate the rack by `pitchRadius·θ`.
+     pinion by θ and translate the rack by `pitchRadius·θ` (**θ in radians** — the `assemblies-motion.md`
+     template sweeps in degrees, so convert: `rackShift = pitchRadius·θ_deg·π/180`, else the rack
+     crawls ~57× too slowly).
    - **worm ↔ wheel:** centre distance `r_worm_pitch + r_wheel_pitch`; rotate the worm by φ and the
      wheel by `φ/ratio` (`ratio = N_wheel / starts`).
 

--- a/packages/brepjs-cad/skills/implement/references/gears.md
+++ b/packages/brepjs-cad/skills/implement/references/gears.md
@@ -50,11 +50,63 @@ Two gears mesh **only if they share the same module and the same pressure angle.
   (two opposite helices, cancels thrust — great for printed gear trains), **internal ring**, **rack**
   (straight → linear), **bevel** (intersecting shafts), **worm + worm gear** (high reduction, 90°).
 
+## Worm + worm wheel (right-angle, high reduction)
+
+A worm drive needs a real thread AND a wheel whose teeth are conjugate to it. A `circularPattern`
+of box/slot cutters is **not** a worm wheel — the slots aren't conjugate, so the pair jams or skips
+(it still passes `isValidSolid`, so the kernel won't catch it).
+
+- **Worm** — a true single-start helicoid: loft rotated **trapezoidal (~20° flank, ACME-form)**
+  cross-sections per `references/threads.md` (`thread()` is not in this build). Axial pitch = lead =
+  `π·m` for a single start, so the worm advances exactly one wheel-tooth pitch per revolution.
+- **Worm wheel** — the reliable, honest build is a **cylindrical involute HELICAL gear** of the
+  _same module_, teeth helix-angled at the worm lead angle `λ = atan(lead / (π·d_worm))` (loft the
+  involute tooth loop across the face with that small conjugate twist). Name it for what it is — a
+  **cylindrical / non-throated** worm wheel (a legitimate crossed-helical drive), not a throated one.
+- **Centre distance = `r_worm_pitch + r_wheel_pitch`** — place them there. Do **NOT** open it up to
+  make the no-jam sweep pass: that's an air gap, not a mesh (see "Build + verify" step 4). A true
+  throated/hobbed wheel (generate it by subtracting rotated copies of the worm from the blank) is
+  conjugate but slow/advanced — reach for it only when a throated wheel is the explicit goal.
+- Reduction = `N_wheel : starts`. Mount the wheel shaft so the frame **clears the wheel's rotation
+  envelope** (radius `ra`): a support that crosses the wheel disk impales it and the wheel can't turn
+  (check frame-vs-wheel interference, not just worm-vs-wheel).
+
+## Rack (rotary → linear)
+
+A rack is the involute of an infinite-radius gear, so its flanks **degenerate to straight lines**.
+
+- **Rack teeth** — straight flanks inclined at the **pressure angle** (20°) to the pitch-line normal;
+  tooth/space split at half the circular pitch (`π·m`); addendum `m` above the pitch line, dedendum
+  `1.25m` below. One closed `polygon` → `extrude`, same machinery as a gear.
+- **The mating pinion stays a normal involute gear** — straight radial pinion teeth do not mesh a rack.
+- Mesh: the pinion pitch circle is tangent to the rack pitch line (pinion axis one pitch radius above
+  it). Validate with the rack↔pinion kinematics in step 4.
+
 ## Build + verify
 
-1. One tooth profile in 2D (involute sampled points, or a trapezoid approximation).
-2. `circularPattern` it `N×` around the axis; union to the root-circle blank.
-3. Extrude (spur) or sweep with a twist law (helical); mirror-stack for herringbone.
-4. **Verify meshing with `references/assemblies-motion.md`:** place two gears at the correct centre
-   distance (`m·(N1+N2)/2`), rotate one, and assert the teeth interpenetrate ~0 through a full turn.
-   A gear pair is "done" only when it sweeps without jamming.
+1. One tooth profile in 2D (involute sampled points, or a trapezoid/straight-rack approximation).
+2. Replicate that point list around all `N` teeth (or along the rack) into **one closed `polygon`**
+   → `extrude` — the verified reliable build above. Do **NOT** `circularPattern` separate per-tooth
+   solids and union them, and do **NOT** cut tooth gaps with a patterned box/slot cutter: those are
+   the slower/flakier per-tooth-boolean paths the one-polygon build exists to avoid, and a box cutter
+   silently produces non-conjugate teeth.
+3. Bore the centre, add hub/keyway with `cut` (spur). Helical/worm-wheel = loft the tooth loop with a
+   twist law; mirror-stack for herringbone.
+4. **Verify meshing — and engagement, not just no-jam.** Place the pair at the correct relative
+   position (per pair type below), sweep the drive parameter, and assert the teeth interpenetrate ~0
+   through the motion (`references/assemblies-motion.md`). A non-jam sweep is necessary but **not
+   sufficient** — a pair pulled too far apart also never collides. So also confirm real **contact**:
+   the running clearance/backlash must be small (~0.1–0.25 mm), and pulling the driver away by the
+   working depth (`2m`) must _break_ the contact. A pair is "done" only when it both meshes (contacts)
+   and doesn't jam. For multi-body drives, also assert the **frame never intersects a moving part**.
+   - **gear ↔ gear:** centre distance `m·(N1+N2)/2`; rotate both at the conjugate ratio `−N1/N2`.
+   - **rack ↔ pinion:** pinion axis one pitch radius (`m·N/2`) above the rack pitch line; rotate the
+     pinion by θ and translate the rack by `pitchRadius·θ`.
+   - **worm ↔ wheel:** centre distance `r_worm_pitch + r_wheel_pitch`; rotate the worm by φ and the
+     wheel by `φ/ratio` (`ratio = N_wheel / starts`).
+
+   Two start-pose details the sweep will flag if wrong: **phase** one member so a tooth seats in the
+   other's space (not tooth-on-tooth — scan a half-pitch to find the seated phase), and get the
+   **rolling sign** right (the driven member advances so the pitch surfaces roll without slipping;
+   the opposite sign jams mid-tooth). A wrong phase or sign shows up as a large interpenetration that
+   vanishes at the right one.


### PR DESCRIPTION
## Why — a clean-room eval of "is brepjs-cad bad at gear teeth?"

Dispatched 3 clean-room author subagents (each reading **only** the implement skill, no playground/source answer keys) to build *meshing* gear pairs. Result: brepjs-cad makes excellent involute **spur** teeth first-build — but is bad at the gear types `gears.md` only **names**.

| pair | outcome | gap |
|---|---|---|
| spur (20T↔40T) | ✅ involute one-polygon, 0 mm³ mesh, first build | flagged a doc contradiction (below) |
| worm + 30T wheel | ⚠️ "passed" only by **opening the centre distance ~5 mm** — a faked air-gap mesh | **no worm-wheel recipe** ("worm + worm gear" named with zero geometry) |
| rack + 18T pinion | ✅ but **derived** the rack flank form + kinematics from outside gear theory, not the skill | **no rack recipe** ("rack (straight → linear)" named only) |

The worm result is the same failure the playground worm gear shipped with (#1541): with no recipe, authors substitute a spur wheel and pull the pair apart to dodge a jam. And the skill's auto-signal (valid + no-jam sweep) can't catch it — **a pair pulled apart never collides.**

## Fixes (all prose in `references/gears.md`, where the prompt-only eval author reads)

- **Worm + worm wheel recipe** — ACME helicoid worm + **cylindrical involute HELICAL wheel** at the worm lead angle, placed at the **true centre distance `r_worm + r_wheel`** (do **not** open it to fake non-jam); named non-throated honestly; frame must clear the wheel envelope (don't impale the gear).
- **Rack recipe** — straight flanks at the pressure angle; **the mating pinion stays involute**; pinion axis one pitch radius above the rack pitch line.
- **Reconcile the contradiction** — build step 2 now says one closed polygon (not `circularPattern`/union of per-tooth solids or a patterned box cutter, which the header already warned against and which silently makes non-conjugate teeth).
- **Strengthen verify** — a no-jam sweep is necessary but **not sufficient**; also confirm real **contact** (small backlash; pulling the driver away by `2m` breaks contact) and that the **frame never enters a moving part**. Added the rack↔pinion and worm↔wheel mesh kinematics + a phase/rolling-sign note.

## RED→GREEN (causally attributable)

Re-ran the worm and rack clean-room authors against the patched skill:

- **worm** — held the true **40 mm** centre distance, did **not** inflate it, and proved the mesh real via the prescribed pull-away test (contact 45.7 → 0 mm³ over a 2 mm pull). *"SKILL_CARRIED_ME: yes — never invented geometry from outside knowledge and never faked the centre distance."*
- **rack** — took the straight-flank-at-PA form, the "pinion stays involute" rule, and the `pr·θ` kinematics **straight from the skill**.

The phase/sign note addresses a **recurring** finding (the spur author phased a half-pitch, the rack author discovered phase+sign, and #1541's rack shipped with an inverted-sign jam) — not a single incident.

Skill-only change; no code/tests touched.