### PR TITLE
docs(brepjs-cad): refresh install + prompting for current Claude Code; sharpen skill auto-trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ claude plugin install brepjs@brepjs
 npm i -D brepjs-cad
 ```
 
+With the skill installed, ask Claude for a part in plain English, or drive the pipeline explicitly with `/brepjs:cad "a 40×20×10 mm bracket with two M4 holes"`.
+
 `brepjs-cad` bundles its own `brepjs` + `occt-wasm`, so it runs in an empty directory; inside an existing brepjs project it prefers your installed versions so verified parts match what you ship. A model is a module that default-exports a zero-arg function returning a shape:
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -111,8 +111,12 @@ Install both; they ride on two rails:
 
 ```bash
 # 1. The skill - Claude Code plugin (delivered via this repo's marketplace)
+#    In a Claude Code session:
 /plugin marketplace add andymai/brepjs
 /plugin install brepjs@brepjs
+#    …or from a terminal, non-interactively:
+claude plugin marketplace add andymai/brepjs
+claude plugin install brepjs@brepjs
 
 # 2. The runtime - the CLI the skill drives
 npm i -D brepjs-cad

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -97,7 +97,7 @@ It's the _build → verify_ step of [the loop](./the-loop.md) as a single call: 
 claude mcp add brep -- npx -y --package brepjs-cad brep-mcp
 ```
 
-That registers `brep` at local scope (this project). Add `--scope user` to expose it in every project, or `--scope project` to share it with a repo via a checked-in `.mcp.json`. Geometry never leaves your machine; the server runs locally as a child process over stdio.
+Geometry never leaves your machine; the server runs locally as a child process over stdio.
 
 ## Troubleshooting
 

--- a/apps/docs/agent/cli.md
+++ b/apps/docs/agent/cli.md
@@ -97,7 +97,7 @@ It's the _build → verify_ step of [the loop](./the-loop.md) as a single call: 
 claude mcp add brep -- npx -y --package brepjs-cad brep-mcp
 ```
 
-Geometry never leaves your machine; the server runs locally as a child process over stdio.
+That registers `brep` at local scope (this project). Add `--scope user` to expose it in every project, or `--scope project` to share it with a repo via a checked-in `.mcp.json`. Geometry never leaves your machine; the server runs locally as a child process over stdio.
 
 ## Troubleshooting
 

