### PR TITLE
fix(kernel): resolve optional backends via variable specifier (#1726)

### DIFF
--- a/scripts/build-quick.js
+++ b/scripts/build-quick.js
@@ -18,12 +18,17 @@ const root = resolve(__dirname, '..');
 const quickJs = `import { initFromOC, registerKernel, OcctWasmAdapter } from './brepjs.js';
 // occt-wasm first (the default kernel); fall back to brepjs-opencascade.
 // Dynamic imports so an install with only one of the two packages still loads.
+// The specifier is passed through a variable so the import() argument is never a
+// string literal: a computed dynamic import is unanalyzable to every bundler, so
+// an uninstalled optional peer is left as a runtime import instead of breaking a
+// consumer's Vite dep pre-bundling (#1726).
+const importBackend = (specifier) => import(/* @vite-ignore */ specifier);
 try {
-  const { OcctKernel } = await import('occt-wasm');
+  const { OcctKernel } = await importBackend('occt-wasm');
   const kernel = await OcctKernel.init();
   registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
 } catch {
-  const { default: opencascade } = await import('brepjs-opencascade');
+  const { default: opencascade } = await importBackend('brepjs-opencascade');
   const oc = await opencascade();
   initFromOC(oc);
 }

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -8,6 +8,7 @@ import { DefaultAdapter } from './occt/defaultAdapter.js';
 import { BrepkitAdapter } from './brepkit/brepkitAdapter.js';
 import { ManifoldAdapter } from './manifold/manifoldAdapter.js';
 import { OcctWasmAdapter } from './occtWasm/occtWasmAdapter.js';
+import { importOptionalBackend } from './optionalBackend.js';
 import { resetMeasureDetectionCache } from './occt/measureOps.js';
 import { resetTransformDetectionCache } from './occt/transformOps.js';
 import { resetBooleanBatchDetectionCache } from './occt/booleanBatchOps.js';
@@ -263,8 +264,8 @@ export async function init(): Promise<string> {
   // Try occt-wasm first (the default kernel). Browser-safe: OcctKernel.init()
   // auto-locates its .wasm via import.meta.url.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import
-    const { OcctKernel } = (await import(/* @vite-ignore */ 'occt-wasm')) as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import of optional peer
+    const { OcctKernel } = (await importOptionalBackend('occt-wasm')) as any;
     const kernel = await OcctKernel.init();
     registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
     return 'occt-wasm';
@@ -274,8 +275,8 @@ export async function init(): Promise<string> {
 
   // Fallback: brepjs-opencascade (legacy default kernel)
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import
-    const mod = (await import(/* @vite-ignore */ 'brepjs-opencascade')) as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import of optional peer
+    const mod = (await importOptionalBackend('brepjs-opencascade')) as any;
     const oc = await mod.default();
     initFromOC(oc);
     return 'occt';
@@ -285,8 +286,8 @@ export async function init(): Promise<string> {
 
   // Fallback: brepkit
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import
-    const bk = (await import(/* @vite-ignore */ 'brepkit-wasm')) as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import of optional peer
+    const bk = (await importOptionalBackend('brepkit-wasm')) as any;
     if (typeof bk.default === 'function') await bk.default();
     registerKernel('brepkit', new BrepkitAdapter(new bk.BrepKernel()));
     return 'brepkit';

--- a/src/kernel/optionalBackend.ts
+++ b/src/kernel/optionalBackend.ts
@@ -1,0 +1,17 @@
+/**
+ * Dynamically import an optional kernel backend (`occt-wasm`,
+ * `brepjs-opencascade`, `brepkit-wasm`) at runtime.
+ *
+ * The specifier is passed through a parameter so the `import()` argument is a
+ * variable, never a string literal. A computed dynamic import is unanalyzable
+ * to every bundler (esbuild dep pre-bundling, Rollup, Vite import-analysis), so
+ * an uninstalled optional peer is always left as a runtime import instead of
+ * hard-failing a build. A string literal guarded only by a `@vite-ignore`
+ * comment regresses the moment a consumer's Vite pre-bundles brepjs and reflows
+ * the comment off the specifier (#1726); the `@vite-ignore` here only suppresses
+ * Vite's "cannot be analyzed" dev warning and its placement no longer affects
+ * correctness.
+ */
+export function importOptionalBackend(specifier: string): Promise<unknown> {
+  return import(/* @vite-ignore */ specifier);
+}

--- a/src/quick.ts
+++ b/src/quick.ts
@@ -1,16 +1,17 @@
 import { initFromOC, registerKernel, OcctWasmAdapter } from './kernel/index.js';
+import { importOptionalBackend } from './kernel/optionalBackend.js';
 
 // occt-wasm first (the default kernel); fall back to brepjs-opencascade.
 // Both imports are dynamic so an install with only one of the two packages
 // doesn't fail at module load.
 try {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import
-  const { OcctKernel } = (await import(/* @vite-ignore */ 'occt-wasm')) as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import of optional peer
+  const { OcctKernel } = (await importOptionalBackend('occt-wasm')) as any;
   const kernel = await OcctKernel.init();
   registerKernel('occt-wasm', OcctWasmAdapter.fromKernel(kernel));
 } catch {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import
-  const { default: opencascade } = (await import(/* @vite-ignore */ 'brepjs-opencascade')) as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic import of optional peer
+  const { default: opencascade } = (await importOptionalBackend('brepjs-opencascade')) as any;
   const oc = await opencascade();
   initFromOC(oc);
 }

--- a/tests/optionalBackendImport.test.ts
+++ b/tests/optionalBackendImport.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { importOptionalBackend } from '@/kernel/optionalBackend.js';
+
+const read = (relFromRepoRoot: string): string =>
+  readFileSync(fileURLToPath(new URL(`../${relFromRepoRoot}`, import.meta.url)), 'utf8');
+
+// Matches a dynamic import whose argument is a *string literal* naming an
+// optional kernel backend — the fragile pattern that breaks Vite dep
+// pre-bundling for consumers who haven't installed every optional peer (#1726).
+// A variable specifier (`import(specifier)`) or a plain call argument
+// (`importOptionalBackend('occt-wasm')`) must NOT match.
+const LITERAL_BACKEND_IMPORT =
+  /import\(\s*(?:\/\*[^*]*\*\/\s*)?['"](?:occt-wasm|brepjs-opencascade|brepkit-wasm)['"]/;
+
+describe('importOptionalBackend', () => {
+  it('performs a real runtime import (rejects for an absent specifier)', async () => {
+    await expect(importOptionalBackend('brepjs-__definitely-not-installed__')).rejects.toThrow();
+  });
+
+  // The whole point of the helper: the import() argument is a variable, so no
+  // bundler can statically resolve it. If anyone reintroduces a literal
+  // `import('occt-wasm')` in the auto-detect paths, a consumer's Vite build
+  // 500s on the uninstalled peer. Guard the source so that can't regress.
+  it.each([
+    'src/kernel/index.ts',
+    'src/quick.ts',
+    'src/kernel/optionalBackend.ts',
+    'scripts/build-quick.js',
+  ])('%s never imports an optional backend by string literal', (file) => {
+    expect(read(file)).not.toMatch(LITERAL_BACKEND_IMPORT);
+  });
+});


### PR DESCRIPTION
## What

Fixes #1726 — `init()`'s kernel auto-detect (and the `brepjs/quick` entry) imported optional kernel peers with **literal** specifiers guarded only by `/* @vite-ignore */`:

```js
await import(/* @vite-ignore */ 'occt-wasm')
```

A string-literal `import()` is statically analyzable, so the `@vite-ignore` comment is the *only* thing stopping a bundler from resolving it. When a consumer's Vite pre-bundles brepjs (`optimizeDeps`), esbuild reflows the source and displaces the comment off the specifier. Vite's import-analysis then tries to resolve an **uninstalled** optional peer (`brepjs-opencascade`) and hard-500s the dev server — even though that code path never runs. It's masked under npm's hoisting (the peer is auto-installed top-level) and fatal under pnpm's non-hoisted layout or any setup that doesn't install every backend.

## Fix

Route every optional-backend import through a one-line helper so the `import()` argument is a **variable**:

```ts
// src/kernel/optionalBackend.ts
export function importOptionalBackend(specifier: string): Promise<unknown> {
  return import(/* @vite-ignore */ specifier);
}
```

A computed dynamic import is unanalyzable to **every** bundler (esbuild dep pre-bundling, Rollup, Vite import-analysis), so an uninstalled peer is always left as a runtime import — never resolved at build time. This is the issue's "Option 1", generalized to all three backends. The `@vite-ignore` now only suppresses Vite's "cannot be analyzed" dev warning; its placement no longer affects correctness, so pre-bundle reflow can't reintroduce the 500.

Runtime semantics are identical to before (the same module resolves at runtime) — the only change is literal → variable at the `import()` site.

### Changes

- **`src/kernel/optionalBackend.ts`** (new) — the `importOptionalBackend` helper, internal (not exported from the public barrel).
- **`src/kernel/index.ts`** — `init()` auto-detect routes all three backends through the helper.
- **`src/quick.ts`** — same, for the `brepjs/quick` source.
- **`scripts/build-quick.js`** — the shipped `dist/quick.js` is a hand-written template that bypasses the bundler, so it carries the variable-specifier trick **inline** (it previously emitted a literal `import('occt-wasm')` with *no* guard at all).
- **`tests/optionalBackendImport.test.ts`** (new) — regression guard: asserts the helper performs a real runtime import, and statically asserts none of the auto-detect sources/templates reintroduce a literal backend `import()`.

## Verification

- `dist/` inspected after build: **no** analyzable literal backend `import()` remains in either `dist/brepjs.*` or `dist/quick.js`; both emit runtime variable imports.
- End-to-end: `init()` auto-detect resolves occt-wasm through the helper and builds geometry (volume of `box(2,3,4)` ≈ 24).
- typecheck / lint / boundaries / pattern-checker / format: clean.

Supersedes the consumer-side `optimizeDeps.exclude: ['brepjs']` workaround in the issue — no consumer config needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

