### PR TITLE
ci(release): merge root brepjs release before its leaves

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,66 +54,82 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Auto-merge the root brepjs release PR plus the acyclic leaf packages
-  # brepjs-bim, brepjs-sheetmetal, and brepjs-cad. Those leaves depend only on
-  # root brepjs (nothing depends back on them), so the workspace dep graph stays
-  # acyclic and node-workspace propagation terminates after one root->leaves
-  # ripple — no release loop is possible. Only brepjs-opencascade stays held
-  # (expensive WASM build, manual review). The brepjs-cad<->viewer re-pin loop
-  # that once justified holding cad is gone: brepjs-viewer is unmanaged by
-  # release-please, and cad's `brepjs` dep is a caret node-workspace never
-  # re-pins. Auto-PUBLISH fires when each release PR merges.
+  # Auto-merge release PRs, but SERIALIZE root brepjs before its leaves.
+  #
+  # The leaves (brepjs-cad / brepjs-bim / brepjs-sheetmetal) consume root brepjs,
+  # and the node-workspace plugin re-pins a leaf's `brepjs` dependency to the
+  # version of the *pending* root release. If a leaf were allowed to merge while
+  # the root brepjs release PR is still open, main would carry a leaf pinned to a
+  # brepjs version that isn't on npm yet — `npm install` then fails with ETARGET
+  # and every Vercel deploy breaks (the 2026-06-25 outage). Merging a leaf early
+  # also conflicts the still-open root PR on the shared .release-please-manifest.
+  #
+  # Fix: while the root brepjs release PR is open, arm auto-merge ONLY on it and
+  # HOLD every leaf. Once root merges (and bumps main + publishes), the next
+  # release-please run regenerates each leaf PR with a now-valid pin against an
+  # up-to-date main, and this job — which runs on every push — arms their
+  # auto-merge then. brepjs-opencascade stays permanently held (expensive WASM
+  # build, manual review). Auto-PUBLISH fires when each release PR merges.
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [release-please]
-    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
+    if: ${{ needs.release-please.result == 'success' }}
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
           private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
-      - name: Enable auto-merge for root brepjs + leaf package release PRs
+      - name: Auto-merge release PRs (root brepjs before leaves)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # Prefer the plural `prs` array (separate-pull-requests: true emits
-          # one PR per component); fall back to the singular `pr`.
-          PRS_DATA: ${{ needs.release-please.outputs.prs }}
-          PR_DATA: ${{ needs.release-please.outputs.pr }}
           GH_REPO: ${{ github.repository }}
+          # The root "." component's release branch (component name "brepjs").
+          # Leaf branches carry a `-<pkg>` suffix, so this matches root exactly.
+          ROOT_BRANCH: release-please--branches--main--components--brepjs
         run: |
-          prs_json="$PRS_DATA"
-          if [ -z "$prs_json" ] || [ "$prs_json" = "null" ]; then
-            # Wrap the singular PR object into a one-element array.
-            prs_json=$(echo "$PR_DATA" | jq -c 'if . == null or . == "" then [] else [.] end')
-          fi
+          # Query the live set of open release PRs (release-please labels every
+          # one `autorelease: pending`) rather than trusting the action outputs,
+          # so a held leaf is picked up on whichever later run unblocks it.
+          prs=$(gh pr list --state open --label 'autorelease: pending' \
+            --repo "$GH_REPO" --json number,title,headRefName)
 
-          count=$(echo "$prs_json" | jq 'length')
+          count=$(echo "$prs" | jq 'length')
           if [ "$count" -eq 0 ]; then
-            echo "No release PRs found, skipping"
+            echo "No open release PRs, nothing to do"
             exit 0
           fi
 
