### PR TITLE
chore(deps): bump occt-wasm to 3.6.0 for located() fast path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "knip": "6.16.1",
         "lint-staged": "17.0.7",
         "lz-string": "1.5.0",
-        "occt-wasm": "3.4.0",
+        "occt-wasm": "3.6.0",
         "prettier": "3.8.4",
         "puppeteer": "25.1.0",
         "size-limit": "12.1.0",
@@ -60,7 +60,7 @@
         "brepjs-manifold": "^0.1.0",
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-        "occt-wasm": "^3.4.0"
+        "occt-wasm": "^3.6.0"
       },
       "peerDependenciesMeta": {
         "brepjs-manifold": {
@@ -10833,9 +10833,9 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.4.0.tgz",
-      "integrity": "sha512-tsTiL7EyvHmMGgzfC6NxFx5dQgPuN1YHx2vOPqxnFsg+M4E9QAECr6VxCZE66h/83tyhv8ggYxNxfQTtCimY+Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.6.0.tgz",
+      "integrity": "sha512-qDTnqaRL73DkrqM7cdCJN8FStJm28W9TVXqJXofZQihlA/mX6mnkmE19FkWNrSsixVE676FMtL3V80lzAbG+GQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "comlink": "^4.4.2"

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "knip": "6.16.1",
     "lint-staged": "17.0.7",
     "lz-string": "1.5.0",
-    "occt-wasm": "3.4.0",
+    "occt-wasm": "3.6.0",
     "prettier": "3.8.4",
     "puppeteer": "25.1.0",
     "size-limit": "12.1.0",
@@ -284,7 +284,7 @@
     "brepjs-manifold": "^0.1.0",
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
     "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-    "occt-wasm": "^3.4.0"
+    "occt-wasm": "^3.6.0"
   },
   "peerDependenciesMeta": {
     "brepjs-manifold": {


### PR DESCRIPTION
## Summary

Bumps the `occt-wasm` dependency from **3.4.0 → 3.6.0** (devDependency exact pin + `peerDependencies` range `^3.4.0` → `^3.6.0`).

occt-wasm 3.6.0 ([andymai/occt-wasm#188](https://github.com/andymai/occt-wasm/pull/188)) adds `located(id, matrix)` — a cheap, location-only rigid move that re-tags a shape's `TopLoc_Location` instead of deep-copying topology (O(1) vs O(topology size); measured ~57× cheaper on a 200-face solid).

brepjs already feature-detects `located` and falls back to the copying `transform` when absent (#1633), so this bump is what flips the default kernel onto the fast path.

## Validation

- `npm install` → lockfile updated to `occt-wasm@3.6.0` (resolved + integrity).
- `tsc --noEmit` clean.
- `vitest run --project occt-wasm`: **4466 passed, 76 skipped, 0 failed**.

Diff is dep-only (`package.json` + `package-lock.json`).