### PR TITLE
fix(release): unbreak Vercel — repin brepjs-cad to brepjs >=18.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,7 +2,7 @@
   ".": "18.117.0",
   "packages/brepjs-opencascade": "0.16.0",
   "packages/brepjs-voxel-wasm": "0.7.0",
-  "packages/brepjs-cad": "0.37.0",
+  "packages/brepjs-cad": "0.37.39",
   "packages/brepjs-bim": "0.3.1",
   "packages/brepjs-sheetmetal": "0.3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14490,11 +14490,11 @@
       }
     },
     "packages/brepjs-cad": {
-      "version": "0.37.0",
+      "version": "0.37.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "brepjs": "^18.117.0",
+        "brepjs": ">=18.0.0",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0",
         "typescript": "^6.0.3"

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "brepjs": "^18.117.1",
+    "brepjs": ">=18.0.0",
     "commander": "^15.0.0",
     "occt-wasm": "^3.0.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
## Why deploys are failing

Every **production** Vercel deploy has been erroring in ~6s at the very first step, `npm install --legacy-peer-deps`:

```
npm error code ETARGET
npm error notarget No matching version found for brepjs@^18.117.1.
```

`packages/brepjs-cad/package.json` pinned `brepjs@^18.117.1`, but **only 18.117.0 is published** — the `brepjs 18.117.1` release (#1669) is still an open, unmerged release-please PR. The workspace's local `brepjs@18.117.0` doesn't satisfy `^18.117.1`, and the registry's newest is 18.117.0, so install aborts and every prod deploy errors before the build even starts.

### How the bad pin got there (the runaway loop)

release-please's node-workspace plugin saw brepjs *would be* 18.117.1 and re-pinned brepjs-cad to `^18.117.1`. The auto-merge added in #1665 then merged a cascade of brepjs-cad release PRs (**0.37.32 → 0.37.39** in minutes), landing the broken pin on `main` ahead of the library release it depends on.

Worse, the release state had drifted — `package.json` was at `0.37.39` while `.release-please-manifest.json` and the latest tag/npm publish were still `0.37.0`. release-please kept re-cutting the same 0.37.x line because the manifest never advanced.

## The fix

- **Repin** brepjs-cad's `brepjs` dep `^18.117.1` → `>=18.0.0`. The local workspace `brepjs@18.117.0` now satisfies it, so install succeeds with no publish required. This range matches `brepjs-bim`/`brepjs-sheetmetal` — which release-please's node-workspace plugin never re-pins, so brepjs-cad becomes immune to the same cascade.
- **Resync** `.release-please-manifest.json` brepjs-cad `0.37.0` → `0.37.39` to match `package.json`, so release-please stops re-cutting the already-bumped line.
- **Surgically update** the brepjs-cad lockfile node (version + brepjs range) — no full lockfile regeneration.

## Verification

- `npm install --legacy-peer-deps --dry-run` now resolves with **no ETARGET** (exit 0).
- No `^18.117.1` remains in any tracked manifest/lockfile.

## Not in scope (intentionally)

- Release PR **#1669 (brepjs 18.117.1)** is **held**. It's currently conflicting on the corrupted manifest, and merging it would neither fix the deploy break nor stop the loop. After this lands, brepjs-cad no longer needs 18.117.1, so #1669 can be cleanly rebased and merged on its own merit (or closed).
- Worth a follow-up: reconsider whether brepjs-cad release PRs should auto-merge *ahead of* the library release that gates them (the ordering inversion that caused this).