### PR TITLE
feat(shaperef): semantic face roles for cylinder/cone/sphere (#1606)

### DIFF
--- a/src/topology/shapeRef/shapeRefFns.ts
+++ b/src/topology/shapeRef/shapeRefFns.ts
@@ -52,37 +52,63 @@ function boxRoleFromNormal(n: readonly [number, number, number]): string | undef
   return undefined;
 }
 
+/** Axial cap name for a Z-axis primitive: 'top' (+Z) / 'bottom' (-Z). */
+function axialCapName(prefix: string, face: Face): string | undefined {
+  if (faceGeomType(face) !== 'PLANE') return undefined;
+  const z = normalAt(face)[2];
+  if (z > AXIS_THRESHOLD) return `${prefix}:top`;
+  if (z < -AXIS_THRESHOLD) return `${prefix}:bottom`;
+  return undefined;
+}
+
+/** Semantic role for a Z-axis cylinder face: top/bottom caps + lateral wall. */
+function cylinderRole(face: Face): string | undefined {
+  return faceGeomType(face) === 'CYLINDRE' ? 'cylinder:lateral' : axialCapName('cylinder', face);
+}
+
+/** Semantic role for a Z-axis cone/frustum face: top/bottom caps + lateral. */
+function coneRole(face: Face): string | undefined {
+  return faceGeomType(face) === 'CONE' ? 'cone:lateral' : axialCapName('cone', face);
+}
+
+/** Semantic role for a sphere's single spherical face. */
+function sphereRole(face: Face): string | undefined {
+  return faceGeomType(face) === 'SPHERE' ? 'sphere:surface' : undefined;
+}
+
+/** Per-primitive semantic face namers, keyed by operation type. */
+const ROLE_ASSIGNERS: Record<string, (face: Face) => string | undefined> = {
+  box: (face) => boxRoleFromNormal(normalAt(face)),
+  cylinder: cylinderRole,
+  cone: coneRole,
+  sphere: sphereRole,
+};
+
 /**
- * Auto-assign role names to the faces of a shape based on operation type.
+ * Auto-assign role names to a shape's faces from its operation type.
  *
- * For 'box': uses face normals to assign cardinal names
- * ('box:top', 'box:bottom', 'box:front', 'box:back', 'box:left', 'box:right').
- * **Note:** Box role detection assumes axis-aligned faces (normal within 0.9 of
- * a cardinal axis). Rotated boxes may receive fewer than 6 named roles; remaining
- * faces fall through to sequential naming.
+ * Known primitives get **semantic** names from face geometry — rebuild-stable
+ * across parameter edits that preserve orientation:
+ * - `box`: cardinal names by normal ('box:top'/'bottom'/'front'/'back'/'left'/'right').
+ * - `cylinder`/`cone` (Z-axis): 'top'/'bottom' caps + 'lateral' wall.
+ * - `sphere`: 'sphere:surface'.
  *
- * For other types: sequential naming ('opType:face_0', 'opType:face_1', ...).
+ * Faces a primitive namer doesn't recognize (a rotated box's non-cardinal faces),
+ * and every face of any other operation type, fall back to positional names
+ * ('opType:face_0', 'opType:face_1', ...) — so each face always gets a role.
  *
  * @returns Map from role name to its face hash codes (one at assignment time;
  *   a role accrues more hashes only later, when `updateRoles` tracks a split).
  */
 export function assignRoles(shape: Shape3D, operationType: string): Map<string, number[]> {
-  const faces = getFaces(shape);
   const roles = new Map<string, number[]>();
-
-  if (operationType === 'box') {
-    for (const face of faces) {
-      const role = boxRoleFromNormal(normalAt(face));
-      if (role !== undefined && !roles.has(role)) {
-        roles.set(role, [getHashCode(face)]);
-      }
-    }
-    return roles;
-  }
-
+  const assigner = ROLE_ASSIGNERS[operationType];
   let index = 0;
-  for (const face of faces) {
-    roles.set(`${operationType}:face_${index}`, [getHashCode(face)]);
+  for (const face of getFaces(shape)) {
+    const semantic = assigner?.(face);
+    const role =
+      semantic !== undefined && !roles.has(semantic) ? semantic : `${operationType}:face_${index}`;
+    roles.set(role, [getHashCode(face)]);
     index++;
   }
   return roles;

--- a/tests/refReplay.test.ts
+++ b/tests/refReplay.test.ts
@@ -9,9 +9,11 @@ import { initKernel } from './setup.js';
 import { currentKernelId } from './helpers/kernelDivergences.js';
 import {
   box,
+  cylinder,
   getFaces,
   getHashCode,
   isEdge,
+  isFace,
   measureVolume,
   unwrap,
   type Edge,
@@ -19,10 +21,12 @@ import {
 } from '@/index.js';
 import { sharedEdges, verticesOfEdge } from '@/topology/adjacencyFns.js';
 import { vertexPosition } from '@/topology/topologyQueryFns.js';
+import { faceGeomType } from '@/topology/faceFns.js';
 import { filletWithEvolution } from '@/topology/evolutionFns.js';
 import {
   assignRoles,
   createEdgeRef,
+  createRef,
   isEdgeRef,
   isFaceRef,
   isLineageRef,
@@ -106,5 +110,22 @@ describe.skipIf(!isOcctFamily)('lineage refs as a parametric-replay consumer', (
     expect(isFaceRef(edgeRef)).toBe(false);
     expect(isLineageRef(edgeRef)).toBe(true);
     expect(isLineageRef({ radius: 2 })).toBe(false);
+  });
+
+  it('a face ref follows a cylinder across a radius rebuild (semantic roles)', () => {
+    // Name the lateral wall on an r=5 cylinder — only possible now that
+    // assignRoles names cylinders semantically, not positionally.
+    const c1 = cylinder(5, 10);
+    const roles1 = assignRoles(c1, 'cylinder');
+    const lateralHashes = roles1.get('cylinder:lateral') ?? [];
+    const lateral = getFaces(c1).find((f) => lateralHashes.includes(getHashCode(f)));
+    if (lateral === undefined) throw new Error('no lateral face');
+    const ref = createRef('cylinder', 'cylinder:lateral', lateral);
+
+    // Rebuild with r=8: the ref re-resolves to the new cylinder's lateral wall.
+    const resolved = resolveRefIn(ref, cylinder(8, 10));
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok || !isFace(resolved.entity)) return;
+    expect(faceGeomType(resolved.entity)).toBe('CYLINDRE');
   });
 });

--- a/tests/shapeRef.test.ts
+++ b/tests/shapeRef.test.ts
@@ -3,6 +3,9 @@ import { initKernel } from './setup.js';
 import { shouldSkipSuite } from './helpers/kernelDivergences.js';
 import {
   box,
+  cylinder,
+  sphere,
+  cone,
   translate,
   getFaces,
   getEdges,
@@ -68,6 +71,25 @@ describe('assignRoles', () => {
     expect(roles.size).toBe(6);
     expect(roles.has('myOp:face_0')).toBe(true);
     expect(roles.has('myOp:face_5')).toBe(true);
+  });
+
+  it('names cylinder faces semantically (caps + lateral wall)', () => {
+    const roles = assignRoles(cylinder(5, 10), 'cylinder');
+    expect(roles.has('cylinder:top')).toBe(true);
+    expect(roles.has('cylinder:bottom')).toBe(true);
+    expect(roles.has('cylinder:lateral')).toBe(true);
+  });
+
+  it('names a sphere by its single spherical face', () => {
+    const roles = assignRoles(sphere(5), 'sphere');
+    expect(roles.has('sphere:surface')).toBe(true);
+  });
+
+  it('names cone/frustum faces semantically (caps + lateral)', () => {
+    const roles = assignRoles(cone(5, 2, 10), 'cone');
+    expect(roles.has('cone:lateral')).toBe(true);
+    expect(roles.has('cone:bottom')).toBe(true);
+    expect(roles.has('cone:top')).toBe(true);
   });
 });
 

