### PR TITLE
refactor(tech-debt): hoist duplicated 2D arc builders into geometry2d

### DIFF
--- a/src/kernel/brepkit/kernel2dOps.ts
+++ b/src/kernel/brepkit/kernel2dOps.ts
@@ -77,120 +77,6 @@ export function makeCircle2d(
   return bk2d.makeCircle2d(cx, cy, radius, sense);
 }
 
-export function makeArc2dThreePoints(
-  x1: number,
-  y1: number,
-  xm: number,
-  ym: number,
-  x2: number,
-  y2: number
-): Curve2dHandle {
-  // Circumscribed circle through 3 points
-  const d = 2 * (x1 * (ym - y2) + xm * (y2 - y1) + x2 * (y1 - ym));
-  if (Math.abs(d) < 1e-12) {
-    // Degenerate (collinear): return a line
-    return bk2d.makeLine2d(x1, y1, x2, y2);
-  }
-  const cx =
-    ((x1 * x1 + y1 * y1) * (ym - y2) +
-      (xm * xm + ym * ym) * (y2 - y1) +
-      (x2 * x2 + y2 * y2) * (y1 - ym)) /
-    d;
-  const cy =
-    ((x1 * x1 + y1 * y1) * (x2 - xm) +
-      (xm * xm + ym * ym) * (x1 - x2) +
-      (x2 * x2 + y2 * y2) * (xm - x1)) /
-    d;
-  const radius = Math.sqrt((x1 - cx) ** 2 + (y1 - cy) ** 2);
-
-  // Compute angles for start (p1), mid (pm), and end (p2)
-  const a1 = Math.atan2(y1 - cy, x1 - cx);
-  const am = Math.atan2(ym - cy, xm - cx);
-  const a2 = Math.atan2(y2 - cy, x2 - cx);
-
-  // Determine sense: CCW if mid-point angle is between start and end going CCW
-  let da1m = am - a1;
-  if (da1m < 0) da1m += 2 * Math.PI;
-  let da12 = a2 - a1;
-  if (da12 < 0) da12 += 2 * Math.PI;
-  const sense = da1m < da12; // CCW if midpoint comes before endpoint
-
-  const circle = bk2d.makeCircle2d(cx, cy, radius, sense);
-  if (!sense) {
-    // CW circle evaluates angle = -t, so parameter t = -angle.
-    // Map start/end angles to the CW parameter space.
-    const tStart = -a1;
-    let tEnd = -a2;
-    // Ensure tEnd >= tStart so the linear interpolation
-    // tStart + t*(tEnd-tStart) traverses the arc in the correct (CW) direction.
-    if (tEnd < tStart - 1e-9) tEnd += 2 * Math.PI;
-    return { __bk2d: 'trimmed', basis: circle, tStart, tEnd } as Curve2dObj;
-  }
-  // CCW: ensure tEnd >= tStart so interpolation goes in the CCW direction.
-  let tEnd = a2;
-  if (tEnd < a1 - 1e-9) tEnd += 2 * Math.PI;
-  return { __bk2d: 'trimmed', basis: circle, tStart: a1, tEnd } as Curve2dObj;
-}
-
-export function makeArc2dTangent(
-  sx: number,
-  sy: number,
-  tx: number,
-  ty: number,
-  ex: number,
-  ey: number
-): Curve2dHandle {
-  // Exact tangent arc: find circle center C where:
-  //   (C - S) . T = 0        (tangent constraint)
-  //   |C - S| = |C - E|      (equidistant = on circle)
-  // Solution: C = S + t * perp(T), with t = -chord^2 / (2 * ((sy-ey)*ntx - (sx-ex)*nty))
-  const len = Math.sqrt(tx * tx + ty * ty);
-  const ntx = len > 0 ? tx / len : 0;
-  const nty = len > 0 ? ty / len : 0;
-
-  const dx = sx - ex;
-  const dy = sy - ey;
-  const denom = 2 * (dy * ntx - dx * nty);
-
-  if (Math.abs(denom) < 1e-12) {
-    // Degenerate: tangent parallel to S->E chord
-    return bk2d.makeLine2d(sx, sy, ex, ey);
-  }
-
-  const chord2 = dx * dx + dy * dy;
-  const t = -chord2 / denom;
-  const cx = sx - t * nty;
-  const cy = sy + t * ntx;
-  const radius = Math.abs(t);
-
-  // Pick the arc midpoint on the correct side (matching tangent direction).
-  const a1 = Math.atan2(sy - cy, sx - cx);
-  const a2 = Math.atan2(ey - cy, ex - cx);
-
-  // At S the CCW tangent is perpendicular to the radius: (-sin(a1), cos(a1))
-  const ccwTanX = -(sy - cy) / radius;
-  const ccwTanY = (sx - cx) / radius;
-  const dotCcw = ntx * ccwTanX + nty * ccwTanY;
-
-  let aMid: number;
-  if (dotCcw > 0) {
-    // CCW arc from S to E
-    let da = a2 - a1;
-    if (da <= 0) da += 2 * Math.PI;
-    aMid = a1 + da / 2;
-  } else {
-    // CW arc from S to E
-    let da = a2 - a1;
-    if (da >= 0) da -= 2 * Math.PI;
-    aMid = a1 + da / 2;
-  }
-
-  const mx = cx + radius * Math.cos(aMid);
-  const my = cy + radius * Math.sin(aMid);
-
-  return makeArc2dThreePoints(sx, sy, mx, my, ex, ey);
-}
-
 export function makeEllipse2d(
   cx: number,
   cy: number,
@@ -1281,8 +1167,9 @@ export function makeKernel2dOps(bk: BrepkitKernel) {
     createCurve2dAdaptor: (handle) => createCurve2dAdaptor(handle),
     makeLine2d: (x1, y1, x2, y2) => makeLine2d(x1, y1, x2, y2),
     makeCircle2d: (cx, cy, radius, sense) => makeCircle2d(cx, cy, radius, sense),
-    makeArc2dThreePoints: (x1, y1, xm, ym, x2, y2) => makeArc2dThreePoints(x1, y1, xm, ym, x2, y2),
-    makeArc2dTangent: (sx, sy, tx, ty, ex, ey) => makeArc2dTangent(sx, sy, tx, ty, ex, ey),
+    makeArc2dThreePoints: (x1, y1, xm, ym, x2, y2) =>
+      bk2d.makeArc2dThreePoints(x1, y1, xm, ym, x2, y2),
+    makeArc2dTangent: (sx, sy, tx, ty, ex, ey) => bk2d.makeArc2dTangent(sx, sy, tx, ty, ex, ey),
     makeEllipse2d: (cx, cy, major, minor, xDirX, xDirY, sense) =>
       makeEllipse2d(cx, cy, major, minor, xDirX, xDirY, sense),
     makeEllipseArc2d: (cx, cy, major, minor, start, end, xDirX, xDirY, sense) =>

--- a/src/kernel/geometry2d.ts
+++ b/src/kernel/geometry2d.ts
@@ -214,6 +214,108 @@ export function makeCircle2d(cx: number, cy: number, radius: number, sense = tru
   return { __bk2d: 'circle', cx, cy, radius, sense };
 }
 
+export function makeArc2dThreePoints(
+  x1: number,
+  y1: number,
+  xm: number,
+  ym: number,
+  x2: number,
+  y2: number
+): Curve2dObj {
+  // Circumscribed circle through 3 points
+  const d = 2 * (x1 * (ym - y2) + xm * (y2 - y1) + x2 * (y1 - ym));
+  if (Math.abs(d) < 1e-12) {
+    // Degenerate (collinear): return a line
+    return makeLine2d(x1, y1, x2, y2);
+  }
+  const cx =
+    ((x1 * x1 + y1 * y1) * (ym - y2) +
+      (xm * xm + ym * ym) * (y2 - y1) +
+      (x2 * x2 + y2 * y2) * (y1 - ym)) /
+    d;
+  const cy =
+    ((x1 * x1 + y1 * y1) * (x2 - xm) +
+      (xm * xm + ym * ym) * (x1 - x2) +
+      (x2 * x2 + y2 * y2) * (xm - x1)) /
+    d;
+  const radius = Math.sqrt((x1 - cx) ** 2 + (y1 - cy) ** 2);
+
+  // Compute angles for start (p1), mid (pm), and end (p2)
+  const a1 = Math.atan2(y1 - cy, x1 - cx);
+  const am = Math.atan2(ym - cy, xm - cx);
+  const a2 = Math.atan2(y2 - cy, x2 - cx);
+
+  // Determine sense: CCW if mid-point angle is between start and end going CCW
+  let da1m = am - a1;
+  if (da1m < 0) da1m += 2 * Math.PI;
+  let da12 = a2 - a1;
+  if (da12 < 0) da12 += 2 * Math.PI;
+  const sense = da1m < da12; // CCW if midpoint comes before endpoint
+
+  const circle = makeCircle2d(cx, cy, radius, sense);
+  if (!sense) {
+    // CW circle evaluates angle = -t, so parameter t = -angle.
+    const tStart = -a1;
+    let tEnd = -a2;
+    if (tEnd < tStart - 1e-9) tEnd += 2 * Math.PI;
+    return { __bk2d: 'trimmed', basis: circle, tStart, tEnd };
+  }
+  // CCW: ensure tEnd >= tStart
+  let tEnd = a2;
+  if (tEnd < a1 - 1e-9) tEnd += 2 * Math.PI;
+  return { __bk2d: 'trimmed', basis: circle, tStart: a1, tEnd };
+}
+
+export function makeArc2dTangent(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  ex: number,
+  ey: number
+): Curve2dObj {
+  const len = Math.sqrt(tx * tx + ty * ty);
+  const ntx = len > 0 ? tx / len : 0;
+  const nty = len > 0 ? ty / len : 0;
+
+  const dx = sx - ex;
+  const dy = sy - ey;
+  const denom = 2 * (dy * ntx - dx * nty);
+
+  if (Math.abs(denom) < 1e-12) {
+    return makeLine2d(sx, sy, ex, ey);
+  }
+
+  const chord2 = dx * dx + dy * dy;
+  const t = -chord2 / denom;
+  const cx = sx - t * nty;
+  const cy = sy + t * ntx;
+  const radius = Math.abs(t);
+
+  const a1 = Math.atan2(sy - cy, sx - cx);
+  const a2 = Math.atan2(ey - cy, ex - cx);
+
+  const ccwTanX = -(sy - cy) / radius;
+  const ccwTanY = (sx - cx) / radius;
+  const dotCcw = ntx * ccwTanX + nty * ccwTanY;
+
+  let aMid: number;
+  if (dotCcw > 0) {
+    let da = a2 - a1;
+    if (da <= 0) da += 2 * Math.PI;
+    aMid = a1 + da / 2;
+  } else {
+    let da = a2 - a1;
+    if (da >= 0) da -= 2 * Math.PI;
+    aMid = a1 + da / 2;
+  }
+
+  const mx = cx + radius * Math.cos(aMid);
+  const my = cy + radius * Math.sin(aMid);
+
+  return makeArc2dThreePoints(sx, sy, mx, my, ex, ey);
+}
+
 export function makeEllipse2d(
   cx: number,
   cy: number,

--- a/src/kernel/occt/kernel2dOps.ts
+++ b/src/kernel/occt/kernel2dOps.ts
@@ -86,108 +86,6 @@ export function makeCircle2d(
   return g2d.makeCircle2d(cx, cy, radius, sense);
 }
 
-export function makeArc2dThreePoints(
-  x1: number,
-  y1: number,
-  xm: number,
-  ym: number,
-  x2: number,
-  y2: number
-): Curve2dHandle {
-  // Circumscribed circle through 3 points
-  const d = 2 * (x1 * (ym - y2) + xm * (y2 - y1) + x2 * (y1 - ym));
-  if (Math.abs(d) < 1e-12) {
-    // Degenerate (collinear): return a line
-    return g2d.makeLine2d(x1, y1, x2, y2);
-  }
-  const cx =
-    ((x1 * x1 + y1 * y1) * (ym - y2) +
-      (xm * xm + ym * ym) * (y2 - y1) +
-      (x2 * x2 + y2 * y2) * (y1 - ym)) /
-    d;
-  const cy =
-    ((x1 * x1 + y1 * y1) * (x2 - xm) +
-      (xm * xm + ym * ym) * (x1 - x2) +
-      (x2 * x2 + y2 * y2) * (xm - x1)) /
-    d;
-  const radius = Math.sqrt((x1 - cx) ** 2 + (y1 - cy) ** 2);
-
-  // Compute angles for start (p1), mid (pm), and end (p2)
-  const a1 = Math.atan2(y1 - cy, x1 - cx);
-  const am = Math.atan2(ym - cy, xm - cx);
-  const a2 = Math.atan2(y2 - cy, x2 - cx);
-
-  // Determine sense: CCW if mid-point angle is between start and end going CCW
-  let da1m = am - a1;
-  if (da1m < 0) da1m += 2 * Math.PI;
-  let da12 = a2 - a1;
-  if (da12 < 0) da12 += 2 * Math.PI;
-  const sense = da1m < da12; // CCW if midpoint comes before endpoint
-
-  const circle = g2d.makeCircle2d(cx, cy, radius, sense);
-  if (!sense) {
-    // CW circle evaluates angle = -t, so parameter t = -angle.
-    const tStart = -a1;
-    let tEnd = -a2;
-    if (tEnd < tStart - 1e-9) tEnd += 2 * Math.PI;
-    return { __bk2d: 'trimmed', basis: circle, tStart, tEnd } as Curve2dObj;
-  }
-  // CCW: ensure tEnd >= tStart
-  let tEnd = a2;
-  if (tEnd < a1 - 1e-9) tEnd += 2 * Math.PI;
-  return { __bk2d: 'trimmed', basis: circle, tStart: a1, tEnd } as Curve2dObj;
-}
-
-export function makeArc2dTangent(
-  sx: number,
-  sy: number,
-  tx: number,
-  ty: number,
-  ex: number,
-  ey: number
-): Curve2dHandle {
-  const len = Math.sqrt(tx * tx + ty * ty);
-  const ntx = len > 0 ? tx / len : 0;
-  const nty = len > 0 ? ty / len : 0;
-
-  const dx = sx - ex;
-  const dy = sy - ey;
-  const denom = 2 * (dy * ntx - dx * nty);
-
-  if (Math.abs(denom) < 1e-12) {
-    return g2d.makeLine2d(sx, sy, ex, ey);
-  }
-
-  const chord2 = dx * dx + dy * dy;
-  const t = -chord2 / denom;
-  const cx = sx - t * nty;
-  const cy = sy + t * ntx;
-  const radius = Math.abs(t);
-
-  const a1 = Math.atan2(sy - cy, sx - cx);
-  const a2 = Math.atan2(ey - cy, ex - cx);
-
-  const ccwTanX = -(sy - cy) / radius;
-  const ccwTanY = (sx - cx) / radius;
-  const dotCcw = ntx * ccwTanX + nty * ccwTanY;
-
-  let aMid: number;
-  if (dotCcw > 0) {
-    let da = a2 - a1;
-    if (da <= 0) da += 2 * Math.PI;
-    aMid = a1 + da / 2;
-  } else {
-    let da = a2 - a1;
-    if (da >= 0) da -= 2 * Math.PI;
-    aMid = a1 + da / 2;
-  }
-
-  const mx = cx + radius * Math.cos(aMid);
-  const my = cy + radius * Math.sin(aMid);
-
-  return makeArc2dThreePoints(sx, sy, mx, my, ex, ey);
-}
-
 export function makeEllipse2d(
   cx: number,
   cy: number,
@@ -1117,9 +1015,10 @@ export function makeKernel2dOps(oc: KernelInstance) {
     createAxis2d: (px, py, dx, dy) => createAxis2d(px, py, dx, dy),
     makeLine2d: (x1, y1, x2, y2) => makeLine2d(x1, y1, x2, y2),
     makeCircle2d: (cx, cy, radius, sense) => makeCircle2d(cx, cy, radius, sense),
-    makeArc2dThreePoints: (x1, y1, xm, ym, x2, y2) => makeArc2dThreePoints(x1, y1, xm, ym, x2, y2),
+    makeArc2dThreePoints: (x1, y1, xm, ym, x2, y2) =>
+      g2d.makeArc2dThreePoints(x1, y1, xm, ym, x2, y2),
     makeArc2dTangent: (startX, startY, tangentX, tangentY, endX, endY) =>
-      makeArc2dTangent(startX, startY, tangentX, tangentY, endX, endY),
+      g2d.makeArc2dTangent(startX, startY, tangentX, tangentY, endX, endY),
     makeEllipse2d: (cx, cy, majorRadius, minorRadius, xDirX, xDirY, sense) =>
       makeEllipse2d(cx, cy, majorRadius, minorRadius, xDirX, xDirY, sense),
     makeEllipseArc2d: (

--- a/tests/brepkitAdapter.test.ts
+++ b/tests/brepkitAdapter.test.ts
@@ -1308,51 +1308,49 @@ describe('BrepkitAdapter', () => {
       const mock = createMockBrepKernel();
       const adapter = new BrepkitAdapter(mock);
 
-      // Quarter-circle: start=(1,0), tangent=(0,1), end=(0,1)
-      // Expected center = (0,0), radius = 1
-      const spy = vi.spyOn(adapter, 'makeArc2dThreePoints');
-      adapter.makeArc2dTangent(1, 0, 0, 1, 0, 1);
+      // Quarter-circle: start=(1,0), tangent=(0,1), end=(0,1) → unit circle at origin.
+      const arc = adapter.makeArc2dTangent(1, 0, 0, 1, 0, 1);
 
-      expect(spy).toHaveBeenCalledOnce();
-      const [sx, sy, mx, my, ex, ey] = spy.mock.calls[0];
-      expect(sx).toBeCloseTo(1, 10);
-      expect(sy).toBeCloseTo(0, 10);
-      expect(ex).toBeCloseTo(0, 10);
-      expect(ey).toBeCloseTo(1, 10);
-      // Midpoint should be on the unit circle at ~45°
-      const midR = Math.sqrt(mx * mx + my * my);
-      expect(midR).toBeCloseTo(1, 5);
+      expect(adapter.getCurve2dType(arc)).toBe('CIRCLE');
+      const start = adapter.evaluateCurve2d(arc, 0);
+      const end = adapter.evaluateCurve2d(arc, 1);
+      expect(start[0]).toBeCloseTo(1, 6);
+      expect(start[1]).toBeCloseTo(0, 6);
+      expect(end[0]).toBeCloseTo(0, 6);
+      expect(end[1]).toBeCloseTo(1, 6);
+      // The swept arc rides the unit circle.
+      const mid = adapter.evaluateCurve2d(arc, 0.5);
+      expect(Math.hypot(mid[0], mid[1])).toBeCloseTo(1, 5);
     });
 
     it('falls back to a line for collinear tangent', () => {
       const mock = createMockBrepKernel();
       const adapter = new BrepkitAdapter(mock);
 
-      // Start=(0,0), tangent=(1,0), end=(5,0) — tangent parallel to chord
-      const spy = vi.spyOn(adapter, 'makeArc2dThreePoints');
+      // Start=(0,0), tangent=(1,0), end=(5,0) — tangent parallel to chord.
       const result = adapter.makeArc2dTangent(0, 0, 1, 0, 5, 0);
-
-      // Should NOT call makeArc2dThreePoints (degenerate case)
-      expect(spy).not.toHaveBeenCalled();
-      // Returns a line (from bk2d.makeLine2d)
-      expect(result).toBeDefined();
+      expect(adapter.getCurve2dType(result)).toBe('LINE');
     });
 
     it('handles CW arc direction', () => {
       const mock = createMockBrepKernel();
       const adapter = new BrepkitAdapter(mock);
 
-      // Start=(1,0), tangent=(0,-1) → CW, end=(0,-1)
-      const spy = vi.spyOn(adapter, 'makeArc2dThreePoints');
-      adapter.makeArc2dTangent(1, 0, 0, -1, 0, -1);
+      // Start=(1,0), tangent=(0,-1) → CW, end=(0,-1) on the unit circle.
+      const arc = adapter.makeArc2dTangent(1, 0, 0, -1, 0, -1);
 
-      expect(spy).toHaveBeenCalledOnce();
-      const [, , mx, my] = spy.mock.calls[0];
-      // Midpoint should be in the positive-x, negative-y quadrant (CW arc)
-      const midR = Math.sqrt(mx * mx + my * my);
-      expect(midR).toBeCloseTo(1, 5);
-      expect(mx).toBeGreaterThan(0);
-      expect(my).toBeLessThan(0);
+      expect(adapter.getCurve2dType(arc)).toBe('CIRCLE');
+      const start = adapter.evaluateCurve2d(arc, 0);
+      const end = adapter.evaluateCurve2d(arc, 1);
+      expect(start[0]).toBeCloseTo(1, 6);
+      expect(start[1]).toBeCloseTo(0, 6);
+      expect(end[0]).toBeCloseTo(0, 6);
+      expect(end[1]).toBeCloseTo(-1, 6);
+      // CW sweep passes through the positive-x, negative-y quadrant.
+      const mid = adapter.evaluateCurve2d(arc, 0.5);
+      expect(Math.hypot(mid[0], mid[1])).toBeCloseTo(1, 5);
+      expect(mid[0]).toBeGreaterThan(0);
+      expect(mid[1]).toBeLessThan(0);
     });
   });
 });


### PR DESCRIPTION
## Problem

`makeArc2dThreePoints` and `makeArc2dTangent` were **byte-identical** (modulo the `g2d` vs `bk2d` import alias — both aliasing the *same* `geometry2d` module) in the `occt` and `brepkit` kernel2dOps adapters. That's two full copies of the circumscribed-circle-through-3-points and exact-tangent-arc math (~210 lines duplicated).

## Change (no behavioral change)

- Move both functions into the shared `src/kernel/geometry2d.ts`, which already owns their only dependencies (`makeLine2d`, `makeCircle2d`, `Curve2dObj`).
- Delegate from each adapter's wiring (`g2d.makeArc2dThreePoints` / `bk2d.makeArc2dThreePoints`).
- The shared versions return the precise `Curve2dObj` union instead of the adapters' `Curve2dHandle` (= `any`), so this also **tightens the types** and drops the `as Curve2dObj` casts.

**occtWasm is intentionally out of scope** — its `makeArc2dThreePoints` wraps each return in `c2dWrap` (identity today, but a real seam) and its `makeArc2dTangent` uses a *different* algorithm. Folding it in would couple behavior, not remove textual duplication.

## Verification

Behavior parity confirmed — the full 2D suite passes **identically** on all three kernels:

| Suite | occt-wasm | occt | brepkit |
|-------|-----------|------|---------|
| `2d`, `curve2dFns`, `blueprintFns`, `cannedSketches`, `make2dOffset`, `boolean2dRegression` | ✅ 175 | ✅ 175 | ✅ 175 |

`npm run validate` green (3859 tests). Net: ~100 lines of duplication removed (2 copies → 1 shared), types tightened.

## Acceptance

- [x] occt + brepkit delegate to the shared `geometry2d` functions
- [x] occtWasm untouched (different impl)
- [x] 2D arc behavior identical across all kernels; `npm run validate` passes