### PR TITLE
refactor(tech-debt): consolidate KernelType alias + remove four misused `any` escapes

### DIFF
--- a/src/core/kernelBoundary.ts
+++ b/src/core/kernelBoundary.ts
@@ -7,9 +7,8 @@
  */
 
 import type { Vec3 } from './types.js';
+import type { KernelType } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel types
-type KernelType = any;
 
 // ---------------------------------------------------------------------------
 // Direct conversions (caller must delete)

--- a/src/io/dxfImportFns.ts
+++ b/src/io/dxfImportFns.ts
@@ -79,7 +79,9 @@ function getNum(data: Map<number, string>, code: number, fallback = 0): number {
   return isNaN(n) ? fallback : n;
 }
 
-function entityToEdge(entity: DXFEntity): KernelShape {
+// Returns `unknown` (not KernelShape) so callers must narrow: the fallthrough
+// path yields undefined for unsupported entity types.
+function entityToEdge(entity: DXFEntity): unknown {
   const { type, data } = entity;
   const kernel = getKernel();
 

--- a/src/io/dxfImportFns.ts
+++ b/src/io/dxfImportFns.ts
@@ -3,6 +3,7 @@
  */
 
 import { getKernel } from '@/kernel/index.js';
+import type { KernelShape } from '@/kernel/types.js';
 import type { Wire } from '@/core/shapeTypes.js';
 import { createWire } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
@@ -78,7 +79,7 @@ function getNum(data: Map<number, string>, code: number, fallback = 0): number {
   return isNaN(n) ? fallback : n;
 }
 
-function entityToEdge(entity: DXFEntity): unknown {
+function entityToEdge(entity: DXFEntity): KernelShape {
   const { type, data } = entity;
   const kernel = getKernel();
 
@@ -144,8 +145,7 @@ export async function importDXF(blob: Blob, options?: DXFImportOptions): Promise
     return ok([]);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel edge types
-  const edges: Array<any> = [];
+  const edges: KernelShape[] = [];
   try {
     for (const entity of entities) {
       const edge = entityToEdge(entity);

--- a/src/io/threemfExportFns.ts
+++ b/src/io/threemfExportFns.ts
@@ -47,8 +47,7 @@ for (let i = 0; i < 256; i++) {
 function crc32(data: Uint8Array): number {
   let crc = 0xffffffff;
   for (const byte of data) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- typed array access
-    crc = (crcTable[(crc ^ byte) & 0xff] as any) ^ (crc >>> 8);
+    crc = (crcTable[(crc ^ byte) & 0xff] ?? 0) ^ (crc >>> 8);
   }
   return (crc ^ 0xffffffff) >>> 0;
 }

--- a/src/operations/extrudeUtils.ts
+++ b/src/operations/extrudeUtils.ts
@@ -3,10 +3,8 @@
  * Used by both class-based (extrude.ts) and functional (extrudeFns.ts) APIs.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel types are dynamic
-type KernelType = any;
-
 import { getKernel } from '@/kernel/index.js';
+import type { KernelType } from '@/kernel/types.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { validationError } from '@/core/errors.js';
 

--- a/src/operations/sweepFns.ts
+++ b/src/operations/sweepFns.ts
@@ -5,11 +5,8 @@
  * Consolidated from extrudeFns, multiSweepFns, and guidedSweepFns.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel types are dynamic
-type KernelType = any;
-
 import { getKernel } from '@/kernel/index.js';
-import type { KernelShape } from '@/kernel/types.js';
+import type { KernelShape, KernelType } from '@/kernel/types.js';
 import type { Vec3 } from '@/core/types.js';
 import { vecAdd, vecLength } from '@/core/vecOps.js';
 import type { ClosedWire, Dimension, Wire, Shell, Solid, Shape3D } from '@/core/shapeTypes.js';

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -32,9 +32,6 @@ import {
 } from './metadata/metadataPropagation.js';
 import { makeFace } from './surfaceBuilders.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel types are dynamic
-type KernelType = any;
-
 // ---------------------------------------------------------------------------
 // Pre-validation
 // ---------------------------------------------------------------------------
@@ -50,7 +47,7 @@ function validateShape3D(shape: Shape3D, label: string): Result<undefined> {
 // Types
 // ---------------------------------------------------------------------------
 
-import type { BooleanOptions, BooleanDiagnostics } from '@/kernel/types.js';
+import type { BooleanOptions, BooleanDiagnostics, KernelType } from '@/kernel/types.js';
 import type { ValidSolid } from '@/core/validityTypes.js';
 export type { BooleanOptions };
 

--- a/src/topology/cast.ts
+++ b/src/topology/cast.ts
@@ -1,4 +1,4 @@
-import type { KernelShape, KernelType } from '@/kernel/types.js';
+import type { KernelShape, KernelType, ShapeType } from '@/kernel/types.js';
 import type { AnyShape, CompSolid, Dimension } from '@/core/shapeTypes.js';
 import { castShape } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
@@ -44,7 +44,7 @@ export const asTopo = (entity: TopoEntity): KernelType => {
  * @remarks Uses the kernel adapter's iterShapes rather than direct TopExp_Explorer.
  */
 // Static map: TopoEntity → ShapeType for kernel adapter
-const TOPO_TO_SHAPE_TYPE: Readonly<Record<string, string>> = {
+const TOPO_TO_SHAPE_TYPE: Readonly<Record<TopoEntity, ShapeType>> = {
   vertex: 'vertex',
   edge: 'edge',
   wire: 'wire',
@@ -60,12 +60,8 @@ export const iterTopo = function* iterTopo(
   shape: KernelShape,
   topo: TopoEntity
 ): IterableIterator<KernelShape> {
-  const shapeType = TOPO_TO_SHAPE_TYPE[topo];
-  if (shapeType) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ShapeType string mapping
-    const shapes = getKernel().iterShapes(shape, shapeType as any);
-    for (const s of shapes) yield s;
-  }
+  const shapes = getKernel().iterShapes(shape, TOPO_TO_SHAPE_TYPE[topo]);
+  for (const s of shapes) yield s;
 };
 
 /** Get the TopAbs_ShapeEnum type of an kernel shape, returning Err for null shapes. */

--- a/src/topology/evolutionFns.ts
+++ b/src/topology/evolutionFns.ts
@@ -13,12 +13,9 @@ import { castShape, isShape3D } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError, typeCastError, kernelError, BrepErrorCode } from '@/core/errors.js';
-import type { BooleanOptions, KernelShape, ShapeEvolution } from '@/kernel/types.js';
+import type { BooleanOptions, KernelShape, ShapeEvolution, KernelType } from '@/kernel/types.js';
 import { getEdges } from './shapeFns.js';
 import { collectInputFaceHashes, propagateAllMetadata } from './metadata/metadataPropagation.js';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel types are dynamic
-type KernelType = any;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/topology/surfaceBuilders.ts
+++ b/src/topology/surfaceBuilders.ts
@@ -140,10 +140,9 @@ export function makePolygon(points: Vec3[]): Result<OrientedFace & PlanarFace> {
       validationError('POLYGON_MIN_POINTS', 'You need at least 3 points to make a polygon')
     );
 
-  const edges = zip([points, [...points.slice(1), points[0]]]).map(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- zip returns untyped pairs
-    ([p1, p2]: any) => makeLine(p1, p2)
-  );
+  // points.length >= 3 is guaranteed above, so the wrap-around point is defined.
+  const closing = [...points.slice(1), points[0]] as Vec3[];
+  const edges = zip([points, closing] as [Vec3[], Vec3[]]).map(([p1, p2]) => makeLine(p1, p2));
   // Polygon edges always form a closed, coplanar loop — safe to narrow
   return andThen(assembleWire(edges), (wire) => makeFace(wire as ClosedWire & PlanarWire));
 }


### PR DESCRIPTION
## Problem

The sanctioned `any` escape `KernelType` (canonically `export type KernelType = any` in `src/kernel/types.ts:29`) was **redeclared in five other files**, scattering the escape hatch across six sites each with its own `eslint-disable`. Separately, four `as any` / `Array<any>` escapes had proper types available.

## Change (no behavioral change)

**KernelType consolidation** — delete the local `type KernelType = any` (+ its disable comment) in `booleanFns`, `evolutionFns`, `sweepFns`, `extrudeUtils`, `kernelBoundary`; import the canonical alias from `@/kernel/types.js` instead. The escape now lives in exactly one place.

**Four `any` escapes replaced with real types:**
| File | Before | After |
|------|--------|-------|
| `io/threemfExportFns.ts` | `crcTable[i] as any` | `crcTable[i] ?? 0` — `Uint32Array(256)`, index masked to `0xff` so always in-bounds; `?? 0` is unreachable but satisfies `noUncheckedIndexedAccess` |
| `topology/cast.ts` | `iterShapes(shape, shapeType as any)` | typed `TOPO_TO_SHAPE_TYPE` as `Record<TopoEntity, ShapeType>`; `iterShapes` now gets a real `ShapeType`. The lookup is total, so the now-dead `if (shapeType)` guard was removed (ESLint `no-unnecessary-condition`). |
| `topology/surfaceBuilders.ts` | `.map(([p1, p2]: any) => …)` | tuple-typed the `zip` input as `[Vec3[], Vec3[]]` so pairs destructure as `[Vec3, Vec3]` (no `undefined` from `noUncheckedIndexedAccess`) |
| `io/dxfImportFns.ts` | `entityToEdge(): unknown` + `edges: Array<any>` | `entityToEdge(): KernelShape` + `edges: KernelShape[]` (the canonical kernel-object alias, not raw `any`) |

## Verification

- `npm run typecheck`, `npm run lint`, `npm run check:boundaries`, `npm run check:patterns` all clean
- `npm run validate` passes (full changed-file test run green)
- Net: **−34 / +16 lines**, six `eslint-disable`/`any` sites removed, zero runtime behavior change

## Acceptance

- [x] Only `src/kernel/types.ts` declares `type KernelType`
- [x] No `as any` remains at the four sites; types are real
- [x] `npm run validate` passes; no behavioral change; coverage unaffected