--- a/tests/shapeRefIntegration.test.ts
+++ b/tests/shapeRefIntegration.test.ts
@@ -210,16 +210,16 @@ describe('symmetric geometry', () => {
   );
 
   it.skipIf(shouldSkipSuite('shapeRefIntegration.geometricFallback'))(
-    'cylinder: roles assigned sequentially, survive fillet',
+    'cylinder: roles assigned semantically, survive fillet',
     () => {
       const cyl = cylinder(5, 10);
       const roles = assignRoles(cyl, 'cylinder');
 
-      // Cylinder has 3 faces: top cap, bottom cap, barrel
+      // Cylinder has 3 faces, named semantically: top cap, bottom cap, barrel.
       expect(roles.size).toBe(3);
-      expect(roles.has('cylinder:face_0')).toBe(true);
-      expect(roles.has('cylinder:face_1')).toBe(true);
-      expect(roles.has('cylinder:face_2')).toBe(true);
+      expect(roles.has('cylinder:top')).toBe(true);
+      expect(roles.has('cylinder:bottom')).toBe(true);
+      expect(roles.has('cylinder:lateral')).toBe(true);
 
       // Create refs
       const refs = new Map<string, ShapeRef>();
@@ -258,7 +258,7 @@ describe('symmetric geometry', () => {
 
       const ref = createRef(
         'step_0',
-        'sphere:face_0',
+        'sphere:surface',
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- sphere has 1 face
         getFaces(s)[0]!
       );


### PR DESCRIPTION
## Context

Completes the reach of the parametric-replay consumer (#1645). That consumer re-derives roles on a rebuilt shape via `assignRoles(shape, origin)` — but `assignRoles` only named **boxes** semantically; every other primitive got positional `face_N` (by iteration order), which isn't rebuild-stable. So the consumer was effectively box-only.

## Change

Extends the per-operationType dispatch (already used for `box`) to the common primitives:

- **cylinder / cone** (Z-axis): `top` / `bottom` planar caps + `lateral` wall.
- **sphere**: `sphere:surface`.
- **box**: unchanged.
- Generic ops: still positional — preserves the design intent and the existing `myOp:face_N` test.

It also makes every face always get a role: faces a primitive namer doesn't recognize (a rotated box's non-cardinal faces, any generic op) fall back to `face_N`, where the old `box` branch silently *dropped* them. The docstring already claimed this behavior — now it's true.

## Demo

`refReplay.test.ts` adds: a face ref captured on a cylinder's lateral wall re-resolves correctly after the cylinder is rebuilt with a different radius — the consumer now follows features on cylinders, not just boxes.

Verified: typecheck · lint · boundaries · format · check:patterns · knip · size green; `box` + `myOp` behavior preserved; 18 shapeRef + replay tests pass on **occt-wasm and occt**.

Refs #1606
