### PR TITLE
fix(brepjs-cad): close gear-teeth edge cases found by /eval-skill (ring, worm tip relief, GT2)

### DIFF
--- a/packages/brepjs-cad/skills/implement/references/booleans.md
+++ b/packages/brepjs-cad/skills/implement/references/booleans.md
@@ -52,5 +52,6 @@ Keep the color literal **inline** (as above) or type any color you factor into a
 - Returning a `Result` from the default export is supported; the verifier unwraps it and reports an `Err`.
 - Booleans on touching-but-not-overlapping solids can yield empty/invalid results; give operands a small overlap. (A `compound` does NOT need overlap; bodies stay distinct.)
 - **`fuse` of solids that only meet on a coplanar face/ring can silently return a loose `Compound`** — `ok:true`, but the bodies are NOT welded (the report's `manifold` flag / an undropped face count is the tell, not `shapeType`). For one watertight solid, give the operands a real overlap and use `fuseAll(shapes, { unsafe: true })`. If it's an assembly, a loose `Compound` is correct — just don't mistake it for a weld.
+- **Don't gate your own guards on `isSolid()`/`shapeType` after a boolean.** A clean, fully-overlapping `cut`/`fuse` of an **extruded** (`Shape3D`) operand frequently reports `shapeType: 'Compound'` and `isSolid() === false` while being a perfectly valid single body (`isValidSolid === true`). A hand-written `if (!isSolid(x)) throw` will false-trip on it — check `isValidSolid` / positive volume instead, and let `verify` judge validity.
 
 See also: docs/function-lookup.md → brepjs/topology.

--- a/packages/brepjs-cad/skills/implement/references/gears.md
+++ b/packages/brepjs-cad/skills/implement/references/gears.md
@@ -96,10 +96,11 @@ annular disc minus a full external gear of the same `m`/PA, leaving the conjugat
   pair _adds_ radii; the internal pair subtracts). For a planetary set the planets orbit at
   `r_sun + r_planet = r_ring − r_planet`, which forces `N_ring = N_sun + 2·N_planet`; ratio (ring
   fixed, carrier out) = `1 + N_ring/N_sun`.
-- **Backlash sign INVERTS.** Because the cutter is _subtracted_, a fatter cutter tooth makes a
-  _thinner_ ring tooth → more clearance: use **negative** backlash / a slightly oversized cutter
-  (plus a touch of extra addendum to deepen the ring valleys past the planet tip). Counterintuitive —
-  the opposite of an external gear.
+- **The backlash ADJUSTMENT inverts** (the clearance itself stays positive — don't call it "negative
+  backlash", which means an interference fit). Because the cutter is _subtracted_, an **oversized**
+  cutter tooth leaves a _thinner_ ring tooth → more running clearance. So on an internal ring you add
+  clearance by **fattening the cutter**, the inverse of an external gear (where you thin the tooth
+  directly); a touch of extra addendum also deepens the ring valleys past the planet tip.
 
 ## Timing-belt pulleys (non-involute)
 
@@ -137,8 +138,9 @@ hub with `cut`.
      crawls ~57× too slowly).
    - **worm ↔ wheel:** centre distance `r_worm_pitch + r_wheel_pitch`; rotate the worm by φ and the
      wheel by `φ/ratio` (`ratio = N_wheel / starts`).
