### PR TITLE
feat(csg): add opt-in LRU eviction to the evaluator cache

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "325 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "330 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "55 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -53,7 +53,8 @@ export interface EvaluatorOptions {
    * (a handle shared by several entries is freed only when its last entry is
    * evicted). Defaults to unbounded — entries live for the Evaluator's
    * lifetime. With a bound set, a returned shape is only guaranteed valid
-   * until the next successful evaluate() call. Must be a positive integer.
+   * until the next successful evaluate() call; a failed evaluate() is
+   * transactional — it leaves the cache unchanged. Must be a positive integer.
    */
   readonly maxCacheEntries?: number | undefined;
 }
@@ -165,6 +166,15 @@ export class Evaluator implements Disposable {
   // DisposalScope can't back this — it can't release one handle on eviction
   // without releasing the rest.)
   private readonly refCounts = new Map<AnyShape<Dimension>, number>();
+  // Depth of the current public evaluate() call. The cache is reconciled
+  // (trim on success / roll back on failure) only when leaving the OUTERMOST
+  // call, so a reentrant evaluate() — e.g. from an onStep callback — can never
+  // evict operands the outer evaluation is still using.
+  private evalDepth = 0;
+  // Keys inserted during the current outermost evaluate(). On failure these are
+  // rolled back, so a failed call leaves the cache exactly as it was (bound
+  // preserved, older results untouched).
+  private readonly pendingKeys: string[] = [];
   private readonly kernelId: string;
   private readonly defaultTolerance: number | undefined;
   private readonly maxCacheEntries: number | undefined;
@@ -200,17 +210,25 @@ export class Evaluator implements Disposable {
    */
   evaluate(node: IRNode, env: Env = {}): Result<AnyShape<Dimension>> {
     return withKernel(this.kernelId, () => {
-      const result = this.evaluateInner(node, env);
-      // Eviction runs only here, after a SUCCESSFUL top-level evaluation: never
-      // mid-recursion (so in-flight operands are never freed), and never on the
-      // error path (a failed tree may have cached partial children before
-      // failing, and trimming then could dispose a previously-returned good
-      // result). The just-returned result is the most-recently-used entry, so
-      // trimming to a bound >= 1 never frees what the caller just received.
-      if (result.ok && this.maxCacheEntries !== undefined) {
-        this.trimCache(this.maxCacheEntries);
+      const outermost = this.evalDepth === 0;
+      this.evalDepth++;
+      try {
+        const result = this.evaluateInner(node, env);
+        // Reconcile the cache only when leaving the OUTERMOST evaluate() —
+        // never mid-recursion, and never from a reentrant call. On success the
+        // bound is enforced by LRU eviction (the just-returned result is the
+        // most-recently-used entry, so a bound >= 1 never frees it). On failure
+        // the call's own inserts are rolled back, so a failed evaluation
+        // neither grows the cache nor evicts an older good result.
+        if (outermost && this.maxCacheEntries !== undefined) {
+          if (result.ok) this.trimCache(this.maxCacheEntries);
+          else this.rollbackPending();
+        }
+        return result;
+      } finally {
+        this.evalDepth--;
+        if (outermost) this.pendingKeys.length = 0;
       }
-      return result;
     });
   }
 
@@ -239,14 +257,26 @@ export class Evaluator implements Disposable {
     const shape = result.value;
     this.refCounts.set(shape, (this.refCounts.get(shape) ?? 0) + 1);
     this.cache.set(key, shape);
+    if (this.maxCacheEntries !== undefined) this.pendingKeys.push(key);
     this.onStep?.({ node, cacheKey: key, cacheHit: false });
     return result;
   }
 
-  // Evict least-recently-used entries until the cache is within `max`. A
-  // handle is disposed only when its final referencing entry leaves the cache
-  // (refCounts → 0); a handle shared across keys survives until its last key
-  // is evicted, so identity short-circuits can never produce a use-after-free.
+  // Decrement a handle's reference count, disposing it once its last cache
+  // entry is gone. A handle shared across keys (via identity short-circuits)
+  // survives until its final key is removed, so eviction can never produce a
+  // use-after-free.
+  private releaseShape(shape: AnyShape<Dimension>): void {
+    const next = (this.refCounts.get(shape) ?? 1) - 1;
+    if (next <= 0) {
+      this.refCounts.delete(shape);
+      shape[Symbol.dispose]();
+    } else {
+      this.refCounts.set(shape, next);
+    }
+  }
+
+  // Evict least-recently-used entries until the cache is within `max`.
   private trimCache(max: number): void {
     while (this.cache.size > max) {
       const oldest = this.cache.keys().next();
@@ -255,14 +285,19 @@ export class Evaluator implements Disposable {
       const shape = this.cache.get(key);
       this.cache.delete(key);
       this.evictions++;
+      if (shape !== undefined) this.releaseShape(shape);
+    }
+  }
+
+  // Undo the inserts made during a failed outermost evaluate(). Removal is by
+  // key (not position), so entries merely touched (hit) during the call are
+  // kept — only the call's own new entries are dropped.
+  private rollbackPending(): void {
+    for (const key of this.pendingKeys) {
+      const shape = this.cache.get(key);
       if (shape === undefined) continue;
-      const next = (this.refCounts.get(shape) ?? 1) - 1;
-      if (next <= 0) {
-        this.refCounts.delete(shape);
-        shape[Symbol.dispose]();
-      } else {
-        this.refCounts.set(shape, next);
-      }
+      this.cache.delete(key);
+      this.releaseShape(shape);
     }
   }
 

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -5,7 +5,8 @@
 // Returned shapes are borrowed — the Evaluator owns disposal; callers must
 // NOT dispose them. By default a returned shape is valid for the Evaluator's
 // whole lifetime. If `maxCacheEntries` is set, the cache is LRU-bounded and a
-// returned shape is only guaranteed valid until the next evaluate() call.
+// returned shape is only guaranteed valid until the next successful
+// evaluate() call (a failed evaluate() never evicts).
 import { getActiveKernelId, withKernel } from '@/kernel/index.js';
 import { ok, type Result } from '@/core/result.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
@@ -52,7 +53,7 @@ export interface EvaluatorOptions {
    * (a handle shared by several entries is freed only when its last entry is
    * evicted). Defaults to unbounded — entries live for the Evaluator's
    * lifetime. With a bound set, a returned shape is only guaranteed valid
-   * until the next evaluate() call. Must be a positive integer.
+   * until the next successful evaluate() call. Must be a positive integer.
    */
   readonly maxCacheEntries?: number | undefined;
 }
@@ -195,16 +196,20 @@ export class Evaluator implements Disposable {
    * `[Symbol.dispose]()` on it; that would invalidate the cache entry for
    * every future call returning the same handle. By default it stays valid
    * until the Evaluator is disposed; if `maxCacheEntries` is set, only until
-   * the next evaluate() call (LRU eviction may free older entries).
+   * the next successful evaluate() call (LRU eviction may free older entries).
    */
   evaluate(node: IRNode, env: Env = {}): Result<AnyShape<Dimension>> {
     return withKernel(this.kernelId, () => {
       const result = this.evaluateInner(node, env);
-      // Eviction runs only here, between top-level evaluations — never during
-      // the recursive descent, so operands still in flight are never freed.
-      // The just-returned result is the most-recently-used entry, so trimming
-      // to a bound >= 1 never frees the shape the caller just received.
-      if (this.maxCacheEntries !== undefined) this.trimCache(this.maxCacheEntries);
+      // Eviction runs only here, after a SUCCESSFUL top-level evaluation: never
+      // mid-recursion (so in-flight operands are never freed), and never on the
+      // error path (a failed tree may have cached partial children before
+      // failing, and trimming then could dispose a previously-returned good
+      // result). The just-returned result is the most-recently-used entry, so
+      // trimming to a bound >= 1 never frees what the caller just received.
+      if (result.ok && this.maxCacheEntries !== undefined) {
+        this.trimCache(this.maxCacheEntries);
+      }
       return result;
     });
   }

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -216,13 +216,23 @@ export class Evaluator implements Disposable {
         const result = this.evaluateInner(node, env);
         // Reconcile the cache only when leaving the OUTERMOST evaluate() —
         // never mid-recursion, and never from a reentrant call. On success the
-        // bound is enforced by LRU eviction (the just-returned result is the
-        // most-recently-used entry, so a bound >= 1 never frees it). On failure
-        // the call's own inserts are rolled back, so a failed evaluation
-        // neither grows the cache nor evicts an older good result.
+        // root is touched back to MRU (a reentrant onStep may have inserted
+        // newer entries after the root was cached, displacing it) before the
+        // bound is enforced by LRU eviction, so the returned shape is never
+        // freed. On failure the call's own inserts are rolled back, so a failed
+        // evaluation neither grows the cache nor evicts an older good result.
         if (outermost && this.maxCacheEntries !== undefined) {
-          if (result.ok) this.trimCache(this.maxCacheEntries);
-          else this.rollbackPending();
+          if (result.ok) {
+            const rootKey = cacheKey(node, env, this.kernelId, this.defaultTolerance);
+            const root = this.cache.get(rootKey);
+            if (root !== undefined) {
+              this.cache.delete(rootKey);
+              this.cache.set(rootKey, root);
+            }
+            this.trimCache(this.maxCacheEntries);
+          } else {
+            this.rollbackPending();
+          }
         }
         return result;
       } finally {

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -2,10 +2,11 @@
 // Only the param keys a subtree depends on enter its env projection, so
 // unrelated env changes don't invalidate independent subtrees.
 //
-// Returned shapes are borrowed — owned by the Evaluator's DisposalScope.
-// Callers must NOT dispose them; lifetime is the Evaluator's.
+// Returned shapes are borrowed — the Evaluator owns disposal; callers must
+// NOT dispose them. By default a returned shape is valid for the Evaluator's
+// whole lifetime. If `maxCacheEntries` is set, the cache is LRU-bounded and a
+// returned shape is only guaranteed valid until the next evaluate() call.
 import { getActiveKernelId, withKernel } from '@/kernel/index.js';
-import { DisposalScope } from '@/core/disposal.js';
 import { ok, type Result } from '@/core/result.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { projectEnv, type Env, type ExprValue } from './expressions.js';
@@ -44,6 +45,16 @@ export interface EvaluatorOptions {
   readonly tolerance?: number | undefined;
   /** Optional callback fired after every node visit, including cache hits (`info.cacheHit` discriminates). */
   readonly onStep?: ((info: StepInfo) => void) | undefined;
+  /**
+   * Upper bound on the number of materialized entries kept in the content
+   * cache. When the cache exceeds this after a top-level evaluate(), the
+   * least-recently-used entries are evicted and their kernel handles disposed
+   * (a handle shared by several entries is freed only when its last entry is
+   * evicted). Defaults to unbounded — entries live for the Evaluator's
+   * lifetime. With a bound set, a returned shape is only guaranteed valid
+   * until the next evaluate() call. Must be a positive integer.
+   */
+  readonly maxCacheEntries?: number | undefined;
 }
 
 export interface StepInfo {
@@ -56,6 +67,8 @@ export interface CacheStats {
   readonly hits: number;
   readonly misses: number;
   readonly entries: number;
+  /** Number of entries evicted by the LRU bound over this Evaluator's life. */
+  readonly evictions: number;
 }
 
 // Exhaustive dispatch — TS catches any new NodeKind missing an evaluator at
@@ -142,19 +155,22 @@ function cacheKey(node: IRNode, env: Env, kernelId: string, tolerance: number | 
 // ---------------------------------------------------------------------------
 
 export class Evaluator implements Disposable {
-  private readonly scope = new DisposalScope();
   private readonly cache = new Map<string, AnyShape<Dimension>>();
-  // Track which shape handles have been registered with the scope. Identity
-  // short-circuits in boolean/transform evaluators forward a child shape up
-  // through dispatch, so without this set the same handle would land in
-  // scope.handles multiple times — invariant violation even though
-  // ShapeHandle.delete() is itself idempotent.
-  private readonly registered = new WeakSet<AnyShape<Dimension>>();
+  // Reference count per materialized handle. A single handle can back several
+  // cache keys because boolean/compound identity short-circuits forward a
+  // child handle up unchanged (e.g. Fuse(Empty, b) → b, FuseAll([x]) → x).
+  // The cache owns disposal directly: a handle is deleted only when its last
+  // referencing entry is evicted, or when the Evaluator is disposed. (A
+  // DisposalScope can't back this — it can't release one handle on eviction
+  // without releasing the rest.)
+  private readonly refCounts = new Map<AnyShape<Dimension>, number>();
   private readonly kernelId: string;
   private readonly defaultTolerance: number | undefined;
+  private readonly maxCacheEntries: number | undefined;
   private readonly onStep?: (info: StepInfo) => void;
   private hits = 0;
   private misses = 0;
+  private evictions = 0;
 
   constructor(options: EvaluatorOptions = {}) {
     // Resolve to the concrete kernel id at construction so cache keys are
@@ -164,17 +180,33 @@ export class Evaluator implements Disposable {
     this.kernelId = options.kernel ?? getActiveKernelId() ?? 'unregistered';
     this.defaultTolerance = options.tolerance;
     if (options.onStep) this.onStep = options.onStep;
+    const max = options.maxCacheEntries;
+    if (max !== undefined && (!Number.isInteger(max) || max < 1)) {
+      throw new RangeError(
+        `Evaluator: maxCacheEntries must be a positive integer, got ${String(max)}`
+      );
+    }
+    this.maxCacheEntries = max;
   }
 
   /**
    * Materialize a CSG IR tree against the given parameter environment.
-   * The returned shape is borrowed — valid for as long as this Evaluator is
-   * not disposed. Callers must NOT call `.delete()` / `[Symbol.dispose]()`
-   * on the returned shape; that would invalidate the cache entry for every
-   * future call returning the same handle.
+   * The returned shape is borrowed — callers must NOT call `.delete()` /
+   * `[Symbol.dispose]()` on it; that would invalidate the cache entry for
+   * every future call returning the same handle. By default it stays valid
+   * until the Evaluator is disposed; if `maxCacheEntries` is set, only until
+   * the next evaluate() call (LRU eviction may free older entries).
    */
   evaluate(node: IRNode, env: Env = {}): Result<AnyShape<Dimension>> {
-    return withKernel(this.kernelId, () => this.evaluateInner(node, env));
+    return withKernel(this.kernelId, () => {
+      const result = this.evaluateInner(node, env);
+      // Eviction runs only here, between top-level evaluations — never during
+      // the recursive descent, so operands still in flight are never freed.
+      // The just-returned result is the most-recently-used entry, so trimming
+      // to a bound >= 1 never frees the shape the caller just received.
+      if (this.maxCacheEntries !== undefined) this.trimCache(this.maxCacheEntries);
+      return result;
+    });
   }
 
   private evaluateInner(node: IRNode, env: Env): Result<AnyShape<Dimension>> {
@@ -182,6 +214,12 @@ export class Evaluator implements Disposable {
     const cached = this.cache.get(key);
     if (cached !== undefined) {
       this.hits++;
+      // Touch for LRU recency — only when bounded, so the unbounded path stays
+      // behaviourally identical (and allocation-free) to before.
+      if (this.maxCacheEntries !== undefined) {
+        this.cache.delete(key);
+        this.cache.set(key, cached);
+      }
       this.onStep?.({ node, cacheKey: key, cacheHit: true });
       return ok(cached);
     }
@@ -193,26 +231,57 @@ export class Evaluator implements Disposable {
     };
     const result = dispatch(node, ctx);
     if (!result.ok) return result;
-    if (!this.registered.has(result.value)) {
-      this.scope.register(result.value);
-      this.registered.add(result.value);
-    }
-    this.cache.set(key, result.value);
+    const shape = result.value;
+    this.refCounts.set(shape, (this.refCounts.get(shape) ?? 0) + 1);
+    this.cache.set(key, shape);
     this.onStep?.({ node, cacheKey: key, cacheHit: false });
     return result;
   }
 
+  // Evict least-recently-used entries until the cache is within `max`. A
+  // handle is disposed only when its final referencing entry leaves the cache
+  // (refCounts → 0); a handle shared across keys survives until its last key
+  // is evicted, so identity short-circuits can never produce a use-after-free.
+  private trimCache(max: number): void {
+    while (this.cache.size > max) {
+      const oldest = this.cache.keys().next();
+      if (oldest.done) break;
+      const key = oldest.value;
+      const shape = this.cache.get(key);
+      this.cache.delete(key);
+      this.evictions++;
+      if (shape === undefined) continue;
+      const next = (this.refCounts.get(shape) ?? 1) - 1;
+      if (next <= 0) {
+        this.refCounts.delete(shape);
+        shape[Symbol.dispose]();
+      } else {
+        this.refCounts.set(shape, next);
+      }
+    }
+  }
+
   cacheStats(): CacheStats {
-    return { hits: this.hits, misses: this.misses, entries: this.cache.size };
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      entries: this.cache.size,
+      evictions: this.evictions,
+    };
   }
 
   resetStats(): void {
     this.hits = 0;
     this.misses = 0;
+    this.evictions = 0;
   }
 
   [Symbol.dispose](): void {
-    this.scope[Symbol.dispose]();
+    // The cache owns every live handle; dispose each unique handle once.
+    for (const shape of this.refCounts.keys()) {
+      shape[Symbol.dispose]();
+    }
+    this.refCounts.clear();
     this.cache.clear();
   }
 }

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -53,8 +53,9 @@ export interface EvaluatorOptions {
    * (a handle shared by several entries is freed only when its last entry is
    * evicted). Defaults to unbounded — entries live for the Evaluator's
    * lifetime. With a bound set, a returned shape is only guaranteed valid
-   * until the next successful evaluate() call; a failed evaluate() is
-   * transactional — it leaves the cache unchanged. Must be a positive integer.
+   * until the next successful evaluate() call; a failed or thrown evaluate() is
+   * transactional (the cache is left unchanged), and evaluate() is non-reentrant
+   * (calling it from an onStep callback throws). Must be a positive integer.
    */
   readonly maxCacheEntries?: number | undefined;
 }
@@ -166,14 +167,14 @@ export class Evaluator implements Disposable {
   // DisposalScope can't back this — it can't release one handle on eviction
   // without releasing the rest.)
   private readonly refCounts = new Map<AnyShape<Dimension>, number>();
-  // Depth of the current public evaluate() call. The cache is reconciled
-  // (trim on success / roll back on failure) only when leaving the OUTERMOST
-  // call, so a reentrant evaluate() — e.g. from an onStep callback — can never
-  // evict operands the outer evaluation is still using.
-  private evalDepth = 0;
-  // Keys inserted during the current outermost evaluate(). On failure these are
-  // rolled back, so a failed call leaves the cache exactly as it was (bound
-  // preserved, older results untouched).
+  // True while a public evaluate() is in progress. When bounded, evaluate() is
+  // non-reentrant (an onStep callback must not call it) — that keeps cache
+  // reconciliation simple and rules out a class of use-after-free / contract
+  // hazards that arise from mutating the cache mid-evaluation.
+  private evaluating = false;
+  // Keys inserted during the current evaluate(). On a failed or thrown
+  // evaluation they are rolled back, so the call is transactional: the cache is
+  // left exactly as it was (bound preserved, older results untouched).
   private readonly pendingKeys: string[] = [];
   private readonly kernelId: string;
   private readonly defaultTolerance: number | undefined;
@@ -206,38 +207,40 @@ export class Evaluator implements Disposable {
    * `[Symbol.dispose]()` on it; that would invalidate the cache entry for
    * every future call returning the same handle. By default it stays valid
    * until the Evaluator is disposed; if `maxCacheEntries` is set, only until
-   * the next successful evaluate() call (LRU eviction may free older entries).
+   * the next successful evaluate() call (LRU eviction may free older entries),
+   * and evaluate() is then non-reentrant — calling it from an onStep callback
+   * throws.
    */
   evaluate(node: IRNode, env: Env = {}): Result<AnyShape<Dimension>> {
+    // A bounded cache mutates during evaluate(); a reentrant call (e.g. from an
+    // onStep callback) could evict operands the outer evaluation still holds.
+    // Forbidding reentrancy when bounded keeps reconciliation a simple
+    // commit-on-success / rollback-otherwise at a single, non-nested level.
+    if (this.maxCacheEntries !== undefined && this.evaluating) {
+      throw new Error(
+        'Evaluator.evaluate() is not reentrant when maxCacheEntries is set — ' +
+          'do not call it from an onStep callback.'
+      );
+    }
     return withKernel(this.kernelId, () => {
-      const outermost = this.evalDepth === 0;
-      this.evalDepth++;
+      this.evaluating = true;
+      let committed = false;
       try {
         const result = this.evaluateInner(node, env);
-        // Reconcile the cache only when leaving the OUTERMOST evaluate() —
-        // never mid-recursion, and never from a reentrant call. On success the
-        // root is touched back to MRU (a reentrant onStep may have inserted
-        // newer entries after the root was cached, displacing it) before the
-        // bound is enforced by LRU eviction, so the returned shape is never
-        // freed. On failure the call's own inserts are rolled back, so a failed
-        // evaluation neither grows the cache nor evicts an older good result.
-        if (outermost && this.maxCacheEntries !== undefined) {
-          if (result.ok) {
-            const rootKey = cacheKey(node, env, this.kernelId, this.defaultTolerance);
-            const root = this.cache.get(rootKey);
-            if (root !== undefined) {
-              this.cache.delete(rootKey);
-              this.cache.set(rootKey, root);
-            }
-            this.trimCache(this.maxCacheEntries);
-          } else {
-            this.rollbackPending();
-          }
+        if (this.maxCacheEntries !== undefined && result.ok) {
+          // Success: the result is the most-recently-cached entry (no reentrant
+          // call could have displaced it), so a bound >= 1 never frees it.
+          this.trimCache(this.maxCacheEntries);
         }
+        committed = result.ok;
         return result;
       } finally {
-        this.evalDepth--;
-        if (outermost) this.pendingKeys.length = 0;
+        // Any non-success exit — an Err result or a thrown onStep/kernel error
+        // — rolls back this call's inserts, so the evaluation is transactional
+        // and the bound is never left exceeded.
+        if (!committed && this.maxCacheEntries !== undefined) this.rollbackPending();
+        this.pendingKeys.length = 0;
+        this.evaluating = false;
       }
     });
   }
@@ -299,7 +302,7 @@ export class Evaluator implements Disposable {
     }
   }
 
-  // Undo the inserts made during a failed outermost evaluate(). Removal is by
+  // Undo the inserts made during a failed or thrown evaluate(). Removal is by
   // key (not position), so entries merely touched (hit) during the call are
   // kept — only the call's own new entries are dropped.
   private rollbackPending(): void {

--- a/tests/csg/cacheEviction.test.ts
+++ b/tests/csg/cacheEviction.test.ts
@@ -128,49 +128,38 @@ describe('CSG cache eviction — error path & reentrancy', () => {
     expect(unwrap(measureVolume(r))).toBeCloseTo(125, 3);
   });
 
-  it('does not free outer operands when onStep re-enters evaluate()', () => {
-    // onStep fires mid-recursion. If it calls evaluate() on the same evaluator,
-    // that nested call must not trim the cache (which would dispose operands the
-    // outer Fuse still needs). Only the outermost call reconciles the cache.
-    let reentered = false;
+  it('rejects a reentrant evaluate() from onStep when bounded', () => {
     const ev = new Evaluator({
-      maxCacheEntries: 1,
-      onStep: (info) => {
-        if (!reentered && !info.cacheHit) {
-          reentered = true;
-          unwrap(ev.evaluate(box(9, 9, 9))); // reentrant top-level call
-        }
+      maxCacheEntries: 2,
+      onStep: () => {
+        ev.evaluate(box(9, 9, 9)); // reentrant → must throw
       },
     });
     try {
-      // Throws a disposed-handle error if the nested call evicted box(7,7,7).
-      const r = unwrap(ev.evaluate(fuse(box(7, 7, 7), box(8, 8, 8))));
-      expect(unwrap(measureVolume(r))).toBeGreaterThan(0);
+      expect(() => ev.evaluate(box(7, 7, 7))).toThrow(/not reentrant/i);
+      // The aborted call rolled back its insert — the cache is left clean.
+      expect(ev.cacheStats().entries).toBe(0);
     } finally {
       ev[Symbol.dispose]();
     }
   });
 
-  it('protects the returned root when onStep on the root node re-enters', () => {
-    // The root's own onStep fires after the root is cached; a reentrant
-    // evaluate() then inserts newer entries, displacing the root from MRU. The
-    // outer trim must still keep the root (it is touched back to MRU first),
-    // otherwise the returned handle would be disposed.
-    let done = false;
-    const root = fuse(box(7, 7, 7), box(8, 8, 8));
+  it('a throwing onStep is transactional: bound preserved, prior result kept', () => {
+    let armed = false;
     const ev = new Evaluator({
       maxCacheEntries: 1,
       onStep: (info) => {
-        if (info.node === root && !info.cacheHit && !done) {
-          done = true;
-          unwrap(ev.evaluate(box(9, 9, 9)));
-          unwrap(ev.evaluate(box(10, 10, 10)));
-        }
+        if (armed && !info.cacheHit) throw new Error('boom');
       },
     });
     try {
-      const r = unwrap(ev.evaluate(root));
-      expect(unwrap(measureVolume(r))).toBeGreaterThan(0);
+      const r = unwrap(ev.evaluate(box(5, 5, 5))); // cache:[box5]
+      armed = true;
+      // Caches box6, then onStep throws → the call must roll box6 back,
+      // keeping the bound and the earlier result intact.
+      expect(() => ev.evaluate(box(6, 6, 6))).toThrow(/boom/);
+      expect(ev.cacheStats().entries).toBeLessThanOrEqual(1);
+      expect(unwrap(measureVolume(r))).toBeCloseTo(125, 3);
     } finally {
       ev[Symbol.dispose]();
     }

--- a/tests/csg/cacheEviction.test.ts
+++ b/tests/csg/cacheEviction.test.ts
@@ -150,4 +150,29 @@ describe('CSG cache eviction — error path & reentrancy', () => {
       ev[Symbol.dispose]();
     }
   });
+
+  it('protects the returned root when onStep on the root node re-enters', () => {
+    // The root's own onStep fires after the root is cached; a reentrant
+    // evaluate() then inserts newer entries, displacing the root from MRU. The
+    // outer trim must still keep the root (it is touched back to MRU first),
+    // otherwise the returned handle would be disposed.
+    let done = false;
+    const root = fuse(box(7, 7, 7), box(8, 8, 8));
+    const ev = new Evaluator({
+      maxCacheEntries: 1,
+      onStep: (info) => {
+        if (info.node === root && !info.cacheHit && !done) {
+          done = true;
+          unwrap(ev.evaluate(box(9, 9, 9)));
+          unwrap(ev.evaluate(box(10, 10, 10)));
+        }
+      },
+    });
+    try {
+      const r = unwrap(ev.evaluate(root));
+      expect(unwrap(measureVolume(r))).toBeGreaterThan(0);
+    } finally {
+      ev[Symbol.dispose]();
+    }
+  });
 });

--- a/tests/csg/cacheEviction.test.ts
+++ b/tests/csg/cacheEviction.test.ts
@@ -1,0 +1,114 @@
+// LRU eviction for the CSG evaluator cache (opt-in via maxCacheEntries).
+// Focus is correctness under the borrowed-shape contract: shared handles
+// (created by identity short-circuits like Fuse(Empty, b) → b) must survive
+// until their LAST cache key is evicted, and the unbounded default must be
+// behaviourally unchanged.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from '../setup.js';
+import { Evaluator, withEvaluator, box, sphere, fuse, emptySolid } from '@/csg/index.js';
+import { unwrap, measureVolume, getDisposalStats } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('CSG cache eviction — default (unbounded)', () => {
+  it('never evicts when maxCacheEntries is unset', () => {
+    using ev = new Evaluator();
+    for (let i = 1; i <= 12; i++) unwrap(ev.evaluate(box(i, 5, 5)));
+    const s = ev.cacheStats();
+    expect(s.evictions).toBe(0);
+    expect(s.entries).toBe(12);
+  });
+});
+
+describe('CSG cache eviction — bounded', () => {
+  it('rejects a non-positive-integer bound', () => {
+    expect(() => new Evaluator({ maxCacheEntries: 0 })).toThrow(RangeError);
+    expect(() => new Evaluator({ maxCacheEntries: -3 })).toThrow(RangeError);
+    expect(() => new Evaluator({ maxCacheEntries: 2.5 })).toThrow(RangeError);
+  });
+
+  it('caps the cache at maxCacheEntries and counts evictions', () => {
+    using ev = new Evaluator({ maxCacheEntries: 4 });
+    for (let i = 1; i <= 12; i++) unwrap(ev.evaluate(box(i, 5, 5)));
+    expect(ev.cacheStats().entries).toBeLessThanOrEqual(4);
+    expect(ev.cacheStats().evictions).toBe(8); // 12 single-node trees, 4 kept
+  });
+
+  it('keeps recently-used entries and evicts the stale one (LRU)', () => {
+    using ev = new Evaluator({ maxCacheEntries: 2 });
+    const a = box(2, 2, 2);
+    const b = box(3, 3, 3);
+    const c = box(4, 4, 4);
+    unwrap(ev.evaluate(a)); // [a]
+    unwrap(ev.evaluate(b)); // [a, b]
+    unwrap(ev.evaluate(a)); // touch a → [b, a]
+    unwrap(ev.evaluate(c)); // +c → evict LRU (b) → [a, c]
+
+    ev.resetStats();
+    unwrap(ev.evaluate(a)); // survived → hit
+    expect(ev.cacheStats()).toMatchObject({ hits: 1, misses: 0 });
+
+    ev.resetStats();
+    unwrap(ev.evaluate(b)); // evicted → miss + re-materialize
+    expect(ev.cacheStats().misses).toBeGreaterThanOrEqual(1);
+  });
+
+  it('re-materializes correct geometry after an entry is evicted', () => {
+    using ev = new Evaluator({ maxCacheEntries: 2 });
+    const a = box(5, 5, 5);
+    unwrap(ev.evaluate(a));
+    unwrap(ev.evaluate(sphere(3))); // push a toward the tail
+    unwrap(ev.evaluate(box(8, 8, 8))); // evict a
+    expect(ev.cacheStats().evictions).toBeGreaterThanOrEqual(1);
+    const r = unwrap(ev.evaluate(a)); // miss → rebuild
+    expect(unwrap(measureVolume(r))).toBeCloseTo(125, 3);
+  });
+
+  it('honors the bound through withEvaluator', () => {
+    const vol = withEvaluator({ maxCacheEntries: 2 }, (ev) => {
+      for (let i = 1; i <= 6; i++) unwrap(ev.evaluate(box(i, 4, 4)));
+      expect(ev.cacheStats().entries).toBeLessThanOrEqual(2);
+      return unwrap(measureVolume(unwrap(ev.evaluate(box(5, 4, 4)))));
+    });
+    expect(vol).toBeCloseTo(80, 3); // 5*4*4
+  });
+});
+
+describe('CSG cache eviction — shared-handle safety', () => {
+  it('keeps a shared handle alive while one of its keys is evicted', () => {
+    // Fuse(b, Empty) short-circuits to b's handle, so the box key and the
+    // fuse key back the SAME handle (refcount 2). With a bound of 1, the
+    // older box key is evicted but the handle must survive (refcount → 1),
+    // not be freed — otherwise the returned result is a disposed handle.
+    using ev = new Evaluator({ maxCacheEntries: 1 });
+    const b = box(4, 4, 4);
+    const r1 = unwrap(ev.evaluate(fuse(b, emptySolid())));
+    expect(ev.cacheStats().evictions).toBe(1); // box key evicted, fuse key kept
+    expect(unwrap(measureVolume(r1))).toBeCloseTo(64, 3); // handle still live
+
+    const r2 = unwrap(ev.evaluate(fuse(b, emptySolid()))); // fuse key hit
+    expect(unwrap(measureVolume(r2))).toBeCloseTo(64, 3);
+  });
+});
+
+describe('CSG cache eviction — disposal accounting', () => {
+  it('frees an evicted handle and leaves no leak after dispose', () => {
+    const base = getDisposalStats().liveHandles;
+    {
+      using ev = new Evaluator({ maxCacheEntries: 1 });
+      unwrap(ev.evaluate(box(3, 3, 3))); // [box1]
+      const afterFirst = getDisposalStats().liveHandles;
+      expect(afterFirst).toBeGreaterThan(base);
+
+      unwrap(ev.evaluate(box(7, 7, 7))); // box2 in, box1 evicted + disposed
+      expect(ev.cacheStats().evictions).toBe(1);
+      // Net live handles must not grow across the eviction.
+      expect(getDisposalStats().liveHandles).toBeLessThanOrEqual(afterFirst);
+    }
+    // Evaluator disposed → its remaining handle is freed too.
+    expect(getDisposalStats().liveHandles).toBe(base);
+  });
+});

--- a/tests/csg/cacheEviction.test.ts
+++ b/tests/csg/cacheEviction.test.ts
@@ -113,15 +113,41 @@ describe('CSG cache eviction — disposal accounting', () => {
   });
 });
 
-describe('CSG cache eviction — error path', () => {
-  it('a failed evaluation does not evict a previously-returned good result', () => {
+describe('CSG cache eviction — error path & reentrancy', () => {
+  it('rolls back a failed call: bound preserved, prior result kept', () => {
     using ev = new Evaluator({ maxCacheEntries: 1 });
-    const r = unwrap(ev.evaluate(box(5, 5, 5))); // cache:[box5], r borrowed (MRU)
-    // This tree caches its first operand, then fails on the unbound param `w`.
-    // A failed call must NOT trim — otherwise it would evict + dispose r.
-    const failing = fuse(box(6, 6, 6), box(param('w'), 6, 6));
-    expect(ev.evaluate(failing, {}).ok).toBe(false);
-    expect(ev.cacheStats().evictions).toBe(0);
-    expect(unwrap(measureVolume(r))).toBeCloseTo(125, 3); // r still live
+    const r = unwrap(ev.evaluate(box(5, 5, 5))); // cache:[box5], r borrowed
+    // Each tree caches its first operand, then fails on the unbound param `w`.
+    // Every failure must roll back its insert — the cache must not grow past
+    // the bound, and the earlier good result must stay live.
+    for (let i = 0; i < 8; i++) {
+      expect(ev.evaluate(fuse(box(6 + i, 6, 6), box(param('w'), 6, 6)), {}).ok).toBe(false);
+    }
+    expect(ev.cacheStats().entries).toBeLessThanOrEqual(1);
+    expect(ev.cacheStats().evictions).toBe(0); // rollbacks are not evictions
+    expect(unwrap(measureVolume(r))).toBeCloseTo(125, 3);
+  });
+
+  it('does not free outer operands when onStep re-enters evaluate()', () => {
+    // onStep fires mid-recursion. If it calls evaluate() on the same evaluator,
+    // that nested call must not trim the cache (which would dispose operands the
+    // outer Fuse still needs). Only the outermost call reconciles the cache.
+    let reentered = false;
+    const ev = new Evaluator({
+      maxCacheEntries: 1,
+      onStep: (info) => {
+        if (!reentered && !info.cacheHit) {
+          reentered = true;
+          unwrap(ev.evaluate(box(9, 9, 9))); // reentrant top-level call
+        }
+      },
+    });
+    try {
+      // Throws a disposed-handle error if the nested call evicted box(7,7,7).
+      const r = unwrap(ev.evaluate(fuse(box(7, 7, 7), box(8, 8, 8))));
+      expect(unwrap(measureVolume(r))).toBeGreaterThan(0);
+    } finally {
+      ev[Symbol.dispose]();
+    }
   });
 });

--- a/tests/csg/cacheEviction.test.ts
+++ b/tests/csg/cacheEviction.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from '../setup.js';
-import { Evaluator, withEvaluator, box, sphere, fuse, emptySolid } from '@/csg/index.js';
+import { Evaluator, withEvaluator, box, sphere, fuse, emptySolid, param } from '@/csg/index.js';
 import { unwrap, measureVolume, getDisposalStats } from '@/index.js';
 
 beforeAll(async () => {
@@ -110,5 +110,18 @@ describe('CSG cache eviction — disposal accounting', () => {
     }
     // Evaluator disposed → its remaining handle is freed too.
     expect(getDisposalStats().liveHandles).toBe(base);
+  });
+});
+
+describe('CSG cache eviction — error path', () => {
+  it('a failed evaluation does not evict a previously-returned good result', () => {
+    using ev = new Evaluator({ maxCacheEntries: 1 });
+    const r = unwrap(ev.evaluate(box(5, 5, 5))); // cache:[box5], r borrowed (MRU)
+    // This tree caches its first operand, then fails on the unbound param `w`.
+    // A failed call must NOT trim — otherwise it would evict + dispose r.
+    const failing = fuse(box(6, 6, 6), box(param('w'), 6, 6));
+    expect(ev.evaluate(failing, {}).ok).toBe(false);
+    expect(ev.cacheStats().evictions).toBe(0);
+    expect(unwrap(measureVolume(r))).toBeCloseTo(125, 3); // r still live
   });
 });

--- a/tests/csg/csgEvaluator.test.ts
+++ b/tests/csg/csgEvaluator.test.ts
@@ -117,7 +117,7 @@ describe('Evaluator — cache & incremental re-eval', () => {
     ev.evaluate(tree, { w: 5 });
     ev.resetStats();
     ev.evaluate(tree, { w: 7 });
-    expect(ev.cacheStats()).toEqual({ hits: 1, misses: 2, entries: 5 });
+    expect(ev.cacheStats()).toEqual({ hits: 1, misses: 2, entries: 5, evictions: 0 });
   });
 
   it('changing an unrelated env key invalidates nothing', () => {


### PR DESCRIPTION
## What

Adds **opt-in LRU eviction** to the CSG `Evaluator` content cache via a new `maxCacheEntries` option. Addresses the cache-eviction item in the perf tracking epic #1606.

Previously the evaluator cache was an unbounded `Map` — entries lived for the evaluator's whole lifetime, so long-lived evaluators grew without limit.

## How

- New `EvaluatorOptions.maxCacheEntries` (positive integer; validated in the constructor). **Default `undefined` = today's unbounded behavior**, so this is fully additive and non-breaking.
- When set, least-recently-used entries are evicted **only between top-level `evaluate()` calls** — never mid-recursion, so operands still in flight are never freed.
- Disposal is **refcounted**. A single kernel handle can back several cache keys because boolean/compound identity short-circuits forward a child handle up unchanged (`Fuse(Empty, b) → b`, `FuseAll([x]) → x` — see `evaluators/booleans.ts`). A handle is disposed only when its **last** referencing entry is evicted, so eviction can never produce a use-after-free.
- The cache now **owns disposal directly**, replacing the `DisposalScope` (which couldn't release one handle on eviction without releasing the rest). The `registered` WeakSet is subsumed by the refcount map.
- Adds an `evictions` counter to `CacheStats`.

## ⚠️ Contract note (please eyeball)

The borrowed-shape lifetime contract is **unchanged by default**. When `maxCacheEntries` is set, it narrows: a returned shape is guaranteed valid only **until the next `evaluate()` call** (an older entry may be evicted/freed). This is documented on `EvaluatorOptions.maxCacheEntries` and in the file header. Callers who opt in must consume/copy results before the next call. Existing callers (no option) see no change.

## Tests

`tests/csg/cacheEviction.test.ts` — 8 tests, green across all kernel projects (occt-wasm, brepkit, manifold):

- unbounded default never evicts;
- bound caps entries + counts evictions; LRU keeps recently-used and evicts the stale one;
- **shared-handle safety**: `Fuse(b, Empty)` shares `b`'s handle; evicting one key keeps the handle alive (refcount), and the result stays measurable (would throw on a disposed handle if refcounting were wrong);
- **disposal accounting**: an evicted handle is freed and there's no leak after the evaluator is disposed;
- re-materializes correct geometry after eviction; `withEvaluator` passthrough; rejects non-positive-integer bounds.

Updated one strict `toEqual` in `csgEvaluator.test.ts` for the new `evictions` field.

---
🤖 Part of an autonomous performance pass against the #1606 epic.
