### PR TITLE
feat(site): add Vercel Speed Insights to docs and playground

### DIFF
--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -83,6 +83,9 @@ const theme: Theme = {
     // emit pageviews automatically once mounted.
     if (typeof window !== 'undefined') {
       void import('@vercel/analytics').then(({ inject }) => inject());
+      void import('@vercel/speed-insights').then(({ injectSpeedInsights }) =>
+        injectSpeedInsights(),
+      );
       void initPostHog();
       registerPreloadErrorRecovery();
     }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "2.0.1",
+    "@vercel/speed-insights": "2.0.0",
     "posthog-js": "1.387.0",
     "three": "0.184.0",
     "three-stdlib": "2.36.1"

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -24,6 +24,7 @@
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.6.1",
     "@vercel/analytics": "2.0.1",
+    "@vercel/speed-insights": "2.0.0",
     "brepjs": "*",
     "brepjs-bim": "*",
     "brepjs-sheetmetal": "*",

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -1,4 +1,5 @@
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 import PlaygroundPage from './components/playground/PlaygroundPage';
 
 export default function App() {
@@ -6,6 +7,7 @@ export default function App() {
     <>
       <PlaygroundPage />
       <Analytics />
+      <SpeedInsights />
     </>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vercel/analytics": "2.0.1",
+        "@vercel/speed-insights": "2.0.0",
         "posthog-js": "1.387.0",
         "three": "0.184.0",
         "three-stdlib": "2.36.1"
@@ -103,6 +104,7 @@
         "@react-three/drei": "10.7.7",
         "@react-three/fiber": "9.6.1",
         "@vercel/analytics": "2.0.1",
+        "@vercel/speed-insights": "2.0.0",
         "brepjs": "*",
         "brepjs-bim": "*",
         "brepjs-sheetmetal": "*",
@@ -5735,6 +5737,44 @@
         }
       }
     },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
@@ -6565,8 +6605,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.117.1"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -14468,7 +14507,7 @@
       }
     },
     "packages/brepjs-bim": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "*",


### PR DESCRIPTION
## What

Wire [`@vercel/speed-insights`](https://www.npmjs.com/package/@vercel/speed-insights) into both Vercel-deployed apps to collect real-user Core Web Vitals (LCP, CLS, INP, …), mirroring the existing Vercel Analytics integration.

| App | File | Change |
|-----|------|--------|
| Playground (React/Vite) | `apps/playground/src/App.tsx` | Added `<SpeedInsights />` from `@vercel/speed-insights/react` |
| Docs (VitePress) | `apps/docs/.vitepress/theme/index.ts` | SSR-guarded dynamic `injectSpeedInsights()`, alongside the existing `inject()` and PostHog init |
| both | `package.json` ×2 + `package-lock.json` | Pinned `@vercel/speed-insights@2.0.0` (exact, matching the `@vercel/analytics` pin style) |

## Why

Surfaces field performance data next to the existing pageview analytics. Zero-config on Vercel — no env vars required.

## Notes

- Speed Insights only ingests on **Production** deployments with the feature enabled in each project's Vercel dashboard (Vercel shows a one-click "Enable" prompt once it detects the package on a deploy).
- Playground `tsc -b` passes; the `injectSpeedInsights` export resolves at runtime.