-   - **planet ↔ ring (internal):** spacing `r_ring − r_planet` (a subtraction); planet spins, ring
-     fixed. (sun ↔ planet is a normal gear↔gear pair.)
+   - **planet ↔ ring (internal):** spacing `r_ring − r_planet` (a subtraction); hold the carrier and
+     rotate the planet in place by θ — the ring is fixed, so there is no second-body ratio. (sun ↔
+     planet is a normal gear↔gear pair.)
 
    Mesh sweeps are **expensive** — `intersect` on two high-face-count involute gears is seconds per
    call, and a multi-mesh assembly (a planetary's sun+3-planet+ring) can blow the CLI timeout. Keep

--- a/packages/brepjs-cad/skills/implement/references/gears.md
+++ b/packages/brepjs-cad/skills/implement/references/gears.md
@@ -67,6 +67,11 @@ of box/slot cutters is **not** a worm wheel — the slots aren't conjugate, so t
   make the no-jam sweep pass: that's an air gap, not a mesh (see "Build + verify" step 4). A true
   throated/hobbed wheel (generate it by subtracting rotated copies of the worm from the blank) is
   conjugate but slow/advanced — reach for it only when a throated wheel is the explicit goal.
+- **Relieve the tooth tips (the cylindrical-wheel jam).** At the _fixed_ centre distance, full-depth
+  addenda make `r_wheel_tip + r_worm_crest > centre distance`, so the wheel tip collides the worm
+  crest every revolution — a **geometric** jam no phase or sign choice fixes (don't chase phasing for
+  it). Use stub/relieved addenda plus backlash so the two tip radii sum stays under the centre
+  distance; the wheel tooth tip then rides in the thread groove instead of hitting the crest.
 - Reduction = `N_wheel : starts`. Mount the wheel shaft so the frame **clears the wheel's rotation
   envelope** (radius `ra`): a support that crosses the wheel disk impales it and the wheel can't turn
   (check frame-vs-wheel interference, not just worm-vs-wheel).
@@ -82,6 +87,28 @@ A rack is the involute of an infinite-radius gear, so its flanks **degenerate to
 - Mesh: the pinion pitch circle is tangent to the rack pitch line (pinion axis one pitch radius above
   it). Validate with the rack↔pinion kinematics in step 4.
 
+## Internal ring gear (epicyclic / planetary)
+
+A ring gear has **inward-pointing** involute teeth — build it as **`disc − external-cutter`**: an
+annular disc minus a full external gear of the same `m`/PA, leaving the conjugate internal teeth.
+
+- **Centre distance is a SUBTRACTION.** Planet↔ring spacing = `r_ring − r_planet` (every external
+  pair _adds_ radii; the internal pair subtracts). For a planetary set the planets orbit at
+  `r_sun + r_planet = r_ring − r_planet`, which forces `N_ring = N_sun + 2·N_planet`; ratio (ring
+  fixed, carrier out) = `1 + N_ring/N_sun`.
+- **Backlash sign INVERTS.** Because the cutter is _subtracted_, a fatter cutter tooth makes a
+  _thinner_ ring tooth → more clearance: use **negative** backlash / a slightly oversized cutter
+  (plus a touch of extra addendum to deepen the ring valleys past the planet tip). Counterintuitive —
+  the opposite of an external gear.
+
+## Timing-belt pulleys (non-involute)
+
+Belt pulleys (GT2, HTD, MXL, T) are **not** involute gears — the tooth is a shallow **curved trough**
+fixed by the belt standard (GT2 = a circular-arc valley at 2 mm pitch), sized to the belt, not a
+mating gear, so there is no meshing pair to validate. Model the trough (an arc or a cosine dip) per
+the standard and use the same **one closed `polygon` → `extrude`** rim build; add flanges and a bored
+hub with `cut`.
+
 ## Build + verify
 
 1. One tooth profile in 2D (involute sampled points, or a trapezoid/straight-rack approximation).
@@ -89,7 +116,11 @@ A rack is the involute of an infinite-radius gear, so its flanks **degenerate to
    → `extrude` — the verified reliable build above. Do **NOT** `circularPattern` separate per-tooth
    solids and union them, and do **NOT** cut tooth gaps with a patterned box/slot cutter: those are
    the slower/flakier per-tooth-boolean paths the one-polygon build exists to avoid, and a box cutter
-   silently produces non-conjugate teeth.
+   silently produces non-conjugate teeth. **Dedupe coincident consecutive points** in the computed
+   loop (a tooth's trailing point is the next tooth's leading point) or `polygon` throws
+   `makeLineEdge: construction failed` — see `references/sketching-2d.md`. After the boolean (bore /
+   hub `cut`), don't gate your own guards on `isSolid()`/`shapeType` — a clean cut of an extruded
+   gear often reports `Compound` while being one valid body; check `isValidSolid` / positive volume.
 3. Bore the centre, add hub/keyway with `cut` (spur). Helical/worm-wheel = loft the tooth loop with a
    twist law; mirror-stack for herringbone.
 4. **Verify meshing — and engagement, not just no-jam.** Place the pair at the correct relative
@@ -106,6 +137,13 @@ A rack is the involute of an infinite-radius gear, so its flanks **degenerate to
      crawls ~57× too slowly).
    - **worm ↔ wheel:** centre distance `r_worm_pitch + r_wheel_pitch`; rotate the worm by φ and the
      wheel by `φ/ratio` (`ratio = N_wheel / starts`).
