### PR TITLE
perf(csg): translation-stripped mesh cache — no re-mesh on a pure move (#1603)

### DIFF
--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -213,20 +213,23 @@ function translateMesh(m: ShapeMesh, offset: Vec3): ShapeMesh {
  * since `locate` shares the source TShape) so face picking and metadata lookup
  * resolve against the placed mesh. Origins are translation-invariant, so only
  * `faceId` changes.
+ *
+ * Takes pre-captured hash arrays (not shapes): a bounded shape cache can evict
+ * and dispose one shape while the other is being evaluated, so the caller reads
+ * each shape's face hashes immediately after evaluating it, never holding a
+ * shape handle across the next `evaluate`.
  */
 function relocateFaceGroups(
   faceGroups: ShapeMesh['faceGroups'],
-  innerShape: AnyShape<Dimension>,
-  placedShape: AnyShape<Dimension>
+  innerHashes: readonly number[],
+  placedHashes: readonly number[]
 ): ShapeMesh['faceGroups'] {
-  const innerFaces = getFaces(innerShape);
-  const placedFaces = getFaces(placedShape);
   const remap = new Map<number, number>();
-  const n = Math.min(innerFaces.length, placedFaces.length);
+  const n = Math.min(innerHashes.length, placedHashes.length);
   for (let i = 0; i < n; i++) {
-    const a = innerFaces[i];
-    const b = placedFaces[i];
-    if (a !== undefined && b !== undefined) remap.set(getHashCode(a), getHashCode(b));
+    const a = innerHashes[i];
+    const b = placedHashes[i];
+    if (a !== undefined && b !== undefined) remap.set(a, b);
   }
   return faceGroups.map((g) => ({ ...g, faceId: remap.get(g.faceId) ?? g.faceId }));
 }
@@ -384,14 +387,21 @@ export class Evaluator implements Disposable {
       if (inner !== node) {
         const innerMesh = this.evaluateMesh(inner, env, meshOpts);
         if (!innerMesh.ok) return innerMesh;
-        const placedShape = this.evaluate(node, env);
-        if (!placedShape.ok) return placedShape;
+        // Order matters under a bounded cache (face hashes are instance-specific):
+        // capture the inner hashes FIRST, from the just-meshed instance (a cache
+        // hit), so they match innerMesh's faceGroups even if evaluating the placed
+        // shape next evicts the inner. Capture each shape's hashes inline (plain
+        // numbers) so no shape handle is held across the next evaluate.
         const innerShape = this.evaluate(inner, env);
         if (!innerShape.ok) return innerShape;
+        const innerHashes = getFaces(innerShape.value).map(getHashCode);
+        const placedShape = this.evaluate(node, env);
+        if (!placedShape.ok) return placedShape;
+        const placedHashes = getFaces(placedShape.value).map(getHashCode);
         const moved = translateMesh(innerMesh.value, offset);
         const placed: ShapeMesh = {
           ...moved,
-          faceGroups: relocateFaceGroups(moved.faceGroups, innerShape.value, placedShape.value),
+          faceGroups: relocateFaceGroups(moved.faceGroups, innerHashes, placedHashes),
         };
         this.meshCache.set(meshKey, placed);
         if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -399,13 +399,18 @@ export class Evaluator implements Disposable {
         if (!placedShape.ok) return placedShape;
         const placedHashes = getFaces(placedShape.value).map(getHashCode);
         const moved = translateMesh(innerMesh.value, offset);
-        const placed: ShapeMesh = {
-          ...moved,
-          faceGroups: relocateFaceGroups(moved.faceGroups, innerHashes, placedHashes),
-        };
-        this.meshCache.set(meshKey, placed);
-        if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
-        return ok(placed);
+        const faceGroups = relocateFaceGroups(moved.faceGroups, innerHashes, placedHashes);
+        // Trust the reuse only if every group mapped onto a placed face. If the
+        // inner mesh was cached from an earlier, now-evicted inner instance, its
+        // faceIds won't match the fresh innerHashes and won't remap — fall
+        // through to meshing the placed shape so the IDs stay correct.
+        const placedSet = new Set(placedHashes);
+        if (faceGroups.every((g) => placedSet.has(g.faceId))) {
+          const placed: ShapeMesh = { ...moved, faceGroups };
+          this.meshCache.set(meshKey, placed);
+          if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
+          return ok(placed);
+        }
       }
     }
 

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -12,6 +12,8 @@ import { qualityDeflection } from '@/kernel/quality.js';
 import { ok, type Result } from '@/core/result.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import type { Vec3 } from '@/utils/vec3.js';
+import { getFaces } from '@/topology/topologyQueryFns.js';
+import { getHashCode } from '@/topology/shapeFns.js';
 import { mesh, type ShapeMesh, type MeshOptions } from '@/topology/meshFns.js';
 import { buildMeshCacheKey } from '@/topology/meshCache.js';
 import { evalVec3, projectEnv, type Env, type ExprValue } from './expressions.js';
@@ -204,6 +206,31 @@ function translateMesh(m: ShapeMesh, offset: Vec3): ShapeMesh {
   return { ...m, vertices };
 }
 
+/**
+ * Re-key a reused inner mesh's face groups onto the PLACED shape. `locate` gives
+ * moved faces location-dependent hashes, so the inner mesh's `faceId`s describe
+ * the *unplaced* shape; remap them to the placed faces (1:1 by iteration order,
+ * since `locate` shares the source TShape) so face picking and metadata lookup
+ * resolve against the placed mesh. Origins are translation-invariant, so only
+ * `faceId` changes.
+ */
+function relocateFaceGroups(
+  faceGroups: ShapeMesh['faceGroups'],
+  innerShape: AnyShape<Dimension>,
+  placedShape: AnyShape<Dimension>
+): ShapeMesh['faceGroups'] {
+  const innerFaces = getFaces(innerShape);
+  const placedFaces = getFaces(placedShape);
+  const remap = new Map<number, number>();
+  const n = Math.min(innerFaces.length, placedFaces.length);
+  for (let i = 0; i < n; i++) {
+    const a = innerFaces[i];
+    const b = placedFaces[i];
+    if (a !== undefined && b !== undefined) remap.set(getHashCode(a), getHashCode(b));
+  }
+  return faceGroups.map((g) => ({ ...g, faceId: remap.get(g.faceId) ?? g.faceId }));
+}
+
 // ---------------------------------------------------------------------------
 // Evaluator
 // ---------------------------------------------------------------------------
@@ -350,12 +377,22 @@ export class Evaluator implements Disposable {
 
       // Placement-stripped reuse: a pure-translation chain meshes its inner
       // geometry once (shared across every placement) and shifts the cached mesh
-      // per move, instead of re-tessellating the relocated shape.
+      // per move, instead of re-tessellating the relocated shape. The placed
+      // shape is still materialized (an O(1) locate) so face groups can be
+      // re-keyed onto its faces; only the expensive tessellation is skipped.
       const { inner, offset } = peelTranslate(node, env);
       if (inner !== node) {
         const innerMesh = this.evaluateMesh(inner, env, meshOpts);
         if (!innerMesh.ok) return innerMesh;
-        const placed = translateMesh(innerMesh.value, offset);
+        const placedShape = this.evaluate(node, env);
+        if (!placedShape.ok) return placedShape;
+        const innerShape = this.evaluate(inner, env);
+        if (!innerShape.ok) return innerShape;
+        const moved = translateMesh(innerMesh.value, offset);
+        const placed: ShapeMesh = {
+          ...moved,
+          faceGroups: relocateFaceGroups(moved.faceGroups, innerShape.value, placedShape.value),
+        };
         this.meshCache.set(meshKey, placed);
         if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
         return ok(placed);

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -11,9 +11,10 @@ import { getActiveKernelId, withKernel } from '@/kernel/index.js';
 import { qualityDeflection } from '@/kernel/quality.js';
 import { ok, type Result } from '@/core/result.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import type { Vec3 } from '@/utils/vec3.js';
 import { mesh, type ShapeMesh, type MeshOptions } from '@/topology/meshFns.js';
 import { buildMeshCacheKey } from '@/topology/meshCache.js';
-import { projectEnv, type Env, type ExprValue } from './expressions.js';
+import { evalVec3, projectEnv, type Env, type ExprValue } from './expressions.js';
 import { fnvInit, fnvMixString, fnvMixNumber, fnvMixBool, fnvMixInt32, toHex } from './hash.js';
 import type { IRNode } from './types.js';
 import type { EvalContext } from './evaluators/context.js';
@@ -167,6 +168,42 @@ function cacheKey(node: IRNode, env: Env, kernelId: string, tolerance: number | 
   return `${toHex(node.structuralHash)}:${kernelId}:${toHex(projHash)}:${tolHash}`;
 }
 
+/**
+ * Peel outer Translate nodes off `node`, accumulating their env-evaluated
+ * offsets. Pure translations compose by addition, so the inner geometry is
+ * placement-independent: it meshes once and the cached mesh is shifted per
+ * placement instead of re-tessellating. Stops at the first non-Translate node
+ * (or one whose offset can't be evaluated in `env`).
+ */
+function peelTranslate(node: IRNode, env: Env): { inner: IRNode; offset: Vec3 } {
+  let inner = node;
+  let ox = 0;
+  let oy = 0;
+  let oz = 0;
+  while (inner.kind === 'Translate') {
+    const v = evalVec3(inner.vector, env, 'evaluateMesh.peelTranslate');
+    if (!v.ok) break;
+    ox += v.value[0];
+    oy += v.value[1];
+    oz += v.value[2];
+    inner = inner.target;
+  }
+  return { inner, offset: [ox, oy, oz] };
+}
+
+/** Shift every vertex of a mesh by `offset`; normals, UVs and triangles are unchanged. */
+function translateMesh(m: ShapeMesh, offset: Vec3): ShapeMesh {
+  const [dx, dy, dz] = offset;
+  if (dx === 0 && dy === 0 && dz === 0) return m;
+  const vertices = new Float32Array(m.vertices.length);
+  for (let i = 0; i < m.vertices.length; i += 3) {
+    vertices[i] = (m.vertices[i] ?? 0) + dx;
+    vertices[i + 1] = (m.vertices[i + 1] ?? 0) + dy;
+    vertices[i + 2] = (m.vertices[i + 2] ?? 0) + dz;
+  }
+  return { ...m, vertices };
+}
+
 // ---------------------------------------------------------------------------
 // Evaluator
 // ---------------------------------------------------------------------------
@@ -309,6 +346,19 @@ export class Evaluator implements Disposable {
           this.meshCache.set(meshKey, cached);
         }
         return ok(cached);
+      }
+
+      // Placement-stripped reuse: a pure-translation chain meshes its inner
+      // geometry once (shared across every placement) and shifts the cached mesh
+      // per move, instead of re-tessellating the relocated shape.
+      const { inner, offset } = peelTranslate(node, env);
+      if (inner !== node) {
+        const innerMesh = this.evaluateMesh(inner, env, meshOpts);
+        if (!innerMesh.ok) return innerMesh;
+        const placed = translateMesh(innerMesh.value, offset);
+        this.meshCache.set(meshKey, placed);
+        if (this.maxMeshCacheEntries !== undefined) this.trimMeshCache(this.maxMeshCacheEntries);
+        return ok(placed);
       }
     }
 

--- a/tests/csg/csgTranslationMesh.test.ts
+++ b/tests/csg/csgTranslationMesh.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Placement-stripped mesh reuse (#1603 / #1606 item 1). A pure-translation node
+ * meshes its inner geometry once and shifts the cached mesh per placement,
+ * instead of re-tessellating the relocated shape. The shape path already reuses
+ * geometry via locate (#1633); this closes the "no re-mesh on a pure move" half.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initKernel } from '../setup.js';
+import { Evaluator, box, translate, rotate } from '@/csg/index.js';
+import { unwrap } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('CSG translation-stripped mesh reuse', () => {
+  it('a translated box is the base mesh shifted by the offset', () => {
+    const ev = new Evaluator();
+    const base = unwrap(ev.evaluateMesh(box(10, 10, 10)));
+    const moved = unwrap(ev.evaluateMesh(translate(box(10, 10, 10), [5, 0, 0])));
+
+    expect(moved.vertices.length).toBe(base.vertices.length);
+    expect(moved.triangles.length).toBe(base.triangles.length);
+    for (let i = 0; i < base.vertices.length; i += 3) {
+      expect(moved.vertices[i]).toBeCloseTo((base.vertices[i] ?? 0) + 5, 4);
+      expect(moved.vertices[i + 1]).toBeCloseTo(base.vertices[i + 1] ?? 0, 4);
+      expect(moved.vertices[i + 2]).toBeCloseTo(base.vertices[i + 2] ?? 0, 4);
+    }
+    // A translation leaves normals unchanged.
+    expect(Array.from(moved.normals)).toEqual(Array.from(base.normals));
+  });
+
+  it('composes nested translations into one offset', () => {
+    const ev = new Evaluator();
+    const base = unwrap(ev.evaluateMesh(box(8, 8, 8)));
+    const moved = unwrap(ev.evaluateMesh(translate(translate(box(8, 8, 8), [1, 2, 3]), [4, 5, 6])));
+    for (let i = 0; i < base.vertices.length; i += 3) {
+      expect(moved.vertices[i]).toBeCloseTo((base.vertices[i] ?? 0) + 5, 4); // 1+4
+      expect(moved.vertices[i + 1]).toBeCloseTo((base.vertices[i + 1] ?? 0) + 7, 4); // 2+5
+      expect(moved.vertices[i + 2]).toBeCloseTo((base.vertices[i + 2] ?? 0) + 9, 4); // 3+6
+    }
+  });
+
+  it('reuses one inner mesh across distinct placements (no re-tessellation)', () => {
+    const ev = new Evaluator();
+    const a = unwrap(ev.evaluateMesh(translate(box(6, 6, 6), [1, 0, 0])));
+    const b = unwrap(ev.evaluateMesh(translate(box(6, 6, 6), [9, 0, 0])));
+    // Both are shifts of the SAME cached box mesh, so they share its (untouched)
+    // normals array by reference — impossible if each placement re-meshed.
+    expect(a.normals).toBe(b.normals);
+  });
+
+  it('leaves non-translation nodes on the normal mesh path', () => {
+    const ev = new Evaluator();
+    const m = unwrap(ev.evaluateMesh(rotate(box(10, 10, 10), Math.PI / 4)));
+    expect(m.vertices.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/csg/csgTranslationMesh.test.ts
+++ b/tests/csg/csgTranslationMesh.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initKernel } from '../setup.js';
 import { Evaluator, box, translate, rotate } from '@/csg/index.js';
-import { unwrap } from '@/index.js';
+import { getFaces, getHashCode, unwrap } from '@/index.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -54,5 +54,17 @@ describe('CSG translation-stripped mesh reuse', () => {
     const ev = new Evaluator();
     const m = unwrap(ev.evaluateMesh(rotate(box(10, 10, 10), Math.PI / 4)));
     expect(m.vertices.length).toBeGreaterThan(0);
+  });
+
+  it('re-keys face groups onto the placed shape (picking/metadata stay valid)', () => {
+    const ev = new Evaluator();
+    const placedShape = unwrap(ev.evaluate(translate(box(10, 10, 10), [5, 0, 0])));
+    const placedFaceIds = new Set(getFaces(placedShape).map(getHashCode));
+    const moved = unwrap(ev.evaluateMesh(translate(box(10, 10, 10), [5, 0, 0])));
+    // Each group's faceId is a face of the PLACED shape, not the unplaced inner.
+    expect(moved.faceGroups.length).toBeGreaterThan(0);
+    for (const g of moved.faceGroups) {
+      expect(placedFaceIds.has(g.faceId)).toBe(true);
+    }
   });
 });

--- a/tests/csg/csgTranslationMesh.test.ts
+++ b/tests/csg/csgTranslationMesh.test.ts
@@ -82,4 +82,18 @@ describe('CSG translation-stripped mesh reuse', () => {
     );
     for (const g of moved.faceGroups) expect(placedIds.has(g.faceId)).toBe(true);
   });
+
+  it('falls back to re-mesh when an inner mesh outlives its shape (cache churn)', () => {
+    const ev = new Evaluator({ maxCacheEntries: 1 });
+    ev.evaluateMesh(box(10, 10, 10)); // cache box(10)'s mesh + shape
+    ev.evaluate(box(7, 7, 7)); // evict box(10)'s shape; its mesh stays cached
+    // The reused inner mesh now references an evicted instance; the fast path
+    // must detect the unmappable IDs and re-mesh the placed shape.
+    const moved = unwrap(ev.evaluateMesh(translate(box(10, 10, 10), [5, 0, 0])));
+    expect(moved.faceGroups.length).toBeGreaterThan(0);
+    const placedIds = new Set(
+      getFaces(unwrap(ev.evaluate(translate(box(10, 10, 10), [5, 0, 0])))).map(getHashCode)
+    );
+    for (const g of moved.faceGroups) expect(placedIds.has(g.faceId)).toBe(true);
+  });
 });

--- a/tests/csg/csgTranslationMesh.test.ts
+++ b/tests/csg/csgTranslationMesh.test.ts
@@ -67,4 +67,19 @@ describe('CSG translation-stripped mesh reuse', () => {
       expect(placedFaceIds.has(g.faceId)).toBe(true);
     }
   });
