### PR TITLE
feat(api): export locate() — placement-only rigid transform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1137,6 +1137,7 @@ export {
   mirror,
   scale,
   clone,
+  locate,
   applyMatrix,
   composeTransforms,
   transformCopy,

--- a/src/topology/api.ts
+++ b/src/topology/api.ts
@@ -120,6 +120,19 @@ export function transformCopy<T extends AnyShape<Dimension>>(
   return transforms.transformCopy(resolve(shape), composed);
 }
 
+/**
+ * Placement-only rigid move (translate / rotate) via the kernel's cheap location
+ * re-tag — O(1) on occt-wasm ≥3.6.0, falling back to a copy elsewhere. Same
+ * face-metadata guarantee as `translate`, at location-swap cost. Ideal for
+ * placing one cached cell at N positions without paying for N deep copies.
+ */
+export function locate<T extends AnyShape<Dimension>>(
+  shape: Shapeable<T>,
+  placement: transforms.TransformOp | readonly transforms.TransformOp[]
+): T {
+  return transforms.locate(resolve(shape), placement);
+}
+
 // ---------------------------------------------------------------------------
 // Booleans — accept Shapeable, preserve first operand type T
 // ---------------------------------------------------------------------------

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -78,6 +78,7 @@ export {
   applyMatrix,
   composeTransforms,
   transformCopy,
+  locate,
 } from './transformFns.js';
 export type { TransformOp, ComposedTransform } from './transformFns.js';
 

--- a/src/topology/transformFns.ts
+++ b/src/topology/transformFns.ts
@@ -13,8 +13,10 @@ import { ok, err } from '@/core/result.js';
 import { validationError, BrepErrorCode } from '@/core/errors.js';
 import {
   collectInputFaceHashes,
+  hasAnyMetadata,
   propagateAllMetadata,
   propagateMetadataByHash,
+  propagateMetadataThroughRelocation,
 } from './metadata/metadataPropagation.js';
 
 // ---------------------------------------------------------------------------
@@ -322,6 +324,36 @@ export function composeTransforms(ops: readonly TransformOp[]): ComposedTransfor
   });
   const { handle, dispose } = getKernel().composeTransform(kernelOps);
   return { trsf: handle, cleanup: dispose };
