### PR TITLE
feat(meshing): progressive (async) LOD refine

### DIFF
--- a/apps/docs/advanced/performance.md
+++ b/apps/docs/advanced/performance.md
@@ -186,11 +186,30 @@ console.log('LOD levels:', levels.length);
 
 Pass `tolerances: [...]` for absolute control, or tune `relativeTolerance` (finest level as a fraction of the diagonal) and `spacing` (ratio between levels). For just two tiers — preview + export — the older `meshMultiLOD` / `toLODGeometryData` pair still works.
 
+### Progressive refinement
+
+`meshLODsProgressive` delivers the levels over time instead of all at once: the coarse mesh lands first (an instant first frame), and finer levels arrive on later ticks via `onLevel`, so the UI stays responsive. An `AbortSignal` stops refinement when the shape changes.
+
+```typescript
+import { box, meshLODsProgressive } from 'brepjs/quick';
+
+const part = box(40, 40, 40);
+const ac = new AbortController();
+
+await meshLODsProgressive(part, {
+  levels: 3,
+  signal: ac.signal,
+  onLevel: (level) => console.log('LOD ready:', level.mesh.triangles.length / 3, 'tris'),
+});
+```
+
+By default each level is meshed synchronously on the calling thread. To refine truly off the main thread, pass a `meshLevel` that serializes the shape with `toBREP` and meshes it on a worker (see [Web Workers](./workers)): the library owns the coarse-first scheduling and cancellation, you own where the meshing runs.
+
 ## Knobs you do not have
 
 These are optimizations from real-time mesh engines that B-Rep meshing doesn't do for you:
 
-- **Automatic, kernel-side LOD selection**: brepjs gives you `meshLODs` (above), but the kernel meshes one tolerance per call — there's no behind-the-scenes detail switching, and no _progressive_ refinement (meshing is synchronous, so every level is computed up front; mesh the coarsest first if you need an instant first frame).
+- **Automatic, kernel-side LOD selection**: brepjs gives you `meshLODs` and `meshLODsProgressive` (above), but the kernel meshes one tolerance per call — there's no behind-the-scenes detail switching the renderer didn't ask for.
 - **Spatial partitioning of the kernel state**: the kernel sees one shape at a time. There's no octree behind the scenes — build spatial indices on brepjs's bounding boxes (`flatbush`, above) instead.
 - **Streaming booleans**: operations are atomic. You can't progressively refine a boolean — you mesh the finished result at whatever tolerance you choose.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -657,12 +657,15 @@ export {
   exportIGES,
   meshMultiLOD,
   meshLODs,
+  meshLODsProgressive,
   type ShapeMesh,
   type EdgeMesh,
   type MeshOptions,
   type MultiLODMesh,
   type LODMesh,
   type MeshLODsOptions,
+  type MeshLODsProgressiveOptions,
+  type MeshLevelFn,
 } from './topology/meshFns.js';
 
 export { clearMeshCache, createMeshCache, type MeshCacheContext } from './topology/meshCache.js';

--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -401,6 +401,29 @@ function boundsDiagonal(shape: AnyShape<Dimension>): number {
   return Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
 }
 
