### PR TITLE
perf(csg): rotation-stripped mesh reuse — no re-mesh on a pure rotate

### DIFF
--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -242,6 +242,37 @@ function isIdentityQuat(q: Quat): boolean {
 }
 
 /**
+ * Write `src` (flat xyz) rigidly transformed by quaternion (qw,qx,qy,qz) then
+ * translation (tx,ty,tz) into `dst`. The quaternion-rotate math is inlined with
+ * scalar locals — no per-vertex array allocation — because this runs once per
+ * mesh vertex/normal and helper-allocated vector math regressed the gridfinity
+ * benchmark 17% (see `utils/vec3.ts`). Pass zero translation for normals.
+ */
+function rotateXyzBuffer(
+  dst: Float32Array,
+  src: Float32Array,
+  qw: number,
+  qx: number,
+  qy: number,
+  qz: number,
+  tx: number,
+  ty: number,
+  tz: number
+): void {
+  for (let i = 0; i < src.length; i += 3) {
+    const vx = src[i] ?? 0;
+    const vy = src[i + 1] ?? 0;
+    const vz = src[i + 2] ?? 0;
+    const cx = 2 * (qy * vz - qz * vy);
+    const cy = 2 * (qz * vx - qx * vz);
+    const cz = 2 * (qx * vy - qy * vx);
+    dst[i] = vx + qw * cx + (qy * cz - qz * cy) + tx;
+    dst[i + 1] = vy + qw * cy + (qz * cx - qx * cz) + ty;
+    dst[i + 2] = vz + qw * cz + (qx * cy - qy * cx) + tz;
+  }
+}
+
+/**
  * Apply a rigid motion to a mesh: vertices get the rotation then translation,
  * normals get the rotation only (a unit rotation preserves length, so no
  * renormalization). UVs and triangles are motion-invariant. A pure translation
@@ -264,20 +295,11 @@ function transformMeshRigid(m: ShapeMesh, rot: Quat, trans: Vec3): ShapeMesh {
     return { ...m, vertices };
   }
 
-  for (let i = 0; i < src.length; i += 3) {
-    const p = quatRotate(rot, [src[i] ?? 0, src[i + 1] ?? 0, src[i + 2] ?? 0]);
-    vertices[i] = p[0] + tx;
-    vertices[i + 1] = p[1] + ty;
-    vertices[i + 2] = p[2] + tz;
-  }
+  const [qw, qx, qy, qz] = rot;
+  rotateXyzBuffer(vertices, src, qw, qx, qy, qz, tx, ty, tz);
   const sn = m.normals;
   const normals = new Float32Array(sn.length);
-  for (let i = 0; i < sn.length; i += 3) {
-    const n = quatRotate(rot, [sn[i] ?? 0, sn[i + 1] ?? 0, sn[i + 2] ?? 0]);
-    normals[i] = n[0];
-    normals[i + 1] = n[1];
-    normals[i + 2] = n[2];
-  }
+  rotateXyzBuffer(normals, sn, qw, qx, qy, qz, 0, 0, 0);
   return { ...m, vertices, normals };
 }
 

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -12,13 +12,14 @@ import { qualityDeflection } from '@/kernel/quality.js';
 import { ok, type Result } from '@/core/result.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import type { Vec3 } from '@/utils/vec3.js';
+import { quatFromAxisAngle, quatMultiply, quatRotate, type Quat } from '@/utils/quaternion.js';
 import { getFaces } from '@/topology/topologyQueryFns.js';
 import { getHashCode } from '@/topology/shapeFns.js';
 import { mesh, type ShapeMesh, type MeshOptions } from '@/topology/meshFns.js';
 import { buildMeshCacheKey } from '@/topology/meshCache.js';
-import { evalVec3, projectEnv, type Env, type ExprValue } from './expressions.js';
+import { evalScalar, evalVec3, projectEnv, type Env, type ExprValue } from './expressions.js';
 import { fnvInit, fnvMixString, fnvMixNumber, fnvMixBool, fnvMixInt32, toHex } from './hash.js';
-import type { IRNode } from './types.js';
+import type { IRNode, RotateNode } from './types.js';
 import type { EvalContext } from './evaluators/context.js';
 import {
   evalBox,
@@ -170,40 +171,114 @@ function cacheKey(node: IRNode, env: Env, kernelId: string, tolerance: number | 
   return `${toHex(node.structuralHash)}:${kernelId}:${toHex(projHash)}:${tolHash}`;
 }
 
-/**
- * Peel outer Translate nodes off `node`, accumulating their env-evaluated
- * offsets. Pure translations compose by addition, so the inner geometry is
- * placement-independent: it meshes once and the cached mesh is shifted per
- * placement instead of re-tessellating. Stops at the first non-Translate node
- * (or one whose offset can't be evaluated in `env`).
- */
-function peelTranslate(node: IRNode, env: Env): { inner: IRNode; offset: Vec3 } {
-  let inner = node;
-  let ox = 0;
-  let oy = 0;
-  let oz = 0;
-  while (inner.kind === 'Translate') {
-    const v = evalVec3(inner.vector, env, 'evaluateMesh.peelTranslate');
-    if (!v.ok) break;
-    ox += v.value[0];
-    oy += v.value[1];
-    oz += v.value[2];
-    inner = inner.target;
-  }
-  return { inner, offset: [ox, oy, oz] };
+const IDENTITY_QUAT: Quat = [1, 0, 0, 0];
+
+/** Resolve a Rotate node's angle/axis/center in `env`, applying the same
+ *  defaults as the evaluator (Z axis, origin pivot). Null if any free param
+ *  can't be evaluated, so the caller stops peeling there. */
+function evalRotateParams(
+  node: RotateNode,
+  env: Env
+): { angle: number; axis: Vec3; center: Vec3 } | null {
+  const a = evalScalar(node.angle, env, 'evaluateMesh.peelRigid');
+  if (!a.ok) return null;
+  const axis = node.axis ? evalVec3(node.axis, env, 'evaluateMesh.peelRigid') : ok<Vec3>([0, 0, 1]);
+  if (!axis.ok) return null;
+  const center = node.at ? evalVec3(node.at, env, 'evaluateMesh.peelRigid') : ok<Vec3>([0, 0, 0]);
+  if (!center.ok) return null;
+  return { angle: a.value, axis: axis.value, center: center.value };
 }
 
-/** Shift every vertex of a mesh by `offset`; normals, UVs and triangles are unchanged. */
-function translateMesh(m: ShapeMesh, offset: Vec3): ShapeMesh {
-  const [dx, dy, dz] = offset;
-  if (dx === 0 && dy === 0 && dz === 0) return m;
-  const vertices = new Float32Array(m.vertices.length);
-  for (let i = 0; i < m.vertices.length; i += 3) {
-    vertices[i] = (m.vertices[i] ?? 0) + dx;
-    vertices[i + 1] = (m.vertices[i + 1] ?? 0) + dy;
-    vertices[i + 2] = (m.vertices[i + 2] ?? 0) + dz;
+/**
+ * Peel outer rigid-motion nodes (Translate / Rotate) off `node`, composing them
+ * into a single rotation + translation. A rigid motion shares its inner
+ * geometry's tessellation — the shape path re-tags it via `locate` (#1633) — so
+ * the inner meshes once and the cached mesh is moved per placement instead of
+ * re-tessellating. Stops at the first non-rigid node (Scale/Mirror/boolean/…) or
+ * one whose parameters can't be evaluated in `env`.
+ *
+ * Composition is outer∘inner: peeling outward, each node's local transform acts
+ * on points the inner nodes already placed, so it post-multiplies the
+ * accumulator. A pure-translation chain keeps the identity rotation, so the mesh
+ * move below degenerates to the exact vertex-shift fast path (normals untouched).
+ */
+function peelRigid(node: IRNode, env: Env): { inner: IRNode; rot: Quat; trans: Vec3 } {
+  let inner = node;
+  let rot: Quat = IDENTITY_QUAT;
+  let trans: Vec3 = [0, 0, 0];
+  for (;;) {
+    if (inner.kind === 'Translate') {
+      const v = evalVec3(inner.vector, env, 'evaluateMesh.peelRigid');
+      if (!v.ok) break;
+      // f(p + v) = rot·p + (rot·v + trans): the offset enters the current frame.
+      const rv = quatRotate(rot, v.value);
+      trans = [trans[0] + rv[0], trans[1] + rv[1], trans[2] + rv[2]];
+      inner = inner.target;
+    } else if (inner.kind === 'Rotate') {
+      const p = evalRotateParams(inner, env);
+      if (!p) break;
+      // CSG rotate angle is in degrees (the kernel applies ·π/180); match it.
+      const r = quatFromAxisAngle(p.axis, (p.angle * Math.PI) / 180);
+      const newRot = quatMultiply(rot, r);
+      // f(r·(p − c) + c) = (rot·r)·p + [rot·c − (rot·r)·c + trans].
+      const rotC = quatRotate(rot, p.center);
+      const newRotC = quatRotate(newRot, p.center);
+      trans = [
+        trans[0] + rotC[0] - newRotC[0],
+        trans[1] + rotC[1] - newRotC[1],
+        trans[2] + rotC[2] - newRotC[2],
+      ];
+      rot = newRot;
+      inner = inner.target;
+    } else {
+      break;
+    }
   }
-  return { ...m, vertices };
+  return { inner, rot, trans };
+}
+
+function isIdentityQuat(q: Quat): boolean {
+  return q[0] === 1 && q[1] === 0 && q[2] === 0 && q[3] === 0;
+}
+
+/**
+ * Apply a rigid motion to a mesh: vertices get the rotation then translation,
+ * normals get the rotation only (a unit rotation preserves length, so no
+ * renormalization). UVs and triangles are motion-invariant. A pure translation
+ * (identity rotation) keeps the source normals array by reference and only
+ * shifts vertices — the exact previous translation-only fast path.
+ */
+function transformMeshRigid(m: ShapeMesh, rot: Quat, trans: Vec3): ShapeMesh {
+  const [tx, ty, tz] = trans;
+  const pureTranslation = isIdentityQuat(rot);
+  if (pureTranslation && tx === 0 && ty === 0 && tz === 0) return m;
+
+  const src = m.vertices;
+  const vertices = new Float32Array(src.length);
+  if (pureTranslation) {
+    for (let i = 0; i < src.length; i += 3) {
+      vertices[i] = (src[i] ?? 0) + tx;
+      vertices[i + 1] = (src[i + 1] ?? 0) + ty;
+      vertices[i + 2] = (src[i + 2] ?? 0) + tz;
+    }
+    return { ...m, vertices };
+  }
+
+  for (let i = 0; i < src.length; i += 3) {
+    const p = quatRotate(rot, [src[i] ?? 0, src[i + 1] ?? 0, src[i + 2] ?? 0]);
+    vertices[i] = p[0] + tx;
+    vertices[i + 1] = p[1] + ty;
+    vertices[i + 2] = p[2] + tz;
+  }
+  const sn = m.normals;
+  const normals = new Float32Array(sn.length);
+  for (let i = 0; i < sn.length; i += 3) {
+    const n = quatRotate(rot, [sn[i] ?? 0, sn[i + 1] ?? 0, sn[i + 2] ?? 0]);
+    normals[i] = n[0];
+    normals[i + 1] = n[1];
+    normals[i + 2] = n[2];
+  }
+  return { ...m, vertices, normals };
 }
 
 /**
@@ -211,8 +286,8 @@ function translateMesh(m: ShapeMesh, offset: Vec3): ShapeMesh {
  * moved faces location-dependent hashes, so the inner mesh's `faceId`s describe
  * the *unplaced* shape; remap them to the placed faces (1:1 by iteration order,
  * since `locate` shares the source TShape) so face picking and metadata lookup
- * resolve against the placed mesh. Origins are translation-invariant, so only
- * `faceId` changes.
+ * resolve against the placed mesh. Origins are boolean-lineage tags, invariant
+ * under any rigid motion, so only `faceId` changes.
  *
  * Takes pre-captured hash arrays (not shapes): a bounded shape cache can evict
  * and dispose one shape while the other is being evaluated, so the caller reads
@@ -378,12 +453,12 @@ export class Evaluator implements Disposable {
         return ok(cached);
       }
 
-      // Placement-stripped reuse: a pure-translation chain meshes its inner
-      // geometry once (shared across every placement) and shifts the cached mesh
-      // per move, instead of re-tessellating the relocated shape. The placed
-      // shape is still materialized (an O(1) locate) so face groups can be
-      // re-keyed onto its faces; only the expensive tessellation is skipped.
-      const { inner, offset } = peelTranslate(node, env);
+      // Placement-stripped reuse: a rigid-motion chain (translate/rotate) meshes
+      // its inner geometry once (shared across every placement) and moves the
+      // cached mesh per placement, instead of re-tessellating the relocated
+      // shape. The placed shape is still materialized (an O(1) locate) so face
+      // groups can be re-keyed onto its faces; only the tessellation is skipped.
+      const { inner, rot, trans } = peelRigid(node, env);
       if (inner !== node) {
         const innerMesh = this.evaluateMesh(inner, env, meshOpts);
         if (!innerMesh.ok) return innerMesh;
@@ -398,7 +473,7 @@ export class Evaluator implements Disposable {
         const placedShape = this.evaluate(node, env);
         if (!placedShape.ok) return placedShape;
         const placedHashes = getFaces(placedShape.value).map(getHashCode);
-        const moved = translateMesh(innerMesh.value, offset);
+        const moved = transformMeshRigid(innerMesh.value, rot, trans);
         const faceGroups = relocateFaceGroups(moved.faceGroups, innerHashes, placedHashes);
         // Trust the reuse only if every group mapped onto a placed face. If the
         // inner mesh was cached from an earlier, now-evicted inner instance, its

--- a/tests/csg/csgTranslationMesh.test.ts
+++ b/tests/csg/csgTranslationMesh.test.ts
@@ -1,19 +1,20 @@
 /**
- * Placement-stripped mesh reuse (#1603 / #1606 item 1). A pure-translation node
- * meshes its inner geometry once and shifts the cached mesh per placement,
- * instead of re-tessellating the relocated shape. The shape path already reuses
- * geometry via locate (#1633); this closes the "no re-mesh on a pure move" half.
+ * Placement-stripped mesh reuse (#1603 / #1606 item 1). A rigid-motion node
+ * (translate/rotate) meshes its inner geometry once and moves the cached mesh
+ * per placement, instead of re-tessellating the relocated shape. The shape path
+ * already reuses geometry via locate (#1633); this closes the "no re-mesh on a
+ * pure move" half for both translation and rotation.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { initKernel } from '../setup.js';
+import { initKernel, currentKernel } from '../setup.js';
 import { Evaluator, box, translate, rotate } from '@/csg/index.js';
-import { getFaces, getHashCode, unwrap } from '@/index.js';
+import { getFaces, getHashCode, mesh, unwrap } from '@/index.js';
 
 beforeAll(async () => {
   await initKernel();
 }, 30000);
 
-describe('CSG translation-stripped mesh reuse', () => {
+describe('CSG placement-stripped mesh reuse (translation + rotation)', () => {
   it('a translated box is the base mesh shifted by the offset', () => {
     const ev = new Evaluator();
     const base = unwrap(ev.evaluateMesh(box(10, 10, 10)));
@@ -50,10 +51,101 @@ describe('CSG translation-stripped mesh reuse', () => {
     expect(a.normals).toBe(b.normals);
   });
 
-  it('leaves non-translation nodes on the normal mesh path', () => {
+  // Convention lock: the reused (rotation-stripped) mesh must equal the kernel's
+  // own tessellation of the located shape, pinning the degree/axis/sign
+  // convention against real kernel output. OCCT-family only: locate shares the
+  // source triangulation so vertex order is preserved 1:1; brepkit/manifold
+  // re-tessellate the located shape in a different order (the analytic tests
+  // below cover those — they compare against the base mesh, not kernel output).
+  it.skipIf(!currentKernel.startsWith('occt'))(
+    'a rotated box matches the kernel-meshed rotation (vertices + normals)',
+    () => {
+      const ev = new Evaluator();
+      const node = rotate(box(10, 10, 10), 90, { axis: [0, 0, 1] });
+      const reused = unwrap(ev.evaluateMesh(node));
+      const direct = mesh(unwrap(ev.evaluate(node)), { cache: false });
+
+      expect(reused.vertices.length).toBe(direct.vertices.length);
+      for (let i = 0; i < direct.vertices.length; i++) {
+        expect(reused.vertices[i]).toBeCloseTo(direct.vertices[i] ?? 0, 4);
+      }
+      expect(reused.normals.length).toBe(direct.normals.length);
+      for (let i = 0; i < direct.normals.length; i++) {
+        expect(reused.normals[i]).toBeCloseTo(direct.normals[i] ?? 0, 4);
+      }
+    }
+  );
+
+  it('rotates the cached inner mesh: 90° about Z maps (x,y,z) → (−y,x,z)', () => {
     const ev = new Evaluator();
-    const m = unwrap(ev.evaluateMesh(rotate(box(10, 10, 10), Math.PI / 4)));
-    expect(m.vertices.length).toBeGreaterThan(0);
+    const base = unwrap(ev.evaluateMesh(box(10, 10, 10)));
+    const rotated = unwrap(ev.evaluateMesh(rotate(box(10, 10, 10), 90, { axis: [0, 0, 1] })));
+
+    expect(rotated.vertices.length).toBe(base.vertices.length);
+    for (let i = 0; i < base.vertices.length; i += 3) {
+      const bx = base.vertices[i] ?? 0;
+      const by = base.vertices[i + 1] ?? 0;
+      const bz = base.vertices[i + 2] ?? 0;
+      expect(rotated.vertices[i]).toBeCloseTo(-by, 4);
+      expect(rotated.vertices[i + 1]).toBeCloseTo(bx, 4);
+      expect(rotated.vertices[i + 2]).toBeCloseTo(bz, 4);
+    }
+    // Normals rotate too (a rotation is not normal-invariant) — fresh array.
+    expect(rotated.normals).not.toBe(base.normals);
+    for (let i = 0; i < base.normals.length; i += 3) {
+      const nx = base.normals[i] ?? 0;
+      const ny = base.normals[i + 1] ?? 0;
+      expect(rotated.normals[i]).toBeCloseTo(-ny, 4);
+      expect(rotated.normals[i + 1]).toBeCloseTo(nx, 4);
+    }
+  });
+
+  it('composes a mixed translate∘rotate chain (rotate then translate)', () => {
+    // Outer translate applies after inner rotate: p → rot90Z(p) → +[5,0,0].
+    const ev = new Evaluator();
+    const base = unwrap(ev.evaluateMesh(box(8, 8, 8)));
+    const node = translate(rotate(box(8, 8, 8), 90, { axis: [0, 0, 1] }), [5, 0, 0]);
+    const moved = unwrap(ev.evaluateMesh(node));
+
+    expect(moved.vertices.length).toBe(base.vertices.length);
+    for (let i = 0; i < base.vertices.length; i += 3) {
+      const bx = base.vertices[i] ?? 0;
+      const by = base.vertices[i + 1] ?? 0;
+      const bz = base.vertices[i + 2] ?? 0;
+      expect(moved.vertices[i]).toBeCloseTo(-by + 5, 4);
+      expect(moved.vertices[i + 1]).toBeCloseTo(bx, 4);
+      expect(moved.vertices[i + 2]).toBeCloseTo(bz, 4);
+    }
+  });
+
+  it('rotates about an off-origin pivot (R·(p−c)+c)', () => {
+    const ev = new Evaluator();
+    const base = unwrap(ev.evaluateMesh(box(6, 6, 6)));
+    const c = [3, 3, 0] as const;
+    const node = rotate(box(6, 6, 6), 45, { axis: [0, 0, 1], at: [...c] });
+    const moved = unwrap(ev.evaluateMesh(node));
+    const cos = Math.cos(Math.PI / 4);
+    const sin = Math.sin(Math.PI / 4);
+
+    expect(moved.vertices.length).toBe(base.vertices.length);
+    for (let i = 0; i < base.vertices.length; i += 3) {
+      const dx = (base.vertices[i] ?? 0) - c[0];
+      const dy = (base.vertices[i + 1] ?? 0) - c[1];
+      expect(moved.vertices[i]).toBeCloseTo(dx * cos - dy * sin + c[0], 4);
+      expect(moved.vertices[i + 1]).toBeCloseTo(dx * sin + dy * cos + c[1], 4);
+      expect(moved.vertices[i + 2]).toBeCloseTo(base.vertices[i + 2] ?? 0, 4);
+    }
+  });
+
+  it('re-keys face groups onto the placed rotated shape', () => {
+    const ev = new Evaluator();
+    const node = rotate(box(10, 10, 10), 90, { axis: [1, 0, 0] });
+    const placedFaceIds = new Set(getFaces(unwrap(ev.evaluate(node))).map(getHashCode));
+    const moved = unwrap(ev.evaluateMesh(node));
+    expect(moved.faceGroups.length).toBeGreaterThan(0);
+    for (const g of moved.faceGroups) {
+      expect(placedFaceIds.has(g.faceId)).toBe(true);
+    }
   });
 
   it('re-keys face groups onto the placed shape (picking/metadata stay valid)', () => {

--- a/tests/csg/csgTranslationMesh.test.ts
+++ b/tests/csg/csgTranslationMesh.test.ts
@@ -118,6 +118,26 @@ describe('CSG placement-stripped mesh reuse (translation + rotation)', () => {
     }
   });
 
+  it('composes a mixed rotate∘translate chain (translate then rotate)', () => {
+    // Inner translate applies before outer rotate: p → p+[5,0,0] → rot90Z = (−by, bx+5, bz).
+    // Exercises peelRigid's Translate branch with a non-identity accumulated rotation
+    // (rv = quatRotate(rot, v)) — the inverse of the translate∘rotate case above.
+    const ev = new Evaluator();
+    const base = unwrap(ev.evaluateMesh(box(8, 8, 8)));
+    const node = rotate(translate(box(8, 8, 8), [5, 0, 0]), 90, { axis: [0, 0, 1] });
+    const moved = unwrap(ev.evaluateMesh(node));
+
+    expect(moved.vertices.length).toBe(base.vertices.length);
+    for (let i = 0; i < base.vertices.length; i += 3) {
+      const bx = base.vertices[i] ?? 0;
+      const by = base.vertices[i + 1] ?? 0;
+      const bz = base.vertices[i + 2] ?? 0;
+      expect(moved.vertices[i]).toBeCloseTo(-by, 4);
+      expect(moved.vertices[i + 1]).toBeCloseTo(bx + 5, 4);
+      expect(moved.vertices[i + 2]).toBeCloseTo(bz, 4);
+    }
+  });
+
   it('rotates about an off-origin pivot (R·(p−c)+c)', () => {
     const ev = new Evaluator();
     const base = unwrap(ev.evaluateMesh(box(6, 6, 6)));


### PR DESCRIPTION
## What

Generalizes the placement-stripped mesh fast path in the CSG evaluator from **translation-only** to **full rigid motions** (translate + rotate). A pure rotation — or any translate/rotate chain — now reuses the inner geometry's tessellation instead of re-meshing the relocated shape.

Closes #1603. Refs #1606 (last concrete sub-item of the perf epic).

## Why

`peelTranslate`/`translateMesh` (shipped in #1649) only recognized `Translate` chains, so a pure `Rotate` fell through and re-tessellated. The shape path already re-tags rotations cheaply via `locate` (#1633 — active on the default kernel since occt-wasm 3.6.0); this closes the matching *"no re-mesh on a pure move"* half for rotation.

## How

- **`peelTranslate` → `peelRigid`**: peels outer `Translate`/`Rotate` nodes, composing them into one rotation (quaternion) + translation. Composition is outer∘inner (post-multiply while peeling outward); a rotation about a pivot `c` is handled as `R·(p − c) + c`. Stops at the first non-rigid node (`Scale`/`Mirror`/boolean/…) or a free param.
- **`translateMesh` → `transformMeshRigid`**: vertices get the full motion, normals get the rotation only (a unit rotation preserves length → no renormalization). A pure translation keeps the identity quaternion and degenerates to the **exact** previous vertex-shift path (normals shared by reference) — zero behavior change for the translation case.
- Angle convention matched to the kernel: CSG `rotate` is in **degrees** (`advancedOps.ts` applies `·π/180`).
- Reuses the existing `@/utils/quaternion.js` helpers (Layer 0) — no new math.

## Tests

`tests/csg/csgTranslationMesh.test.ts` extended with rotation coverage:

- 90°-about-Z maps `(x,y,z)→(−y,x,z)` on vertices **and** normals (asserts a fresh normals array).
- Mixed `translate∘rotate` composition and off-origin-pivot rotation, both checked **analytically** against the base mesh (kernel-independent → keeps brepkit green).
- A kernel-comparison test (reused mesh == the kernel's own located-mesh) gated to the OCCT family, pinning the degree/axis/sign convention against real kernel output.
- Face-group re-keying onto the placed rotated shape.

**Gate (`occt-wasm`):** full CSG suite **200/200** green; typecheck, eslint, prettier, `check:patterns`, boundaries all clean. brepkit stays green; manifold shows the same pre-existing placement-stripped divergence as the existing translation tests (face-hash semantics; not part of the CI gate).
