### PR TITLE
docs(landing): prompt-first agent hero terminal

### DIFF
--- a/apps/docs/.vitepress/theme/components/Landing.vue
+++ b/apps/docs/.vitepress/theme/components/Landing.vue
@@ -231,12 +231,11 @@ onBeforeUnmount(() => observer?.disconnect());
               </div>
               <pre
                 class="term"
-              ><code><span class="p">$</span> <span class="c">/plugin marketplace add</span> andymai/brepjs
-<span class="p">$</span> <span class="c">/plugin install</span> brepjs@brepjs
-<span class="p">$</span> <span class="c">npm i -D</span> brepjs-cad brepjs occt-wasm
+              ><code><span class="p">$</span> <span class="c">/plugin install</span> brepjs@brepjs   <span class="cm"># the skill</span>
+<span class="p">$</span> <span class="c">npm i -D</span> brepjs-cad             <span class="cm"># the runtime</span>
 
-<span class="p">$</span> brep <span class="kk">verify</span> bin.ts
-<span class="p">›</span> running on occt-wasm kernel…
+<span class="p">&gt;</span> <span class="c">/brepjs:cad</span> a 1×1 gridfinity bin
+<span class="p">›</span> brainstorm → design → implement → verify
 <span class="ok">✓ valid Solid</span> · vol 14 043.4 mm³ · 91 faces
 <span class="ok">✓ assertions 3/3</span> · wrote bin.step</code></pre>
             </div>
@@ -983,6 +982,9 @@ pre.term {
 }
 .term .c {
   color: var(--teal-200);
+}
+.term .cm {
+  color: var(--ink-2);
 }
 
 /* AI section */


### PR DESCRIPTION
## What

Reworks the homepage's \"CAD an agent can prove\" terminal (in \`Landing.vue\`) to be **prompt-first**: it now leads with the actual prompt a user types — \`/brepjs:cad a 1×1 gridfinity bin\` — and the \`brainstorm → design → implement → verify\` flow, instead of jumping straight to a manual \`brep verify\`.

## Why

The section is headlined \"CAD an agent can prove\" / \"Point your agent at a spec,\" but the old terminal never showed the prompt step — it went install → \`brep verify bin.ts\`. After we made \"how to prompt\" the centerpiece of the agent docs, the homepage was the last place telling a CLI-only story.

## Correctness

- **Truthful prompt.** The rendered part + report numbers (\`14043.4 mm³\`, \`bounds 41.7×41.7×30.5\`, \`91 faces\`) are baked by \`scripts/genLandingImages.ts\`, which builds a **1×1 gridfinity bin with no magnet holes**. The prompt now says exactly that (my first draft wrongly said \"2×1, magnet holes\"). Report panel + snapshots are unchanged.
- **Tested prompt.** Ran \"a 1×1 gridfinity bin\" through the implement+verify loop on the real occt-wasm kernel: \`ok:true\` first try, valid manifold solid, sensible measurements. It's a reliably-good headline prompt, not an aspirational one.
- **Visually verified.** Headless-rendered the dev server and confirmed the terminal: teal commands, aligned muted comments, green \`✓\` lines, \`×\` glyph correct. Added a \`.term .cm\` rule (the existing \`.cm\` style is scoped to \`.code\`, not \`.term\`).

Docs/marketing-visual only; Prettier-clean.