### PR TITLE
chore(size): raise total-JS budget + add per-entry budgets for untracked exports

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -12,5 +12,13 @@
   { "name": "brepjs/measurement", "path": "dist/measurement.js", "limit": "500 B" },
   { "name": "brepjs/io", "path": "dist/io.js", "limit": "8 kB" },
   { "name": "brepjs/worker", "path": "dist/worker.js", "limit": "2 kB" },
-  { "name": "brepjs/quick", "path": "dist/quick.js", "limit": "500 B" }
+  { "name": "brepjs/quick", "path": "dist/quick.js", "limit": "500 B" },
+  { "name": "brepjs/text", "path": "dist/text.js", "limit": "500 B" },
+  { "name": "brepjs/projection", "path": "dist/projection.js", "limit": "500 B" },
+  { "name": "brepjs/shapeRef", "path": "dist/shapeRef.js", "limit": "500 B" },
+  {
+    "name": "brepjs/kernel/occtWasm/occtWasmAdapter",
+    "path": "dist/kernel/occtWasm/occtWasmAdapter.js",
+    "limit": "1 kB"
+  }
 ]

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "330 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "340 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "55 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },


### PR DESCRIPTION
Proactive headroom (user-approved) for the in-flight #1606 performance pass. The library was sitting at its 325 kB `total (all JS)` ceiling; #1603 (cache key) and #1604 (instancing node) add library code that would otherwise trip the budget per PR. Current actual is ~325 kB; per-entry budgets (incl. `brepjs` 55 kB) are unchanged.

Part of #1606.