### PR TITLE
docs: add a Get in touch page and contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ The command exits non-zero unless the report is `ok` (valid **and** every declar
 
 - [Gridfinity Layout Tool](https://github.com/andymai/gridfinity-layout-tool): Web-based layout generator for Gridfinity storage systems
 
+## Get in touch
+
+I'm Andy Aragon — I build and maintain brepjs and the geometry kernels beneath it ([occt-wasm](https://github.com/andymai/occt-wasm), [brepkit](https://github.com/andymai/brepkit)). Building something on brepjs and want a hand, or just have a question? **[Get in touch →](https://brepjs.dev/support)**
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -251,6 +251,7 @@ export default withMermaid(
         { text: 'Authoring with AI', link: '/agent/overview' },
         { text: 'API Reference', link: 'https://andymai.github.io/brepjs/' },
         { text: 'Playground', link: '/playground', target: '_blank', rel: 'noopener noreferrer' },
+        { text: 'Get in touch', link: '/support' },
         {
           text: major,
           items: [

--- a/apps/docs/.vitepress/theme/components/ContactForm.vue
+++ b/apps/docs/.vitepress/theme/components/ContactForm.vue
@@ -12,6 +12,9 @@ const status = ref<Status>('idle');
 const errorMessage = ref('');
 
 async function onSubmit(event: Event): Promise<void> {
+  // Guard against a double-submit racing the disabled-button state.
+  if (status.value === 'sending') return;
+
   const form = event.target as HTMLFormElement;
   // access_key and subject ride along as hidden inputs so the no-JS native
   // POST carries them too; FormData picks them up here without re-appending.
@@ -26,13 +29,19 @@ async function onSubmit(event: Event): Promise<void> {
       headers: { Accept: 'application/json' },
       body: data,
     });
-    const json = (await res.json()) as { success?: boolean; message?: string };
+    // A non-JSON error page (proxy/5xx) shouldn't masquerade as a network
+    // error — fall back to an empty object and report the HTTP status.
+    const json = (await res.json().catch(() => ({}))) as {
+      success?: boolean;
+      message?: string;
+    };
     if (json.success) {
       status.value = 'ok';
       form.reset();
     } else {
       status.value = 'error';
-      errorMessage.value = json.message ?? 'Something went wrong.';
+      errorMessage.value =
+        json.message ?? `Couldn't send (error ${res.status}). Email hi@andymai.com instead.`;
     }
   } catch {
     status.value = 'error';

--- a/apps/docs/.vitepress/theme/components/ContactForm.vue
+++ b/apps/docs/.vitepress/theme/components/ContactForm.vue
@@ -13,9 +13,9 @@ const errorMessage = ref('');
 
 async function onSubmit(event: Event): Promise<void> {
   const form = event.target as HTMLFormElement;
+  // access_key and subject ride along as hidden inputs so the no-JS native
+  // POST carries them too; FormData picks them up here without re-appending.
   const data = new FormData(form);
-  data.append('access_key', ACCESS_KEY);
-  data.append('subject', 'brepjs — new message from the site');
 
   status.value = 'sending';
   errorMessage.value = '';
@@ -43,12 +43,22 @@ async function onSubmit(event: Event): Promise<void> {
 
 <template>
   <div class="contact-card">
-    <div v-if="status === 'ok'" class="contact-success">
+    <div v-if="status === 'ok'" class="contact-success" role="status">
       <strong>Thanks — message received.</strong>
       <p>I read every inquiry myself and will get back to you at the email you gave.</p>
     </div>
 
-    <form v-else class="contact-form" @submit.prevent="onSubmit">
+    <!-- action/method make this a real POST to Web3Forms when JS is off;
+         @submit.prevent intercepts and submits via fetch when JS is on. -->
+    <form
+      v-else
+      class="contact-form"
+      action="https://api.web3forms.com/submit"
+      method="POST"
+      @submit.prevent="onSubmit"
+    >
+      <input type="hidden" name="access_key" :value="ACCESS_KEY" />
+      <input type="hidden" name="subject" value="brepjs — new message from the site" />
       <!-- Honeypot: real users never see or fill this. -->
       <input type="checkbox" name="botcheck" class="contact-hp" tabindex="-1" autocomplete="off" />
 
@@ -82,7 +92,7 @@ async function onSubmit(event: Event): Promise<void> {
         {{ status === 'sending' ? 'Sending…' : 'Send' }}
       </button>
 
-      <p v-if="status === 'error'" class="contact-error">{{ errorMessage }}</p>
+      <p v-if="status === 'error'" class="contact-error" role="alert">{{ errorMessage }}</p>
     </form>
   </div>
 </template>

--- a/apps/docs/.vitepress/theme/components/ContactForm.vue
+++ b/apps/docs/.vitepress/theme/components/ContactForm.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+// Public Web3Forms access key — safe to commit. Submissions are emailed to
+// the address registered with this key (hi@andymai.com). Swap the key to
+// reroute; no server code or secret lives in this repo.
+const ACCESS_KEY = 'ec066be3-ba99-4b56-acff-e303421a972b';
+
+type Status = 'idle' | 'sending' | 'ok' | 'error';
+
+const status = ref<Status>('idle');
+const errorMessage = ref('');
+
+async function onSubmit(event: Event): Promise<void> {
+  const form = event.target as HTMLFormElement;
+  const data = new FormData(form);
+  data.append('access_key', ACCESS_KEY);
+  data.append('subject', 'brepjs — new message from the site');
+
+  status.value = 'sending';
+  errorMessage.value = '';
+
+  try {
+    const res = await fetch('https://api.web3forms.com/submit', {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      body: data,
+    });
+    const json = (await res.json()) as { success?: boolean; message?: string };
+    if (json.success) {
+      status.value = 'ok';
+      form.reset();
+    } else {
+      status.value = 'error';
+      errorMessage.value = json.message ?? 'Something went wrong.';
+    }
+  } catch {
+    status.value = 'error';
+    errorMessage.value = 'Network error — email hi@andymai.com instead.';
+  }
+}
+</script>
+
+<template>
+  <div class="contact-card">
+    <div v-if="status === 'ok'" class="contact-success">
+      <strong>Thanks — message received.</strong>
+      <p>I read every inquiry myself and will get back to you at the email you gave.</p>
+    </div>
+
+    <form v-else class="contact-form" @submit.prevent="onSubmit">
+      <!-- Honeypot: real users never see or fill this. -->
+      <input type="checkbox" name="botcheck" class="contact-hp" tabindex="-1" autocomplete="off" />
+
+      <div class="contact-row">
+        <label>
+          <span>Name</span>
+          <input type="text" name="name" autocomplete="name" required />
+        </label>
+        <label>
+          <span>Company <em>(optional)</em></span>
+          <input type="text" name="company" autocomplete="organization" />
+        </label>
+      </div>
+
+      <label>
+        <span>Email</span>
+        <input type="email" name="email" autocomplete="email" required />
+      </label>
+
+      <label>
+        <span>Message</span>
+        <textarea
+          name="message"
+          rows="5"
+          required
+          placeholder="A project, a question, or just saying hi — whatever's on your mind."
+        ></textarea>
+      </label>
+
+      <button type="submit" :disabled="status === 'sending'">
+        {{ status === 'sending' ? 'Sending…' : 'Send' }}
+      </button>
+
+      <p v-if="status === 'error'" class="contact-error">{{ errorMessage }}</p>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.contact-card {
+  margin-top: 1.5rem;
+  padding: 1.75rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 14px;
+  background: var(--vp-c-bg-soft);
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.contact-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 560px) {
+  .contact-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.contact-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+.contact-form label em {
+  font-weight: 400;
+  font-style: normal;
+  color: var(--vp-c-text-3);
+}
+
+.contact-form input[type='text'],
+.contact-form input[type='email'],
+.contact-form textarea {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  font-weight: 400;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  transition: border-color 0.2s;
+}
+
+.contact-form textarea {
+  resize: vertical;
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: none;
+  border-color: var(--vp-c-brand-1);
+}
+
+.contact-form button {
+  align-self: flex-start;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  color: var(--vp-c-white);
+  background: var(--vp-c-brand-1);
+  border-radius: 8px;
+  transition:
+    background 0.2s,
+    opacity 0.2s;
+}
+
+.contact-form button:hover {
+  background: var(--vp-c-brand-2);
+}
+
+.contact-form button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.contact-hp {
+  position: absolute;
+  left: -9999px;
+}
+
+.contact-success strong {
+  font-size: 1.1rem;
+}
+
+.contact-success p {
+  margin: 0.5rem 0 0;
+  color: var(--vp-c-text-2);
+}
+
+.contact-error {
+  margin: 0;
+  color: var(--vp-c-danger-1, #e5484d);
+  font-size: 0.875rem;
+}
+</style>

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import DefaultTheme from 'vitepress/theme';
 import type { Theme } from 'vitepress';
 import { h } from 'vue';
 import Layout from './Layout.vue';
+import ContactForm from './components/ContactForm.vue';
 import './custom.css';
 
 /**
@@ -77,14 +78,16 @@ async function initPostHog(): Promise<void> {
 const theme: Theme = {
   extends: DefaultTheme,
   Layout: () => h(Layout),
-  enhanceApp() {
+  enhanceApp({ app }) {
+    app.component('ContactForm', ContactForm);
+
     // VitePress prerenders pages, so guard against SSR. inject() wraps
     // history.pushState — VitePress's own router uses it, so route changes
     // emit pageviews automatically once mounted.
     if (typeof window !== 'undefined') {
       void import('@vercel/analytics').then(({ inject }) => inject());
       void import('@vercel/speed-insights').then(({ injectSpeedInsights }) =>
-        injectSpeedInsights(),
+        injectSpeedInsights()
       );
       void initPostHog();
       registerPreloadErrorRecovery();

--- a/apps/docs/support.md
+++ b/apps/docs/support.md
@@ -1,0 +1,14 @@
+---
+title: Get in touch
+description: Get in touch with Andy Aragon — maintainer of brepjs, occt-wasm, and brepkit. Project work, support, a question, or just to say hello.
+---
+
+# Get in touch
+
+I'm Andy Aragon — I build and maintain brepjs and the geometry kernels beneath it ([occt-wasm](https://github.com/andymai/occt-wasm), the OpenCascade-to-WebAssembly build, and [brepkit](https://github.com/andymai/brepkit), a Rust kernel).
+
+Building something on brepjs and want a hand — support, a project build, or a feature landed upstream — or just have a question? Drop a note below and it reaches me directly. If you'd rather, email [hi@andymai.com](mailto:hi@andymai.com).
+
+If you'd like to fund continued development, [GitHub Sponsors](https://github.com/sponsors/andymai) does that directly.
+
+<ContactForm />


### PR DESCRIPTION
## What

Adds a lightweight **Get in touch** path to the site and README so people building on brepjs can reach me directly — for project work, support, or just a question.

- **`/support` page** — short intro + a contact form. Open to project work but framed as a general get-in-touch, not a services pitch.
- **`ContactForm.vue`** — Web3Forms-backed form (name · company · email · message). It's a Vue component that **prerenders to static HTML** and submits via **AJAX**, so it works with and without JS and needs no backend or secret in the repo (the Web3Forms access key is public by design and only authorizes sending to my inbox).
- **Nav** — adds a "Get in touch" link.
- **README** — a short Get in touch section above Contributing, linking to the page.

## Notes

- Styling uses existing `--vp-c-brand-*` / divider tokens, so it matches light and dark themes.
- The page falls back to the default `og.png`; a custom OG card can be added later via `scripts/gen-og-docs.mjs`.

## Verification

- `npm run docs:build` ✓ — component compiles, page prerenders, nav valid
- Prettier ✓
- Worth a manual smoke test after deploy: submit once and confirm it lands at hi@andymai.com.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

