### PR TITLE
docs(tech-debt): correct misleading 'WASM array indices' comments in geometry2d

### DIFF
--- a/src/kernel/geometry2d.ts
+++ b/src/kernel/geometry2d.ts
@@ -963,7 +963,7 @@ function evaluateBezier(poles: [number, number][], t: number): [number, number] 
   // De Casteljau
   const n = poles.length;
   const work = poles.map(([x, y]) => [x, y] as [number, number]);
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM array indices */
+  /* eslint-disable @typescript-eslint/no-non-null-assertion -- array indices known valid by loop bounds */
   for (let r = 1; r < n; r++) {
     for (let i = 0; i < n - r; i++) {
       const wi = work[i]!;
@@ -977,7 +977,7 @@ function evaluateBezier(poles: [number, number][], t: number): [number, number] 
 }
 
 function evaluateBSpline2d(c: BSpline2d, t: number): [number, number] {
-  /* eslint-disable @typescript-eslint/no-non-null-assertion -- WASM array indices */
+  /* eslint-disable @typescript-eslint/no-non-null-assertion -- knot-vector indices known valid by loop bounds */
   // Expand knots with multiplicities
   const fullKnots: number[] = [];
   for (let i = 0; i < c.knots.length; i++) {


### PR DESCRIPTION
## Problem

`src/kernel/geometry2d.ts` is **pure-TypeScript with no WASM boundary crossing** (per its module header: *"No WASM boundary crossing required"*). Yet two `no-non-null-assertion` eslint-disable comments — in the De Casteljau (Bézier) and B-spline evaluators — were labelled `-- WASM array indices`. They actually guard plain JS array accesses (`work[i]!`, `c.knots[i]!`) bounded by their own loops.

## Change

Relabel the two comments to accurately describe the guarantee, matching the accurate ones already in the file (e.g. `-- typed array indices known valid`):
- `array indices known valid by loop bounds` (De Casteljau)
- `knot-vector indices known valid by loop bounds` (B-spline)

Comment-only; no code, behavior, or test impact.

## Acceptance

- [x] No remaining misleading WASM references on pure-TS array accesses
- [x] lint/format clean; no behavioral change