### PR TITLE
feat(brepjs-cad): surface fragmentation in verify --check (the #1 design defect)

### DIFF
--- a/packages/brepjs-cad/skills/implement/SKILL.md
+++ b/packages/brepjs-cad/skills/implement/SKILL.md
@@ -77,6 +77,9 @@ predict `xMin = 0` for a corner chamfered at `x = 0`, never `xMin = -chamfer`.
   single `Solid` — and that's fine, because `shapeType` is report-only/non-authorable and
   bounds/volume/validity still pass. Don't burn attempts trying to force a `Solid`; only do so (and
   then only worry) when a **downstream `fillet`/`shell`/`offset`** needs a `ValidSolid` (next rule).
+  The report's `notes` flags a **multi-body Compound and its solid count** — if a part you meant as
+  ONE piece comes back as N bodies, the weld failed (overlap + `fuseAll` unsafe); a count matching a
+  deliberate assembly is fine.
 - **`fillet`/`chamfer`/`shell`/`offset` need a `ValidSolid`.** Primitives already are one and
   booleans preserve it, so a primitive-rooted chain feeds them directly. A shape from a 2D-sketch
   `.extrude()`/`.revolve()` (or `loft`/`sweep`) is typed `Shape3D`; passing it to these ops is

--- a/packages/brepjs-cad/src/verify/checks.ts
+++ b/packages/brepjs-cad/src/verify/checks.ts
@@ -94,6 +94,20 @@ export function runChecks(
     }
   }
 
+  // Fragmentation advisory (non-failing): a part meant to be ONE solid that came back as N un-welded
+  // bodies is the #1 design defect in eval, and it's invisible to an author running plain --check (the
+  // body count needs --metrics). Surface the count + the fix here. Cheap — `solids` is already in hand,
+  // no interference computation (that stays gated behind --metrics). A single-solid Compound (the usual
+  // boolean result) and a real assembly are both legitimate, so this never touches `ok`.
+  if (!isSolid(shape) && solids.length > 1) {
+    (r.notes ??= []).push(
+      `shapeType is ${r.shapeType} with ${solids.length} solids. If this is meant to be ONE part, the ` +
+        `bodies are NOT welded — give the operands a real overlap and fuseAll(shapes, { unsafe: true }). ` +
+        `If it is a deliberate assembly, this is expected. Run --metrics to see whether the bodies touch ` +
+        `(a failed weld) or sit apart (an assembly).`
+    );
+  }
+
   // Volume + positiveVolume for ANY 3D shape. Booleans/modifiers (cut/fuse/chamfer) routinely
   // return a Compound wrapping a single solid; measureVolume sums solids, so gating this on
   // isSolid would silently skip validation for ~half of real multi-feature parts (and leave

--- a/packages/brepjs-cad/src/verify/report.ts
+++ b/packages/brepjs-cad/src/verify/report.ts
@@ -108,6 +108,12 @@ export interface VerifyReport {
   /** Actionable, code-keyed guidance derived from `errorInfos`. */
   hints: VerifyHint[];
   /**
+   * Non-failing advisories surfaced on the default `--check` path (do NOT affect `ok`). The author
+   * runs `--check` without `--metrics`, so a part that came back as many un-welded bodies is otherwise
+   * invisible to them — the dominant design defect in eval. A multi-body Compound gets a note here.
+   */
+  notes?: string[];
+  /**
    * Measured-vs-expected comparisons from a part's `export const expected`. Empty when the part
    * declares no expectations; when non-empty, `ok` additionally requires every assertion pass.
    */

--- a/packages/brepjs-cad/tests/checks.test.ts
+++ b/packages/brepjs-cad/tests/checks.test.ts
@@ -27,6 +27,25 @@ describe('runChecks', () => {
     expect(report.checks.some((c) => c.name === 'positiveVolume' && c.passed)).toBe(true);
   });
 
+  it('flags a multi-body Compound in notes (fragmentation advisory) without failing the report', () => {
+    // Two boxes sitting apart → a 2-solid Compound. An author on plain --check otherwise can't see
+    // the part fragmented; the advisory surfaces the count + fix but must not affect `ok`.
+    const asm = compound([box(10, 10, 10), box(10, 10, 10, { at: [40, 0, 0] })]);
+    const report = runChecks(brep, asm);
+    const note = report.notes?.find((n) => n.includes('2 solids'));
+    expect(note).toBeDefined();
+    expect(note).toMatch(/not welded/i);
+    // advisory only — every check still passes
+    expect(report.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it('does NOT flag a single solid or a single-solid Compound', () => {
+    expect(runChecks(brep, box(10, 10, 10)).notes).toBeUndefined();
+    // overlapping fuse → one welded solid wrapped in a Compound (solids.length === 1): no advisory
+    const fused = unwrap(fuse(box(10, 10, 10), box(10, 10, 10, { at: [5, 0, 0] })));
+    expect(runChecks(brep, fused).notes).toBeUndefined();
+  });
+
   it('reports topology counts (faces/edges/wires/vertices) for a solid', () => {
     const report = runChecks(brep, box(10, 10, 10));
     expect(report.topology).toBeDefined();


### PR DESCRIPTION
## What

The full-corpus eval flywheel (46 parts) found **fragmentation — a part meant to be ONE solid returning as N un-welded bodies — flagged in 21/45 parts**, the single most pervasive design defect, *persisting despite* the weld rules I'd just strengthened (#1552, #1554).

The root cause is **structural, not a doc gap**: authors run `verify --check` (no `--metrics`), so the body count is **invisible** to them — they never see that their "one bracket" came back as 8 loose solids. No prose rule fixes a defect the feedback loop can't show.

## Fix

`--check` now emits a non-failing `notes` advisory when the result is a multi-body Compound:

```
shapeType is Compound with 8 solids. If this is meant to be ONE part, the bodies are NOT welded —
give the operands a real overlap and fuseAll(shapes, { unsafe: true }). If it is a deliberate
assembly, this is expected. Run --metrics to see whether the bodies touch (a failed weld) or sit
apart (an assembly).
```

- **Cheap + hot-path-safe:** `solids` is already computed for the validity check; **no interference math** (that stays gated behind `--metrics`).
- **Advisory only:** `notes` never touches `ok` — a deliberate assembly is a valid multi-body compound. Silent on a single solid and on a single-solid (welded) Compound (the usual boolean result).

## Changes
- `report.ts`: `notes?: string[]`
- `checks.ts`: push the multi-body-Compound note (`solids.length > 1`)
- `SKILL.md`: point the author at the `notes` flag from the fuse rule
- `tests/checks.test.ts`: fires on a 2-body compound (`ok` stays true); silent on single solid + welded compound

Full cad suite 187/187, knip clean. End-to-end confirmed in real `--check` output.

This closes the loop the full flywheel opened: validity is solved (100%), and the dominant *design* defect is now visible in the author's own verify step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)