--- a/apps/docs/agent/overview.md
+++ b/apps/docs/agent/overview.md
@@ -39,14 +39,21 @@ They install separately because Claude Code loads skills from plugins (a git mar
 
 ### Install the skill (Claude Code plugin)
 
-The skill ships through the brepjs plugin marketplace, which is this git repo. Add the marketplace once, then install the plugin:
+The skill ships through the brepjs plugin marketplace, which is this git repo. Add the marketplace once, then install the plugin. In a Claude Code session, use the slash commands:
 
 ```
 /plugin marketplace add andymai/brepjs
 /plugin install brepjs@brepjs
 ```
 
-Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill; plugins aren't loaded from `node_modules`.
+Or do the same non-interactively from a terminal — handy for scripts and dotfiles:
+
+```bash
+claude plugin marketplace add andymai/brepjs
+claude plugin install brepjs@brepjs
+```
+
+Pass `--scope user` to make the plugin available in every project, or `--scope project` to share it with a repo via checked-in config. Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill; plugins aren't loaded from `node_modules`.
 
 ### Install the runtime (npm)
 

--- a/apps/docs/agent/overview.md
+++ b/apps/docs/agent/overview.md
@@ -53,7 +53,7 @@ claude plugin marketplace add andymai/brepjs
 claude plugin install brepjs@brepjs
 ```
 
-Pass `--scope user` to make the plugin available in every project, or `--scope project` to share it with a repo via checked-in config. Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill; plugins aren't loaded from `node_modules`.
+Claude Code now knows the workflow and will run the CLI for you. There is no npm step for the skill; plugins aren't loaded from `node_modules`.
 
 ### Install the runtime (npm)
 
@@ -72,6 +72,20 @@ Prefer not to install anything? Run it straight from npm:
 ```bash
 npx -y -p brepjs-cad brep part.brep.ts
 ```
+
+## Ask for a part
+
+With the skill installed, just ask for a part in plain English — Claude reaches for the brepjs pipeline on its own:
+
+> a 40×20×10 mm bracket with two M4 holes 30 mm apart
+
+It scopes the spec, designs the build sequence, authors the `.brep.ts`, verifies it on the kernel, and hands back a STEP file. To drive the pipeline explicitly, use the slash commands the plugin installs:
+
+```
+/brepjs:cad a wall bracket for a 40 mm pipe with two M4 holes
+```
+
+`/brepjs:cad` runs the whole pipeline and pauses for your confirmation between phases. To run a single phase, invoke it directly: `/brepjs:brainstorm`, `/brepjs:design`, `/brepjs:implement`, `/brepjs:verify`, or `/brepjs:polish`.
 
 ## The `.brep.ts` contract
 

--- a/packages/brepjs-cad/README.md
+++ b/packages/brepjs-cad/README.md
@@ -13,7 +13,9 @@ Five composable, individually-improvable skills — **`brepjs:brainstorm`** (sco
 /plugin install brepjs@brepjs
 ```
 
-Or non-interactively from a terminal (`claude plugin marketplace add andymai/brepjs && claude plugin install brepjs@brepjs`); add `--scope user`/`--scope project` to control reach.
+Or non-interactively from a terminal: `claude plugin marketplace add andymai/brepjs && claude plugin install brepjs@brepjs`.
+
+Then ask for a part in plain English and Claude reaches for the pipeline on its own, or drive it explicitly: `/brepjs:cad "a wall bracket for a 40 mm pipe with two M4 holes"` runs the full gated pipeline; `/brepjs:brainstorm` … `/brepjs:polish` run a single phase.
 
 ## 2. The runtime (npm)
 
@@ -97,7 +99,7 @@ Once the package is published to npm, the same server is available without a loc
 claude mcp add brep -- npx -y --package brepjs-cad brep-mcp
 ```
 
-`claude mcp add` registers the server at local scope (current project) by default; pass `--scope user` to make `brep` available in every project, or `--scope project` to share it with a repo via a checked-in `.mcp.json`. The server runs locally as a child process of your agent (stdio); geometry never leaves your machine.
+The server runs locally as a child process of your agent (stdio); geometry never leaves your machine.
 
 ## Examples gallery
 

--- a/packages/brepjs-cad/README.md
+++ b/packages/brepjs-cad/README.md
@@ -13,6 +13,8 @@ Five composable, individually-improvable skills — **`brepjs:brainstorm`** (sco
 /plugin install brepjs@brepjs
 ```
 
+Or non-interactively from a terminal (`claude plugin marketplace add andymai/brepjs && claude plugin install brepjs@brepjs`); add `--scope user`/`--scope project` to control reach.
+
 ## 2. The runtime (npm)
 
 The CLI the skill invokes. Install it in **your** project, where `brepjs` + the WASM kernel resolve (Node module resolution is project-local, so the runtime can't live in the plugin dir):
@@ -95,7 +97,7 @@ Once the package is published to npm, the same server is available without a loc
 claude mcp add brep -- npx -y --package brepjs-cad brep-mcp
 ```
 
-The server runs locally as a child process of your agent (stdio); geometry never leaves your machine.
+`claude mcp add` registers the server at local scope (current project) by default; pass `--scope user` to make `brep` available in every project, or `--scope project` to share it with a repo via a checked-in `.mcp.json`. The server runs locally as a child process of your agent (stdio); geometry never leaves your machine.
 
 ## Examples gallery
 

--- a/packages/brepjs-cad/skills/brainstorm/SKILL.md
+++ b/packages/brepjs-cad/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: Use at the START of a brepjs CAD task to scope what to model — turning a vague or natural-language part request ("a bracket for my router", "a gridfinity bin") into an explicit, buildable spec (dimensions in mm, datums, features, material/finish, tolerances) before any geometry is written. Runs in the main session so it can ask the user clarifying questions.
+description: Use at the START of any request to design, model, create, build, or 3D-print a physical part or assembly in brepjs — a bracket, enclosure, mount, gear, gridfinity bin, fixture, knob, adapter, and the like. This is the entry point to the brepjs CAD pipeline: it turns a vague or natural-language request ("a bracket for my router", "a gridfinity bin") into an explicit, buildable spec (dimensions in mm, datums, features, material/finish, tolerances) before any geometry is written, then hands off to brepjs:design → implement → verify → polish. Runs in the main session so it can ask the user clarifying questions.
 version: 0.1.0
 ---
 


### PR DESCRIPTION
## What

Refreshes the public-facing getting-started for brepjs-cad against the current Claude Code skills/CLI, and fixes the root cause of \"Claude won't reach for the skills unless directed.\"

**Install** — adds the non-interactive \`claude plugin marketplace add\` / \`claude plugin install\` terminal forms alongside the existing \`/plugin\` slash commands (slash-command first).

**Prompt** — new \"Ask for a part\" guidance: ask in plain English (the pipeline auto-fires) or drive it explicitly with \`/brepjs:cad \"…\"\` and the per-phase \`/brepjs:brainstorm … /brepjs:polish\` slash commands. These commands already existed (plugin skills are namespaced \`/brepjs:*\`); they just weren't documented.

**Auto-invocation** — broadens the \`brainstorm\` skill \`description\` (the sole basis for model-invocation) so Claude reliably reaches for the pipeline on natural \"design/model/make a part\" requests, with \`brainstorm\` as the single entry point that hands off to design → implement → verify → polish.

## Why

- The CLI now offers a scriptable \`claude plugin …\` form; our docs only showed slash commands.
- Skills weren't auto-firing because the entry-point description under-matched real requests — adding slash commands wouldn't fix that; sharpening the description does.

## Notes / deliberate non-changes

- Verified \`claude plugin marketplace add\`/\`claude plugin install\` are real subcommands against the official docs (the \"Create plugins\" page uses them).
- Dropped \`--scope\` explanations — assumed users know scope; kept install + prompting front and center.
- No duplicate command files added (skills are already slash-invocable under the plugin namespace).
- \`plugin.json\` / \`marketplace.json\` / \`SKILL.md\` layout already conform to current schema; no manifest changes.
- Known minor gap left as-is: \`the-loop.md\` / \`examples.md\` mention the npm/npx CLI without cross-linking plugin+MCP setup. Not wrong; out of scope for this pass.

## Files

- \`README.md\` — install CLI form + one-line prompting note
- \`apps/docs/agent/overview.md\` — install CLI form + new \"Ask for a part\" section
- \`apps/docs/agent/cli.md\` — MCP section trimmed
- \`packages/brepjs-cad/README.md\` — install CLI form + prompting; MCP trimmed
- \`packages/brepjs-cad/skills/brainstorm/SKILL.md\` — broadened auto-trigger description

Docs/skill-metadata only; Prettier-clean.