### PR TITLE
test(tech-debt): re-enable stale-RC-skipped tests passing on occt-wasm 3.4.0

### DIFF
--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -365,6 +365,14 @@ export const divergences: DivergenceMap = {
 
   occt: {
     // -----------------------------------------------------------------------
+    // importFns.test.ts / kernel-ops.test.ts
+    // -----------------------------------------------------------------------
+    'importFns.stlImport': {
+      kind: 'not-implemented',
+      reason:
+        'occt (OpenCascade.js) StlAPI_Reader.Read returns no shape, so importSTL yields Err; occt-wasm 3.4.0 and brepkit import STL correctly',
+    },
+    // -----------------------------------------------------------------------
     // brepkit-only suites (descBk pattern)
     // -----------------------------------------------------------------------
     brepkitSketchArc: {

--- a/tests/importFns.test.ts
+++ b/tests/importFns.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { skipIfDiverges } from './helpers/kernelDivergences.js';
 import {
   box,
   castShape,
@@ -57,8 +58,8 @@ describe('importSTEP', () => {
 });
 
 describe('importSTL', () => {
-  // OCCT V8 RC4: StlAPI_Reader.Read throws internally — revisit when V8.0.0 final ships
-  it.skip('imports an STL file exported from a box', async () => {
+  it('imports an STL file exported from a box', async (ctx) => {
+    skipIfDiverges(ctx, 'importFns.stlImport');
     const b = castShape(box(10, 10, 10).wrapped);
     const stlBlob = unwrap(exportSTL(b));
 
@@ -80,8 +81,8 @@ describe('importSTL', () => {
     expect(isErr(result)).toBe(true);
   });
 
-  // OCCT V8 RC4: StlAPI_Reader.Read throws internally — revisit when V8.0.0 final ships
-  it.skip('imports ASCII STL format (closed tetrahedron)', async () => {
+  it('imports ASCII STL format (closed tetrahedron)', async (ctx) => {
+    skipIfDiverges(ctx, 'importFns.stlImport');
     // A valid closed tetrahedron with 4 triangular facets
     const asciiStl = [
       'solid tetra',

--- a/tests/kernel-ops.test.ts
+++ b/tests/kernel-ops.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { skipIfDiverges } from './helpers/kernelDivergences.js';
 import { getKernel } from '@/kernel/index.js';
 import type { KernelAdapter } from '@/kernel/types.js';
 import {
@@ -392,8 +393,8 @@ describe('ioOps', () => {
     expect((stl as ArrayBuffer).byteLength).toBeGreaterThan(80);
   });
 
-  // OCCT V8 RC4: StlAPI_Reader.Read throws internally — revisit when V8.0.0 final ships
-  it.skip('STL import', () => {
+  it('STL import', (ctx) => {
+    skipIfDiverges(ctx, 'importFns.stlImport');
     const b = oc(box(10, 10, 10));
     kernel.mesh(b, { tolerance: 0.1, angularTolerance: 0.5 });
     const stl = kernel.exportSTL(b, false);

--- a/tests/modifierFns.test.ts
+++ b/tests/modifierFns.test.ts
@@ -191,8 +191,7 @@ describe('offset', () => {
 });
 
 describe('fillet with array radius', () => {
-  // OCCT V8 RC4: variable radius fillet crashes with memory access out of bounds
-  it.skip('fillets a specific edge with variable radius [r1, r2]', (ctx) => {
+  it('fillets a specific edge with variable radius [r1, r2]', (ctx) => {
     skipIfDiverges(ctx, 'modifierFns.variableFilletRadius');
     const b = box(10, 10, 10);
     const edges = getEdges(b);
@@ -231,8 +230,7 @@ describe('fillet with callback returning null or array', () => {
     expect(unwrapErr(result).code).toBe('FILLET_NO_EDGES');
   });
 
-  // OCCT V8 RC4: variable radius fillet crashes with memory access out of bounds
-  it.skip('callback returning [r1, r2] applies variable fillet', (ctx) => {
+  it('callback returning [r1, r2] applies variable fillet', (ctx) => {
     skipIfDiverges(ctx, 'modifierFns.variableFilletCallback');
     const b = box(10, 10, 10);
     const edges = getEdges(b);

--- a/tests/multiSweepFns.test.ts
+++ b/tests/multiSweepFns.test.ts
@@ -39,7 +39,8 @@ describe.skipIf(shouldSkipSuite('multiSweepFns'))('OCCT-specific: multiSweepFns'
   });
 
   describe('multiSectionSweep', () => {
-    // OCCT V8 RC4: ThruSections produces zero-volume solid — revisit when V8.0.0 final ships
+    // ThruSections still produces a zero-volume solid under the occt kernel
+    // (verified on occt-wasm 3.4.0); re-enable once the kernel builds a closed solid.
     it.skip('sweeps two circles along a straight line producing a solid with positive volume', () => {
       const spine = makeLineSpine(50);
       const circle1 = makeCircleWire(10);

--- a/tests/topology.test.ts
+++ b/tests/topology.test.ts
@@ -371,8 +371,7 @@ describe('fillet', () => {
     const zEdges = edgeFinder().inDirection('Z').findAll(b);
     expect(unwrap(fillet(b, zEdges, 1))).toBeDefined();
   });
-  // OCCT V8 RC4: variable radius fillet crashes with memory access out of bounds
-  it.skip('[r1,r2]', () => {
+  it('[r1,r2]', () => {
     const b = box(10, 10, 10);
     const zEdges = edgeFinder().inDirection('Z').findAll(b);
     expect(unwrap(fillet(b, zEdges, [1, 2]))).toBeDefined();

--- a/tests/variableFillet.test.ts
+++ b/tests/variableFillet.test.ts
@@ -55,7 +55,10 @@ describe.skipIf(shouldSkipSuite('variableFillet'))(
         expect(Math.abs(constVol - varVol)).toBeGreaterThan(0.01);
       });
 
-      // V8 RC4 regression: memory access out of bounds in variable radius fillet
+      // occt-wasm invokes the variable-radius callback once per fillet operation,
+      // not once per edge, so callCount is 1 (not 2) here. The fillet itself
+      // applies correctly (volume is reduced). Skipped pending a decision on the
+      // intended per-edge vs per-operation callback contract.
       it.skip('applies per-edge callback returning variable radius', () => {
         const b = box(10, 10, 10);
         const edges = getEdges(b);


### PR DESCRIPTION
## Problem

Several tests were `it.skip`'d with **'OCCT V8 RC4'** reasons that no longer hold — the installed kernel is `occt-wasm` **3.4.0** (a stable release past that RC). The skipped coverage was silently dead.

## What changed

**Re-enabled (verified passing):**
| Test | occt-wasm | brepkit | occt (legacy) |
|------|-----------|---------|---------------|
| STL import — `importFns` ×2, `kernel-ops` ×1 | ✅ pass | ✅ pass | ⛔ guarded |
| Array-form variable fillet `[r1,r2]` — `modifierFns`, `topology` | ✅ pass | (gated) | ✅ pass |
| Callback-form variable fillet — `modifierFns` | ✅ pass | (gated) | ✅ pass |

The legacy `occt` (OpenCascade.js) `StlAPI_Reader.Read` returns no shape, so STL import yields `Err` there. Rather than run unguarded, this registers a new `importFns.stlImport` divergence in the `occt` block and gates the three STL tests with `skipIfDiverges` — matching the established per-kernel divergence pattern.

**Kept skipped — these are *not* stale RC, the failure is real (verified on 3.4.0):**
- `multiSweep` ThruSections still produces a **zero-volume** solid under occt — comment corrected.
- `variableFillet` kernel-level callback: occt-wasm invokes the variable-radius callback **once per fillet operation, not once per edge** (so `callCount` is 1, not 2). The fillet itself applies correctly; this needs a decision on the per-edge vs per-operation callback contract before asserting. Comment corrected.

## Verification

All three kernels green on the affected files:
- occt-wasm: 216 passed, 7 skipped
- occt: 214 passed, 9 skipped
- brepkit: 207 passed, 16 skipped

`npm run validate` passes. Coverage only increases (tests added, none removed).

## Acceptance

- [x] Re-enabled tests pass on every kernel that supports the feature
- [x] Genuinely-failing tests stay skipped with accurate, verified reasons
- [x] `npm run validate` passes; no production change