### PR TITLE
fix(brepjs-cad): polish skill — bosses on shells must fuse, or they float (eval finding)

### DIFF
--- a/packages/brepjs-cad/skills/polish/references/design-polish.md
+++ b/packages/brepjs-cad/skills/polish/references/design-polish.md
@@ -36,10 +36,14 @@ primitives glued together?"** Specifically:
 (`FILLET_FAILED`). Prefer building the detail from geometry you fuse/cut:
 
 - **Rounded end** — a `sphere` of the shaft radius, flush on a rod end; or a short `cone` taper.
-- **Chamfered rim** — fuse/subtract a `cone` ring at an edge instead of calling `chamfer`.
+- **Chamfered rim** — fuse/subtract a `cone` ring at a circular edge instead of calling `chamfer`.
+  (A continuous rounded-rectangle _outer_ perimeter has no `cone`-ring equivalent — leave it raw, or
+  carefully `fillet` a selected edge list; don't force it.)
 - **Cooling fins / ribs** — a stack of thin `cylinder` discs (slightly larger R) at even spacing.
-- **Gusset / web** — a `cone` or triangular `box` bracing a post where it meets a base: reads as
-  engineered AND carries the load.
+- **Gusset / web** — a `cone` or triangular prism bracing a post where it meets a base: reads as
+  engineered AND carries the load. brepjs `box` is rectangular, so build the triangular prism as a
+  `box` minus a 45°-rotated `box` cutter (or `polygon`+`extrude` a right triangle), then `fuse` it
+  spanning the post-to-base corner.
 - **Lightening holes** — small `cut` cylinders through a disc/web (flywheel look); implies stress relief.
 - **Groove / seat** — an annular `cut` (ring tool = outer cylinder − inner cylinder) for a
   square-bottom groove; **cut a `torus`** for a round-bottom groove (ball raceway, o-ring seat).
@@ -49,7 +53,17 @@ primitives glued together?"** Specifically:
   TAPERED grip, set each cutter's centre at `wallRadius − biteDepth` (not a fixed radius), or the
   bite is uneven and too shallow to read.
 - **D-shaft socket** — a blind `cylinder` bore `cut` with a thin chord `box` gives the shaft flat.
-- **Boss / pad** — a short raised `cylinder`/`box` where another feature mounts.
+- **Boss / pad** — a short raised `cylinder`/`box` where another feature mounts. On a **shelled /
+  thin-wall** part the boss MUST overlap and `fuse` to a real wall or floor (and blend in with a
+  fillet or gusset); a free-standing cylinder dropped into the cavity **floats** — it still passes
+  `ok:true` (it's a disjoint solid), but it detaches on export and reads as a glued-on primitive,
+  _worse_ than the plain shell. After adding bosses to a shell, confirm `getSolids(part).length`
+  equals the body count you expect — a floating boss bumps it.
+- **Shell / enclosure detail** — thin-wall parts have a thinner menu than solid posts/rods. Beyond a
+  wall-`fuse`d boss (above), reach for **screw towers** (a boss fused to a wall, blended with corner
+  gussets), **internal ribs/stiffeners** run flat along a wall face, or a **rim lip / rabbet** (a
+  thin raised step on the opening edge where a lid seats). A free-standing interior cylinder is not
+  polish — it's a floating defect.
 
 When you DO use `fillet`/`chamfer`, **select edges** (`edgeFinder()…findAll`) with small radii, and
 round the edges a human touches first.


### PR DESCRIPTION
## Why

`/eval-skill polish` — a pre/post **blind-judge** sweep over 3 first-valid parts (render pre → polish → render post; post must be valid AND judge-preferred AND attributable to a named rule).

| part | post valid | judge (post > pre) | verdict |
|---|---|---|---|
| extruded-bracket | ✓ | ✓ high (Boss/pad + countersinks) | polish confirmed |
| mounting-bracket | ✓ | ✓ high (load-path gusset) | polish confirmed |
| **hollow-enclosure** | ✓* | **✗ high — PRE preferred** | **polish HURT** |

The polish skill **works on solid parts** but **fails on shells**: applying `Boss/pad` to the hollow enclosure produced four mounting bosses that never fused to the shell — a **5-solid disjoint compound** (`*` it's `ok:true` because each solid is individually valid, but it detaches on export). The blind judge preferred the *un-polished* shell — *"primitive boss cylinders glued to the walls plus a stray floating peg in the cavity."* The only case this session where polish made a part **measurably worse**.

## Fix (`skills/polish/references/design-polish.md`, prose only)

- **`Boss/pad`** — on a shelled/thin-wall part a boss **MUST overlap and `fuse` to a real wall/floor** (blend with a fillet/gusset); a free-standing cylinder floats — a disjoint solid that passes `ok:true` but detaches on export and reads worse than the plain shell. **Check `getSolids` === expected** after adding bosses to a shell.
- **Shell / enclosure detail** — a new move list (screw towers, internal ribs/stiffeners, rim lip/rabbet); the menu was thin for thin-wall parts and only `Boss/pad` applied (and naively it floats).
- **`Gusset/web`** — add the triangular-prism recipe (`box` minus a 45°-rotated `box`); every polisher had to invent it because the skill said "triangular `box`" with no how (brepjs `box` is rectangular).
- **`Chamfered rim`** — note a continuous rounded-rect *outer* perimeter has no cone-ring equivalent (leave raw or carefully `fillet` a selected edge list).

## RED→GREEN (causally attributable)

Re-ran the shell polisher against the patched skill: it quoted the new rule, fused each tower to the walls+floor, and reported the connectivity check **`getSolids = 1`** — one connected solid, no floating bosses. The exact RED defect is gone.

## Separate (not in this PR)

The snapshot pipeline was silently broken by a **stale viewer `dist/`** (`globalThis.__setScene is not a function`) — this session's `viewer/src` merges changed the scene global, but the eval/heal **setup only rebuilds the viewer if `dist/` is missing, not stale**. I rebuilt it to run this eval. That setup instruction lives in the plugin command source (not this repo), so it's flagged here rather than patched.

Skill-only; no code/tests touched.