### PR TITLE
fix(brepkit): harden rotation/scale matrix builders against non-Vec3 axis/center

### DIFF
--- a/src/kernel/brepkit/helpers.ts
+++ b/src/kernel/brepkit/helpers.ts
@@ -218,7 +218,11 @@ export function rotationMatrix(
   axisInput: readonly [number, number, number] = [0, 0, 1],
   centerInput: readonly [number, number, number] = [0, 0, 0]
 ): number[] {
-  const axis = asVec3(axisInput, [0, 0, 1]);
+  const rawAxis = asVec3(axisInput, [0, 0, 1]);
+  // A zero-length axis can't be normalised (len === 0 → division by zero → NaN);
+  // fall back to +Z, matching the `undefined`/non-Vec3 default.
+  const axis: readonly [number, number, number] =
+    rawAxis[0] === 0 && rawAxis[1] === 0 && rawAxis[2] === 0 ? [0, 0, 1] : rawAxis;
   const center = asVec3(centerInput, [0, 0, 0]);
   const rad = (angleDeg * Math.PI) / 180;
   const c = Math.cos(rad);

--- a/src/kernel/brepkit/helpers.ts
+++ b/src/kernel/brepkit/helpers.ts
@@ -186,12 +186,40 @@ export function translationMatrix(x: number, y: number, z: number): number[] {
   ];
 }
 