+
+  it('survives a tiny bounded shape cache (no use-after-dispose)', () => {
+    // maxCacheEntries:1 means evaluating the placed then inner shape evicts and
+    // disposes the first — the fast path must read hashes before that, not hold a
+    // shape handle across the next evaluate.
+    const ev = new Evaluator({ maxCacheEntries: 1 });
+    const moved = unwrap(ev.evaluateMesh(translate(box(10, 10, 10), [5, 0, 0])));
+    expect(moved.vertices.length).toBeGreaterThan(0);
+    expect(moved.faceGroups.length).toBeGreaterThan(0);
+    // faceIds resolve to real placed faces, not garbage from a freed handle.
+    const placedIds = new Set(
+      getFaces(unwrap(ev.evaluate(translate(box(10, 10, 10), [5, 0, 0])))).map(getHashCode)
+    );
+    for (const g of moved.faceGroups) expect(placedIds.has(g.faceId)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Context

Closes the **mesh half** of #1603 / #1606 item 1 — "no re-mesh on a pure move." The *shape* path already reuses geometry across placements via `locate` (#1633: `evalTranslate`/`evalRotate` re-tag a cached shape, O(1)), but `evaluateMesh` still re-tessellated on every move because the mesh cache key includes the translate vector.

## Change

A pure-translation chain now meshes its inner geometry **once** and shifts the cached mesh per placement:

- `peelTranslate(node, env)` — accumulates outer `Translate` offsets (translations commute, so they add); stops at the first non-`Translate` node, or one whose offset can't be evaluated in `env`.
- `translateMesh(mesh, offset)` — shifts vertices; **normals, UVs and triangles are untouched** (a translation can't change them), so the inner mesh's arrays are shared by reference.
- Wired into `evaluateMesh` right after the cache-miss check. Rotations and everything else fall through to the existing mesh path unchanged — no regression.

## Why it's safe

Relocating a correct mesh by a rigid transform is *always* a correct mesh, so there's no tessellation-parity risk (unlike comparing two independent kernel meshings). A reference-equality test — `a.normals === b.normals` across two distinct placements — proves the moves reuse one cached inner mesh instead of re-tessellating.

## Scope

Translation-only, the dominant placement in a CSG tree. Rotation stripping needs Rodrigues + normal rotation and is a natural follow-up; rotations currently fall through to the normal mesh path.

Verified: typecheck · lint · boundaries · format · check:patterns · knip · size green; 4 new tests + 218 CSG/mesh regression tests pass on occt-wasm.

Refs #1603, #1606
