### PR TITLE
ci(release): auto-merge brepjs-cad release PRs (drop stale hold)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,14 +54,15 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Auto-merge the root brepjs release PR plus the leaf packages brepjs-bim and
-  # brepjs-sheetmetal. Those leaves depend only on root brepjs (nothing depends
-  # back on them), so the workspace dep graph stays acyclic and node-workspace
-  # propagation terminates after one root->leaves ripple — no release loop is
-  # possible. brepjs-opencascade (expensive WASM build, manual review) and
-  # brepjs-cad / brepjs-viewer are still held: verify cross-links viewer, the
-  # one pairing that historically re-pinned to an unpublished version and looped
-  # the pipeline. Auto-PUBLISH still works — it fires when the release PR merges.
+  # Auto-merge the root brepjs release PR plus the acyclic leaf packages
+  # brepjs-bim, brepjs-sheetmetal, and brepjs-cad. Those leaves depend only on
+  # root brepjs (nothing depends back on them), so the workspace dep graph stays
+  # acyclic and node-workspace propagation terminates after one root->leaves
+  # ripple — no release loop is possible. Only brepjs-opencascade stays held
+  # (expensive WASM build, manual review). The brepjs-cad<->viewer re-pin loop
+  # that once justified holding cad is gone: brepjs-viewer is unmanaged by
+  # release-please, and cad's `brepjs` dep is a caret node-workspace never
+  # re-pins. Auto-PUBLISH fires when each release PR merges.
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -101,13 +102,12 @@ jobs:
               echo "PR with no number, skipping"
               continue
             fi
-            # Hold brepjs-opencascade (expensive WASM build, manual review) and
-            # brepjs-cad / brepjs-viewer (verify cross-links viewer — the
-            # pairing that historically looped the pipeline via unpublished
-            # re-pins). The root brepjs PR and the acyclic leaves brepjs-bim /
-            # brepjs-sheetmetal auto-merge.
+            # Hold only brepjs-opencascade (expensive WASM build, manual review).
+            # The root brepjs PR and the acyclic leaves brepjs-bim /
+            # brepjs-sheetmetal / brepjs-cad auto-merge. (cad's old viewer
+            # re-pin loop is gone — viewer is unmanaged by release-please.)
             case "$pr_title" in
-              *brepjs-opencascade* | *brepjs-cad* | *brepjs-viewer*)
+              *brepjs-opencascade*)
                 echo "Holding auto-merge for PR #$pr_number ($pr_title) — manual merge"
                 continue
                 ;;


### PR DESCRIPTION
## Why
brepjs-cad release PRs were held from auto-merge and piling up for manual merge — for a reason that no longer exists.

The `auto-merge` job's hold-list (`*brepjs-opencascade* | *brepjs-cad* | *brepjs-viewer*`) held brepjs-cad because of the historical **verify↔viewer re-pin loop** (node-workspace re-pinning cad's build-time `brepjs-viewer` devDep to viewer's *unpublished* version, breaking `npm ci`). That loop was already fixed by **unmanaging brepjs-viewer** (it's no longer in `release-please-config.json`), and cad's viewer devDep is `"*"`, which node-workspace never touches.

So **brepjs-cad is now a clean acyclic leaf** — structurally identical to `brepjs-bim` / `brepjs-sheetmetal`, which already auto-merge:
- it depends only on root `brepjs` (nothing depends back on it → no cycle);
- its `brepjs` dep is a caret (`^18.83.2`) that node-workspace doesn't re-pin (it's still `^18.83.2` while core is at 18.117.0 — proof there's no re-pin loop).

The hold was a safety guard that outlived its cause. (Investigation prompted by the maintainer noticing brepjs-cad cuts a release every cycle and never auto-merges.)

## What
- Narrow the hold-list to **`*brepjs-opencascade*` only** (the expensive WASM build still warrants manual review).
- `brepjs-cad` now auto-merges **and** auto-publishes on each release, like the other leaves.
- Correct the stale comments (they claimed the viewer loop was still a risk).

No change to the input handling — `$pr_title` is still the jq-extracted shell var from the trusted `release-please` output (no new injection surface).

## Effect
Future brepjs-cad release PRs merge + publish automatically. Loop-safe: acyclic leaf, viewer unmanaged, caret dep never re-pinned.