### PR TITLE
ci(tech-debt): regenerate pattern baseline and enforce check:patterns in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup
       - run: npm run check:boundaries
+      - run: npm run check:patterns
       - run: npm run knip
 
   build:

--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated": "2026-05-25T16:47:45.082Z",
+  "generated": "2026-06-23T07:47:44.881Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -28,9 +28,104 @@
       "fingerprint": "src/kernel/geometry2d.ts|max-function-lines|numericalIntersect|#0"
     },
     {
-      "file": "src/kernel/occt/hullOps.ts",
+      "file": "src/kernel/manifold/booleanOps.ts",
       "rule": "max-function-lines",
-      "fingerprint": "src/kernel/occt/hullOps.ts|max-function-lines|quickHull|#0"
+      "fingerprint": "src/kernel/manifold/booleanOps.ts|max-function-lines|makeBooleanOps|#0"
+    },
+    {
+      "file": "src/kernel/manifold/builderOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/builderOps.ts|max-function-lines|makeBuilderOps|#0"
+    },
+    {
+      "file": "src/kernel/manifold/ioOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/ioOps.ts|max-function-lines|exportGLB|#0"
+    },
+    {
+      "file": "src/kernel/manifold/ioOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/ioOps.ts|max-function-lines|parseGLB|#0"
+    },
+    {
+      "file": "src/kernel/manifold/ioOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/ioOps.ts|max-function-lines|makeIoOps|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|g as unknown as Affine|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|base as unknown as Affine|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|bb as unknown as { min: Vec2; max: Vec2 }|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|bb as unknown as { min: Vec2; max: Vec2 }|#1"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|t as unknown as { min: Vec2; max: Vec2 }|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|o as unknown as { min: Vec2; max: Vec2 }|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|a as unknown as { min: Vec2; max: Vec2 }|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|b as unknown as { min: Vec2; max: Vec2 }|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|no-double-cast|bb as unknown as { min: Vec2; max: Vec2 }|#2"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dNative.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/kernel2dNative.ts|max-function-lines|makeNativeKernel2DOps|#0"
+    },
+    {
+      "file": "src/kernel/manifold/kernel2dOps.ts",
+      "rule": "no-double-cast",
+      "fingerprint": "src/kernel/manifold/kernel2dOps.ts|no-double-cast|occt as unknown as Record<keyof Kernel2DCapability, (...a: unknown[]) => unkn...|#0"
+    },
+    {
+      "file": "src/kernel/manifold/nativeEdges.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/nativeEdges.ts|max-function-lines|extractEdges|#0"
+    },
+    {
+      "file": "src/kernel/manifold/nativeFaces.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/nativeFaces.ts|max-function-lines|extractFaces|#0"
+    },
+    {
+      "file": "src/kernel/manifold/profileOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/profileOps.ts|max-function-lines|makeProfileBuilders|#0"
+    },
+    {
+      "file": "src/kernel/manifold/sweepOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/manifold/sweepOps.ts|max-function-lines|sweepFamilyEntries|#0"
     },
     {
       "file": "src/operations/straightSkeleton.ts",


### PR DESCRIPTION
## Problem

`.pattern-baseline.json` was generated **2026-05-25**, before `src/kernel/manifold/` landed (2026-06-04). `npm run check:patterns` reported **20 drifted violations** (10 `no-double-cast`, 10 `max-function-lines`) across 9 manifold files and exited 1 — but `check:patterns` only ran in `lint-staged` on *staged* files, so this main-branch drift never failed CI. It only blocked the next contributor who happened to stage a manifold file.

The 10 double-casts are the **sanctioned WASM-gap form** (e.g. `kernel2dNative.ts:450 g as unknown as Affine`) the baseline mechanism exists to record.

## Change

1. Regenerate `.pattern-baseline.json` via `npm run check:patterns:baseline`. Net diff = main (10 entries) **+ 20 manifold entries − 1 stale entry = 29**.
   - **Added (20):** all under `src/kernel/manifold/`.
   - **Removed (1):** the stale `src/kernel/occt/hullOps.ts|max-function-lines|quickHull` entry. `quickHull` was relocated to `src/kernel/hullGeometry.ts` at an earlier point, so the file-scoped entry no longer matched any function in `hullOps.ts`. In its new home it carries an explicit inline exemption (`hullGeometry.ts:208 // brepjs-patterns-disable: max-function-lines`), so dropping the stale entry leaves **no uncovered violation** — `check:patterns` stays clean.
2. Add `npm run check:patterns` to the CI `quality` job (next to `check:boundaries`/`knip`) so full-tree baseline drift becomes a hard gate going forward.

## Risk

Regenerating locks in current manifold violations as known debt — reviewed the full diff to confirm scope (20 manifold additions + 1 stale removal, nothing else). The 14 `max-function-lines` entries remain real future-paydown candidates. No runtime behavior changes — baseline + CI config only.

## Acceptance

- [x] `npm run check:patterns` exits 0
- [x] Baseline diff = 20 manifold additions + 1 stale `quickHull` removal (relocated fn, covered by inline disable), nothing else
- [x] `npm run validate` passes
- [x] No behavioral change; coverage unaffected (no source delta)