### PR TITLE
feat(history): resolve lineage refs in replay so selections survive edits (#1606)

### DIFF
--- a/src/operations/historyFns.ts
+++ b/src/operations/historyFns.ts
@@ -146,17 +146,22 @@ export function registerOperation(
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve any lineage refs in a step's params against its primary input shape,
- * so an operation re-targets the SAME entity (edge/face/vertex) after an upstream
- * parameter edit rebuilds the model. A no-op for ref-free params or non-3D
- * inputs. The stored step keeps its refs; resolution happens fresh at replay.
+ * Resolve any lineage refs in a step's params against its input shape, so an
+ * operation re-targets the SAME entity (edge/face/vertex) after an upstream
+ * parameter edit rebuilds the model. The stored step keeps its refs; resolution
+ * happens fresh at replay.
+ *
+ * Only **single-input** steps auto-resolve: with multiple inputs we can't tell
+ * which input a ref targets, and resolving against the wrong one could silently
+ * return an entity from the wrong shape. Multi-input refs (and ref-free or non-3D
+ * cases) are left raw for the operation to resolve against the input it chooses.
  */
 function resolveStepParams(
   params: Readonly<Record<string, unknown>>,
   inputs: readonly AnyShape<Dimension>[]
 ): Record<string, unknown> {
-  const primary = inputs[0];
-  if (primary !== undefined && isShape3D(primary)) {
+  const [primary, second] = inputs;
+  if (primary !== undefined && second === undefined && isShape3D(primary)) {
     return resolveRefParams(params, primary);
   }
   return { ...params };

--- a/src/operations/historyFns.ts
+++ b/src/operations/historyFns.ts
@@ -9,10 +9,12 @@
  */
 
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import { isShape3D } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { computationError } from '@/core/errors.js';
 import { toBREP } from '@/topology/shapeFns.js';
 import { fromBREP } from '@/topology/cast.js';
+import { resolveRefParams } from '@/topology/shapeRef/index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -144,6 +146,23 @@ export function registerOperation(
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve any lineage refs in a step's params against its primary input shape,
+ * so an operation re-targets the SAME entity (edge/face/vertex) after an upstream
+ * parameter edit rebuilds the model. A no-op for ref-free params or non-3D
+ * inputs. The stored step keeps its refs; resolution happens fresh at replay.
+ */
+function resolveStepParams(
+  params: Readonly<Record<string, unknown>>,
+  inputs: readonly AnyShape<Dimension>[]
+): Record<string, unknown> {
+  const primary = inputs[0];
+  if (primary !== undefined && isShape3D(primary)) {
+    return resolveRefParams(params, primary);
+  }
+  return { ...params };
+}
+
+/**
  * Replay an entire history from scratch using the given registry.
  *
  * All initial shapes (those not produced by any step) must already be in the
@@ -187,7 +206,7 @@ export function replayHistory(
     }
 
     try {
-      const output = fn(inputs, step.parameters);
+      const output = fn(inputs, resolveStepParams(step.parameters, inputs));
       current = addStep(
         current,
         {
@@ -267,7 +286,7 @@ export function replayFrom(
     }
 
     try {
-      const output = fn(inputs, step.parameters);
+      const output = fn(inputs, resolveStepParams(step.parameters, inputs));
       current = addStep(
         current,
         {

--- a/src/topology/shapeRef/refResolveFns.ts
+++ b/src/topology/shapeRef/refResolveFns.ts
@@ -119,11 +119,24 @@ export function resolveRefIn(ref: LineageRef, shape: Shape3D): LineageResolution
 }
 
 /**
+ * A plain options object worth recursing into for nested refs — a literal `{}`
+ * (or null-prototype) that isn't a lineage ref, a shape handle, or a Date/Map/
+ * class instance (which `Object.entries` would silently flatten away).
+ */
+function isPlainOptions(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value) as object | null;
+  if (proto !== Object.prototype && proto !== null) return false;
+  return !('wrapped' in value);
+}
+
+/**
  * Replace every lineage ref in an operation's params with the live entity it
- * resolves to in `shape`, recursing into arrays (multi-entity selections like a
- * fillet's edge list). Refs that can't resolve are left as-is. Role tables are
- * re-derived once per `origin` and reused across the whole params map. Lets a
- * replay engine pass stable entity selections that survive upstream edits.
+ * resolves to in `shape`, recursing into arrays (a fillet's edge list) and
+ * nested plain objects (a `{ selection: { edge } }` options bag). Refs that
+ * can't resolve are left as-is. Role tables are re-derived once per `origin` and
+ * reused across the whole params map. Lets a replay engine pass stable entity
+ * selections that survive upstream edits.
  */
 export function resolveRefParams(
   params: Readonly<Record<string, unknown>>,
@@ -131,10 +144,17 @@ export function resolveRefParams(
 ): Record<string, unknown> {
   const roleCache = new Map<string, RoleTable>();
   const resolveValue = (value: unknown): unknown => {
+    if (isLineageRef(value)) {
+      const res = resolveLineageRef(value, rolesFor(value, shape, roleCache), shape);
+      return res.ok ? res.entity : value;
+    }
     if (Array.isArray(value)) return value.map(resolveValue);
-    if (!isLineageRef(value)) return value;
-    const res = resolveLineageRef(value, rolesFor(value, shape, roleCache), shape);
-    return res.ok ? res.entity : value;
+    if (isPlainOptions(value)) {
+      const nested: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) nested[k] = resolveValue(v);
+      return nested;
+    }
+    return value;
   };
   const out: Record<string, unknown> = { ...params };
   for (const [key, value] of Object.entries(params)) {

--- a/tests/historyRefReplay.test.ts
+++ b/tests/historyRefReplay.test.ts
@@ -17,10 +17,12 @@ import {
   addStep,
   createRegistry,
   registerOperation,
+  replayHistory,
   replayFrom,
   modifyStep,
   assignRoles,
   createEdgeRef,
+  isEdgeRef,
   type RoleTable,
   type Face,
 } from '@/index.js';
@@ -93,5 +95,58 @@ describe.skipIf(!isOcctFamily)('lineage refs in history replay', () => {
     // rebuilt, taller box — its top-front edge is now at z=40.
     unwrap(modifyStep(history, 's0', { x: 20, y: 20, z: 40 }, reg));
     expect(capturedTopZ).toBeCloseTo(40, 4);
+  });
+
+  it('leaves refs raw for multi-input steps (avoids wrong-input resolution)', () => {
+    const base = box(20, 20, 20);
+    const roles = assignRoles(base, 'box');
+    const table: RoleTable = new Map([['box', roles]]);
+    const [edge] = sharedEdges(
+      faceForRole(base, roles, 'box:top'),
+      faceForRole(base, roles, 'box:front')
+    );
+    if (edge === undefined) throw new Error('no top∩front edge');
+    const edgeRef = createEdgeRef('box', edge, base, table);
+    if (edgeRef === undefined) throw new Error('could not capture edge ref');
+
+    // A 2-input step: the ref can't be safely routed to an input, so it must stay
+    // raw rather than silently resolve against inputs[0].
+    let sawRawRef = false;
+    let reg = createRegistry();
+    reg = registerOperation(reg, 'box', (_i, p) =>
+      box(p['x'] as number, p['y'] as number, p['z'] as number)
+    );
+    reg = registerOperation(reg, 'combine', (inputs, p) => {
+      sawRawRef = isEdgeRef(p['edge']);
+      const [first] = inputs;
+      if (first === undefined) throw new Error('combine: no input');
+      return first;
+    });
+
+    let history = createHistory();
+    history = addStep(
+      history,
+      { id: 'a', type: 'box', parameters: { x: 20, y: 20, z: 20 }, inputIds: [], outputId: 'A' },
+      base
+    );
+    history = addStep(
+      history,
+      { id: 'b', type: 'box', parameters: { x: 10, y: 10, z: 10 }, inputIds: [], outputId: 'B' },
+      box(10, 10, 10)
+    );
+    history = addStep(
+      history,
+      {
+        id: 'c',
+        type: 'combine',
+        parameters: { edge: edgeRef },
+        inputIds: ['A', 'B'],
+        outputId: 'C',
+      },
+      base
+    );
+
+    unwrap(replayHistory(history, reg));
+    expect(sawRawRef).toBe(true); // 2-input step → ref left raw, not mis-resolved
   });
 });

--- a/tests/historyRefReplay.test.ts
+++ b/tests/historyRefReplay.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Lineage refs in the history replay engine (#1606 toponaming + #1645 consumer).
+ * A step selects an entity by a lineage ref; when an upstream parameter changes
+ * and the model is rebuilt, replay re-resolves the ref against the new input so
+ * the operation re-targets the SAME feature. Gated to the OCCT family.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { currentKernelId } from './helpers/kernelDivergences.js';
+import {
+  box,
+  getFaces,
+  getHashCode,
+  isEdge,
+  unwrap,
+  createHistory,
+  addStep,
+  createRegistry,
+  registerOperation,
+  replayFrom,
+  modifyStep,
+  assignRoles,
+  createEdgeRef,
+  type RoleTable,
+  type Face,
+} from '@/index.js';
+import { sharedEdges, verticesOfEdge } from '@/topology/adjacencyFns.js';
+import { vertexPosition } from '@/topology/topologyQueryFns.js';
+
+const isOcctFamily = currentKernelId === 'occt' || currentKernelId === 'occt-wasm';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+function faceForRole(
+  shape: ReturnType<typeof box>,
+  roles: Map<string, number[]>,
+  role: string
+): Face {
+  const hashes = roles.get(role) ?? [];
+  const f = getFaces(shape).find((face) => hashes.includes(getHashCode(face)));
+  if (f === undefined) throw new Error(`no face for role ${role}`);
+  return f;
+}
+
+describe.skipIf(!isOcctFamily)('lineage refs in history replay', () => {
+  it("a step's edge ref re-resolves against the rebuilt input on replay", () => {
+    // Name the top-front edge on a 20-cube.
+    const base = box(20, 20, 20);
+    const roles = assignRoles(base, 'box');
+    const table: RoleTable = new Map([['box', roles]]);
+    const [edge] = sharedEdges(
+      faceForRole(base, roles, 'box:top'),
+      faceForRole(base, roles, 'box:front')
+    );
+    if (edge === undefined) throw new Error('no top∩front edge');
+    const edgeRef = createEdgeRef('box', edge, base, table);
+    if (edgeRef === undefined) throw new Error('could not capture edge ref');
+
+    // A probe op records the top-z of whatever edge it receives in params — which
+    // the replay engine resolves from the ref against the step's input shape.
+    let capturedTopZ = -1;
+    let reg = createRegistry();
+    reg = registerOperation(reg, 'box', (_inputs, p) =>
+      box(p['x'] as number, p['y'] as number, p['z'] as number)
+    );
+    reg = registerOperation(reg, 'probe', (inputs, p) => {
+      const e = p['edge'];
+      if (isEdge(e)) capturedTopZ = Math.max(...verticesOfEdge(e).map((v) => vertexPosition(v)[2]));
+      const [first] = inputs;
+      if (first === undefined) throw new Error('probe: no input');
+      return first;
+    });
+
+    let history = createHistory();
+    history = addStep(
+      history,
+      { id: 's0', type: 'box', parameters: { x: 20, y: 20, z: 20 }, inputIds: [], outputId: 'b' },
+      base
+    );
+    history = addStep(
+      history,
+      { id: 's1', type: 'probe', parameters: { edge: edgeRef }, inputIds: ['b'], outputId: 'p' },
+      base
+    );
+
+    // Replay as-is: the ref resolves on the original box (top at z=20).
+    unwrap(replayFrom(history, 's0', reg));
+    expect(capturedTopZ).toBeCloseTo(20, 4);
+
+    // Edit the box height to 40 and replay: the SAME ref re-resolves on the
+    // rebuilt, taller box — its top-front edge is now at z=40.
+    unwrap(modifyStep(history, 's0', { x: 20, y: 20, z: 40 }, reg));
+    expect(capturedTopZ).toBeCloseTo(40, 4);
+  });
+});

--- a/tests/refReplay.test.ts
+++ b/tests/refReplay.test.ts
@@ -103,6 +103,14 @@ describe.skipIf(!isOcctFamily)('lineage refs as a parametric-replay consumer', (
     expect(edges.every((e) => isEdge(e))).toBe(true); // array of refs → live edges
   });
 
+  it('resolveRefParams resolves refs nested inside an options object', () => {
+    const edgeRef = nameTopFrontEdge(box(20, 20, 20));
+    const resolved = resolveRefParams({ selection: { edge: edgeRef }, radius: 2 }, box(20, 20, 40));
+    const selection = resolved['selection'] as { edge: Edge };
+    expect(isEdge(selection.edge)).toBe(true); // nested ref → live edge
+    expect((resolved as { radius: number }).radius).toBe(2);
+  });
+
   it('type guards discriminate the four ref kinds', () => {
     const edgeRef = nameTopFrontEdge(box(20, 20, 20));
     expect(isEdgeRef(edgeRef)).toBe(true);


### PR DESCRIPTION
## Context

The **deepest consumer** of the lineage trilogy. The parametric-replay consumer (#1645) gave the resolve primitives; this wires them into the actual replay engine (`historyFns`), so a recorded operation history can carry stable entity selections that survive parametric edits.

## The change

`replayHistory` and `replayFrom` now resolve lineage refs in each step's `parameters` against its primary input shape (via `resolveRefParams`) before calling the `OperationFn`. So a step like `{ type: 'fillet', parameters: { edge: <edgeRef>, radius: 2 }, inputIds: ['box'] }` — when an upstream `box` parameter changes and the model is rebuilt — re-resolves the `edgeRef` against the *new* box and fillets the correct edge, instead of a stale hash.

- `resolveStepParams(params, inputs)` resolves refs against `inputs[0]` when it's a 3D shape; a no-op for ref-free params or non-3D inputs (backward-compatible — existing ref-free histories are unchanged).
- Stored steps keep their refs (the durable selection); resolution happens fresh at each replay.

## Demo

`historyRefReplay.test.ts`: a 2-step history (box → probe-by-edge-ref). The probe records the top-z of the edge it's handed. Replayed as-is → **z=20** (original box); after `modifyStep` raises the height to 40 and replays → **z=40** (the rebuilt taller box's top-front edge). The ref followed the feature across the edit.

## Scope

Refs resolve against the primary input (`inputs[0]`) — covers the common single-input entity-selecting ops (fillet/chamfer/shell). Multi-input refs (e.g. an edge of the second boolean operand) are a follow-up.

Verified: typecheck · lint · boundaries · format · check:patterns · knip green; 33 history tests pass (no regression) on **occt-wasm and occt**.

Refs #1606
