### PR TITLE
ci(tech-debt): baseline liftCurve2dToPlane long-function introduced by #1588

### DIFF
--- a/.pattern-baseline.json
+++ b/.pattern-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated": "2026-06-23T07:47:44.881Z",
+  "generated": "2026-06-23T08:32:05.468Z",
   "entries": [
     {
       "file": "src/core/dimensionTypes.ts",
@@ -21,6 +21,11 @@
       "file": "src/kernel/brepkit/constructionOps.ts",
       "rule": "max-function-lines",
       "fingerprint": "src/kernel/brepkit/constructionOps.ts|max-function-lines|makeEllipseNurbs|#0"
+    },
+    {
+      "file": "src/kernel/brepkit/kernel2dOps.ts",
+      "rule": "max-function-lines",
+      "fingerprint": "src/kernel/brepkit/kernel2dOps.ts|max-function-lines|liftCurve2dToPlane|#0"
     },
     {
       "file": "src/kernel/geometry2d.ts",


### PR DESCRIPTION
## Problem

The `check:patterns` CI gate (added in #1589) is failing on **every** open PR — because GitHub tests PRs *merged with main*, and main contains an unbaselined pattern violation:

```
src/kernel/brepkit/kernel2dOps.ts
  ✖ 927:1  Function `liftCurve2dToPlane` has 95 effective lines (limit: 60)
```

`liftCurve2dToPlane` was grown to 95 lines by **#1588** (exact 2D ellipse-arc lift), which landed *before* the gate existed, so it was never recorded in `.pattern-baseline.json`.

## Change

Regenerate the baseline to capture this single pre-existing entry. Verified the diff adds **only** `brepkit/kernel2dOps.ts|max-function-lines|liftCurve2dToPlane` and removes nothing.

This accepts it as known debt (consistent with the other 14 `max-function-lines` baseline entries). Extracting helpers from the ellipse-arc lift math is real follow-up paydown but out of scope here — the immediate need is to unblock the PR queue.

## Acceptance

- [x] `npm run check:patterns` exits 0
- [x] Diff = exactly one added entry (`liftCurve2dToPlane`), nothing else
- [x] No source/behavior change