+/**
+ * Coerce a possibly-malformed value into a Vec3 tuple, falling back to `fallback`.
+ *
+ * The matrix builders sit at the JS↔WASM boundary where `no-unsafe-*` is off, so
+ * an `axis`/`center` typed as `Vec3` can arrive as a non-iterable at runtime (a
+ * `{x,y,z}` object, `null`, a scalar from a malformed compose op). Default
+ * parameters only guard `undefined`, so destructuring such a value throws a
+ * cryptic `center is not iterable`. This extends the existing `undefined → default`
+ * tolerance to any non-Vec3 input instead of crashing.
+ */
+function asVec3(
+  value: unknown,
+  fallback: readonly [number, number, number]
+): readonly [number, number, number] {
+  if (!Array.isArray(value) || value.length < 3) return fallback;
+  const [x, y, z] = value as [unknown, unknown, unknown];
+  return typeof x === 'number' &&
+    typeof y === 'number' &&
+    typeof z === 'number' &&
+    Number.isFinite(x) &&
+    Number.isFinite(y) &&
+    Number.isFinite(z)
+    ? [x, y, z]
+    : fallback;
+}
+
 /** Build a row-major 4x4 rotation matrix (angle in degrees, optional axis/center). */
 export function rotationMatrix(
   angleDeg: number,
-  axis: readonly [number, number, number] = [0, 0, 1],
-  center: readonly [number, number, number] = [0, 0, 0]
+  axisInput: readonly [number, number, number] = [0, 0, 1],
+  centerInput: readonly [number, number, number] = [0, 0, 0]
 ): number[] {
+  const axis = asVec3(axisInput, [0, 0, 1]);
+  const center = asVec3(centerInput, [0, 0, 0]);
   const rad = (angleDeg * Math.PI) / 180;
   const c = Math.cos(rad);
   const s = Math.sin(rad);
@@ -227,8 +255,11 @@ export function rotationMatrix(
 }
 
 /** Build a row-major 4x4 uniform scale matrix about a center point. */
-export function scaleMatrix(center: readonly [number, number, number], factor: number): number[] {
-  const [cx, cy, cz] = center;
+export function scaleMatrix(
+  centerInput: readonly [number, number, number],
+  factor: number
+): number[] {
+  const [cx, cy, cz] = asVec3(centerInput, [0, 0, 0]);
   const tx = cx * (1 - factor);
   const ty = cy * (1 - factor);
   const tz = cz * (1 - factor);

--- a/tests/brepkitMatrixHelpers.test.ts
+++ b/tests/brepkitMatrixHelpers.test.ts
@@ -45,6 +45,14 @@ describe('brepkit matrix helpers', () => {
       expect(guarded.every((n) => Number.isFinite(n))).toBe(true);
       expect(guarded).toEqual(rotationMatrix(90, [0, 0, 1]));
     });
+
+    // A degenerate zero-length axis is finite (so it passes asVec3) but can't be
+    // normalized — it must fall back to +Z rather than divide by zero.
+    it('falls back to the default Z axis for a degenerate zero-length axis (no NaN)', () => {
+      const guarded = rotationMatrix(90, [0, 0, 0]);
+      expect(guarded.every((n) => Number.isFinite(n))).toBe(true);
+      expect(guarded).toEqual(rotationMatrix(90, [0, 0, 1]));
+    });
   });
 
   describe('scaleMatrix', () => {

--- a/tests/brepkitMatrixHelpers.test.ts
+++ b/tests/brepkitMatrixHelpers.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure-function tests for the brepkit adapter's matrix builders.
+ *
+ * These exercise `rotationMatrix` / `scaleMatrix` directly — no kernel or WASM
+ * init required — so they run in every kernel project's gate (unlike the
+ * mock-adapter suite in brepkitAdapter.test.ts, which is excluded from all
+ * projects). Regression coverage for gh issue #1719: a non-iterable
+ * `axis`/`center` reaching these builders used to throw `center is not iterable`
+ * because the `= [0,0,0]` default only guarded `undefined`.
+ */
+import { describe, expect, it } from 'vitest';
+import { rotationMatrix, scaleMatrix } from '@/kernel/brepkit/helpers.js';
+
+describe('brepkit matrix helpers', () => {
+  describe('rotationMatrix', () => {
+    it('produces a correct 90° rotation about Z', () => {
+      const m = rotationMatrix(90, [0, 0, 1]);
+      expect(m[0]).toBeCloseTo(0); // cos
+      expect(m[1]).toBeCloseTo(-1); // -sin
+      expect(m[4]).toBeCloseTo(1); // sin
+      expect(m[5]).toBeCloseTo(0); // cos
+    });
+
+    it('applies a valid non-origin center (conjugated translation)', () => {
+      const m = rotationMatrix(90, [0, 0, 1], [1, 0, 0]);
+      expect(m[3]).toBeCloseTo(1); // tx
+      expect(m[7]).toBeCloseTo(-1); // ty
+    });
+
+    // gh #1719: a non-iterable center must not throw and must fall back to origin.
+    it('tolerates a non-iterable center without throwing', () => {
+      const malformed = { x: 1, y: 2, z: 3 } as unknown as [number, number, number];
+      const guarded = rotationMatrix(90, [0, 1, 0], malformed);
+      expect(guarded).toEqual(rotationMatrix(90, [0, 1, 0], [0, 0, 0]));
+    });
+
+    it('tolerates a null center without throwing', () => {
+      const guarded = rotationMatrix(90, [0, 1, 0], null as unknown as [number, number, number]);
+      expect(guarded.every((n) => Number.isFinite(n))).toBe(true);
+    });
+
+    it('falls back to the default Z axis for a non-iterable axis (no NaN)', () => {
+      const malformed = { x: 0, y: 1, z: 0 } as unknown as [number, number, number];
+      const guarded = rotationMatrix(90, malformed);
+      expect(guarded.every((n) => Number.isFinite(n))).toBe(true);
+      expect(guarded).toEqual(rotationMatrix(90, [0, 0, 1]));
+    });
+  });
+
+  describe('scaleMatrix', () => {
+    it('produces a correct uniform scale about origin', () => {
+      const m = scaleMatrix([0, 0, 0], 3);
+      expect(m[0]).toBe(3);
+      expect(m[5]).toBe(3);
+      expect(m[10]).toBe(3);
+    });
+
+    // gh #1719: scaleMatrix shares the same destructuring pattern.
+    it('tolerates a non-iterable center without throwing', () => {
+      const malformed = { x: 1, y: 2, z: 3 } as unknown as [number, number, number];
+      const guarded = scaleMatrix(malformed, 3);
+      expect(guarded).toEqual(scaleMatrix([0, 0, 0], 3));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1719 — a `rotate(...)` through the **brepkit adapter** could throw a cryptic `TypeError: center is not iterable` from `rotationMatrix` in `src/kernel/brepkit/helpers.ts`.

**Root cause:** `rotationMatrix` / `scaleMatrix` destructure their vector args directly (`const [cx, cy, cz] = center`) and rely on a default parameter (`center = [0,0,0]`) for the empty case. But TS default parameters only fire on `undefined` — any *other* non-iterable value reaching that slot (a `{x,y,z}`-shaped object, `null`, a scalar from a malformed compose op) sails past the default and throws on the destructure. `scaleMatrix` had the identical pattern.

## Fix

Added a small `asVec3(value, fallback)` coercion helper and routed `axis`/`center` through it in both builders. It:
- extends the *existing* `undefined → default` tolerance to **any** non-Vec3 input, so the builders never throw;
- validates each element is a finite number, so a malformed value can't silently inject `NaN` into the matrix.

Valid `Vec3` inputs are unchanged (same numbers out).

## Investigation note

The issue reporter couldn't isolate a minimal repro. I traced every `rotationMatrix`/`scaleMatrix` caller (public `rotate({at, axis})`, fluent `shape().rotateX()`, the CSG evaluator, and the `composeTransform` replay path) — all *static* paths deliver clean `Vec3`s. The crash only happens when an untyped value crosses the JS↔WASM boundary, where `no-unsafe-*` is disabled and the `Vec3` annotation isn't enforced at runtime. Hardening the fragile destructuring site is the right fix, as the issue recommended.

## Tests

New `tests/brepkitMatrixHelpers.test.ts` (pure-function, no WASM):
- correct rotation/scale matrices for valid input + valid non-origin center;
- non-iterable / `null` center and non-iterable axis no longer throw and fall back cleanly.

Placed in a dedicated file because the mock-adapter suite (`brepkitAdapter.test.ts`) is **excluded from every Vitest project** and never runs in any gate — a regression there would look covered while protecting nothing. This file runs in the default occt-wasm gate and all kernel projects.

**RED→GREEN verified:** stashing the fix reproduces the exact `center is not iterable` error; restoring it passes. Full pre-commit suite (3972 tests) green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

