### PR TITLE
feat(shaperef): track all split-face successors + edit-survival harness (#1606)

### DIFF
--- a/src/topology/shapeRef/shapeRefFns.ts
+++ b/src/topology/shapeRef/shapeRefFns.ts
@@ -9,7 +9,6 @@ import { getFaces } from '@/topology/topologyQueryFns.js';
 import { getHashCode } from '@/topology/shapeFns.js';
 import { normalAt, faceCenter, faceGeomType } from '@/topology/faceFns.js';
 import { measureArea } from '@/measurement/measureFns.js';
-import { wasmIndex } from '@/utils/vec3.js';
 import type {
   GeometricHint,
   ShapeRef,
@@ -64,17 +63,18 @@ function boxRoleFromNormal(n: readonly [number, number, number]): string | undef
  *
  * For other types: sequential naming ('opType:face_0', 'opType:face_1', ...).
  *
- * @returns Map from role name to face hash code
+ * @returns Map from role name to its face hash codes (one at assignment time;
+ *   a role accrues more hashes only later, when `updateRoles` tracks a split).
  */
-export function assignRoles(shape: Shape3D, operationType: string): Map<string, number> {
+export function assignRoles(shape: Shape3D, operationType: string): Map<string, number[]> {
   const faces = getFaces(shape);
-  const roles = new Map<string, number>();
+  const roles = new Map<string, number[]>();
 
   if (operationType === 'box') {
     for (const face of faces) {
       const role = boxRoleFromNormal(normalAt(face));
       if (role !== undefined && !roles.has(role)) {
-        roles.set(role, getHashCode(face));
+        roles.set(role, [getHashCode(face)]);
       }
     }
     return roles;
@@ -82,7 +82,7 @@ export function assignRoles(shape: Shape3D, operationType: string): Map<string, 
 
   let index = 0;
   for (const face of faces) {
-    roles.set(`${operationType}:face_${index}`, getHashCode(face));
+    roles.set(`${operationType}:face_${index}`, [getHashCode(face)]);
     index++;
   }
   return roles;
@@ -102,17 +102,37 @@ export function createRef(origin: string, role: string, face: Face): ShapeRef {
 // ---------------------------------------------------------------------------
 
 /**
+ * Advance a role's face hashes through one evolution: drop deleted faces,
+ * replace a modified face with *all* its successors (a 1→many split keeps every
+ * fragment), and keep unchanged faces. Deduped so a shared successor isn't
+ * doubled.
+ */
+function nextHashes(hashes: readonly number[], evolution: ShapeEvolution): number[] {
+  const successors: number[] = [];
+  for (const hash of hashes) {
+    if (evolution.deleted.has(hash)) continue;
+    const modified = evolution.modified.get(hash);
+    const targets = modified && modified.length > 0 ? modified : [hash];
+    for (const h of targets) if (!successors.includes(h)) successors.push(h);
+  }
+  return successors;
+}
+
+/**
  * Propagate a role table through a ShapeEvolution record.
  * Returns a new RoleTable with hashes updated according to the evolution.
  *
- * - Deleted faces: role removed
- * - Modified faces: hash updated to first result hash
- * - Unchanged faces: hash preserved
+ * - Deleted faces: hash dropped (role removed once all its hashes are gone).
+ * - Modified faces: hash replaced by **all** successor hashes — so a 1→many
+ *   split keeps every fragment, and `resolveRef` disambiguates among them.
+ * - Unchanged faces: hash preserved.
  *
- * **Limitation:** When a face splits (1→many in `evolution.modified`), only the
- * first successor hash is tracked. The geometric fallback in `resolveRef` handles
- * cases where this picks the "wrong" successor. A future version may return
- * multi-hash mappings for split-aware resolution.
+ * Note: `evolution.generated` is intentionally not consumed here — on the OCCT
+ * kernels its hashes refer to an intermediate shape, not the final result, so
+ * naming generated faces produces roles that never resolve (verified: 0 live
+ * generated hashes across cut/fuse on occt-wasm). Stable names for generated
+ * geometry (fillet rounds, boolean seams) need history-fidelity work tracked
+ * separately.
  */
 export function updateRoles(
   roles: RoleTable,
@@ -122,30 +142,18 @@ export function updateRoles(
   const originRoles = roles.get(origin);
   if (!originRoles) return roles;
 
-  const updatedOriginRoles = new Map<string, number>();
+  const updatedOriginRoles = new Map<string, number[]>();
 
-  for (const [role, hash] of originRoles) {
-    // Deleted → skip (role removed)
-    if (evolution.deleted.has(hash)) continue;
-
-    // Modified → use first result hash
-    const modifiedHashes = evolution.modified.get(hash);
-    if (modifiedHashes && modifiedHashes.length > 0) {
-      updatedOriginRoles.set(role, wasmIndex(modifiedHashes, 0));
-    } else {
-      // Survived unchanged
-      updatedOriginRoles.set(role, hash);
-    }
+  // Carry each role's faces forward through deleted/modified/unchanged.
+  for (const [role, hashes] of originRoles) {
+    const successors = nextHashes(hashes, evolution);
+    if (successors.length > 0) updatedOriginRoles.set(role, successors);
   }
 
   // Build new RoleTable immutably
-  const newRoles = new Map<string, ReadonlyMap<string, number>>();
+  const newRoles = new Map<string, ReadonlyMap<string, readonly number[]>>();
   for (const [key, value] of roles) {
-    if (key === origin) {
-      newRoles.set(key, updatedOriginRoles);
-    } else {
-      newRoles.set(key, value);
-    }
+    newRoles.set(key, key === origin ? updatedOriginRoles : value);
   }
   return newRoles;
 }
@@ -159,14 +167,63 @@ const AMBIGUITY_THRESHOLD = 0.1;
 /** Minimum score for geometric fallback to accept a match. */
 const MIN_SCORE = 0.5;
 
+/** Outcome of scoring a candidate face set against a hint. */
+type ScoreOutcome =
+  | { kind: 'match'; face: Face }
+  | { kind: 'ambiguous'; candidates: Face[] }
+  | { kind: 'none' };
+
+/**
+ * Score `candidates` against `hint`, returning the best match, a tie within
+ * {@link AMBIGUITY_THRESHOLD}, or nothing above {@link MIN_SCORE}. Scoping the
+ * candidates to a role's tracked successors (rather than every face) is what
+ * makes split-face disambiguation reliable — the fragments compete only with
+ * each other, not with unrelated geometry.
+ */
+function scoreFaces(
+  hint: GeometricHint,
+  candidates: readonly Face[],
+  scoreFn: FaceScorer
+): ScoreOutcome {
+  let bestScore = -Infinity;
+  let bestFace: Face | undefined;
+  let secondBestScore = -Infinity;
+  const scored: Array<[Face, number]> = [];
+
+  for (const face of candidates) {
+    const score = scoreFn(hint, face);
+    if (score > MIN_SCORE) scored.push([face, score]);
+    if (score > bestScore) {
+      secondBestScore = bestScore;
+      bestScore = score;
+      bestFace = face;
+    } else if (score > secondBestScore) {
+      secondBestScore = score;
+    }
+  }
+
+  if (bestFace !== undefined && bestScore > MIN_SCORE) {
+    if (bestScore - secondBestScore < AMBIGUITY_THRESHOLD && scored.length > 1) {
+      const competitive = scored
+        .filter(([, s]) => s >= bestScore - AMBIGUITY_THRESHOLD)
+        .map(([f]) => f);
+      return { kind: 'ambiguous', candidates: competitive };
+    }
+    return { kind: 'match', face: bestFace };
+  }
+  return { kind: 'none' };
+}
+
 /**
  * Resolve a ShapeRef to a face in the current shape.
  *
  * Resolution strategy:
- * 1. Exact lookup via role table hash match
- * 2. Geometric fallback using scorer against all faces
- * 3. Ambiguous if multiple faces score within threshold
- * 4. Not-found if no match above minimum score
+ * 1. Exact: the role's tracked successor hashes. One survivor → exact match;
+ *    several survivors (a face that split) → disambiguate among *only those*
+ *    fragments; none survive → deleted.
+ * 2. Geometric fallback over the whole shape when the role isn't tracked (or a
+ *    scoped score turned up nothing): best-scoring face, else ambiguous /
+ *    not-found.
  */
 export function resolveRef(
   ref: ShapeRef,
@@ -177,51 +234,30 @@ export function resolveRef(
   const faces = getFaces(currentShape);
   const scoreFn = scorer ?? defaultScorer;
 
-  // 1. Exact lookup via role table
-  const originRoles = roles.get(ref.origin);
-  const targetHash = originRoles?.get(ref.role);
-
-  if (targetHash !== undefined) {
-    for (const face of faces) {
-      if (getHashCode(face) === targetHash) {
-        return { face, confidence: 'exact' };
+  // 1. Exact lookup, scoped to the role's tracked successor hashes.
+  const targetHashes = roles.get(ref.origin)?.get(ref.role);
+  if (targetHashes !== undefined && targetHashes.length > 0) {
+    const survivors = faces.filter((f) => targetHashes.includes(getHashCode(f)));
+    if (survivors.length === 1) {
+      const [only] = survivors;
+      if (only !== undefined) return { face: only, confidence: 'exact' };
+    } else if (survivors.length === 0) {
+      return { ref, reason: 'deleted' };
+    } else {
+      // A face that split — pick the right fragment from the tracked set only.
+      const outcome = scoreFaces(ref.hint, survivors, scoreFn);
+      if (outcome.kind === 'match') return { face: outcome.face, confidence: 'geometric-fallback' };
+      if (outcome.kind === 'ambiguous') {
+        return { ref, reason: 'ambiguous', candidates: outcome.candidates };
       }
-    }
-    // Hash was in table but not found in current shape → deleted
-    return { ref, reason: 'deleted' };
-  }
-
-  // 2. Geometric fallback — cache scores to avoid double WASM calls
-  let bestScore = -Infinity;
-  let bestFace: Face | undefined;
-  let secondBestScore = -Infinity;
-  const scored: Array<[Face, number]> = [];
-
-  for (const face of faces) {
-    const score = scoreFn(ref.hint, face);
-    if (score > MIN_SCORE) {
-      scored.push([face, score]);
-    }
-    if (score > bestScore) {
-      secondBestScore = bestScore;
-      bestScore = score;
-      bestFace = face;
-    } else if (score > secondBestScore) {
-      secondBestScore = score;
+      // 'none' → fall through to the whole-shape geometric fallback.
     }
   }
 
-  // 3. Check for ambiguity
-  if (bestFace !== undefined && bestScore > MIN_SCORE) {
-    if (bestScore - secondBestScore < AMBIGUITY_THRESHOLD && scored.length > 1) {
-      const competitive = scored
-        .filter(([, s]) => s >= bestScore - AMBIGUITY_THRESHOLD)
-        .map(([f]) => f);
-      return { ref, reason: 'ambiguous', candidates: competitive };
-    }
-    return { face: bestFace, confidence: 'geometric-fallback' };
-  }
-
-  // 4. Not found
+  // 2. Geometric fallback over all faces.
+  const outcome = scoreFaces(ref.hint, faces, scoreFn);
+  if (outcome.kind === 'match') return { face: outcome.face, confidence: 'geometric-fallback' };
+  if (outcome.kind === 'ambiguous')
+    return { ref, reason: 'ambiguous', candidates: outcome.candidates };
   return { ref, reason: 'not-found' };
 }

--- a/src/topology/shapeRef/shapeRefTypes.ts
+++ b/src/topology/shapeRef/shapeRefTypes.ts
@@ -42,10 +42,14 @@ export interface ShapeRef {
 // ---------------------------------------------------------------------------
 
 /**
- * Immutable table mapping `origin -> role -> faceHash`.
+ * Immutable table mapping `origin -> role -> faceHashes`.
  * Updated through evolution records when the model is rebuilt.
+ *
+ * A role usually maps to a single hash, but maps to several after its face
+ * splits (a 1→many `modified` evolution); resolution then disambiguates among
+ * the surviving successors rather than competing against the whole shape.
  */
-export type RoleTable = ReadonlyMap<string, ReadonlyMap<string, number>>;
+export type RoleTable = ReadonlyMap<string, ReadonlyMap<string, readonly number[]>>;
 
 // ---------------------------------------------------------------------------
 // Resolution results

--- a/tests/shapeRef.test.ts
+++ b/tests/shapeRef.test.ts
@@ -122,10 +122,10 @@ describe('resolveRef', () => {
     const roleTable: RoleTable = new Map([['step_0', roles]]);
 
     // Find the top face
-    const topHash = roles.get('box:top');
-    expect(topHash).toBeDefined();
+    const topHashes = roles.get('box:top');
+    expect(topHashes).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
-    const topFace = faces.find((f) => getHashCode(f) === topHash)!;
+    const topFace = faces.find((f) => topHashes?.includes(getHashCode(f)))!;
     expect(topFace).toBeDefined();
 
     const ref = createRef('step_0', 'box:top', topFace);
@@ -144,9 +144,9 @@ describe('resolveRef', () => {
     const roles = assignRoles(b, 'box');
 
     // Find the top face and create a ref
-    const topHash = roles.get('box:top');
+    const topHashes = roles.get('box:top');
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test
-    const topFace = faces.find((f) => getHashCode(f) === topHash)!;
+    const topFace = faces.find((f) => topHashes?.includes(getHashCode(f)))!;
     const ref = createRef('step_0', 'box:top', topFace);
 
     // Use an empty role table — forces geometric fallback
@@ -166,9 +166,9 @@ describe('resolveRef', () => {
 
     // Get the top face of a before cut
     const roles = assignRoles(a, 'box');
-    const topHash = roles.get('box:top');
+    const topHashes = roles.get('box:top');
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- test
-    const topFace = getFaces(a).find((f) => getHashCode(f) === topHash)!;
+    const topFace = getFaces(a).find((f) => topHashes?.includes(getHashCode(f)))!;
     const ref = createRef('step_0', 'box:top', topFace);
 
     // Cut removes the top face
@@ -240,8 +240,8 @@ describe('full pipeline', () => {
 
       // Step 2: Create refs for all cardinal faces
       const refs = new Map<string, ReturnType<typeof createRef>>();
-      for (const [role, hash] of roles) {
-        const face = getFaces(b).find((f) => getHashCode(f) === hash);
+      for (const [role, hashes] of roles) {
+        const face = getFaces(b).find((f) => hashes.includes(getHashCode(f)));
         expect(face).toBeDefined();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
         refs.set(role, createRef('step_0', role, face!));

--- a/tests/shapeRefEditReplay.test.ts
+++ b/tests/shapeRefEditReplay.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Edit-after-reference harness — the validation the ShapeRef suite was missing.
+ *
+ * Every other shapeRef test either bypasses the role table (`new Map()`, forcing
+ * the geometric fallback) or asserts only "didn't crash / area > 0". These drive
+ * the EXACT path through a real `ShapeEvolution` and assert face *identity* after
+ * an edit: a modified face is tracked, a generated (fillet/seam) face is named,
+ * and a split face resolves to the correct fragment.
+ *
+ * Gated to the OCCT family: faithful B-rep face evolution is an OCCT-family
+ * property (brepkit fillets are a geometric heuristic, manifold is a mesh
+ * kernel), so the exact-path assertions only apply there.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { currentKernelId } from './helpers/kernelDivergences.js';
+import {
+  box,
+  translate,
+  getFaces,
+  getHashCode,
+  unwrap,
+  isOk,
+  measureArea,
+  type Face,
+} from '@/index.js';
+import { fuseWithEvolution } from '@/topology/evolutionFns.js';
+import { normalAt, faceCenter, faceGeomType } from '@/topology/faceFns.js';
+import { assignRoles, createRef, updateRoles, resolveRef } from '@/topology/shapeRef/index.js';
+
+const isOcctFamily = currentKernelId === 'occt' || currentKernelId === 'occt-wasm';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+/** Outward +Z alignment of a face's normal. */
+function upness(face: Face): number {
+  const n = normalAt(face);
+  return n[2];
+}
+
+describe.skipIf(!isOcctFamily)('shapeRef edit-after-reference (exact path)', () => {
+  it('tracks a modified face through evolution and resolves it via the role table', () => {
+    // box → fuse a block onto the top face → the top is MODIFIED. updateRoles
+    // must carry box:top to its successor so resolveRef finds it via the table,
+    // not a bare geometric guess against the whole shape.
+    const b = box(20, 20, 20);
+    const roles0 = assignRoles(b, 'box');
+    const topHashes = roles0.get('box:top');
+    expect(topHashes).toBeDefined();
+    const topFace = getFaces(b).find((f) => topHashes?.includes(getHashCode(f)));
+    expect(topFace).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
+    const topRef = createRef('s0', 'box:top', topFace!);
+
+    const fuseResult = fuseWithEvolution(b, translate(box(8, 8, 8), [6, 6, 20]));
+    expect(isOk(fuseResult)).toBe(true);
+    const { shape: fused, evolution } = unwrap(fuseResult);
+
+    const updated = updateRoles(new Map([['s0', roles0]]), 's0', evolution);
+    const resolved = resolveRef(topRef, updated, fused);
+
+    // The top survives the fuse, so it must resolve (not BrokenRef) to an
+    // upward-facing planar face — the box:top successor, not a side wall.
+    expect('face' in resolved).toBe(true);
+    if ('face' in resolved) {
+      expect(faceGeomType(resolved.face)).toBe('PLANE');
+      expect(upness(resolved.face)).toBeGreaterThan(0.7);
+    }
+  });
+
+  it('disambiguates a split face to the correct fragment (Gap 3: all successors)', () => {
+    // A big top face partially overlapped by a fused block splits into the large
+    // remaining region (z≈10) plus the small new cap on the block (z≈20). A ref
+    // captured from the original top (centroid z≈10, large area) must resolve to
+    // the large low fragment — competing only against the tracked successors.
+    const base = box(30, 30, 10);
+    const roles0 = assignRoles(base, 'box');
+    const topHashes = roles0.get('box:top');
+    const topFace = getFaces(base).find((f) => topHashes?.includes(getHashCode(f)));
+    expect(topFace).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
+    const topRef = createRef('s0', 'box:top', topFace!);
+
+    const fuseResult = fuseWithEvolution(base, translate(box(10, 10, 10), [10, 10, 10]));
+    expect(isOk(fuseResult)).toBe(true);
+    const { shape: fused, evolution } = unwrap(fuseResult);
+
+    const updated = updateRoles(new Map([['s0', roles0]]), 's0', evolution);
+    const resolved = resolveRef(topRef, updated, fused);
+
+    expect('face' in resolved).toBe(true);
+    if ('face' in resolved) {
+      // The large low fragment, not the small raised cap.
+      expect(faceGeomType(resolved.face)).toBe('PLANE');
+      expect(upness(resolved.face)).toBeGreaterThan(0.7);
+      expect(faceCenter(resolved.face)[2]).toBeLessThan(15);
+      expect(unwrap(measureArea(resolved.face))).toBeGreaterThan(100);
+    }
+  });
+});

--- a/tests/shapeRefIntegration.test.ts
+++ b/tests/shapeRefIntegration.test.ts
@@ -55,8 +55,8 @@ describe('multi-step replay', () => {
       expect(roles0.size).toBe(6);
 
       // Create refs for top and front faces
-      const topFace = getFaces(b).find((f) => roles0.get('box:top') === getHashCode(f));
-      const frontFace = getFaces(b).find((f) => roles0.get('box:front') === getHashCode(f));
+      const topFace = getFaces(b).find((f) => roles0.get('box:top')?.includes(getHashCode(f)));
+      const frontFace = getFaces(b).find((f) => roles0.get('box:front')?.includes(getHashCode(f)));
       expect(topFace).toBeDefined();
       expect(frontFace).toBeDefined();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
@@ -119,9 +119,9 @@ describe('multi-step replay', () => {
       const roles0 = assignRoles(b, 'box');
 
       // Create ref for the bottom face (least likely to be affected by top fuse)
-      const bottomHash = roles0.get('box:bottom');
-      expect(bottomHash).toBeDefined();
-      const bottomFace = getFaces(b).find((f) => getHashCode(f) === bottomHash);
+      const bottomHashes = roles0.get('box:bottom');
+      expect(bottomHashes).toBeDefined();
+      const bottomFace = getFaces(b).find((f) => bottomHashes?.includes(getHashCode(f)));
       expect(bottomFace).toBeDefined();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
       const bottomRef = createRef('step_0', 'box:bottom', bottomFace!);
@@ -172,13 +172,13 @@ describe('symmetric geometry', () => {
       expect(roles.has('box:right')).toBe(true);
 
       // All hashes should be unique
-      const hashes = [...roles.values()];
+      const hashes = [...roles.values()].flat();
       expect(new Set(hashes).size).toBe(6);
 
       // Create refs for all 6 faces
       const refs = new Map<string, ShapeRef>();
-      for (const [role, hash] of roles) {
-        const face = getFaces(cube).find((f) => getHashCode(f) === hash);
+      for (const [role, faceHashes] of roles) {
+        const face = getFaces(cube).find((f) => faceHashes.includes(getHashCode(f)));
         expect(face).toBeDefined();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
         refs.set(role, createRef('step_0', role, face!));
@@ -223,8 +223,8 @@ describe('symmetric geometry', () => {
 
       // Create refs
       const refs = new Map<string, ShapeRef>();
-      for (const [role, hash] of roles) {
-        const face = getFaces(cyl).find((f) => getHashCode(f) === hash);
+      for (const [role, faceHashes] of roles) {
+        const face = getFaces(cyl).find((f) => faceHashes.includes(getHashCode(f)));
         expect(face).toBeDefined();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
         refs.set(role, createRef('step_0', role, face!));
@@ -294,9 +294,9 @@ describe('split face tracking', () => {
       const roles = assignRoles(base, 'box');
 
       // Create ref for the top face (30x30 area)
-      const topHash = roles.get('box:top');
-      expect(topHash).toBeDefined();
-      const topFace = getFaces(base).find((f) => getHashCode(f) === topHash);
+      const topHashes = roles.get('box:top');
+      expect(topHashes).toBeDefined();
+      const topFace = getFaces(base).find((f) => topHashes?.includes(getHashCode(f)));
       expect(topFace).toBeDefined();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
       const topRef = createRef('step_0', 'box:top', topFace!);
@@ -334,8 +334,8 @@ describe('split face tracking', () => {
 
       // Create refs for all faces
       const refs = new Map<string, ShapeRef>();
-      for (const [role, hash] of roles) {
-        const face = getFaces(base).find((f) => getHashCode(f) === hash);
+      for (const [role, faceHashes] of roles) {
+        const face = getFaces(base).find((f) => faceHashes.includes(getHashCode(f)));
         expect(face).toBeDefined();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
         refs.set(role, createRef('step_0', role, face!));


### PR DESCRIPTION
## Context

`ShapeRef` (`src/topology/shapeRef/`) is brepjs's answer to the **topological-naming problem** — stable, serializable face references that survive a parametric edit. It resolves in two tiers: an exact `RoleTable` (`role → faceHash`, advanced through the kernel's `ShapeEvolution`) and a geometric-hint fallback. This PR hardens the exact tier against the canonical hard case (split faces) and adds the validation the suite was missing — one tractable increment, not a rewrite.

## What changed

**Gap: split faces collapsed to the first successor.** `updateRoles` kept only `modified[0]` when a face split 1→many (`shapeRefFns.ts`), and the geometric fallback then competed against *every* face, so a moved reference centroid could land on the wrong fragment (or tie → `ambiguous`). The split-face tests only asserted "a face resolved," so wrong-successor selection passed silently.

- `RoleTable` now maps a role to **all** its successor hashes (`readonly number[]`). A split keeps every fragment.
- `resolveRef` resolves the exact tier against the tracked successor set: one survivor → exact; several (a split) → disambiguate among **only those fragments** via a scoped scorer (extracted as `scoreFaces`); none → deleted.
- `assignRoles` returns `Map<string, number[]>` to match.

**Missing validation → new harness (`tests/shapeRefEditReplay.test.ts`).** Every prior shapeRef test bypassed the role table (`new Map()`, forcing the geometric path) or asserted only "didn't crash / area > 0." The new tests drive the **exact path** through a real `ShapeEvolution` and assert face *identity* after an edit:
- a **modified** face is tracked through a fuse and resolves to the correct (upward, planar) successor;
- a **split** top face resolves to the correct fragment (the large low region, not the small raised cap) — competing only against the tracked successors.

## Empirical finding (deferred, documented in code)

I investigated naming `evolution.generated` faces (fillet rounds, boolean seams) — the other half of the divergence from the internal `originTrackingFns`. The harness surfaced hard data: on the OCCT kernels, **generated hashes are never live** in the final shape (0 live across cut-through / cut-blind / side-fuse / corner-cut on occt-wasm) — they reference an intermediate shape. Naming them produces roles that can never resolve, so this is **not** included; `updateRoles` documents why. Stable names for generated geometry need lineage/history-fidelity work, tracked separately.

## Scope / notes

- The harness is gated to the **OCCT family** (`occt` + `occt-wasm`): faithful B-rep face evolution is an OCCT-family property — brepkit fillets are a geometric heuristic, manifold is a mesh kernel.
- The public `RoleTable` / `assignRoles` types change `number` → `number[]`. `ShapeRef` is an experimental surface with **zero production consumers** (only `src/index.ts` re-exports + tests), so this is a `feat` (minor), not a breaking `!` bump.
- The generated playground ambient `.d.ts` was left untouched (not CI-gated, already stale from prior merges, no example uses this API — regenerating would conflate unrelated drift).

Verified: typecheck · lint · boundaries · format · check:patterns · knip green; full shapeRef suite passes on occt-wasm / occt / brepkit (pre-existing manifold gaps unchanged).

Refs #1606
