### PR TITLE
feat(viewer): instanced-mesh render path for instanced shapes

### DIFF
--- a/packages/brepjs-viewer/src/geometry.ts
+++ b/packages/brepjs-viewer/src/geometry.ts
@@ -9,6 +9,66 @@ export function buildGeometry(data: MeshData): THREE.BufferGeometry {
   return geo;
 }
 
+/** A per-instance transform: a THREE.Matrix4 or a brepjs row-major 4x4. */
+export type InstancePlacement = THREE.Matrix4 | ReadonlyArray<ReadonlyArray<number>>;
+
+/**
+ * Convert a brepjs row-major 4x4 (`[[row0],[row1],[row2],[row3]]`, as returned
+ * by brepjs `instancedMesh().instances`) to a THREE.Matrix4. THREE.Matrix4.set
+ * is row-major, so the rows map directly.
+ */
+export function instanceMatrix(m: ReadonlyArray<ReadonlyArray<number>>): THREE.Matrix4 {
+  const r0 = m[0] as readonly number[];
+  const r1 = m[1] as readonly number[];
+  const r2 = m[2] as readonly number[];
+  const r3 = m[3] as readonly number[];
+  // prettier-ignore
+  return new THREE.Matrix4().set(
+    r0[0] as number, r0[1] as number, r0[2] as number, r0[3] as number,
+    r1[0] as number, r1[1] as number, r1[2] as number, r1[3] as number,
+    r2[0] as number, r2[1] as number, r2[2] as number, r2[3] as number,
+    r3[0] as number, r3[1] as number, r3[2] as number, r3[3] as number,
+  );
+}
+
+export interface InstancedMeshOptions {
+  /** Material color (defaults to data.color, then the viewer's neutral grey). */
+  color?: string;
+}
+
+/**
+ * Build a THREE.InstancedMesh from one source MeshData (meshed once) plus N
+ * per-instance transforms — the "one tessellation, N placements" render of a
+ * brepjs `instancedMesh()` payload, so a 10x10 grid is a single GPU draw.
+ * Placements may be THREE.Matrix4 or brepjs row-major 4x4 arrays.
+ *
+ * The caller owns the returned mesh: dispose its geometry + material on unmount.
+ */
+export function buildInstancedMesh(
+  data: MeshData,
+  placements: ReadonlyArray<InstancePlacement>,
+  opts: InstancedMeshOptions = {},
+): THREE.InstancedMesh {
+  const geometry = buildGeometry(data);
+  geometry.computeBoundingSphere();
+  const color = opts.color ?? data.color ?? '#d4d8dc';
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    metalness: 0,
+    roughness: 0.45,
+    emissive: new THREE.Color(color),
+    emissiveIntensity: 0.08,
+  });
+  const mesh = new THREE.InstancedMesh(geometry, material, placements.length);
+  for (let i = 0; i < placements.length; i++) {
+    const p = placements[i];
+    if (p === undefined) continue;
+    mesh.setMatrixAt(i, p instanceof THREE.Matrix4 ? p : instanceMatrix(p));
+  }
+  mesh.instanceMatrix.needsUpdate = true;
+  return mesh;
+}
+
 export interface MeshBounds {
   min: [number, number, number];
   max: [number, number, number];

--- a/packages/brepjs-viewer/src/geometry.ts
+++ b/packages/brepjs-viewer/src/geometry.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import type { MeshData, FaceGroup } from './types.js';
+import type { MeshData, FaceGroup, ViewMode } from './types.js';
 
 export function buildGeometry(data: MeshData): THREE.BufferGeometry {
   const geo = new THREE.BufferGeometry();
@@ -34,13 +34,21 @@ export function instanceMatrix(m: ReadonlyArray<ReadonlyArray<number>>): THREE.M
 export interface InstancedMeshOptions {
   /** Material color (defaults to data.color, then the viewer's neutral grey). */
   color?: string;
+  /** Render mode, mirroring Renderer: 'solid' (default) | 'wireframe' | 'xray'. */
+  viewMode?: ViewMode;
+  /** Section clipping planes, as built by `sectionPlane`. */
+  clippingPlanes?: THREE.Plane[] | null;
 }
 
 /**
- * Build a THREE.InstancedMesh from one source MeshData (meshed once) plus N
+ * Build a THREE.InstancedMesh from one source mesh (meshed once) plus N
  * per-instance transforms — the "one tessellation, N placements" render of a
  * brepjs `instancedMesh()` payload, so a 10x10 grid is a single GPU draw.
- * Placements may be THREE.Matrix4 or brepjs row-major 4x4 arrays.
+ *
+ * `data` is the source as viewer MeshData — convert a brepjs `ShapeMesh`
+ * (vertices/normals/triangles) the same way you already do for `Renderer`.
+ * `placements` is `instancedMesh().instances` (THREE.Matrix4 or brepjs row-major
+ * 4x4). The material mirrors `Renderer` (color/modes/clipping).
  *
  * The caller owns the returned mesh: dispose its geometry + material on unmount.
  */
@@ -50,14 +58,23 @@ export function buildInstancedMesh(
   opts: InstancedMeshOptions = {},
 ): THREE.InstancedMesh {
   const geometry = buildGeometry(data);
-  geometry.computeBoundingSphere();
   const color = opts.color ?? data.color ?? '#d4d8dc';
+  const viewMode = opts.viewMode ?? 'solid';
   const material = new THREE.MeshStandardMaterial({
     color,
     metalness: 0,
     roughness: 0.45,
     emissive: new THREE.Color(color),
     emissiveIntensity: 0.08,
+    side: viewMode === 'solid' ? THREE.FrontSide : THREE.DoubleSide,
+    wireframe: viewMode === 'wireframe',
+    transparent: viewMode === 'xray',
+    opacity: viewMode === 'xray' ? 0.35 : 1,
+    depthWrite: viewMode !== 'xray',
+    polygonOffset: true,
+    polygonOffsetFactor: 1,
+    polygonOffsetUnits: 1,
+    clippingPlanes: opts.clippingPlanes ?? null,
   });
   const mesh = new THREE.InstancedMesh(geometry, material, placements.length);
   for (let i = 0; i < placements.length; i++) {
@@ -66,6 +83,10 @@ export function buildInstancedMesh(
     mesh.setMatrixAt(i, p instanceof THREE.Matrix4 ? p : instanceMatrix(p));
   }
   mesh.instanceMatrix.needsUpdate = true;
+  // InstancedMesh keeps its own bounds for frustum culling / raycasting, and
+  // setMatrixAt doesn't update them — recompute over the instance matrices so
+  // a grid translated far from the source mesh isn't wrongly culled.
+  mesh.computeBoundingSphere();
   return mesh;
 }
 

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -13,10 +13,14 @@ export {
 export * from './types.js';
 export {
   buildGeometry,
+  buildInstancedMesh,
+  instanceMatrix,
   findFaceGroupAt,
   meshSize,
   meshBounds,
   sectionPlane,
   type MeshBounds,
   type SectionAxis,
+  type InstancePlacement,
+  type InstancedMeshOptions,
 } from './geometry.js';

--- a/packages/brepjs-viewer/tests/geometry.test.ts
+++ b/packages/brepjs-viewer/tests/geometry.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { buildGeometry, findFaceGroupAt, meshBounds, meshSize, sectionPlane } from '@/geometry.js';
+import * as THREE from 'three';
+import {
+  buildGeometry,
+  buildInstancedMesh,
+  instanceMatrix,
+  findFaceGroupAt,
+  meshBounds,
+  meshSize,
+  sectionPlane,
+} from '@/geometry.js';
 import type { MeshData } from '@/types.js';
 
 const data: MeshData = {
@@ -42,5 +51,49 @@ describe('bounds + section', () => {
     const flipped = sectionPlane('x', 1, true);
     expect(flipped.distanceToPoint({ x: 3, y: 0, z: 0 } as never)).toBeLessThan(0);
     expect(flipped.distanceToPoint({ x: -1, y: 0, z: 0 } as never)).toBeGreaterThan(0);
+  });
+});
+
+describe('instancing', () => {
+  const tri: MeshData = {
+    position: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normal: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    index: new Uint32Array([0, 1, 2]),
+    edges: new Float32Array([]),
+  };
+
+  it('instanceMatrix maps a row-major 4x4 to a THREE.Matrix4 translation', () => {
+    const m = instanceMatrix([
+      [1, 0, 0, 5],
+      [0, 1, 0, 6],
+      [0, 0, 1, 7],
+      [0, 0, 0, 1],
+    ]);
+    // THREE stores column-major; the translation lives in elements[12..14].
+    expect(m.elements[12]).toBe(5);
+    expect(m.elements[13]).toBe(6);
+    expect(m.elements[14]).toBe(7);
+  });
+
+  it('buildInstancedMesh is one InstancedMesh + N placements, geometry meshed once', () => {
+    const mesh = buildInstancedMesh(tri, [
+      [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ],
+      [
+        [1, 0, 0, 10],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ],
+    ]);
+    expect(mesh.count).toBe(2);
+    expect(mesh.geometry.getAttribute('position').count).toBe(3); // one source mesh
+    const out = new THREE.Matrix4();
+    mesh.getMatrixAt(1, out);
+    expect(out.elements[12]).toBe(10); // second instance translated +10 in x
   });
 });

--- a/packages/brepjs-viewer/tests/geometry.test.ts
+++ b/packages/brepjs-viewer/tests/geometry.test.ts
@@ -96,4 +96,25 @@ describe('instancing', () => {
     mesh.getMatrixAt(1, out);
     expect(out.elements[12]).toBe(10); // second instance translated +10 in x
   });
+
+  it('computes instance-aware bounds covering far-translated placements', () => {
+    const mesh = buildInstancedMesh(tri, [
+      [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ],
+      [
+        [1, 0, 0, 100],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+      ],
+    ]);
+    // Source spans x~0..1; the far instance sits at x=100, so the InstancedMesh
+    // bounds must reach it (geometry-only bounds would be ~radius 1).
+    expect(mesh.boundingSphere).not.toBeNull();
+    expect(mesh.boundingSphere?.radius ?? 0).toBeGreaterThan(40);
+  });
 });


### PR DESCRIPTION
#1605 — render a brepjs `instancedMesh()` payload (one source mesh + N placements) as a single `THREE.InstancedMesh`, so a 10×10 grid is **one GPU draw** instead of 100 meshes.

- `buildInstancedMesh(data, placements, opts?)`: one geometry (meshed once) + `setMatrixAt` per instance, matching the Renderer's material conventions (color/metalness/roughness/emissive).
- `instanceMatrix(m)`: brepjs row-major 4×4 → `THREE.Matrix4`; `buildInstancedMesh` accepts `THREE.Matrix4` or brepjs 4×4 arrays.
- exported from the viewer index. Consumes the `instancedMesh()` payload added in #1613.

Tests in `packages/brepjs-viewer/tests/geometry.test.ts`. Completes the instancing render story (#1604/#1606).