### PR TITLE
chore(lint): ban enum and require exhaustive switches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,8 @@ Monorepo packages:
 - Consistent type imports (`import type` enforced)
 - No `var`, strict equality, `prefer-const`, `prefer-readonly`
 - `no-unsafe-*` rules disabled due to WASM type gaps
-- `no-restricted-syntax` bans `.oc` access, `.wrapped.method()` calls in Layer 2+ code, and `export let` everywhere
+- `no-restricted-syntax` bans `.oc` access, `.wrapped.method()` calls in Layer 2+ code, `export let` everywhere, and `enum` (use an `as const` object + literal union)
+- `switch-exhaustiveness-check`: switches over a union/enum must handle every case (a `default` clause counts as exhaustive)
 - `ban-ts-comment` requires `@ts-expect-error -- reason` format; `@ts-ignore` and `@ts-nocheck` are banned
 - `no-console` is an error (only `console.error`/`console.warn` allowed)
 - Pattern checker inline disable: `// brepjs-patterns-disable: <rule-id>` (line above or inline)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,10 @@ const sharedRules = {
   '@typescript-eslint/no-unsafe-argument': 'off',
   '@typescript-eslint/no-this-alias': 'error',
   '@typescript-eslint/prefer-readonly': 'error',
+  '@typescript-eslint/switch-exhaustiveness-check': [
+    'error',
+    { considerDefaultExhaustiveForUnions: true },
+  ],
   // Require @ts-expect-error with "-- reason" format; ban @ts-ignore entirely
   '@typescript-eslint/ban-ts-comment': [
     'error',
@@ -43,6 +47,12 @@ const noMutableExport = {
   message: 'Mutable exports (`export let`) are forbidden. Use a getter function or const instead.',
 };
 
+const noEnum = {
+  selector: 'TSEnumDeclaration',
+  message:
+    '`enum` is banned. Use an `as const` object + literal union instead — better refactoring, serialization, and tree-shaking. See CLAUDE.md.',
+};
+
 // ─── Config ──────────────────────────────────────────────────────────
 
 export default tseslint.config(
@@ -58,7 +68,7 @@ export default tseslint.config(
     },
     rules: {
       ...sharedRules,
-      'no-restricted-syntax': ['error', noMutableExport],
+      'no-restricted-syntax': ['error', noMutableExport, noEnum],
     },
   },
   // Kernel internal: suppress redundant-type-constituents since KernelShape=any is intentional
@@ -96,6 +106,7 @@ export default tseslint.config(
       'no-restricted-syntax': [
         'error',
         noMutableExport,
+        noEnum,
         {
           selector: 'MemberExpression[property.name="oc"]',
           message:


### PR DESCRIPTION
## What

Two zero-violation harness guardrails, sourced from common TypeScript practice and chosen because they were *enforceable* and *currently unguarded*:

1. **Ban `enum`** — a `noEnum` `no-restricted-syntax` selector (`TSEnumDeclaration`), mirroring the existing `noMutableExport` pattern, applied in both the `src/**` and Layer-2+ config blocks. The codebase has **0 enums** and already prefers `as const` literal unions by convention (per CLAUDE.md), so this just prevents drift.
2. **`switch-exhaustiveness-check`** (error) — added to `sharedRules` so it covers `src/` and `tests/`, with `considerDefaultExhaustiveForUnions: true` so a `default` clause counts as exhaustive. All 52 existing switches already pass.

Plus a CLAUDE.md lint-rules note for both.

## Why

These map to two of the "TypeScript tips everyone should know" (avoid `enum`, exhaustive checks with `never`) that the project practiced by convention but didn't enforce. Both land with **zero** code to fix — pure guardrails that fail only on future regressions.

## Verification

- `src/` lint: clean (exit 0) — both rules add nothing to fix.
- `tests/`: 57 pre-existing errors, **identical on `main`** (stash-compared); none from these rules.
- Planted-violation probe confirmed both rules actually fire (an `enum` and a non-exhaustive `switch` each errored).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

