### PR TITLE
feat(brepjs-cad): grade judge quality against a reference exemplar

### DIFF
--- a/packages/brepjs-cad/bench/judge.ts
+++ b/packages/brepjs-cad/bench/judge.ts
@@ -12,7 +12,9 @@ const JUDGE_SYSTEM = `You are a meticulous CAD reviewer. You are shown rendered 
 
 Judge ONLY whether the rendered geometry matches the request and rubric: the right features are present (holes, walls, grooves, fillets, slots), the overall shape is right, and proportions are roughly correct. Ignore color, lighting, camera, and exact dimensions you cannot measure from a render. Be strict about missing or wrong features — a bored hole that isn't there, a hollow part rendered solid, or the wrong overall form is a fail.
 
-You may also be given "Measured facts" computed deterministically from the kernel (exact body count, which bodies sit apart vs touch/overlap, and the count of internal bores with their smallest radius). Treat these as ground truth the render cannot show, and reconcile them with what you see — if the facts report N bodies or B internal bores, confirm you see them (the xray view exposes bores). A reported interference is ambiguous on its own: decide from the request and image whether it is an intended assembly (e.g. an exploded view or a part that legitimately overlaps another) or an accidental collision. Also judge manufacturability: whether the part reads as a producible object (no zero-thickness walls, stray disconnected bodies, or self-colliding geometry the request did not ask for).
+You may also be given "Measured facts" computed deterministically from the kernel (exact body count, which bodies sit apart vs touch/overlap, and the count of internal bores with their smallest radius). Treat these as ground truth the render cannot show, and reconcile them with what you see — if the facts report N bodies or B internal bores, confirm you see them (the xray view exposes bores). A reported interference is ambiguous on its own: decide from the request and image whether it is an intended assembly (e.g. an exploded view or a part that legitimately overlaps another) or an accidental collision. The bore count can over-report (a boss/seam cylinder is sometimes miscounted as a bore), so the IMAGE is decisive when the facts and what you see disagree about whether an internal hole exists. Also judge manufacturability: whether the part reads as a producible object (no zero-thickness walls, stray disconnected bodies, or self-colliding geometry the request did not ask for).
+
+When a REFERENCE exemplar is shown — a known-good build of the SAME request, rendered the same way — additionally grade the candidate's quality RELATIVE to it: 'worse', 'on-par', or 'better' on form, proportion, feature fidelity, and finish (NOT on size/scale alone — a uniformly larger or smaller part of the same form is 'on-par'). \`pass\` stays the absolute floor (every required feature present + correct); \`quality\` is the gradient ABOVE the floor, so a part can pass yet be 'worse' (e.g. grotesque proportions, a barely-there wall, or a coarse approximation of a feature the reference renders cleanly). Set \`quality\` to null only when no reference is shown.
 
 Work in this order. FIRST decompose the request into its named features — the holes, bores, walls, bodies, blades, teeth, slots, fillets, etc. it implies — and grade EACH one for \`present\` (legible in the render) and \`correct\` (right count / form / proportion, not faked or distorted), reconciling any count against the measured facts. THEN set \`pass\` true only if every feature the request requires is present and correct; base \`reason\` on the decisive feature(s), naming any that are missing or wrong. Decomposing first guards against a "looks roughly right" pass and against hallucinating features that aren't there.`;
 
