### PR TITLE
fix(brepjs-cad): handle brepjs/playground refs + summarize body relations in the digest

### DIFF
--- a/packages/brepjs-cad/bench/adaptReference.ts
+++ b/packages/brepjs-cad/bench/adaptReference.ts
@@ -19,11 +19,37 @@ import { pathToFileURL } from 'node:url';
 // Render the result WITHOUT `--check`: playground `code` is type-checked against the looser Monaco
 // ambient surface, so strict-CLI type gaps (e.g. `sketchOnPlane('XY')`) are expected and irrelevant
 // to the image the judge needs.
+//
+// `brepjs/playground` (`color`, `present`) is a playground-only runtime the CLI can't resolve. Those
+// helpers are cosmetic — `color(shape, hex)` tags a GLB material, `present(shape, artifacts)` attaches
+// downloads — neither changes geometry, and CLI snapshots are grey anyway. Shim each to identity on
+// the shape so the part runs.
 
 const QUICK = 'brepjs/quick';
 
+/** Replace `import { a, b } from 'brepjs/playground'` with no-op shims returning the shape (1st arg). */
+function shimPlaygroundImports(code: string): string {
+  return code.replace(
+    /import\s*\{([^}]*)\}\s*from\s*['"]brepjs\/playground['"];?/g,
+    (_full, names: string) => {
+      const locals = names
+        .split(',')
+        .map((n) =>
+          n
+            .trim()
+            .split(/\s+as\s+/)
+            .pop()
+            ?.trim()
+        )
+        .filter((n): n is string => Boolean(n));
+      return locals.map((n) => `const ${n} = (shape) => shape;`).join('\n');
+    }
+  );
+}
+
 /** Pure transform: playground example `code` → CLI-renderable reference part source. */
