### PR TITLE
feat(csg): content-addressed mesh cache (Evaluator.evaluateMesh)

### DIFF
--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -282,8 +282,14 @@ export class Evaluator implements Disposable {
   evaluateMesh(
     node: IRNode,
     env: Env = {},
-    meshOpts: MeshOptions & { skipNormals?: boolean; includeUVs?: boolean } = {}
+    meshOpts: MeshOptions & { skipNormals?: boolean; includeUVs?: boolean; cache?: boolean } = {}
   ): Result<ShapeMesh> {
+    // Honor an already-aborted signal up front, matching mesh()'s contract:
+    // otherwise a cancelled call could still return a cached mesh, or do a full
+    // materialize (and trigger shape-cache eviction) before mesh() finally throws.
+    meshOpts.signal?.throwIfAborted();
+
+    const useCache = meshOpts.cache ?? true;
     const quality = qualityDeflection();
     const tolerance = meshOpts.tolerance ?? quality.tolerance;
     const angularTolerance = meshOpts.angularTolerance ?? quality.angularTolerance;
@@ -295,22 +301,27 @@ export class Evaluator implements Disposable {
       meshOpts.includeUVs ?? false
     )}`;
 
-    const cached = this.meshCache.get(meshKey);
-    if (cached !== undefined) {
-      if (this.maxMeshCacheEntries !== undefined) {
-        this.meshCache.delete(meshKey);
-        this.meshCache.set(meshKey, cached);
+    if (useCache) {
+      const cached = this.meshCache.get(meshKey);
+      if (cached !== undefined) {
+        if (this.maxMeshCacheEntries !== undefined) {
+          this.meshCache.delete(meshKey);
+          this.meshCache.set(meshKey, cached);
+        }
+        return ok(cached);
       }
-      return ok(cached);
     }
 
     const shape = this.evaluate(node, env);
     if (!shape.ok) return shape;
     // Mesh under the evaluator's kernel so getKernel() doesn't pick up an
     // unrelated ambient kernel after evaluate() restores the prior context.
+    // `cache: false` flows through to mesh(), bypassing its identity cache too.
     const built = withKernel(this.kernelId, () => mesh(shape.value, meshOpts));
-    this.meshCache.set(meshKey, built);
-    if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
+    if (useCache) {
+      this.meshCache.set(meshKey, built);
+      if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
+    }
     return ok(built);
   }
 

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -8,8 +8,11 @@
 // returned shape is only guaranteed valid until the next successful
 // evaluate() call (a failed evaluate() never evicts).
 import { getActiveKernelId, withKernel } from '@/kernel/index.js';
+import { qualityDeflection } from '@/kernel/quality.js';
 import { ok, type Result } from '@/core/result.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import { mesh, type ShapeMesh, type MeshOptions } from '@/topology/meshFns.js';
+import { buildMeshCacheKey } from '@/topology/meshCache.js';
 import { projectEnv, type Env, type ExprValue } from './expressions.js';
 import { fnvInit, fnvMixString, fnvMixNumber, fnvMixBool, fnvMixInt32, toHex } from './hash.js';
 import type { IRNode } from './types.js';
@@ -59,6 +62,14 @@ export interface EvaluatorOptions {
    * (calling it from an onStep callback throws). Must be a positive integer.
    */
   readonly maxCacheEntries?: number | undefined;
+  /**
+   * Upper bound on entries in the {@link Evaluator.evaluateMesh} content cache,
+   * which is independent of the shape cache. Defaults to unbounded. Bounding it
+   * separately is what lets a mesh outlive its (evicted) kernel shape, so a
+   * re-`evaluateMesh` is a pure data hit with no re-materialization. Must be a
+   * positive integer.
+   */
+  readonly maxMeshCacheEntries?: number | undefined;
 }
 
 export interface StepInfo {
@@ -182,6 +193,11 @@ export class Evaluator implements Disposable {
   private readonly kernelId: string;
   private readonly defaultTolerance: number | undefined;
   private readonly maxCacheEntries: number | undefined;
+  private readonly maxMeshCacheEntries: number | undefined;
+  // Content-addressed mesh cache, keyed by the shape's cache key + mesh params.
+  // A mesh is plain data (not a kernel handle), so this can outlive an evicted
+  // shape — a re-evaluateMesh of evicted content is a pure hit, no kernel work.
+  private readonly meshCache = new Map<string, ShapeMesh>();
   private readonly onStep?: (info: StepInfo) => void;
   private hits = 0;
   private misses = 0;
@@ -202,6 +218,13 @@ export class Evaluator implements Disposable {
       );
     }
     this.maxCacheEntries = max;
+    const meshMax = options.maxMeshCacheEntries;
+    if (meshMax !== undefined && (!Number.isInteger(meshMax) || meshMax < 1)) {
+      throw new RangeError(
+        `Evaluator: maxMeshCacheEntries must be a positive integer, got ${String(meshMax)}`
+      );
+    }
+    this.maxMeshCacheEntries = meshMax;
   }
 
   /**
@@ -246,6 +269,49 @@ export class Evaluator implements Disposable {
         this.evaluating = false;
       }
     });
+  }
+
+  /**
+   * Materialize a node and mesh it, caching the mesh by the shape's content key
+   * plus the mesh parameters. The mesh cache is independent of the shape cache:
+   * a hit returns the cached mesh without evaluating or meshing — even after the
+   * shape was LRU-evicted (a mesh is plain data, not a kernel handle). The
+   * returned mesh is borrowed (do not mutate it); it stays valid for the
+   * Evaluator's lifetime, or until `maxMeshCacheEntries` evicts it.
+   */
+  evaluateMesh(
+    node: IRNode,
+    env: Env = {},
+    meshOpts: MeshOptions & { skipNormals?: boolean; includeUVs?: boolean } = {}
+  ): Result<ShapeMesh> {
+    const quality = qualityDeflection();
+    const tolerance = meshOpts.tolerance ?? quality.tolerance;
+    const angularTolerance = meshOpts.angularTolerance ?? quality.angularTolerance;
+    const shapeKey = cacheKey(node, env, this.kernelId, this.defaultTolerance);
+    const meshKey = `${shapeKey}|${buildMeshCacheKey(
+      tolerance,
+      angularTolerance,
+      meshOpts.skipNormals ?? false,
+      meshOpts.includeUVs ?? false
+    )}`;
+
+    const cached = this.meshCache.get(meshKey);
+    if (cached !== undefined) {
+      if (this.maxMeshCacheEntries !== undefined) {
+        this.meshCache.delete(meshKey);
+        this.meshCache.set(meshKey, cached);
+      }
+      return ok(cached);
+    }
+
+    const shape = this.evaluate(node, env);
+    if (!shape.ok) return shape;
+    // Mesh under the evaluator's kernel so getKernel() doesn't pick up an
+    // unrelated ambient kernel after evaluate() restores the prior context.
+    const built = withKernel(this.kernelId, () => mesh(shape.value, meshOpts));
+    this.meshCache.set(meshKey, built);
+    if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
+    return ok(built);
   }
 
   private evaluateInner(node: IRNode, env: Env): Result<AnyShape<Dimension>> {
@@ -305,6 +371,16 @@ export class Evaluator implements Disposable {
     }
   }
 
+  // Evict least-recently-used mesh entries until within `max`. A mesh is plain
+  // data (no kernel handle), so eviction just drops the reference — no disposal.
+  private trimMeshCache(max: number): void {
+    while (this.meshCache.size > max) {
+      const oldest = this.meshCache.keys().next();
+      if (oldest.done) break;
+      this.meshCache.delete(oldest.value);
+    }
+  }
+
   // Undo the inserts made during a failed or thrown evaluate(). Removal is by
   // key (not position), so entries merely touched (hit) during the call are
   // kept — only the call's own new entries are dropped.
@@ -339,6 +415,7 @@ export class Evaluator implements Disposable {
     }
     this.refCounts.clear();
     this.cache.clear();
+    this.meshCache.clear();
   }
 }
 

--- a/tests/csg/csgMesh.test.ts
+++ b/tests/csg/csgMesh.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Evaluator.evaluateMesh — content-addressed mesh caching tied to the CSG cache.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from '../setup.js';
+import { Evaluator, box, sphere, param } from '@/csg/index.js';
+import { unwrap } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('Evaluator.evaluateMesh', () => {
+  it('materializes a node and returns a mesh', () => {
+    using ev = new Evaluator();
+    const m = unwrap(ev.evaluateMesh(box(10, 10, 10)));
+    expect(m.triangles.length).toBeGreaterThan(0);
+    expect(m.vertices.length).toBeGreaterThan(0);
+  });
+
+  it('a repeat call is a content-cache hit: same mesh object, no re-materialization', () => {
+    using ev = new Evaluator();
+    const node = box(10, 10, 10);
+    const m1 = unwrap(ev.evaluateMesh(node));
+    ev.resetStats();
+    const m2 = unwrap(ev.evaluateMesh(node));
+    expect(m2).toBe(m1); // cached mesh returned by identity
+    // A mesh-cache hit never touches the shape cache.
+    expect(ev.cacheStats().misses).toBe(0);
+    expect(ev.cacheStats().hits).toBe(0);
+  });
+
+  it('keys the mesh by mesh params: a finer tolerance is a distinct, denser mesh', () => {
+    using ev = new Evaluator();
+    const node = sphere(10);
+    // Both linear and angular deflection bind a sphere's tessellation, so vary
+    // both — otherwise whichever default is finer dominates and the counts match.
+    const coarse = unwrap(ev.evaluateMesh(node, {}, { tolerance: 3, angularTolerance: 1.2 }));
+    const fine = unwrap(ev.evaluateMesh(node, {}, { tolerance: 0.05, angularTolerance: 0.1 }));
+    expect(fine).not.toBe(coarse); // mesh params are part of the cache key
+    expect(fine.triangles.length).toBeGreaterThan(coarse.triangles.length);
+  });
+
+  it('keys the mesh by env: same params hit, different params miss', () => {
+    using ev = new Evaluator();
+    const node = box(param('w'), 10, 10);
+    const m5 = unwrap(ev.evaluateMesh(node, { w: 5 }));
+    const m5again = unwrap(ev.evaluateMesh(node, { w: 5 }));
+    const m20 = unwrap(ev.evaluateMesh(node, { w: 20 }));
+    expect(m5again).toBe(m5); // same env → cache hit
+    expect(m20).not.toBe(m5); // different env → distinct entry (no stale hit)
+  });
+
+  it('a mesh outlives an evicted shape: re-meshing evicted content is zero kernel work', () => {
+    // Shape cache bounded to 1; mesh cache unbounded (the default).
+    using ev = new Evaluator({ maxCacheEntries: 1 });
+    const a = box(10, 10, 10);
+    const meshA = unwrap(ev.evaluateMesh(a)); // shape A cached + meshed
+    unwrap(ev.evaluateMesh(sphere(8))); // materializing B evicts shape A from the bound-1 cache
+    ev.resetStats();
+
+    const meshA2 = unwrap(ev.evaluateMesh(a));
+    expect(meshA2).toBe(meshA); // the mesh survived shape eviction
+    expect(ev.cacheStats().misses).toBe(0); // shape A was NOT re-materialized
+  });
+
+  it('maxMeshCacheEntries evicts: a mesh no longer outlives its evicted shape', () => {
+    // Same shape-eviction setup as above, but the mesh cache is also bounded —
+    // so the mesh does NOT survive (the contrast isolates maxMeshCacheEntries).
+    using ev = new Evaluator({ maxCacheEntries: 1, maxMeshCacheEntries: 1 });
+    const a = box(10, 10, 10);
+    const meshA = unwrap(ev.evaluateMesh(a));
+    unwrap(ev.evaluateMesh(sphere(8))); // evicts both shape A and mesh A
+    const meshA2 = unwrap(ev.evaluateMesh(a)); // both miss → re-materialize + re-mesh
+    expect(meshA2).not.toBe(meshA);
+  });
+
+  it('rejects an invalid maxMeshCacheEntries', () => {
+    expect(() => new Evaluator({ maxMeshCacheEntries: 0 })).toThrow('positive integer');
+    expect(() => new Evaluator({ maxMeshCacheEntries: 1.5 })).toThrow('positive integer');
+  });
+});

--- a/tests/csg/csgMesh.test.ts
+++ b/tests/csg/csgMesh.test.ts
@@ -80,4 +80,29 @@ describe('Evaluator.evaluateMesh', () => {
     expect(() => new Evaluator({ maxMeshCacheEntries: 0 })).toThrow('positive integer');
     expect(() => new Evaluator({ maxMeshCacheEntries: 1.5 })).toThrow('positive integer');
   });
+
+  it('throws on an aborted signal even when the mesh is cached', () => {
+    using ev = new Evaluator();
+    const node = box(10, 10, 10);
+    unwrap(ev.evaluateMesh(node)); // populate the content cache
+    const ctrl = new AbortController();
+    ctrl.abort();
+    expect(() => ev.evaluateMesh(node, {}, { signal: ctrl.signal })).toThrow();
+  });
+
+  it('throws on an aborted signal before materializing the node', () => {
+    using ev = new Evaluator();
+    const ctrl = new AbortController();
+    ctrl.abort();
+    expect(() => ev.evaluateMesh(box(10, 10, 10), {}, { signal: ctrl.signal })).toThrow();
+    expect(ev.cacheStats().misses).toBe(0); // the CSG node was never evaluated
+  });
+
+  it('cache: false bypasses the cache and re-meshes each call', () => {
+    using ev = new Evaluator();
+    const node = box(10, 10, 10);
+    const m1 = unwrap(ev.evaluateMesh(node, {}, { cache: false }));
+    const m2 = unwrap(ev.evaluateMesh(node, {}, { cache: false }));
+    expect(m2).not.toBe(m1); // no content cache; cache:false bypasses mesh()'s identity cache too
+  });
 });


### PR DESCRIPTION
## What

Adds `Evaluator.evaluateMesh(node, env?, meshOpts?): Result<ShapeMesh>` — meshes a CSG node and caches the mesh **by content** (the evaluator's cache key) rather than by kernel-shape identity. The content-addressing slice of the mesh↔CSG cache integration (#1606 tail). Closes #1630.

```ts
const ev = new Evaluator({ maxCacheEntries: 64 });
const m1 = unwrap(ev.evaluateMesh(part));   // materialize + mesh
const m2 = unwrap(ev.evaluateMesh(part));   // cache hit — no evaluate, no mesh
```

## Why

The mesh cache keys by kernel-shape **identity** (`WeakMap` on `shape.wrapped`); the CSG evaluator is **content**-addressed with LRU eviction. So when a CSG node is evicted and re-materialized — or identical content is rebuilt — the new shape has a fresh identity and the mesh cache misses, re-tessellating identical geometry.

## Scope (the rest of the tail item)

The #1606 tail "integrate the mesh cache with the CSG cache" has three parts:
- **reuse tessellation across placements** — already done by `instancedMesh()`.
- **don't re-mesh on a pure move** — needs a kernel location-only transform (`locate`), the same blocker as deferred #1603. Not in scope.
- **content-address the mesh cache** — this PR.

## How

`evaluateMesh` keys the mesh by `cacheKey(node, env, kernelId, tol)` (the evaluator's own `structuralHash:kernelId:projEnvHash:tolHash` — so it accounts for free params) plus `buildMeshCacheKey(tolerance, angularTolerance, skipNormals, includeUVs)`:

- The mesh cache is **independent** of the shape cache (`maxMeshCacheEntries`, default unbounded). A mesh is plain data, not a kernel handle, so it can **outlive an evicted shape** — re-requesting an evicted node's mesh is a pure data hit with **no re-materialization and no re-tessellation**. Bounding it separately is the whole point: a small shape-cache bound can free kernel handles while the (cheap) mesh data stays.
- A hit returns the cached `ShapeMesh` without calling `evaluate()` or `mesh()`.
- Meshes under the evaluator's kernel (so `getKernel()` doesn't pick up an unrelated ambient kernel after `evaluate()` restores the prior context).

Purely **additive** — no change to the existing shape cache / eviction / `cacheStats` / dispose paths (the strict `cacheStats` `toEqual` test is untouched and green).

## Tests

`tests/csg/csgMesh.test.ts` (7 cases): meshes a node; repeat call is a content-cache hit (same object, no shape miss); mesh params in the key (coarse vs fine → distinct, denser); env in the key (same params hit, different params miss — no stale hit); **a mesh outlives an evicted shape** (shape cache bound 1, mesh unbounded → re-mesh of evicted content is zero kernel work); `maxMeshCacheEntries` evicts (the contrast that isolates it); invalid bound throws. The full CSG suite (181) stays green.

## Acceptance (from #1630)

- [x] Repeat `evaluateMesh` → same mesh object, no re-materialization.
- [x] Key includes mesh params + env projection (no stale hits).
- [x] A mesh outlives an evicted shape (zero kernel work on re-request).
- [x] `maxMeshCacheEntries` bounds the cache; invalid value throws.
- [x] Existing evaluator behavior unchanged; full gate green.

Closes #1630. Part of #1606.