@@ -37,6 +39,12 @@ const VERDICT = z.object({
   pass: z
     .boolean()
     .describe('true only if every feature the request requires is present and correct'),
+  quality: z
+    .enum(['worse', 'on-par', 'better'])
+    .nullable()
+    .describe(
+      "candidate quality RELATIVE to the reference exemplar (form/proportion/feature-fidelity/finish, NOT size); null when no reference is shown. A part can `pass` yet be 'worse'."
+    ),
   manufacturable: z
     .boolean()
     .describe(
@@ -65,13 +73,16 @@ export interface JudgeInput {
   model: string;
   /** Deterministic metrics the render can't show; rendered into the user message as ground truth. */
   metrics?: MetricsDigest;
+  /** Renders of a known-good exemplar of the SAME request. When present, the judge grades the
+   * candidate's `quality` relative to it — the gradient above the absolute `pass` floor. */
+  referencePngPaths?: readonly string[];
 }
 
-export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdict> {
-  // Up to 8 views — the four orthographic shots, the xray internal pass, the aimed section, and the
-  // marked view. The xray/section reveal internals the opaque views can't; the marks let the judge
-  // reference features by id — all must reach the judge.
-  const images = input.pngPaths.slice(0, 8).map((p) => ({
+// One image content block per PNG (base64-inlined). Up to 8 views — the four orthographic shots, the
+// xray internal pass, the aimed section, and the marked view. The xray/section reveal internals the
+// opaque views can't; the marks let the judge reference features by id — all must reach the judge.
+function toImages(paths: readonly string[]): Anthropic.ImageBlockParam[] {
+  return paths.slice(0, 8).map((p) => ({
     type: 'image' as const,
     source: {
       type: 'base64' as const,
@@ -79,6 +90,34 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
       data: readFileSync(p).toString('base64'),
     },
   }));
+}
+
+export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdict> {
+  const reference = input.referencePngPaths ?? [];
+  // Label the candidate group, then (when present) the reference group, so the model never confuses
+  // which renders it is grading — the relative `quality` axis depends on that separation.
+  const content: Anthropic.ContentBlockParam[] = [
+    { type: 'text', text: 'CANDIDATE part renders:' },
+    ...toImages(input.pngPaths),
+  ];
+  if (reference.length > 0) {
+    content.push(
+      {
+        type: 'text',
+        text: 'REFERENCE exemplar renders (a known-good build of the SAME request — grade the candidate relative to this):',
+      },
+      ...toImages(reference)
+    );
+  }
+  content.push({
+    type: 'text',
+    text:
+      `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\n` +
+      (input.metrics ? `${formatDigest(input.metrics)}\n\n` : '') +
+      (reference.length > 0
+        ? `Does the candidate satisfy the request and rubric, and how does its quality compare to the reference?`
+        : `Does the rendered part satisfy the request and rubric?`),
+  });
 
   const response = await client.messages.parse(
     {
@@ -86,21 +125,7 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
       max_tokens: 1024,
       // Frozen across every prompt → cache it (prefix match; verify via cache_read_input_tokens).
       system: [{ type: 'text', text: JUDGE_SYSTEM, cache_control: { type: 'ephemeral' } }],
-      messages: [
-        {
-          role: 'user',
-          content: [
-            ...images,
-            {
-              type: 'text',
-              text:
-                `Request:\n${input.prompt}\n\nRubric (must be satisfied):\n${input.rubric}\n\n` +
-                (input.metrics ? `${formatDigest(input.metrics)}\n\n` : '') +
-                `Does the rendered part satisfy the request and rubric?`,
-            },
-          ],
-        },
-      ],
+      messages: [{ role: 'user', content }],
       output_config: { format: zodOutputFormat(VERDICT) },
     },
     { signal: AbortSignal.timeout(120_000) }
@@ -110,6 +135,7 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
     response.parsed_output ?? {
       features: [],
       pass: false,
+      quality: null,
       manufacturable: false,
       usedMetrics: false,
       reason: 'judge returned no parseable verdict',

--- a/packages/brepjs-cad/bench/judge.ts
+++ b/packages/brepjs-cad/bench/judge.ts
@@ -131,14 +131,15 @@ export async function judge(client: Anthropic, input: JudgeInput): Promise<Verdi
     { signal: AbortSignal.timeout(120_000) }
   );
 
-  return (
-    response.parsed_output ?? {
-      features: [],
-      pass: false,
-      quality: null,
-      manufacturable: false,
-      usedMetrics: false,
-      reason: 'judge returned no parseable verdict',
-    }
-  );
+  const verdict = response.parsed_output ?? {
+    features: [],
+    pass: false,
+    quality: null,
+    manufacturable: false,
+    usedMetrics: false,
+    reason: 'judge returned no parseable verdict',
+  };
+  // With no reference shown the relative grade is meaningless — force null so a spurious model
+  // 'worse' can't block the loop's convergence (preserves the no-reference back-compat path).
+  return reference.length === 0 ? { ...verdict, quality: null } : verdict;
 }

--- a/packages/brepjs-cad/bench/live.ts
+++ b/packages/brepjs-cad/bench/live.ts
@@ -9,6 +9,7 @@ import { playgroundPrompts } from './playgroundCorpus.js';
 import { formatScorecard, type EvalResult, type Scorecard } from './score.js';
 import { runAttemptLoop, type ChatMessage, type LoopDeps } from './loop.js';
 import { judge, missingFeatures } from './judge.js';
+import { adaptReferenceCode } from './adaptReference.js';
 import { createTelemetry } from './langfuse.js';
 import { skillVersion } from './skillVersion.js';
 
@@ -148,6 +149,27 @@ async function evalPrompt(
   args: Args,
   workdir: string
 ): Promise<EvalResult> {
+  // Render the reference exemplar once per prompt (the corpus example's own source, adapted to a
+  // CLI-renderable module). Its renders give the judge a known-good build of the SAME request to
+  // grade quality against — the gradient above the absolute pass floor. Best-effort: if the
+  // reference can't build/render, the judge degrades to absolute grading (quality:null).
+  let referencePngPaths: readonly string[] = [];
+  if (p.referenceCode) {
+    try {
+      const refStep = join(workdir, `${p.id}-ref.step`);
+      const refOutcome = await runProgramWithStep(adaptReferenceCode(p.referenceCode), refStep, {
+        metrics: false,
+      });
+      if (refOutcome.outcome === 'completed' && refOutcome.stepPath) {
+        referencePngPaths = await snapshot(refOutcome.stepPath, `${refStep}-shots`);
+      } else {
+        console.warn(`  reference did not build for ${p.id} — judging without exemplar`);
+      }
+    } catch (e) {
+      console.warn(`  reference render skipped (${(e as Error).message.split('\n')[0]})`);
+    }
+  }
+
   // Wire the real author/execute/snapshot/judge into the bounded loop. Execution runs in the
   // sandbox (out-of-process, timeout/OOM-bounded) so an unattended nightly run can't hang on a
   // model-authored infinite loop; the STEP it writes is what the judge renders.
@@ -168,6 +190,7 @@ async function evalPrompt(
           pngPaths: [...pngPaths],
           model: args.judgeModel,
           ...(metrics ? { metrics } : {}),
+          ...(referencePngPaths.length > 0 ? { referencePngPaths } : {}),
         });
         // Surface the per-feature decomposition's misses in the reason so the retry/heal feedback
         // bundle gets actionable specifics ("missing: motor bore") rather than a vague sentence.
@@ -175,7 +198,7 @@ async function evalPrompt(
         const reason = missing.length
           ? `${v.reason} [missing/wrong: ${missing.join(', ')}]`
           : v.reason;
-        return { pass: v.pass, reason, manufacturable: v.manufacturable };
+        return { pass: v.pass, reason, manufacturable: v.manufacturable, quality: v.quality };
       } catch (e) {
         console.warn(`  judge failed (${(e as Error).message.split('\n')[0]})`);
         return null;

--- a/packages/brepjs-cad/bench/live.ts
+++ b/packages/brepjs-cad/bench/live.ts
@@ -156,6 +156,12 @@ async function evalPrompt(
   let referencePngPaths: readonly string[] = [];
   if (p.referenceCode) {
     try {
+      // The reference is a playground example — the corpus is gated to valid, single-connected
+      // solids (the connectivity test in playgroundExamples.test.ts), so it builds a STEP under the
+      // sandboxed `--check --step` path. A reference that fails to build is excluded (quality:null →
+      // absolute grading): better to fall back than to anchor against a broken exemplar. (The
+      // strict path is the only sandboxed step export; the lenient snapshot/runPart render gates on
+      // Result.Ok not validity, but needs an in-process kernel the eval process doesn't init.)
       const refStep = join(workdir, `${p.id}-ref.step`);
       const refOutcome = await runProgramWithStep(adaptReferenceCode(p.referenceCode), refStep, {
         metrics: false,

--- a/packages/brepjs-cad/bench/loop.ts
+++ b/packages/brepjs-cad/bench/loop.ts
@@ -1,4 +1,10 @@
-import { checkAuto, type AttemptResult, type AutoResult, type EvalResult } from './score.js';
+import {
+  checkAuto,
+  type AttemptResult,
+  type AutoResult,
+  type EvalResult,
+  type QualityGrade,
+} from './score.js';
 import { digestMetrics, type MetricsDigest } from './metrics.js';
 import type { EvalPrompt } from './prompts.js';
 import type { RunProgramWithStepResult } from '../src/sandbox/runProgram.js';
@@ -27,7 +33,14 @@ export interface LoopDeps {
   judge: (
     pngPaths: readonly string[],
     metrics?: MetricsDigest
-  ) => Promise<{ pass: boolean; reason: string; manufacturable?: boolean } | null>;
+  ) => Promise<{
+    pass: boolean;
+    reason: string;
+    manufacturable?: boolean;
+    /** Quality vs the reference exemplar (null = no reference shown). A 'worse' verdict keeps the
+     * loop iterating even when the part passes the absolute floor. */
+    quality?: QualityGrade | null;
+  } | null>;
 }
 
 export interface LoopOptions {
@@ -64,9 +77,17 @@ function codesFromOutcome(outcome: RunProgramWithStepResult): string[] {
 function buildFeedbackBundle(
   outcome: RunProgramWithStepResult,
   auto: AutoResult,
-  judgeReason: string | undefined
+  judgeReason: string | undefined,
+  quality: QualityGrade | null | undefined
 ): string {
-  const lines = ['The previous attempt did not pass. Fix it and return the full corrected module.'];
+  // A part can be objectively valid yet graded WORSE than the reference — then the only reason to
+  // retry is quality, and "did not pass" would misdescribe it. Lead with the right framing.
+  const onlyQuality = auto.pass && quality === 'worse';
+  const lines = [
+    onlyQuality
+      ? 'The previous attempt is valid but lower quality than a known-good reference part. Improve it and return the full corrected module.'
+      : 'The previous attempt did not pass. Fix it and return the full corrected module.',
+  ];
   if (outcome.outcome === 'completed') {
     for (const info of outcome.report.errorInfos) lines.push(`- error: ${info.message}`);
     for (const h of outcome.report.hints) lines.push(`- fix (${h.code}): ${h.fix} ${h.nextStep}`);
@@ -78,6 +99,10 @@ function buildFeedbackBundle(
     lines.push(`- the program crashed: ${outcome.detail}`);
   }
   for (const f of auto.failures) lines.push(`- check failed: ${f}`);
+  if (quality === 'worse')
+    lines.push(
+      `- a reviewer judged the rendered part WORSE than a reference build of the same request — improve its form/proportion/feature fidelity.`
+    );
   if (judgeReason) lines.push(`- a reviewer of the rendered part said: ${judgeReason}`);
   return lines.join('\n');
 }
@@ -106,6 +131,7 @@ export async function runAttemptLoop(
     let judgePass: boolean | undefined;
     let judgeReason: string | undefined;
     let manufacturable: boolean | undefined;
+    let quality: QualityGrade | null | undefined;
     if (wantJudge && outcome.outcome === 'completed' && outcome.stepPath) {
       const pngs = await deps.snapshot(outcome.stepPath);
       if (pngs.length > 0) {
@@ -115,6 +141,7 @@ export async function runAttemptLoop(
           judgePass = v.pass;
           judgeReason = v.reason;
           manufacturable = v.manufacturable;
+          quality = v.quality;
         }
       }
     }
@@ -128,10 +155,13 @@ export async function runAttemptLoop(
     if (judgePass !== undefined) result.judgePass = judgePass;
     if (judgeReason !== undefined) result.judgeReason = judgeReason;
     if (manufacturable !== undefined) result.manufacturable = manufacturable;
+    if (quality !== undefined) result.quality = quality;
     attempts.push(result);
 
-    // An absent judge does not block convergence (judge:— is a legitimate skip, not a fail).
-    if (auto.pass && (judgePass ?? true)) {
+    // Converge only when the part clears the absolute floor AND is not graded WORSE than the
+    // reference exemplar. An absent judge or absent reference doesn't block (judge:—/quality:null
+    // are legitimate skips, not fails) — only an explicit 'worse' keeps the loop iterating.
+    if (auto.pass && (judgePass ?? true) && quality !== 'worse') {
       termination = 'CONVERGED';
       break;
     }
@@ -141,7 +171,10 @@ export async function runAttemptLoop(
     }
     // Retry: append the prior code (extracted text only — no raw thinking blocks) + the feedback.
     messages.push({ role: 'assistant', content: code });
-    messages.push({ role: 'user', content: buildFeedbackBundle(outcome, auto, judgeReason) });
+    messages.push({
+      role: 'user',
+      content: buildFeedbackBundle(outcome, auto, judgeReason, quality),
+    });
   }
 
   const firstTry = attempts[0];
@@ -160,5 +193,6 @@ export async function runAttemptLoop(
   if (eventual?.judgePass !== undefined) out.judgePass = eventual.judgePass;
   if (eventual?.judgeReason !== undefined) out.judgeReason = eventual.judgeReason;
   if (eventual?.manufacturable !== undefined) out.manufacturable = eventual.manufacturable;
+  if (eventual?.quality !== undefined) out.quality = eventual.quality;
   return out;
 }

--- a/packages/brepjs-cad/bench/loop.ts
+++ b/packages/brepjs-cad/bench/loop.ts
@@ -77,12 +77,15 @@ function codesFromOutcome(outcome: RunProgramWithStepResult): string[] {
 function buildFeedbackBundle(
   outcome: RunProgramWithStepResult,
   auto: AutoResult,
+  judgePass: boolean | undefined,
   judgeReason: string | undefined,
   quality: QualityGrade | null | undefined
 ): string {
-  // A part can be objectively valid yet graded WORSE than the reference — then the only reason to
-  // retry is quality, and "did not pass" would misdescribe it. Lead with the right framing.
-  const onlyQuality = auto.pass && quality === 'worse';
+  // A part can be objectively valid AND clear the judge's floor yet still be graded WORSE than the
+  // reference — then the only reason to retry is quality, and "did not pass" would misdescribe it.
+  // Require judgePass===true so a real judge FAILURE (a missing/wrong feature) keeps the corrective
+  // framing instead of being softened to a quality nudge.
+  const onlyQuality = auto.pass && judgePass === true && quality === 'worse';
   const lines = [
     onlyQuality
       ? 'The previous attempt is valid but lower quality than a known-good reference part. Improve it and return the full corrected module.'
@@ -173,7 +176,7 @@ export async function runAttemptLoop(
     messages.push({ role: 'assistant', content: code });
     messages.push({
       role: 'user',
-      content: buildFeedbackBundle(outcome, auto, judgeReason, quality),
+      content: buildFeedbackBundle(outcome, auto, judgePass, judgeReason, quality),
     });
   }
 

--- a/packages/brepjs-cad/bench/playgroundCorpus.ts
+++ b/packages/brepjs-cad/bench/playgroundCorpus.ts
@@ -34,6 +34,9 @@ export async function playgroundPrompts(): Promise<EvalPrompt[]> {
         category: c.id as EvalPrompt['category'],
         prompt: e.description,
         rubric: e.description,
+        // The example's own source is the known-good reference the judge grades against — so the
+        // eval measures the author's part vs the curated build of the same request, not vs nothing.
+        referenceCode: e.code,
       })
     )
   );

--- a/packages/brepjs-cad/bench/prompts.ts
+++ b/packages/brepjs-cad/bench/prompts.ts
@@ -24,6 +24,10 @@ export interface EvalPrompt {
   prompt: string;
   /** What a correct part must show — handed to the multimodal judge. */
   rubric: string;
+  /** A known-good `.brep.ts` source for this request (e.g. the playground example). When present,
+   * the live eval renders it and hands the judge a reference exemplar so it can grade quality
+   * relative to it — the gradient above the absolute pass floor. */
+  referenceCode?: string;
   /** Objective dimensional checks, when the prompt pins them unambiguously. */
   expected?: {
     volume?: number;

--- a/packages/brepjs-cad/bench/score.ts
+++ b/packages/brepjs-cad/bench/score.ts
@@ -5,8 +5,9 @@ import type { EvalPrompt } from './prompts.js';
 // Pure scoring + scorecard formatting for the live eval. No I/O, no network —
 // unit-tested directly (see tests/liveEvalScore.test.ts).
 
-/** Score/scorecard schema version — bump when the score/scorecard shape changes (vision §H). */
-export const SCHEMA_VERSION = 2;
+/** Score/scorecard schema version — bump when the score/scorecard shape changes (vision §H).
+ * v3 adds the judge's relative `quality` grade to each attempt/result. */
+export const SCHEMA_VERSION = 3;
 
 export interface AutoResult {
   /** Objective signal: valid solid (ok=true) AND any pinned dims within tolerance. */
@@ -313,9 +314,13 @@ export function formatScorecard(card: Scorecard): string {
     lines.push(`  manufacturable ${pct(ok, mfgJudged.length)}  (n=${mfgJudged.length})`);
   }
 
-  // Quality gradient vs the reference exemplar (the gating axis above the floor): how many passing
-  // parts the judge ranked worse/on-par/better than a known-good build of the same request.
-  const graded = card.results.filter((r) => r.quality !== null && r.quality !== undefined);
+  // Quality gradient vs the reference exemplar (the gating axis ABOVE the floor): of the parts that
+  // cleared the floor (valid + judge-pass), how many the judge ranked worse/on-par/better than a
+  // known-good build of the same request. Floor-failing parts are excluded — their grade isn't an
+  // above-floor signal (a missing-feature part can still carry a 'worse' grade).
+  const graded = card.results.filter(
+    (r) => r.quality !== null && r.quality !== undefined && r.auto.pass && r.judgePass === true
+  );
   if (graded.length > 0) {
     const n = (g: QualityGrade): number => graded.filter((r) => r.quality === g).length;
     lines.push(

--- a/packages/brepjs-cad/bench/score.ts
+++ b/packages/brepjs-cad/bench/score.ts
@@ -14,6 +14,10 @@ export interface AutoResult {
   failures: string[];
 }
 
+/** The judge's quality grade RELATIVE to a reference exemplar — the gradient above the `pass` floor.
+ * null when no reference was shown (the judge graded absolutely). */
+export type QualityGrade = 'worse' | 'on-par' | 'better';
+
 /** The scorer's normalized per-attempt unit — deliberately free of sandbox types. */
 export interface AttemptResult {
   auto: AutoResult;
@@ -21,6 +25,9 @@ export interface AttemptResult {
   judgeReason?: string | undefined;
   /** The judge's manufacturability axis (separate from `pass`/match). Non-gating; recorded only. */
   manufacturable?: boolean | undefined;
+  /** The judge's quality grade vs the reference exemplar; null = no reference, undefined = not judged.
+   * GATES convergence: a 'worse' attempt keeps iterating even when it `pass`es the floor. */
+  quality?: QualityGrade | null | undefined;
   outcome: 'completed' | 'timeout' | 'crashed';
   /** Whether this attempt produced a STEP (a valid solid the judge could render). */
   hasStep: boolean;
@@ -38,6 +45,8 @@ export interface EvalResult {
   judgeReason?: string | undefined;
   /** The eventual attempt's manufacturability axis (non-gating; recorded for the scorecard). */
   manufacturable?: boolean | undefined;
+  /** The eventual attempt's quality grade vs the reference exemplar (null = no reference shown). */
+  quality?: QualityGrade | null | undefined;
   /** undefined when generation/build failed before a report existed. */
   error?: string | undefined;
   /** Per-attempt trail from the bounded loop (absent for the legacy single-shot path). */
@@ -274,7 +283,8 @@ export function formatScorecard(card: Scorecard): string {
     const a = r.error ? 'ERR ' : r.auto.pass ? 'valid' : 'INVALID';
     const j = r.judgePass === undefined ? 'judge:—' : r.judgePass ? 'judge:✓' : 'judge:✗';
     const mfg = r.manufacturable === false ? ' mfg:⚠' : '';
-    lines.push(`  ${r.id.padEnd(pad)}  ${a.padEnd(7)} ${j}${mfg}`);
+    const q = r.quality ? ` q:${r.quality}` : '';
+    lines.push(`  ${r.id.padEnd(pad)}  ${a.padEnd(7)} ${j}${mfg}${q}`);
     if (r.error) lines.push(`        ${r.error}`);
     else {
       for (const f of r.auto.failures) lines.push(`        auto: ${f}`);
@@ -301,6 +311,16 @@ export function formatScorecard(card: Scorecard): string {
   if (mfgJudged.length > 0) {
     const ok = mfgJudged.filter((r) => r.manufacturable === true).length;
     lines.push(`  manufacturable ${pct(ok, mfgJudged.length)}  (n=${mfgJudged.length})`);
+  }
+
+  // Quality gradient vs the reference exemplar (the gating axis above the floor): how many passing
+  // parts the judge ranked worse/on-par/better than a known-good build of the same request.
+  const graded = card.results.filter((r) => r.quality !== null && r.quality !== undefined);
+  if (graded.length > 0) {
+    const n = (g: QualityGrade): number => graded.filter((r) => r.quality === g).length;
+    lines.push(
+      `  quality vs ref  better ${n('better')}  on-par ${n('on-par')}  worse ${n('worse')}  (n=${graded.length})`
+    );
   }
 
   // The lodestar signal: does iterating beat single-shot? (Omitted for legacy single-shot results.)

--- a/packages/brepjs-cad/tests/liveEvalLoop.test.ts
+++ b/packages/brepjs-cad/tests/liveEvalLoop.test.ts
@@ -247,6 +247,32 @@ describe('runAttemptLoop', () => {
     expect(second?.[2]?.content).toContain('lower quality');
   });
 
+  it('keeps the "did not pass" framing when the judge FAILED the part, even if also graded worse', async () => {
+    const seen: ChatMessage[][] = [];
+    let n = 0;
+    await runAttemptLoop(
+      PROMPT,
+      deps({
+        author: (messages) => {
+          seen.push(messages);
+          return Promise.resolve(`// v${++n}\nexport default () => box(1,1,1);`);
+        },
+        // judge FAILS the part (missing feature) and grades it worse — the retry must read as a
+        // real failure to fix, not a soft "lower quality" nudge.
+        judge: () =>
+          Promise.resolve(
+            n === 1
+              ? { pass: false, reason: 'missing the bore', quality: 'worse' as const }
+              : { pass: true, reason: 'ok' }
+          ),
+      }),
+      { maxAttempts: 3 }
+    );
+    const second = seen[1];
+    expect(second?.[2]?.content).toContain('did not pass');
+    expect(second?.[2]?.content).not.toContain('lower quality');
+  });
+
   it('an absent quality grade (no reference) does not block convergence', async () => {
     const res = await runAttemptLoop(
       PROMPT,

--- a/packages/brepjs-cad/tests/liveEvalLoop.test.ts
+++ b/packages/brepjs-cad/tests/liveEvalLoop.test.ts
@@ -188,6 +188,77 @@ describe('runAttemptLoop', () => {
     expect(res.code).toBe('export default () => box(5, 5, 5);');
   });
 
+  it('keeps iterating when the part passes the floor but is graded WORSE than the reference', async () => {
+    // Valid + judge-pass every attempt, but always 'worse' → the binary would have converged on
+    // attempt 1; the quality gate must keep it iterating to the cap instead.
+    const res = await runAttemptLoop(
+      PROMPT,
+      deps({
+        judge: () => Promise.resolve({ pass: true, reason: 'crude', quality: 'worse' as const }),
+      }),
+      { maxAttempts: 3 }
+    );
+    expect(res.iterations).toBe(3);
+    expect(res.termination).toBe('EXHAUSTED');
+    expect(res.auto.pass).toBe(true); // objectively valid the whole way
+    expect(res.judgePass).toBe(true); // and clears the absolute floor
+    expect(res.quality).toBe('worse'); // but never beats the reference
+  });
+
+  it('converges once quality climbs from worse to on-par (the gradient is climbable)', async () => {
+    let n = 0;
+    const res = await runAttemptLoop(
+      PROMPT,
+      deps({
+        judge: () =>
+          Promise.resolve(
+            ++n === 1
+              ? { pass: true, reason: 'crude', quality: 'worse' as const }
+              : { pass: true, reason: 'clean', quality: 'on-par' as const }
+          ),
+      }),
+      { maxAttempts: 3 }
+    );
+    expect(res.iterations).toBe(2);
+    expect(res.termination).toBe('CONVERGED');
+    expect(res.quality).toBe('on-par');
+  });
+
+  it('frames a worse-grade retry as valid-but-lower-quality, not "did not pass"', async () => {
+    const seen: ChatMessage[][] = [];
+    let n = 0;
+    await runAttemptLoop(
+      PROMPT,
+      deps({
+        author: (messages) => {
+          seen.push(messages);
+          return Promise.resolve(`// v${++n}\nexport default () => box(1,1,1);`);
+        },
+        judge: () =>
+          Promise.resolve(
+            n === 1
+              ? { pass: true, reason: 'crude', quality: 'worse' as const }
+              : { pass: true, reason: 'ok' }
+          ),
+      }),
+      { maxAttempts: 3 }
+    );
+    const second = seen[1];
+    expect(second?.[2]?.content).toContain('lower quality');
+  });
+
+  it('an absent quality grade (no reference) does not block convergence', async () => {
+    const res = await runAttemptLoop(
+      PROMPT,
+      // judge returns no `quality` field → must behave exactly like the pre-grading binary.
+      deps({ judge: () => Promise.resolve({ pass: true, reason: 'ok' }) }),
+      { maxAttempts: 3 }
+    );
+    expect(res.iterations).toBe(1);
+    expect(res.termination).toBe('CONVERGED');
+    expect(res.quality).toBeUndefined();
+  });
+
   it('captures the eventual code after a retry, not the first attempt', async () => {
     let authorN = 0;
     let execN = 0;

--- a/packages/brepjs-cad/tests/liveEvalScore.test.ts
+++ b/packages/brepjs-cad/tests/liveEvalScore.test.ts
@@ -109,6 +109,38 @@ describe('formatScorecard', () => {
     // 2/3 valid overall, 1/3 judged matching, 1/3 both.
     expect(out).toMatch(/TOTAL\s+valid 67%\s+judge 33%\s+both 33%/);
   });
+
+  it('counts only floor-clearing parts in the quality-vs-ref summary', () => {
+    const results: EvalResult[] = [
+      // cleared the floor (valid + judge-pass) but graded worse → an above-floor 'worse'.
+      {
+        id: 'crude',
+        category: 'mechanical',
+        auto: { pass: true, failures: [] },
+        judgePass: true,
+        quality: 'worse',
+      },
+      // cleared the floor and on-par.
+      {
+        id: 'good',
+        category: 'mechanical',
+        auto: { pass: true, failures: [] },
+        judgePass: true,
+        quality: 'on-par',
+      },
+      // FAILED the floor yet still carries a 'worse' grade — must NOT count as above-floor quality.
+      {
+        id: 'no-bore',
+        category: 'mechanical',
+        auto: { pass: true, failures: [] },
+        judgePass: false,
+        quality: 'worse',
+      },
+    ];
+    const out = formatScorecard({ model: 'm', brepjsVersion: 'v', date: 'd', results });
+    // worse=1 (crude only — the floor-failing no-bore is excluded), on-par=1, n=2.
+    expect(out).toMatch(/quality vs ref\s+better 0\s+on-par 1\s+worse 1\s+\(n=2\)/);
+  });
 });
 
 describe('runScores', () => {

--- a/packages/brepjs-cad/tests/manufacturability.test.ts
+++ b/packages/brepjs-cad/tests/manufacturability.test.ts
@@ -187,6 +187,7 @@ describe('missingFeatures (decomposed rubric)', () => {
   const verdict = (features: Verdict['features']): Verdict => ({
     features,
     pass: false,
+    quality: null,
     manufacturable: true,
     usedMetrics: false,
     reason: 'x',


### PR DESCRIPTION
## Problem

The live eval judge (`bench/judge.ts` → `bench/loop.ts`) returned an **absolute boolean with no comparand**, so the repair loop converged the instant a part cleared the "valid solid with the named features present" floor (`loop.ts`: `auto.pass && (judgePass ?? true)`). It had no way to rank *quality* above that floor.

A controlled A/B test (one part, five variants, judged on the real 5-view loop input) confirmed the failure:

| Variant | Reality | Old binary judge |
|---|---|---|
| golden | clean | **pass** |
| crude | all features, grotesque proportions | **pass** |
| scaled | 2× uniform | **pass** |
| thin-wall | 0.2 mm wall, near-degenerate | **pass** (`manufacturable:true`) |
| no-bore | named feature deleted | fail |

Everything that cleared the floor passed identically — no gradient. The enriched evidence layers (xray/section/marks) couldn't help because the verdict *type* couldn't express "worse," and a judge shown one part in isolation has nothing to calibrate against.

## Fix

Put a **reference exemplar + a graded relative verdict on the gating path**:

- **`judge.ts`** — `JudgeInput.referencePngPaths`; `VERDICT.quality` (`'worse' | 'on-par' | 'better'`, nullable). `JUDGE_SYSTEM` now grades quality *relative to a labelled reference* (explicitly **not** on size/scale) as the gradient above the absolute `pass` floor, and treats the image as decisive when the deterministic bore count over-reports.
- **`loop.ts`** — convergence now also requires `quality !== 'worse'`: a passing-but-worse part keeps iterating with a reframed "valid but lower quality" feedback bundle. An absent quality/reference does **not** block (fully back-compatible with the no-reference path).
- **`live.ts`** — render the corpus example once per prompt via the existing `adaptReferenceCode` and hand it to the judge. The reference is **free** — the playground *is* the corpus.
- **`playgroundCorpus.ts` / `prompts.ts`** — carry the example source as `EvalPrompt.referenceCode`.
- **`score.ts`** — `QualityGrade` type + `quality` on the attempt/result + scorecard surfacing (`q:worse` row tag, "quality vs ref" summary).

## Proof

Re-ran the same A/B with the reference shown:

| Variant | Old | New (vs reference) | Loop now |
|---|---|---|---|
| crude | pass → done | pass · **worse** | retries |
| scaled | pass → done | pass · **on-par** | converge (scale not penalized) |
| thin-wall | pass → done | pass · **worse** | retries — *the 0.2 mm wall is obvious side-by-side* |
| no-bore | fail | fail · worse | retries |

The gradient the binary lacked now exists. Notably the relative comparison catches the thin wall that no single-part absolute view could.

## Verification

`bench/` is outside the root pre-commit lint-staged/vitest scope, so it was verified with the package's own gates:

- `npm run typecheck -w brepjs-cad` ✅
- `npm run lint -w brepjs-cad` ✅
- `npm run test -w brepjs-cad` ✅ — 193 tests (+4 new loop gating tests covering: worse blocks convergence, the gradient is climbable, the retry framing, and back-compat for an absent grade)
- prettier ✅

## Caveat

The graded judge was validated **in-session** (the harness default `judgeModel` is `claude-opus-4-8`, so me-as-judge is the real decision conditions) because the billed `judge()` path needs an `ANTHROPIC_API_KEY` not present locally. The definitive confirmation is one billed `eval:live` run on CI, where the new `q:*` columns appear and the loop iterates past first-pass on low-quality parts instead of stopping at the floor.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

