### PR TITLE
fix(brepjs-cad): add the "realize the designed object" bar to the implement skill

### DIFF
--- a/packages/brepjs-cad/skills/implement/SKILL.md
+++ b/packages/brepjs-cad/skills/implement/SKILL.md
@@ -20,6 +20,23 @@ Otherwise: `npx -y -p brepjs-cad brep verify …`.
 - Scaffold with `brep init <name>`. **Edit source, never generated artifacts** (STEP/STL/GLB derive
   from the `.brep.ts`).
 
+## Realize the designed object — not just a valid one
+
+`--check` passing means **buildable**, not **correct**. The bar is the part the brief names, recognisable
+as _that_ designed object — and the way that fails is **simplification**: a valid, generic version that
+drops the one feature that makes it itself.
+
+1. Decompose the brief into named features, then mark the **ONE defining feature** — the geometry without
+   which it's a generic blob. `GT2 pulley` → the belt-tooth profile (a smooth groove is not a GT2 pulley);
+   `fluted knob` → full-height flutes around the **whole** perimeter (scattered scallops are not flutes);
+   `twisted impeller` → the blade twist (`extrude(h, { twistAngle })`, not flat blades); `scroll chuck` →
+   the spiral face groove; `involute gear` → the tooth flank (`references/gears.md`).
+2. Build that feature **to spec**, not an eyeballed approximation. Each of the above passes `--check` while
+   missing its headline feature — a blob that verifies. If the feature needs real math (gear/thread/involute/
+   scroll), use the reference recipe; don't substitute a smooth or sparse stand-in.
+3. Before finishing, re-read the brief noun by noun and confirm each named feature is actually in the
+   geometry — including count (e.g. _four_ mount holes, _N_ teeth), not just present-ish.
+
 ## Choose the operation (reliability tiers)
 
 Prefer ops that succeed first-try; lean on the report and small steps for advanced ops. Full table:


### PR DESCRIPTION
## What

The full-corpus flywheel's **second** design finding: authors produce *valid but generic* parts that drop the one defining feature — gt2-pulley → smooth groove (no GT2 teeth), fluted-knob → scattered scallops (not flutes), axial-fan → flat blades (no twist). The skill framed everything around **validity** ("judge by the report") and never stated the **design bar**, so authors stopped at a part that passes `--check`.

Adds a "Realize the designed object — not just a valid one" section: decompose the brief → mark the ONE defining feature → build it to spec via the reference recipe (not an eyeballed stand-in) → re-check each named feature + count before finishing.

## Verified by re-authoring + visual inspection (not self-report)

Re-ran the simplified parts against the patched skill and **looked at the renders** (the authors self-reported `builtToSpec:true` for all three — the finding is precisely that they think they built it):

| Part | Before | After (patched skill) |
|---|---|---|
| gt2-pulley | smooth groove | ✅ **real teeth** — followed the gears.md timing-belt recipe the discipline pointed to |
| fluted-knob | scattered scallops | ✅ **full-height perimeter flutes** |
| axial-fan | flat radial blades | ~ twist op applied (better), but thin blades still don't read as a swept airfoil |

**Honest scope:** the nudge works where a concrete recipe backs the feature (GT2→arcs, flutes→`circularPattern`); it's weaker where the feature needs nuanced modeling judgment (a convincing impeller is camber+thickness+twist, not just `twistAngle`). The axial-fan airfoil-quality residual is a separate, deeper finding — a feature recipe, not a discipline nudge — recorded, not papered over.

Markdown-only (the deployed author is prompt-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)