### PR TITLE
fix(bim): make BCF XML tokenizer linear (polynomial ReDoS)

### DIFF
--- a/.github/workflows/eval-on-demand.yml
+++ b/.github/workflows/eval-on-demand.yml
@@ -24,6 +24,11 @@ on:
         default: '3'
         type: string
 
+# Least privilege: this workflow only reads the repo and exchanges build
+# artifacts (which use the Actions runtime token, not GITHUB_TOKEN scopes).
+permissions:
+  contents: read
+
 jobs:
   shard:
     # Map: each runner authors + judges a round-robin 1/5 slice of the corpus and uploads its

--- a/packages/brepjs-bim/src/bcf/bcfXml.ts
+++ b/packages/brepjs-bim/src/bcf/bcfXml.ts
@@ -57,7 +57,10 @@ interface MutableNode {
 
 function parseAttrs(raw: string): Record<string, string> {
   const attrs: Record<string, string> = {};
-  const attrRe = /([\w:.-]+)\s*=\s*"([^"]*)"/g;
+  // Sticky (`y`), not global (`g`): pin matching to `lastIndex` so a name run with no
+  // `=` can't trigger the global flag's O(n²) re-scan at every offset (polynomial ReDoS).
+  // The leading `\s*` takes over the inter-attribute whitespace skip the forward scan did.
+  const attrRe = /\s*([\w:.-]+)\s*=\s*"([^"]*)"/y;
   let m: RegExpExecArray | null;
   while ((m = attrRe.exec(raw)) !== null) {
     const key = m[1];
@@ -73,12 +76,19 @@ function parseAttrs(raw: string): Record<string, string> {
  * structure (unbalanced tags); callers wrap this in a `Result`.
  */
 export function parseXml(xml: string): XmlNode {
-  const tokenRe = /<!--[\s\S]*?-->|<\?[\s\S]*?\?>|<\/([\w:.-]+)\s*>|<([\w:.-]+)((?:\s+[\w:.-]+\s*=\s*"[^"]*")*)\s*(\/?)>|([^<]+)/g;
+  // Sticky (`y`), not global (`g`): match only at `lastIndex`, never scanning forward on
+  // failure. Under `g`, an unterminated `<!--`/`<?` rescans to end-of-input at every `<`
+  // — O(n²) on hostile input (polynomial ReDoS). Sticky fails fast; the `consumed` check
+  // below rejects any untokenizable tail as malformed XML.
+  const tokenRe =
+    /<!--[\s\S]*?-->|<\?[\s\S]*?\?>|<\/([\w:.-]+)\s*>|<([\w:.-]+)((?:\s+[\w:.-]+\s*=\s*"[^"]*")*)\s*(\/?)>|([^<]+)/y;
   const root: MutableNode = { tag: '#root', attrs: {}, children: [], text: '' };
   const stack: MutableNode[] = [root];
 
   let m: RegExpExecArray | null;
+  let consumed = 0;
   while ((m = tokenRe.exec(xml)) !== null) {
+    consumed = tokenRe.lastIndex;
     const [full, closeTag, openTag, attrsRaw, selfClose, textRun] = m;
 
     if (full.startsWith('<!--') || full.startsWith('<?')) continue;
@@ -115,6 +125,9 @@ export function parseXml(xml: string): XmlNode {
     }
   }
 
+  if (consumed !== xml.length) {
+    throw new Error(`Malformed XML: unexpected token at offset ${String(consumed)}`);
+  }
   if (stack.length !== 1) {
     throw new Error('Unbalanced XML: unclosed elements remain');
   }

--- a/packages/brepjs-bim/src/bcf/bcfXml.ts
+++ b/packages/brepjs-bim/src/bcf/bcfXml.ts
@@ -55,83 +55,115 @@ interface MutableNode {
   text: string;
 }
 
-function parseAttrs(raw: string): Record<string, string> {
-  const attrs: Record<string, string> = {};
-  // Sticky (`y`), not global (`g`): pin matching to `lastIndex` so a name run with no
-  // `=` can't trigger the global flag's O(n²) re-scan at every offset (polynomial ReDoS).
-  // The leading `\s*` takes over the inter-attribute whitespace skip the forward scan did.
-  const attrRe = /\s*([\w:.-]+)\s*=\s*"([^"]*)"/y;
-  let m: RegExpExecArray | null;
-  while ((m = attrRe.exec(raw)) !== null) {
-    const key = m[1];
-    const val = m[2];
-    if (key !== undefined && val !== undefined) attrs[key] = unescapeXml(val);
-  }
-  return attrs;
+function isNameChar(c: string): boolean {
+  return /[\w:.-]/.test(c);
+}
+
+function isWhitespace(c: string): boolean {
+  return /\s/.test(c);
 }
 
 /**
- * Parse an XML string into a tree. Tolerant of the XML declaration, comments,
- * whitespace, self-closing tags, and CDATA-free text. Throws on malformed
- * structure (unbalanced tags); callers wrap this in a `Result`.
+ * Parse an XML string into a tree. Tolerant of the XML declaration, processing
+ * instructions, comments, whitespace, self-closing tags, and CDATA-free text.
+ * Throws on malformed or unbalanced structure; callers wrap this in a `Result`.
+ *
+ * This is a hand-written cursor scan rather than a single tokenizing regex: the
+ * input is an untrusted `.bcfzip` payload, and a backtracking regex over
+ * uncontrolled data is a polynomial-ReDoS vector. Every construct here is
+ * consumed by an `indexOf` or a single-character advance, so the parse is linear
+ * in the input length. The sibling `ids/idsXml.ts` parser scans the same way.
  */
 export function parseXml(xml: string): XmlNode {
-  // Sticky (`y`), not global (`g`): match only at `lastIndex`, never scanning forward on
-  // failure. Under `g`, an unterminated `<!--`/`<?` rescans to end-of-input at every `<`
-  // — O(n²) on hostile input (polynomial ReDoS). Sticky fails fast; the `consumed` check
-  // below rejects any untokenizable tail as malformed XML.
-  const tokenRe =
-    /<!--[\s\S]*?-->|<\?[\s\S]*?\?>|<\/([\w:.-]+)\s*>|<([\w:.-]+)((?:\s+[\w:.-]+\s*=\s*"[^"]*")*)\s*(\/?)>|([^<]+)/y;
   const root: MutableNode = { tag: '#root', attrs: {}, children: [], text: '' };
   const stack: MutableNode[] = [root];
+  const len = xml.length;
+  let i = 0;
 
-  let m: RegExpExecArray | null;
-  let consumed = 0;
-  while ((m = tokenRe.exec(xml)) !== null) {
-    consumed = tokenRe.lastIndex;
-    const [full, closeTag, openTag, attrsRaw, selfClose, textRun] = m;
+  const fail = (msg: string): never => {
+    throw new Error(`Malformed XML: ${msg} at offset ${String(i)}`);
+  };
+  const skipWhitespace = (): void => {
+    while (i < len && isWhitespace(xml.charAt(i))) i += 1;
+  };
+  const readName = (): string => {
+    const start = i;
+    while (i < len && isNameChar(xml.charAt(i))) i += 1;
+    return xml.slice(start, i);
+  };
+  const readAttrs = (): Record<string, string> => {
+    const attrs: Record<string, string> = {};
+    for (;;) {
+      skipWhitespace();
+      const c = xml.charAt(i);
+      if (i >= len || c === '>' || c === '/') return attrs;
+      const name = readName();
+      if (name.length === 0) fail('expected attribute name');
+      skipWhitespace();
+      if (xml.charAt(i) !== '=') fail(`expected '=' after attribute "${name}"`);
+      i += 1;
+      skipWhitespace();
+      if (xml.charAt(i) !== '"') fail(`expected '"' opening attribute "${name}"`);
+      i += 1;
+      const end = xml.indexOf('"', i);
+      if (end === -1) fail(`unterminated value for attribute "${name}"`);
+      attrs[name] = unescapeXml(xml.slice(i, end));
+      i = end + 1;
+    }
+  };
 
-    if (full.startsWith('<!--') || full.startsWith('<?')) continue;
-
-    if (closeTag !== undefined) {
+  while (i < len) {
+    if (xml.startsWith('<!--', i)) {
+      const end = xml.indexOf('-->', i + 4);
+      if (end === -1) fail('unterminated comment');
+      i = end + 3;
+    } else if (xml.startsWith('<?', i)) {
+      const end = xml.indexOf('?>', i + 2);
+      if (end === -1) fail('unterminated processing instruction');
+      i = end + 2;
+    } else if (xml.startsWith('</', i)) {
+      i += 2;
+      const name = readName();
+      skipWhitespace();
+      if (xml.charAt(i) !== '>') fail(`expected '>' closing </${name}>`);
+      i += 1;
       const top = stack[stack.length - 1];
-      if (top === undefined || top.tag !== closeTag) {
-        throw new Error(`Unbalanced XML: unexpected </${closeTag}>`);
+      if (top === undefined || top.tag !== name) {
+        throw new Error(`Unbalanced XML: unexpected </${name}>`);
       }
       stack.pop();
-      continue;
-    }
-
-    if (openTag !== undefined) {
-      const node: MutableNode = {
-        tag: openTag,
-        attrs: parseAttrs(attrsRaw ?? ''),
-        children: [],
-        text: '',
-      };
+    } else if (xml.charAt(i) === '<') {
+      i += 1;
+      const tag = readName();
+      if (tag.length === 0) fail('expected element name');
+      const node: MutableNode = { tag, attrs: readAttrs(), children: [], text: '' };
       const parent = stack[stack.length - 1];
       if (parent === undefined) throw new Error('Unbalanced XML: empty stack');
       parent.children.push(node);
-      if (selfClose !== '/') stack.push(node);
-      continue;
-    }
-
-    if (textRun !== undefined) {
-      const decoded = unescapeXml(textRun);
+      skipWhitespace();
+      if (xml.startsWith('/>', i)) {
+        i += 2;
+      } else if (xml.charAt(i) === '>') {
+        i += 1;
+        stack.push(node);
+      } else {
+        fail(`expected '>' in <${tag}>`);
+      }
+    } else {
+      const next = xml.indexOf('<', i);
+      const end = next === -1 ? len : next;
+      const decoded = unescapeXml(xml.slice(i, end));
       if (decoded.trim().length > 0) {
         const top = stack[stack.length - 1];
         if (top !== undefined) top.text += decoded;
       }
+      i = end;
     }
   }
 
-  if (consumed !== xml.length) {
-    throw new Error(`Malformed XML: unexpected token at offset ${String(consumed)}`);
-  }
   if (stack.length !== 1) {
     throw new Error('Unbalanced XML: unclosed elements remain');
   }
-
   const top = root.children[0];
   if (top === undefined) throw new Error('Empty XML document');
   return freezeNode(top);

--- a/packages/brepjs-bim/tests/bcfXml.test.ts
+++ b/packages/brepjs-bim/tests/bcfXml.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { parseXml, findChild, childText } from '../src/bcf/bcfXml.js';
+
+/**
+ * Low-level BCF XML tokenizer tests. The tokenizer reads untrusted `.bcfzip`
+ * payloads, so the ReDoS-resistance cases below are load-bearing, not cosmetic:
+ * the sticky-flag tokenizer must stay linear on hostile input.
+ */
+
+describe('parseXml', () => {
+  it('parses a declaration, comment, nested elements, and attributes', () => {
+    const node = parseXml(
+      '<?xml version="1.0"?>\n<!-- c --><Root a="1" ns:b="x.y-z"><Child>hi &amp; bye</Child><Empty/></Root>'
+    );
+    expect(node.tag).toBe('Root');
+    expect(node.attrs.a).toBe('1');
+    expect(node.attrs['ns:b']).toBe('x.y-z');
+    expect(childText(node, 'Child')).toBe('hi & bye');
+    expect(findChild(node, 'Empty')?.children).toEqual([]);
+  });
+
+  it('throws on unbalanced tags', () => {
+    expect(() => parseXml('<A><B></A>')).toThrow(/Unbalanced/);
+  });
+
+  it('throws on a tail it cannot tokenize (no silent mis-parse)', () => {
+    // An unterminated comment is malformed XML; the sticky tokenizer stalls at
+    // the offending offset rather than scanning forward and mis-tokenizing.
+    expect(() => parseXml('<A/><!-- never closed')).toThrow(/Malformed XML/);
+  });
+
+  // Polynomial-ReDoS guards (CodeQL js/polynomial-redos). Each adversarial input
+  // is O(n²) under a global-flag tokenizer — seconds-to-minutes at these sizes —
+  // and linear (sub-millisecond) under the sticky tokenizer. The 1s budget is a
+  // ~1000x margin over the fixed cost while still failing loudly on regression.
+  const BUDGET_MS = 1000;
+  it.each([
+    ['unterminated comments', '<!--'.repeat(100_000)],
+    ['unterminated processing instructions', '<?'.repeat(100_000)],
+    ['attribute name run with no "="', `<a ${'-'.repeat(100_000)}/>`],
+  ])('resists ReDoS: %s', (_label, payload) => {
+    const t0 = performance.now();
+    expect(() => parseXml(payload)).toThrow(/Malformed XML/);
+    expect(performance.now() - t0).toBeLessThan(BUDGET_MS);
+  });
+});


### PR DESCRIPTION
Closes the 4 open alerts on the [code-scanning page](https://github.com/andymai/brepjs/security/code-scanning) (the "30" shown there is GitHub's default page size — the full set is 39 fixed + 8 dismissed + **4 open**).

## 🔴 High — Polynomial ReDoS (`js/polynomial-redos`), alerts 35 & 36
`packages/brepjs-bim/src/bcf/bcfXml.ts` — the hand-rolled XML tokenizer reached from the public `parseBcfFiles`, which parses **untrusted `.bcfzip` payloads**. The token and attribute regexes were genuinely O(n²) on hostile input (confirmed by benchmark: an 800 KB `<!--` payload stalled `parseXml` for **minutes**).

**Root cause** — the global (`/g`) flag's forward-scan-on-failure: an unterminated `<!--`/`<?` lazily scans to end-of-input, fails, advances one char, and re-scans at the next `<` → O(n) failing offsets × O(n) scan = O(n²). `attrRe` had the same shape via `[\w:.-]+` backtracking when no `=` follows.

**Fix** — replace the tokenizing regex (and the folded-in `parseAttrs`) with a **hand-written cursor scan**: comments, processing instructions, and attribute values are consumed with `indexOf`; names and whitespace with single-character advances. The parse is **linear by construction** (the same 1.6 MB payload now throws in ~5 ms) and carries no backtracking regex over untrusted input. This mirrors the sibling `ids/idsXml.ts` parser, which scans the same way and was never flagged.

> Note for reviewers: the first commit tried a minimal sticky-flag (`/y`) fix. It is linear at runtime (verified ~1000×), but CodeQL's `js/polynomial-redos` analyzes the regex *literal* statically and doesn't model the `g`→`y` flag, so it kept re-flagging the pattern. The cursor rewrite (second `fix(bim)` commit) is what actually clears the alert; it supersedes the sticky approach.

## 🟡 Medium — Missing workflow permissions (`actions/missing-workflow-permissions`), alerts 59 & 60
`.github/workflows/eval-on-demand.yml` declared no `permissions:` block. Added a top-level least-privilege `contents: read` (artifact up/download use the Actions runtime token, not `GITHUB_TOKEN` scopes), covering both the `shard` and `combine` jobs. (`osv-scan.yml` already sets per-job permissions — left untouched.)

## Test plan
- New `packages/brepjs-bim/tests/bcfXml.test.ts`: valid-doc parity (declaration/comment/nesting/namespaced attrs/entities), malformed-tail rejection, and 3 ReDoS-budget guards (each adversarial input must throw within 1 s — a wide margin over the ~5 ms fixed cost, vs seconds-to-minutes under the old code).
- Package gates: prettier ✓, eslint ✓, `tsc --noEmit` ✓, `check:patterns` ✓.
- 14/14 BCF tests pass (8 existing round-trip + 6 new); output and error semantics unchanged.