+   - **planet ↔ ring (internal):** spacing `r_ring − r_planet` (a subtraction); planet spins, ring
+     fixed. (sun ↔ planet is a normal gear↔gear pair.)
+
+   Mesh sweeps are **expensive** — `intersect` on two high-face-count involute gears is seconds per
+   call, and a multi-mesh assembly (a planetary's sun+3-planet+ring) can blow the CLI timeout. Keep
+   the involute sample count low and sweep **coarsely** (a few steps over one tooth pitch), not a
+   fine full turn.
 
    Two start-pose details the sweep will flag if wrong: **phase** one member so a tooth seats in the
    other's space (not tooth-on-tooth — scan a half-pitch to find the seated phase), and get the


### PR DESCRIPTION
## Why

`/eval-skill implement` (gear-teeth subset) re-authored the playground gear examples clean-room (authors reading **only** the implement skill). All four reached `ok:true` — confirming the #1544 heal works (the rack author reported `SKILL_GAP: NONE`; the worm author held the **true** centre distance and proved contact via the pull-away test instead of faking it) — but they surfaced concrete gaps where the skill left the **hardest tooth work unguided**:

| example | gap found |
|---|---|
| worm-gear-drive | **tip relief missing** — full-depth addenda make `r_wheel_tip + r_worm_crest > centre distance`, so the wheel tip collides the worm crest every revolution (a *geometric* jam no phase/sign fixes); step 4's phase/sign note even misdirected the author to hunt phasing first |
| planetary-gear-reducer | **internal ring only named, no recipe** — centre distance is `r_ring − r_planet` (a *subtraction*, unlike every external pair) and the **backlash sign inverts** (negative backlash thins the ring tooth since the cutter is subtracted) |
| gt2-pulley | **no non-involute guidance** — `gears.md` is involute-only; the curved GT2 belt trough had to be invented |

## Edits (prose only, `references/gears.md` + `booleans.md`)

- **Worm:** add a tip-relief bullet — stub/relieved addenda so the two tip radii sum stays under the centre distance; the jam is geometric, not phasing. *(completes the #1544 worm-wheel recipe.)*
- **Internal ring gear** section — `disc − external-cutter`, subtractive centre distance, inverted backlash sign, planetary tooth-count (`N_ring = N_sun + 2·N_planet`) + ratio.
- **Timing-belt pulleys (non-involute)** section — curved trough per the belt standard; no meshing pair; same one-polygon-extrude rim build.
- **Step 2:** cross-reference the dedupe-consecutive-points rule (already in `sketching-2d.md`, but a GT2 author tripped `makeLineEdge` because they read `gears.md`), and note not to gate guards on `isSolid()`/`shapeType` after a boolean (a clean `cut` of an extruded gear reports `Compound` while valid).
- **Step 4:** add planet↔ring (internal) mesh kinematics + a mesh-cost note (`intersect` on high-face-count gears is slow — sweep coarsely, or a planetary blows the CLI timeout).
- **`booleans.md`:** the `isSolid`-after-boolean false-trip pitfall in general form (a self-guard `if (!isSolid(x)) throw` false-trips a valid extruded-operand boolean).

## Note on phantoms

Finding #4 (duplicate-vertex crash) was **already** documented in `sketching-2d.md:64`, so I added a cross-reference instead of duplicating it. The blind-judge (designed-object) signal was **not** collected — these self-validating parts (the planetary author ran ~47 min on mesh sweeps) were impractical to snapshot here; `judge:—` is a coverage gap, reported, not a pass.

Skill-only; no code/tests touched. Follow-up to #1544.