+/** Per-level linear tolerances for a LOD ladder, coarse (large) → fine (small). */
+function lodTolerances(shape: AnyShape<Dimension>, options: MeshLODsOptions): number[] {
+  let tolerances: number[];
+  if (options.tolerances && options.tolerances.length > 0) {
+    tolerances = [...options.tolerances];
+  } else {
+    const levels = Math.max(1, Math.floor(options.levels ?? 3));
+    const spacing = options.spacing ?? 4;
+    const relative = options.relativeTolerance ?? 0.0005;
+    const finest = relative * boundsDiagonal(shape) || Number.EPSILON;
+    tolerances = [];
+    for (let i = levels - 1; i >= 0; i--) tolerances.push(finest * spacing ** i);
+  }
+  // Sorted so the documented coarse → fine order holds for explicit input and a spacing < 1.
+  tolerances.sort((a, b) => b - a);
+  return tolerances;
+}
+
+/** A level's angular deflection scales with how much coarser it is than the finest (capped at 1 rad). */
+function levelAngular(tolerance: number, finestTol: number, finestAngular: number): number {
+  return Math.min(finestAngular * (tolerance / finestTol), 1);
+}
+
 /**
  * Mesh a shape at several levels of detail, coarse → fine.
  *
@@ -414,29 +437,12 @@ function boundsDiagonal(shape: AnyShape<Dimension>): number {
  * @see toLODGeometryLevels — convert to THREE.LOD geometry data
  */
 export function meshLODs(shape: AnyShape<Dimension>, options: MeshLODsOptions = {}): LODMesh[] {
-  const quality = qualityDeflection();
-  const finestAngular = options.angularTolerance ?? quality.angularTolerance;
+  const finestAngular = options.angularTolerance ?? qualityDeflection().angularTolerance;
   const cache = options.cache ?? true;
-
-  // Per-level linear tolerances. Sorted coarse (large) → fine (small) below so
-  // the documented order holds for explicit input and for a spacing < 1.
-  let tolerances: number[];
-  if (options.tolerances && options.tolerances.length > 0) {
-    tolerances = [...options.tolerances];
-  } else {
-    const levels = Math.max(1, Math.floor(options.levels ?? 3));
-    const spacing = options.spacing ?? 4;
-    const relative = options.relativeTolerance ?? 0.0005;
-    const finest = relative * boundsDiagonal(shape) || Number.EPSILON;
-    tolerances = [];
-    for (let i = levels - 1; i >= 0; i--) tolerances.push(finest * spacing ** i);
-  }
-  tolerances.sort((a, b) => b - a);
-
+  const tolerances = lodTolerances(shape, options);
   const finestTol = Math.min(...tolerances);
   return tolerances.map((tolerance) => {
-    // Scale angular detail with how much coarser this level is than the finest.
-    const angularTolerance = Math.min(finestAngular * (tolerance / finestTol), 1);
+    const angularTolerance = levelAngular(tolerance, finestTol, finestAngular);
     const levelMesh = mesh(shape, {
       tolerance,
       angularTolerance,
@@ -445,4 +451,88 @@ export function meshLODs(shape: AnyShape<Dimension>, options: MeshLODsOptions = 
     });
     return { tolerance, angularTolerance, mesh: levelMesh };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Progressive (async) LOD meshing
+// ---------------------------------------------------------------------------
+
+/**
+ * Mesh one LOD level. Defaults to the synchronous main-thread {@link mesh}; pass
+ * an async implementation (e.g. one that serializes the shape with `toBREP` and
+ * meshes it on a worker) to refine finer levels off the main thread.
+ */
+export type MeshLevelFn = (
+  shape: AnyShape<Dimension>,
+  tolerance: number,
+  angularTolerance: number
+) => ShapeMesh | Promise<ShapeMesh>;
+
+/** Options for {@link meshLODsProgressive}. */
+export interface MeshLODsProgressiveOptions extends MeshLODsOptions {
+  /**
+   * Called as each level finishes, coarsest first, so a viewer can show the
+   * coarse preview immediately and swap in finer meshes as they arrive.
+   */
+  readonly onLevel?: (level: LODMesh, index: number) => void;
+  /** How to mesh one level. Defaults to the synchronous main-thread {@link mesh}. */
+  readonly meshLevel?: MeshLevelFn;
+}
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+/**
+ * Mesh a shape at several levels of detail, delivering them over time coarse →
+ * fine instead of all at once — so a viewer paints the coarse preview first and
+ * refines as finer levels land.
+ *
+ * The coarsest level is meshed first and reported via `onLevel`; control then
+ * yields to the event loop before each finer (heavier) level so the UI stays
+ * responsive. Each level is meshed synchronously on the calling thread by
+ * default; pass `meshLevel` to offload finer levels (e.g. to a worker). An
+ * aborted `signal` stops refinement and resolves with the levels produced so far.
+ *
+ * @returns the delivered LOD levels, coarsest → finest.
+ * @see meshLODs — the synchronous, all-at-once variant
+ */
+export async function meshLODsProgressive(
+  shape: AnyShape<Dimension>,
+  options: MeshLODsProgressiveOptions = {}
+): Promise<LODMesh[]> {
+  const finestAngular = options.angularTolerance ?? qualityDeflection().angularTolerance;
+  const cache = options.cache ?? true;
+  const meshLevel: MeshLevelFn =
+    options.meshLevel ??
+    ((s, tolerance, angularTolerance) =>
+      mesh(s, {
+        tolerance,
+        angularTolerance,
+        cache,
+        ...(options.signal ? { signal: options.signal } : {}),
+      }));
+
+  const tolerances = lodTolerances(shape, options);
+  const finestTol = Math.min(...tolerances);
+  const results: LODMesh[] = [];
+
+  for (const [index, tolerance] of tolerances.entries()) {
+    if (options.signal?.aborted) break;
+    const angularTolerance = levelAngular(tolerance, finestTol, finestAngular);
+    // A level that finished meshing is always delivered; abort stops the next one.
+    const level: LODMesh = {
+      tolerance,
+      angularTolerance,
+      mesh: await meshLevel(shape, tolerance, angularTolerance),
+    };
+    results.push(level);
+    options.onLevel?.(level, index);
+    if (options.signal?.aborted || index === tolerances.length - 1) break;
+    // Yield before the next (finer, heavier) level so the caller can paint.
+    await nextTick();
+  }
+  return results;
 }

--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -522,12 +522,18 @@ export async function meshLODsProgressive(
   for (const [index, tolerance] of tolerances.entries()) {
     if (options.signal?.aborted) break;
     const angularTolerance = levelAngular(tolerance, finestTol, finestAngular);
+    let levelMesh: ShapeMesh;
+    try {
+      levelMesh = await meshLevel(shape, tolerance, angularTolerance);
+    } catch (e) {
+      // An async (e.g. worker-backed) meshLevel may reject when it observes the
+      // abort; treat that as a clean stop and keep the levels already produced.
+      // Rethrow a genuine meshing failure.
+      if (options.signal?.aborted) break;
+      throw e;
+    }
     // A level that finished meshing is always delivered; abort stops the next one.
-    const level: LODMesh = {
-      tolerance,
-      angularTolerance,
-      mesh: await meshLevel(shape, tolerance, angularTolerance),
-    };
+    const level: LODMesh = { tolerance, angularTolerance, mesh: levelMesh };
     results.push(level);
     options.onLevel?.(level, index);
     if (options.signal?.aborted || index === tolerances.length - 1) break;

--- a/tests/meshLODsProgressive.test.ts
+++ b/tests/meshLODsProgressive.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { box, sphere, meshLODsProgressive } from '@/index.js';
+import type { ShapeMesh, MeshLevelFn } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+const fakeMesh = (): ShapeMesh => ({
+  vertices: new Float32Array(),
+  normals: new Float32Array(),
+  triangles: new Uint32Array(),
+  uvs: new Float32Array(),
+  faceGroups: [],
+});
+
+describe('meshLODsProgressive', () => {
+  it('meshes and delivers levels coarse -> fine, calling onLevel in order', async () => {
+    const meshedOrder: number[] = [];
+    const delivered: Array<[number, number]> = [];
+    const meshLevel: MeshLevelFn = (_s, tolerance) => {
+      meshedOrder.push(tolerance);
+      return fakeMesh();
+    };
+
+    const levels = await meshLODsProgressive(box(10, 10, 10), {
+      tolerances: [0.05, 0.5, 0.2], // unsorted on purpose
+      meshLevel,
+      onLevel: (level, index) => delivered.push([index, level.tolerance]),
+    });
+
+    // Ladder is sorted coarse -> fine before meshing.
+    expect(levels.map((l) => l.tolerance)).toEqual([0.5, 0.2, 0.05]);
+    expect(meshedOrder).toEqual([0.5, 0.2, 0.05]); // coarsest meshed first
+    expect(delivered).toEqual([
+      [0, 0.5],
+      [1, 0.2],
+      [2, 0.05],
+    ]);
+  });
+
+  it('supports an async (worker-like) meshLevel', async () => {
+    const meshLevel: MeshLevelFn = async () => {
+      await Promise.resolve();
+      return fakeMesh();
+    };
+    const levels = await meshLODsProgressive(box(10, 10, 10), {
+      tolerances: [1, 0.1],
+      meshLevel,
+    });
+    expect(levels.length).toBe(2);
+  });
+
+  it('a pre-aborted signal yields no levels', async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const levels = await meshLODsProgressive(box(10, 10, 10), {
+      tolerances: [1, 0.1, 0.01],
+      meshLevel: fakeMesh,
+      signal: ctrl.signal,
+    });
+    expect(levels).toEqual([]);
+  });
+
+  it('aborting during a level delivers that level and stops refinement', async () => {
+    const ctrl = new AbortController();
+    const meshLevel: MeshLevelFn = () => {
+      ctrl.abort(); // abort while meshing the first level
+      return fakeMesh();
+    };
+    const levels = await meshLODsProgressive(box(10, 10, 10), {
+      tolerances: [1, 0.1, 0.01],
+      meshLevel,
+      signal: ctrl.signal,
+    });
+    expect(levels.length).toBe(1); // first level delivered, no further levels
+  });
+
+  it('default meshLevel meshes real geometry, coarse -> fine', async () => {
+    const levels = await meshLODsProgressive(sphere(10), { levels: 3 });
+    expect(levels.length).toBe(3);
+    const counts = levels.map((l) => l.mesh.triangles.length);
+    expect(counts.every((n) => n > 0)).toBe(true);
+    // non-decreasing triangle count coarse -> fine
+    expect([...counts].sort((a, b) => a - b)).toEqual(counts);
+  });
+});

--- a/tests/meshLODsProgressive.test.ts
+++ b/tests/meshLODsProgressive.test.ts
@@ -85,4 +85,31 @@ describe('meshLODsProgressive', () => {
     // non-decreasing triangle count coarse -> fine
     expect([...counts].sort((a, b) => a - b)).toEqual(counts);
   });
+
+  it('a meshLevel that rejects on abort still resolves with the prior levels', async () => {
+    const ctrl = new AbortController();
+    let calls = 0;
+    const meshLevel: MeshLevelFn = async () => {
+      await Promise.resolve(); // simulate the worker round-trip
+      calls += 1;
+      if (calls === 1) return fakeMesh(); // first level succeeds
+      ctrl.abort(); // a worker-backed meshLevel observes the abort...
+      throw new Error('aborted'); // ...and rejects
+    };
+    const levels = await meshLODsProgressive(box(10, 10, 10), {
+      tolerances: [1, 0.1, 0.01],
+      meshLevel,
+      signal: ctrl.signal,
+    });
+    expect(levels.length).toBe(1); // first level kept; abort rejection swallowed as a stop
+  });
+
+  it('rethrows a genuine meshLevel error (not an abort)', async () => {
+    const meshLevel: MeshLevelFn = () => {
+      throw new Error('kernel exploded');
+    };
+    await expect(
+      meshLODsProgressive(box(10, 10, 10), { tolerances: [1], meshLevel })
+    ).rejects.toThrow('kernel exploded');
+  });
 });

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -513,6 +513,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'mesh',
   'meshEdges',
   'meshLODs',
+  'meshLODsProgressive',
   'meshMultiLOD',
   'minkowski',
   'mirror',


### PR DESCRIPTION
## What

Adds `meshLODsProgressive(shape, options)` — async LOD meshing that delivers levels **over time, coarse → fine** instead of all at once. The follow-up to the N-level LOD work (#1621) and the worker pool (#1618). Closes #1622.

```ts
const ac = new AbortController();
await meshLODsProgressive(part, {
  levels: 3,
  signal: ac.signal,
  onLevel: (level) => render(level), // coarse first, then refinements
});
```

## Why

`meshLODs` computes every level up front, blocking until the finest is done. For large scenes you want an **instant first frame**: paint the coarse mesh now, refine as finer levels land, and stop refining when the shape changes.

## Design: dependency-inverted, not pool-coupled

The library **doesn't own the worker** — consumers create and register their own (the playground has its own `cad.worker.ts`). So rather than couple the topology layer to a `pool` (and a worker-op convention it can't dictate), `meshLODsProgressive` owns the **orchestration** (coarse-first delivery, event-loop yielding, cancellation) and accepts an injectable **`meshLevel`** for the *how*:

- **Default** — sync main-thread `mesh()`: instant coarse frame, then each finer level on a later tick (`setTimeout(0)` between levels) so the UI stays responsive.
- **Offload** — pass a `meshLevel` that `toBREP`-serializes the shape and meshes it on a worker (the feasibility is all there: `toBREP`/`fromBREP` are sync, mesh data structured-clones across `postMessage`). The library never has to own worker setup, yet fully enables it.

`onLevel(level, index)` fires per level (coarsest first); an aborted `signal` stops refinement and resolves with the levels produced so far (a completed level is always delivered — abort stops the *next* one).

Extracted the shared `lodTolerances` / `levelAngular` helpers so `meshLODs` and `meshLODsProgressive` share one ladder implementation (the `meshLODs` refactor is behavior-preserving — its tests are untouched and green).

## Tests

`tests/meshLODsProgressive.test.ts`: orchestration via a fake `meshLevel` (no WASM) — coarse→fine mesh + `onLevel` order, async (worker-like) `meshLevel`, pre-aborted signal → no levels, abort-during-a-level → that level delivered then stop; plus a real default-path integration test (`sphere`, 3 levels, non-decreasing triangle counts). The `performance.md` progressive example is extracted and run by `test:docs`.

## Acceptance (from #1622)

- [x] Coarse level delivered first (instant first frame); finer levels via `onLevel` over subsequent ticks.
- [x] `meshLevel` seam enables worker offload without the library owning worker setup.
- [x] `AbortSignal` cancels refinement (resolves with partial levels).
- [x] Exported; full gate green (typecheck / lint / boundaries / format / tests / `test:docs` / knip / check:patterns).

## Follow-up (not in scope)

A turnkey worker helper pair (a registerable `mesh` operation handler + a `meshLevel` factory from a `WorkerClient`) could make the offload path zero-glue — left out here to keep the surface to one function + the `meshLevel` seam, and because the worker-op convention is a separate decision.

Closes #1622. Part of #1606.