+}
+
+/**
+ * Placement-only rigid move (translate / rotate) via the kernel's cheap location
+ * re-tag — an O(1) `TopLoc_Location` swap on occt-wasm ≥3.6.0, falling back to a
+ * copying transform on kernels without it. Unlike `translate` / `rotate` (which
+ * deep-copy through the history-tracking path), `locate` shares the source
+ * geometry and only re-tags its placement, then re-keys face metadata
+ * (tags/colors) onto the moved faces so it survives — the same metadata
+ * guarantee `translate` gives, at location-swap cost. For per-position placement
+ * of one cached cell (template instancing), this is the move without the copy.
+ *
+ * Accepts a single op or an ordered list (applied first-to-last, e.g. rotate
+ * then translate). Non-rigid ops (`scale`) aren't a placement and don't belong
+ * here — use `applyMatrix` for those.
+ */
+export function locate<T extends AnyShape<Dimension>>(
+  shape: T,
+  placement: TransformOp | readonly TransformOp[]
+): T {
+  const ops = 'type' in placement ? [placement] : placement;
+  const { trsf, cleanup } = composeTransforms(ops);
+  let moved: T;
+  try {
+    moved = castShape(getKernel().locate(shape.wrapped, trsf)) as T;
+  } finally {
+    cleanup();
+  }
+  if (hasAnyMetadata(shape)) propagateMetadataThroughRelocation(shape, moved);
+  return moved;
 }
 
 /**

--- a/tests/locate.test.ts
+++ b/tests/locate.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { currentKernelId } from './helpers/kernelDivergences.js';
+import {
+  box,
+  locate,
+  translate,
+  getBounds,
+  getFaces,
+  tagFaces,
+  findFacesByTag,
+  colorFaces,
+  getFaceColor,
+  measureVolume,
+  unwrap,
+} from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('locate', () => {
+  it('moves geometry identically to translate', () => {
+    const moved = locate(box(10, 10, 10), { type: 'translate', v: [5, -3, 2] });
+    const ref = translate(box(10, 10, 10), [5, -3, 2]);
+    const a = getBounds(moved);
+    const e = getBounds(ref);
+    expect(a.xMin).toBeCloseTo(e.xMin, 6);
+    expect(a.xMax).toBeCloseTo(e.xMax, 6);
+    expect(a.yMin).toBeCloseTo(e.yMin, 6);
+    expect(a.zMax).toBeCloseTo(e.zMax, 6);
+  });
+
+  it('preserves volume (a rigid move)', () => {
+    const v0 = unwrap(measureVolume(box(10, 20, 30)));
+    const moved = locate(box(10, 20, 30), { type: 'translate', v: [100, -50, 7] });
+    expect(unwrap(measureVolume(moved))).toBeCloseTo(v0, 4);
+  });
+
+  it('re-keys face tags through the move', () => {
+    const b = box(10, 10, 10);
+    const faces = getFaces(b);
+    expect(faces.length).toBe(6);
+    const [f0] = faces;
+    if (!f0) throw new Error('expected a face');
+    tagFaces(b, [f0], 'marked');
+    const moved = locate(b, { type: 'translate', v: [25, 0, 0] });
+    const tagged = findFacesByTag(moved, 'marked');
+    // The tag survives the move on every kernel (the #1660 guarantee).
+    expect(tagged.length).toBeGreaterThanOrEqual(1);
+    // occt-family preserves face identity 1:1; manifold's mesh metadata spreads.
+    if (currentKernelId !== 'manifold') expect(tagged.length).toBe(1);
+  });
+
+  it('re-keys per-face colors through the move', () => {
+    const b = box(10, 10, 10);
+    const faces = getFaces(b);
+    const [f0] = faces;
+    if (!f0) throw new Error('expected a face');
+    colorFaces(b, [f0], '#00ff00');
+    const moved = locate(b, { type: 'translate', v: [25, 0, 0] });
+    const colored = getFaces(moved).filter((f) => getFaceColor(moved, f) !== undefined);
+    expect(colored.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('composes an ordered list (rotate then translate), preserving volume', () => {
+    const placed = locate(box(10, 10, 10), [
+      { type: 'rotate', angle: 90, axis: [0, 0, 1] },
+      { type: 'translate', v: [20, 0, 0] },
+    ]);
+    expect(unwrap(measureVolume(placed))).toBeCloseTo(1000, 3);
+  });
+
+  it('accepts a single op or a one-element array equivalently', () => {
+    const one = locate(box(5, 5, 5), { type: 'translate', v: [3, 0, 0] });
+    const arr = locate(box(5, 5, 5), [{ type: 'translate', v: [3, 0, 0] }]);
+    expect(getBounds(one).xMax).toBeCloseTo(getBounds(arr).xMax, 6);
+  });
+});

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -493,6 +493,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'line',
   'linearPattern',
   'loadFont',
+  'locate',
   'loft',
   'loftAll',
   'makeBaseBox',


### PR DESCRIPTION
Closes #1660.

## Why
`locate` (the O(1) location-only move added in #1603 / occt-wasm 3.6.0's `located()` facade) was **CSG-internal** — wired into the evaluator's `Translate`/`Rotate` re-tag path but not exported. Direct topology consumers (not going through the CSG `Evaluator`) had no way to get the cheap placement move and always paid the metadata-preserving deep copy via `translate`/`rotate`. For template instancing (cache one cell, place N copies), that's pure overhead on top of the unavoidable clone.

## What
Export `locate` as a placement-only rigid transform:
- Uses the kernel `located()` fast path (occt-wasm ≥3.6.0), falling back to the copying transform elsewhere — same geometry, only the cost differs.
- Re-keys face metadata (tags/colors) through the move, the same guarantee `translate` gives, at location-swap cost.
- Reuses the existing public `TransformOp` / `composeTransforms` surface; accepts a single op or an ordered list (applied first-to-last, e.g. rotate then translate). Non-rigid `scale` stays with `applyMatrix`.

Wired like `translate`: `transformFns` (impl) → `shapeFns` re-export → `api.ts` (`Shapeable` wrapper) → main barrel. Registered in the public-API export snapshot.

## Test
`tests/locate.test.ts` — geometry parity with `translate`, volume invariance, metadata survival (tags + colors), and op composition. Runs across all 4 kernel projects; the strict "exactly the tagged face, no spread" check is occt-family-only (manifold's mesh metadata spreads through a rigid move — documented inline).

## Verification
typecheck ✓ · lint ✓ · check:patterns ✓ · check:boundaries ✓ · full changed-file test set green (3842 passed) · `tests/locate.test.ts` 24/24 across 4 kernels.