### PR TITLE
test(brepkit): wire BrepkitAdapter mock unit tests into the gate and fix drift

### DIFF
--- a/tests/brepkitAdapter.test.ts
+++ b/tests/brepkitAdapter.test.ts
@@ -34,8 +34,19 @@ function createMockBrepKernel() {
     // Booleans
     fuse: vi.fn((_a: number, _b: number) => allocId()),
     cut: vi.fn((_a: number, _b: number) => allocId()),
+    compoundCut: vi.fn((_target: number, _toolIds: Uint32Array | number[]) => allocId()),
     intersect: vi.fn((_a: number, _b: number) => allocId()),
     section: vi.fn(() => [allocId()]),
+    fuseWithEvolution: vi.fn((_a: number, _b: number) =>
+      JSON.stringify({
+        solid: allocId(),
+        evolution: {
+          modified: {},
+          generated: { 100: [100], 101: [101], 102: [102] },
+          deleted: [10, 11],
+        },
+      })
+    ),
 
     // Operations
     extrude: vi.fn(() => allocId()),
@@ -98,6 +109,7 @@ function createMockBrepKernel() {
     // Classification
     classifyPoint: vi.fn(() => 'inside'),
     validateSolid: vi.fn(() => 0),
+    validateSolidRelaxed: vi.fn(() => 0),
 
     // I/O
     exportStep: vi.fn(() => new TextEncoder().encode('ISO-10303;')),
@@ -120,6 +132,8 @@ function createMockBrepKernel() {
     makeVertex: vi.fn((_x: number, _y: number, _z: number) => allocId()),
     makeLineEdge: vi.fn(() => allocId()),
     makeNurbsEdge: vi.fn(() => allocId()),
+    makeCircleEdge: vi.fn(() => allocId()),
+    makeCircleArc3d: vi.fn(() => allocId()),
     makeWire: vi.fn((_edges: number[], _closed: boolean) => allocId()),
     makeFaceFromWire: vi.fn((_wire: number) => allocId()),
     solidFromShell: vi.fn((_shell: number) => allocId()),
@@ -146,6 +160,7 @@ function createMockBrepKernel() {
     sweepAlongEdges: vi.fn(() => allocId()),
     convexHull: vi.fn(() => allocId()),
     offsetSolid: vi.fn(() => allocId()),
+    offsetSolidV2: vi.fn(() => allocId()),
     getEdgeNurbsData: vi.fn(() => null),
     tessellateEdge: vi.fn((_edge: number, numPoints: number) => {
       // Return numPoints evenly spaced along X axis
@@ -169,6 +184,11 @@ function createMockBrepKernel() {
     loftSmooth: vi.fn(() => allocId()),
     sweepSmooth: vi.fn(() => allocId()),
     meshEdges: vi.fn((_solid: number, _deflection: number) => ({
+      positions: [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0],
+      offsets: [0, 6],
+      edgeCount: 2,
+    })),
+    meshEdgesAll: vi.fn((_solid: number, _deflection: number, _angularTolerance?: number) => ({
       positions: [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0],
       offsets: [0, 6],
       edgeCount: 2,
@@ -350,7 +370,9 @@ describe('BrepkitAdapter', () => {
       const tools = [adapter.makeBox(1, 1, 1), adapter.makeBox(1, 1, 1)];
       adapter.cutAll(shape, tools);
 
-      expect(mock.cut).toHaveBeenCalledTimes(2);
+      expect(mock.compoundCut).toHaveBeenCalledTimes(1);
+      const toolIds = Array.from(mock.compoundCut.mock.calls[0]?.[1] as ArrayLike<number>);
+      expect(toolIds).toHaveLength(2);
     });
   });
 
@@ -952,7 +974,7 @@ describe('BrepkitAdapter', () => {
       const edge = adapter.makeCircleEdge([0, 0, 0], [0, 0, 1], 5);
 
       expect((edge as BrepkitHandle).type).toBe('edge');
-      expect(mock.makeNurbsEdge).toHaveBeenCalled();
+      expect(mock.makeCircleEdge).toHaveBeenCalled();
     });
 
     it('makeCircleArc creates partial arc', () => {
@@ -1097,7 +1119,7 @@ describe('BrepkitAdapter', () => {
       const result = adapter.offset(box, 0.5);
 
       expect((result as BrepkitHandle).type).toBe('solid');
-      expect(mock.offsetSolid).toHaveBeenCalled();
+      expect(mock.offsetSolidV2).toHaveBeenCalled();
     });
 
     it('hullFromPoints delegates to WASM convexHull', () => {
@@ -1125,8 +1147,8 @@ describe('BrepkitAdapter', () => {
       const box = adapter.makeBox(1, 1, 1);
       const result = adapter.meshEdges(box, 0.1, 0.5);
 
-      // Should call native meshEdges (not tessellateEdge)
-      expect(mock.meshEdges).toHaveBeenCalled();
+      // Should call native meshEdgesAll (not per-edge tessellateEdge)
+      expect(mock.meshEdgesAll).toHaveBeenCalled();
       expect(result.lines.length).toBeGreaterThan(0);
       expect(result.edgeGroups.length).toBe(2); // mock returns 2 edges
     });
@@ -1138,8 +1160,7 @@ describe('BrepkitAdapter', () => {
 
       adapter.meshEdges(box, 0.05, 0.5);
 
-      // Falls back to native meshEdges when meshEdgesAll is unavailable (pre-1.0.8)
-      expect(mock.meshEdges).toHaveBeenCalledWith(expect.any(Number), 0.05);
+      expect(mock.meshEdgesAll).toHaveBeenCalledWith(expect.any(Number), 0.05, 0.5);
     });
 
     it('meshEdges prefers meshEdgesAll when available (1.0.8+)', () => {
@@ -1154,7 +1175,7 @@ describe('BrepkitAdapter', () => {
 
       adapter.meshEdges(box, 0.1, 0.5);
 
-      expect(mock.meshEdgesAll).toHaveBeenCalledWith(expect.any(Number), 0.1);
+      expect(mock.meshEdgesAll).toHaveBeenCalledWith(expect.any(Number), 0.1, 0.5);
       expect(mock.meshEdges).not.toHaveBeenCalled();
     });
   });
@@ -1189,7 +1210,7 @@ describe('BrepkitAdapter', () => {
       const box = adapter.makeBox(1, 1, 1);
 
       expect(adapter.isValid(box)).toBe(true);
-      expect(mock.validateSolid).toHaveBeenCalled();
+      expect(mock.validateSolidRelaxed).toHaveBeenCalled();
     });
 
     it('isValid returns false for non-handle', () => {
@@ -1266,7 +1287,7 @@ describe('BrepkitAdapter', () => {
       const adapter = new BrepkitAdapter(mock);
 
       const solid = adapter.makeBox(10, 10, 10);
-      const edges = (adapter.getEdges(solid) as BrepkitHandle[]).slice(0, 2);
+      const edges = (adapter.iterShapes(solid, 'edge') as BrepkitHandle[]).slice(0, 2);
       adapter.fillet(solid, edges, [1, 3]);
 
       expect(mock.filletVariable).toHaveBeenCalledOnce();
@@ -1281,7 +1302,7 @@ describe('BrepkitAdapter', () => {
       const adapter = new BrepkitAdapter(mock);
 
       const solid = adapter.makeBox(10, 10, 10);
-      const edges = (adapter.getEdges(solid) as BrepkitHandle[]).slice(0, 1);
+      const edges = (adapter.iterShapes(solid, 'edge') as BrepkitHandle[]).slice(0, 1);
       adapter.fillet(solid, edges, () => [2, 4]);
 
       expect(mock.filletVariable).toHaveBeenCalledOnce();
@@ -1295,7 +1316,7 @@ describe('BrepkitAdapter', () => {
       const adapter = new BrepkitAdapter(mock);
 
       const solid = adapter.makeBox(10, 10, 10);
-      const edges = (adapter.getEdges(solid) as BrepkitHandle[]).slice(0, 1);
+      const edges = (adapter.iterShapes(solid, 'edge') as BrepkitHandle[]).slice(0, 1);
       adapter.fillet(solid, edges, 2);
 
       expect(mock.fillet).toHaveBeenCalledOnce();

--- a/tests/helpers/kernelRegistry.ts
+++ b/tests/helpers/kernelRegistry.ts
@@ -82,7 +82,6 @@ export const kernelConfigs: readonly KernelConfig[] = [
     // adapter; they stay excluded even though occt-wasm is now the default project.
     excludeTests: [
       'tests/brepkitExtended.test.ts',
-      'tests/brepkitAdapter.test.ts',
       'tests/brepkitSketchArc.test.ts',
       'tests/brepkitOffsetV2.test.ts',
       'tests/gltfRoundTrip.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,12 +8,14 @@ import {
 
 /**
  * Tests excluded from all kernel projects:
- * - brepkit-only tests that use a mock BrepKernel or brepkit-only setup
+ * - brepkit-only tests that need a real brepkit-wasm install or local link
  * - cross-kernel comparison tests that manage their own dual-kernel init
  * - standard non-test directories
+ *
+ * Note: brepkitAdapter.test.ts is NOT here — it drives BrepkitAdapter with a
+ * pure mock kernel (no WASM), so it runs in every project's gate as a unit test.
  */
 const alwaysExclude = [
-  'tests/brepkitAdapter.test.ts',
   'tests/brepkit-adapter.test.ts',
   'tests/brepkit-validation.test.ts',
   'tests/kernel-agreement.test.ts',


### PR DESCRIPTION
## Background

While fixing #1719 I found that `tests/brepkitAdapter.test.ts` — a 1356-line, 99-test unit suite that drives `BrepkitAdapter` with a **pure mock kernel** (no WASM) — was listed in **both** `alwaysExclude` (vitest.config.ts) and **occt-wasm's** `excludeTests` (kernelRegistry.ts). CI's gate only runs the occt-wasm project, so this suite executed in **no** project at all.

"Excluded so it can't fail" → it silently rotted: **13 of 99 tests** referenced kernel/adapter methods that had since been renamed or replaced.

## What this does

1. **Fixes the drift** (test-only, no production code, no weakened assertions): syncs the mock kernel and a few renamed adapter calls to the current source:
   - mock gained `compoundCut`, `meshEdgesAll`, `fuseWithEvolution`, `makeCircleEdge`, `makeCircleArc3d`, `offsetSolidV2`, `validateSolidRelaxed` (each return shape matched to what the adapter actually reads);
   - `adapter.getEdges(...)` → `adapter.iterShapes(..., 'edge')` (the current public edge-enumeration method) in the 3 variable-fillet tests;
   - call/assertion targets updated to the new method names (e.g. `offsetSolid`→`offsetSolidV2`, `validateSolid`→`validateSolidRelaxed`, `meshEdges`→`meshEdgesAll` with its 3-arg signature).
2. **Wires it into the gate**: removes the file from both exclude lists. It's mock-based and kernel-agnostic, so it now runs as a unit test in **every** project — including the occt-wasm CI gate — and can't drift unnoticed again.

## Verification

- `npx vitest run --project occt-wasm tests/brepkitAdapter.test.ts` → **99 passed** (the CI gate now covers it).
- Also green under the `brepkit` project. ~1s, no WASM needed (own mock).
- typecheck + eslint clean on changed files.

## Scope note

The sibling excluded files are intentionally left as on-demand dev tools: `brepkit-adapter.test.ts` needs a local `npm link` to a brepkit dev build, `brepkit-validation.test.ts` / `kernel-agreement.test.ts` need real brepkit-wasm and/or dual-kernel init (they skip gracefully), and `io-stress.test.ts` runs via `vitest.stress.config.ts`. Only the mock suite belonged in the gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

