### PR TITLE
fix(eval-skill): rebuild the snapshot viewer when stale, and from the right package

### DIFF
--- a/.claude/commands/eval-skill.md
+++ b/.claude/commands/eval-skill.md
@@ -42,7 +42,12 @@ The visual judge needs rendered snapshots → the built CLI + viewer + Chrome. B
 what's missing:
 
 1. Root library — `test -f dist/index.js || npm run build`
-2. Viewer — `test -d packages/brepjs-cad/viewer/dist || npm run build --workspace=brepjs-viewer`
+2. Snapshot viewer — `packages/brepjs-cad/viewer/dist`, built by the **brepjs-cad** viewer build
+   (NOT `brepjs-viewer` — that's a different package whose build does NOT produce this dist).
+   Rebuild if missing **OR stale** — a dist older than `viewer/src` throws
+   `globalThis.__setScene is not a function` and then every `--snapshot` fails silently (this is
+   easy to hit after pulling: a `viewer/src` change leaves the committed dist behind):
+   `[ -f packages/brepjs-cad/viewer/dist/index.html ] && [ -z "$(find packages/brepjs-cad/viewer/src -newer packages/brepjs-cad/viewer/dist/index.html)" ] || (cd packages/brepjs-cad && npx vite build --config viewer/vite.config.ts)`
 3. CLI — `test -f packages/brepjs-cad/dist/cli/main.js || npm run build --workspace=brepjs-cad`
 4. Chrome — `cd packages/brepjs-cad && npx puppeteer browsers install chrome`
 

--- a/.claude/commands/heal-skill.md
+++ b/.claude/commands/heal-skill.md
@@ -47,7 +47,10 @@ signal above and the same diagnose → fix → RED→GREEN → ship discipline.
 ## 0. Pre-flight (once)
 
 Build only what's missing: root lib (`test -f dist/index.js || npm run build`), CLI
-(`--workspace=brepjs-cad`), viewer (`--workspace=brepjs-viewer`), Chrome
+(`--workspace=brepjs-cad`), snapshot viewer (`packages/brepjs-cad/viewer/dist`, from the
+**brepjs-cad** build — NOT `brepjs-viewer`; rebuild if missing **or stale**, since a dist older than
+`viewer/src` throws `globalThis.__setScene is not a function` and silently fails every `--snapshot`:
+`[ -f packages/brepjs-cad/viewer/dist/index.html ] && [ -z "$(find packages/brepjs-cad/viewer/src -newer packages/brepjs-cad/viewer/dist/index.html)" ] || (cd packages/brepjs-cad && npx vite build --config viewer/vite.config.ts)`), Chrome
 (`cd packages/brepjs-cad && npx puppeteer browsers install chrome`). Scratch ESM dir:
 `mkdir -p /tmp/brepjs-eval && printf '{"type":"module"}\n' > /tmp/brepjs-eval/package.json`.
 **Smoke-test the harness** before fanning out: author a trivial `box` part and `verify --check`;


### PR DESCRIPTION
## Why

The `/eval-skill` and `/heal-skill` setup steps for the snapshot viewer had two bugs that **silently broke every `--snapshot`** — the part renders to nothing and `verify` reports `globalThis.__setScene is not a function`. This bit the polish eval this session: rendering was dead until I hand-rebuilt the viewer, and it's also why the implement-eval judge couldn't render earlier.

1. **Stale-blind** — it only rebuilt the viewer when `packages/brepjs-cad/viewer/dist` was *missing*, never when *stale*. After pulling a `viewer/src` change (this session's merges renamed the scene global), the committed `dist/` is left behind and every render fails.
2. **Wrong package** — it rebuilt `--workspace=brepjs-viewer`, which is the *shared renderer* and does **not** produce `packages/brepjs-cad/viewer/dist`. The snapshot viewer comes from the **brepjs-cad** build (`vite build --config viewer/vite.config.ts`).

## Fix

Both `.claude/commands/eval-skill.md` and `heal-skill.md` now rebuild the snapshot viewer when the dist is **missing OR older than `viewer/src`**, via the correct (brepjs-cad) viewer build:

```
[ -f packages/brepjs-cad/viewer/dist/index.html ] \
  && [ -z "$(find packages/brepjs-cad/viewer/src -newer packages/brepjs-cad/viewer/dist/index.html)" ] \
  || (cd packages/brepjs-cad && npx vite build --config viewer/vite.config.ts)
```

Verified both branches of the guard: no-op when the dist is fresh, rebuild when a `viewer/src` file is newer.

Docs/setup only (`.claude/commands/**`); no code/tests touched.