-          echo "$prs_json" | jq -c '.[]' | while read -r pr; do
-            pr_number=$(echo "$pr" | jq -r '.number // empty')
-            pr_title=$(echo "$pr" | jq -r '.title // empty')
-            if [ -z "$pr_number" ]; then
-              echo "PR with no number, skipping"
-              continue
-            fi
-            # Hold only brepjs-opencascade (expensive WASM build, manual review).
-            # The root brepjs PR and the acyclic leaves brepjs-bim /
-            # brepjs-sheetmetal / brepjs-cad auto-merge. (cad's old viewer
-            # re-pin loop is gone — viewer is unmanaged by release-please.)
-            case "$pr_title" in
-              *brepjs-opencascade*)
-                echo "Holding auto-merge for PR #$pr_number ($pr_title) — manual merge"
+          root_open=$(echo "$prs" | jq --arg b "$ROOT_BRANCH" \
+            '[.[] | select(.headRefName == $b)] | length')
+
+          echo "$prs" | jq -c '.[]' | while read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            title=$(echo "$pr" | jq -r '.title')
+            branch=$(echo "$pr" | jq -r '.headRefName')
+
+            case "$branch" in
+              *--components--brepjs-opencascade)
+                echo "HOLD #$number ($title) — opencascade is manual (expensive WASM build)"
+                continue
+                ;;
+              "$ROOT_BRANCH")
+                echo "MERGE #$number ($title) — root brepjs release goes first"
+                gh pr merge "$number" --auto --squash --repo "$GH_REPO"
                 continue
                 ;;
             esac
-            echo "Enabling auto-merge for brepjs PR #$pr_number"
-            gh pr merge "$pr_number" --auto --squash --repo "$GH_REPO"
+
+            # Any other component is a leaf. Hold it while the root brepjs
+            # release PR is open; it is regenerated with a valid pin and
+            # auto-merged on the next run, after root merges + publishes.
+            if [ "$root_open" -gt 0 ]; then
+              echo "HOLD #$number ($title) — waiting for root brepjs release to merge first"
+            else
+              echo "MERGE #$number ($title) — no root brepjs release pending"
+              gh pr merge "$number" --auto --squash --repo "$GH_REPO"
+            fi
           done
 
   # brepjs-opencascade is published via publish-opencascade.yml — manual


### PR DESCRIPTION
## Problem

This hardens the release pipeline against the failure mode that took down Vercel on 2026-06-25 (fixed by #1711).

release-please's `node-workspace` plugin re-pins a leaf package's `brepjs` dependency to the version of the **pending** root release. The old `auto-merge` job armed auto-merge on the root brepjs PR **and every leaf PR simultaneously**, so:

1. A leaf (e.g. brepjs-cad) could win the merge race and land on `main` pinned to a brepjs version **not yet published to npm** → `npm install --legacy-peer-deps` fails with `ETARGET` → every production Vercel deploy errors at install. This is exactly what happened: brepjs-cad got re-pinned to `^18.117.1` while only 18.117.0 was published.
2. An early leaf merge also bumps the shared `.release-please-manifest.json`, flipping the still-open **root** brepjs PR to `CONFLICTING` (this is why #1669 sat stuck).

## Fix — serialize root before leaves

While the **root brepjs** release PR is open, arm auto-merge **only on it** and **hold every leaf**. Once root merges (bumping `main` + publishing brepjs), the next release-please run regenerates each leaf PR with a now-valid pin against an up-to-date `main`, and this job arms their auto-merge then.

Key changes to the `auto-merge` job:
- **Runs on every successful release-please run** (`if: needs.release-please.result == 'success'`) instead of only when `prs_created == 'true'`, so a leaf held in one cycle is picked up on whichever later cycle unblocks it.
- **Queries the live set of open release PRs** via `gh pr list --label 'autorelease: pending'` (matched by head-branch component) rather than trusting the action's `prs`/`pr` outputs — robust to the multi-cycle hold/resume.
- **Root-before-leaf ordering**: root brepjs branch arms immediately; any leaf is held while root is open; `brepjs-opencascade` stays permanently held (manual WASM build).

Once root merges first, `main` already carries the new brepjs version, so leaf pins resolve against the **workspace** regardless of npm publish timing — the ETARGET window is closed.

## Why this is safe

- The root brepjs PR is not in any hold list, so it always auto-merges on its own — no deadlock.
- Holding leaves for the (typically minutes-long) window a root PR is open is the only behavior cost; they still auto-merge automatically the next cycle.
- If a root PR's CI is red, leaves wait rather than racing ahead with a broken pin — the safe failure mode.

## Security

All PR-derived data (`title`, `branch`, `number`) is read at runtime from `gh pr list --json` into quoted shell variables; none is interpolated through `${{ }}`, and only the integer `$number` reaches `gh pr merge`. No `github.event.*` input is used.

## Verification

- YAML parses; `bash -n` clean; Prettier-clean.
- Decision logic dry-run across three scenarios (root+cad+bim open → root merges, leaves held; leaves-only → leaves merge, opencascade held; root-only → root merges) all behave as intended.