### PR TITLE
fix(brepjs-cad): bore detector misses full-cylinder through-holes (#1551)

### DIFF
--- a/packages/brepjs-cad/src/verify/manufacturability.ts
+++ b/packages/brepjs-cad/src/verify/manufacturability.ts
@@ -185,7 +185,7 @@ function computeCylinderFeatures(
       const p = pointOnSurface(f, 0.5, 0.5);
       const rel = v3sub(p, o);
       const radial = v3unit(v3sub(rel, v3scale(d, v3dot(rel, d))));
-      const n = v3unit(normalAt(f));
+      const n = v3unit(normalAt(f, p));
       if (v3dot(n, radial) < -BORE_DOT) {
         bores.push({ radius, axisOrigin: [o[0], o[1], o[2]], axisDir: [d[0], d[1], d[2]] });
       }

--- a/packages/brepjs-cad/src/verify/manufacturability.ts
+++ b/packages/brepjs-cad/src/verify/manufacturability.ts
@@ -27,8 +27,9 @@ const VOL_EPS = 1e-9;
 // A cylindrical face counts as a real bore/shaft (not a fillet strip) only above this angular extent
 // (radians): a drilled bore sweeps ~2π, a corner/edge fillet only ~π/2. Empirically separates them.
 const SUBSTANTIAL_USPAN = 2.5;
-// Outward-material-normal · radial > this ⇒ the cylinder is concave (an internal bore). Boss/shaft
-// faces give ≈ -1, bores ≈ +1, so 0.5 is a safe split. Determined empirically against the kernel.
+// Outward-material-normal · radial < -this ⇒ the wall faces the axis (an internal bore). A
+// boss/shaft wall faces away (≈ +1), a bore wall faces in (≈ -1), so 0.5 is a safe split.
+// occt-wasm's surfaceNormal is already orientation-aware, so no manual face-orientation flip.
 const BORE_DOT = 0.5;
 
 type V3 = readonly [number, number, number];
@@ -135,9 +136,8 @@ function computeCylinderFeatures(
   const {
     getFaces,
     faceGeomType,
-    faceCenter,
+    pointOnSurface,
     normalAt,
-    faceOrientation,
     faceAxis,
     measureCurvatureAtMid,
     uvBounds,
@@ -175,16 +175,18 @@ function computeCylinderFeatures(
       continue;
     }
     minRadius = minRadius === undefined ? radius : Math.min(minRadius, radius);
-    // Internal (bore) test: the outward material normal at the wall points away from the axis.
+    // Internal (bore) test: the outward material normal at the wall points toward the axis.
+    // Sample the radial at a uv-mid wall point, not the face centroid — for a full cylinder the
+    // centroid sits ON the axis, where the radial is degenerate and its sign is numerically
+    // random (the recall bug from #1551). normalAt is already orientation-aware on occt-wasm.
     try {
-      const p = faceCenter(f);
       const o = ax.origin;
       const d = v3unit(ax.direction);
+      const p = pointOnSurface(f, 0.5, 0.5);
       const rel = v3sub(p, o);
       const radial = v3unit(v3sub(rel, v3scale(d, v3dot(rel, d))));
-      const n = normalAt(f);
-      const out = faceOrientation(f) === 'forward' ? n : v3scale(n, -1);
-      if (v3dot(v3unit(out), radial) > BORE_DOT) {
+      const n = v3unit(normalAt(f));
+      if (v3dot(n, radial) < -BORE_DOT) {
         bores.push({ radius, axisOrigin: [o[0], o[1], o[2]], axisDir: [d[0], d[1], d[2]] });
       }
     } catch {

--- a/packages/brepjs-cad/tests/manufacturability.test.ts
+++ b/packages/brepjs-cad/tests/manufacturability.test.ts
@@ -76,6 +76,33 @@ describe('bore detection (--metrics)', () => {
     expect(m?.minRadius).toBeCloseTo(5, 1);
     expect(m?.bores).toBeUndefined();
   });
+
+  // Recall regression (#1551): the centroid-based radial was degenerate for a full cylinder
+  // (centroid on the axis) so the bore/shaft sign was random — these genuine through-holes
+  // were undercounted. The drilled-bracket playground example reported bores: 0.
+  it('detects the drilled-bracket through-hole even after a corner fillet', () => {
+    const drilled = unwrap(cut(box(30, 20, 10), cylinder(5, 15, { at: [15, 10, -2] })));
+    const part = unwrap(fillet(drilled, edgeFinder().inDirection('Z').findAll(drilled), 1.5));
+    const m = runChecks(brep, part, { metrics: true }).manufacturability;
+    expect(m?.bores?.length).toBe(1);
+    expect(m?.bores?.[0]?.radius).toBeCloseTo(5, 1);
+  });
+
+  it('detects all four corner mount holes (nema-stepper recall)', () => {
+    let plate: brep.AnyShape = box(40, 40, 8, { centered: true });
+    const corners: Array<[number, number]> = [
+      [15, 15],
+      [-15, 15],
+      [15, -15],
+      [-15, -15],
+    ];
+    for (const [x, y] of corners) {
+      plate = unwrap(cut(plate, cylinder(2, 12, { at: [x, y, -6] })));
+    }
+    const m = runChecks(brep, plate, { metrics: true }).manufacturability;
+    expect(m?.bores?.length).toBe(4);
+    expect(m?.minRadius).toBeCloseTo(2, 1);
+  });
 });
 
 describe('digestMetrics (pure)', () => {


### PR DESCRIPTION
Closes #1551.

## Root cause

Probing `drilled-bracket` (which reported `bores: 0`) against the passing test bore revealed **two compounding bugs** in `computeCylinderFeatures`'s internal-bore test — and that the `SUBSTANTIAL_USPAN` gate was *not* the culprit:

1. **Degenerate radial.** The radial direction was sampled from `faceCenter` (`surfaceCenterOfMass`). For a full 2π cylinder the centroid sits **on the axis**, so the radial vector is ≈ zero and `v3unit` of it returns an arbitrary direction. The bore/shaft dot then had a **random sign** — the passing test happened to land `+0.965`, `drilled-bracket` landed `-1.000`, and `nema-stepper` caught 2 of its 4 holes by luck.

2. **Double-counted orientation.** occt-wasm's `surfaceNormal` is already orientation-aware (a reversed bore face reports an inward normal — see `surfaceOps.ts:91-94`). The code's manual `faceOrientation` flip undid exactly that, cancelling the signal that separates a bore from a shaft.

### Probe evidence

| feature | old `boreDot` (centroid) | raw-normal · wall-radial |
|---|---|---|
| test bore (through-hole) | +0.965 | **−1.000** ✓ bore |
| external shaft | −0.993 | **+1.000** ✓ not bore |
| drilled-bracket bore | −1.000 ✗ | **−1.000** ✓ bore |
| corner fillet strips | ±1 (excluded by uSpan) | excluded by uSpan |

## Fix

- Sample the radial at a uv-mid **wall point** (`pointOnSurface(f, 0.5, 0.5)`), which is always off-axis.
- Drop the `faceOrientation` flip; `normalAt` already gives the outward-material normal.
- New test: a bore's wall normal points toward the axis → `n · radial < -BORE_DOT`.

The conservative `SUBSTANTIAL_USPAN` gate is untouched, so fillet strips remain excluded — no new false positives.

## Tests

Adds recall regressions (RED before, GREEN after):
- the `drilled-bracket` through-hole, asserted **after** the corner fillet
- a four-corner mount-hole plate (nema-stepper shape) → expects all 4 bores

All 15 `manufacturability.test.ts` tests pass; package typecheck + lint clean.