### PR TITLE
fix(kernel): forward angularTolerance to brepkit meshEdges

### DIFF
--- a/src/kernel/brepkit/brepkitWasmTypes.ts
+++ b/src/kernel/brepkit/brepkitWasmTypes.ts
@@ -567,9 +567,13 @@ export interface BrepkitKernel {
   tessellateEdge(edge: number, numPoints: number): Float64Array;
 
   /** @unwired */
-  meshEdges(solid: number, deflection: number): BrepkitEdgeLines;
+  meshEdges(solid: number, deflection: number, angularTolerance?: number | null): BrepkitEdgeLines;
 
-  meshEdgesAll(solid: number, deflection: number): BrepkitEdgeLines;
+  meshEdgesAll(
+    solid: number,
+    deflection: number,
+    angularTolerance?: number | null
+  ): BrepkitEdgeLines;
 
   meshBoolean(
     positionsA: Float64Array | number[],

--- a/src/kernel/brepkit/meshOps.ts
+++ b/src/kernel/brepkit/meshOps.ts
@@ -11,7 +11,7 @@ import type {
   MeshOptions,
 } from '@/kernel/types.js';
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
-import { type BrepkitHandle, unwrap, toArray, warnOnce, DEFAULT_DEFLECTION } from './helpers.js';
+import { type BrepkitHandle, unwrap, toArray, DEFAULT_DEFLECTION } from './helpers.js';
 import { wasmIndex } from '@/utils/vec3.js';
 
 export function mesh(
@@ -48,20 +48,18 @@ export function meshEdges(
   tolerance: number,
   angularTolerance: number
 ): KernelEdgeMeshResult {
-  if (angularTolerance > 0) {
-    warnOnce(
-      'mesh-edges-angular',
-      'meshEdges angularTolerance is not supported; only linear deflection is used.'
-    );
-  }
   const bkHandle = shape as BrepkitHandle;
 
   if (bkHandle.type !== 'solid') {
     return { lines: new Float32Array(0), edgeGroups: [] };
   }
 
+  // Forward the angular tolerance like the face/solid tessellation paths do; a
+  // non-positive value means "unspecified" → the kernel's default angular cap.
+  const angularTol = angularTolerance > 0 ? angularTolerance : undefined;
+
   // Use meshEdgesAll (unfiltered) for OCCT parity
-  const edgeLines = bk.meshEdgesAll(bkHandle.id, tolerance);
+  const edgeLines = bk.meshEdgesAll(bkHandle.id, tolerance, angularTol);
   const positions = edgeLines.positions;
   const offsets = edgeLines.offsets;
   const edgeCount = edgeLines.edgeCount;

--- a/src/kernel/interfaces/meshOps.ts
+++ b/src/kernel/interfaces/meshOps.ts
@@ -16,10 +16,8 @@ export interface KernelMeshOps {
   mesh(shape: KernelShape, options: MeshOptions): KernelMeshResult;
 
   /**
-   * Tessellate edges for wireframe display.
-   *
-   * **Cross-kernel note**: brepkit only supports linear deflection;
-   * `angularTolerance` is ignored (a one-time warning is emitted).
+   * Tessellate edges for wireframe display. Both linear `tolerance`
+   * (deflection) and `angularTolerance` are honored across kernels.
    */
   meshEdges(shape: KernelShape, tolerance: number, angularTolerance: number): KernelEdgeMeshResult;
 


### PR DESCRIPTION
## Summary

The brepkit adapter's `meshEdges` silently dropped the caller's `angularTolerance` — it emitted a "not supported" warning and called `meshEdgesAll(solid, deflection)` with the linear tolerance only. So curved feature edges (circle rims, ellipse/NURBS) always discretized at the kernel's fixed default angular cap, regardless of the requested angular tolerance. The sibling `mesh()` path (face/solid tessellation) already forwards `angularTolerance`; only the edge path didn't.

## Changes

- `src/kernel/brepkit/meshOps.ts` — `meshEdges` now forwards `angularTolerance` to `meshEdgesAll`, mirroring `mesh()`: a non-positive value passes `undefined` → the kernel's default cap. Removed the obsolete `warnOnce("not supported")` (and its now-unused import).
- `src/kernel/brepkit/brepkitWasmTypes.ts` — widened the `meshEdges` / `meshEdgesAll` signatures to accept the optional `angularTolerance?: number | null`, matching the `tessellate*` methods.

## Compatibility

Pairs with **brepkit#953**, which adds the `angular_tolerance` parameter to the WASM `meshEdges`/`meshEdgesAll` bindings. Against an older brepkit-wasm (2-arg) the extra argument is harmlessly ignored by the wasm-bindgen shim, so this is safe to land before/after the kernel publishes — it just becomes effective once a brepkit-wasm with #953 is in use.

## Verification

- `tsc --noEmit` clean; `eslint` clean on both files.
- `tests/brepkitAdapter.test.ts` passes. The 7 failures in `tests/meshFns.test.ts` are confined to the `|manifold|` project (exportSTEP/STL FS mocks, box meshing) and reproduce identically on `origin/main` without this change — pre-existing/environmental, unrelated to the brepkit edge path.

## Downstream

Once this lands and a brepkit-wasm with #953 is picked up, the Gridfinity Layout Tool's draft previews (which already pass `edgeAngular` into `meshEdges`) will get angular-refined brepkit edges, closing the curved-edge smoothness gap vs OCCT.
