### PR TITLE
fix(tech-debt): thread kernel error cause through Result.Err builders

### DIFF
--- a/src/2d/lib/makeCurves.ts
+++ b/src/2d/lib/makeCurves.ts
@@ -201,8 +201,8 @@ export function make2dInerpolatedBSplineCurve(
       continuity: 'C2',
     });
     return ok(new Curve2D(handle));
-  } catch {
-    return err(computationError('BSPLINE_2D_FAILED', 'B-spline approximation failed'));
+  } catch (e) {
+    return err(computationError('BSPLINE_2D_FAILED', 'B-spline approximation failed', e));
   }
 }
 

--- a/src/io/importFns.ts
+++ b/src/io/importFns.ts
@@ -35,8 +35,8 @@ export async function importSTEP(blob: Blob): Promise<Result<UnknownDimShape>> {
     }
 
     return ok(castShape(shapes[0]));
-  } catch {
-    return err(ioError('STEP_IMPORT_FAILED', 'Failed to load STEP file'));
+  } catch (e) {
+    return err(ioError('STEP_IMPORT_FAILED', 'Failed to load STEP file', e));
   }
 }
 
@@ -64,8 +64,8 @@ export async function importSTL(blob: Blob): Promise<Result<UnknownDimShape>> {
       return err(ioError('STL_IMPORT_FAILED', 'Failed to create solid from STL mesh'));
     }
     return ok(castShape(shape));
-  } catch {
-    return err(ioError('STL_IMPORT_FAILED', 'Failed to load STL file'));
+  } catch (e) {
+    return err(ioError('STL_IMPORT_FAILED', 'Failed to load STL file', e));
   }
 }
 
@@ -91,7 +91,7 @@ export async function importIGES(blob: Blob): Promise<Result<UnknownDimShape>> {
     }
 
     return ok(castShape(shapes[0]));
-  } catch {
-    return err(ioError('IGES_IMPORT_FAILED', 'Failed to load IGES file'));
+  } catch (e) {
+    return err(ioError('IGES_IMPORT_FAILED', 'Failed to load IGES file', e));
   }
 }

--- a/src/io/ioUtils.ts
+++ b/src/io/ioUtils.ts
@@ -49,8 +49,8 @@ export function sewMeshToSolid(
     // If sewing/solid fails, try sewing alone
     try {
       return ok(castShape(kernel.sew(triFaces, tolerance)));
-    } catch {
-      return err(ioError(errorCode, 'Failed to sew triangular faces'));
+    } catch (e) {
+      return err(ioError(errorCode, 'Failed to sew triangular faces', e));
     }
   }
 }

--- a/src/topology/cast.ts
+++ b/src/topology/cast.ts
@@ -87,8 +87,8 @@ export function downcast(shape: KernelShape): Result<GenericTopo> {
   }
   try {
     return ok(getKernel().downcast(shape));
-  } catch {
-    return err(typeCastError('NO_WRAPPER', 'Could not find a wrapper for this shape type'));
+  } catch (e) {
+    return err(typeCastError('NO_WRAPPER', 'Could not find a wrapper for this shape type', e));
   }
 }
 

--- a/src/topology/curveBuilders.ts
+++ b/src/topology/curveBuilders.ts
@@ -151,8 +151,8 @@ export function makeBSplineApproximation(
         getKernel().approximatePoints(mutablePoints, { tolerance, degMin, degMax, smoothing })
       )
     );
-  } catch {
-    return err(kernelError('BSPLINE_FAILED', 'B-spline approximation failed'));
+  } catch (e) {
+    return err(kernelError('BSPLINE_FAILED', 'B-spline approximation failed', e));
   }
 }
 
@@ -175,8 +175,8 @@ export function makeBSplineInterpolation(
   try {
     const mutablePoints: [number, number, number][] = points.map((p) => [...p]);
     return ok(createEdge(getKernel().interpolatePoints(mutablePoints, { periodic, tolerance })));
-  } catch {
-    return err(kernelError('BSPLINE_INTERP_FAILED', 'B-spline interpolation failed'));
+  } catch (e) {
+    return err(kernelError('BSPLINE_INTERP_FAILED', 'B-spline interpolation failed', e));
   }
 }
 

--- a/src/topology/surfaceBuilders.ts
+++ b/src/topology/surfaceBuilders.ts
@@ -50,9 +50,13 @@ export function makeFace<D extends Dimension = '3D'>(
       );
     }
     return ok(face as OrientedFace<D> & PlanarFace<D>);
-  } catch {
+  } catch (e) {
     return err(
-      kernelError('FACE_BUILD_FAILED', 'Failed to build the face. Your wire might be non planar.')
+      kernelError(
+        'FACE_BUILD_FAILED',
+        'Failed to build the face. Your wire might be non planar.',
+        e
+      )
     );
   }
 }
@@ -99,8 +103,8 @@ export function makeNonPlanarFace<D extends Dimension = '3D'>(
       }
       return ok(newFace as OrientedFace<D>);
     });
-  } catch {
-    return err(kernelError('FACE_BUILD_FAILED', 'Failed to create a non-planar face'));
+  } catch (e) {
+    return err(kernelError('FACE_BUILD_FAILED', 'Failed to create a non-planar face', e));
   }
 }
 


### PR DESCRIPTION
## Problem

Ten bare `catch {` sites in layers 2-3 built a `Result.Err` **without passing the caught error as `cause`**, discarding the underlying kernel/parse diagnostic. A user importing a malformed STEP file got `'Failed to load STEP file'` with no underlying reader error. Every error constructor already accepts `cause?: unknown` (3rd positional arg) and `makeError` stores it (`errors.ts:242`); most of the codebase already threads it (`extrudeFns`, `objImportFns`, `gltfImportFns`, `dxfImportFns`, `2d/lib/intersections`).

## Change (diagnostic-only, no behavioral change)

Bind the caught error and pass it through — `code`, `kind`, and `message` are unchanged; only the previously-`undefined` `cause` field is now populated:

| File | Sites |
|------|-------|
| `io/importFns.ts` | STEP / STL / IGES import failures |
| `io/ioUtils.ts` | inner sew-fallback failure (the **outer** catch is a legitimate sew-alone fallback and is left bare) |
| `2d/lib/makeCurves.ts` | `BSPLINE_2D_FAILED` |
| `topology/cast.ts` | `NO_WRAPPER` downcast |
| `topology/curveBuilders.ts` | `BSPLINE_FAILED`, `BSPLINE_INTERP_FAILED` |
| `topology/surfaceBuilders.ts` | `FACE_BUILD_FAILED` (planar `makeFace` + non-planar) |

## Verification

- `npm run typecheck`, `npm run lint`, `npm run validate` all pass locally
- Behavior preserved: error code/kind/message identical; `cause` was already a key on every `BrepError` (previously `undefined`), now carries the real exception

## Acceptance

- [x] Every bare error-building `catch` in these files threads `cause`
- [x] The one intentional best-effort fallback (`ioUtils` outer catch) stays bare
- [x] `npm run validate` passes; no behavioral change; coverage unaffected

> Note: CI's `check:patterns` may flag a pre-existing `liftCurve2dToPlane` violation introduced by #1588 (unrelated to this PR) — addressed by a separate baseline-bump PR; this branch will go green once that lands on main.