### PR TITLE
feat(brepjs-cad): add airfoils.md feature recipe (swept fans/props/impellers)

### DIFF
--- a/packages/brepjs-cad/skills/implement/SKILL.md
+++ b/packages/brepjs-cad/skills/implement/SKILL.md
@@ -29,7 +29,8 @@ drops the one feature that makes it itself.
 1. Decompose the brief into named features, then mark the **ONE defining feature** — the geometry without
    which it's a generic blob. `GT2 pulley` → the belt-tooth profile (a smooth groove is not a GT2 pulley);
    `fluted knob` → full-height flutes around the **whole** perimeter (scattered scallops are not flutes);
-   `twisted impeller` → the blade twist (`sketch.extrude(h, { twistAngle })`, not flat blades); `scroll chuck` →
+   `twisted impeller`/`swept fan` → a **cambered** airfoil section extruded **radially** with a pitch twist
+   (`references/airfoils.md`), not flat blades or `twistAngle` on a paddle; `scroll chuck` →
    the spiral face groove; `involute gear` → the tooth flank (`references/gears.md`).
 2. Build that feature **to spec**, not an eyeballed approximation. Each of the above passes `--check` while
    missing its headline feature — a blob that verifies. If the feature needs real math (gear/thread/involute/
@@ -144,7 +145,8 @@ predict `xMin = 0` for a corner chamfered at `x = 0`, never `xMin = -chamfer`.
 `references/getting-started.md` · `primitives.md` · `sketching-2d.md` · `booleans.md` ·
 `modifiers.md` · `transforms.md` · `measurement-validation.md` · `assemblies-motion.md` ·
 `operation-tiers.md`. Maker recipes: `fdm-conventions.md` · `mechanical-joints.md` ·
-`gridfinity.md` · `gears.md` · `threads.md`. **Backstop:** any symbol not covered →
+`gridfinity.md` · `gears.md` · `threads.md` · `airfoils.md` (fans/props/impellers/vanes).
+**Backstop:** any symbol not covered →
 `reference/llms-full.txt` (every export with signatures), bundled in the package.
 
 ## Examples index (read the closest before authoring)

--- a/packages/brepjs-cad/skills/implement/references/airfoils.md
+++ b/packages/brepjs-cad/skills/implement/references/airfoils.md
@@ -31,7 +31,7 @@ const section = () =>
 //    hub radius, then extrude RADIALLY by SPAN with a pitch twist. Camber + twist = a swept airfoil.
 const blade = () =>
   section()
-    .sketchOnPlane('YZ', [R_HUB, 0, 0])
+    .sketchOnPlane('YZ', R_HUB) // scalar origin = offset R_HUB along the plane normal (+X)
     .extrude(SPAN, { twistAngle: PITCH, origin: [0, 0] });
 
 export default () => {
@@ -51,7 +51,7 @@ export default () => {
 
 ## Notes
 
-- **Span direction sets the fan type.** Extruding the section **radially** (`sketchOnPlane('YZ', [R_HUB,0,0])`
+- **Span direction sets the fan type.** Extruding the section **radially** (`sketchOnPlane('YZ', R_HUB)`
   → +X) gives an **axial** fan / propeller (blades reach out to a shroud). Extruding **up the axis** (+Z)
   gives the barber-pole of fins that reads wrong — that's the common mistake.
 - **Camber is what makes it an airfoil.** Drop the camber (set both sagittas to ±THICK/2) and you get a

--- a/packages/brepjs-cad/skills/implement/references/airfoils.md
+++ b/packages/brepjs-cad/skills/implement/references/airfoils.md
@@ -1,0 +1,63 @@
+# Swept blades & airfoils (fans, props, impellers, twisted vanes)
+
+The reason a "twisted impeller" / "swept fan" comes out looking like thin flat fins is **two mistakes**,
+not one: a **flat rectangle** section, and extruding it **along the axis** instead of **radially**. A
+convincing blade needs all three of: a **cambered** (curved) airfoil section, a **radial** span from hub
+to tip, and a **pitch twist** along that span. `twistAngle` alone on a flat paddle is not enough.
+
+## The recipe (verified — builds `ok:true`, reads as a real impeller)
+
+```ts
+import { draw, cylinder, fuse, fuseAll, cut, circularPattern, unwrap } from 'brepjs';
+
+const R_HUB = 8,
+  R_TIP = 28,
+  SPAN = R_TIP - R_HUB;
+const CHORD = 18,
+  CAMBER = 3.2,
+  THICK = 1.6,
+  PITCH = 38; // PITCH = root→tip twist, degrees
+const N = 7;
+
+// 1. CAMBERED thin-plate airfoil section. The upper surface bulges (camber + half-thickness),
+//    the lower returns with (camber − half-thickness): a thin crescent, not a flat strip.
+const section = () =>
+  draw([-CHORD / 2, 0])
+    .sagittaArcTo([CHORD / 2, 0], CAMBER + THICK / 2) // upper surface
+    .sagittaArcTo([-CHORD / 2, 0], -(CAMBER - THICK / 2)) // lower surface back to the leading edge
+    .close();
+
+// 2. One blade: sketch the section in the plane PERPENDICULAR to the span (YZ → extrudes +X) at the
+//    hub radius, then extrude RADIALLY by SPAN with a pitch twist. Camber + twist = a swept airfoil.
+const blade = () =>
+  section()
+    .sketchOnPlane('YZ', [R_HUB, 0, 0])
+    .extrude(SPAN, { twistAngle: PITCH, origin: [0, 0] });
+
+export default () => {
+  const hub = cylinder(R_HUB + 1, 22, { at: [0, 0, -11] });
+  const blades = unwrap(circularPattern(blade(), [0, 0, 1], N)); // N blades around the fan axis
+  const impeller = unwrap(fuse(hub, blades));
+  // optional duct/shroud — a ring with a little tip clearance over R_TIP
+  const ring = unwrap(
+    cut(
+      cylinder(R_TIP + 3, 26, { at: [0, 0, -13] }),
+      cylinder(R_TIP + 0.5, 30, { at: [0, 0, -15] })
+    )
+  );
+  return unwrap(fuseAll([impeller, ring], { unsafe: true }));
+};
+```
+
+## Notes
+
+- **Span direction sets the fan type.** Extruding the section **radially** (`sketchOnPlane('YZ', [R_HUB,0,0])`
+  → +X) gives an **axial** fan / propeller (blades reach out to a shroud). Extruding **up the axis** (+Z)
+  gives the barber-pole of fins that reads wrong — that's the common mistake.
+- **Camber is what makes it an airfoil.** Drop the camber (set both sagittas to ±THICK/2) and you get a
+  flat twisted plate again. Keep `CAMBER` ≈ 15–25 % of `CHORD`.
+- **Pitch twist:** ~25–45° root→tip for a fan/prop. More twist = more aggressive blade.
+- The result is a multi-body `Compound` (`ok:true`, valid) — fine, per the booleans rule; don't chase a
+  single `Solid` unless something downstream needs one.
+- For a **centrifugal** impeller instead, sweep the cambered sections backward in the XY plane and stack
+  them; for **turbine/stator vanes**, the same section + radial extrude with little or no twist.


### PR DESCRIPTION
## What

Closes the **airfoil-quality residual** the flywheel surfaced. The "Realize the designed object" discipline (#1563) got authors to *apply* `twistAngle`, but a twist on a flat paddle still reads as thin fins — this is a feature that needs a **recipe**, not just a nudge.

Adds `references/airfoils.md` with a **verified** recipe for swept blades (fans, props, impellers, vanes):
- a **cambered** airfoil section (two `sagittaArcTo` arcs → a thin crescent, not a flat strip),
- sketched **perpendicular to the span** and extruded **radially** (`sketchOnPlane('YZ', [R_HUB,0,0])` → +X),
- with a **pitch twist** along the span.

It names the two real mistakes (flat-rectangle section; extruding *up the axis* instead of radially). Wired into the reference index + the twisted-impeller cue in the designed-object section.

## Before / after

| | result |
|---|---|
| before (twist on flat paddle) | thin warped fins — judged `partial` |
| after (airfoils.md recipe) | broad cambered pitched blades radiating to the shroud — a real axial impeller |

## Verification (end to end, visual — not self-report)

1. The recipe **builds `ok:true` verbatim** (extracted from the markdown, before and after prettier).
2. A **clean-room author** given only the brief + `airfoils.md` produced a convincing swept impeller **first try** — confirmed by **rendering it** (the flat-fin author had *also* claimed `builtToSpec:true`, which is exactly why the verification is visual).

Markdown-only (new reference + two SKILL.md pointers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)