-export function adaptReferenceCode(code: string): string {
+export function adaptReferenceCode(rawCode: string): string {
+  const code = shimPlaygroundImports(rawCode);
   // Keep whatever brepjs entry the example already uses; default to the kernel-auto-init `quick`.
   const usesPlain = /from ['"]brepjs['"]/.test(code) && !/from ['"]brepjs\/quick['"]/.test(code);
   const src = usesPlain ? 'brepjs' : QUICK;

--- a/packages/brepjs-cad/bench/metrics.ts
+++ b/packages/brepjs-cad/bench/metrics.ts
@@ -8,8 +8,11 @@ import type { VerifyReport } from '../src/verify/report.js';
 export interface MetricsDigest {
   /** Number of distinct solid bodies (1 for a single solid). */
   bodyCount: number;
-  /** One human-legible line per body pair, e.g. "bodies 0&1: interfering (clearance 0.00mm)". */
-  bodyRelations: string[];
+  /** Only the non-separate pairs (interfering/touching/nested) — the signal. Separate pairs are
+   * summarized as a count, not listed, so a high-body assembly doesn't dump O(n²) noise. */
+  interferences: string[];
+  /** How many body pairs sit apart (the separate pairs, counted not listed). */
+  separatePairCount: number;
   /** Count of internal cylindrical bores detected (a "has internal features" signal). */
   internalBores?: number;
   /** Smallest *bore* radius (mm) — derived from the bores, not the global min cylinder. */
@@ -23,15 +26,19 @@ export interface MetricsDigest {
 /** Project a report's metrics into a digest, or `undefined` if metrics were not computed. */
 export function digestMetrics(report: VerifyReport): MetricsDigest | undefined {
   if (!report.manufacturability && !report.bodies && !report.bodyRelations) return undefined;
-  const relations = (report.bodyRelations ?? []).map((r) => {
-    const clearance = r.clearance === undefined ? '' : ` (clearance ${r.clearance.toFixed(2)}mm)`;
-    return `bodies ${r.a}&${r.b}: ${r.relation}${clearance}`;
-  });
+  const rels = report.bodyRelations ?? [];
+  const interferences = rels
+    .filter((r) => r.relation !== 'separate')
+    .map((r) => {
+      const clearance = r.clearance === undefined ? '' : ` (clearance ${r.clearance.toFixed(2)}mm)`;
+      return `bodies ${r.a}&${r.b}: ${r.relation}${clearance}`;
+    });
   const m = report.manufacturability;
   const bores = m?.bores ?? [];
   return {
     bodyCount: report.bodies?.length ?? 1,
-    bodyRelations: relations,
+    interferences,
+    separatePairCount: rels.length - interferences.length,
     ...(bores.length > 0
       ? { internalBores: bores.length, minBoreRadius: Math.min(...bores.map((b) => b.radius)) }
       : {}),
@@ -44,7 +51,11 @@ export function digestMetrics(report: VerifyReport): MetricsDigest | undefined {
 export function formatDigest(d: MetricsDigest): string {
   const lines = [`Measured facts (ground truth the render cannot show — trust these):`];
   lines.push(`- distinct bodies: ${d.bodyCount}`);
-  if (d.bodyRelations.length) lines.push(`- body relations: ${d.bodyRelations.join('; ')}`);
+  if (d.interferences.length > 0) {
+    lines.push(`- interfering/touching pairs: ${d.interferences.join('; ')}`);
+  }
+  if (d.separatePairCount > 0)
+    lines.push(`- (${d.separatePairCount} other body pair(s) sit apart)`);
   if (d.internalBores !== undefined) {
     const r =
       d.minBoreRadius !== undefined ? `, smallest bore radius ${d.minBoreRadius.toFixed(2)}mm` : '';

--- a/packages/brepjs-cad/tests/adaptReference.test.ts
+++ b/packages/brepjs-cad/tests/adaptReference.test.ts
@@ -70,3 +70,27 @@ describe('adaptReferenceCode (blind-judge reference adaptation)', () => {
     ).toThrow(/no .export default/);
   });
 });
+
+describe('adaptReferenceCode — brepjs/playground shim', () => {
+  it('replaces a brepjs/playground import with identity shims (cosmetic helpers)', () => {
+    const code = [
+      "import { box } from 'brepjs/quick';",
+      "import { color } from 'brepjs/playground';",
+      'export default [color(box(1, 1, 1), "#f00")];',
+    ].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).not.toContain("from 'brepjs/playground'");
+    expect(out).toContain('const color = (shape) => shape;');
+  });
+
+  it('shims every name (e.g. color, present) and handles aliases', () => {
+    const code = [
+      "import { color, present as show } from 'brepjs/playground';",
+      "import { box } from 'brepjs/quick';",
+      'export default show(color(box(1, 1, 1), "#f00"), {});',
+    ].join('\n');
+    const out = adaptReferenceCode(code);
+    expect(out).toContain('const color = (shape) => shape;');
+    expect(out).toContain('const show = (shape) => shape;');
+  });
+});

--- a/packages/brepjs-cad/tests/manufacturability.test.ts
+++ b/packages/brepjs-cad/tests/manufacturability.test.ts
@@ -83,21 +83,28 @@ describe('digestMetrics (pure)', () => {
     expect(digestMetrics(emptyReport())).toBeUndefined();
   });
 
-  it('projects bodies + relations into a legible digest', () => {
+  it('lists interfering pairs but only counts separate pairs (no O(n²) wall)', () => {
     const report = emptyReport();
     report.bodies = [
       { index: 0, volume: 1000, valid: true },
       { index: 1, volume: 1000, valid: true },
+      { index: 2, volume: 1000, valid: true },
     ];
-    report.bodyRelations = [{ a: 0, b: 1, relation: 'interfering', clearance: 0 }];
+    report.bodyRelations = [
+      { a: 0, b: 1, relation: 'interfering', clearance: 0 },
+      { a: 0, b: 2, relation: 'separate', clearance: 5 },
+      { a: 1, b: 2, relation: 'separate' },
+    ];
     report.manufacturability = { violations: [] };
     const d = digestMetrics(report);
     if (!d) throw new Error('expected a digest');
-    expect(d.bodyCount).toBe(2);
-    expect(d.bodyRelations).toEqual(['bodies 0&1: interfering (clearance 0.00mm)']);
+    expect(d.bodyCount).toBe(3);
+    expect(d.interferences).toEqual(['bodies 0&1: interfering (clearance 0.00mm)']);
+    expect(d.separatePairCount).toBe(2);
     const block = formatDigest(d);
-    expect(block).toContain('distinct bodies: 2');
     expect(block).toContain('bodies 0&1: interfering');
+    expect(block).toContain('2 other body pair(s) sit apart');
+    expect(block).not.toContain('bodies 0&2'); // separate pairs are summarized, not listed
   });
 
   it('surfaces bore count + smallest radius in the digest', () => {


### PR DESCRIPTION
## What

Two fixes surfaced by a consolidated **end-to-end run** of the upgraded design judge on the recently-added playground mechanisms (scotch-yoke, worm-gear-drive, rack-and-pinion, three-jaw-chuck).

1. **`adaptReference` — `brepjs/playground` shim.** The newer examples import `color`/`present` from `brepjs/playground` (a playground-only runtime the CLI can't resolve), so they failed to render (`Cannot find package 'brepjs'`). Those helpers are cosmetic — `color(shape, hex)` tags a GLB material, `present(shape, artifacts)` attaches downloads — neither changes geometry, and CLI snapshots are grey anyway. Shim each to identity-on-the-shape so the geometry runs. Unblocks the recent mechanisms **and** the bim/sheet-metal corpus.
2. **metrics digest — summarize body relations.** `formatDigest` dumped every body pair (O(n²)); a 23-body part produced a **253-line wall** that buried the signal and would blow the judge's token budget. Now it lists only the interfering/touching pairs and summarizes the separates as a count (`(219 other body pair(s) sit apart)`).

## The e2e run that found these (all 4 judged with the full evidence set + facts digest; `usedMetrics: true` on every one)

| part | judge verdict | what the metrics caught |
|---|---|---|
| scotch-yoke | **pass** | confirmed exactly 3 bodies; crank pin engages slot (xray); only "distinct colors" failed (grey render, flagged as a render limitation) |
| worm-gear-drive | fail | **23 solids vs the required 3** — wheel/worm fragmented into dozens of 0.00mm-interfering bodies (backlash gap closed) — invisible in renders, caught via the digest |
| rack-and-pinion | fail | verified conjugate mesh via touching pairs at 0.00mm; failed "3 bodies" (kernel reports 6 — fragmentation) |
| three-jaw-chuck | fail | confirmed 5 bodies + 3 jaws gripping stock + Ø20 bore (10mm radius) the images left ambiguous; found missing scroll groove, serrations, 2 of 3 pinion sockets |

The upgraded judge **failed 3 of 4 references on real geometry/feature defects** the old exterior-only judge would have passed — which is the point. (These are also reference-quality issues worth fixing in the examples.)

## Verification

- `tests/adaptReference.test.ts`: playground-shim cases (color/present, aliases). `tests/manufacturability.test.ts`: digest lists interfering pairs, counts separates, doesn't dump them.
- Full package suite **183/183**; typecheck/eslint/prettier/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)