### PR TITLE
docs(skills): add engineering skill library under .claude/skills

### DIFF
--- a/.claude/skills/adding-operations/SKILL.md
+++ b/.claude/skills/adding-operations/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: adding-operations
+description: This skill should be used when adding or extending a geometric shape operation in brepjs — the end-to-end recipe once the target module is chosen (which is decided by architecture-navigation) — when a task says "add a new operation", "add a fillet/draft/shell variant", "expose this Fns function in the public API", "add a method to the shape() fluent wrapper", "new function is missing from function-lookup.md", "knip flags my new export", or "where do I export this from". Covers the *Fns.ts implementation template, the six export surfaces, the function-lookup CI gate, and what to test.
+---
+
+# Adding a geometric operation
+
+End-to-end playbook for adding a shape operation: implement in a `*Fns.ts` file, surface through up to six export layers, test, and pass the docs gate. Supersedes the outline in `.claude/commands/new-operation.md` (whose step 7 test naming, `tests/fn-<name>.test.ts`, is stale — no such files exist; use `tests/<moduleName>.test.ts`). `docs/codebase-map.md` repeats the same stale `fn-*` names — do not copy from it.
+
+## Step 0 — Scope and home
+
+- **Needs a new kernel capability?** If OCCT must do something the `KernelAdapter` interface cannot express yet, add the kernel method first: follow `.claude/commands/new-kernel-method.md` (interface in `src/kernel/types.ts` / `src/kernel/interfaces/*.ts`, implementation in `src/kernel/occt/*Ops.ts`, wire `src/kernel/occt/defaultAdapter.ts` plus the occtWasm and brepkit adapters). See the kernel-abstraction skill. Test the new capability only through the Layer-2 API, never `*Ops` directly.
+- **Pick the module**: `src/topology/` for shape-transforming ops (booleans, modifiers, healing), `src/operations/` for construction ops (extrude, revolve, loft), other Layer-2 dirs per the architecture-navigation skill. Read that module's `README.md` first — `src/topology/README.md` documents the two API styles, validity brands, and six gotchas.
+- **Extend before creating**: prefer adding to an existing `*Fns.ts` (e.g. `modifierFns.ts` for a new modifier) over a new file.
+
+## Step 1 — Implement in `*Fns.ts`
+
+New functionality goes in `*Fns.ts` files first (`src/topology/README.md`, gotcha 6). Canonical templates: `src/topology/booleanFns.ts` (fuse/cut with evolution tracking) and `src/topology/modifierFns.ts` (the `draft` function, with rich validation via `validateDraftInputs`). The five-part shape of a Fns function:
+
+**(a) Branded signature, validity-brand overloads.** Take and return branded types from `src/core/shapeTypes.ts`. Ops that require topological validity take brands (`ValidSolid`, `ClosedWire`, ...) and offer an `unsafe: true` overload for trusted callers — the pattern in `booleanFns.ts`:
+
+```ts
+export function fuse(a: ValidSolid, b: ValidSolid, options?: BooleanOptions): Result<ValidSolid>;
+export function fuse(
+  a: Shape3D,
+  b: Shape3D,
+  options: BooleanOptions & { unsafe: true }
+): Result<Shape3D>;
+```
+
+**(b) Validate inputs → `err(validationError(...))`.** Check null shapes, parameter bounds, empty selections. Add new codes to the `BrepErrorCode` `as const` object in `src/core/errors.ts` (`enum` is lint-banned). Constructor signature: `validationError(code, message, cause?, metadata?, suggestion?)` — always fill `suggestion` with an actionable hint. Model: `validateDraftInputs` in `modifierFns.ts` (zero-angle, out-of-range, empty face list, each with a suggestion). See the result-error-handling skill for code taxonomy.
+
+**(c) Call the kernel via `getKernel()`.** `getKernel().method(shape.wrapped, ...)` — reading `.wrapped` as an argument is fine, but calling methods on it (or touching `.oc`) is ESLint-banned in Layer 2+; the `architecture-navigation` skill owns that rule. For shape-mutating ops, follow the evolution pattern from `fuse`: default `trackEvolution = true`, `collectInputFaceHashes(inputs)` + `HASH_CODE_MAX`, call the `*WithHistory` kernel variant, then `propagateAllMetadata(evolution, inputs, result)` on success (helpers in `src/topology/metadata/metadataPropagation.ts`). On history-path diagnostics errors with a null result, `fuse` disposes it, `console.warn`s, and retries the plain kernel call — only `console.warn`/`console.error` pass lint.
+
+**(d) Cast and verify the result.** `castShape(raw)` (`src/core/shapeTypes.ts`, defaults to 3D) then a type guard (`isShape3D`, `isSolid`, ...). On guard failure, **dispose the wrapped shape before returning the error** — copy `castToShape3D` in `booleanFns.ts`, which calls `wrapped[Symbol.dispose]()` and returns `err(typeCastError(...))` naming the actual TopAbs type. Modifiers share `finalizeShape3D` in `modifierFns.ts` (cast + metadata propagation in one call).
+
+**(e) Never throw — wrap kernel calls in try/catch.** Convert exceptions to `err(kernelError(code, msg, cause, metadata))` with operation metadata (`{ operation, faceCount, angle }` in `draft`). One deliberate exception: abort signals rethrow (`if (signal?.aborted) throw signal.reason;` at the top of `fuse`).
+
+Keep functions short — `npm run check:patterns` fails lint-staged on long functions and double-casts; extract helpers rather than adding a baseline entry (quality-gates skill).
+
+## Step 2 — Surface it (export checklist)
+
+There are two barrels per module and they are **not** chained: `src/topology/index.ts` is a small internal Layer-2 barrel, while `src/topology.ts` is the published `brepjs/topology` sub-path entry. `src/index.ts` (root entry) re-exports **most** Fns/api symbols directly from their source files (the `booleanFns` and `api.js` blocks); a smaller set of topology helpers (`cast`, `downcast`, `applyGlue`, `isNumber`, ...) is still re-exported via the `./topology/index.js` barrel. New operations belong in the direct `api.js`/`booleanFns` blocks. Work through this table top to bottom:
+
+| #   | Surface                | File                                                                                                         | When                                                                                                 |
+| --- | ---------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| 1   | Implementation         | `src/<module>/<x>Fns.ts`                                                                                     | Always                                                                                               |
+| 2   | Short-named public api | `src/topology/api.ts` (or `src/operations/api.ts`)                                                           | If it deserves a clean short name                                                                    |
+| 3   | Root `brepjs` entry    | `src/index.ts` — add to the matching export block (the `./topology/api.js` block, or the `booleanFns` block) | Always                                                                                               |
+| 4   | Sub-path entry         | `src/topology.ts` / `src/operations.ts` / etc.                                                               | If it should be importable from `brepjs/topology` — **this is what feeds `docs/function-lookup.md`** |
+| 5   | Namespace API          | `src/ns/<group>.ts` (e.g. `src/ns/booleans.ts` re-exports from `@/topology/api.js`)                          | If a matching namespace group exists                                                                 |
+| 6   | Fluent facade          | `src/topology/wrapperFns.ts`                                                                                 | If chaining reads naturally                                                                          |
+
+Notes per surface:
+
+- **api.ts (2)**: accept `Shapeable<T>` and call `resolve()` (both from `src/topology/apiTypes.ts`); take an options object, not positional params (`DraftOptions` in `apiTypes.ts`; `RotateOptions` in `api.ts`); delegate to the Fns function passing `unsafe: true` when bridging a validity-brand requirement (see `fuse` in `api.ts`). Finder-style selection params type as `Face[] | FinderFn<Face> | ShapeFinder<Face>` resolved via `resolveFaces`.
+- **Sub-path (4)**: `scripts/generate-function-lookup.ts` scans only the `SUBPATHS` map (`src/core.ts`, `src/topology.ts`, `src/operations.ts`, `src/2d.ts`, `src/sketching.ts`, `src/query.ts`, `src/measurement.ts`, `src/io.ts`, `src/worker.ts`, `src/shapeRef.ts`) — never `src/index.ts`. A root-only export silently never appears in `docs/function-lookup.md` and the gate stays green: the short api.ts names (`fuse`, `cut`, `draft`, `fillet`...) are root-only today, so none of them are in the lookup. Decide deliberately which side of that line the new op sits on.
+- **`brepjs/quick`** needs no step — `src/quick.ts` does `export * from './index.js'`.
+- **wrapperFns (6)**: two edits — add the method to the right `Wrapped`/`Wrapped3D` interface, and to the matching factory (`create3DBooleans`, `create3DModifiers`, `create3DCompoundOps`, ...). Methods call the api.ts function, `unwrapOrThrow` (throws `BrepWrapperError`), and bridge validity brands via the centralized trust-casts `asValidSolid` / `trustAsT` (already carrying `brepjs-patterns-disable: no-double-cast`). Pattern: `draft: (faces, opts) => wrap3D(trustAsT<T>(unwrapOrThrow(draftFn(asValidSolid(val), faces, opts))))`. Never add a wrapper method without a Fns implementation behind it.
+
+## Step 3 — Regenerate the function lookup
+
+If step 4 changed a sub-path entry:
+
+```bash
+npm run docs:generate-lookup
+```
+
+CI's `build` job (`.github/workflows/ci.yml`) regenerates, runs `npx prettier --write docs/function-lookup.md`, then `git diff --exit-code` — a stale file **or** a committed raw-generator (compact, un-prettified) file both fail it. lint-staged prettifies the file on commit, so regenerate-then-commit normally suffices; otherwise run prettier on it manually. Pre-commit also runs `scripts/check-function-lookup.sh`, a non-blocking reminder when `*Fns.ts` or index files are staged without the lookup.
+
+## Step 4 — Tests
+
+Full skeleton, assertions, kernel projects, and coverage rules live in the writing-tests skill. Operation-specific minimum:
+
+- File: `tests/<moduleName>.test.ts` (e.g. `draftFns.test.ts`) — extend the module's existing file.
+- Happy path: `isOk` + `unwrap`, shape-kind guard, and a real measurement (`unwrap(measureVolume(shape))` with `toBeCloseTo`).
+- Every validation branch: `isErr` + `expect(unwrapErr(result).code).toBe('DRAFT_INVALID_ANGLE')`-style code assertions.
+- Null-shape input error path (`NULL_SHAPE_INPUT`).
+- If behavior differs across kernels, gate via the divergence registry (`skipIfDiverges` / `shouldSkipSuite` from `tests/helpers/kernelDivergences.js`), never inline kernel checks.
+- Coverage functions floor is 91% — an untested exported function will fail `npm run test:full`.
+
+## Step 5 — Gates before commit
+
+```bash
+npm run validate   # typecheck → lint → check:boundaries → format:check → changed tests
+```
+
+Pre-push runs **knip only**. A new export nothing imports yet trips it; if the export is exercised only from `tests/`, tag it `@testOnly` in JSDoc (`knip.config.ts` treats the tag as used). Full gate anatomy: quality-gates skill.
+
+Consider a playground example for user-visible ops (playground-examples skill).
+
+## Worked example — `draft` across every surface
+
+| Surface            | Location                                                                                                                                                                                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Kernel interface   | `src/kernel/interfaces/modifierOps.ts` (`draft`), `src/kernel/interfaces/evolutionOps.ts` (`draftWithHistory`)                                                                                                                                                                        |
+| Fns implementation | `src/topology/modifierFns.ts`, the `draft` function: `draft(shape: ValidSolid, faces, pullDirection, neutralPlane, angle): Result<ValidSolid>`; `validateDraftInputs`; `getKernel().draftWithHistory(...)`; `finalizeShape3D`; catch → `kernelError(BrepErrorCode.DRAFT_FAILED, ...)` |
+| Param types        | `src/topology/apiTypes.ts` (`DraftOptions`, `DraftAngle`)                                                                                                                                                                                                                             |
+| Public api         | `src/topology/api.ts`, the `draft` function: `draft<T extends ValidSolid>(shape: Shapeable<T>, faces, options: DraftOptions)` with `resolveFaces`                                                                                                                                     |
+| Fluent             | `src/topology/wrapperFns.ts`: `Wrapped3D` interface entry + `create3DModifiers`                                                                                                                                                                                                       |
+| Root export        | `src/index.ts` (inside the `./topology/api.js` block)                                                                                                                                                                                                                                 |
+| Sub-path           | **absent** from `src/topology.ts` — hence `draft` does not appear in `docs/function-lookup.md` (the root-only-export gap, live)                                                                                                                                                       |
+| Tests              | `tests/draftFns.test.ts` (`initKernel`, error-code assertions, `shouldSkipSuite`)                                                                                                                                                                                                     |
+
+## Symptom → cause → fix
+
+| Symptom                                                                       | Cause                                                                   | Fix                                                                                                       |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `Direct method calls on .wrapped are banned` (ESLint)                         | Called `shape.wrapped.Method()` in Layer 2+                             | Route through `getKernel().method(shape.wrapped)`; missing kernel capability → new-kernel-method playbook |
+| CI build job fails on `git diff --exit-code docs/function-lookup.md`          | Forgot `npm run docs:generate-lookup`, or committed unprettified output | Regenerate, `npx prettier --write docs/function-lookup.md`, commit                                        |
+| New function missing from function-lookup.md, gate green                      | Exported from `src/index.ts` only                                       | Export from the sub-path entry (`src/topology.ts` etc.) if it belongs in the table                        |
+| knip fails on pre-push for the new export                                     | Nothing outside the file imports it yet                                 | Wire the remaining surfaces, or tag `@testOnly` if test-only                                              |
+| `check:patterns` max-function-lines on the new Fns function                   | Validation + kernel call + finalize inlined                             | Extract a `validate<Op>Inputs` helper and reuse `finalizeShape3D`/`castToShape3D`                         |
+| Type error: `Shape3D` not assignable to `ValidSolid` at the api/wrapper layer | Validity-brand overload not bridged                                     | api.ts passes `unsafe: true`; wrapperFns uses `asValidSolid`/`trustAsT`                                   |
+| Coverage functions threshold fails after adding the op                        | Exported function or error branch untested                              | Cover each validation branch and the happy path (writing-tests skill)                                     |
+
+## Additional resources
+
+- `src/topology/README.md` — module map, API styles, validity brands, gotchas.
+- `.claude/commands/new-kernel-method.md` — kernel-layer prerequisite steps.
+- `docs/which-api.md` — fluent vs functional vs sketcher guidance for placement decisions.
+- Sibling skills: `architecture-navigation` (which layer/module), `kernel-abstraction` (adapters and `getKernel`), `result-error-handling` (Result/BrepError conventions), `writing-tests` (test skeleton and multi-kernel gating), `quality-gates` (validate/hooks/knip/patterns), `memory-and-disposal` (`using`/dispose-on-failure rationale), `debugging-geometry` (when the op returns invalid geometry), `playground-examples` (showcasing the op).

--- a/.claude/skills/architecture-navigation/SKILL.md
+++ b/.claude/skills/architecture-navigation/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: architecture-navigation
+description: This skill should be used when deciding which layer or module a new file, function, or directory belongs in, or when a layer-boundary check fails. It owns the placement decision (which layer/module) and the import-direction rules — not the end-to-end recipe for wiring an operation through the API ladder (that is adding-operations). Trigger phrases include "where should this file/function go", "which layer is X in", "can topology import from sketching", "layer boundary violation", "check:boundaries failed", "VIOLATION: src/... imports from", "Direct .oc access is banned", "method calls on .wrapped are banned", or adding a new src/ directory or module.
+---
+
+# Navigating the layered architecture
+
+brepjs enforces a four-layer architecture where imports flow downward or sideways, never upward. The enforcement script is the source of truth for layer membership — `CLAUDE.md` and `docs/architecture.md` summaries lag behind it.
+
+## Layer table (source of truth: `scripts/check-layer-boundaries.sh`)
+
+| Layer | Directories                                                                                                  | May import from                    |
+| ----- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| 0     | `kernel/`, `utils/`                                                                                          | nothing internal (same-layer only) |
+| 1     | `core/`                                                                                                      | layer 0                            |
+| 2     | `topology/`, `2d/`, `operations/`, `query/`, `measurement/`, `io/`, `worker/`, `csg/`, `voxel/`, `implicit/` | layers 0–1 + each other            |
+| 3     | `sketching/`, `text/`, `projection/`, `gear/`, `ns/`, `lattice/`                                             | layers 0–2 + each other            |
+
+Rules and caveats:
+
+- The rule is `target_layer <= source_layer` (the `if (( target_layer > src_layer ))` check in `scripts/check-layer-boundaries.sh`). Same-layer imports are always legal — e.g. `src/topology/wrapperFns.ts` imports `@/operations/api.js` and `@/measurement/measureFns.js` (both Layer 2).
+- Files at the `src/` root (`index.ts`, `quick.ts`, sub-path entries like `topology.ts`, `core.ts`, `result.ts`) are **exempt** — the script assigns them layer `-1` and skips them. They exist to re-export everything.
+- The script resolves both `@/` alias and relative imports, but only greps `from '...'` statements — dynamic `import()` expressions without `from` are not checked. Do not rely on that gap.
+- When adding a **new top-level `src/` directory**, add it to the `case` statement in the `get_layer()` function in `scripts/check-layer-boundaries.sh` and to the error-message layer listing at the bottom of the same script, or its imports go entirely unchecked.
+
+## Decision procedure: where does new code belong?
+
+Work through this list in order; stop at the first match.
+
+1. **A raw kernel/OCCT API call** (anything touching `oc.*` or WASM objects) → a `*Ops.ts` file under `src/kernel/occt/` (or `src/kernel/brepkit/`), exposed as a method on `KernelAdapter` in `src/kernel/types.ts`. Follow the `/new-kernel-method` command in `.claude/commands/`. See the kernel-abstraction skill.
+2. **A pure helper with no geometry dependency** (string/array/math utilities) → `src/utils/`.
+3. **Shared types, `Result`, vectors, memory/disposal, branded shape types** → `src/core/` (e.g. `src/core/result.ts`, `src/core/shapeTypes.ts`, `src/core/disposal.ts`).
+4. **A shape operation** (transform, boolean, modifier, query, measurement, I/O) → the matching Layer 2 module's `*Fns.ts` file, then climb the API ladder below. See the adding-operations skill for the full recipe.
+5. **High-level sugar composing Layer 2 operations** (sketch DSL, text, projection, gear generators, namespace re-exports) → the matching Layer 3 module.
+6. **In doubt between two layers** → put it in the _lower_ layer that has everything it needs. Code can always be re-exported upward; it can never import upward.
+
+### The API ladder (Layer 2 shape operations)
+
+New functionality goes in `*Fns.ts` first, then surfaces upward. The full chain (mermaid diagram in `src/topology/README.md`):
+
+```
+shape() fluent facade (wrapperFns.ts)
+  → api.ts (functional public API)
+    → *Fns.ts implementations
+      → cast.ts / getKernel()
+```
+
+Checklist when adding an operation:
+
+1. Implement in the module's `*Fns.ts` (e.g. `src/topology/booleanFns.ts`), taking/returning branded types from `src/core/shapeTypes.ts`, returning `Result<T, E>` for fallible operations (see the result-error-handling skill).
+2. Add a short-named wrapper in `src/topology/api.ts` that accepts `Shapeable<T>` and delegates via `resolve()` (both from `src/topology/apiTypes.ts`), using an options object for optional parameters. Pattern:
+
+   ```typescript
+   export function translate<T extends AnyShape<Dimension>>(shape: Shapeable<T>, v: Vec3): T {
+     return transforms.translate(resolve(shape), v);
+   }
+   ```
+
+3. Optionally add a chainable method on `Wrapped<T>` in `src/topology/wrapperFns.ts` — it must delegate to `api.ts`, never contain its own implementation.
+4. Export from `src/index.ts` (organized by layer with `// ── Layer N ──` banners) and the matching sub-path entry at `src/` root (`topology.ts`, `operations.ts`, etc. — table in `docs/codebase-map.md`).
+5. Update the module's `README.md` if one exists (pre-commit prints a non-blocking reminder via `scripts/check-readme-reminders.sh`).
+
+## Import and naming rules
+
+| Rule                                                                                                            | Enforced by                                                                |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Imports flow downward/same-layer only                                                                           | `check:boundaries` (pre-commit, CI, `npm run validate`)                    |
+| Cross-directory imports use `@/` alias (`@/kernel/index.js`); same-directory imports stay relative (`./foo.js`) | convention only                                                            |
+| All `.ts` imports use `.js` extensions (ESM; Vite transforms at build time)                                     | convention only — typecheck passes without it, so review for it explicitly |
+| camelCase filenames (no PascalCase, no kebab-case)                                                              | convention only                                                            |
+| `import type` for type-only imports                                                                             | ESLint `consistent-type-imports`                                           |
+
+The `@/` alias maps to `./src/*` via `tsconfig.json` `paths` and `vite.config.ts` `resolve.alias`.
+
+## The kernel-abstraction rule
+
+Layer 2+ code treats shapes as opaque handles. Read `shape.wrapped` only to pass it into a kernel method — never call methods on it, and never touch `.oc`:
+
+```typescript
+// Correct: .wrapped passed as an argument
+const volume = getKernel().volume(shape.wrapped);
+
+// Banned: method called ON .wrapped
+const hash = shape.wrapped.HashCode(1000);
+```
+
+ESLint enforces both bans via the `no-restricted-syntax` rule in the "Kernel abstraction boundary" config block in `eslint.config.js`, but only for ten enumerated directories: `topology/`, `operations/`, `measurement/`, `query/`, `io/`, `2d/`, `sketching/`, `projection/`, `text/`, `worker/`. The rule applies just as much in `csg/`, `voxel/`, `implicit/`, `gear/`, `ns/`, and `lattice/` — lint simply does not cover them yet, so apply it by discipline there (and add new directories to the ESLint file list when creating them).
+
+If an operation needs a kernel capability that `KernelAdapter` lacks, the fix is never to reach through `.wrapped` — add the method to the adapter first (kernel-abstraction skill, `/new-kernel-method` command).
+
+## Fixing violations
+
+| Symptom                                                                                                                                  | Cause                                                                                                                                      | Fix                                                                                                                                                                                                                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VIOLATION: src/operations/foo.ts (layer 2: operations) imports from '@/sketching/draw.js' (layer 3: sketching)` from `check:boundaries` | Lower layer imports a higher one                                                                                                           | One of: (a) move the importing code up to the higher layer, (b) extract the shared logic down into a layer both can import (usually `core/` or a Layer 2 sibling), (c) invert the dependency — have the higher layer pass data/callbacks down |
+| `Direct .oc access is banned in Layer 2+ code` (ESLint)                                                                                  | Raw OCCT call outside `kernel/`                                                                                                            | Move the call into a kernel `*Ops.ts` file behind a `KernelAdapter` method, then call `getKernel().method(...)`                                                                                                                               |
+| `Direct method calls on .wrapped are banned in Layer 2+ code` (ESLint)                                                                   | Treating a shape handle as an object with behavior                                                                                         | Find (or add) the equivalent `KernelAdapter` method in `src/kernel/types.ts` and call it via `getKernel()`                                                                                                                                    |
+| Boundary check passes locally but fails in CI                                                                                            | Pre-commit runs only the **staged** variant (`check:boundaries:staged`, `.husky/pre-commit` Tier 1); CI's `quality` job runs the full tree | Run `npm run check:boundaries` (full) before pushing                                                                                                                                                                                          |
+| New directory's imports never flagged                                                                                                    | Directory missing from the script's `case` statement (layer `-1` is skipped)                                                               | Register it in `scripts/check-layer-boundaries.sh`                                                                                                                                                                                            |
+
+Reproduce locally:
+
+```bash
+npm run check:boundaries          # full tree
+npm run check:boundaries:staged   # staged files only (what pre-commit runs)
+npx eslint src/ --quiet           # .oc / .wrapped bans
+npm run validate                  # typecheck + lint + boundaries + format + changed tests
+```
+
+Where each gate runs: pre-commit Tier 1 (staged boundaries, parallel with lint-staged and typecheck), CI `quality` job in `.github/workflows/ci.yml` (full boundaries + `check:patterns` + `knip`), and `scripts/validate-change.sh` via `npm run validate`. See the quality-gates skill for the full gate matrix.
+
+## Additional resources
+
+- `docs/architecture.md` — layer diagrams, data flow, key patterns with correct/banned `.wrapped` examples (layer lists predate `csg/voxel/implicit/gear/ns/lattice`; trust the script).
+- `docs/codebase-map.md` — sub-path entry-point table and module→key-file maps.
+- `docs/which-api.md` — choosing between the fluent wrapper, Sketcher, functional API, and Drawing as a _consumer_.
+- `CONTRIBUTING.md` — "Layer Boundaries" and "ESM Imports" sections, including the boundary-error walkthrough.
+- Module READMEs exist for `2d`, `core`, `io`, `kernel`, `kernel/manifold`, `measurement`, `operations`, `projection`, `query`, `sketching`, `text`, `topology`, `utils` — read the target module's README before adding code there. (`worker`, `csg`, `voxel`, `implicit`, `gear`, `ns`, `lattice` have none yet.)
+- ADRs for the "why": `docs/decisions/0001-layered-architecture.md`, `0002-kernel-abstraction.md`, `0006-domain-boundaries.md`, `0007-kernel-interface-segregation.md`.
+- Sibling skills: `adding-operations` (end-to-end operation recipe), `kernel-abstraction` (adapter methods, `getKernel`/`withKernel`), `result-error-handling` (`Result<T,E>` conventions), `quality-gates` (all local/CI checks).

--- a/.claude/skills/assembly-solver/SKILL.md
+++ b/.claude/skills/assembly-solver/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: assembly-solver
+description: This skill should be used when working on brepjs assemblies, constraint solving, or kinematics — debugging a solve that returns ASSEMBLY_NOT_CONVERGED / ASSEMBLY_MATE_INVALID / ASSEMBLY_SOLVE_FAILED, adding or extending a mate or solver entity-pair, adding a joint type, or driving a mechanism. Trigger phrases include "assembly won't converge", "Unsupported constraint types", "solveAssembly returns Err", "add a mate/joint/constraint type", "extend TRANSLATIONAL_PAIRS", "solveMate: unsupported entity pair escaped filter", "revolute/prismatic/cylindrical/planar/spherical joint", "forwardKinematics", "inverse kinematics / IK target", "DH table / Denavit-Hartenberg", "export/import URDF", or "positioned STEP export from an assembly". Not for boolean fuse/cut compounds (that is debugging-geometry).
+---
+
+# Assemblies, constraint solving, and kinematic joints
+
+Covers two Layer-2 subsystems: the immutable assembly tree with its analytical constraint solver, and drivable kinematic joints (forward/inverse kinematics, DH, URDF). All of it is pure data + math with no kernel calls, except the STEP export at the very end.
+
+## Two unrelated meanings of "assembly" — do not conflate
+
+This is the number-one source of confusion. There are two "assembly" APIs that share a word and nothing else.
+
+1. **Assembly tree + mates + joints** — an immutable `AssemblyNode` tree (`src/operations/assemblyFns.ts`), constraint mates (`src/operations/mateFns.ts`), and kinematic joints (`src/operations/jointFns.ts`). Pure data + math. This is what the constraint solver and all the kinematics operate on.
+2. **Assembly STEP export** — `exportAssemblySTEP` / `createAssembly` / `exportSTEP` (`src/operations/exporterFns.ts`, `src/operations/exporters.ts`). An XCAF colored/named multi-shape STEP writer. It takes a flat `ShapeOptions[]`, **not** an `AssemblyNode`, and never reads mates, joints, or solved transforms.
+
+There is **no bridge** between them. A solved tree's transforms are not fed into `exportAssemblySTEP`. To write a positioned STEP, apply the solved transforms to the shapes and pass them as `ShapeOptions[]`.
+
+## The solver mental model
+
+Read `CLAUDE.md`'s "Assembly solver composes constraints down a chain" gotcha first — it is the authoritative one-liner. `solveConstraints(nodes, constraints)` in `src/kernel/solverAdapter.ts` is the analytical (closed-form, non-iterative) core. Its algorithm:
+
+- Every node starts at origin/identity.
+- A **positioning mate** is one of `coincident`, `distance`, `angle`, `concentric` (the `POSITIONING_TYPES` set) with both entities present. **`entityA` is the reference, `entityB` is the dependent.**
+- **Anchors sit at the origin**: any node that is never a dependent (a chain root), plus any explicit `fixed` node.
+- Well-typed mates resolve in **topological rounds**: a mate places its dependent once its reference is already placed, solving against the reference's _solved world-space pose_ (rotation included), so multi-body chains compose.
+- Diagnostics: an entity-type mismatch is pushed as `type(a-b)` and dropped; a mate whose reference never resolves (cycle/dangling) is pushed as `type(unanchored)`. `converged = unsupported.length === 0`.
+
+`mateFns.solveAssembly` wraps this: it extracts geometry, calls `solveConstraints`, and maps the result to a `Result<AssemblySolveResult>`.
+
+## From `MateEntity` to a solver entity type
+
+A `MateEntity` is `{ node, face?, edge?, point? }`. `extractEntity` in `mateFns.ts` maps it to a solver entity typed `plane`, `axis`, or `point`:
+
+- **face** → `faceAxis(face)` (from `faceFns.ts`); non-null (a cylindrical/axial face) → `axis`, else `plane` via `faceCenter` + `normalAt`. `faceAxis` returning null is the axial-vs-planar discriminator.
+- **edge** → `LINE` type → `axis` along its tangent; else `curveAxis` (circular edge, e.g. a bore rim) → `axis`; else `null`.
+- **point** → `point`.
+
+If extraction returns null for either entity, `solveAssembly` fails with `ASSEMBLY_MATE_INVALID` ("could not extract geometry from mate entities").
+
+## Supported constraint pairs
+
+`isSupportedPair` (in `solverAdapter.ts`) decides solvability:
+
+| Mate type                | Allowed `(entityA-entityB)` pairs                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `coincident`, `distance` | `TRANSLATIONAL_PAIRS`: plane-plane, plane-point, point-plane, point-point, axis-axis, axis-point, point-axis |
+| `concentric`             | `REQUIRED_ENTITIES`: axis-axis only                                                                          |
+| `angle`                  | `REQUIRED_ENTITIES`: plane-plane only                                                                        |
+| `fixed`                  | one entity, anchors that node at origin                                                                      |
+
+Both orders are listed for translational pairs, so entities need not be pre-ordered.
+
+## Debugging a failed solve
+
+The three error codes live in `src/core/errors.ts` (`ASSEMBLY_MATE_INVALID`, `ASSEMBLY_SOLVE_FAILED`, `ASSEMBLY_NOT_CONVERGED`). URDF errors instead use the generic `VALIDATION_FAILED`; STEP export uses `STEP_EXPORT_FAILED`.
+
+## Symptom → cause → fix
+
+| Symptom                                                                          | Cause                                                                                                               | Fix                                                                                              |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `ASSEMBLY_MATE_INVALID: no mates defined`                                        | Called `solveAssembly` before `addMate`                                                                             | Add at least one mate                                                                            |
+| `ASSEMBLY_MATE_INVALID: could not extract geometry`                              | A `MateEntity` face/edge yielded no plane/axis/point (e.g. a non-line, non-circular edge)                           | Pick an axial/planar face, a straight or circular edge, or a point                               |
+| `ASSEMBLY_NOT_CONVERGED: Unsupported constraint types: coincident(axis-plane) …` | Entity-type mismatch — pair not in the supported table (the canonical case is `coincident(axis-plane)`)             | Fix the entities so the pair is supported (e.g. axis-axis for concentric, plane-plane for angle) |
+| `ASSEMBLY_NOT_CONVERGED: … concentric(plane-plane) …`                            | `concentric`/`angle` got the wrong entity types (they require axis-axis / plane-plane)                              | Feed the required entity types                                                                   |
+| `ASSEMBLY_NOT_CONVERGED: … coincident(unanchored) …`                             | Reference never resolved — a mutual-reference cycle (a→b, b→a) or a dangling reference, with no root/`fixed` anchor | Add a `fixed` mate to anchor the chain, or break the loop                                        |
+| `ASSEMBLY_NOT_CONVERGED: … solver did not converge` (no `unsupported` list)      | Rare: no diagnostics but still not converged                                                                        | Inspect the mate graph for an unanchored dependent                                               |
+| `ASSEMBLY_SOLVE_FAILED: …`                                                       | An exception was thrown inside the solve (see below)                                                                | Read the wrapped message; likely the `solveMate` escaped-filter invariant                        |
+
+The `dof` in the message is the sum over unsupported mates of `UNSUPPORTED_DOF` (coincident 3, concentric 4, distance 1, angle 1). `tests/mateFns.test.ts` has worked examples of every diagnostic, including the axis-plane and the a→b/b→a cycle.
+
+## Extending the solver (new mate or entity pair)
+
+The load-bearing invariant: `solveMate`'s default branch **throws** `"solveMate: unsupported entity pair escaped filter"` when `solveTranslational` returns null after `isSupportedPair` passed — i.e. the pair set and the dispatch switch drifted out of sync (surfaces as `ASSEMBLY_SOLVE_FAILED`).
+
+To add a translational entity pair (e.g. a new axis-plane handling), update **both** in `solverAdapter.ts`:
+
+1. Add the key to `TRANSLATIONAL_PAIRS`.
+2. Add the matching `case` in the `solveTranslational` switch (with a per-pair solve function like the existing `solvePlanePair`, `solveConcentric`, `solveAxisToPoint`).
+
+For a new orientation/axis mate, add to `REQUIRED_ENTITIES` and give it a branch in `solveMate`; add its type to `POSITIONING_TYPES` and `UNSUPPORTED_DOF`. Then surface it through `mateFns.ts`: extend the `MateConstraint` union and `mateToSolverConstraint`, and export from the public surface. See the `adding-operations` skill for the export/`function-lookup.md` gate and `result-error-handling` for adding an error code.
+
+## Joints and kinematics
+
+`src/operations/jointFns.ts` defines five joint types. A `Joint` connects `parent` (stationary reference) → `child` (moving); `dofs` is the source of truth; `value`/`min`/`max` mirror the primary (first) DOF for single-DOF ergonomics, and `axis` is the joint's anchor/primary axis (equal to the primary DOF axis only for single-axis joints, not for spherical/planar). Every DOF value is always clamped to `[min, max]` (`makeDof` normalizes inverted ranges).
+
+| Joint         | DOFs                                         | Default ranges               |
+| ------------- | -------------------------------------------- | ---------------------------- |
+| `revolute`    | 1 rotation                                   | -180..180                    |
+| `prismatic`   | 1 translation (ignores `axis.origin`)        | 0..100                       |
+| `cylindrical` | rotation + slide on one axis                 | rot -180..180, trans 0..100  |
+| `planar`      | u-trans, v-trans, rotation about normal      | u/v -100..100, rot -180..180 |
+| `spherical`   | x, y, z rotations about a pivot (`Rx·Ry·Rz`) | each -180..180               |
+
+- **Drive**: `setJointValues(joint, number[])` sets per-DOF positionally; `setJointValue(joint, n)` sets only the primary. `jointTransform(joint, value?)` returns the child's local pose — a single `number` overrides the primary DOF only, an array overrides positionally.
+- **Forward kinematics**: `forwardKinematics(assembly, jointValues?)` returns a world `JointPose` for every node, keyed by **child** name, resolved topologically: `childWorld = parentWorld ∘ jointTransform ∘ offset?`. Roots sit at origin. `mechanismDOF` sums open-chain DOFs (closed-loop Grübler/Kutzbach is future work).
+- **Add a joint type**: write a constructor building `dofs` via `makeDof` + `buildJoint`. FK/IK differentiate through `dofs`, so kinematics stays joint-agnostic automatically.
+
+## Driving: inverse kinematics and trajectories
+
+`src/operations/ikFns.ts`. `inverseKinematics(assembly, endEffector, target, options?)` is damped-least-squares over a numerically-differentiated Jacobian of `forwardKinematics` — joint-type agnostic. `IKTarget` is `{ position, rotation? }`; omit `rotation` for position-only (m=3 vs m=6). Options: `maxIterations` (200), `tolerance` (1e-5), `damping` (0.05), `seed`, `tip`. Gotcha: the finite-difference Jacobian steps _inward_ from a bound, because `forwardKinematics` clamps each DOF — a forward `+eps` at a limit would give a zero column and trap the solver.
+
+`jointTrajectory(assembly, from, to, steps)` samples a straight line in joint space, returning `steps + 1` samples (both endpoints inclusive). Joints absent from `from`/`to` hold their stored value.
+
+## DH and URDF interchange
+
+`src/operations/dhFns.ts` — `jointsFromDH(rows, {base?})` builds a serial revolute/prismatic chain from a distal DH table. Each row → one joint; the variable is θ (revolute) or d (prismatic) about/along +z, and the fixed link geometry `Rz(θ)·Tz(d)·Tx(a)·Rx(α)` rides on `Joint.offset` so each row contributes exactly one DOF.
+
+`src/operations/urdfFns.ts` — `exportURDF` round-trips only `revolute`/`prismatic`; it **errors** (`VALIDATION_FAILED`) on any multi-DOF joint or any joint carrying an `offset` (so DH chains cannot `exportURDF`). Revolute limits convert degrees↔radians on the boundary; prismatic emits a zero origin (brepjs prismatic FK ignores `axis.origin`). `importURDF(xml)` is a regex reader: `continuous` → revolute -180..180, and `fixed`/`floating`/`planar` joints are skipped (their links still listed).
+
+## Assembly STEP / XCAF export
+
+`exportAssemblySTEP(shapes: ShapeOptions[], { unit?, modelUnit? })` → `Result<Blob>` (MIME `application/STEP`). `ShapeOptions` is `{ shape, color?, alpha?, name? }`. The OOP twin `createAssembly` returns a disposable `AssemblyExporter` (a `KernelHandle`); `exportSTEP` disposes it via `Symbol.dispose`. See `src/operations/README.md` for units/colors — do not restate them. This path needs the kernel's `createXCAFDocument` / `writeXCAFToSTEP`; assembly-STEP XCAF is a known occt-wasm divergence, so check the `kernel-abstraction` skill for current support. For handle disposal see `memory-and-disposal`.
+
+## Where things are exported (asymmetry to know)
+
+Everything is in `src/operations.ts` and re-exported from root `brepjs` — **except mates**: `addMate`, `solveAssembly`, `MateConstraint`, `MateEntity`, `AssemblySolveResult` are exported **only from root `brepjs`** (`src/index.ts`), not from `brepjs/operations`. The solver core (`solveConstraints`, `SolverEntity`, `SolverConstraint`) is not barrelled at all — import it directly from `@/kernel/solverAdapter.js`, as the tests do.
+
+## Additional resources
+
+- `tests/mateFns.test.ts` — every solve + diagnostic case; `tests/jointFns.test.ts`, `tests/dhFns.test.ts`, `tests/ikFns.test.ts`, `tests/urdfFns.test.ts`, `tests/assemblyFns.test.ts` — usage examples.
+- `src/operations/README.md` — the STEP/XCAF export details (units, colors, disposal).
+
+### Sibling skills
+
+- `result-error-handling` — unwrapping `Result`, adding a `BrepErrorCode`.
+- `kernel-abstraction` — whether `createXCAFDocument`/`writeXCAFToSTEP` are supported per kernel.
+- `adding-operations` — the export surfaces + `function-lookup.md` gate when adding a mate/joint function.
+- `writing-tests` — the test skeleton.
+- `memory-and-disposal` — the `AssemblyExporter` `KernelHandle` and `using`.
+- `debugging-geometry` — for fused-compound "assemblies", which are a different thing entirely.

--- a/.claude/skills/brepjs-verify
+++ b/.claude/skills/brepjs-verify
@@ -1,1 +1,0 @@
-../../packages/brepjs-verify/skill

--- a/.claude/skills/ci-triage/SKILL.md
+++ b/.claude/skills/ci-triage/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: ci-triage
+description: This skill should be used when a brepjs GitHub Actions job is red or behaving oddly on github.com (a remote CI run, not a local pre-commit/pre-push hook) — "CI failed", "ci-pass is failing", "npm ci failed with EUSAGE/ETARGET in CI", "test shard timed out", "function-lookup.md diff failed in the build job", "check:patterns fails in CI on code I didn't touch", "npm publish workflow failed", "docs deploy didn't run", "playground smoke is red", "OSV scan is red", "release PR won't auto-merge", or npm ci fails in a CI run after a Dependabot bump on a workspace "*" dependency. Maps each CI job's known failure modes to causes and fixes. For a hook blocking a local commit, use quality-gates or git-pr-workflow instead.
+---
+
+# CI failure triage
+
+Diagnose a red or stuck brepjs GitHub Actions run. Triage in two moves: first classify **which workflow and job** failed and **on what event** (PR vs push-to-main vs manual dispatch vs deployment); then match the symptom to the table below.
+
+Most failure modes are documented in inline comments in the workflow files themselves — cite line refs (e.g. `.github/workflows/ci.yml:244-250`) rather than re-deriving. This skill is the index and the recovery recipes.
+
+## Job map — what runs, when
+
+The single required PR check is **`ci-pass`** (`ci.yml:431-459`). It `needs` every gate job and fails if any result is `failure` or `cancelled` (a `skipped` result passes). Its needs-list: `changes, typecheck, lint, quality, build, playground-build, packages-viewer, packages-verify, packages-sheetmetal, packages-bim, voxel-wasm-rust, test, size, benchmark`. Deliberately **not** in the list: `coverage`.
+
+The `changes` job (`ci.yml:18-67`) path-filters into three outputs — `code`, `playground`, `voxel` — that gate the rest. Branches named `release-please--*` skip the filter entirely (`ci.yml:29-36`): release PRs run no code jobs (they touch only CHANGELOG/version/manifest).
+
+| Job                                        | Command(s)                                                                                                   | Event / gate                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| `typecheck`                                | `npm run typecheck`                                                                                          | PR+push, `code`                    |
+| `lint`                                     | `npm run lint` + `format:check`                                                                              | PR+push, `code`                    |
+| `quality`                                  | `check:boundaries` + `check:patterns` + `knip`                                                               | PR+push, `code`                    |
+| `build`                                    | `npm run build` + `docs:api` + function-lookup staleness gate                                                | PR+push, `code`                    |
+| `playground-build`                         | build root + brepjs-bim + brepjs-sheetmetal + apps/playground (mirrors Vercel)                               | PR+push, `playground`              |
+| `packages-viewer` / `-sheetmetal` / `-bim` | typecheck+lint+test+build per workspace (root `build` first for `-sheetmetal`/`-bim`; viewer builds no root) | PR+push, `code`                    |
+| `packages-verify` (brepjs-cad)             | build root+viewer+cad, then `eval`, `smoke`, `smoke:standalone`                                              | PR+push, `code`                    |
+| `voxel-wasm-rust`                          | `cargo test` + `cargo clippy -D warnings`                                                                    | PR+push, `voxel` only              |
+| `test`                                     | `test:ci --shard=N/4`, matrix `[1,2,3,4]`                                                                    | PR+push, `code`                    |
+| `coverage`                                 | `test:full` (maxWorkers=2, timeout 180s)                                                                     | **push-only**, `continue-on-error` |
+| `size`                                     | size-limit-action                                                                                            | **PR-only**                        |
+| `benchmark`                                | compare vs main, 25% regression threshold                                                                    | **PR-only**                        |
+
+Consequence: a **PR** failure can never come from `coverage` (push-only); a **main-only** failure can never come from `size`/`benchmark` (PR-only).
+
+Concurrency: `ci-${{ github.ref }}`, `cancel-in-progress` on non-main refs only (`ci.yml:10-12`).
+
+## Symptom → cause → fix
+
+Ordered roughly by frequency.
+
+### `npm ci` fails with EUSAGE in every job's setup step
+
+Lock file out of sync with `package.json` ("lock file does not satisfy"). Classic trigger: a Dependabot group bump silently drops the two top-level `@emnapi/*` peer-dep entries (`package-lock.json` `node_modules/@emnapi/core` + `node_modules/@emnapi/runtime`, ~lines 1180-1201) that satisfy `@napi-rs/wasm-runtime`'s `peerDependencies` (~lines 2285-2286). **Fix: surgically restore the dropped entries — never regenerate the lockfile from scratch.** Run `--package-lock-only` from main to reproduce the correct shape. See the `git-pr-workflow` and `companion-packages` skills for lockfile-surgery discipline.
+
+### `npm ci` fails with ETARGET / 404 on an internal package (in a CI run)
+
+An internal workspace package is pinned to a version not yet on npm. Two causes:
+
+1. **release-please re-pin**: the node-workspace plugin repins a leaf's `brepjs` dep to a _pending_ (unmerged) root release version. This is why leaf release PRs are held until root merges+publishes (see auto-merge below).
+2. **0.x caret exclusion**: a `^0.<older>` range excludes the next `0.(x+1)` minor, so an internal bump 404s any consumer still on the caret.
+
+**Fix: use an open floor range, not a pin.** Main already does this — `packages/brepjs-cad/package.json:60` (`"brepjs": ">=18.117.1"`) and `packages/brepjs-voxel/package.json:24` (`"brepjs-voxel-wasm": ">=0.2.0"`). Full mechanics in the `release-publishing` skill.
+
+Note: for **internal workspace** devDeps the `"*"` wildcard is intentional (e.g. `brepjs-cad`'s `"brepjs-viewer": "*"`, `package.json:81`) — pinning it to a concrete version is what repeatedly broke `npm ci` when the pin outran what was published. A Dependabot alert on such a `"*"` spec is a false positive: raise the floor (`>=x.y.z`) if it must be cleared, don't pin it or bump the lockfile.
+
+### `build` job fails on `git diff --exit-code docs/function-lookup.md`
+
+A `*Fns.ts` change added/renamed an exported function but `docs/function-lookup.md` wasn't regenerated (the gate at `ci.yml:112-117` runs `docs:generate-lookup` → `prettier --write` → diff; pre-commit only _reminds_, so it's easy to miss locally). **Fix: regenerate + prettier-align + commit the file** — full recipe in the `adding-operations` skill.
+
+### `quality` job fails `check:patterns` on code the PR didn't touch
+
+An unbaselined pattern violation reached main and now fails the `quality` job on _every_ open PR at once. **Fix: land a tiny baseline-bump PR first**, then rebase the others. Mechanism and baseline mechanics live in the `quality-gates` skill.
+
+### `test` shard times out or stalls
+
+OCCT WASM linear memory grows monotonically across tests; a long run over-commits the 16 GB runner into swap and a fork stalls past the 90s per-test timeout (`#1102`, rationale at `ci.yml:244-250`). The 4-way shard exists precisely so each fork exits before accumulation hits that threshold. **Do not "fix" by widening the timeout.** Check whether one shard is genuinely slower (real leak / new heavy test) or just an infra blip — re-run the single shard. Coverage can't shard (vitest `--merge-reports` can't recombine v8 coverage here), which is why the `coverage` job runs single-runner with a raised timeout. Test-authoring details in the `writing-tests` skill.
+
+### `packages-verify` fails on `smoke` or `smoke:standalone`
+
+`smoke` runs the **built** brepjs-cad CLI under plain node (catches bin/TS-load breaks that tsx/vitest hide in-repo). `smoke:standalone` packs the tarball into a clean project with **no brepjs present** (catches bundling / fallback-resolve breaks invisible in-repo). A green in-repo test with a red standalone smoke means a packaging or resolution regression, not a logic bug. See the `companion-packages` skill.
+
+### `playground-build` fails but the library builds fine
+
+Type-resolution or bundler regression scoped to `apps/playground` (this job mirrors what Vercel runs). Historical example: a duplicate `@types/three` install broke `tsc -b` only inside the playground (`#963`, `ci.yml:119-137`). See the `playground-examples` skill.
+
+### `npm publish` failed
+
+Publishes are OIDC-bound to the exact workflow **filename** — inlining `npm publish` elsewhere fails auth. Never re-run the failed push-event job; **re-dispatch the same workflow**. Recovery recipes:
+
+- **Root brepjs**: `gh workflow run release-please.yml -f republish=true` (input at `release-please.yml:6-12`; publish gate at `:146-149`).
+- **A satellite** (cad/bim/sheetmetal/viewer/opencascade): `gh workflow run publish-<pkg>.yml -f dry_run=false --ref <release-tag>` — `dry_run` defaults to **true**, and dispatch against the immutable tag, not main.
+
+Full recipe set and the OIDC-binding rationale: the `release-publishing` skill.
+
+### `prepack` fails: "Too many files" or ".d.ts.map"
+
+`scripts/validate-pack.sh` (root `prepack` hook, `package.json:216`) caps the packed tarball at `MAX_FILES=500` and rejects any `.d.ts.map` sidecars (count must be 0). It fires during **pack/publish**, not PR CI. Fix "too many files" by trimming the published set; fix `.d.ts.map` by keeping `declarationMap` off in `vite.config.ts`.
+
+### "Deploy API Docs" didn't run after a main merge
+
+`docs.yml` triggers on `workflow_run` of **CI completing on main with `conclusion == 'success'`**. A red CI on main blocks the docs deploy. This is exactly why `coverage` is `continue-on-error` (`ci.yml:260-266`): an informational threshold dip must not flip CI's conclusion to failure and starve the docs gate. Emergency redeploy: `gh workflow run docs.yml` (`workflow_dispatch` bypasses the CI gate, main-only).
+
+### "Playground Smoke" is red
+
+`playground-smoke.yml` runs on `deployment_status` from Vercel, loads the deployed playground headless, and requires the WASM kernel to reach `Ready` within 60s. A red here is a **CSP / COEP / COOP / asset-path** class regression that blocks engine init — not a build-class failure (the static build already passed).
+
+### "OSV Scan" is red
+
+`osv-scan.yml` scans `package-lock.json` for known-vulnerable versions. It splits by event: **`scan-pr` ("OSV Scan (report-only)")** on pull requests never fails the merge (findings surface in the Security tab only), while **`scan-main` ("OSV Scan (blocking)")** on push-to-main and the weekly cron fails closed. So a red OSV check on a PR is informational; a red one on main is a real gate. Fix a genuine finding by bumping the vulnerable transitive dep (lockfile surgery, see `git-pr-workflow`).
+
+### Dependabot flags a security alert on a workspace `"*"` dependency
+
+False positive. An internal devDep pinned to `"*"` (e.g. `brepjs-cad`'s `"brepjs-viewer": "*"`) is intentional — pinning it to a concrete version is what repeatedly broke `npm ci`. **Fix: raise the spec floor to `>=x.y.z` if the alert must be cleared — do not pin the spec or bump the lockfile.** Mechanism in the `companion-packages` skill.
+
+### A release PR won't auto-merge
+
+Expected during a release train: while the **root** brepjs release PR (branch `release-please--branches--main--components--brepjs`) is open, every **leaf** PR (cad/bim/sheetmetal) is held; leaves auto-merge only after root merges+publishes. `brepjs-opencascade` is held **permanently** (manual, expensive WASM build). Mechanism at `release-please.yml:57-133`; deep dive in the `release-publishing` skill.
+
+## Looks like a failure but isn't
+
+- **`coverage` red on main**: informational only (`continue-on-error`, push-only, out of `ci-pass`). Not a gate.
+- **benchmark "main install failed" warning**: `continue-on-error` on the main-baseline install so a broken main can't deadlock the PR that fixes it (`ci.yml:323-330`). The PR's own benchmark still runs; only the comparison is skipped.
+- **benchmark shows ±9-15% noise**: shared runners vary run-to-run; the threshold is 25% for that reason (`ci.yml:366`).
+- **held release PRs**: opencascade always held; leaves held while root is open. See above.
+- **`skipped` jobs**: a skipped `needs` result passes `ci-pass` — only `failure`/`cancelled` fail it.
+
+## Blind spots — things CI never runs
+
+- **`alwaysExclude` tests never execute in any CI project** (`vitest.config.ts:18-36`): `tests/brepkit-adapter.test.ts`, `tests/brepkit-validation.test.ts`, `tests/kernel-agreement.test.ts`, `tests/io-stress.test.ts`, plus `benchmarks/`, the cad/viewer packages (own jobs), `apps/`, and worktree dirs. They rot silently — run them locally when touching that code.
+- **The brepkit kernel is not a PR gate**: the default gate runs occt-wasm only. Run `npm run test:brepkit` locally for brepkit-affecting changes (see `kernel-abstraction`).
+- **apps/playground is outside root lint + vitest**: only `tsc -b` (via `playground-build`) gates it in CI. See `playground-examples`.
+
+## Stale docs — do not inherit
+
+`CONTRIBUTING.md` (~lines 222-235) lists coverage thresholds as **83/73/64/73** and claims "CI runs the full test suite with coverage enforcement." Both are wrong. Actual thresholds (`vitest.config.ts:91-96`): **statements 85, branches 71, functions 91, lines 88**. Coverage is main-only, informational, and `continue-on-error` — never a PR gate. Trust `vitest.config.ts`, not `CONTRIBUTING.md`.
+
+## Additional resources
+
+Sibling skills (each fact lives in exactly one — link, don't duplicate):
+
+- `release-publishing` — release-please serialization (root-before-leaves), OIDC filename binding, per-package dispatch recipes, republish recovery, concurrency/label races.
+- `quality-gates` — check:patterns / knip / boundary rule details and baseline mechanics.
+- `git-pr-workflow` — hooks, conventional commits, worktrees, merge / auto-merge, lockfile surgery.
+- `companion-packages` — workspace deps, ETARGET / build order, workspace `"*"` specs.
+- `writing-tests` — test skeleton, shard/coverage authoring, kernel divergence skips.
+- `adding-operations` — the function-lookup gate and export surfaces.
+- `playground-examples` — the three playground gates (types, geometry, thumbnail).

--- a/.claude/skills/ci-triage/SKILL.md
+++ b/.claude/skills/ci-triage/SKILL.md
@@ -116,13 +116,13 @@ Expected during a release train: while the **root** brepjs release PR (branch `r
 
 ## Blind spots — things CI never runs
 
-- **`alwaysExclude` tests never execute in any CI project** (`vitest.config.ts:18-36`): `tests/brepkit-adapter.test.ts`, `tests/brepkit-validation.test.ts`, `tests/kernel-agreement.test.ts`, `tests/io-stress.test.ts`, plus `benchmarks/`, the cad/viewer packages (own jobs), `apps/`, and worktree dirs. They rot silently — run them locally when touching that code.
+- **`alwaysExclude` tests never execute in any CI project** (`vitest.config.ts`): `tests/brepkit-adapter.test.ts`, `tests/brepkit-validation.test.ts`, `tests/kernel-agreement.test.ts`, `tests/io-stress.test.ts`, plus `benchmarks/`, the cad/viewer packages (own jobs), `apps/`, and worktree dirs. They rot silently — run them locally when touching that code.
 - **The brepkit kernel is not a PR gate**: the default gate runs occt-wasm only. Run `npm run test:brepkit` locally for brepkit-affecting changes (see `kernel-abstraction`).
 - **apps/playground is outside root lint + vitest**: only `tsc -b` (via `playground-build`) gates it in CI. See `playground-examples`.
 
 ## Stale docs — do not inherit
 
-`CONTRIBUTING.md` (~lines 222-235) lists coverage thresholds as **83/73/64/73** and claims "CI runs the full test suite with coverage enforcement." Both are wrong. Actual thresholds (`vitest.config.ts:91-96`): **statements 85, branches 71, functions 91, lines 88**. Coverage is main-only, informational, and `continue-on-error` — never a PR gate. Trust `vitest.config.ts`, not `CONTRIBUTING.md`.
+`CONTRIBUTING.md` (~lines 222-235) lists coverage thresholds as **83/73/64/73** and claims "CI runs the full test suite with coverage enforcement." Both are wrong. Actual thresholds (`vitest.config.ts`): **statements 85, branches 71, functions 91, lines 88**. Coverage is main-only, informational, and `continue-on-error` — never a PR gate. Trust `vitest.config.ts`, not `CONTRIBUTING.md`.
 
 ## Additional resources
 

--- a/.claude/skills/companion-packages/SKILL.md
+++ b/.claude/skills/companion-packages/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: companion-packages
+description: This skill should be used when orienting in the brepjs monorepo's packages/ and apps/ directories — answering "what is brepjs-viewer / brepjs-cad / brepjs-voxel", "is package X published", "which workspace do I edit", "why does npm ci fail with ETARGET on a workspace version-range", "playground shows stale behavior from brepjs-bim/sheetmetal", "in what order do I build the packages", "Dependabot flags a workspace `*` dependency", "add a new workspace package", or deciding how a change in one package ripples into its consumers.
+---
+
+# Monorepo companion packages
+
+The root `package.json` `workspaces` field is the source of truth for the monorepo layout: 9 packages under `packages/` plus `apps/playground` and `apps/docs`. The `## Packages` list in `CLAUDE.md` is a curated subset — when it disagrees with the manifests, trust the manifests.
+
+## Package map
+
+| Workspace                     | Purpose                                                          | npm status                                                                            |
+| ----------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `brepjs` (root)               | Core CAD library                                                 | Published; auto-released via release-please                                           |
+| `packages/brepjs-opencascade` | Custom OpenCascade WASM build (fallback kernel)                  | Published; **manual publish only** (`publish-opencascade.yml` — expensive WASM build) |
+| `packages/brepjs-bim`         | IFC4 parametric building elements + IFC import/export            | Published, experimental; auto-released                                                |
+| `packages/brepjs-sheetmetal`  | Flange authoring, fold/unfold flat patterns, DXF/STEP            | Published, experimental; auto-released                                                |
+| `packages/brepjs-cad`         | Agent skill pipeline + `brep`/`brep-mcp` CLI bins + WASM viewer  | Published; auto-released                                                              |
+| `packages/brepjs-viewer`      | Shared React/R3F renderer (playground + brepjs-cad)              | Published; **manual publish, deliberately unmanaged by release-please**               |
+| `packages/brepjs-manifold`    | Manifold mesh/CSG preview kernel adapter                         | Unpublished, source-shipped (`exports` → `./src/index.ts`, no build)                  |
+| `packages/brepjs-voxel-wasm`  | Rust→WASM voxel/SDF engine (`wasm-pack` build, committed `pkg/`) | Versioned/tagged by release-please but **no publish workflow — not on npm**           |
+| `packages/brepjs-voxel`       | TS loader for brepjs-voxel-wasm                                  | Unpublished, source-shipped                                                           |
+| `packages/brepjs-vscode`      | VS Code extension: live 3D preview for `.brep.ts`                | `private: true` — the only truly-private package                                      |
+| `apps/playground`             | Interactive docs playground (Vercel)                             | `private: true`                                                                       |
+| `apps/docs`                   | VitePress docs site                                              | `private: true`                                                                       |
+
+Three tiers, and the rules differ per tier:
+
+1. **Published satellites** (opencascade, bim, sheetmetal, cad, viewer): consumers may resolve them from the npm registry, so their manifests must always describe an installable package.
+2. **Source-shipped internals** (manifold, voxel, voxel-wasm): resolved only through workspace symlinks; manifold and voxel have no build step at all — editing their `src/` is immediately live for consumers.
+3. **Private** (vscode, playground, docs): never published; playground and docs deploy via Vercel/Pages instead.
+
+READMEs exist only for bim, sheetmetal, cad, and viewer — point users there for per-package API detail rather than restating it.
+
+## Workspace dependency rules
+
+- **Satellites depend on `brepjs` as a floor-ranged peerDependency**: `"brepjs": ">=18.0.0"` in `packages/brepjs-bim/package.json` and `packages/brepjs-sheetmetal/package.json`. Exception: `brepjs-cad` takes brepjs as a real dependency (`">=18.117.1"`) because its CLI must run standalone.
+- **Root brepjs's kernel packages are optional peers**: `brepjs-manifold`, `brepjs-opencascade`, `brepkit-wasm`, `occt-wasm` are all `optional: true` under `peerDependenciesMeta` in the root `package.json`. Never promote one to a hard dependency — consumers pick exactly one kernel.
+- **Internal cross-references use `"*"`** (e.g. `"brepjs-viewer": "*"` in `apps/playground` and in brepjs-cad's devDependencies). npm workspaces symlink these locally. Gotcha: Dependabot scans each sub-manifest without a co-located lockfile, so an unconstrained `"*"` on an _external_ dev tool reads as permitting every vulnerable version. Fix by constraining a floor on the flagged spec (`"vite": "^8.0.0"`, `"vitest": "^4.0.0"` — see `packages/brepjs-viewer/package.json`), not by lockfile churn.
+- **`brepjs-viewer` role differs per consumer**: runtime `dependency` of the playground; build-time `devDependency` of brepjs-cad (its viewer bundle inlines it — see the `packages-verify` comment in `.github/workflows/ci.yml`). Viewer declares its react/three/fiber/drei peers as floor ranges (`>=19`, `>=0.184`, etc.) compatible with the playground's versions, so npm dedups to one copy monorepo-wide; rationale in `packages/brepjs-viewer/README.md`.
+- **npm overrides use nested-object syntax**: `"vitepress": { "vite": "6.4.3" }` in root `package.json` `overrides`, plus scoped-range keys like `"esbuild@<0.25.0": "^0.25.0"`. There is no pnpm-style `parent>dep` separator in npm.
+- **Never regenerate `package-lock.json` from scratch.** For security floors, edit the spec then run `npm install --package-lock-only` (no re-resolution, no churn). Full regeneration has historically dropped required `@emnapi/*` peer entries and broken CI.
+- **0.x caret hazard**: `brepjs-voxel` pins `"brepjs-voxel-wasm": ">=0.2.0"` as a plain range, not `^0.x` — a `^0.1.0` caret excludes `0.2.0`, and an internal 0.x bump once left consumers pointing at a version that was never published, 404-ing `npm ci` repo-wide. Use `>=` floors for unpublished internal 0.x packages.
+
+## Build order
+
+Workspace symlinks resolve _manifests_ instantly, but built packages resolve through their `dist/` — a stale or missing dist fails typecheck or, worse, silently runs old code.
+
+Three ordered chains, all encoded in scripts (prefer running the script over hand-ordering):
+
+1. **Playground** — `build:deps` in `apps/playground/package.json` builds brepjs-bim, brepjs-sheetmetal, and brepjs-viewer, and runs automatically as `predev`/`prebuild`. If playground behavior looks stale after editing a companion package, this chain (or a manual `npm run build --workspace=<pkg>`) is the fix.
+2. **Full site** — root `build:site`: provision-fonts → root build → brepjs-bim → brepjs-sheetmetal → apps/playground → apps/docs → copy playground dist into the docs dist.
+3. **brepjs-cad** — root `npm run build` → `npm run build --workspace=brepjs-viewer` → `npm run build --workspace=brepjs-cad`. The cad viewer worker imports `brepjs` and bundles `brepjs-viewer`, so both dists must exist first; CI's `packages-verify` job and `publish-brepjs-cad.yml` both follow this order.
+
+**WASM bootstrap**: the OpenCascade runtime files (`brepjs_single.js`/`.wasm`) are gitignored. Root `prepare` runs `scripts/ensure-wasm.sh`, which downloads them from the published `brepjs-opencascade` npm package into `packages/brepjs-opencascade/src`, keyed by a `.wasm-version` marker. Corollary: `npm ci --ignore-scripts` skips the download — fine when WASM is not needed (`publish-brepjs-viewer.yml` does this deliberately), otherwise re-run `bash scripts/ensure-wasm.sh` manually (`publish-brepjs-cad.yml` does, with retries).
+
+## Release and publish (summary)
+
+The package topology that shapes the pipeline lives in [references/publish-pipeline.md](references/publish-pipeline.md); the operator mechanics live in the **release-publishing** skill. The shape:
+
+- `release-please-config.json` manages 6 components: root, opencascade, voxel-wasm, cad, bim, sheetmetal — with the `node-workspace` plugin and separate PRs per component. Viewer and voxel are deliberately excluded.
+- Leaf release PRs are **held until the root brepjs release merges** — merging a leaf first pins it to an unpublished brepjs version and breaks `npm ci` with ETARGET.
+- npm OIDC trusted publishers are bound to specific workflow **filenames**, so release-please _dispatches_ each `publish-brepjs-*.yml` rather than inlining `npm publish`.
+- Every `publish-*.yml` is `workflow_dispatch` with `dry_run` defaulting to **true** — a bare manual dispatch is a safe dry run; pass `dry_run=false` to actually publish.
+
+See the **release-publishing** skill for the operator playbook on cutting and recovering releases; this skill covers only how the package topology shapes that pipeline.
+
+## CI coverage per package
+
+| Workspace                                         | CI gate (`.github/workflows/ci.yml`)                                                      |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| root                                              | typecheck/lint/boundaries/patterns + 4-way sharded tests                                  |
+| brepjs-viewer                                     | `packages-viewer`: typecheck, lint, test, build                                           |
+| brepjs-cad                                        | `packages-verify`: typecheck, lint, test, build, eval, smoke, smoke:standalone            |
+| brepjs-sheetmetal                                 | `packages-sheetmetal`: typecheck, lint, test, build                                       |
+| brepjs-bim                                        | `packages-bim`: typecheck, lint, test, build                                              |
+| brepjs-voxel-wasm                                 | `voxel-wasm-rust`: cargo test + clippy (path-filtered on `packages/brepjs-voxel-wasm/**`) |
+| apps/playground                                   | `playground-build` (path-filtered; mirrors the Vercel build)                              |
+| brepjs-vscode, brepjs-manifold, brepjs-voxel (TS) | **no CI job** — changes here are ungated; run their checks manually                       |
+
+Two consequences worth internalizing: root `npm run validate` does **not** cover satellites (run `npm run <script> --workspace=<name>` directly when touching one), and the ungated packages rot silently — verify manually before relying on them.
+
+## Symptom → cause → fix
+
+| Symptom                                                               | Cause                                                                                                | Fix                                                                                                                   |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `npm ci`/Vercel fails with ETARGET on a `brepjs` or workspace version | A manifest pins a version not yet on npm (leaf merged before root, or 0.x caret on an internal bump) | Merge/publish the root release first, or widen the internal range to a `>=` floor; see references/publish-pipeline.md |
+| Playground ignores an edit in brepjs-bim/sheetmetal/viewer            | Playground worker runs the companion's built `dist`, which is stale                                  | `npm run build:deps` in `apps/playground` (automatic on `predev`/`prebuild`)                                          |
+| brepjs-cad typecheck/build fails on missing `brepjs` or viewer types  | Root or viewer dist missing                                                                          | Build in order: root → viewer → cad                                                                                   |
+| Kernel init fails locally with missing `brepjs_single.js`             | Gitignored WASM never downloaded (`--ignore-scripts`, fresh clone glitch)                            | `bash scripts/ensure-wasm.sh`                                                                                         |
+| Dependabot alert on a workspace `"*"` dev-dep                         | Sub-manifest scanned without lockfile context                                                        | Constrain a floor version on the spec; `npm install --package-lock-only`                                              |
+| Manual publish dispatch "succeeded" but nothing on npm                | `dry_run` defaults to true                                                                           | Re-dispatch with `dry_run=false`                                                                                      |
+| A satellite change passed root `validate` but fails CI                | Root validate does not run satellite gates                                                           | Run `typecheck`/`lint`/`test`/`build` with `--workspace=<name>` before pushing                                        |
+
+## Adding a new workspace package — checklist
+
+1. Add the directory to root `package.json` `workspaces`.
+2. Decide the tier: published (needs build, `files`, exports to `dist/`, a `publish-<name>.yml` workflow, and an npm trusted-publisher entry bound to that filename), source-shipped (`exports` → `./src/index.ts`, no build — copy `packages/brepjs-voxel/package.json`), or `private: true`.
+3. Dependency shape: `brepjs` as `">=18.0.0"` peerDependency for library satellites; internal siblings as `"*"`; floor-constrain any external dev tool that Dependabot might flag.
+4. If published: add entries to `release-please-config.json` and `.release-please-manifest.json`, and a dispatch job in `release-please.yml` (mirror `publish-brepjs-bim`). If it must not auto-release (like viewer), leave it out of the config _and_ add it to the root component's `exclude-paths`.
+5. Add a CI job in `ci.yml` modeled on `packages-bim` (build root first if the package imports `brepjs` through dist exports).
+6. If the playground consumes it, append it to `build:deps` in `apps/playground/package.json`.
+7. `npm install` from the repo root to register the workspace in the lockfile — never regenerate the lockfile wholesale.
+
+## Additional resources
+
+- [references/publish-pipeline.md](references/publish-pipeline.md) — release topology: which packages release-please manages/excludes and why, and the build order baked into each publish workflow (operator mechanics live in the **release-publishing** skill)
+- `packages/brepjs-cad/README.md` — the two-rail distribution model: skills install via the repo's Claude plugin marketplace (`.claude-plugin/marketplace.json` → `packages/brepjs-cad`), runtime via `npm i -D brepjs-cad brepjs occt-wasm`
+- `packages/brepjs-viewer/README.md` — exports and peer-pinning rationale
+- Workflow comments in `.github/workflows/release-please.yml` and `ci.yml` — the best inline docs for release mechanics and per-package build-order rationale
+- Sibling skills: `release-publishing` (operating the release pipeline), `ci-triage` (diagnosing red CI), `playground-examples` (adding examples inside `apps/playground`), `quality-gates` (root repo gates), `wasm-interop` (kernel WASM behavior beyond the bootstrap covered here)

--- a/.claude/skills/companion-packages/SKILL.md
+++ b/.claude/skills/companion-packages/SKILL.md
@@ -9,20 +9,20 @@ The root `package.json` `workspaces` field is the source of truth for the monore
 
 ## Package map
 
-| Workspace                     | Purpose                                                          | npm status                                                                            |
-| ----------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `brepjs` (root)               | Core CAD library                                                 | Published; auto-released via release-please                                           |
-| `packages/brepjs-opencascade` | Custom OpenCascade WASM build (fallback kernel)                  | Published; **manual publish only** (`publish-opencascade.yml` — expensive WASM build) |
-| `packages/brepjs-bim`         | IFC4 parametric building elements + IFC import/export            | Published, experimental; auto-released                                                |
-| `packages/brepjs-sheetmetal`  | Flange authoring, fold/unfold flat patterns, DXF/STEP            | Published, experimental; auto-released                                                |
-| `packages/brepjs-cad`         | Agent skill pipeline + `brep`/`brep-mcp` CLI bins + WASM viewer  | Published; auto-released                                                              |
-| `packages/brepjs-viewer`      | Shared React/R3F renderer (playground + brepjs-cad)              | Published; **manual publish, deliberately unmanaged by release-please**               |
-| `packages/brepjs-manifold`    | Manifold mesh/CSG preview kernel adapter                         | Unpublished, source-shipped (`exports` → `./src/index.ts`, no build)                  |
-| `packages/brepjs-voxel-wasm`  | Rust→WASM voxel/SDF engine (`wasm-pack` build, committed `pkg/`) | Versioned/tagged by release-please but **no publish workflow — not on npm**           |
-| `packages/brepjs-voxel`       | TS loader for brepjs-voxel-wasm                                  | Unpublished, source-shipped                                                           |
-| `packages/brepjs-vscode`      | VS Code extension: live 3D preview for `.brep.ts`                | `private: true` — the only truly-private package                                      |
-| `apps/playground`             | Interactive docs playground (Vercel)                             | `private: true`                                                                       |
-| `apps/docs`                   | VitePress docs site                                              | `private: true`                                                                       |
+| Workspace                     | Purpose                                                          | npm status                                                                                           |
+| ----------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `brepjs` (root)               | Core CAD library                                                 | Published; auto-released via release-please                                                          |
+| `packages/brepjs-opencascade` | Custom OpenCascade WASM build (fallback kernel)                  | Published; **manual publish only** (`publish-opencascade.yml` — expensive WASM build)                |
+| `packages/brepjs-bim`         | IFC4 parametric building elements + IFC import/export            | Published, experimental; auto-released                                                               |
+| `packages/brepjs-sheetmetal`  | Flange authoring, fold/unfold flat patterns, DXF/STEP            | Published, experimental; auto-released                                                               |
+| `packages/brepjs-cad`         | Agent skill pipeline + `brep`/`brep-mcp` CLI bins + WASM viewer  | Published; auto-released                                                                             |
+| `packages/brepjs-viewer`      | Shared React/R3F renderer (playground + brepjs-cad)              | Published; **manual publish, deliberately unmanaged by release-please**                              |
+| `packages/brepjs-manifold`    | Manifold mesh/CSG preview kernel adapter                         | Unpublished, source-shipped (`exports` → `./src/index.ts`, no build)                                 |
+| `packages/brepjs-voxel-wasm`  | Rust→WASM voxel/SDF engine (`wasm-pack` build, committed `pkg/`) | Versioned/tagged by release-please but **no publish workflow — not on npm**                          |
+| `packages/brepjs-voxel`       | TS loader for brepjs-voxel-wasm                                  | Unpublished, source-shipped                                                                          |
+| `packages/brepjs-vscode`      | VS Code extension: live 3D preview for `.brep.ts`                | `private: true` — the only `packages/` workspace that is private (not published, not source-shipped) |
+| `apps/playground`             | Interactive docs playground (Vercel)                             | `private: true`                                                                                      |
+| `apps/docs`                   | VitePress docs site                                              | `private: true`                                                                                      |
 
 Three tiers, and the rules differ per tier:
 

--- a/.claude/skills/companion-packages/references/publish-pipeline.md
+++ b/.claude/skills/companion-packages/references/publish-pipeline.md
@@ -1,0 +1,37 @@
+# Release topology
+
+How the monorepo's package layout shapes what release-please manages and how the publish workflows build each package. This is the topology view only — the operator playbook (auto-merge serialization, OIDC dispatch, `dry_run`, recovery, and the known-failure table) lives in the **release-publishing** skill; do not duplicate it here.
+
+## What release-please manages
+
+Six components, each with its own release PR (`separate-pull-requests: true`) and the `node-workspace` plugin:
+
+| Component            | Path                          | Published by                                                                                                             |
+| -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `brepjs` (root)      | `.`                           | Inline `npm publish --provenance` in `release-please.yml`                                                                |
+| `brepjs-opencascade` | `packages/brepjs-opencascade` | Manual `publish-opencascade.yml` dispatch only (expensive WASM build)                                                    |
+| `brepjs-voxel-wasm`  | `packages/brepjs-voxel-wasm`  | **Nobody** — versioned and tagged (with a `Cargo.toml` extra-file bump) but no publish workflow exists; it is not on npm |
+| `brepjs-cad`         | `packages/brepjs-cad`         | Dispatched `publish-brepjs-cad.yml`                                                                                      |
+| `brepjs-bim`         | `packages/brepjs-bim`         | Dispatched `publish-brepjs-bim.yml`                                                                                      |
+| `brepjs-sheetmetal`  | `packages/brepjs-sheetmetal`  | Dispatched `publish-brepjs-sheetmetal.yml`                                                                               |
+
+## What is deliberately unmanaged
+
+- `brepjs-viewer` — the `node-workspace` plugin kept re-pinning brepjs-cad's build-time `brepjs-viewer` devDependency to viewer's pending, unpublished version on every release, repeatedly breaking `npm ci`. Viewer is versioned by hand and published via manual `publish-brepjs-viewer.yml` dispatch. Rationale comment: bottom of `release-please.yml`.
+- `brepjs-voxel` — an unpublished workspace consumer, so there is nothing to release.
+
+## The `exclude-paths` nuance
+
+`brepjs-voxel`, `packages/brepjs-cad`, `packages/brepjs-viewer`, and `apps` are listed in the root component's `exclude-paths` so root commits touching them do not bump the root library version. Note `packages/brepjs-cad` appears in _both_ the managed list (its own component) and the root's `exclude-paths` (so cad-only commits do not bump root). Adding a new managed package that root does not import means adding it to `exclude-paths` too.
+
+## Build prerequisites inside publish workflows
+
+The publish workflows re-encode the same build order the CI `packages-*` jobs use, because each package resolves its dependencies through built `dist/`:
+
+- `publish-brepjs-viewer.yml` runs `npm ci --ignore-scripts` — viewer needs no OpenCascade WASM, and skipping the root `prepare` (husky + `scripts/ensure-wasm.sh`) makes the job faster and network-independent.
+- `publish-brepjs-cad.yml` needs the WASM: it re-runs `bash scripts/ensure-wasm.sh` explicitly with a 3-attempt retry loop, then builds root → viewer → cad in that order (the viewer worker imports `brepjs`; cad bundles `brepjs-viewer`).
+- `publish-brepjs-bim.yml` and `publish-brepjs-sheetmetal.yml` build root `brepjs` first, because their `vite-plugin-dts` step needs root's emitted types.
+
+## Operating the pipeline
+
+For the release _mechanics_ — how auto-merge holds leaves until root, why OIDC binds to workflow filenames, `dry_run` defaults, recovery routes, and the known-failure table — see the **release-publishing** skill.

--- a/.claude/skills/debugging-geometry/SKILL.md
+++ b/.claude/skills/debugging-geometry/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: debugging-geometry
+description: This skill should be used when debugging a geometry failure in brepjs — when a task says "boolean returned an invalid shape", "fuse/cut/intersect returned Err", "the result is empty", "measureVolume returns 0", "autoHeal didn't fix it", "shape is invalid", "STEP export crashed" or "WebAssembly.RuntimeError during export", "the part looks wrong, render it", "works on occt-wasm but fails on brepkit", or "is this a kernel divergence". Covers triage, numeric sanity checks, the healing pipeline, boolean failure modes (including the #1126 disjoint-fuse corruption), visual debugging with the brep CLI, and kernel-divergence isolation.
+---
+
+# Debugging geometry failures
+
+A symptom-ordered playbook for the five failure classes: an `Err` result, wrong-but-`Ok` geometry, an empty/degenerate result, a crash/trap, or a kernel divergence. Verify every hypothesis with numbers and a render before changing code.
+
+## Step 1 — Triage by failure class
+
+| Symptom                                                | Class            | First move                                                             |
+| ------------------------------------------------------ | ---------------- | ---------------------------------------------------------------------- |
+| Op returned `Result.Err`                               | error result     | Read `error.code` + `error.suggestion` + `error.metadata?.diagnostics` |
+| Result is `Ok` but geometry is wrong                   | bad geometry     | Numeric sanity (Step 2), then render (Step 5)                          |
+| Result is empty / `measureVolume`==0                   | degenerate/empty | `isEmpty`, `getBounds`, volume-normalization rule (Step 2)             |
+| Session crashed / `WebAssembly.RuntimeError` on export | kernel trap      | The #1126 export-crash class (Step 4 + references/boolean-failures.md) |
+| Passes on one kernel, fails on another                 | divergence       | Isolate under `TEST_KERNEL` (Step 6)                                   |
+
+Every fallible op returns `Result<T, BrepError>` with `kind/code/message/suggestion?/cause?/metadata?`. The full code catalog with per-code recovery advice lives in `docs/errors.md` — look codes up there, don't guess. `error.suggestion` is a first-class field; read it first (`src/core/errors.ts`).
+
+## Step 2 — Numeric sanity before trusting any render
+
+Confirm the defect with numbers before opening an image; a render can hide a zero-thickness sliver or an open shell.
+
+- `measureVolume` / `measureArea` / `measureLength` / `measureDistance` in `src/measurement/measureFns.ts` — all return `Result<T>` and pre-check null → `NULL_SHAPE_INPUT`.
+- **`volume === 0` is itself a diagnostic.** Volume is normalized to `0` for anything that is not a solid/compsolid/compound (`measureVolumeProps`, `measureFns.ts:55-65`, kernel divergence #1361). A "solid" reporting 0 volume is almost always an **open shell** that never got sewn/closed. Check `describe(shape)` and the shape type before assuming the volume math is wrong.
+- `isEmpty(shape)` (`src/topology/shapeFns.ts:45`) is only a **kernel null check** — it does not detect degenerate-but-non-null geometry.
+- `getBounds(shape)` (`src/topology/topologyQueryFns.ts`) returns the AABB and **can throw on degenerate shapes** — that throw is the basis of the pre-export probe (Step 4).
+- `describe(shape)` (`src/topology/topologyQueryFns.ts`) gives a structural fingerprint (type + sub-shape counts) — use it to confirm "is this actually a solid, or a compound of two solids?".
+- **Measurements and validity are cached per shape.** After healing or any in-place kernel repair, a stale `isValid`/measurement can lie — call `invalidateShapeCache` (exported from the index) if a value looks stale.
+
+## Step 3 — Invalid shapes and the healing pipeline
+
+Full tables in `references/healing.md`. Core loop:
+
+1. Check `isValid(shape)` (`src/topology/healingFns.ts`).
+2. `autoHeal(shape, options?)` → `Result<{ shape, report: HealingReport }>`.
+3. Escalate only if `report.isValid` is still false.
+
+**Critical caveat — the short-circuit.** `autoHeal` returns immediately when the input is already valid: `report.alreadyValid === true`, `steps === ['Shape already valid']`, and `diagnostics` contains ONLY `{ name:'validation', attempted:true, succeeded:true }` (`healingFns.ts:202-216`). The absence of `sew`/`fixSelfIntersection`/`healSolid` diagnostics does **not** mean those passes found nothing — **they never ran**. Never conclude "healing found no problems" from an `alreadyValid` report.
+
+Two more traps:
+
+- `wiresHealed`/`facesHealed` are `Math.abs(after - before)` **count deltas**, a heuristic change-detector — not a count of repaired defects.
+- Sewing only runs when `sewTolerance` is passed; `fixSelfIntersection` defaults to `false`.
+
+Escalation ladder when `autoHeal` leaves it invalid: pass a `sewTolerance` → `fixShape` (general `ShapeFix_Shape`) → `solidFromShell` for a shell that should be a solid → give up with `HEAL_SOLID_INCOMPLETE` / `HEAL_NO_EFFECT`. All in `healingFns.ts`; details in `references/healing.md`.
+
+## Step 4 — Failed booleans
+
+Full recipes in `references/boolean-failures.md`. Two distinct diagnostic surfaces — do not conflate them:
+
+- **`checkBoolean(base, tool, op)`** (`src/topology/booleanDiagnosticFns.ts`) is a **pre-flight predictor**: it returns `{ valid, issues }` where issues are only `'null-shape' | 'not-valid'` per operand. It predicts failure; it does not explain a failure after the fact.
+- **`BooleanDiagnostics`** (`{ hasErrors, hasWarnings, messages }`) rides on results/errors when `trackEvolution` is on (default). **`messages` is currently always empty** — OCCT's `Standard_OStream` reporting is not reachable in WASM builds (`src/kernel/types.ts:150-159`). Rely on `hasErrors`/`hasWarnings`, not on message text. On `hasErrors` + null result the op retries without evolution tracking; on `hasErrors` + non-null it warns and continues (`booleanFns.ts:154-173`).
+
+Boolean ops pre-validate null operands → `NULL_SHAPE_INPUT` before touching the kernel (`booleanFns.ts:39-44`). When the result cannot cast to 3D the error names the actual type ("Got COMPOUND instead.", `booleanFns.ts:58-91`) — a strong signal the boolean degenerated.
+
+Symptom → cause → fix:
+
+| Symptom                                      | Likely cause                       | Fix                                                                  |
+| -------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `FUSE_*` Err, "Got COMPOUND"                 | operands don't actually overlap    | give a real overlap; for a weld, `fuseAll(shapes, { unsafe: true })` |
+| `BOOLEAN_HAS_ERRORS`                         | coincident/near-tangent faces      | perturb one operand slightly, or set `fuzzyValue`                    |
+| overlapping coplanar / zero-thickness input  | non-manifold input                 | `autoHeal()` operands first (the baked-in FUSE suggestion)           |
+| in-memory checks all pass, STEP writer traps | **#1126 disjoint-fuse corruption** | `fuseAll(shapes, { strategy: 'pairwise' })`                          |
+
+**The #1126 export-crash class** is the nastiest: `fuseAll` with the default `strategy: 'native'` (N-way `BRepAlgoAPI_BuilderAlgo`) can silently corrupt certain disjoint inputs so the result passes `isValid`, `validSolid`, `mesh`, `measureArea`, and `getBounds` — yet traps the STEP writer with a `WebAssembly.RuntimeError` that **corrupts the Emscripten heap and poisons the kernel for the rest of the session** (`meshFns.ts:185-196`). No known non-trapping check detects it; the only safety nets are the pre-export bounding-box probe (`probeSerializable`, catches _some_ degenerates → `STEP_EXPORT_UNSERIALIZABLE`/`STL_EXPORT_UNSERIALIZABLE` with the offending sub-solid localized) and `exportError` classifying the trap as `*_EXPORT_CRASHED`. The **fix** is `strategy: 'pairwise'` (divide-and-conquer over `BRepAlgoAPI_Fuse`, a different algorithm that is unaffected; `booleanFns.ts:427-465`). Tracked upstream at andymai/opencascade.js#3.
+
+**Where export lives (structural gotcha).** Import functions live in `src/io/` (`importFns.ts`), but the STEP/STL/IGES _export_ functions live in `src/topology/meshFns.ts` (`exportSTEP`/`exportSTL`/`exportIGES`) and assembly STEP in `src/operations/exporterFns.ts` — not in `io/`. `importSTL` auto-runs `ShapeUpgrade_UnifySameDomain` on the read shape (`src/kernel/occt/ioOps.ts`); IGES round-trips both ways.
+
+## Finder mis-selection (fillet/chamfer hit the wrong edges)
+
+When a modifier lands on the wrong entities, the defect is the _selection_, not the op. Finder USAGE (predicates, `when`/`inList`/`not`, sorting) lives in the docs finders page (`apps/docs/tasks/finders.md`) and `src/query/README.md`; this skill owns the debugging angle. Core surface: `findAll(shape)` returns every match, `findUnique(shape)` returns `Result<T>` and errors when 0 or >1 match (`src/query/finderCore.ts`, `findUniqueIn`).
+
+| Symptom                                                          | Likely cause                                                                                                     | Fix                                                                                                                            |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Fillet/chamfer landed on extra/other edges                       | predicate too loose — more entities matched than intended                                                        | `findAll` to count what actually matched, render with `brep snapshot --label` to see them, then tighten the predicate          |
+| `findUnique` returned `Err` (0 or >1 match)                      | predicate too strict (0) or ambiguous (>1)                                                                       | Inspect `findAll` length; add a discriminating clause or switch to `findAll` if many are intended                              |
+| `normalAt(face)` / a normal comes back null on the picked entity | the selected face/edge is degenerate, so the surface normal is undefined (`normalAt`, `src/topology/faceFns.ts`) | Confirm with `describe`/`getBounds` (Step 2); the finder selected a degenerate sub-shape — re-find geometrically or heal first |
+
+## Step 5 — Visual debugging with the `brep` CLI
+
+The `brep` CLI (bin in `packages/brepjs-cad`) renders and validates `.brep.ts` modules. For interpreting the verify **report** (checks, hints, body relations, the multi-body fragmentation advisory), defer to the sibling skill `brepjs:verify` (`packages/brepjs-cad/skills/verify/SKILL.md`) — this skill covers the debugging loop, not the report anatomy.
+
+- `brep verify <file>.brep.ts [--check] [--json] [--metrics]` is the primary loop. `--check` typechecks first; `--metrics` adds deterministic manufacturability metrics + the interference matrix (off by default, slow). `--expect-code <CODE>` / `--expect-invalid` assert a known-bad part fails the _right_ way.
+- `brep snapshot <file>.brep.ts [--out dir] [--label tag]` renders all views in one pass: `iso`, `front`, `top`, `right`, `iso-xray` (reveals bores/internal walls an opaque render is blind to), plus a conditional aimed `section` shot and a `marks` (Set-of-Marks B#/H# label) shot when the report detects bores/bodies (`snapshot/shoot.ts:22-41`). Each PNG has its bbox size (W×D×H) burned in, so scale is readable from the image. `--label` writes to a subfolder for pre/post A/B pairing.
+- Snapshots use a private ephemeral render server (`fresh: true`), so parallel snapshots don't contend on the shared `:7373` server.
+- Puppeteer is lazily/optionally imported: without it, the JSON report still emits and the CLI prints `snapshots need puppeteer/Chrome — run: npm i puppeteer`.
+- **Prefer one `brep snapshot` over rendering each angle separately** — one pass gives every standard view. Judge fine surface finish (fine threads, small chamfers) from a real playground render rather than the snapshot, which can exaggerate thin features.
+
+Compare geometry with `brep diff <a> <b>` (volumeDelta/areaDelta/bboxDelta/symmetricDifferenceVolume) and `brep measure <a> [b]`.
+
+## Step 6 — Kernel-divergence isolation
+
+Full mechanics in `references/kernel-divergence.md`. When a part passes on the default kernel but fails elsewhere (or vice-versa):
+
+1. **Re-run under the other kernel.** `npm run test:occt` and `npm run test:brepkit` set `TEST_KERNEL` and run that vitest project (`vitest.config.ts`; `tests/setup-kernel.ts`). **CI runs only `occt-wasm`** (`.github/workflows/ci.yml`), so brepkit/manifold divergences must be reproduced locally.
+2. **Localize the diverging op.** The in-repo technique (`tests/kernelDivergenceCoverage.test.ts`): compare against an **analytic reference** AND against an **alternate representation** of the same shape — e.g. a torus _primitive_ is exact while a _revolve_ sweep undershoots its volume by ~2%, which pins the loss to the sweep, not the primitive (#968).
+3. **When confirmed, register it** in `tests/helpers/kernelDivergences.ts` (single source of truth; key = `operation.specificCase`, kinds `not-implemented | skip | tolerance | topology-differs`) and gate tests with `skipIfDiverges(ctx, key)`. Always cite the upstream issue. The conformance matrix `docs/kernel-conformance.md` is auto-generated (`npm run conformance:generate`).
+
+Note: the default **occt-wasm kernel exposes no raw `oc` handle** (`kernelDivergences.ts:421-458`) — raw-OCCT debugging tricks (poking `TopoDS_*`, patching `FS`) are unavailable there.
+
+## Step 7 — Writing the repro test
+
+1. `import { initKernel } from './setup.js'` (`initOC` is a legacy alias) and `beforeAll(async () => { await initKernel(); }, 30000)`.
+2. Use `unwrap(result)` in tests; assert geometry with `toBeCloseTo(expected, precision)` — never exact float equality.
+3. To force the **invalid-shape** healing path deterministically, spy `kernel.isValid` to return `false` on the first call then delegate — the `mockKernelIsValid` pattern in `tests/autoHeal.test.ts:121-133`. See the sibling skill `writing-tests`.
+
+## Additional resources
+
+- `references/healing.md` — `HealingReport`/diagnostic-name tables, `AutoHealOptions`, escalation ladder, short-circuit semantics.
+- `references/boolean-failures.md` — `checkBoolean` vs `BooleanDiagnostics`, error codes + baked-in suggestions, `fuzzyValue`, the #1126 case study.
+- `references/kernel-divergence.md` — registry mechanics, divergence kinds, kernel capability table, occt-wasm no-raw-`oc` limits, brepkit #965–968 family status.
+- `docs/errors.md` — full error-code catalog. `docs/getting-started.md` §Troubleshooting — the 4-step boolean recovery recipe. `docs/kernel-conformance.md` — capability matrix.
+- Sibling skills: `result-error-handling` (Result/BrepError construction), `writing-tests` (test skeleton + divergence skips), `kernel-abstraction` (adding kernel methods), `brepjs:verify` (CLI report interpretation).

--- a/.claude/skills/debugging-geometry/SKILL.md
+++ b/.claude/skills/debugging-geometry/SKILL.md
@@ -24,8 +24,8 @@ Every fallible op returns `Result<T, BrepError>` with `kind/code/message/suggest
 Confirm the defect with numbers before opening an image; a render can hide a zero-thickness sliver or an open shell.
 
 - `measureVolume` / `measureArea` / `measureLength` / `measureDistance` in `src/measurement/measureFns.ts` — all return `Result<T>` and pre-check null → `NULL_SHAPE_INPUT`.
-- **`volume === 0` is itself a diagnostic.** Volume is normalized to `0` for anything that is not a solid/compsolid/compound (`measureVolumeProps`, `measureFns.ts:55-65`, kernel divergence #1361). A "solid" reporting 0 volume is almost always an **open shell** that never got sewn/closed. Check `describe(shape)` and the shape type before assuming the volume math is wrong.
-- `isEmpty(shape)` (`src/topology/shapeFns.ts:45`) is only a **kernel null check** — it does not detect degenerate-but-non-null geometry.
+- **`volume === 0` is itself a diagnostic.** Volume is normalized to `0` for anything that is not a solid/compsolid/compound (`measureVolumeProps`, `measureFns.ts`, kernel divergence #1361). A "solid" reporting 0 volume is almost always an **open shell** that never got sewn/closed. Check `describe(shape)` and the shape type before assuming the volume math is wrong.
+- `isEmpty(shape)` (`src/topology/shapeFns.ts`) is only a **kernel null check** — it does not detect degenerate-but-non-null geometry.
 - `getBounds(shape)` (`src/topology/topologyQueryFns.ts`) returns the AABB and **can throw on degenerate shapes** — that throw is the basis of the pre-export probe (Step 4).
 - `describe(shape)` (`src/topology/topologyQueryFns.ts`) gives a structural fingerprint (type + sub-shape counts) — use it to confirm "is this actually a solid, or a compound of two solids?".
 - **Measurements and validity are cached per shape.** After healing or any in-place kernel repair, a stale `isValid`/measurement can lie — call `invalidateShapeCache` (exported from the index) if a value looks stale.
@@ -38,7 +38,7 @@ Full tables in `references/healing.md`. Core loop:
 2. `autoHeal(shape, options?)` → `Result<{ shape, report: HealingReport }>`.
 3. Escalate only if `report.isValid` is still false.
 
-**Critical caveat — the short-circuit.** `autoHeal` returns immediately when the input is already valid: `report.alreadyValid === true`, `steps === ['Shape already valid']`, and `diagnostics` contains ONLY `{ name:'validation', attempted:true, succeeded:true }` (`healingFns.ts:202-216`). The absence of `sew`/`fixSelfIntersection`/`healSolid` diagnostics does **not** mean those passes found nothing — **they never ran**. Never conclude "healing found no problems" from an `alreadyValid` report.
+**Critical caveat — the short-circuit.** `autoHeal` returns immediately when the input is already valid: `report.alreadyValid === true`, `steps === ['Shape already valid']`, and `diagnostics` contains ONLY `{ name:'validation', attempted:true, succeeded:true }` (`healingFns.ts`). The absence of `sew`/`fixSelfIntersection`/`healSolid` diagnostics does **not** mean those passes found nothing — **they never ran**. Never conclude "healing found no problems" from an `alreadyValid` report.
 
 Two more traps:
 
@@ -52,9 +52,9 @@ Escalation ladder when `autoHeal` leaves it invalid: pass a `sewTolerance` → `
 Full recipes in `references/boolean-failures.md`. Two distinct diagnostic surfaces — do not conflate them:
 
 - **`checkBoolean(base, tool, op)`** (`src/topology/booleanDiagnosticFns.ts`) is a **pre-flight predictor**: it returns `{ valid, issues }` where issues are only `'null-shape' | 'not-valid'` per operand. It predicts failure; it does not explain a failure after the fact.
-- **`BooleanDiagnostics`** (`{ hasErrors, hasWarnings, messages }`) rides on results/errors when `trackEvolution` is on (default). **`messages` is currently always empty** — OCCT's `Standard_OStream` reporting is not reachable in WASM builds (`src/kernel/types.ts:150-159`). Rely on `hasErrors`/`hasWarnings`, not on message text. On `hasErrors` + null result the op retries without evolution tracking; on `hasErrors` + non-null it warns and continues (`booleanFns.ts:154-173`).
+- **`BooleanDiagnostics`** (`{ hasErrors, hasWarnings, messages }`) rides on results/errors when `trackEvolution` is on (default). **`messages` is currently always empty** — OCCT's `Standard_OStream` reporting is not reachable in WASM builds (`src/kernel/types.ts`). Rely on `hasErrors`/`hasWarnings`, not on message text. On `hasErrors` + null result the op retries without evolution tracking; on `hasErrors` + non-null it warns and continues (`booleanFns.ts`).
 
-Boolean ops pre-validate null operands → `NULL_SHAPE_INPUT` before touching the kernel (`booleanFns.ts:39-44`). When the result cannot cast to 3D the error names the actual type ("Got COMPOUND instead.", `booleanFns.ts:58-91`) — a strong signal the boolean degenerated.
+Boolean ops pre-validate null operands → `NULL_SHAPE_INPUT` before touching the kernel (`booleanFns.ts`). When the result cannot cast to 3D the error names the actual type ("Got COMPOUND instead.", `booleanFns.ts`) — a strong signal the boolean degenerated.
 
 Symptom → cause → fix:
 
@@ -65,7 +65,7 @@ Symptom → cause → fix:
 | overlapping coplanar / zero-thickness input  | non-manifold input                 | `autoHeal()` operands first (the baked-in FUSE suggestion)           |
 | in-memory checks all pass, STEP writer traps | **#1126 disjoint-fuse corruption** | `fuseAll(shapes, { strategy: 'pairwise' })`                          |
 
-**The #1126 export-crash class** is the nastiest: `fuseAll` with the default `strategy: 'native'` (N-way `BRepAlgoAPI_BuilderAlgo`) can silently corrupt certain disjoint inputs so the result passes `isValid`, `validSolid`, `mesh`, `measureArea`, and `getBounds` — yet traps the STEP writer with a `WebAssembly.RuntimeError` that **corrupts the Emscripten heap and poisons the kernel for the rest of the session** (`meshFns.ts:185-196`). No known non-trapping check detects it; the only safety nets are the pre-export bounding-box probe (`probeSerializable`, catches _some_ degenerates → `STEP_EXPORT_UNSERIALIZABLE`/`STL_EXPORT_UNSERIALIZABLE` with the offending sub-solid localized) and `exportError` classifying the trap as `*_EXPORT_CRASHED`. The **fix** is `strategy: 'pairwise'` (divide-and-conquer over `BRepAlgoAPI_Fuse`, a different algorithm that is unaffected; `booleanFns.ts:427-465`). Tracked upstream at andymai/opencascade.js#3.
+**The #1126 export-crash class** is the nastiest: `fuseAll` with the default `strategy: 'native'` (N-way `BRepAlgoAPI_BuilderAlgo`) can silently corrupt certain disjoint inputs so the result passes `isValid`, `validSolid`, `mesh`, `measureArea`, and `getBounds` — yet traps the STEP writer with a `WebAssembly.RuntimeError` that **corrupts the Emscripten heap and poisons the kernel for the rest of the session** (`meshFns.ts`). No known non-trapping check detects it; the only safety nets are the pre-export bounding-box probe (`probeSerializable`, catches _some_ degenerates → `STEP_EXPORT_UNSERIALIZABLE`/`STL_EXPORT_UNSERIALIZABLE` with the offending sub-solid localized) and `exportError` classifying the trap as `*_EXPORT_CRASHED`. The **fix** is `strategy: 'pairwise'` (divide-and-conquer over `BRepAlgoAPI_Fuse`, a different algorithm that is unaffected; `booleanFns.ts`). Tracked upstream at andymai/opencascade.js#3.
 
 **Where export lives (structural gotcha).** Import functions live in `src/io/` (`importFns.ts`), but the STEP/STL/IGES _export_ functions live in `src/topology/meshFns.ts` (`exportSTEP`/`exportSTL`/`exportIGES`) and assembly STEP in `src/operations/exporterFns.ts` — not in `io/`. `importSTL` auto-runs `ShapeUpgrade_UnifySameDomain` on the read shape (`src/kernel/occt/ioOps.ts`); IGES round-trips both ways.
 
@@ -84,7 +84,7 @@ When a modifier lands on the wrong entities, the defect is the _selection_, not 
 The `brep` CLI (bin in `packages/brepjs-cad`) renders and validates `.brep.ts` modules. For interpreting the verify **report** (checks, hints, body relations, the multi-body fragmentation advisory), defer to the sibling skill `brepjs:verify` (`packages/brepjs-cad/skills/verify/SKILL.md`) — this skill covers the debugging loop, not the report anatomy.
 
 - `brep verify <file>.brep.ts [--check] [--json] [--metrics]` is the primary loop. `--check` typechecks first; `--metrics` adds deterministic manufacturability metrics + the interference matrix (off by default, slow). `--expect-code <CODE>` / `--expect-invalid` assert a known-bad part fails the _right_ way.
-- `brep snapshot <file>.brep.ts [--out dir] [--label tag]` renders all views in one pass: `iso`, `front`, `top`, `right`, `iso-xray` (reveals bores/internal walls an opaque render is blind to), plus a conditional aimed `section` shot and a `marks` (Set-of-Marks B#/H# label) shot when the report detects bores/bodies (`snapshot/shoot.ts:22-41`). Each PNG has its bbox size (W×D×H) burned in, so scale is readable from the image. `--label` writes to a subfolder for pre/post A/B pairing.
+- `brep snapshot <file>.brep.ts [--out dir] [--label tag]` renders all views in one pass: `iso`, `front`, `top`, `right`, `iso-xray` (reveals bores/internal walls an opaque render is blind to), plus a conditional aimed `section` shot and a `marks` (Set-of-Marks B#/H# label) shot when the report detects bores/bodies (`snapshot/shoot.ts`). Each PNG has its bbox size (W×D×H) burned in, so scale is readable from the image. `--label` writes to a subfolder for pre/post A/B pairing.
 - Snapshots use a private ephemeral render server (`fresh: true`), so parallel snapshots don't contend on the shared `:7373` server.
 - Puppeteer is lazily/optionally imported: without it, the JSON report still emits and the CLI prints `snapshots need puppeteer/Chrome — run: npm i puppeteer`.
 - **Prefer one `brep snapshot` over rendering each angle separately** — one pass gives every standard view. Judge fine surface finish (fine threads, small chamfers) from a real playground render rather than the snapshot, which can exaggerate thin features.
@@ -99,13 +99,13 @@ Full mechanics in `references/kernel-divergence.md`. When a part passes on the d
 2. **Localize the diverging op.** The in-repo technique (`tests/kernelDivergenceCoverage.test.ts`): compare against an **analytic reference** AND against an **alternate representation** of the same shape — e.g. a torus _primitive_ is exact while a _revolve_ sweep undershoots its volume by ~2%, which pins the loss to the sweep, not the primitive (#968).
 3. **When confirmed, register it** in `tests/helpers/kernelDivergences.ts` (single source of truth; key = `operation.specificCase`, kinds `not-implemented | skip | tolerance | topology-differs`) and gate tests with `skipIfDiverges(ctx, key)`. Always cite the upstream issue. The conformance matrix `docs/kernel-conformance.md` is auto-generated (`npm run conformance:generate`).
 
-Note: the default **occt-wasm kernel exposes no raw `oc` handle** (`kernelDivergences.ts:421-458`) — raw-OCCT debugging tricks (poking `TopoDS_*`, patching `FS`) are unavailable there.
+Note: the default **occt-wasm kernel exposes no raw `oc` handle** (`kernelDivergences.ts`) — raw-OCCT debugging tricks (poking `TopoDS_*`, patching `FS`) are unavailable there.
 
 ## Step 7 — Writing the repro test
 
 1. `import { initKernel } from './setup.js'` (`initOC` is a legacy alias) and `beforeAll(async () => { await initKernel(); }, 30000)`.
 2. Use `unwrap(result)` in tests; assert geometry with `toBeCloseTo(expected, precision)` — never exact float equality.
-3. To force the **invalid-shape** healing path deterministically, spy `kernel.isValid` to return `false` on the first call then delegate — the `mockKernelIsValid` pattern in `tests/autoHeal.test.ts:121-133`. See the sibling skill `writing-tests`.
+3. To force the **invalid-shape** healing path deterministically, spy `kernel.isValid` to return `false` on the first call then delegate — the `mockKernelIsValid` pattern in `tests/autoHeal.test.ts`. See the sibling skill `writing-tests`.
 
 ## Additional resources
 

--- a/.claude/skills/debugging-geometry/references/boolean-failures.md
+++ b/.claude/skills/debugging-geometry/references/boolean-failures.md
@@ -6,37 +6,37 @@ Symbols in `src/topology/booleanFns.ts`, `src/topology/booleanDiagnosticFns.ts`,
 
 ### 1. `checkBoolean(base, tool, op)` — pre-flight predictor
 
-`booleanDiagnosticFns.ts:23-26` → `CheckBooleanResult { valid, issues: BooleanIssue[] }`. Each issue is `{ operand: 'base'|'tool', issue: 'null-shape'|'not-valid', message }` (`kernel/types.ts:166-180`). It only checks operands for null/invalid **before** the op — it never explains a failure after the fact. Exported from `src/index.ts`. Tests: `tests/booleanDiagnostics.test.ts:69-100`.
+`booleanDiagnosticFns.ts` → `CheckBooleanResult { valid, issues: BooleanIssue[] }`. Each issue is `{ operand: 'base'|'tool', issue: 'null-shape'|'not-valid', message }` (`kernel/types.ts`). It only checks operands for null/invalid **before** the op — it never explains a failure after the fact. Exported from `src/index.ts`. Tests: `tests/booleanDiagnostics.test.ts`.
 
 ### 2. `BooleanDiagnostics` — post-op signal
 
-`{ hasErrors, hasWarnings, messages }` (`kernel/types.ts:147-159`). `fuse`/`cut`/`intersect` with `trackEvolution` (default `true`) call the `*WithHistory` kernel path and attach this.
+`{ hasErrors, hasWarnings, messages }` (`kernel/types.ts`). `fuse`/`cut`/`intersect` with `trackEvolution` (default `true`) call the `*WithHistory` kernel path and attach this.
 
 - **`messages` is always empty** — OCCT's `Standard_OStream` reporting is unreachable in WASM builds (documented on the type). Branch on `hasErrors`/`hasWarnings`, never on message text.
 - `hasErrors` + null result → the op retries once **without** evolution tracking (`console.warn`).
-- `hasErrors` + non-null result → warns and continues (`booleanFns.ts:154-173`).
-- When the result cannot cast to 3D, diagnostics ride into `error.metadata.diagnostics` (`booleanFns.ts:82-90`).
+- `hasErrors` + non-null result → warns and continues (`booleanFns.ts`).
+- When the result cannot cast to 3D, diagnostics ride into `error.metadata.diagnostics` (`booleanFns.ts`).
 
 ## Built-in guards and knobs
 
-- Null operands are rejected pre-kernel via `validateShape3D` → `NULL_SHAPE_INPUT` (`booleanFns.ts:39-44`, used at `:132-135`).
-- The 3D cast failure names the actual type: "Got COMPOUND instead." / "Got FACE instead." (`booleanFns.ts:58-91`) — a compound out of a fuse means the operands didn't merge.
-- The FUSE error carries a baked-in suggestion: _"Common causes: overlapping coplanar faces, zero-thickness geometry, or non-manifold input. Try autoHeal() on inputs first."_ (`booleanFns.ts:178`).
-- `fuzzyValue` (a `BooleanOptions` field, `booleanFns.ts:126,141`) widens tolerance for near-coincident geometry.
-- `BOOLEAN_HAS_ERRORS` (`src/core/errors.ts:44`) — the `brep` CLI hint table reads it as "often coincident faces or near-tangent contact — perturb one operand slightly" (`packages/brepjs-cad/src/verify/report.ts:293-297`).
+- Null operands are rejected pre-kernel via `validateShape3D` → `NULL_SHAPE_INPUT` (`booleanFns.ts`, used at `:132-135`).
+- The 3D cast failure names the actual type: "Got COMPOUND instead." / "Got FACE instead." (`booleanFns.ts`) — a compound out of a fuse means the operands didn't merge.
+- The FUSE error carries a baked-in suggestion: _"Common causes: overlapping coplanar faces, zero-thickness geometry, or non-manifold input. Try autoHeal() on inputs first."_ (`booleanFns.ts`).
+- `fuzzyValue` (a `BooleanOptions` field, `booleanFns.ts`) widens tolerance for near-coincident geometry.
+- `BOOLEAN_HAS_ERRORS` (`src/core/errors.ts`) — the `brep` CLI hint table reads it as "often coincident faces or near-tangent contact — perturb one operand slightly" (`packages/brepjs-cad/src/verify/report.ts`).
 
 ## The #1126 disjoint-fuse corruption class
 
-**Symptom.** `fuseAll(shapes)` (default `strategy: 'native'`, N-way `BRepAlgoAPI_BuilderAlgo`) silently corrupts the topology of certain disjoint inputs — the canonical case is an annular-sector tread fused with a frenet-swept rail. The result passes `isValid`, `validSolid`, `mesh`, `measureArea`, and `getBounds`, and `autoHeal` cannot repair it. It only manifests when the STEP writer runs, as a `WebAssembly.RuntimeError` that **corrupts the Emscripten heap and poisons the kernel for the rest of the session** (`meshFns.ts:185-196`).
+**Symptom.** `fuseAll(shapes)` (default `strategy: 'native'`, N-way `BRepAlgoAPI_BuilderAlgo`) silently corrupts the topology of certain disjoint inputs — the canonical case is an annular-sector tread fused with a frenet-swept rail. The result passes `isValid`, `validSolid`, `mesh`, `measureArea`, and `getBounds`, and `autoHeal` cannot repair it. It only manifests when the STEP writer runs, as a `WebAssembly.RuntimeError` that **corrupts the Emscripten heap and poisons the kernel for the rest of the session** (`meshFns.ts`).
 
 **Detection nets** (neither is a full guard):
 
-- `probeSerializable` (`meshFns.ts:234-266`) runs a pre-export bounding-box probe and catches _some_ degenerates → `STEP_EXPORT_UNSERIALIZABLE` / `STL_EXPORT_UNSERIALIZABLE`, localizing the offending sub-solid. It does **not** catch the canonical #1126 shape.
-- `exportError` classifies the writer trap as `*_EXPORT_CRASHED` (`meshFns.ts:200-232`) — the only signal for the non-probeable case.
+- `probeSerializable` (`meshFns.ts`) runs a pre-export bounding-box probe and catches _some_ degenerates → `STEP_EXPORT_UNSERIALIZABLE` / `STL_EXPORT_UNSERIALIZABLE`, localizing the offending sub-solid. It does **not** catch the canonical #1126 shape.
+- `exportError` classifies the writer trap as `*_EXPORT_CRASHED` (`meshFns.ts`) — the only signal for the non-probeable case.
 
-**Fix.** `fuseAll(shapes, { strategy: 'pairwise' })` — recursive divide-and-conquer over `BRepAlgoAPI_Fuse`, a different OCCT algorithm that is unaffected (`booleanFns.ts:427-465`). Tracked upstream at andymai/opencascade.js#3.
+**Fix.** `fuseAll(shapes, { strategy: 'pairwise' })` — recursive divide-and-conquer over `BRepAlgoAPI_Fuse`, a different OCCT algorithm that is unaffected (`booleanFns.ts`). Tracked upstream at andymai/opencascade.js#3.
 
-## Recovery sequence (from `docs/getting-started.md:390-399`)
+## Recovery sequence (from `docs/getting-started.md`)
 
 1. Read `error.suggestion`.
 2. Check the operands actually overlap.

--- a/.claude/skills/debugging-geometry/references/boolean-failures.md
+++ b/.claude/skills/debugging-geometry/references/boolean-failures.md
@@ -1,0 +1,44 @@
+# Boolean failure reference
+
+Symbols in `src/topology/booleanFns.ts`, `src/topology/booleanDiagnosticFns.ts`, `src/topology/meshFns.ts`, and `src/kernel/types.ts`.
+
+## Two diagnostic surfaces — keep them separate
+
+### 1. `checkBoolean(base, tool, op)` — pre-flight predictor
+
+`booleanDiagnosticFns.ts:23-26` → `CheckBooleanResult { valid, issues: BooleanIssue[] }`. Each issue is `{ operand: 'base'|'tool', issue: 'null-shape'|'not-valid', message }` (`kernel/types.ts:166-180`). It only checks operands for null/invalid **before** the op — it never explains a failure after the fact. Exported from `src/index.ts`. Tests: `tests/booleanDiagnostics.test.ts:69-100`.
+
+### 2. `BooleanDiagnostics` — post-op signal
+
+`{ hasErrors, hasWarnings, messages }` (`kernel/types.ts:147-159`). `fuse`/`cut`/`intersect` with `trackEvolution` (default `true`) call the `*WithHistory` kernel path and attach this.
+
+- **`messages` is always empty** — OCCT's `Standard_OStream` reporting is unreachable in WASM builds (documented on the type). Branch on `hasErrors`/`hasWarnings`, never on message text.
+- `hasErrors` + null result → the op retries once **without** evolution tracking (`console.warn`).
+- `hasErrors` + non-null result → warns and continues (`booleanFns.ts:154-173`).
+- When the result cannot cast to 3D, diagnostics ride into `error.metadata.diagnostics` (`booleanFns.ts:82-90`).
+
+## Built-in guards and knobs
+
+- Null operands are rejected pre-kernel via `validateShape3D` → `NULL_SHAPE_INPUT` (`booleanFns.ts:39-44`, used at `:132-135`).
+- The 3D cast failure names the actual type: "Got COMPOUND instead." / "Got FACE instead." (`booleanFns.ts:58-91`) — a compound out of a fuse means the operands didn't merge.
+- The FUSE error carries a baked-in suggestion: _"Common causes: overlapping coplanar faces, zero-thickness geometry, or non-manifold input. Try autoHeal() on inputs first."_ (`booleanFns.ts:178`).
+- `fuzzyValue` (a `BooleanOptions` field, `booleanFns.ts:126,141`) widens tolerance for near-coincident geometry.
+- `BOOLEAN_HAS_ERRORS` (`src/core/errors.ts:44`) — the `brep` CLI hint table reads it as "often coincident faces or near-tangent contact — perturb one operand slightly" (`packages/brepjs-cad/src/verify/report.ts:293-297`).
+
+## The #1126 disjoint-fuse corruption class
+
+**Symptom.** `fuseAll(shapes)` (default `strategy: 'native'`, N-way `BRepAlgoAPI_BuilderAlgo`) silently corrupts the topology of certain disjoint inputs — the canonical case is an annular-sector tread fused with a frenet-swept rail. The result passes `isValid`, `validSolid`, `mesh`, `measureArea`, and `getBounds`, and `autoHeal` cannot repair it. It only manifests when the STEP writer runs, as a `WebAssembly.RuntimeError` that **corrupts the Emscripten heap and poisons the kernel for the rest of the session** (`meshFns.ts:185-196`).
+
+**Detection nets** (neither is a full guard):
+
+- `probeSerializable` (`meshFns.ts:234-266`) runs a pre-export bounding-box probe and catches _some_ degenerates → `STEP_EXPORT_UNSERIALIZABLE` / `STL_EXPORT_UNSERIALIZABLE`, localizing the offending sub-solid. It does **not** catch the canonical #1126 shape.
+- `exportError` classifies the writer trap as `*_EXPORT_CRASHED` (`meshFns.ts:200-232`) — the only signal for the non-probeable case.
+
+**Fix.** `fuseAll(shapes, { strategy: 'pairwise' })` — recursive divide-and-conquer over `BRepAlgoAPI_Fuse`, a different OCCT algorithm that is unaffected (`booleanFns.ts:427-465`). Tracked upstream at andymai/opencascade.js#3.
+
+## Recovery sequence (from `docs/getting-started.md:390-399`)
+
+1. Read `error.suggestion`.
+2. Check the operands actually overlap.
+3. `unwrap(autoHeal(shape))` on the operands.
+4. Branch on `error.code` (look it up in `docs/errors.md`).

--- a/.claude/skills/debugging-geometry/references/healing.md
+++ b/.claude/skills/debugging-geometry/references/healing.md
@@ -6,7 +6,7 @@ All symbols in `src/topology/healingFns.ts` unless noted.
 
 The one-call entry point. Dispatches to `ShapeFix_Solid`/`Face`/`Wire` by shape type. Marked `// brepjs-patterns-disable: max-function-lines`.
 
-### `AutoHealOptions` (`healingFns.ts:156-167`)
+### `AutoHealOptions` (`healingFns.ts`)
 
 | Option                | Default | Effect                                     |
 | --------------------- | ------- | ------------------------------------------ |
@@ -16,7 +16,7 @@ The one-call entry point. Dispatches to `ShapeFix_Solid`/`Face`/`Wire` by shape 
 | `sewTolerance`        | _unset_ | **Sewing runs only when this is provided** |
 | `fixSelfIntersection` | `false` | Fix wire self-intersections                |
 
-### `HealingReport` (`healingFns.ts:170-179`)
+### `HealingReport` (`healingFns.ts`)
 
 ```
 { isValid, alreadyValid, wiresHealed, facesHealed, solidHealed, steps: string[], diagnostics: HealingStepDiagnostic[] }
@@ -24,12 +24,12 @@ The one-call entry point. Dispatches to `ShapeFix_Solid`/`Face`/`Wire` by shape 
 
 `HealingStepDiagnostic` = `{ name, attempted, succeeded, detail? }`.
 
-- `wiresHealed`/`facesHealed` are `Math.abs(after - before)` **count deltas** (`healingFns.ts:301-305`) — a heuristic change-detector, not a repair count.
-- On the invalid path, diagnostic `name`s appear in order: `sew`, `fixSelfIntersection`, then `healSolid`/`healFace`/`healWire` (or `healShape` with `detail:'skipped by options'`), then `finalValidation` (`healingFns.ts:228-313`).
+- `wiresHealed`/`facesHealed` are `Math.abs(after - before)` **count deltas** (`healingFns.ts`) — a heuristic change-detector, not a repair count.
+- On the invalid path, diagnostic `name`s appear in order: `sew`, `fixSelfIntersection`, then `healSolid`/`healFace`/`healWire` (or `healShape` with `detail:'skipped by options'`), then `finalValidation` (`healingFns.ts`).
 
 ### The short-circuit (the #1 trap)
 
-When `isValid(shape)` is already true, `autoHeal` returns immediately (`healingFns.ts:202-216`):
+When `isValid(shape)` is already true, `autoHeal` returns immediately (`healingFns.ts`):
 
 ```
 report = {
@@ -40,21 +40,21 @@ report = {
 }
 ```
 
-No `sew`/`fixSelfIntersection`/`healSolid` diagnostics because **those passes never executed**. Do not read an `alreadyValid` report as "healing inspected the shape and found nothing." Confirmed by `tests/autoHeal.test.ts:27-38` and `:100-105`.
+No `sew`/`fixSelfIntersection`/`healSolid` diagnostics because **those passes never executed**. Do not read an `alreadyValid` report as "healing inspected the shape and found nothing." Confirmed by `tests/autoHeal.test.ts` and `:100-105`.
 
 ## Escalation ladder
 
 When `autoHeal` leaves `report.isValid === false`:
 
 1. Retry with an explicit `sewTolerance` (turns on the sewing pass).
-2. `fixShape(shape)` — general `ShapeFix_Shape` repair (`healingFns.ts:337-345`).
-3. `solidFromShell(shell)` — promote a closed shell to a solid (`healingFns.ts:352-376`).
-4. `fixSelfIntersection(wire)` — targeted self-intersection repair (`healingFns.ts:383-401`).
+2. `fixShape(shape)` — general `ShapeFix_Shape` repair (`healingFns.ts`).
+3. `solidFromShell(shell)` — promote a closed shell to a solid (`healingFns.ts`).
+4. `fixSelfIntersection(wire)` — targeted self-intersection repair (`healingFns.ts`).
 5. Give up: surface `HEAL_SOLID_INCOMPLETE` / `HEAL_NO_EFFECT` to the caller.
 
 ## Type-specific healers and their failure codes
 
-`healSolid(solid)` → `Result<ValidSolid>` (`healingFns.ts:36-76`) validates the healed result and fails three ways:
+`healSolid(solid)` → `Result<ValidSolid>` (`healingFns.ts`) validates the healed result and fails three ways:
 
 | Kernel result               | Input state   | Outcome                              |
 | --------------------------- | ------------- | ------------------------------------ |
@@ -62,8 +62,8 @@ When `autoHeal` leaves `report.isValid === false`:
 | `null`                      | invalid       | `HEAL_NO_EFFECT`                     |
 | non-null but re-check fails | —             | `HEAL_SOLID_INCOMPLETE`              |
 
-`healSolid` calls `invalidateShapeCache(cast)` because brepkit heals **in-place** and returns the same handle, so the cached `isValid` would otherwise be stale (`healingFns.ts:62-64`). Other healers: `healFace` (`:83`), `healWire(wire, face?)` (`:106`, `face` gives surface context). The polymorphic `heal(shape)` (`:129-141`) dispatches solid/face/wire and returns any other type unchanged.
+`healSolid` calls `invalidateShapeCache(cast)` because brepkit heals **in-place** and returns the same handle, so the cached `isValid` would otherwise be stale (`healingFns.ts`). Other healers: `healFace` (`:83`), `healWire(wire, face?)` (`:106`, `face` gives surface context). The polymorphic `heal(shape)` (`:129-141`) dispatches solid/face/wire and returns any other type unchanged.
 
 ## Validity caching
 
-`isValid` delegates to `getCachedIsValid` (`healingFns.ts:23-25`). When a value looks stale after an in-place repair, call `invalidateShapeCache` (in `src/topology/topologyQueryFns.ts`, re-exported from the index).
+`isValid` delegates to `getCachedIsValid` (`healingFns.ts`). When a value looks stale after an in-place repair, call `invalidateShapeCache` (in `src/topology/topologyQueryFns.ts`, re-exported from the index).

--- a/.claude/skills/debugging-geometry/references/healing.md
+++ b/.claude/skills/debugging-geometry/references/healing.md
@@ -1,0 +1,69 @@
+# Healing pipeline reference
+
+All symbols in `src/topology/healingFns.ts` unless noted.
+
+## `autoHeal(shape, options?)` → `Result<{ shape, report }>`
+
+The one-call entry point. Dispatches to `ShapeFix_Solid`/`Face`/`Wire` by shape type. Marked `// brepjs-patterns-disable: max-function-lines`.
+
+### `AutoHealOptions` (`healingFns.ts:156-167`)
+
+| Option                | Default | Effect                                     |
+| --------------------- | ------- | ------------------------------------------ |
+| `fixWires`            | `true`  | Fix wire gaps/connectivity                 |
+| `fixFaces`            | `true`  | Fix face orientation/geometry              |
+| `fixSolids`           | `true`  | Fix shell gaps/orientation                 |
+| `sewTolerance`        | _unset_ | **Sewing runs only when this is provided** |
+| `fixSelfIntersection` | `false` | Fix wire self-intersections                |
+
+### `HealingReport` (`healingFns.ts:170-179`)
+
+```
+{ isValid, alreadyValid, wiresHealed, facesHealed, solidHealed, steps: string[], diagnostics: HealingStepDiagnostic[] }
+```
+
+`HealingStepDiagnostic` = `{ name, attempted, succeeded, detail? }`.
+
+- `wiresHealed`/`facesHealed` are `Math.abs(after - before)` **count deltas** (`healingFns.ts:301-305`) — a heuristic change-detector, not a repair count.
+- On the invalid path, diagnostic `name`s appear in order: `sew`, `fixSelfIntersection`, then `healSolid`/`healFace`/`healWire` (or `healShape` with `detail:'skipped by options'`), then `finalValidation` (`healingFns.ts:228-313`).
+
+### The short-circuit (the #1 trap)
+
+When `isValid(shape)` is already true, `autoHeal` returns immediately (`healingFns.ts:202-216`):
+
+```
+report = {
+  isValid: true, alreadyValid: true,
+  wiresHealed: 0, facesHealed: 0, solidHealed: false,
+  steps: ['Shape already valid'],
+  diagnostics: [{ name: 'validation', attempted: true, succeeded: true }],
+}
+```
+
+No `sew`/`fixSelfIntersection`/`healSolid` diagnostics because **those passes never executed**. Do not read an `alreadyValid` report as "healing inspected the shape and found nothing." Confirmed by `tests/autoHeal.test.ts:27-38` and `:100-105`.
+
+## Escalation ladder
+
+When `autoHeal` leaves `report.isValid === false`:
+
+1. Retry with an explicit `sewTolerance` (turns on the sewing pass).
+2. `fixShape(shape)` — general `ShapeFix_Shape` repair (`healingFns.ts:337-345`).
+3. `solidFromShell(shell)` — promote a closed shell to a solid (`healingFns.ts:352-376`).
+4. `fixSelfIntersection(wire)` — targeted self-intersection repair (`healingFns.ts:383-401`).
+5. Give up: surface `HEAL_SOLID_INCOMPLETE` / `HEAL_NO_EFFECT` to the caller.
+
+## Type-specific healers and their failure codes
+
+`healSolid(solid)` → `Result<ValidSolid>` (`healingFns.ts:36-76`) validates the healed result and fails three ways:
+
+| Kernel result               | Input state   | Outcome                              |
+| --------------------------- | ------------- | ------------------------------------ |
+| `null`                      | already valid | returns the original solid unchanged |
+| `null`                      | invalid       | `HEAL_NO_EFFECT`                     |
+| non-null but re-check fails | —             | `HEAL_SOLID_INCOMPLETE`              |
+
+`healSolid` calls `invalidateShapeCache(cast)` because brepkit heals **in-place** and returns the same handle, so the cached `isValid` would otherwise be stale (`healingFns.ts:62-64`). Other healers: `healFace` (`:83`), `healWire(wire, face?)` (`:106`, `face` gives surface context). The polymorphic `heal(shape)` (`:129-141`) dispatches solid/face/wire and returns any other type unchanged.
+
+## Validity caching
+
+`isValid` delegates to `getCachedIsValid` (`healingFns.ts:23-25`). When a value looks stale after an in-place repair, call `invalidateShapeCache` (in `src/topology/topologyQueryFns.ts`, re-exported from the index).

--- a/.claude/skills/debugging-geometry/references/healing.md
+++ b/.claude/skills/debugging-geometry/references/healing.md
@@ -54,7 +54,7 @@ When `autoHeal` leaves `report.isValid === false`:
 
 ## Type-specific healers and their failure codes
 
-`healSolid(solid)` → `Result<ValidSolid>` (`healingFns.ts`) validates the healed result and fails three ways:
+`healSolid(solid)` → `Result<ValidSolid>` (`healingFns.ts`) validates the healed result and resolves to one of three outcomes (one success, two errors):
 
 | Kernel result               | Input state   | Outcome                              |
 | --------------------------- | ------------- | ------------------------------------ |
@@ -62,7 +62,7 @@ When `autoHeal` leaves `report.isValid === false`:
 | `null`                      | invalid       | `HEAL_NO_EFFECT`                     |
 | non-null but re-check fails | —             | `HEAL_SOLID_INCOMPLETE`              |
 
-`healSolid` calls `invalidateShapeCache(cast)` because brepkit heals **in-place** and returns the same handle, so the cached `isValid` would otherwise be stale (`healingFns.ts`). Other healers: `healFace` (`:83`), `healWire(wire, face?)` (`:106`, `face` gives surface context). The polymorphic `heal(shape)` (`:129-141`) dispatches solid/face/wire and returns any other type unchanged.
+`healSolid` calls `invalidateShapeCache(cast)` because brepkit heals **in-place** and returns the same handle, so the cached `isValid` would otherwise be stale (`healingFns.ts`). Other healers: `healFace`, `healWire(wire, face?)` (`face` gives surface context). The polymorphic `heal(shape)` dispatches solid/face/wire and returns any other type unchanged.
 
 ## Validity caching
 

--- a/.claude/skills/debugging-geometry/references/kernel-divergence.md
+++ b/.claude/skills/debugging-geometry/references/kernel-divergence.md
@@ -2,7 +2,7 @@
 
 ## Kernels and how to run each
 
-Registry: `tests/helpers/kernelRegistry.ts:41-113` — four kernels, `occt-wasm` is the default (`tests/setup-kernel.ts` reads `TEST_KERNEL`, defaulting via `defaultKernelId()`):
+Registry: `tests/helpers/kernelRegistry.ts` — four kernels, `occt-wasm` is the default (`tests/setup-kernel.ts` reads `TEST_KERNEL`, defaulting via `defaultKernelId()`):
 
 | id          | Notes                                                   |
 | ----------- | ------------------------------------------------------- |
@@ -11,7 +11,7 @@ Registry: `tests/helpers/kernelRegistry.ts:41-113` — four kernels, `occt-wasm`
 | `brepkit`   | External `brepkit-wasm`. Local-only.                    |
 | `manifold`  | Mesh/CSG preview kernel. Local-only, several ops gated. |
 
-Commands (root `package.json`): `npm run test` / `test:ci` / `test:full` run the `occt-wasm` project only; `npm run test:occt` and `npm run test:brepkit` run those projects. Each vitest project sets `env: { TEST_KERNEL: k.id }` (`vitest.config.ts:98-102`). **CI runs only `occt-wasm`** (`.github/workflows/ci.yml:254-258`, sharded 4-way) — reproduce brepkit/manifold divergences locally.
+Commands (root `package.json`): `npm run test` / `test:ci` / `test:full` run the `occt-wasm` project only; `npm run test:occt` and `npm run test:brepkit` run those projects. Each vitest project sets `env: { TEST_KERNEL: k.id }` (`vitest.config.ts`). **CI runs only `occt-wasm`** (`.github/workflows/ci.yml:254-258`, sharded 4-way) — reproduce brepkit/manifold divergences locally.
 
 Kernel capability flags (`kernelRegistry.ts`): `projection`, `constraintSketch`, `kernel2D`, `variableFillet`, `offsetSolidV2`, `gridPattern`. `excludeTests` lists files a kernel can't run (occt-wasm excludes brepkit-only + gltfRoundTrip files).
 
@@ -35,19 +35,19 @@ Tests gate with `skipIfDiverges(ctx, key)` (`:548-556`). Cross-kernel assertions
 1. Analytic reference (closed-form volume/area).
 2. An alternate representation of the same shape.
 
-Worked example (#968): a torus **primitive** matches its analytic volume exactly, but a **revolve** sweep of the same profile undershoots by ~2% (inscribed-polygon surface). Two references isolate the loss to the _sweep_, not the primitive (`kernelDivergenceCoverage.test.ts:67-95`).
+Worked example (#968): a torus **primitive** matches its analytic volume exactly, but a **revolve** sweep of the same profile undershoots by ~2% (inscribed-polygon surface). Two references isolate the loss to the _sweep_, not the primitive (`kernelDivergenceCoverage.test.ts`).
 
 ## Known brepkit inscribed-polygon family (#965–968)
 
 Status as of brepkit-wasm 2.116.1:
 
-- **#967** (fillet-on-cylinder-rim collapse) — **FIXED** on brepkit; the test now runs green there as a regression tripwire. Only **manifold** stays gated (`kernelDivergenceCoverage.test.ts:30-39`; registry `manifold.modifierFns.filletCylindricalEdge`).
+- **#967** (fillet-on-cylinder-rim collapse) — **FIXED** on brepkit; the test now runs green there as a regression tripwire. Only **manifold** stays gated (`kernelDivergenceCoverage.test.ts`; registry `manifold.modifierFns.filletCylindricalEdge`).
 - **#968** (`extrudeFns.revolveCircularProfile`) — **still divergent** on brepkit (~2% torus-volume undershoot).
 - #965 (sweep) / #966 (extrude) — same inscribed-polygon family. Tests cite upstream andymai/brepkit issues.
 
 ## occt-wasm has no raw `oc`
 
-The default kernel exposes no raw OCCT handle (`kernelDivergences.ts:421-458`). Raw-API debugging tricks — inspecting `TopoDS_*` null shapes, patching Emscripten `FS.readFile` — do not exist there; use the branded-shape query surface (`describe`, `getBounds`, `measure*`) instead.
+The default kernel exposes no raw OCCT handle (`kernelDivergences.ts`). Raw-API debugging tricks — inspecting `TopoDS_*` null shapes, patching Emscripten `FS.readFile` — do not exist there; use the branded-shape query surface (`describe`, `getBounds`, `measure*`) instead.
 
 ## Conformance matrix
 

--- a/.claude/skills/debugging-geometry/references/kernel-divergence.md
+++ b/.claude/skills/debugging-geometry/references/kernel-divergence.md
@@ -1,0 +1,54 @@
+# Kernel-divergence reference
+
+## Kernels and how to run each
+
+Registry: `tests/helpers/kernelRegistry.ts:41-113` — four kernels, `occt-wasm` is the default (`tests/setup-kernel.ts` reads `TEST_KERNEL`, defaulting via `defaultKernelId()`):
+
+| id          | Notes                                                   |
+| ----------- | ------------------------------------------------------- |
+| `occt-wasm` | Default. No raw `oc` handle exposed. CI gate.           |
+| `occt`      | opencascade.js WASM (`initFromOC`).                     |
+| `brepkit`   | External `brepkit-wasm`. Local-only.                    |
+| `manifold`  | Mesh/CSG preview kernel. Local-only, several ops gated. |
+
+Commands (root `package.json`): `npm run test` / `test:ci` / `test:full` run the `occt-wasm` project only; `npm run test:occt` and `npm run test:brepkit` run those projects. Each vitest project sets `env: { TEST_KERNEL: k.id }` (`vitest.config.ts:98-102`). **CI runs only `occt-wasm`** (`.github/workflows/ci.yml:254-258`, sharded 4-way) — reproduce brepkit/manifold divergences locally.
+
+Kernel capability flags (`kernelRegistry.ts`): `projection`, `constraintSketch`, `kernel2D`, `variableFillet`, `offsetSolidV2`, `gridPattern`. `excludeTests` lists files a kernel can't run (occt-wasm excludes brepkit-only + gltfRoundTrip files).
+
+## The divergence registry — single source of truth
+
+`tests/helpers/kernelDivergences.ts`. Key = `operation.specificCase`. Kinds:
+
+| kind               | Meaning                                       |
+| ------------------ | --------------------------------------------- |
+| `not-implemented`  | op absent on this kernel                      |
+| `skip`             | intentionally not run                         |
+| `tolerance`        | numeric result differs beyond default epsilon |
+| `topology-differs` | valid but structurally different result       |
+
+Tests gate with `skipIfDiverges(ctx, key)` (`:548-556`). Cross-kernel assertions use `expectClose` / `expectKernelsAgree` (`:566-589`). Register every confirmed divergence here with an upstream issue link, then gate the affected test.
+
+## Localizing a divergence (the in-repo technique)
+
+`tests/kernelDivergenceCoverage.test.ts` — compare against **two independent references** to pin which op diverges:
+
+1. Analytic reference (closed-form volume/area).
+2. An alternate representation of the same shape.
+
+Worked example (#968): a torus **primitive** matches its analytic volume exactly, but a **revolve** sweep of the same profile undershoots by ~2% (inscribed-polygon surface). Two references isolate the loss to the _sweep_, not the primitive (`kernelDivergenceCoverage.test.ts:67-95`).
+
+## Known brepkit inscribed-polygon family (#965–968)
+
+Status as of brepkit-wasm 2.116.1:
+
+- **#967** (fillet-on-cylinder-rim collapse) — **FIXED** on brepkit; the test now runs green there as a regression tripwire. Only **manifold** stays gated (`kernelDivergenceCoverage.test.ts:30-39`; registry `manifold.modifierFns.filletCylindricalEdge`).
+- **#968** (`extrudeFns.revolveCircularProfile`) — **still divergent** on brepkit (~2% torus-volume undershoot).
+- #965 (sweep) / #966 (extrude) — same inscribed-polygon family. Tests cite upstream andymai/brepkit issues.
+
+## occt-wasm has no raw `oc`
+
+The default kernel exposes no raw OCCT handle (`kernelDivergences.ts:421-458`). Raw-API debugging tricks — inspecting `TopoDS_*` null shapes, patching Emscripten `FS.readFile` — do not exist there; use the branded-shape query surface (`describe`, `getBounds`, `measure*`) instead.
+
+## Conformance matrix
+
+`docs/kernel-conformance.md` tabulates capabilities and per-test divergences across all four kernels. It is auto-generated — run `npm run conformance:generate` after registry changes; do not hand-edit.

--- a/.claude/skills/git-pr-workflow/SKILL.md
+++ b/.claude/skills/git-pr-workflow/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: git-pr-workflow
+description: This skill should be used when committing, pushing, branching, or merging in the brepjs repository — when a task involves "pre-commit hook failed" (which tier ran, how to bypass), "commit rejected by commitlint", "subject may not be empty", the pre-push knip tier firing, "create a branch", "set up a worktree", "open a PR", "arm auto-merge", or deciding whether a commit needs a `!` breaking marker. Covers hook anatomy and tiers, conventional-commit message format, branching, worktrees, and the PR/merge process. For diagnosing a specific gate or lint error see quality-gates; for a red CI job see ci-triage.
+---
+
+# Git hooks, commits, and PR flow
+
+Hooks are managed by husky (`core.hooksPath` → `.husky/_`, installed by the `prepare` script in `package.json`). The repo `CLAUDE.md` "Git hooks" section summarizes the tiers; this skill covers what to do when a gate fires and the traps around commits, worktrees, and merging.
+
+## Quick map
+
+| Concern              | Where it lives                                                               |
+| -------------------- | ---------------------------------------------------------------------------- |
+| Hook scripts         | `.husky/pre-commit`, `.husky/pre-push`, `.husky/commit-msg`                  |
+| lint-staged config   | `.lintstagedrc.json` (NOT in `package.json`)                                 |
+| Commit message rules | `commitlint.config.js` (`@commitlint/config-conventional`)                   |
+| Local full gate      | `npm run validate` (`scripts/validate-change.sh`)                            |
+| CI gate for merge    | `ci-pass` job in `.github/workflows/ci.yml` — the only required status check |
+| PR template          | `.github/pull_request_template.md`                                           |
+| Merge method         | Squash only; branch auto-deleted on merge                                    |
+
+## Pre-commit anatomy
+
+`.husky/pre-commit` runs three tiers; a `trap` prints `scripts/pre-commit-help.sh` on any failure.
+
+**Tier 1 (parallel):**
+
+- `npx lint-staged` — per `.lintstagedrc.json`: `src/**/*.ts` gets `eslint --fix` + `prettier --write` + the pattern checker (`scripts/check-patterns.ts`); `tests/**/*.ts` gets eslint + prettier only; `*.config.ts` and `*.md` get prettier only. The pattern checker runs only on `src/` files.
+- `npm run typecheck`
+- `npm run check:boundaries:staged` — the staged variant (`scripts/check-layer-boundaries.sh --staged`), not plain `check:boundaries`. On failure, see the architecture-navigation skill.
+
+**Tier 2:** `npm run test` — changed-file tests on the occt-wasm kernel, no coverage thresholds (`vitest run --project occt-wasm --changed`). Set `FULL_TESTS=1` to run `npm run test:full` (full suite with coverage) instead. Test failures: see the writing-tests skill.
+
+**Tier 3 (non-blocking, always exit 0):**
+
+- `npm run check:readme-reminders` — lists READMEs adjacent to staged `.ts` files that may need updating.
+- `bash scripts/check-function-lookup.sh` — fires when a staged path matches `src/**Fns.ts` (any depth) or an `index.ts` at one directory level (`src/index.ts` or `src/<dir>/index.ts`) without `docs/function-lookup.md`. Act on this one: run `npm run docs:generate-lookup` and stage the result. The local reminder is soft and its `index.ts` match is shallow (a deeper `src/kernel/occt/index.ts` won't trip it), but CI's `build` job is the authoritative gate at any depth — it regenerates, prettier-normalizes, and `git diff --exit-code`s the file.
+
+Before committing multi-file changes, prefer `npm run validate` (typecheck → lint → boundaries → format:check → changed tests) and read its output — do not commit on a partially green tree.
+
+Bypass with `git commit --no-verify` only as a last resort; CI runs strictly more than the hook, so a bypassed failure just moves to the PR.
+
+Note: `scripts/pre-commit-help.sh` and `CONTRIBUTING.md` still say coverage thresholds are enforced "at push time" / "in pre-commit hooks". That is stale — coverage thresholds run only in the main-branch-only, non-blocking `coverage` CI job. Locally they run only via `npm run test:full`.
+
+## commit-msg and pre-push
+
+- `.husky/commit-msg` runs `commitlint --edit` with `@commitlint/config-conventional`. A rejected message means the format is wrong, not the content — fix the `type(scope): subject` shape.
+- `.husky/pre-push` runs **only** `npm run knip` (unused-code detection, ~2 seconds). The full test suite is intentionally not re-run on push; CI's sharded `test` job is the full gate. If knip fails, either use the newly-flagged export or remove it — do not add it to `knip.config.ts` without cause.
+- If a push looked odd (interrupted terminal, unusual delay), verify it landed: `git ls-remote origin <branch>`.
+
+## Commits
+
+Format: `type(scope): subject`. Types and examples: `CONTRIBUTING.md` "Commit Conventions" (feat, fix, docs, style, refactor, perf, test, chore).
+
+**The `!` breaking-marker trap.** In `release-please-config.json`, the root `brepjs` package excludes only `apps`, `packages/brepjs-cad`, `packages/brepjs-viewer`, and `packages/brepjs-voxel`. Everything else at the repo root — including `docs/`, `scripts/`, and CI config — feeds the root release. Any commit with `!` (or a `BREAKING CHANGE:` footer) touching those paths major-bumps the published `brepjs` library. Never put `!` on site, docs, or tooling commits. When a change genuinely is breaking, confirm it touches the library surface before marking it. Full release pipeline: release-publishing skill.
+
+## Branches and worktrees
+
+- Branch naming: `<type>/<kebab-description>` where type is the conventional-commit type of the work — `feat/judge-graded-reference-verdict`, `fix/memory-leak`, `docs/api-examples`. (`CONTRIBUTING.md` shows an older `feature/` prefix; current practice uses the commit type.)
+- Worktrees for parallel branches go under `.worktrees/<branch>` inside the repo — gitignored (`.gitignore`) and excluded from the root vitest suite (`vitest.config.ts` excludes `.worktrees/**` and `.claude/worktrees/**`, because a stale worktree copy without WASM set up would otherwise fail the root suite):
+
+  ```bash
+  git worktree add .worktrees/feat-my-change feat/my-change
+  ```
+
+- Run `gh pr merge` from the main repo path, never from inside the worktree — deleting the branch while its worktree has it checked out fails.
+- After merge: `git worktree remove .worktrees/<branch>`, then in the main tree `git checkout main && git pull`. The repo deletes branches on merge, so the local branch goes `[gone]`; prune with `git fetch --prune`.
+
+## PR flow
+
+1. Push the branch and open a PR filling `.github/pull_request_template.md` (what/how-to-test/checklist).
+2. CI runs the jobs feeding `ci-pass`: typecheck, lint (eslint + `format:check`), quality (`check:boundaries` + `check:patterns` + `knip`), build (including the `docs/function-lookup.md` staleness diff), playground-build, per-package jobs (viewer/verify/sheetmetal/bim), voxel-wasm-rust, the 4-way-sharded `test` job, size, and benchmark. The `coverage` job runs on main only, `continue-on-error`, and is not part of `ci-pass`. CI failures: see the ci-triage skill.
+3. The benchmark job posts a PR comment comparing against main with a 25% regression threshold.
+4. **Reviews:** branch protection on `main` requires only the `ci-pass` status check — zero required approvals. Two AI reviewers (Greptile, configured in `.greptile/config.json`, and cubic) review every PR but are not required checks. **Wait for both AI reviews to land before arming `gh pr merge --auto`** — auto-merge armed early merges the moment `ci-pass` goes green, and real defects have been caught in reviews that arrived post-merge.
+5. Merge is squash-only; the squash commit title becomes the release-please changelog entry, so make the PR title a valid conventional commit.
+6. After merge: checkout main and pull immediately (the remote branch is auto-deleted).
+
+**Release PRs** (`release-please--*` head refs) skip the code-CI path and are auto-merged by `.github/workflows/release-please.yml` with strict ordering: the root `brepjs` release PR merges first; leaf release PRs (cad/bim/sheetmetal) are held while root is open, because the node-workspace plugin pins leaves to the pending root version — merging a leaf early leaves main pinned to an unpublished version and breaks `npm ci` with ETARGET. `brepjs-opencascade` is permanently held for manual merge. Do not manually merge release PRs out of this order.
+
+## Symptom → cause → fix
+
+| Symptom                                                             | Cause                                                                  | Fix                                                                             |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Pre-commit fails with layer VIOLATION                               | Upward import across layers                                            | architecture-navigation skill; `npm run check:boundaries` for the full report   |
+| Pre-commit fails in `check-patterns`                                | New pattern violation in staged `src/` file                            | See quality-gates (fix vs. baseline)                                            |
+| Every open PR fails `quality`/`check:patterns`                      | Unbaselined violation reached main (CI checks the PR merged with main) | See quality-gates (baseline-bump-first recovery)                                |
+| CI `build` fails on `git diff --exit-code docs/function-lookup.md`  | Stale generated lookup after `*Fns.ts` change                          | See adding-operations (function-lookup gate)                                    |
+| Commit rejected: "subject may not be empty" / "type must be one of" | Message not `type(scope): subject`                                     | Rewrite per `CONTRIBUTING.md` commit types                                      |
+| Published `brepjs` unexpectedly major-bumped                        | `!` or `BREAKING CHANGE:` on a docs/tooling commit                     | Never mark non-library commits breaking; `docs/` is not in root `exclude-paths` |
+| P1 review comment appears after merge                               | Auto-merge armed before AI reviews landed                              | Wait for Greptile + cubic before `gh pr merge --auto`                           |
+| `npm ci` fails ETARGET after a release merge                        | Leaf release PR merged while root `brepjs` release was open            | Merge root first; let the workflow regenerate leaf PRs                          |
+| `git worktree remove` or branch delete fails                        | Branch checked out in a worktree / merge run from inside it            | Operate from the main repo path; remove the worktree first                      |
+| Local branch shows `[gone]` after merge                             | `delete_branch_on_merge` removed the remote branch                     | `git checkout main && git pull && git fetch --prune`, delete the local branch   |
+
+## Additional resources
+
+- `CLAUDE.md` — "Git hooks" and "Commits" sections (concise summary of the above)
+- `CONTRIBUTING.md` — Development Workflow, Commit Conventions, Pull Request Process
+- `.claude/commands/verify.md` — wraps `npm run validate` + the function-lookup reminder
+- Sibling skills: `architecture-navigation` (boundary failures), `writing-tests` (test failures), `quality-gates` (lint/pattern/knip details), `ci-triage` (CI job debugging), `release-publishing` (release-please pipeline)

--- a/.claude/skills/kernel-abstraction/SKILL.md
+++ b/.claude/skills/kernel-abstraction/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: kernel-abstraction
+description: This skill should be used when working on the brepjs kernel abstraction layer or across multiple kernels — adding a kernel method, wiring or writing an adapter, switching or registering kernels, or reasoning about kernel capability differences. Trigger phrases include "add a kernel method", "new kernel method", "withKernel", "brepjs kernel not initialized", "kernel 'X' is not registered", "is only available with the brepkit kernel", "occt-wasm: ... is not yet implemented", "run this under manifold/brepkit/occt", "which kernel supports X", "kernel capabilities", "quality tier", "regenerate the conformance matrix", or working on adapter/interface/registry/capability design under src/kernel/. Raw Emscripten/heap mechanics belong to the wasm-interop skill.
+---
+
+# Kernel abstraction layer and multi-kernel work
+
+## Mental model
+
+`src/kernel/` is Layer 0 — it imports nothing else in the tree (see the architecture-navigation skill for layer rules and the `.wrapped`/`.oc` bans). Everything above it calls geometry through `getKernel().method(...)` against the `KernelAdapter` interface.
+
+Four in-tree adapters:
+
+| id                    | Class             | File                                     | Backing package                                       | Nature                                                                           |
+| --------------------- | ----------------- | ---------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `occt-wasm` (default) | `OcctWasmAdapter` | `src/kernel/occtWasm/occtWasmAdapter.ts` | `occt-wasm`                                           | exact B-rep, arena/u32 handles                                                   |
+| `occt`                | `DefaultAdapter`  | `src/kernel/occt/defaultAdapter.ts`      | `brepjs-opencascade`                                  | exact B-rep, Emscripten objects                                                  |
+| `brepkit`             | `BrepkitAdapter`  | `src/kernel/brepkit/brepkitAdapter.ts`   | `brepkit-wasm`                                        | exact B-rep                                                                      |
+| `manifold`            | `ManifoldAdapter` | `src/kernel/manifold/manifoldAdapter.ts` | `manifold-3d` (loaded via `packages/brepjs-manifold`) | mesh CSG, approximate; caches an OCCT "replay" B-rep per handle for exact export |
+
+Registry (`src/kernel/index.ts`):
+
+- `registerKernel(id, adapter)` — the first registered kernel becomes the default.
+- `getKernel(id?)` — throws `brepjs kernel not initialized` if nothing is registered.
+- `getKernel2D(id?)` — narrows to `Kernel2DCapability` via the `supportsKernel2D` guard; throws otherwise.
+- `getActiveKernelId()` — stable string for cache keys (used by `src/csg/evaluate.ts`), `null` before init.
+- `init()` — auto-detect chain: `occt-wasm` (`OcctKernel.init()` + `OcctWasmAdapter.fromKernel`) → `brepjs-opencascade` (`initFromOC`, id `'occt'`) → `brepkit-wasm`. Idempotent; throws with install instructions if none resolve. Returns the winning id.
+- `initFromOC(oc)` — registers the OpenCascade WASM backend and forces the default to `'occt'` (the feature-detection cache-reset mechanics live in the wasm-interop skill).
+- `initFromManifold(module)` — registers `'manifold'`.
+- `prewarm()` — builds and disposes a trivial box to move OCCT's ~400-900ms first-call JIT cost off the critical path.
+
+Optional backends load through `importOptionalBackend(specifier)` (`src/kernel/optionalBackend.ts`) using a variable specifier so bundlers cannot statically analyze the `import()` (mechanics in the wasm-interop skill).
+
+## Switching kernels safely
+
+- `withKernel(id, fn)` is **synchronous only**. It has a runtime guard: if `fn` returns a Promise it throws (`withKernel() callback returned a Promise...`), because the default is restored in `finally` and any `getKernel()` after the first `await` would see the wrong kernel. For async code, capture the adapter once with `getKernel(id)` and use it directly.
+- `withQuality(level, fn)` (same sync-only guard) sets a process-global quality level — `'draft' | 'standard' | 'fine'`, deflection table in `src/kernel/quality.ts` (`'standard'` matches the historical `mesh()` defaults 1e-3/0.1) — and calls the kernel's optional `setQuality?()`.
+- `registerKernelTier(name, { kernel, quality })` + `withTier(name, fn)` compose both, so call sites can say `withTier('preview', ...)` instead of hard-coding a kernel id and a quality knob. Tested in `tests/kernelTiers.test.ts`.
+- Quality means different things per kernel (`tessellationModel` in `src/kernel/capabilities.ts`): Manifold is **build-time** — the mesh is fixed when a solid is built, so quality must be applied _before_ building (`ManifoldAdapter.setQuality` maps level → min circular angle). OCCT-family kernels are **extract-time** — shapes are exact and the level only sets the default deflection at `mesh()`/export.
+
+## Adding a kernel method
+
+Full walkthrough with a real cross-adapter example: `references/adapter-wiring.md`. The checklist:
+
+1. **Declare** the method in the matching sub-interface under `src/kernel/interfaces/` (booleanOps, primitiveOps, modifierOps, ioOps, ...; `core.ts` is the mandatory surface). `KernelAdapter` is the intersection of these 15 files plus `Kernel2DCapability` (`src/kernel/interfaces/index.ts`); `src/kernel/types.ts` merely re-exports it. Do **not** add methods to `types.ts`. Note: the `/new-kernel-method` command (`.claude/commands/new-kernel-method.md`) predates this split — where it says "add to `src/kernel/types.ts`" and names an `OcShape` type, read "add to `src/kernel/interfaces/<domain>Ops.ts>`" and `KernelShape`/`KernelType` (`src/kernel/types.ts`).
+2. **Implement** per adapter as a free function in `src/kernel/<adapter>/*Ops.ts`, receiving the raw instance (`oc`, `bk`, ...) as the first parameter — never via `getKernel()` inside kernel code. All kernel methods are synchronous and return plain JS values or opaque `KernelShape` handles (`docs/kernel-swap.md`, "What Must Each Method Return?"). Delete Emscripten intermediates manually (`maker.delete()`); see the memory-and-disposal and wasm-interop skills for handle lifetime and the enum-extraction gotcha.
+3. **Wire** into the adapters. occt, brepkit, and manifold adapters have no body-level methods — add the method to the relevant `make*Ops()` factory's returned object (and its `satisfies Pick<KernelAdapter, ...>` union). A compile-time guard at the bottom of each adapter file errors with the exact missing-method list if any factory forgets one. `OcctWasmAdapter` is the exception: a conventional class — add a real method body.
+4. **Stub** adapters that cannot support it. Two accepted idioms: the occt adapter's `makeBrepkitOnlyStubs()` (`src/kernel/occt/defaultAdapter.ts`, uniform `'<name> is only available with the brepkit kernel'` throw) and occt-wasm's `notImplemented(method)` (`'occt-wasm: <method> is not yet implemented'`). A throwing stub is correct; silently returning a wrong answer is not.
+5. **Surface** through a `*Fns.ts` function that calls `getKernel().method(...)` — see the adding-operations skill for the Fns → `api.ts` → facade pipeline.
+6. **Test** through the Layer 2 functional API, not the adapter directly. Register divergence entries for kernels that skip (writing-tests skill), then run `npm run conformance:generate`.
+
+## Capability and feature detection — three distinct systems
+
+| Need                                                                          | Use                                                                                                                                                                                                                                                                           |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Route by what a kernel _is_ (exact vs mesh, B-rep export, tessellation model) | `getKernelCapabilities(id?)` → `KernelCapabilities` (`src/kernel/capabilities.ts`; `EXACT_BREP_CAPABILITIES` for the B-rep kernels, all-false + `'build-time'` on manifold). Routing is caller-side today — only the quality layer branches on `tessellationModel` internally |
+| Optional method _groups_ on an adapter                                        | Type guards: `supportsProjection` / `supportsConstraintSketch` (`src/kernel/types.ts`), `supportsKernel2D` (`src/kernel/kernel2dTypes.ts`, used by `getKernel2D`)                                                                                                             |
+| Test matrix + generated conformance doc                                       | `kernelConfigs[].capabilities` in `tests/helpers/kernelRegistry.ts` — pure data, no src imports (consumed by `vitest.config.ts` at config-load time)                                                                                                                          |
+
+Do not conflate them: the runtime flags describe kernel _nature_, the guards describe _interface presence_, the registry booleans describe _test expectations_.
+
+Inside adapters, detect optional native features rather than version-checking:
+
+- **WASM-build detection with a resettable cache**: `hasCppMeasurement ??= typeof oc.MeasurementExtractor?.extract === 'function'` in `src/kernel/occt/measureOps.ts`, paired with a `resetMeasureDetectionCache()` that `initFromOC` calls. Any new detection cache must get a reset function registered in `initFromOC` or it leaks state across WASM instances.
+- **Optional-method detection**: `typeof bk.chamferAsymmetric === 'function'` (`src/kernel/brepkit/modifierOps.ts`), with the method declared _optional_ in `src/kernel/brepkit/brepkitWasmTypes.ts` under a `@future Not in brepkit-wasm 2.116.1` doc tag. Fall back with a `warnOnce(...)` so degraded behavior is visible exactly once.
+
+## Multi-kernel testing and conformance
+
+- `tests/helpers/kernelRegistry.ts` is the single source of truth: it drives the four vitest projects (each sets `TEST_KERNEL`), per-kernel coverage excludes (every project excludes the _other_ kernels' `adapterDir`s), per-kernel `excludeTests`, and the conformance doc. **Adding a kernel = a `kernelConfigs` entry plus an init branch in `tests/helpers/kernelInit.ts` `initKernel()`.**
+- CI runs only the occt-wasm project (`test:ci`, sharded 4-way). The others are on-demand: `npm run test:occt`, `npm run test:brepkit`, `npx vitest run --project manifold` (no npm script). `docs/kernel-swap.md`'s claim that CI runs all kernels is stale.
+- Per-kernel skips and tolerances live in `tests/helpers/kernelDivergences.ts` (`skipIfDiverges`, `expectKernelsAgree`); test-authoring detail is in the writing-tests skill. Cross-kernel numeric parity: `tests/kernel-agreement.test.ts` (soft-skips when a kernel is unavailable).
+- After changing a divergence or a registry capability flag: `npm run conformance:generate` rewrites `docs/kernel-conformance.md`. Never hand-edit that file.
+
+## Symptom → cause → fix
+
+| Symptom                                                                               | Cause                                                                                                                                                                 | Fix                                                                                                        |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `BindingError: Cannot pass deleted object` from occt-wasm                             | Adapter built from `new OcctWasmAdapter(kernel.getRawModule(), kernel.getRawKernel())` — the `OcctKernel` wrapper's `FinalizationRegistry` freed the raw kernel on GC | Build with `OcctWasmAdapter.fromKernel(kernel)`, which retains the wrapper (`retainedKernelOwner`)         |
+| `brepjs kernel not initialized`                                                       | `getKernel()` before any registration                                                                                                                                 | `await init()` (or `registerKernel`/`initFromOC`) first; in tests use `initKernel()` from `tests/setup.ts` |
+| `brepjs: kernel 'X' is not registered`                                                | `withKernel`/`getKernel(id)` with an id that was never registered this session                                                                                        | Register it (e.g. `initFromManifold`) before switching                                                     |
+| `withKernel() callback returned a Promise`                                            | Async callback passed to `withKernel`/`withQuality`/`withTier`                                                                                                        | Use `getKernel(id)` directly in async code                                                                 |
+| `X is only available with the brepkit kernel` / `occt-wasm: X is not yet implemented` | Intentional throwing stub on this adapter                                                                                                                             | Switch kernels for that call, or implement the method (recipe above)                                       |
+| Wrong kernel's divergences applied when running vitest without a project              | `currentKernelId` in `kernelDivergences.ts` defaults to `'occt'`, while `kernelInit.ts` defaults to `'occt-wasm'`                                                     | Always run via a `--project` flag or set `TEST_KERNEL` explicitly                                          |
+| Build fails resolving `occt-wasm`/`brepkit-wasm` in a consumer bundle                 | `importOptionalBackend` was replaced with a literal `import()`                                                                                                        | Restore the variable-specifier indirection in `src/kernel/optionalBackend.ts`                              |
+| 2D ops work on occt-wasm despite the raw kernel having no 2D API                      | 2D is fulfilled by the shared pure-TS engine `src/kernel/geometry2d.ts` (also used by brepkit)                                                                        | Nothing to fix — implement 2D features there, not per-kernel                                               |
+
+Known-stale docs (trust code over these spots): `docs/kernel-swap.md` "tests run against all three kernels in CI" + its hardcoded 3-project vitest snippet; `.claude/commands/new-kernel-method.md` (`types.ts`, two adapters, `OcShape`); `src/kernel/README.md` "three adapters" (manifold missing).
+
+## Additional resources
+
+- `references/adapter-wiring.md` — per-adapter wiring walkthrough with a real method (`makeBox`) traced through all four adapters, plus stub and factory-guard patterns.
+- `docs/kernel-swap.md` — authoring a custom out-of-tree `KernelAdapter` (minimal skeleton, handle contract, return-value contract).
+- `docs/decisions/0002-kernel-abstraction.md`, `docs/decisions/0007-kernel-interface-segregation.md` — why the abstraction exists and why the interface is split 15 ways.
+- `src/kernel/README.md` — per-adapter ops-module map and OCCT gotchas (enum extraction, `Uint32Array` conversion).
+- Sibling skills: `architecture-navigation` (layer rules), `adding-operations` (surfacing kernel methods as public API), `writing-tests` (multi-kernel runs, divergence skips), `wasm-interop` (Emscripten interop, raw init/heap mechanics), `memory-and-disposal` (handle lifetime), `debugging-geometry` (invalid-shape triage).

--- a/.claude/skills/kernel-abstraction/references/adapter-wiring.md
+++ b/.claude/skills/kernel-abstraction/references/adapter-wiring.md
@@ -1,0 +1,121 @@
+# Adapter wiring walkthrough
+
+How one kernel method flows through the declaration, all four adapters, and the safety nets. `makeBox` is used as the tracer because it exists everywhere; a new method follows the identical shape.
+
+## 1. Declaration — one sub-interface, never `types.ts`
+
+`src/kernel/interfaces/primitiveOps.ts`:
+
+```ts
+makeBox(width: number, height: number, depth: number): KernelShape;
+```
+
+Pick the sub-interface by domain: `booleanOps`, `builderOps`, `core` (mandatory lifecycle surface: `oc`, `kernelId`, `capabilities`, `setQuality?`, `dispose`, `executeBatch`, checkpoint family), `curveOps`, `evolutionOps`, `ioOps`, `measureOps`, `meshOps`, `modifierOps`, `primitiveOps`, `repairOps`, `surfaceOps`, `sweepOps`, `topologyOps`, `transformOps`. `KernelAdapter` is composed as their intersection in `src/kernel/interfaces/index.ts`.
+
+Return plain JS values (numbers, tuples, string unions) or opaque `KernelShape` handles (`src/kernel/types.ts`). Callers above Layer 0 never invoke methods on a handle — that is the `.wrapped` ban.
+
+## 2. occt adapter — free function + co-located factory
+
+Implementation as a free function taking the raw instance first (`src/kernel/occt/constructorOps.ts`):
+
+```ts
+export function makeBox(
+  oc: KernelInstance,
+  width: number,
+  height: number,
+  depth: number
+): KernelShape {
+  const maker = new oc.BRepPrimAPI_MakeBox_2(width, height, depth);
+  const solid = maker.Solid();
+  maker.delete();
+  return solid;
+}
+```
+
+Note the manual `maker.delete()` — every Emscripten intermediate must be freed; only the returned shape survives (memory-and-disposal skill).
+
+The same file exposes a factory returning the adapter slice, closed over `oc`, with a `satisfies Pick<...>` union that must list the new method:
+
+```ts
+export function makeConstructorOps(oc: KernelInstance) {
+  return {
+    // ...
+    makeBox: (w, h, d) => makeBox(oc, w, h, d),
+    // ...
+  } satisfies Pick<KernelAdapter, /* ... | */ 'makeBox' /* | ... */>;
+}
+```
+
+`DefaultAdapter` (`src/kernel/occt/defaultAdapter.ts`) has **no body-level methods**: the constructor spreads ~20 factories via `Object.assign`, declaration merging (`interface DefaultAdapter extends KernelAdapter`) tells TS the methods exist, and the compile-time guard at the bottom of the file fails with the precise missing-property list if no factory provides the method:
+
+```ts
+type _AssertSatisfiesKernelAdapter = (
+  ...args: ConstructorParameters<typeof DefaultAdapter>
+) => KernelAdapter;
+const _check: _AssertSatisfiesKernelAdapter = (oc) => new DefaultAdapter(oc);
+void _check;
+```
+
+To find any occt method's implementation: `rg 'function makeBox' src/kernel/occt/`.
+
+## 3. brepkit adapter — same shape, id-based handles
+
+`src/kernel/brepkit/constructionOps.ts`:
+
+```ts
+export function makeBox(
+  bk: BrepkitKernel,
+  width: number,
+  height: number,
+  depth: number
+): KernelShape {
+  const id = bk.makeBox(width, height, depth);
+  return solidHandle(id);
+}
+```
+
+Same factory + `satisfies Pick` + `Object.assign` + compile-time guard structure as occt (`src/kernel/brepkit/brepkitAdapter.ts`). If the underlying `brepkit-wasm` method may not exist in the pinned version, declare it _optional_ in `src/kernel/brepkit/brepkitWasmTypes.ts` with a `@future` doc tag and feature-detect at the call site (`typeof bk.chamferAsymmetric === 'function'` in `src/kernel/brepkit/modifierOps.ts` is the model, including the `warnOnce` fallback).
+
+## 4. manifold adapter — build the mesh, record the op-graph node
+
+`src/kernel/manifold/primitiveOps.ts`:
+
+```ts
+makeBox: (width, height, depth) => {
+  const solid = Manifold.cube([width, height, depth] as Vec3, false);
+  return wrap(solid, makeNode('makeBox', { width, height, depth }, []));
+},
+```
+
+Every constructive manifold method records an op-graph node (`src/kernel/manifold/opGraph.ts`) so the shape can later be _replayed_ on an OCCT kernel for exact B-rep export; `dispose` frees both the mesh and any cached replayed B-rep (`src/kernel/manifold/manifoldAdapter.ts`). A manifold implementation without a replay node breaks exact export for anything built from it. Same factory-composition + compile-time-guard wiring as occt/brepkit.
+
+## 5. occt-wasm adapter — the exception: real class methods
+
+`OcctWasmAdapter` (`src/kernel/occtWasm/occtWasmAdapter.ts`) is a conventional `class ... implements KernelAdapter`; add a method body delegating to a module function:
+
+```ts
+makeBox(width: number, height: number, depth: number): KernelShape {
+  return primOps.makeBox(this.k, width, height, depth);
+}
+```
+
+`this.k` is the exception-wrapped raw kernel (`wrapKernelExceptions`); handles are u32 arena ids released via `this.k.release(h.id)` in `dispose`.
+
+## 6. Stubbing adapters that cannot support the method
+
+Both existing idioms throw a recognizable, uniform message:
+
+- occt: add to `makeBrepkitOnlyStubs()` in `src/kernel/occt/defaultAdapter.ts` — `throw new Error('<name> is only available with the brepkit kernel')` — and extend its `satisfies Pick<...>` union.
+- occt-wasm / manifold: `notImplemented('<name>')` → `'occt-wasm: <name> is not yet implemented'` (`occtWasmAdapter.ts`) or the manifold equivalent.
+
+Never stub by returning a fabricated value; higher layers turn the throw into a `Result.Err` (result-error-handling skill).
+
+## 7. After wiring
+
+- Expose through a `*Fns.ts` function calling `getKernel().makeBox(...)` (adding-operations skill).
+- Add tests through the Layer 2 API; register `not-implemented` divergences in `tests/helpers/kernelDivergences.ts` for stubbed kernels, then `npm run conformance:generate`.
+- `npm run validate` — the compile-time guards surface any adapter that was missed as a typecheck failure naming the method.
+
+## Writing a whole custom kernel (out of tree)
+
+Follow `docs/kernel-swap.md` (minimal skeleton, shape-handle contract, return-value contract), then `registerKernel('my-kernel', adapter)`. Two corrections to that doc: CI runs only the occt-wasm test project (not "all three kernels"), and the vitest projects are generated from `tests/helpers/kernelRegistry.ts`, not hardcoded. An in-tree kernel additionally needs a `kernelConfigs` entry there plus an init branch in `tests/helpers/kernelInit.ts`.

--- a/.claude/skills/memory-and-disposal/SKILL.md
+++ b/.claude/skills/memory-and-disposal/SKILL.md
@@ -7,10 +7,10 @@ description: This skill should be used when managing WASM handle lifetimes or hu
 
 ## Mental model
 
-WASM objects are not visible to the JS garbage collector — a leaked shape grows WASM linear memory silently. Every branded shape (`Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `CompSolid`, `Compound`) IS a disposable handle: `src/core/shapeTypes.ts:177-215` wraps each via `createHandle()` (`src/core/disposal.ts:144-182`). Cleanup has one primary rule and one safety net:
+WASM objects are not visible to the JS garbage collector — a leaked shape grows WASM linear memory silently. Every branded shape (`Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `CompSolid`, `Compound`) IS a disposable handle: `src/core/shapeTypes.ts` wraps each via `createHandle()` (`src/core/disposal.ts`). Cleanup has one primary rule and one safety net:
 
 - **Primary**: dispose deterministically with `using` / `Symbol.dispose` / `DisposalScope`. This is the plan.
-- **Safety net**: a `FinalizationRegistry` (`disposal.ts:115-122`) frees handles that were never disposed — non-deterministic, GC-timed, never something to rely on. Environments lacking it get a no-op stub plus a `console.warn` (`disposal.ts:46-57`).
+- **Safety net**: a `FinalizationRegistry` (`disposal.ts`) frees handles that were never disposed — non-deterministic, GC-timed, never something to rely on. Environments lacking it get a no-op stub plus a `console.warn` (`disposal.ts`).
 
 User-facing prose lives in `docs/memory-management.md` (the four mechanisms, `using` examples, LIFO, heap-monitoring snippets, three common leak patterns) and the maintainer deep-dive in `src/core/README.md`. This skill adds what those lack: the tool-selection table, the pattern-checker rule, the kernel-dependent free semantics, and the leak-hunting workflow. Do not re-read those two docs for basics — point users to them.
 
@@ -31,22 +31,22 @@ User-facing prose lives in `docs/memory-management.md` (the four mechanisms, `us
 using box = box(1, 1, 1);
 ```
 
-Any branded shape works directly this way, since every shape is a `ShapeHandle`. Accessing `.wrapped` after disposal throws `'Shape handle has been disposed'` (`disposal.ts:161-163`); the `KernelHandle` variant throws `'kernel handle has been disposed'` (`disposal.ts:200-202`). Double-dispose is safe — dispose is idempotent and inner `delete()` failures are swallowed.
+Any branded shape works directly this way, since every shape is a `ShapeHandle`. Accessing `.wrapped` after disposal throws `'Shape handle has been disposed'` (`disposal.ts`); the `KernelHandle` variant throws `'kernel handle has been disposed'` (`disposal.ts`). Double-dispose is safe — dispose is idempotent and inner `delete()` failures are swallowed.
 
 ### `DisposalScope` — register vs track, and LIFO
 
 Two registration methods, both return their argument for inline use:
 
-- `scope.register(resource)` — for anything `Deletable` (`{ delete() }`); calls `.delete()` on dispose (`disposal.ts:241-250`).
-- `scope.track(disposable)` — for anything with `[Symbol.dispose]` (branded shapes, `Curve2DHandle`); calls `[Symbol.dispose]()` (`disposal.ts:252-262`).
+- `scope.register(resource)` — for anything `Deletable` (`{ delete() }`); calls `.delete()` on dispose (`disposal.ts`).
+- `scope.track(disposable)` — for anything with `[Symbol.dispose]` (branded shapes, `Curve2DHandle`); calls `[Symbol.dispose]()` (`disposal.ts`).
 
-`DisposalScope` disposes in **LIFO** (reverse-registration) order (`disposal.ts:264-271`). The ordering rule (also a CLAUDE.md gotcha): **register a dependency AFTER its dependee**, so the dependent is disposed first. If B is built from A, register A first and B second.
+`DisposalScope` disposes in **LIFO** (reverse-registration) order (`disposal.ts`). The ordering rule (also a CLAUDE.md gotcha): **register a dependency AFTER its dependee**, so the dependent is disposed first. If B is built from A, register A first and B second.
 
 Real code overwhelmingly uses the scope directly — `using scope = new DisposalScope()` then `scope.register(...)` (e.g. `src/sketching/draw3d.ts`, `src/operations/threadFns.ts`, `src/gear/gearFns.ts`). Prefer this idiom.
 
 ### Scope helpers for `Result`-returning ops
 
-`kernelCallScoped(fn, code, message)` (`src/core/kernelCall.ts:125-133`) creates a scope, runs `fn`, and disposes deterministically after return **or throw** — the canonical wrapper for a `*Fns.ts` op that needs intermediate kernel allocations and returns `Result<AnyShape>`:
+`kernelCallScoped(fn, code, message)` (`src/core/kernelCall.ts`) creates a scope, runs `fn`, and disposes deterministically after return **or throw** — the canonical wrapper for a `*Fns.ts` op that needs intermediate kernel allocations and returns `Result<AnyShape>`:
 
 ```ts
 return kernelCallScoped(
@@ -59,22 +59,22 @@ return kernelCallScoped(
 );
 ```
 
-`withScopeResult(fn)` (`disposal.ts:311-316`) is the same scope discipline for any `Result`-returning function. `withScopeResultAsync(fn)` (`disposal.ts:322-327`) is the async variant — its body is `return await fn(scope)`. The `await` is load-bearing: `using` disposes synchronously at end of block, so without `await` the scope would dispose before the promise settles. Keep the `await`.
+`withScopeResult(fn)` (`disposal.ts`) is the same scope discipline for any `Result`-returning function. `withScopeResultAsync(fn)` (`disposal.ts`) is the async variant — its body is `return await fn(scope)`. The `await` is load-bearing: `using` disposes synchronously at end of block, so without `await` the scope would dispose before the promise settles. Keep the `await`.
 
 These helpers are exported and documented but rarely called directly in `src/`; present them as available conveniences, not the dominant convention.
 
 ## The gate: `require-using-for-handles`
 
-The pattern checker (`scripts/check-patterns.ts:251-312`, severity **error**) flags any `createHandle()` / `createKernelHandle()` call not bound with `using`. Message: "`createHandle() without \`using\` keyword risks WASM memory leak.`"
+The pattern checker (`scripts/check-patterns.ts`, severity **error**) flags any `createHandle()` / `createKernelHandle()` call not bound with `using`. Message: "`createHandle() without \`using\` keyword risks WASM memory leak.`"
 
-**Excused positions** (`check-patterns.ts:266-289`):
+**Excused positions** (`check-patterns.ts`):
 
 - `using x = createHandle(...)`
 - `return createHandle(...)` — caller owns lifetime
 - direct argument to another call, e.g. `scope.register(createHandle(...))`
 - property assignment `{ k: createHandle(...) }` or array literal `[createHandle(...)]`
 
-It does **not** catch handles nested in ternaries/sub-expressions — those slip through. Scan scope is `src/**/*.ts` only (tests and scripts exempt, `check-patterns.ts:23-24`).
+It does **not** catch handles nested in ternaries/sub-expressions — those slip through. Scan scope is `src/**/*.ts` only (tests and scripts exempt, `check-patterns.ts`).
 
 Inline disable (line above or inline):
 
@@ -82,15 +82,15 @@ Inline disable (line above or inline):
 // brepjs-patterns-disable: require-using-for-handles
 ```
 
-Real use: `createCurve2DHandle` in `src/core/curve2dHandle.ts:58`, which returns the handle for the caller to own.
+Real use: `createCurve2DHandle` in `src/core/curve2dHandle.ts`, which returns the handle for the caller to own.
 
 Where it runs: `npm run check:patterns`, pre-commit via lint-staged on staged `src/**/*.ts`, and CI's `quality` job. The baseline `.pattern-baseline.json` contains **zero** `require-using-for-handles` entries (see the `quality-gates` skill for the current baseline composition) — so ANY new violation of this rule fails the gate immediately; there is no baseline slack to absorb it. For baseline mechanics and the general pattern-checker workflow, see the `quality-gates` skill.
 
 ## Escape hatches and long-lived objects
 
 - **Return a shape from a scope — do not register it.** A shape returned from `withScope`/`DisposalScope` while intermediates are registered stays valid and meshable after the scope disposes. Registered intermediates are freed; the returned one is not (regression `tests/withScope-disposal.test.ts`, issue #723). Registering the returned value is a use-after-dispose bug.
-- **Object must outlive its creating function** (e.g. closure-captured kernel handle): use `registerForCleanup(owner, deletable)` / `unregisterFromCleanup(deletable)` (`disposal.ts:286-293`) — FinalizationRegistry cleanup keyed on `owner`. Used by `Curve2D` (`src/2d/lib/curve2D.ts:49`).
-- **Validate liveness at a boundary**: `isLive(handle)` (`disposal.ts:341-343`) is a named `!handle.disposed`. Pattern: `if (!isLive(h)) return err(...)`.
+- **Object must outlive its creating function** (e.g. closure-captured kernel handle): use `registerForCleanup(owner, deletable)` / `unregisterFromCleanup(deletable)` (`disposal.ts`) — FinalizationRegistry cleanup keyed on `owner`. Used by `Curve2D` (`src/2d/lib/curve2D.ts`).
+- **Validate liveness at a boundary**: `isLive(handle)` (`disposal.ts`) is a named `!handle.disposed`. Pattern: `if (!isLive(h)) return err(...)`.
 - **Non-shape kernel objects**: `createKernelHandle(ocObj)` for anything `Deletable` (`.value` getter instead of `.wrapped`). `Curve2DHandle` (`src/core/curve2dHandle.ts`) shows the branded-wrapper pattern, including synthesizing a no-op `Deletable` for arena handles that lack `delete()`.
 
 ## Kernel-dependent reality (critical for leak hunting)
@@ -101,7 +101,7 @@ Full file:line breakdown, the arena vs Embind table, Embind vector cleanup, and 
 
 ## Finding leaks
 
-`getDisposalStats()` / `resetDisposalStats()` (`disposal.ts:85-97`) return `{ liveHandles, peakHandles, gcCollected, scopeEnters, scopeExits }`. Workflow:
+`getDisposalStats()` / `resetDisposalStats()` (`disposal.ts`) return `{ liveHandles, peakHandles, gcCollected, scopeEnters, scopeExits }`. Workflow:
 
 1. `resetDisposalStats()` before the suspect operation.
 2. Run it (ideally in a loop to amplify churn).
@@ -109,11 +109,11 @@ Full file:line breakdown, the arena vs Embind table, Embind vector cleanup, and 
 
 Symptom → meaning:
 
-| Reading                        | Meaning                                                                                                                                                                                                                                                            |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `gcCollected > 0`              | Handles were reclaimed by the FinalizationRegistry — code forgot to dispose them. Each is a missed `using`.                                                                                                                                                        |
-| `peakHandles` high in a loop   | Handles accumulate within an iteration; move disposal inside the loop body (a `using` per iteration or a per-iteration scope).                                                                                                                                     |
-| `liveHandles` non-zero at rest | Suggestive, but do **not** assert absolute values — the FinalizationRegistry adjusts it asynchronously after a synchronous reset, so it can even go negative for later readers (`tests/disposalStats.test.ts:39-44`). Use it as a trend signal, not a hard number. |
+| Reading                        | Meaning                                                                                                                                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `gcCollected > 0`              | Handles were reclaimed by the FinalizationRegistry — code forgot to dispose them. Each is a missed `using`.                                                                                                                                                  |
+| `peakHandles` high in a loop   | Handles accumulate within an iteration; move disposal inside the loop body (a `using` per iteration or a per-iteration scope).                                                                                                                               |
+| `liveHandles` non-zero at rest | Suggestive, but do **not** assert absolute values — the FinalizationRegistry adjusts it asynchronously after a synchronous reset, so it can even go negative for later readers (`tests/disposalStats.test.ts`). Use it as a trend signal, not a hard number. |
 
 For heap-monitoring snippets (`performance.memory`, WASM heap size), see `docs/memory-management.md`.
 

--- a/.claude/skills/memory-and-disposal/SKILL.md
+++ b/.claude/skills/memory-and-disposal/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: memory-and-disposal
+description: This skill should be used when managing WASM handle lifetimes or hunting memory leaks in brepjs — when a task mentions "createHandle() without using keyword risks WASM memory leak", "require-using-for-handles", "Shape handle has been disposed", "kernel handle has been disposed", "memory grows / heap keeps climbing", "leaking shapes", "getDisposalStats / gcCollected", "DisposalScope register vs track", "withScopeResult", "kernelCallScoped", "registerForCleanup", "returned shape from withScope is disposed", or deciding how to clean up kernel temporaries in a new *Fns.ts function.
+---
+
+# WASM memory management and disposal
+
+## Mental model
+
+WASM objects are not visible to the JS garbage collector — a leaked shape grows WASM linear memory silently. Every branded shape (`Vertex`, `Edge`, `Wire`, `Face`, `Shell`, `Solid`, `CompSolid`, `Compound`) IS a disposable handle: `src/core/shapeTypes.ts:177-215` wraps each via `createHandle()` (`src/core/disposal.ts:144-182`). Cleanup has one primary rule and one safety net:
+
+- **Primary**: dispose deterministically with `using` / `Symbol.dispose` / `DisposalScope`. This is the plan.
+- **Safety net**: a `FinalizationRegistry` (`disposal.ts:115-122`) frees handles that were never disposed — non-deterministic, GC-timed, never something to rely on. Environments lacking it get a no-op stub plus a `console.warn` (`disposal.ts:46-57`).
+
+User-facing prose lives in `docs/memory-management.md` (the four mechanisms, `using` examples, LIFO, heap-monitoring snippets, three common leak patterns) and the maintainer deep-dive in `src/core/README.md`. This skill adds what those lack: the tool-selection table, the pattern-checker rule, the kernel-dependent free semantics, and the leak-hunting workflow. Do not re-read those two docs for basics — point users to them.
+
+`using` requires `"target": "ES2022"` + `"lib": ["ES2022", "ESNext.Disposable"]`; the repo `tsconfig.json:3,6` already sets this.
+
+## The three tools — when to use each
+
+| Situation                                        | Tool                                                        | Notes                                         |
+| ------------------------------------------------ | ----------------------------------------------------------- | --------------------------------------------- |
+| One temporary, freed at end of block             | `using x = createHandle(...)`                               | Or `using x = someFn()` for any branded shape |
+| Several temporaries in one function              | `using scope = new DisposalScope()` + `scope.register(...)` | LIFO disposal; see ordering rule              |
+| A `Result`-returning `*Fns.ts` op that allocates | `kernelCallScoped(fn, code, msg)` or `withScopeResult(fn)`  | Scope disposed on Ok, Err, AND throw          |
+| Async `Result` op                                | `withScopeResultAsync(fn)`                                  | Note the intentional `return await`           |
+
+### `using` for a single handle
+
+```ts
+using box = box(1, 1, 1);
+```
+
+Any branded shape works directly this way, since every shape is a `ShapeHandle`. Accessing `.wrapped` after disposal throws `'Shape handle has been disposed'` (`disposal.ts:161-163`); the `KernelHandle` variant throws `'kernel handle has been disposed'` (`disposal.ts:200-202`). Double-dispose is safe — dispose is idempotent and inner `delete()` failures are swallowed.
+
+### `DisposalScope` — register vs track, and LIFO
+
+Two registration methods, both return their argument for inline use:
+
+- `scope.register(resource)` — for anything `Deletable` (`{ delete() }`); calls `.delete()` on dispose (`disposal.ts:241-250`).
+- `scope.track(disposable)` — for anything with `[Symbol.dispose]` (branded shapes, `Curve2DHandle`); calls `[Symbol.dispose]()` (`disposal.ts:252-262`).
+
+`DisposalScope` disposes in **LIFO** (reverse-registration) order (`disposal.ts:264-271`). The ordering rule (also a CLAUDE.md gotcha): **register a dependency AFTER its dependee**, so the dependent is disposed first. If B is built from A, register A first and B second.
+
+Real code overwhelmingly uses the scope directly — `using scope = new DisposalScope()` then `scope.register(...)` (e.g. `src/sketching/draw3d.ts`, `src/operations/threadFns.ts`, `src/gear/gearFns.ts`). Prefer this idiom.
+
+### Scope helpers for `Result`-returning ops
+
+`kernelCallScoped(fn, code, message)` (`src/core/kernelCall.ts:125-133`) creates a scope, runs `fn`, and disposes deterministically after return **or throw** — the canonical wrapper for a `*Fns.ts` op that needs intermediate kernel allocations and returns `Result<AnyShape>`:
+
+```ts
+return kernelCallScoped(
+  (scope) => {
+    const axis = scope.register(makeKernelAx1(origin, dir));
+    return getKernel().revolveVec(shape.wrapped, axis);
+  },
+  BrepErrorCode.REVOLUTION_NOT_3D,
+  'Revolution failed'
+);
+```
+
+`withScopeResult(fn)` (`disposal.ts:311-316`) is the same scope discipline for any `Result`-returning function. `withScopeResultAsync(fn)` (`disposal.ts:322-327`) is the async variant — its body is `return await fn(scope)`. The `await` is load-bearing: `using` disposes synchronously at end of block, so without `await` the scope would dispose before the promise settles. Keep the `await`.
+
+These helpers are exported and documented but rarely called directly in `src/`; present them as available conveniences, not the dominant convention.
+
+## The gate: `require-using-for-handles`
+
+The pattern checker (`scripts/check-patterns.ts:251-312`, severity **error**) flags any `createHandle()` / `createKernelHandle()` call not bound with `using`. Message: "`createHandle() without \`using\` keyword risks WASM memory leak.`"
+
+**Excused positions** (`check-patterns.ts:266-289`):
+
+- `using x = createHandle(...)`
+- `return createHandle(...)` — caller owns lifetime
+- direct argument to another call, e.g. `scope.register(createHandle(...))`
+- property assignment `{ k: createHandle(...) }` or array literal `[createHandle(...)]`
+
+It does **not** catch handles nested in ternaries/sub-expressions — those slip through. Scan scope is `src/**/*.ts` only (tests and scripts exempt, `check-patterns.ts:23-24`).
+
+Inline disable (line above or inline):
+
+```ts
+// brepjs-patterns-disable: require-using-for-handles
+```
+
+Real use: `createCurve2DHandle` in `src/core/curve2dHandle.ts:58`, which returns the handle for the caller to own.
+
+Where it runs: `npm run check:patterns`, pre-commit via lint-staged on staged `src/**/*.ts`, and CI's `quality` job. The baseline `.pattern-baseline.json` contains **zero** `require-using-for-handles` entries (see the `quality-gates` skill for the current baseline composition) — so ANY new violation of this rule fails the gate immediately; there is no baseline slack to absorb it. For baseline mechanics and the general pattern-checker workflow, see the `quality-gates` skill.
+
+## Escape hatches and long-lived objects
+
+- **Return a shape from a scope — do not register it.** A shape returned from `withScope`/`DisposalScope` while intermediates are registered stays valid and meshable after the scope disposes. Registered intermediates are freed; the returned one is not (regression `tests/withScope-disposal.test.ts`, issue #723). Registering the returned value is a use-after-dispose bug.
+- **Object must outlive its creating function** (e.g. closure-captured kernel handle): use `registerForCleanup(owner, deletable)` / `unregisterFromCleanup(deletable)` (`disposal.ts:286-293`) — FinalizationRegistry cleanup keyed on `owner`. Used by `Curve2D` (`src/2d/lib/curve2D.ts:49`).
+- **Validate liveness at a boundary**: `isLive(handle)` (`disposal.ts:341-343`) is a named `!handle.disposed`. Pattern: `if (!isLive(h)) return err(...)`.
+- **Non-shape kernel objects**: `createKernelHandle(ocObj)` for anything `Deletable` (`.value` getter instead of `.wrapped`). `Curve2DHandle` (`src/core/curve2dHandle.ts`) shows the branded-wrapper pattern, including synthesizing a no-op `Deletable` for arena handles that lack `delete()`.
+
+## Kernel-dependent reality (critical for leak hunting)
+
+The disposal API is uniform but the WASM-side effect of `.delete()` depends on the active kernel. **Under the default occt-wasm kernel, a handle's `delete()` is a no-op** — the shape lives in a WASM arena and is freed only by `getKernel().dispose(shape.wrapped)` → `k.release(id)`, or `releaseAll()` on kernel teardown. Under Embind kernels (brepjs-opencascade) `.delete()` genuinely frees. So `using` on a branded shape always gives use-after-dispose protection and stats, but only frees arena memory on Embind. This split is the single most common source of confusion when a leak reproduces on one kernel and not another.
+
+Full file:line breakdown, the arena vs Embind table, Embind vector cleanup, and internal `getKernel().dispose()` call sites are in [references/kernel-memory-models.md](references/kernel-memory-models.md). Read it before diagnosing a kernel-specific leak.
+
+## Finding leaks
+
+`getDisposalStats()` / `resetDisposalStats()` (`disposal.ts:85-97`) return `{ liveHandles, peakHandles, gcCollected, scopeEnters, scopeExits }`. Workflow:
+
+1. `resetDisposalStats()` before the suspect operation.
+2. Run it (ideally in a loop to amplify churn).
+3. `getDisposalStats()` after.
+
+Symptom → meaning:
+
+| Reading                        | Meaning                                                                                                                                                                                                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `gcCollected > 0`              | Handles were reclaimed by the FinalizationRegistry — code forgot to dispose them. Each is a missed `using`.                                                                                                                                                        |
+| `peakHandles` high in a loop   | Handles accumulate within an iteration; move disposal inside the loop body (a `using` per iteration or a per-iteration scope).                                                                                                                                     |
+| `liveHandles` non-zero at rest | Suggestive, but do **not** assert absolute values — the FinalizationRegistry adjusts it asynchronously after a synchronous reset, so it can even go negative for later readers (`tests/disposalStats.test.ts:39-44`). Use it as a trend signal, not a hard number. |
+
+For heap-monitoring snippets (`performance.memory`, WASM heap size), see `docs/memory-management.md`.
+
+## Testing disposal code
+
+- `tests/disposal.test.ts` is **skipped on occt-wasm** — `describe.skipIf(shouldSkipSuite('disposal'))` — because it wraps raw Embind `oc` objects that the default kernel does not expose. Do not add default-kernel coverage there.
+- Write kernel-agnostic disposal tests through the **public API**, like `tests/disposalStats.test.ts` (exercises stats, `isLive`, `withScopeResult` without touching `oc`).
+- Use `tests/withScope-disposal.test.ts` as the exemplar for return-value lifecycle assertions.
+
+General test skeleton, geometry assertions, and kernel-skip mechanics are in the `writing-tests` skill.
+
+## History (recognition only)
+
+`gcWithScope`, `gcWithObject`, and `localGC` were removed in commit `d7e33e50` (#331). If old snippets reference them, they are gone — replace with `using`/`DisposalScope`.
+
+## Additional resources
+
+- [references/kernel-memory-models.md](references/kernel-memory-models.md) — per-kernel free semantics (occt-wasm arena vs Embind `.delete()`), Embind vector cleanup, internal `getKernel().dispose()` call sites, with file:line anchors.
+- `docs/memory-management.md` — user-facing cleanup guide + heap monitoring.
+- `src/core/README.md` (disposal section) — maintainer deep-dive with API signatures and rationale.
+- Sibling skills: `quality-gates` (pattern-checker baseline workflow), `kernel-abstraction` (the `.wrapped` / `getKernel()` contract), `writing-tests` (test skeleton + kernel skips), `result-error-handling` (`kernelCall` / error codes), `adding-operations` (where cleanup fits in a new `*Fns.ts`).

--- a/.claude/skills/memory-and-disposal/references/kernel-memory-models.md
+++ b/.claude/skills/memory-and-disposal/references/kernel-memory-models.md
@@ -1,0 +1,77 @@
+# Kernel memory models: what `.delete()` actually frees
+
+The disposal machinery in `src/core/disposal.ts` is uniform, but the WASM-side
+effect of disposing a handle depends on which kernel is active. This matters
+when hunting a leak: the same `using` statement frees memory under one kernel
+and is a no-op under another. Disposal discipline is still mandatory everywhere
+— it is the one contract that is correct on every kernel, and it is the only
+leak protection on the Embind kernels.
+
+## The two models
+
+| Kernel                          | Handle shape                                                  | What `handle.delete()` does                      | Real free path                                                                     |
+| ------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| **occt-wasm** (default)         | plain JS object `{ __occtWasm, type, id, delete: noop, ... }` | **nothing** — `delete` is `noop`                 | `getKernel().dispose(h)` → `k.release(h.id)`, or `releaseAll()` on kernel teardown |
+| **brepjs-opencascade** (Embind) | raw `TopoDS_Shape` Embind proxy                               | genuinely frees the WASM object                  | `handle.delete()` / `[Symbol.dispose]()` frees directly                            |
+| **manifold / brepkit**          | arena / Embind mix                                            | varies; brepkit 2D arena handles lack `delete()` | kernel-managed arena or `dispose()`                                                |
+
+## occt-wasm arena details (the default)
+
+`handle()` in `src/kernel/occtWasm/helpers.ts:24-38` builds the opaque handle. Its
+`delete` field is the shared `noop` (`helpers.ts:22`). The entity lives in a WASM
+linear-memory arena owned by the `occt-wasm` npm package's `OcctKernel`.
+
+Freeing happens only through the adapter (`src/kernel/occtWasm/occtWasmAdapter.ts:182-188`):
+
+```ts
+dispose(h: { delete(): void }): void {
+  if (isOcctWasmHandle(h)) {
+    this.k.release(h.id);
+  } else if (typeof h.delete === 'function') {
+    h.delete();
+  }
+}
+```
+
+Consequence for `createHandle` (`src/core/disposal.ts:144-182`): disposing a branded
+shape calls `ocShape.delete()` (line 153), which is the no-op under occt-wasm. So
+`using`/`Symbol.dispose` on a branded shape:
+
+- **does** mark the JS wrapper disposed (use-after-dispose throws, stats decrement),
+- **does not** release the arena entity.
+
+Under occt-wasm the arena is reclaimed wholesale when the whole `OcctKernel` is
+disposed or GC'd (a kernel-level `FinalizationRegistry` inside the `occt-wasm`
+package). For a single long-lived process this means occt-wasm shapes accumulate
+in the arena until kernel teardown unless internal code calls
+`getKernel().dispose(shape.wrapped)` on raw temporaries it created.
+
+## Embind details (brepjs-opencascade)
+
+Here `.wrapped` is a real `TopoDS_Shape` Embind proxy. `ocShape.delete()` frees
+the WASM object immediately. A missed `using` is a true leak that grows linear
+memory — the `FinalizationRegistry` safety net in `disposal.ts:115-122` is the only
+thing that eventually reclaims it, and only on a non-deterministic GC pass.
+
+## Internal free of raw kernel temporaries
+
+`*Fns.ts` code that allocates a raw kernel shape and then discards it frees it
+directly with `getKernel().dispose(...)` (not `using`, because these are raw
+`KernelShape`s, not branded handles). Real examples:
+
+- `src/topology/booleanFns.ts:157,248,329` — discarded boolean results
+- `src/operations/loftFns.ts:156` — temp vertices
+- `src/core/validityTypes.ts:112,220` — temp validation shapes
+
+## Embind vector temporaries always need real cleanup
+
+`makeVecU32` / `makeVecInt` / `makeVecDouble` (`src/kernel/occtWasm/helpers.ts:86-102`)
+return Embind vectors that **must** be released via `.delete()` in a `try/finally`
+by the caller, on every kernel — these are not arena handles.
+
+## Kernel-swap contract
+
+`KernelShape` is opaque (`any`) — "a pointer into a WASM linear memory arena" or
+an integer handle (`src/kernel/types.ts:17-29`; `docs/kernel-swap.md`). Layer 2+
+code must never call methods on `.wrapped`; route everything through
+`getKernel().method(shape.wrapped)`. See the `kernel-abstraction` skill.

--- a/.claude/skills/memory-and-disposal/references/kernel-memory-models.md
+++ b/.claude/skills/memory-and-disposal/references/kernel-memory-models.md
@@ -17,11 +17,11 @@ leak protection on the Embind kernels.
 
 ## occt-wasm arena details (the default)
 
-`handle()` in `src/kernel/occtWasm/helpers.ts:24-38` builds the opaque handle. Its
-`delete` field is the shared `noop` (`helpers.ts:22`). The entity lives in a WASM
+`handle()` in `src/kernel/occtWasm/helpers.ts` builds the opaque handle. Its
+`delete` field is the shared `noop` (`helpers.ts`). The entity lives in a WASM
 linear-memory arena owned by the `occt-wasm` npm package's `OcctKernel`.
 
-Freeing happens only through the adapter (`src/kernel/occtWasm/occtWasmAdapter.ts:182-188`):
+Freeing happens only through the adapter (`src/kernel/occtWasm/occtWasmAdapter.ts`):
 
 ```ts
 dispose(h: { delete(): void }): void {
@@ -33,7 +33,7 @@ dispose(h: { delete(): void }): void {
 }
 ```
 
-Consequence for `createHandle` (`src/core/disposal.ts:144-182`): disposing a branded
+Consequence for `createHandle` (`src/core/disposal.ts`): disposing a branded
 shape calls `ocShape.delete()` (line 153), which is the no-op under occt-wasm. So
 `using`/`Symbol.dispose` on a branded shape:
 
@@ -50,7 +50,7 @@ in the arena until kernel teardown unless internal code calls
 
 Here `.wrapped` is a real `TopoDS_Shape` Embind proxy. `ocShape.delete()` frees
 the WASM object immediately. A missed `using` is a true leak that grows linear
-memory — the `FinalizationRegistry` safety net in `disposal.ts:115-122` is the only
+memory — the `FinalizationRegistry` safety net in `disposal.ts` is the only
 thing that eventually reclaims it, and only on a non-deterministic GC pass.
 
 ## Internal free of raw kernel temporaries
@@ -59,19 +59,19 @@ thing that eventually reclaims it, and only on a non-deterministic GC pass.
 directly with `getKernel().dispose(...)` (not `using`, because these are raw
 `KernelShape`s, not branded handles). Real examples:
 
-- `src/topology/booleanFns.ts:157,248,329` — discarded boolean results
-- `src/operations/loftFns.ts:156` — temp vertices
-- `src/core/validityTypes.ts:112,220` — temp validation shapes
+- `src/topology/booleanFns.ts` — discarded boolean results
+- `src/operations/loftFns.ts` — temp vertices
+- `src/core/validityTypes.ts` — temp validation shapes
 
 ## Embind vector temporaries always need real cleanup
 
-`makeVecU32` / `makeVecInt` / `makeVecDouble` (`src/kernel/occtWasm/helpers.ts:86-102`)
+`makeVecU32` / `makeVecInt` / `makeVecDouble` (`src/kernel/occtWasm/helpers.ts`)
 return Embind vectors that **must** be released via `.delete()` in a `try/finally`
 by the caller, on every kernel — these are not arena handles.
 
 ## Kernel-swap contract
 
 `KernelShape` is opaque (`any`) — "a pointer into a WASM linear memory arena" or
-an integer handle (`src/kernel/types.ts:17-29`; `docs/kernel-swap.md`). Layer 2+
+an integer handle (`src/kernel/types.ts`; `docs/kernel-swap.md`). Layer 2+
 code must never call methods on `.wrapped`; route everything through
 `getKernel().method(shape.wrapped)`. See the `kernel-abstraction` skill.

--- a/.claude/skills/playground-examples/SKILL.md
+++ b/.claude/skills/playground-examples/SKILL.md
@@ -21,21 +21,21 @@ An example is an `Example { id, label, description, code }` (`apps/playground/sr
 | `apps/playground/src/lib/examples/bim.ts`        | BIM         | imports `brepjs-bim`, uses top-level `await` |
 | `apps/playground/src/lib/examples/index.ts`      | barrel      | builds `CATEGORIES` + flat `EXAMPLES`        |
 
-To add an example: append an `Example` to the appropriate category array. To add a new category: create a file exporting an `Example[]`, then register it in `CATEGORIES` (`index.ts:23-28`).
+To add an example: append an `Example` to the appropriate category array. To add a new category: create a file exporting an `Example[]`, then register it in `CATEGORIES` (`index.ts`).
 
 ### Code-string rules (hard constraints)
 
-The `code` field becomes the Monaco editor buffer verbatim AND is executed by both the browser worker and the root test harness. It must obey (`types.ts:4-9`):
+The `code` field becomes the Monaco editor buffer verbatim AND is executed by both the browser worker and the root test harness. It must obey (`types.ts`):
 
-- **Self-contained.** No shared helpers, no imports of other examples, no TS-only constructs the harness's sucrase strip can't handle (`transforms: ['typescript']`, `tests/helpers/playgroundExampleEval.ts:71-75`).
-- **Named imports only, from the recognized specifiers.** The eval harness rewrites only the `import { … } from '<spec>'` form for these specifiers: `brepjs`, `brepjs/quick`, `brepjs/playground`, `brepjs-sheetmetal`, `brepjs-bim` (`playgroundExampleEval.ts:77-88`). Namespace (`import * as`) and default imports are NOT rewritten and will fail at runtime. Prefer `'brepjs/quick'`.
-- **Ends in `export default <shape | shape[]>`.** Return one shape or an array; an array renders each shape. The harness turns `export default` into `return` (`playgroundExampleEval.ts:88`).
-- **`color()` / `present()` come from `'brepjs/playground'`**, not published API. `color(shape, css)` tags a color; `present(shape, { dxf, ifc, bimTree, overlay2d })` attaches downloadable artifacts. Both are stripped back to the shape before meshing (`playgroundExampleEval.ts:56-65, 108-113`).
+- **Self-contained.** No shared helpers, no imports of other examples, no TS-only constructs the harness's sucrase strip can't handle (`transforms: ['typescript']`, `tests/helpers/playgroundExampleEval.ts`).
+- **Named imports only, from the recognized specifiers.** The eval harness rewrites only the `import { … } from '<spec>'` form for these specifiers: `brepjs`, `brepjs/quick`, `brepjs/playground`, `brepjs-sheetmetal`, `brepjs-bim` (`playgroundExampleEval.ts`). Namespace (`import * as`) and default imports are NOT rewritten and will fail at runtime. Prefer `'brepjs/quick'`.
+- **Ends in `export default <shape | shape[]>`.** Return one shape or an array; an array renders each shape. The harness turns `export default` into `return` (`playgroundExampleEval.ts`).
+- **`color()` / `present()` come from `'brepjs/playground'`**, not published API. `color(shape, css)` tags a color; `present(shape, { dxf, ifc, bimTree, overlay2d })` attaches downloadable artifacts. Both are stripped back to the shape before meshing (`playgroundExampleEval.ts, 108-113`).
 - **`unwrap()` finishing ops — never `x.ok ? x.value : base`.** See Gate 2; the silent-fallback ban is enforced by regex.
 
 ### Comment style
 
-Match `basics.ts`: one punchy header line, aligned trailing dimension comments, terse one-line section notes. Example from `basics.ts:13`:
+Match `basics.ts`: one punchy header line, aligned trailing dimension comments, terse one-line section notes. Example from `basics.ts`:
 
 ```
 const drilled = unwrap(cut(box(30, 20, 10), cylinder(5, 15, { at: [15, 10, -2] })));

--- a/.claude/skills/playground-examples/SKILL.md
+++ b/.claude/skills/playground-examples/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: playground-examples
+description: This skill should be used when adding, editing, or fixing an example in apps/playground — when a task says "add a playground example", "example fails check:examples", "playgroundExamples.test.ts is failing", "regenerate ambient types", "generate-types", "example thumbnail is missing", "run npm run thumbs", "example renders wrong / blank viewer", "example works in tests but breaks in the browser", or when a new example needs to pass its three gates (types, geometry, thumbnail) before merge.
+---
+
+# Playground examples
+
+Add or fix an example in `apps/playground` and clear its three gates: types, geometry, thumbnail. Every example is a self-contained code string that (1) type-checks against the editor's ambient types, (2) evaluates and meshes against the OCCT kernel in the root test suite, and (3) ships a committed `.webp` thumbnail. Miss any one and CI or the gallery breaks.
+
+For bulk import from an OpenSCAD reference library, use the `/scad-to-playground` workflow instead — it encodes the same validate→render→repair loop for many examples at once. This skill is the manual, single-example counterpart.
+
+## Example anatomy
+
+An example is an `Example { id, label, description, code }` (`apps/playground/src/lib/examples/types.ts`). Examples live in category files and are aggregated by a barrel:
+
+| File                                             | Category    | Notes                                        |
+| ------------------------------------------------ | ----------- | -------------------------------------------- |
+| `apps/playground/src/lib/examples/basics.ts`     | Basics      | Calibration for house comment style          |
+| `apps/playground/src/lib/examples/mechanical.ts` | Mechanical  | Largest set                                  |
+| `apps/playground/src/lib/examples/sheetMetal.ts` | Sheet Metal | imports `brepjs-sheetmetal`                  |
+| `apps/playground/src/lib/examples/bim.ts`        | BIM         | imports `brepjs-bim`, uses top-level `await` |
+| `apps/playground/src/lib/examples/index.ts`      | barrel      | builds `CATEGORIES` + flat `EXAMPLES`        |
+
+To add an example: append an `Example` to the appropriate category array. To add a new category: create a file exporting an `Example[]`, then register it in `CATEGORIES` (`index.ts:23-28`).
+
+### Code-string rules (hard constraints)
+
+The `code` field becomes the Monaco editor buffer verbatim AND is executed by both the browser worker and the root test harness. It must obey (`types.ts:4-9`):
+
+- **Self-contained.** No shared helpers, no imports of other examples, no TS-only constructs the harness's sucrase strip can't handle (`transforms: ['typescript']`, `tests/helpers/playgroundExampleEval.ts:71-75`).
+- **Named imports only, from the recognized specifiers.** The eval harness rewrites only the `import { … } from '<spec>'` form for these specifiers: `brepjs`, `brepjs/quick`, `brepjs/playground`, `brepjs-sheetmetal`, `brepjs-bim` (`playgroundExampleEval.ts:77-88`). Namespace (`import * as`) and default imports are NOT rewritten and will fail at runtime. Prefer `'brepjs/quick'`.
+- **Ends in `export default <shape | shape[]>`.** Return one shape or an array; an array renders each shape. The harness turns `export default` into `return` (`playgroundExampleEval.ts:88`).
+- **`color()` / `present()` come from `'brepjs/playground'`**, not published API. `color(shape, css)` tags a color; `present(shape, { dxf, ifc, bimTree, overlay2d })` attaches downloadable artifacts. Both are stripped back to the shape before meshing (`playgroundExampleEval.ts:56-65, 108-113`).
+- **`unwrap()` finishing ops — never `x.ok ? x.value : base`.** See Gate 2; the silent-fallback ban is enforced by regex.
+
+### Comment style
+
+Match `basics.ts`: one punchy header line, aligned trailing dimension comments, terse one-line section notes. Example from `basics.ts:13`:
+
+```
+const drilled = unwrap(cut(box(30, 20, 10), cylinder(5, 15, { at: [15, 10, -2] })));
+```
+
+Keep comments concise — they are read in a small Monaco pane. Avoid multi-line walls of prose.
+
+## The three gates
+
+### Gate 1 — types (`check:examples`)
+
+```
+cd apps/playground && npm run check:examples
+```
+
+`apps/playground/scripts/checkExamples.ts` type-checks every example's `code` against the generated ambient `.d.ts` files (`src/types/brepjs-ambient.d.ts`, `-sheetmetal-`, `-bim-`), wrapped into `declare module` blocks by the same `buildBrepjsModuleDts` the Monaco editor uses, with the editor's compiler options (ES2022, moduleResolution Bundler, strict, skipLibCheck). Passing == "no red squiggles in the editor". It also checks the docs landing hero snippet `docs-hero:PLAYGROUND_PROGRAM` extracted from `apps/docs/.vitepress/theme/components/CodeCadHero.vue` — if that template literal is renamed or moved, the script exits 1 with a pointed message.
+
+On failure, decide the cause:
+
+| Symptom                                                 | Cause               | Fix                                                                                                     |
+| ------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| Error on an API the example uses                        | Example bug         | Fix the `code` string                                                                                   |
+| Method/type exists in `src` but not the ambient `.d.ts` | Stale ambient types | Rebuild the package(s), run `npm run generate-types`, commit the regenerated `src/types/*-ambient.d.ts` |
+| "Could not find PLAYGROUND_PROGRAM"                     | Hero literal moved  | Restore the literal or update the `PLAYGROUND_PROGRAM` regex in `checkExamples.ts`                      |
+
+Regenerating types: `generate-ambient-types.ts` reads each package's built `node_modules/<pkg>/dist/index.d.ts` (build the package first), and deliberately excludes the experimental `implicit/` modules (`EXCLUDED_MODULE_RE = /(^|\/)implicit\//`, generator lines 60-64) because they re-export core primitives aliased as `sdfCylinder` etc. that would otherwise overwrite the real `cylinder`/`box`/`cone`. Satellite packages re-emit their brepjs-sourced names as a top-of-file `import type { … } from 'brepjs'` that resolves against the sibling `declare module 'brepjs'` at consumption time — leave that mechanism intact. See kernel-abstraction and companion-packages skills for package build order.
+
+Where it runs in CI: the playground `build` script is `tsc -b && npm run check:examples && vite build` (`package.json:11`), executed by the `playground-build` job (`.github/workflows/ci.yml:119`), path-gated on `apps/playground/**`. CI builds `brepjs`, `brepjs-bim`, `brepjs-sheetmetal` before building the playground.
+
+### Gate 2 — geometry (`tests/playgroundExamples.test.ts`)
+
+```
+npx vitest run --project occt-wasm tests/playgroundExamples.test.ts
+```
+
+Run from the repo root. This lives in `tests/`, so it is part of the root suite and needs no dist build — root vitest aliases `brepjs`, `brepjs-sheetmetal`, `brepjs-bim` to live `src` (`vitest.config.ts`). Pre-commit's changed-file run (`vitest run --project occt-wasm --changed`) picks it up when an example file changes, because vitest `--changed` follows the import graph into `apps/playground/src/lib/examples/`.
+
+Four assertion families (`tests/playgroundExamples.test.ts`):
+
+1. **Unique `id` and `label`** across all examples (lines 20-25).
+2. **Evals + meshes**: each example produces `shapeCount > 0` and `totalVertices > 0` (lines 27-33).
+3. **No silent finishing-op fallback**: the regex `/(\.ok\s*\?[^:]*:|isOk\s*\([^)]*\)\s*\?[^:]*:)/` must not match — patterns like `x.ok ? x.value : base` or `isOk(x) ? unwrap(x) : base` are banned (lines 40-48). A swallowed fillet/chamfer failure makes a no-op pass the mesh check while shipping an unfinished part. Use `unwrap()` so failures throw and get caught. See result-error-handling.
+4. **Connected-body check** for a hard-coded assembly list `CONNECTED_BODY_EXAMPLES` (universal-joint, geneva-drive, bench-vise, scotch-yoke, three-jaw-chuck, worm-gear-drive, lines 55-62): each exported body must have `getSolids().length === 1`. A disjoint compound still meshes but detaches on STEP/GLB export. **When adding a multi-body mechanism/assembly example, add its id to this list.**
+
+If geometry is wrong (see debugging-geometry for the full triage): common example pitfalls are `revolve()` of a profile whose edge touches the axis (degenerate), features added where they should be cut (inverted boolean), and the silent-fallback pattern above.
+
+### Gate 3 — thumbnail (committed `.webp`)
+
+Each example needs a committed `apps/playground/public/example-thumbs/<id>.webp` (58 static thumbnails committed today; a further 46 optional `.turntable.webp` files also live here), consumed by `ExampleGallery.tsx`. Generating one requires a running dev server:
+
+```
+cd apps/playground
+(npm run dev > tmp/pg.log 2>&1 &) ; sleep 6
+PORT_URL=$(grep -oE 'http://localhost:[0-9]+' tmp/pg.log | head -1)
+npm run thumbs "$PORT_URL" <example-id>
+```
+
+Vite may pick a non-5173 port if one is busy — always sniff the actual URL from the log, don't hardcode. `npm run thumbs` (`shootExamples.ts --thumbs`) frames the model (Iso preset, Fit, grid off) and writes a centred square WebP. Commit `public/example-thumbs/<id>.webp`.
+
+Optional companion: `npm run turntables "$PORT_URL" <id>` writes an animated `<id>.turntable.webp` (needs `img2webp` or `ffmpeg` on PATH and the DEV-only `window.__brepjsOrbit` hook). The gallery lazy-loads it on hover and remembers 404s, so a missing turntable is tolerated — many examples ship only the static webp.
+
+Visual-repair loop: `npm run shoot "$PORT_URL" tmp/shots <id>` writes a full-page PNG; Read it to confirm the shape looks right, edit the `code`, re-run Gate 2, re-shoot. A shape can pass eval+mesh yet render off-centre, floating, or degenerate — the screenshot is the only thing that catches that.
+
+## Symptom → cause → fix
+
+| Symptom                                                   | Cause                                                                                                            | Fix                                                                                                                                                                                |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Gates green, browser shows blank/broken viewer            | Stale companion `dist` (worker lazy-imports `brepjs-bim`/`brepjs-sheetmetal` from their built `dist`, not `src`) | `build:deps` runs on `predev`/`prebuild` and auto-heals; restart a long-running dev server after editing `brepjs-bim`/`brepjs-sheetmetal`/`brepjs-viewer`. See companion-packages. |
+| Namespace/default import fails at runtime but type-checks | Harness only rewrites `import { … } from` form                                                                   | Convert to named imports                                                                                                                                                           |
+| Example edit not lint/format-checked locally              | Playground app code is outside root lint/typecheck/lint-staged                                                   | Its own gates are `tsc -b` + `check:examples` + `vite build` in the path-gated `playground-build` CI job                                                                           |
+| Thumbnail command fails to connect                        | Wrong port                                                                                                       | Sniff the port from the dev-server log                                                                                                                                             |
+| `check:examples` fails on the hero snippet                | Hero literal moved in `CodeCadHero.vue`                                                                          | Keep `PLAYGROUND_PROGRAM` intact or update `checkExamples.ts`                                                                                                                      |
+
+Note: the production `playground-smoke` workflow only checks the deployed engine boots; it does NOT verify examples. Gate 2 is the sole guard that each example runs.
+
+## Checklist for a new example
+
+1. Add the `Example` to the right category file (or register a new category in `index.ts`).
+2. `cd apps/playground && npm run check:examples` — types green.
+3. `npx vitest run --project occt-wasm tests/playgroundExamples.test.ts` — geometry green (add multi-body assemblies to `CONNECTED_BODY_EXAMPLES`).
+4. Start dev server, `npm run thumbs "$URL" <id>`, commit `public/example-thumbs/<id>.webp`.
+5. Optional: `npm run shoot "$URL" tmp/shots <id>` + Read the PNG to confirm framing.
+
+## Additional resources
+
+The in-code file headers are the authoritative depth and stay current with the code; read them rather than a restatement:
+
+- `apps/playground/src/lib/examples/types.ts` — authoring rules
+- `apps/playground/scripts/checkExamples.ts` — Gate 1
+- `tests/playgroundExamples.test.ts` + `tests/helpers/playgroundExampleEval.ts` — Gate 2 + eval harness mechanics
+- `apps/playground/scripts/shootExamples.ts` — Gate 3, audit and turntable modes
+- `apps/playground/scripts/generate-ambient-types.ts` + `apps/playground/src/lib/ambientModule.ts` — the editor type surface
+- `.claude/workflows/scad-to-playground.js` — bulk-import automation precedent
+
+Sibling skills: `debugging-geometry` (wrong/empty geometry), `result-error-handling` (`unwrap` vs fallback), `companion-packages` (dist build order, stale-dist trap), `quality-gates` and `ci-triage` (gate/CI mechanics).

--- a/.claude/skills/quality-gates/SKILL.md
+++ b/.claude/skills/quality-gates/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: quality-gates
+description: This skill should be used when a local brepjs quality gate or `npm run validate` step fails and the specific rule's fix or escape hatch is needed — ESLint errors like "no-explicit-any" or "Direct .oc access is banned", pattern-checker "check:patterns" violations (no-double-cast, max-function-lines, require-using-for-handles), a pattern-baseline update, knip flagging an unused export, or the boundary check printing "Layer boundary violations found". Also covers the pattern-baseline trap where an unbaselined violation on main fails every open PR. Not for a red CI run in general (ci-triage) or for hook orchestration and merges (git-pr-workflow).
+---
+
+# Quality gates
+
+Pass `npm run validate`, understand every gate's failure output, and reach for the
+right escape hatch instead of `--no-verify`. `CLAUDE.md` already lists the headline
+rules and hook tiers; this skill adds the failure-output recipes, escape-hatch
+mechanics, and the traps those summaries omit.
+
+## The gate map
+
+| Gate            | Command                              | Runs in validate |      Runs in pre-commit       | Elsewhere                 |
+| --------------- | ------------------------------------ | :--------------: | :---------------------------: | ------------------------- |
+| Typecheck       | `npm run typecheck` (`tsc --noEmit`) |       1/5        |       Tier 1 (parallel)       | CI `typecheck`            |
+| ESLint          | `npm run lint` (`eslint src/`)       |       2/5        |    Tier 1 via lint-staged     | CI `lint`                 |
+| Boundaries      | `npm run check:boundaries`           |       3/5        |      Tier 1 (`:staged`)       | CI `quality`              |
+| Format          | `npm run format:check`               |       4/5        |    Tier 1 via lint-staged     | CI `lint`                 |
+| Changed tests   | `npm run test`                       |       5/5        |            Tier 2             | CI `test` (sharded, full) |
+| Pattern checker | `npm run check:patterns`             |        —         | lint-staged (staged src only) | CI `quality`              |
+| knip            | `npm run knip`                       |        —         |               —               | pre-push + CI `quality`   |
+
+`validate` is `scripts/validate-change.sh`: five steps, **in order, fail-fast**
+(`set -e`) — it stops at the first red step and prints nothing after it. Fix
+step N before step N+1 is reachable. On success it prints `=== All checks passed ===`.
+
+Pre-commit (`.husky/pre-commit`) runs Tier 1's three checks **in parallel**, so
+their output interleaves — read carefully to attribute an error to the right gate.
+For hook anatomy, `FULL_TESTS=1`, pre-push, commit-msg, and `--no-verify`, see the
+**git-pr-workflow** skill. (Note: `scripts/pre-commit-help.sh` prints "coverage
+thresholds enforced at push time" — that line is stale; pre-push runs only knip.)
+
+## ESLint failures
+
+Full config: `eslint.config.js` (flat config, `strictTypeChecked` base). Rules
+actually hit in practice and their sanctioned escapes:
+
+| Symptom                                     | Rule                          | Fix / escape                                                                                                                               |
+| ------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| "Unexpected any"                            | `no-explicit-any`             | Type it. Only for a real WASM type gap: `// eslint-disable-next-line @typescript-eslint/no-explicit-any -- kernel WASM binding lacks type` |
+| "Forbidden non-null assertion"              | `no-non-null-assertion`       | Narrow with a guard; for `noUncheckedIndexedAccess` array reads, add a bounds check or disable-comment                                     |
+| "must be imported using a type-only import" | `consistent-type-imports`     | Use `import type { ... }`                                                                                                                  |
+| unused var                                  | `no-unused-vars`              | Prefix with `_` (`argsIgnorePattern`/`varsIgnorePattern` = `^_`)                                                                           |
+| "Unnecessary conditional"                   | `no-unnecessary-condition`    | The condition is provably always true/false — remove it, don't disable                                                                     |
+| switch not exhaustive                       | `switch-exhaustiveness-check` | Handle every union case; a `default` counts as exhaustive                                                                                  |
+| "Do not use '// @ts-ignore'"                | `ban-ts-comment`              | Use `// @ts-expect-error -- reason` (the `-- reason` suffix is mandatory); `@ts-ignore`/`@ts-nocheck` are fully banned                     |
+| console call                                | `no-console`                  | Only `console.error`/`console.warn` are allowed                                                                                            |
+| `export let` / `enum`                       | `no-restricted-syntax`        | Use a getter fn or `const`; use `as const` object + literal union                                                                          |
+
+Two Layer-2+ bans — **"Direct .oc access is banned"** and **"Direct method calls on
+.wrapped are banned"** — fire in the domain/high-level dirs. The fix for both is
+`getKernel().method(shape.wrapped)`, **never** a disable-comment. The rule mechanics
+and the exact directory list live in the **architecture-navigation** skill; for the
+correct kernel-method call pattern see **kernel-abstraction**.
+
+`npm run lint` only covers `src/`. Tests are linted at commit time via lint-staged
+(`.lintstagedrc.json`), not by `npm run lint`. Prettier config (`.prettierrc.json`):
+semicolons, single quotes, `trailingComma: es5`, width 100, LF.
+
+## Pattern checker deep-dive
+
+`scripts/check-patterns.ts` — AST checks ESLint can't express. Five rules, all
+severity `error`:
+
+| Rule id                     | Fires when                                                          | Threshold / excusal                                                                                                                |
+| --------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `no-double-cast`            | `as unknown as T`, `as any as T`, `<T><unknown>expr`                | Use a guard, generic, or branded constructor                                                                                       |
+| `no-async-withkernel`       | async callback passed to `withKernel(id, fn)` (bare or member call) | Use `getKernel(id)` for async code (kernel-abstraction skill)                                                                      |
+| `require-using-for-handles` | `createHandle()`/`createKernelHandle()` not bound with `using`      | Excused when: `return`ed, passed **directly** as a call argument, or placed in an object/array literal (memory-and-disposal skill) |
+| `max-function-lines`        | function body > **60 effective** lines                              | Blanks, comments, and lone-brace lines don't count; extract helpers                                                                |
+| `max-nesting-depth`         | > **4** levels of if/for/for-in/for-of/while/do/switch/try          | Depth resets inside nested function bodies; use early returns                                                                      |
+
+The rule id is `require-using-for-handles` (not "missing using") — that exact string
+goes in baselines and disable-comments.
+
+**Inline disable:** `// brepjs-patterns-disable: <rule-id>` on the line above the
+violation or inline on the same line. `<rule-id>` may be a specific rule or `*` for
+all rules on that line.
+
+**Baseline** (`.pattern-baseline.json`, version-2): only _new_ (non-baselined)
+violations fail; exit 1 if any. Currently 30 entries (15 `max-function-lines`,
+14 `no-double-cast`, 1 `max-nesting-depth`). Fingerprints are content-based
+(`file|rule|normalized-80char-snippet|#occurrenceIdx`), so:
+
+- Editing code **above** a violation does NOT reshuffle fingerprints.
+- Editing **the violating line itself** (rename, signature change, cast text)
+  changes the fingerprint → it reports as "new". This is intended: touch it, own it.
+
+Regenerate after intentionally adding/removing violations:
+`npm run check:patterns:baseline` (= `--update-baseline`). Other flags:
+`--no-baseline` (report everything, ignore baseline), `--json`, `--sarif`.
+Only `src/**/*.ts` is ever scanned (no `.d.ts`, no `src/kernel/wasm/`). Console
+failure output ends with the two escape hatches printed verbatim: the disable-comment
+format and the `--update-baseline` command.
+
+## TRAP: an unbaselined violation on main fails every open PR
+
+CI's `quality` job runs `check:patterns` over **all** of `src/` and checks out the
+PR-merged-with-main commit. So a `max-function-lines`/`no-double-cast` violation that
+lands on `main` without a matching baseline entry fails the `quality` job — and thus
+the required `ci-pass` aggregate — on **every open PR at once**, even PRs that never
+touched that file.
+
+Recovery: land a tiny baseline-bump PR first (`npm run check:patterns:baseline`,
+commit `.pattern-baseline.json`). That PR passes because its own merge commit contains
+the new baseline; once merged, the other PRs go green. This happens because
+lint-staged only runs the pattern checker on **staged** files locally, so a long
+function can slip in via a large refactor and only bite in full-src CI. See the
+**ci-triage** skill for other `quality`-job failure modes.
+
+## TRAP: function-lookup CI diff after adding a `*Fns.ts` export
+
+Adding a `*Fns.ts` export makes CI's `build` job flag a `docs/function-lookup.md` diff unless the file is regenerated and prettier-normalized before commit — full recipe in the **adding-operations** skill.
+
+## knip (unused exports)
+
+Runs on pre-push and in CI's `quality` job. Config: `knip.config.ts`.
+
+- **Export used only by tests?** knip can't trace `tests/` (separate tsconfig, `@/`
+  alias). Tag it `@testOnly` in a JSDoc comment — `tags: ['-testOnly']` treats it as
+  used. This is the correct escape, not deleting the export.
+- `ignoreExportsUsedInFile: true`; `duplicates` and `optionalPeerDependencies` are off
+  (intentional API aliases + the `brepjs-opencascade` optional peer).
+- Root workspace checks `src/**/*.ts` only. Companion workspaces (`brepjs-opencascade`,
+  `brepjs-voxel-wasm`, `brepjs-viewer`, `brepjs-cad`, `apps/playground`) are fully
+  ignored; `brepjs-bim` ignores `examples/**`. See **companion-packages**.
+
+## Boundary check
+
+`scripts/check-layer-boundaries.sh` enforces downward-only imports (target layer ≤
+source layer), handling both `@/` alias and relative imports. Violation output:
+
+```
+Layer boundary violations found:
+
+  VIOLATION: src/topology/foo.ts (layer 2: topology) imports from '@/sketching/bar.js' (layer 3: sketching)
+```
+
+The script's layer map is a superset of the `CLAUDE.md` table — it also places
+`csg/voxel/implicit` in Layer 2 and `gear/ns/lattice` in Layer 3. Unrecognized
+top-level dirs and root files (`src/index.ts`) are skipped. `--staged` mode
+(`check:boundaries:staged`, used by pre-commit) checks only staged files; env
+`BOUNDARY_SRC_DIR` overrides the scan root for fixture testing. For where new code
+belongs and how to restructure to fix a violation, see **architecture-navigation**.
+
+## Not gated locally (surfaces only in CI)
+
+- **Coverage**: `test` runs `--changed` (changed files, no coverage); `test:full` runs
+  the whole suite with `--coverage`. Thresholds run on **main pushes only**,
+  `continue-on-error` — informational, never a PR gate. See **writing-tests**.
+- **Full test suite**: only the sharded CI `test` job (`test:ci`, no coverage) runs
+  everything. Pre-commit runs `--changed` only.
+- **size / benchmark**: PR-only CI jobs (`.size-limit.json` budgets; benchmark
+  regression vs main). Not in `validate`.
+
+## Additional resources
+
+Adjacent skills own the neighboring facts: `git-pr-workflow` (hook tiers,
+conventional commits, `--no-verify`), `architecture-navigation` (layer map, the
+`.oc`/`.wrapped` rule + directory list), `kernel-abstraction` (`withKernel` vs
+`getKernel`), `memory-and-disposal` (`using` handles), `ci-triage` (CI job failure
+modes), `writing-tests` (coverage and the vitest runner config), `adding-operations`
+(function-lookup gate), `companion-packages` (workspace layout).

--- a/.claude/skills/release-publishing/SKILL.md
+++ b/.claude/skills/release-publishing/SKILL.md
@@ -24,7 +24,7 @@ Every release in this repo flows through one workflow: `.github/workflows/releas
    - any other leaf → **held while a root release PR is open**; merged on a later run after root lands.
 4. Root release PR merges. CI passes trivially on release PRs — `ci.yml` skips the paths-filter for `release-please--*` branches, and `ci-pass` treats skipped jobs as pass — so `--auto` completes.
 5. `publish-brepjs` runs inline in `release-please.yml`: `npm ci && npm run build && npm publish --provenance` (OIDC). This is the ONLY package published inline.
-6. Merging bumps `main`. The next release-please run regenerates each leaf PR with a now-valid `brepjs` pin, auto-merges them, and each leaf's publish job dispatches its own `publish-brepjs-<pkg>.yml` with `-f dry_run=false --ref <release-tag>`.
+6. Merging bumps `main`. The next release-please run regenerates each leaf PR with a now-valid `brepjs` pin, auto-merges them, and each **auto-publishing** leaf's job dispatches its own `publish-brepjs-<pkg>.yml` with `-f dry_run=false --ref <release-tag>`. (`brepjs-opencascade` is the exception — always manual via `publish-opencascade.yml`; `brepjs-voxel-wasm` has no publish workflow.)
 
 Leaves dispatch against the **immutable release tag** release-please just created, never `main`: the dispatch API accepts a tag but rejects a raw SHA, and the tag pin avoids publishing the wrong commit if another push lands mid-window.
 
@@ -77,7 +77,7 @@ gh workflow run publish-opencascade.yml -f dry_run=false --ref <release-tag>
 | `brepjs-bim`         | yes                      | yes (after root)  | yes, dispatched             | `publish-brepjs-bim.yml`                         |
 | `brepjs-sheetmetal`  | yes                      | yes (after root)  | yes, dispatched             | `publish-brepjs-sheetmetal.yml`                  |
 | `brepjs-opencascade` | yes                      | **held (manual)** | **manual only**             | `publish-opencascade.yml` (Docker WASM)          |
-| `brepjs-voxel-wasm`  | yes (bumps `Cargo.toml`) | n/a               | **no workflow, not on npm** | none                                             |
+| `brepjs-voxel-wasm`  | yes (bumps `Cargo.toml`) | yes (after root)  | **no workflow, not on npm** | none                                             |
 | `brepjs-viewer`      | **no**                   | n/a               | manual                      | `publish-brepjs-viewer.yml`                      |
 | `brepjs-voxel`       | no                       | n/a               | not published               | none                                             |
 

--- a/.claude/skills/release-publishing/SKILL.md
+++ b/.claude/skills/release-publishing/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: release-publishing
+description: This skill should be used when operating releases or npm publishing in brepjs — cutting or merging a release-please PR, recovering a failed npm publish, or deciding whether a commit may carry a breaking marker. Trigger phrases include "release PR", "release-please", "autorelease: pending", "publish to npm", "npm publish failed", "republish", "ETARGET from a leaf release PR ordered ahead of root", "version bump", "why did the major version bump", "breaking change commit", "trusted publisher", "dry_run", "release tag", "manifest conflict", or editing .github/workflows/publish-*.yml or release-please-config.json.
+---
+
+# Releases and npm publishing
+
+Every release in this repo flows through one workflow: `.github/workflows/release-please.yml`. Its inline comments are the canonical deep documentation — read them before changing anything. This skill is the operator's playbook: how a normal release flows, the hard rules that prevent outages, and the recovery recipes when a step fails.
+
+## Mental model
+
+- **release-please, manifest mode.** Versions live in `.release-please-manifest.json`; managed packages are declared in `release-please-config.json`. On every push to `main`, release-please opens/updates a per-package release PR (`separate-pull-requests: true`), bumping the version and CHANGELOG from Conventional Commits.
+- **Six managed packages, two deliberately unmanaged.** Managed: root `.` (`brepjs`), `packages/brepjs-opencascade`, `packages/brepjs-voxel-wasm`, `packages/brepjs-cad`, `packages/brepjs-bim`, `packages/brepjs-sheetmetal`. NOT managed by release-please: `brepjs-viewer` (versioned/published manually — see below) and `packages/brepjs-voxel` (unpublished workspace consumer).
+- **node-workspace re-pins cross-deps.** The `node-workspace` plugin rewrites each leaf package's `brepjs` dependency to the version of the pending root release. This is the source of the ETARGET hazard (below).
+- **npm auth is OIDC trusted publishers, bound to workflow filenames.** Each package's publish authenticates via an npm trusted publisher tied to a specific `.github/workflows/publish-*.yml` filename. Renaming a publish workflow breaks auth silently.
+
+## How a normal release flows
+
+1. Commits land on `main` with Conventional-Commit subjects (enforced by commitlint — see `commitlint.config.js`, `.husky/commit-msg`; format detail lives in the **git-pr-workflow** skill).
+2. The `release-please` job (App token, `googleapis/release-please-action@v5`) opens or updates release PRs labeled `autorelease: pending`.
+3. The `auto-merge` job serializes **root before leaves**: it lists open `autorelease: pending` PRs and, per branch name:
+   - `*--components--brepjs-opencascade` → **permanently held** (manual, expensive WASM build).
+   - root branch `release-please--branches--main--components--brepjs` → `gh pr merge --auto --squash` (merges first).
+   - any other leaf → **held while a root release PR is open**; merged on a later run after root lands.
+4. Root release PR merges. CI passes trivially on release PRs — `ci.yml` skips the paths-filter for `release-please--*` branches, and `ci-pass` treats skipped jobs as pass — so `--auto` completes.
+5. `publish-brepjs` runs inline in `release-please.yml`: `npm ci && npm run build && npm publish --provenance` (OIDC). This is the ONLY package published inline.
+6. Merging bumps `main`. The next release-please run regenerates each leaf PR with a now-valid `brepjs` pin, auto-merges them, and each leaf's publish job dispatches its own `publish-brepjs-<pkg>.yml` with `-f dry_run=false --ref <release-tag>`.
+
+Leaves dispatch against the **immutable release tag** release-please just created, never `main`: the dispatch API accepts a tag but rejects a raw SHA, and the tag pin avoids publishing the wrong commit if another push lands mid-window.
+
+## Hard rules
+
+| Rule                                                                                                                                                                                                                                                      | Why                                                                                                                                                                | Where                             |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| Never put `!`/`BREAKING CHANGE` on a commit unless intentionally breaking the `brepjs` public API.                                                                                                                                                        | Root is 18.x; any breaking marker majors the library immediately.                                                                                                  | `.release-please-manifest.json`   |
+| Root `exclude-paths` are only `apps`, `packages/brepjs-cad`, `packages/brepjs-viewer`, `packages/brepjs-voxel`. A breaking commit touching root `docs/`, `README.md`, `scripts/`, `.github/`, or bim/sheetmetal/opencascade/voxel-wasm still majors root. | Those paths attribute to the root component.                                                                                                                       | `release-please-config.json:8-13` |
+| Never rename or move a `publish-*.yml` file without re-registering the npm trusted publisher for that package.                                                                                                                                            | OIDC auth is bound to the exact filename; a rename makes `npm publish` fail auth.                                                                                  | comments in each `publish-*.yml`  |
+| Never merge a leaf release PR while the root `brepjs` release PR is open.                                                                                                                                                                                 | node-workspace pins the leaf to an unpublished `brepjs` version → `npm install` ETARGET → Vercel deploys break. Also conflicts the root PR on the shared manifest. | `release-please.yml:57-72`        |
+| Never cancel an in-flight Release Please run.                                                                                                                                                                                                             | Cancelling mid-publish leaves a tagged-but-unpublished release; the concurrency group queues, never cancels.                                                       | `release-please.yml:17-24`        |
+| Manual publish dispatches default to `dry_run: true` (build-only). A real publish needs `-f dry_run=false` and a ref.                                                                                                                                     | A bare dispatch is a safe smoke build.                                                                                                                             | every `publish-*.yml`             |
+| `brepjs-opencascade` is always manual.                                                                                                                                                                                                                    | ~60-min Docker WASM build from `ghcr.io/andymai/opencascade.js:v8` (needs `GHCR_TOKEN`).                                                                           | `publish-opencascade.yml`         |
+
+## Recovery playbook
+
+**Root `brepjs` publish failed (release tagged, npm empty).** Do NOT re-run the failed push job — release-please would try to re-tag. Instead re-dispatch the whole workflow in republish mode:
+
+```
+gh workflow run release-please.yml -f republish=true
+```
+
+This skips the `release-please` job and runs only `publish-brepjs` against the current `main` `package.json` version. Republish covers **root brepjs only**.
+
+**A leaf publish failed (`brepjs-cad`/`bim`/`sheetmetal`).** Re-dispatch that leaf's own publish workflow against the release tag:
+
+```
+gh workflow run publish-brepjs-<pkg>.yml -f dry_run=false --ref <release-tag>
+```
+
+**`brepjs-opencascade` needs publishing.** Manual only:
+
+```
+gh workflow run publish-opencascade.yml -f dry_run=false --ref <release-tag>
+```
+
+**Conflicted release PRs (serializer bypassed — e.g. a human merged a leaf early).** Not tooled; manual fix. For each still-open release PR: merge `main` into its branch, take the union of `.release-please-manifest.json` (keep every package's highest intended version), resolve CHANGELOG/package.json, push. Then let the `auto-merge` job re-arm on the next run.
+
+**`npm install`/CI fails with ETARGET after a merge.** A leaf on `main` is pinned to a `brepjs` version not yet on npm. Confirm root actually published (`npm view brepjs version`); if root is fine, the leaf pin is ahead — publish root first (republish above), or bump the leaf's pin down to a published version and open a fix PR. Related consumer-side symptoms are covered in **ci-triage** and **companion-packages**.
+
+**Pack validation failed (`prepack`).** Root `npm pack`/`npm publish` runs `scripts/validate-pack.sh` (wired as `prepack`, with `prepublishOnly: npm run build`). It fails on more than 500 files or any `.d.ts.map` sidecar. Inspect with `npm pack --dry-run`. `.d.ts.map` files mean `declarationMap` got re-enabled — check `vite.config.ts`.
+
+## Package publish matrix
+
+| Package              | Managed?                 | Auto-merge?       | Auto-publish?               | Publish route                                    |
+| -------------------- | ------------------------ | ----------------- | --------------------------- | ------------------------------------------------ |
+| `brepjs` (root)      | yes                      | yes (first)       | yes, inline                 | `release-please.yml` job `publish-brepjs` (OIDC) |
+| `brepjs-cad`         | yes                      | yes (after root)  | yes, dispatched             | `publish-brepjs-cad.yml`                         |
+| `brepjs-bim`         | yes                      | yes (after root)  | yes, dispatched             | `publish-brepjs-bim.yml`                         |
+| `brepjs-sheetmetal`  | yes                      | yes (after root)  | yes, dispatched             | `publish-brepjs-sheetmetal.yml`                  |
+| `brepjs-opencascade` | yes                      | **held (manual)** | **manual only**             | `publish-opencascade.yml` (Docker WASM)          |
+| `brepjs-voxel-wasm`  | yes (bumps `Cargo.toml`) | n/a               | **no workflow, not on npm** | none                                             |
+| `brepjs-viewer`      | **no**                   | n/a               | manual                      | `publish-brepjs-viewer.yml`                      |
+| `brepjs-voxel`       | no                       | n/a               | not published               | none                                             |
+
+Build prerequisites baked into the publish workflows: `brepjs-cad` restores OCCT WASM (`scripts/ensure-wasm.sh`, 3× retry) then builds root + `brepjs-viewer` + itself (viewer is a build-time devDep whose dist is bundled into the `brepjs-cad` build output). `bim` and `sheetmetal` build root `brepjs` first (their `vite-plugin-dts` needs root's emitted types). `brepjs-viewer` uses `npm ci --ignore-scripts` and publishes `--access public`.
+
+## Notes and gotchas
+
+- **`brepjs-viewer` is intentionally de-managed** from release-please. node-workspace kept re-pinning `brepjs-cad`'s build-time `brepjs-viewer` devDep (`"brepjs-viewer": "*"`) to viewer's pending unpublished version, breaking monorepo `npm ci`. Version and publish it by hand via `publish-brepjs-viewer.yml`.
+- **The Claude-plugin marketplace version is independent of the npm version.** release-please does not bump `packages/brepjs-cad/.claude-plugin/plugin.json`; the plugin version and the npm `brepjs-cad` version move separately.
+- **Docs deploy is not release-triggered.** `.github/workflows/docs.yml` chains off successful CI on `main` (`workflow_run`); emergency redeploy is a main-only `workflow_dispatch`.
+- **`scripts/publish-all.sh` is a legacy manual OTP fallback** (opencascade → root only, `--no-provenance`). The OIDC workflows supersede it; use only as a local last resort, and note it does not cover cad/bim/sheetmetal/viewer.
+
+## Additional resources
+
+- Commit format and the `!` decision: `git-pr-workflow` skill.
+- CI job failure modes (npm ci EUSAGE/ETARGET, release PR won't merge, publish red): `ci-triage` skill.
+- Which package to edit and how a change ripples to consumers: `companion-packages` skill.
+- Canonical deep reference: the inline comments in `.github/workflows/release-please.yml`.

--- a/.claude/skills/result-error-handling/SKILL.md
+++ b/.claude/skills/result-error-handling/SKILL.md
@@ -16,7 +16,7 @@ Pick the channel before writing any error-handling code:
 | Expected failure (bad input, kernel op failed, unsupported capability, file won't parse) | `Result` | `err(validationError(...))`, `kernelCall(...)`, etc.                                               |
 | Programmer bug / broken invariant ("this can never happen")                              | Throw    | `bug(location, message)` from `src/utils/bug.ts` — throws `BrepBugError`, never meant to be caught |
 | Out-of-bounds index that is valid by construction (under `noUncheckedIndexedAccess`)     | Throw    | `safeIndex(arr, i, context)` in `src/core/errors.ts` — the sanctioned `arr[i]!` replacement        |
-| Cooperative cancellation                                                                 | Throw    | `if (signal?.aborted) throw signal.reason` (see `src/topology/booleanFns.ts:131`)                  |
+| Cooperative cancellation                                                                 | Throw    | `if (signal?.aborted) throw signal.reason` (see `src/topology/booleanFns.ts`)                      |
 
 The rule for Layers 2–3 (`.claude/commands/new-operation.md`, CLAUDE.md): **never throw for expected failures — return `ok(...)` or `err(...)`**. No ESLint rule enforces this mechanically, so it must be applied by discipline in every new `*Fns.ts` function. The exceptions above (`bug()`, `safeIndex()`, abort rethrows) are the only tolerated throws.
 
@@ -49,7 +49,7 @@ On exception, the error message becomes `` `${message}: ${translated}` `` where 
 
 ### Manual construction: pick the kind-matching constructor
 
-`BrepError` is a plain object: `{ kind, code, message, suggestion?, cause?, metadata? }` (`src/core/errors.ts:221`). There are 9 kinds, each with a constructor sharing the signature `(code, message, cause?, metadata?, suggestion?)`:
+`BrepError` is a plain object: `{ kind, code, message, suggestion?, cause?, metadata? }` (`src/core/errors.ts`). There are 9 kinds, each with a constructor sharing the signature `(code, message, cause?, metadata?, suggestion?)`:
 
 | Kind               | Constructor          | Use for                                                                                      |
 | ------------------ | -------------------- | -------------------------------------------------------------------------------------------- |
@@ -66,7 +66,7 @@ On exception, the error message becomes `` `${message}: ${translated}` `` where 
 Always thread context through:
 
 - **`cause`**: the original exception. Dropping it destroys kernel diagnostics.
-- **`metadata`**: structured context. Real example from `src/topology/modifierFns.ts:306`:
+- **`metadata`**: structured context. Real example from `src/topology/modifierFns.ts`:
 
 ```ts
 return err(
@@ -82,7 +82,7 @@ return err(
 
 ## Error codes
 
-`BrepErrorCode` (`src/core/errors.ts:35-203`) is an `as const` catalog of ~124 codes grouped by category, with a matching literal-union type. Use `BrepErrorCode.X` instead of a raw string whenever the code exists — but know two caveats:
+`BrepErrorCode` (`src/core/errors.ts`) is an `as const` catalog of ~124 codes grouped by category, with a matching literal-union type. Use `BrepErrorCode.X` instead of a raw string whenever the code exists — but know two caveats:
 
 1. `BrepError.code` is typed **`string`**, not the union — a raw-string typo compiles fine. The catalog is advisory; checking it is on the author.
 2. The catalog is **incomplete**: dozens of codes exist in src only as raw string literals (`FILLET_FAILED`, `WIRE_NOT_CLOSED`, `THREAD_INVALID_PITCH`, and whole families). Grep before assuming a code is new.
@@ -110,7 +110,7 @@ To add a new code:
 | Void success                      | `OK` constant (`Ok<Unit>`)                                                 | For operations with nothing to return                                                             |
 | Nullable → Result                 | `fromNullable(value, errorFn)`                                             |                                                                                                   |
 
-The `unwrap()` policy (CLAUDE.md, `docs/getting-started.md`): sanctioned in **tests** (the standard extractor), **scripts/examples**, and internal calls that are **infallible by construction** — e.g. `unwrap(resolvePlane('XY', origin))` in `src/core/planeOps.ts:150`, where the input is a known-valid literal. Never use it on a user-facing fallible path in production code; use `isOk()`/`match()` there.
+The `unwrap()` policy (CLAUDE.md, `docs/getting-started.md`): sanctioned in **tests** (the standard extractor), **scripts/examples**, and internal calls that are **infallible by construction** — e.g. `unwrap(resolvePlane('XY', origin))` in `src/core/planeOps.ts`, where the input is a known-valid literal. Never use it on a user-facing fallible path in production code; use `isOk()`/`match()` there.
 
 Note the kernel-free subpath `brepjs/core` (`src/core.ts`) exports only a subset of combinators — no `pipeline`, `mapBoth`, `tap`/`tapErr`, `fromNullable`, `or`/`orElse`, `zip`. The full set is on the main `brepjs` entry.
 

--- a/.claude/skills/result-error-handling/SKILL.md
+++ b/.claude/skills/result-error-handling/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: result-error-handling
+description: This skill should be used when working with Result<T,E>, BrepError, or error paths in brepjs — deciding whether to throw or return a Result, constructing errors with codes, or handling failures. Trigger phrases include "should this throw or return err", "Called unwrap() on an Err", "add a new error code", "BrepErrorCode", "kernelCall", "unsupportedError", "BrepWrapperError", "the operation failed silently", "error was swallowed", "how do I unwrap this Result", or writing a new *Fns.ts function that can fail.
+---
+
+# Result types and error handling
+
+Every fallible operation in brepjs returns `Result<T, BrepError>` instead of throwing. The type, all combinators, and the extraction helpers live in `src/core/result.ts` (zero internal imports — a pure foundation module). Error kinds, the code catalog, and per-kind constructors live in `src/core/errors.ts`.
+
+## The two failure channels
+
+Pick the channel before writing any error-handling code:
+
+| Situation                                                                                | Channel  | Mechanism                                                                                          |
+| ---------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| Expected failure (bad input, kernel op failed, unsupported capability, file won't parse) | `Result` | `err(validationError(...))`, `kernelCall(...)`, etc.                                               |
+| Programmer bug / broken invariant ("this can never happen")                              | Throw    | `bug(location, message)` from `src/utils/bug.ts` — throws `BrepBugError`, never meant to be caught |
+| Out-of-bounds index that is valid by construction (under `noUncheckedIndexedAccess`)     | Throw    | `safeIndex(arr, i, context)` in `src/core/errors.ts` — the sanctioned `arr[i]!` replacement        |
+| Cooperative cancellation                                                                 | Throw    | `if (signal?.aborted) throw signal.reason` (see `src/topology/booleanFns.ts:131`)                  |
+
+The rule for Layers 2–3 (`.claude/commands/new-operation.md`, CLAUDE.md): **never throw for expected failures — return `ok(...)` or `err(...)`**. No ESLint rule enforces this mechanically, so it must be applied by discipline in every new `*Fns.ts` function. The exceptions above (`bug()`, `safeIndex()`, abort rethrows) are the only tolerated throws.
+
+The one sanctioned Result→throw boundary is the fluent `shape()` facade in `src/topology/wrapperFns.ts`: every chainable method funnels through an internal `unwrapOrThrow` that throws `BrepWrapperError` on `Err`. See "The throwing boundary" below.
+
+## Constructing errors
+
+### Prefer `kernelCall` for kernel operations
+
+`src/core/kernelCall.ts` is the standard error-construction path in `*Fns.ts` files. It wraps try/catch, casts the result, translates cryptic OCCT messages, and auto-attaches a `suggestion`:
+
+```ts
+// src/topology/shapeFns.ts
+return kernelCall(
+  () => getKernel().downcast(shape.wrapped),
+  BrepErrorCode.CLONE_FAILED,
+  'Failed to clone shape'
+) as Result<T>;
+```
+
+Three variants:
+
+| Helper                                       | Returns            | Use when                                                                                                                                       |
+| -------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kernelCall(fn, code, message, kind?)`       | `Result<AnyShape>` | Kernel call returns a `KernelShape`; auto-runs `castShape()`                                                                                   |
+| `kernelCallRaw<T>(fn, code, message, kind?)` | `Result<T>`        | Kernel call returns anything else (string, number, array)                                                                                      |
+| `kernelCallScoped(fn, code, message, kind?)` | `Result<AnyShape>` | `fn(scope)` needs intermediate kernel allocations — the `DisposalScope` is disposed even on the error path (see the memory-and-disposal skill) |
+
+On exception, the error message becomes `` `${message}: ${translated}` `` where `translateKernelError()` (`src/core/kernelErrorTranslation.ts`) maps ~12 cryptic OCCT patterns (BRepAlgoAPI failures, fillet radius too large, degenerate geometry, ...) into actionable text with the original appended as `(kernel: ...)`. Translation applies only when `kind` is `'KERNEL_OPERATION'` (the default). `ERROR_CODE_SUGGESTIONS` in the same file maps a dozen codes (`FUSE_FAILED`, `CUT_FAILED`, `*_NOT_3D`, `SWEEP_FAILED`, `LOFT_FAILED`, `DRAFT_FAILED`, ...) to `suggestion` strings that ride along automatically.
+
+### Manual construction: pick the kind-matching constructor
+
+`BrepError` is a plain object: `{ kind, code, message, suggestion?, cause?, metadata? }` (`src/core/errors.ts:221`). There are 9 kinds, each with a constructor sharing the signature `(code, message, cause?, metadata?, suggestion?)`:
+
+| Kind               | Constructor          | Use for                                                                                      |
+| ------------------ | -------------------- | -------------------------------------------------------------------------------------------- |
+| `VALIDATION`       | `validationError`    | Bad input parameters (check these first, before touching the kernel)                         |
+| `KERNEL_OPERATION` | `kernelError`        | Kernel op failed (prefer `kernelCall` unless building the error by hand)                     |
+| `TYPE_CAST`        | `typeCastError`      | Result was not the expected shape type (e.g. boolean returned non-3D)                        |
+| `COMPUTATION`      | `computationError`   | Geometric computation failed (intersection, skeleton, center of mass)                        |
+| `IO`               | `ioError`            | Import/export failure                                                                        |
+| `QUERY`            | `queryError`         | Shape query failure (e.g. finder not unique)                                                 |
+| `MODULE_INIT`      | `moduleInitError`    | Initialisation failure                                                                       |
+| `UNSUPPORTED`      | `unsupportedError`   | Capability not supported by the current kernel (ADR-0006) — see the kernel-abstraction skill |
+| `SKETCHER_STATE`   | `sketcherStateError` | Currently unused in src; exists for sketcher state transitions                               |
+
+Always thread context through:
+
+- **`cause`**: the original exception. Dropping it destroys kernel diagnostics.
+- **`metadata`**: structured context. Real example from `src/topology/modifierFns.ts:306`:
+
+```ts
+return err(
+  kernelError('FILLET_FAILED', `Fillet operation failed: ${raw}`, e, {
+    operation: 'fillet',
+    edgeCount: selectedCount,
+    radius,
+  })
+);
+```
+
+- **`suggestion`**: a recovery hint. The `shape()` wrapper folds it into the thrown message (`"...\nSuggestion: ..."`), so it reaches users.
+
+## Error codes
+
+`BrepErrorCode` (`src/core/errors.ts:35-203`) is an `as const` catalog of ~124 codes grouped by category, with a matching literal-union type. Use `BrepErrorCode.X` instead of a raw string whenever the code exists — but know two caveats:
+
+1. `BrepError.code` is typed **`string`**, not the union — a raw-string typo compiles fine. The catalog is advisory; checking it is on the author.
+2. The catalog is **incomplete**: dozens of codes exist in src only as raw string literals (`FILLET_FAILED`, `WIRE_NOT_CLOSED`, `THREAD_INVALID_PITCH`, and whole families). Grep before assuming a code is new.
+
+To add a new code:
+
+1. Add the constant to `BrepErrorCode` in `src/core/errors.ts` under its category group (kernel-op, validation, IO, ...).
+2. Use it via the kind-matching constructor, or pass it to `kernelCall`.
+3. Optionally add an entry to `ERROR_CODE_SUGGESTIONS` in `src/core/kernelErrorTranslation.ts` so `kernelCall` auto-attaches a recovery hint.
+4. Optionally add a row to the tables in `docs/errors.md` (hand-maintained, no CI check — see the staleness warning below).
+
+## Consuming Results
+
+| Need                              | Use                                                                        | Notes                                                                                             |
+| --------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Branch on outcome                 | `isOk(r)` / `isErr(r)`                                                     | Type guards; narrow to `Ok<T>` / `Err<E>`                                                         |
+| Handle both arms as an expression | `match(r, { ok: v => ..., err: e => ... })`                                |                                                                                                   |
+| Extract in a test or script       | `unwrap(r)`                                                                | Throws with `[kind] CODE: message` formatting on `Err`                                            |
+| Extract with fallback             | `unwrapOr(r, default)` / `unwrapOrElse(r, fn)`                             | Never use to paper over failures the caller should see                                            |
+| Chain fallible steps              | `andThen` (alias `flatMap`), or `pipeline(input).then(fn).then(fn).result` | Both short-circuit on first `Err`                                                                 |
+| Transform value / error           | `map` / `mapErr` / `mapBoth`                                               |                                                                                                   |
+| Combine many                      | `collect(results)` (alias `all`), `zip(a, b)`                              | `collect` short-circuits on first `Err`; `zip` is re-exported from `src/index.ts` as `zipResults` |
+| Side-effect without consuming     | `tap` / `tapErr`                                                           | `tapErr` is the idiomatic "log and pass through"                                                  |
+| Wrap throwing code                | `tryCatch(fn, mapError)` / `tryCatchAsync`                                 | Use at boundaries with throwing third-party code                                                  |
+| Void success                      | `OK` constant (`Ok<Unit>`)                                                 | For operations with nothing to return                                                             |
+| Nullable → Result                 | `fromNullable(value, errorFn)`                                             |                                                                                                   |
+
+The `unwrap()` policy (CLAUDE.md, `docs/getting-started.md`): sanctioned in **tests** (the standard extractor), **scripts/examples**, and internal calls that are **infallible by construction** — e.g. `unwrap(resolvePlane('XY', origin))` in `src/core/planeOps.ts:150`, where the input is a known-valid literal. Never use it on a user-facing fallible path in production code; use `isOk()`/`match()` there.
+
+Note the kernel-free subpath `brepjs/core` (`src/core.ts`) exports only a subset of combinators — no `pipeline`, `mapBoth`, `tap`/`tapErr`, `fromNullable`, `or`/`orElse`, `zip`. The full set is on the main `brepjs` entry.
+
+For Results inside disposal scopes, `withScopeResult` / `withScopeResultAsync` in `src/core/disposal.ts` combine `DisposalScope` cleanup with a Result-returning body (documented in `src/core/README.md`).
+
+## The throwing boundary: `shape()` and `BrepWrapperError`
+
+The fluent `shape()` wrapper (`src/topology/wrapperFns.ts`) auto-unwraps every `Result` and throws `BrepWrapperError` on `Err`. The class carries `code`, `kind`, `suggestion?`, `metadata?`, and its message includes the suggestion when present. Gotcha: `error.name` is set to `'BrepError'` even though the class is `BrepWrapperError` — match with `instanceof BrepWrapperError` (exported from `src/index.ts`), not by name. The catch pattern is shown in `docs/cheat-sheet.md`.
+
+Escape hatches on the wrapper: `.applyResult(fn)` unwraps a user-supplied Result-returning function; `.done()` / `.val` exit back to plain handles. `docs/which-api.md` frames the fluent-vs-functional trade-off around exactly this Result-handling difference.
+
+## Silent failures: symptom → cause → fix
+
+| Symptom                                                         | Likely cause                                                                                              | Fix                                                                                                                     |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Operation "succeeds" but geometry is missing/wrong downstream   | An `Err` was discarded (result assigned, never checked)                                                   | Check every `Result`; use `tapErr` to log, `match` to handle, or propagate with early `return` on `isErr`               |
+| Failure invisible until far away                                | `unwrapOr(r, fallback)` masking a real error                                                              | Reserve `unwrapOr` for genuinely optional values; otherwise propagate the `Err`                                         |
+| `Called unwrap() on an Err: [KERNEL_OPERATION] ...`             | `unwrap()` on a fallible path                                                                             | Read the formatted `[kind] CODE: message`; handle with `isOk`/`match` at that call site                                 |
+| Error message is cryptic OCCT text with no context              | Hand-rolled try/catch instead of `kernelCall`, or `cause` dropped                                         | Route kernel calls through `kernelCall`/`kernelCallRaw`/`kernelCallScoped`; always pass the caught exception as `cause` |
+| Plain `Error` thrown from a `*Fns.ts` function                  | Layer 2+ rule violated                                                                                    | Convert to `err(<kind>Error(code, message, cause))`; reserve throws for `bug()`                                         |
+| Typo'd error code compiles and ships                            | `code` is typed `string`                                                                                  | Use `BrepErrorCode.X`; add the constant if it does not exist                                                            |
+| Async code fails against the wrong kernel with confusing errors | `withKernel(id, fn)` is sync-only — after the first `await` the callback silently uses the default kernel | Use `getKernel(id)` directly in async code (CLAUDE.md gotcha)                                                           |
+| Bad geometry with an `Ok` result                                | Not an error-channel problem — the kernel produced a valid-but-wrong shape                                | See the debugging-geometry skill                                                                                        |
+
+## Additional resources
+
+- `src/core/result.ts` — the full Result API; short and readable, treat it as the reference.
+- `src/core/errors.ts` — kinds, catalog, constructors, `safeIndex`; ground truth for codes.
+- `src/core/kernelCall.ts` and `src/core/kernelErrorTranslation.ts` — the standard construction path and translation/suggestion tables.
+- `docs/errors.md` — user-facing per-code reference with recovery advice. **Partially stale**: its kind list omits `UNSUPPORTED`, and its code tables drift from `errors.ts` in both directions. When they disagree, `src/core/errors.ts` wins.
+- The `adding-operations` skill — the full recipe for a new `*Fns.ts` operation (validate → `err(validationError(...))` → `kernelCall` → `ok`).
+- The `writing-tests` skill — asserting on `Err` results and using `unwrap` in tests.

--- a/.claude/skills/shaperef-lineage/SKILL.md
+++ b/.claude/skills/shaperef-lineage/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: shaperef-lineage
+description: This skill should be used when debugging or extending stable references (topological naming) and history replay in brepjs — when a task says "ShapeRef resolves to the wrong face/edge", "ref won't resolve / returns not-found / BrokenRef", "resolveRef returns ambiguous", "add a new reference kind / ref type", "fillet face has no stable hash", "generated evolution is empty on occt-wasm", "selection lost after editing an upstream parameter", "history replay re-targets the wrong entity", "role table / assignRoles / updateRoles", "lineage ref", "topological naming", "resolveRefParams", "edit-after-reference", or when editing files under src/topology/shapeRef/ or src/operations/historyFns.ts.
+---
+
+# Stable references (topological naming) and history replay
+
+Stable references name a face, edge, or vertex by its stable adjacent-neighbour roles instead of a kernel hash, so a selection survives the edits that re-hash the model. The full concept — name-by-neighbours, the four ref kinds, `exact` vs `geometric-fallback` confidence, the failure taxonomy, and per-kernel support — is owned by `apps/docs/concepts/stable-references.md`. Read that page first for the "why"; this skill owns only extension (adding a ref kind) and debugging (a ref that resolves wrong, to nothing, or to the wrong entity after a replay).
+
+The public surface is the `brepjs/shapeRef` subpath (`package.json` `exports`), re-exported from `src/shapeRef.ts`, `src/topology/shapeRef/index.ts`, and `src/index.ts`. Implementation lives under `src/topology/shapeRef/`.
+
+## Mental model in six lines
+
+- The **role table** (`RoleTable = ReadonlyMap<origin, ReadonlyMap<role, readonly number[]>>` in `shapeRefTypes.ts`) is the spine: `origin → role → face hash codes`.
+- `assignRoles(shape, origin)` names faces; `updateRoles(roles, origin, evolution)` advances those hashes through one operation's `ShapeEvolution`.
+- **Face refs** ride hashes through evolution — they can resolve `exact`.
+- **Edge / vertex / derived refs** ride their _neighbouring face roles_, never their own hash — so they sidestep generated hashes entirely.
+- `exact` = resolved via a tracked hash in the role table; `geometric-fallback` = resolved via the captured geometric hint (normal, centroid, area).
+- **Derived (fillet/chamfer) faces are always geometric** — confidence is hardcoded `geometric-fallback`, they can never be `exact`.
+
+## The occt-wasm generated / fillet gotcha (read this first)
+
+This is the single most important fact in the area, and the cause of most "why won't my fillet face resolve" confusion.
+
+On the OCCT kernels, `evolution.generated` hashes are **never live** — they refer to an intermediate shape, not the final result — and **fillet/chamfer evolution is empty**. Consequences, all deliberate:
+
+- `updateRoles` **intentionally does not consume `evolution.generated`** (see the comment at the `updateRoles` docblock in `shapeRefFns.ts`: "verified: 0 live generated hashes across cut/fuse on occt-wasm"). Naming a generated face via the role table produces a role that never resolves.
+- Derived faces are re-found **geometrically**, never by hash — see the file header of `derivedFaceRefFns.ts`.
+- `ResolvedDerivedFaceRef.confidence` is hardcoded `'geometric-fallback'` in `shapeRefTypes.ts`.
+- Derived-face replay tests are gated to **occt-wasm only** (not the whole OCCT family) — on OpenCascade.js filleting one edge splits the +Z face into a divergent topology (`tests/shapeRefDerivedReplay.test.ts` header comment).
+
+How the geometric workaround actually resolves a derived face (`resolveDerivedFaceRef` in `derivedFaceRefFns.ts`):
+
+1. Re-derive each of the two bridged faces via the role table, else via `facesByNormal` (faces whose normal dotted with the captured normal exceeds `NORMAL_MATCH = 0.99`).
+2. `betweenFaces` = faces adjacent to **both** bridged faces (via cached edge→face adjacency).
+3. Keep only faces whose normal has a positive component (`> BLEND_THRESHOLD = 0.1`) along **both** bridged normals — this rejects the orthogonal flanking faces that are also adjacent to both.
+4. One survivor → resolved; several → nearest to the captured `edgeMidpoint` (`HINT_MARGIN = 1e-6` tie → ambiguous); none → broken.
+
+## Symptom → cause → fix
+
+| Symptom                                                                                   | Likely cause                                                                                                           | Fix                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Edge/vertex ref returns `not-found`                                                       | Role table stale — `facesForRole` returned `[]` because the tracked hash no longer matches any live face               | `updateRoles` was skipped across an intervening edit; propagate the role table through **every** operation's `ShapeEvolution`. Confirm `ref.origin` matches the string passed to `assignRoles`. This is the #1 cause. |
+| Face ref resolves to the **wrong** face on geometric fallback                             | A scorer reject or a weak hint                                                                                         | Check `defaultScorer` rejects (below); the true face may be scoring `-Infinity`. Supply a custom `FaceScorer` if the geometry is unusual.                                                                             |
+| `resolveRef` returns `ambiguous`                                                          | Two candidates tie within a margin, or a duplicated/symmetric feature                                                  | Inspect `broken.candidates`. Thresholds: `AMBIGUITY_THRESHOLD = 0.1` (face scoring), `HINT_MARGIN = 1e-6` (edge/vertex/derived hint tiebreak).                                                                        |
+| Face ref returns `deleted`; edge/vertex returns `not-found` for the same vanished feature | Different taxonomies by kind (below)                                                                                   | `deleted` is expected-skip for a replay engine; edge/vertex/derived can never report `deleted` (they don't track their own hash) so a vanished entity surfaces as `not-found`.                                        |
+| Non-primitive origin loses stability on rebuild                                           | Only `box`/`cylinder`/`cone`/`sphere` get **semantic** roles; everything else falls back to positional `opType:face_N` | Positional names are stable only if `getFaces` iteration order is stable across the rebuild. Prefer a primitive origin, or maintain a role table across edits instead of relying on `resolveRefIn`.                   |
+| Fillet/chamfer face never resolves via the role table                                     | The generated-hash reality above                                                                                       | Use a `DerivedFaceRef` (geometric), not a face ref. It's inherently `geometric-fallback`.                                                                                                                             |
+| Replay re-targets the wrong entity                                                        | The step has multiple inputs, or a ref points at a non-3D input                                                        | `resolveStepParams` only auto-resolves **single-input 3D** steps; multi-input refs stay raw. See history section below.                                                                                               |
+
+### `defaultScorer` reject thresholds (`scoring.ts`)
+
+A debugger hitting a wrong/absent match usually tripped one of these hard rejects:
+
+- Surface-type set but mismatched → `-Infinity` (hard reject).
+- Normal set and `dot < 0.707` → `-Infinity`.
+- Centroid set and `distSq > 100` (more than 10 units away) → `-Infinity`; otherwise penalty `-distSq/100`.
+- Area penalty only when `|log(hintArea / faceArea)| > 1.0`.
+- After scoring, `resolveRef` rejects anything below `MIN_SCORE = 0.5` → `not-found`.
+
+### Reproduce the role-table path minimally
+
+Mirror `tests/shapeRefEditReplay.test.ts` — build the table, advance it, resolve:
+
+```ts
+const roles = new Map([['box', assignRoles(box, 'box')]]);
+const ref = createRef('box', 'box:top', topFace);
+const { evolution, shape: next } = unwrap(fuseWithEvolution(box, other)); // *WithEvolution → Result
+const advanced = updateRoles(roles, 'box', evolution);
+const resolved = resolveRef(ref, advanced, next); // 'face' in resolved ? exact/fallback : broken
+```
+
+`*WithEvolution` wrappers (`fuseWithEvolution`, `filletWithEvolution`, …) are the layer-2 source of the `ShapeEvolution` fed to `updateRoles` (`src/topology/evolutionFns.ts`, exported from `src/index.ts`). Each returns a `Result` that must be unwrapped or checked before use — mirror `tests/shapeRefEditReplay.test.ts`, which does `const { shape, evolution } = unwrap(fuseResult);`.
+
+## Failure taxonomy by ref kind
+
+- **Face ref** `BrokenRef.reason`: `'deleted' | 'ambiguous' | 'not-found'`. `deleted` means the role table had the role but its tracked successor was removed.
+- **Edge / vertex / derived**: `reason` is only `'ambiguous' | 'not-found'` — **never `deleted`**. They track adjacent face roles, not their own hash, so a vanished entity is `not-found`. This is stated in the type docblocks in `shapeRefTypes.ts`.
+- All broken results carry `candidates?` — the tied entities to inspect.
+
+## Adding a new reference kind
+
+The four existing kinds (face, edge, vertex, derived) share one contract. To add a fifth, work through this checklist against the real files. Follow the export-surface mechanics in the `adding-operations` sibling skill — a new `create*/resolve*` pair must flow through the same six export surfaces plus the `brepjs/shapeRef` subpath.
+
+1. **Types** — in `shapeRefTypes.ts` add `XRef`, its `XHint`, `ResolvedXRef` (with a `confidence`), and `BrokenXRef`. Decide the failure taxonomy up front: it can report `deleted` **only if it tracks its own face hash**; if it names itself by neighbour roles (the recommended pattern), its reason is `'ambiguous' | 'not-found'` like edge/vertex.
+2. **Functions** — new `xRefFns.ts` with `createXRef` (capture the hint on the pre-edit shape) and `resolveXRef`. Follow the established pattern: resolve neighbour roles via `roleLookup.ts` helpers (`facesForRole`, `roleOfFace`), disambiguate with the hint, apply an ambiguity margin. Return early `not-found` when `facesForRole` yields `[]`.
+3. **Dispatch** — in `refResolveFns.ts` add an `isXRef` structural guard and a branch in `resolveLineageRef`, and extend the `LineageRef` union (and `ResolvedEntity` if it resolves to a new entity type). **Guard ordering is load-bearing**: guards discriminate structurally, most-specific first. Current order is derived (`betweenRoles` + `op`) → edge (`faceRoles.length === 2`) → vertex (`faceRoles.length >= 3`) → face (`role` is a string). Place a new guard so it can't be shadowed by a looser one.
+4. **Barrels** — export from `src/topology/shapeRef/index.ts`, `src/shapeRef.ts`, and `src/index.ts`. Once it's in the `LineageRef` union and the guards, it auto-flows through `resolveRefParams` and history replay for free.
+5. **Recursion caveat** — `resolveRefParams` descends via `isPlainOptions`, which skips arrays it already handled, non-plain-prototype objects, and anything with a `wrapped` key. Keep the new ref a **plain serializable object** (like the others); a class instance would be silently skipped by the walker.
+6. **Test** — add `tests/shapeRefXReplay.test.ts` gated to occt-wasm. Use the divergence-skip mechanics owned by the `writing-tests` sibling skill (`currentKernelId`, `shouldSkipSuite`, `describe.skipIf`).
+
+## How history replay resolves refs
+
+Replay lets a stored selection survive an upstream parameter edit. The engine is `src/operations/historyFns.ts` (`ModelHistory` / `OperationStep` are pure data; `OperationRegistry` maps op name → `OperationFn`).
+
+- `resolveStepParams(params, inputs)` resolves refs **only for single-input, 3D steps** — it calls `resolveRefParams` against the sole input. Multi-input, ref-free, or non-3D steps are left raw: with several inputs the target input is ambiguous, and resolving against the wrong input would silently return a wrong-shape entity.
+- Called from both `replayHistory` and `replayFrom` before invoking the `OperationFn`.
+- The **stored step keeps its raw refs**; resolution happens fresh at each replay. A `ShapeRef` is plain JSON, so it survives `serializeHistory`/`deserializeHistory`.
+- `modifyStep(stepId, newParams)` is the parametric-edit loop: it updates the params then `replayFrom`s that step.
+- `tests/historyRefReplay.test.ts` is the canonical worked example (re-targets an edge after a box-height edit; multi-input leaves the ref raw).
+
+Replay errors are `Result.Err` with codes `REPLAY_UNKNOWN_OP` / `REPLAY_MISSING_INPUT` / `REPLAY_STEP_FAILED` / `REPLAY_STEP_NOT_FOUND` / `MODIFY_STEP_NOT_FOUND`.
+
+## Where evolution comes from
+
+`ShapeEvolution = { modified, generated, deleted }` (`src/kernel/types.ts`) is built in `src/kernel/occt/evolutionOps.ts` and produced by the `*WithHistory` kernel methods in `src/kernel/occt/historyOps.ts` (wired via `makeHistoryOps`). Fillet/chamfer go through `BRepFilletAPI_MakeFillet`/`MakeChamfer`; the plumbing populates `generated`, but on occt-wasm those `Generated()` results don't map to final-shape faces — the empty/never-live reality above. For anything kernel-side (adding a `*WithHistory` method, adapter capability differences), defer to the `kernel-abstraction` sibling skill; for the embind enum/hash-code details underlying `evolutionOps.ts`, defer to `wasm-interop`.
+
+## Worked examples in the test suite
+
+`tests/shapeRefEditReplay.test.ts` (modified-face tracking + split-fragment disambiguation), `tests/shapeRefDerivedReplay.test.ts` (fillet/chamfer normal-blend, occt-wasm-gated), `tests/shapeRefEdgeReplay.test.ts`, `tests/shapeRefVertexReplay.test.ts`, `tests/historyRefReplay.test.ts`, and the unit/integration pair `tests/shapeRef.test.ts` + `tests/shapeRefIntegration.test.ts`.
+
+## Sibling skills
+
+- `adding-operations` — the six export surfaces + `function-lookup.md` gate a new `create*/resolve*` pair must pass through.
+- `kernel-abstraction` — kernel-side evolution, `*WithHistory` methods, adapters, capability differences.
+- `wasm-interop` — embind enum `.value`, `Uint32Array` conversion, and hash-code details underlying `evolutionOps.ts`.
+- `writing-tests` — the kernel-divergence skip pattern for gating a new ref-kind test to occt-wasm.

--- a/.claude/skills/wasm-interop/SKILL.md
+++ b/.claude/skills/wasm-interop/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: wasm-interop
+description: This skill should be used when working across the JS/WASM boundary in brepjs — writing or debugging code in src/kernel/occt, src/kernel/occtWasm, or src/kernel/brepkit, or diagnosing symptoms like "enum comparison is always false", "GetType returned an object not a number", "mesh vertices are garbage or zeros", "detached ArrayBuffer", ".map on a Uint32Array produces wrong values", "brepjs kernel not initialized", "brepjs_single.js is missing", "init() falls back to the wrong kernel", "dynamic import of occt-wasm breaks the Vite build", "SetRunParallel has no effect", or deciding whether a kernel bug needs a Docker WASM rebuild. This skill owns the raw JS↔WASM mechanics (Emscripten enums, heap/typed-array reads, threading); adapter, registry, and capability *design* belong to the kernel-abstraction skill.
+---
+
+# WASM and OCCT interop gotchas
+
+Cover the mechanics of the JS↔WASM boundary in the kernel adapters: how Emscripten enums cross, how to read the WASM heap without corrupting it, how initialization and the bundler-safe fallback chain work, and why every shipped build is single-threaded. Adapter/registry/capability _design_ lives in the `kernel-abstraction` skill — this skill stays on the raw Emscripten mechanics.
+
+## When to use
+
+- Editing or debugging any file under `src/kernel/occt/` (brepjs-opencascade facade), `src/kernel/occtWasm/` (occt-wasm, the default kernel), or `src/kernel/brepkit/`.
+- A value works in one kernel but is garbage in another, or an enum comparison is silently always false.
+- Mesh/curve extraction returns zeros, wrong numbers, or a detached-buffer error.
+- Init fails, falls back to the wrong kernel, or a dynamic import breaks a consumer's build.
+
+## Enums across the boundary
+
+OCCT is bound with embind, which surfaces C++ enums as **objects**, not numbers.
+
+**Values coming OUT** — never compare a raw enum result to an integer. Extract with the canonical idiom (`src/kernel/occt/geometryQueryOps.ts:283-284`):
+
+```ts
+const typeVal = adaptor.GetType();
+// OCCT Emscripten returns enum objects with a .value property
+const idx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
+```
+
+Then map the number through a `Record<number, string>` (`geometryQueryOps.ts:286-297`). The same pattern recurs in `nurbsQueryOps.ts` and `manifold/repairOps.ts:24`.
+
+**Values going IN** — pass the enum **object** straight from the `oc` instance, not an integer. Constructors and comparisons both accept the object form (`src/kernel/occt/topologyOps.ts:58-71`):
+
+```ts
+const ta = oc.TopAbs_ShapeEnum;
+new oc.TopExp_Explorer_2(shape, ta.TopAbs_FACE, oc.TopAbs_ShapeEnum.TopAbs_SHAPE);
+```
+
+**Identity comparison against the object works** and is preferred over `.value` on the IN side (`geometryQueryOps.ts:305-312`):
+
+```ts
+const orient = shape.Orientation_1();
+if (orient === oc.TopAbs_Orientation.TopAbs_FORWARD) return 'forward';
+```
+
+Enum-object maps are cached per `oc` instance in a `WeakMap` (`topologyOps.ts:55-70`) — build once, reuse; do not rebuild them per call.
+
+**Overloaded constructors get numeric suffixes.** Embind renames overloads `_1`, `_2`, … — `TopExp_Explorer_2`, `BRepAdaptor_Curve_2`, `Orientation_1`. A "not a constructor" or wrong-arity error usually means the wrong suffix; grep a working call site (`geometryQueryOps.ts:263-266,306`) for the right one.
+
+| Symptom                        | Cause                        | Fix                                                       |
+| ------------------------------ | ---------------------------- | --------------------------------------------------------- |
+| Enum comparison always false   | Compared object to an int    | Extract `.value`, or compare against `oc.<Enum>.<MEMBER>` |
+| `GetType()` returns `[object]` | Embind enum object           | Use the `.value` extraction idiom                         |
+| `X_2 is not a constructor`     | Wrong embind overload suffix | Match the `_N` at a known-good call site                  |
+
+## Typed arrays and the heap
+
+**Read heap pointers, slice before the next WASM call.** The brepjs-opencascade facade returns raw pointers + sizes; copy into an owned TypedArray _before any other WASM call could grow or relocate the heap_ — the build sets `ALLOW_MEMORY_GROWTH=1`, so a stale heap view becomes a detached/garbage buffer (`src/kernel/occt/meshOps.ts:59-60`). Divide byte pointers by 4 for the 32-bit heap index, slice, then free the C++ side with `raw.delete()` (`meshOps.ts:26-29,67,87-88`):
+
+```ts
+const offset = ptr / 4; // byte ptr → HEAPF32 index
+return heap.slice(offset, offset + size); // copy now, before any other WASM call
+```
+
+The occt-wasm adapter reads element-by-element with a `?? 0` fallback because `noUncheckedIndexedAccess` is on (`src/kernel/occtWasm/meshOps.ts:34,40,55`); it uses `>> 2` for the same byte→index divide. For a structurally-guaranteed index (WASM ABI fixed arrays, post-bounds-check loops) use the sanctioned escape hatch `wasmIndex<T>(arr, i)` in `src/utils/vec3.ts:25-27` instead of a bare `!`.
+
+**Convert `Uint32Array` to `number[]` only for JS array methods.** `.map`/`.filter`/`.flatMap` on a `Uint32Array` coerce results back to u32 (and cannot produce objects), so convert first with `toArray(ids)` = `Array.from(ids)` (`src/kernel/brepkit/helpers.ts:105-108`). This is _not_ a rule about passing arrays into the kernel — brepkit methods accept `Uint32Array | number[]`, and `booleanOps.ts` passes `new Uint32Array(...)` straight into `bk.compoundFuse(...)`. (CLAUDE.md's blanket "always convert before passing to kernel methods" overstates it; the real reason is the map/filter coercion.)
+
+**No zero-copy between separate WASM linear memories** — each kernel instance owns its own heap, so copy bytes across with `copyWasmBytes(bytes)` (`helpers.ts:169-172`) or re-serialize via a BREP string. See `docs/decisions/0013-voxel-domain.md:105-110`.
+
+| Symptom                                            | Cause                                    | Fix                                         |
+| -------------------------------------------------- | ---------------------------------------- | ------------------------------------------- |
+| Mesh vertices are garbage / zeros after a later op | Heap view read after a WASM call grew it | Slice into an owned array _immediately_     |
+| Detached ArrayBuffer error                         | Held a HEAP view across an allocation    | Copy first; never store a raw heap subarray |
+| `.map` on IDs yields wrong values                  | u32 coercion of typed-array map          | `Array.from(ids)` / `toArray` first         |
+| Off-by-4 / nonsense offsets                        | Used byte pointer as element index       | Divide by 4 (`ptr / 4` or `>> 2`)           |
+
+Handle `.delete()` on occt-wasm and brepkit handles is a **no-op** — those adapters use an arena/id model, not per-handle embind objects (`occtWasm/occtWasmTypes.ts:22-33`, `brepkit/helpers.ts:26-61`). Free with the adapter's `dispose`/`release`, not by chasing `.delete()`. Disposal semantics belong to the `memory-and-disposal` skill.
+
+## Initialization
+
+`init()` (`src/kernel/index.ts:261-304`) is idempotent (returns the current kernel id immediately) and tries, in order: **occt-wasm** → **brepjs-opencascade** (`initFromOC`, returns `'occt'`) → **brepkit-wasm**, throwing with install instructions if none load. `brepjs/quick` (`src/quick.ts`) does the same as a top-level `await` but with the brepjs-opencascade fallback only (no brepkit). All three kernel packages are optional peerDependencies (`package.json`).
+
+**Every optional backend loads through `importOptionalBackend(specifier)`** (`src/kernel/optionalBackend.ts`). The specifier is a **variable** so no bundler (esbuild, Rollup, Vite import-analysis) can statically resolve it — an uninstalled peer stays a runtime import instead of hard-failing the build. A string literal with only a `@vite-ignore` comment regressed when Vite reflowed the comment (#1726). When adding a new optional backend, route it through this function; never write a literal `import('occt-wasm')`.
+
+`initFromOC(oc)` (`index.ts:199-211`) resets seven feature-detection caches (measure, transform, boolean/loft/extrude/shell/fillet batch), registers `DefaultAdapter` as `'occt'`, and forces it default. Call it when hand-wiring the brepjs-opencascade instance; skipping the cache reset leaves stale capability flags.
+
+`prewarm()` (`index.ts:227-237`) builds and disposes a 1×1×1 box to pay OCCT's ~400-900 ms first-call JIT cost off the critical path. Fire-and-forget after `init()` resolves.
+
+`getKernel()` throws `brepjs kernel not initialized. Call initFromOC() or registerKernel()` when nothing is registered — that message means init was skipped, not that WASM is broken.
+
+**Missing WASM artifacts.** `packages/brepjs-opencascade/src/*.js` and `*.wasm` are **gitignored** (`.gitignore:31-36`); only `.d.ts` files are tracked. A `brepjs_single.js is missing` error means restore them from the published tarball with `bash scripts/ensure-wasm.sh` (version-stamped via `src/.wasm-version`; CI runs it) — **not** a Docker build.
+
+**Tests.** `tests/setup.ts` re-exports `initOC` (alias of `initOCCT`) from `tests/setup-kernel.ts`; `TEST_KERNEL` selects `occt` | `brepkit` | `occt-wasm` | `manifold`, defaulting to `occt-wasm`. Under vitest, `brepkit-wasm` is aliased to its Node CJS entry because the ESM entry uses the unsupported WASM-ESM-integration proposal (`vitest.config.ts:50-53`). See the `writing-tests` skill for the multi-kernel test setup.
+
+## Threading reality
+
+**Every shipped kernel build is single-threaded.** The brepjs-opencascade build compiles without `-pthread` (`packages/brepjs-opencascade/build-config/brepjs.yml`), and occt-wasm's README states "Single WASM thread — each kernel instance is single-threaded." Consequences:
+
+- `op.SetRunParallel(true)` (`src/kernel/occt/booleanOps.ts:44-59`) and the facade's `SetRunParallel(Standard_True)` degrade to sequential in a threadless build — effectively no-ops. Do not expect a speedup from them; the meshing path passes `isInParallel = Standard_False` deliberately.
+- Off-main-thread work uses **message passing, not shared handles**: brepjs's own `src/worker/` exchanges **BREP strings** across the boundary (`workerHandler.ts` calls `initFn(msg.wasmUrl)` on init), and occt-wasm ships an `occt-wasm/worker` export (`OcctWorker.spawn`, Comlink) whose handles are **worker-local**. A handle from one instance is meaningless in another.
+
+Vitest test-runner config (pool, workers, memory cap, timeout) is owned by the `writing-tests` skill; the WASM-specific reason those knobs stay conservative is that OCCT WASM linear memory grows monotonically across a fork's files, so over-committing workers trips timeouts (#1102).
+
+## Kernel-issue debugging discipline
+
+Reproduce a suspected kernel bug **in JS/TS against the installed WASM first**. A Docker rebuild of the OpenCascade WASM (`ghcr.io/andymai/opencascade.js:v8`, via the brepjs-opencascade `buildWasm`/`buildSingle` scripts, then `wasm-opt`) takes on the order of hours — treat it as the last resort. Complete _all_ C++ facade edits before starting a build. The C++ binding surface (facade classes like `MeshExtractor`, `BooleanBatch`, `BooleanPipeline`, `EvolutionExtractor`, `TopoDS_Cast`, manual `Bnd_Box` bindings) and the emcc flags live in `build-config/brepjs.yml`; see `references/opencascade-build.md` for the inventory and flag list. Note `docs/compatibility.md` still says "WASM SIMD ❌ Not used" — that line is **stale**; the build passes `-msimd128 -mrelaxed-simd`. Trust the yml.
+
+## Additional resources
+
+- `references/opencascade-build.md` — brepjs.yml C++ facade-class inventory + emcc flags.
+- `docs/kernel-swap.md` — full init/registration guide for all three kernels.
+- `docs/compatibility.md` — bundler externalization, WASM variants/sizes, threading (SIMD line is stale).
+- `docs/memory-management.md` — `using`/`Symbol.dispose`, `DisposalScope`, manual `delete()`.
+- `kernel-abstraction` skill — `KernelAdapter`, capabilities, `withKernel`/quality-tier semantics.
+- `memory-and-disposal` skill — handle lifecycle and disposal ordering.
+- `writing-tests` skill — vitest runner config and multi-kernel test setup.

--- a/.claude/skills/wasm-interop/SKILL.md
+++ b/.claude/skills/wasm-interop/SKILL.md
@@ -18,7 +18,7 @@ Cover the mechanics of the JS↔WASM boundary in the kernel adapters: how Emscri
 
 OCCT is bound with embind, which surfaces C++ enums as **objects**, not numbers.
 
-**Values coming OUT** — never compare a raw enum result to an integer. Extract with the canonical idiom (`src/kernel/occt/geometryQueryOps.ts:283-284`):
+**Values coming OUT** — never compare a raw enum result to an integer. Extract with the canonical idiom (`src/kernel/occt/geometryQueryOps.ts`):
 
 ```ts
 const typeVal = adaptor.GetType();
@@ -26,25 +26,25 @@ const typeVal = adaptor.GetType();
 const idx = typeof typeVal === 'number' ? typeVal : Number(typeVal?.value ?? typeVal);
 ```
 
-Then map the number through a `Record<number, string>` (`geometryQueryOps.ts:286-297`). The same pattern recurs in `nurbsQueryOps.ts` and `manifold/repairOps.ts:24`.
+Then map the number through a `Record<number, string>` (`geometryQueryOps.ts`). The same pattern recurs in `nurbsQueryOps.ts` and `manifold/repairOps.ts`.
 
-**Values going IN** — pass the enum **object** straight from the `oc` instance, not an integer. Constructors and comparisons both accept the object form (`src/kernel/occt/topologyOps.ts:58-71`):
+**Values going IN** — pass the enum **object** straight from the `oc` instance, not an integer. Constructors and comparisons both accept the object form (`src/kernel/occt/topologyOps.ts`):
 
 ```ts
 const ta = oc.TopAbs_ShapeEnum;
 new oc.TopExp_Explorer_2(shape, ta.TopAbs_FACE, oc.TopAbs_ShapeEnum.TopAbs_SHAPE);
 ```
 
-**Identity comparison against the object works** and is preferred over `.value` on the IN side (`geometryQueryOps.ts:305-312`):
+**Identity comparison against the object works** and is preferred over `.value` on the IN side (`geometryQueryOps.ts`):
 
 ```ts
 const orient = shape.Orientation_1();
 if (orient === oc.TopAbs_Orientation.TopAbs_FORWARD) return 'forward';
 ```
 
-Enum-object maps are cached per `oc` instance in a `WeakMap` (`topologyOps.ts:55-70`) — build once, reuse; do not rebuild them per call.
+Enum-object maps are cached per `oc` instance in a `WeakMap` (`topologyOps.ts`) — build once, reuse; do not rebuild them per call.
 
-**Overloaded constructors get numeric suffixes.** Embind renames overloads `_1`, `_2`, … — `TopExp_Explorer_2`, `BRepAdaptor_Curve_2`, `Orientation_1`. A "not a constructor" or wrong-arity error usually means the wrong suffix; grep a working call site (`geometryQueryOps.ts:263-266,306`) for the right one.
+**Overloaded constructors get numeric suffixes.** Embind renames overloads `_1`, `_2`, … — `TopExp_Explorer_2`, `BRepAdaptor_Curve_2`, `Orientation_1`. A "not a constructor" or wrong-arity error usually means the wrong suffix; grep a working call site (`geometryQueryOps.ts`) for the right one.
 
 | Symptom                        | Cause                        | Fix                                                       |
 | ------------------------------ | ---------------------------- | --------------------------------------------------------- |
@@ -54,18 +54,18 @@ Enum-object maps are cached per `oc` instance in a `WeakMap` (`topologyOps.ts:55
 
 ## Typed arrays and the heap
 
-**Read heap pointers, slice before the next WASM call.** The brepjs-opencascade facade returns raw pointers + sizes; copy into an owned TypedArray _before any other WASM call could grow or relocate the heap_ — the build sets `ALLOW_MEMORY_GROWTH=1`, so a stale heap view becomes a detached/garbage buffer (`src/kernel/occt/meshOps.ts:59-60`). Divide byte pointers by 4 for the 32-bit heap index, slice, then free the C++ side with `raw.delete()` (`meshOps.ts:26-29,67,87-88`):
+**Read heap pointers, slice before the next WASM call.** The brepjs-opencascade facade returns raw pointers + sizes; copy into an owned TypedArray _before any other WASM call could grow or relocate the heap_ — the build sets `ALLOW_MEMORY_GROWTH=1`, so a stale heap view becomes a detached/garbage buffer (`src/kernel/occt/meshOps.ts`). Divide byte pointers by 4 for the 32-bit heap index, slice, then free the C++ side with `raw.delete()` (`meshOps.ts`):
 
 ```ts
 const offset = ptr / 4; // byte ptr → HEAPF32 index
 return heap.slice(offset, offset + size); // copy now, before any other WASM call
 ```
 
-The occt-wasm adapter reads element-by-element with a `?? 0` fallback because `noUncheckedIndexedAccess` is on (`src/kernel/occtWasm/meshOps.ts:34,40,55`); it uses `>> 2` for the same byte→index divide. For a structurally-guaranteed index (WASM ABI fixed arrays, post-bounds-check loops) use the sanctioned escape hatch `wasmIndex<T>(arr, i)` in `src/utils/vec3.ts:25-27` instead of a bare `!`.
+The occt-wasm adapter reads element-by-element with a `?? 0` fallback because `noUncheckedIndexedAccess` is on (`src/kernel/occtWasm/meshOps.ts`); it uses `>> 2` for the same byte→index divide. For a structurally-guaranteed index (WASM ABI fixed arrays, post-bounds-check loops) use the sanctioned escape hatch `wasmIndex<T>(arr, i)` in `src/utils/vec3.ts` instead of a bare `!`.
 
-**Convert `Uint32Array` to `number[]` only for JS array methods.** `.map`/`.filter`/`.flatMap` on a `Uint32Array` coerce results back to u32 (and cannot produce objects), so convert first with `toArray(ids)` = `Array.from(ids)` (`src/kernel/brepkit/helpers.ts:105-108`). This is _not_ a rule about passing arrays into the kernel — brepkit methods accept `Uint32Array | number[]`, and `booleanOps.ts` passes `new Uint32Array(...)` straight into `bk.compoundFuse(...)`. (CLAUDE.md's blanket "always convert before passing to kernel methods" overstates it; the real reason is the map/filter coercion.)
+**Convert `Uint32Array` to `number[]` only for JS array methods.** `.map`/`.filter`/`.flatMap` on a `Uint32Array` coerce results back to u32 (and cannot produce objects), so convert first with `toArray(ids)` = `Array.from(ids)` (`src/kernel/brepkit/helpers.ts`). This is _not_ a rule about passing arrays into the kernel — brepkit methods accept `Uint32Array | number[]`, and `booleanOps.ts` passes `new Uint32Array(...)` straight into `bk.compoundFuse(...)`. (CLAUDE.md's blanket "always convert before passing to kernel methods" overstates it; the real reason is the map/filter coercion.)
 
-**No zero-copy between separate WASM linear memories** — each kernel instance owns its own heap, so copy bytes across with `copyWasmBytes(bytes)` (`helpers.ts:169-172`) or re-serialize via a BREP string. See `docs/decisions/0013-voxel-domain.md:105-110`.
+**No zero-copy between separate WASM linear memories** — each kernel instance owns its own heap, so copy bytes across with `copyWasmBytes(bytes)` (`helpers.ts`) or re-serialize via a BREP string. See `docs/decisions/0013-voxel-domain.md`.
 
 | Symptom                                            | Cause                                    | Fix                                         |
 | -------------------------------------------------- | ---------------------------------------- | ------------------------------------------- |
@@ -74,29 +74,29 @@ The occt-wasm adapter reads element-by-element with a `?? 0` fallback because `n
 | `.map` on IDs yields wrong values                  | u32 coercion of typed-array map          | `Array.from(ids)` / `toArray` first         |
 | Off-by-4 / nonsense offsets                        | Used byte pointer as element index       | Divide by 4 (`ptr / 4` or `>> 2`)           |
 
-Handle `.delete()` on occt-wasm and brepkit handles is a **no-op** — those adapters use an arena/id model, not per-handle embind objects (`occtWasm/occtWasmTypes.ts:22-33`, `brepkit/helpers.ts:26-61`). Free with the adapter's `dispose`/`release`, not by chasing `.delete()`. Disposal semantics belong to the `memory-and-disposal` skill.
+Handle `.delete()` on occt-wasm and brepkit handles is a **no-op** — those adapters use an arena/id model, not per-handle embind objects (`occtWasm/occtWasmTypes.ts`, `brepkit/helpers.ts`). Free with the adapter's `dispose`/`release`, not by chasing `.delete()`. Disposal semantics belong to the `memory-and-disposal` skill.
 
 ## Initialization
 
-`init()` (`src/kernel/index.ts:261-304`) is idempotent (returns the current kernel id immediately) and tries, in order: **occt-wasm** → **brepjs-opencascade** (`initFromOC`, returns `'occt'`) → **brepkit-wasm**, throwing with install instructions if none load. `brepjs/quick` (`src/quick.ts`) does the same as a top-level `await` but with the brepjs-opencascade fallback only (no brepkit). All three kernel packages are optional peerDependencies (`package.json`).
+`init()` (`src/kernel/index.ts`) is idempotent (returns the current kernel id immediately) and tries, in order: **occt-wasm** → **brepjs-opencascade** (`initFromOC`, returns `'occt'`) → **brepkit-wasm**, throwing with install instructions if none load. `brepjs/quick` (`src/quick.ts`) does the same as a top-level `await` but with the brepjs-opencascade fallback only (no brepkit). All three kernel packages are optional peerDependencies (`package.json`).
 
 **Every optional backend loads through `importOptionalBackend(specifier)`** (`src/kernel/optionalBackend.ts`). The specifier is a **variable** so no bundler (esbuild, Rollup, Vite import-analysis) can statically resolve it — an uninstalled peer stays a runtime import instead of hard-failing the build. A string literal with only a `@vite-ignore` comment regressed when Vite reflowed the comment (#1726). When adding a new optional backend, route it through this function; never write a literal `import('occt-wasm')`.
 
-`initFromOC(oc)` (`index.ts:199-211`) resets seven feature-detection caches (measure, transform, boolean/loft/extrude/shell/fillet batch), registers `DefaultAdapter` as `'occt'`, and forces it default. Call it when hand-wiring the brepjs-opencascade instance; skipping the cache reset leaves stale capability flags.
+`initFromOC(oc)` (`index.ts`) resets seven feature-detection caches (measure, transform, boolean/loft/extrude/shell/fillet batch), registers `DefaultAdapter` as `'occt'`, and forces it default. Call it when hand-wiring the brepjs-opencascade instance; skipping the cache reset leaves stale capability flags.
 
-`prewarm()` (`index.ts:227-237`) builds and disposes a 1×1×1 box to pay OCCT's ~400-900 ms first-call JIT cost off the critical path. Fire-and-forget after `init()` resolves.
+`prewarm()` (`index.ts`) builds and disposes a 1×1×1 box to pay OCCT's ~400-900 ms first-call JIT cost off the critical path. Fire-and-forget after `init()` resolves.
 
 `getKernel()` throws `brepjs kernel not initialized. Call initFromOC() or registerKernel()` when nothing is registered — that message means init was skipped, not that WASM is broken.
 
 **Missing WASM artifacts.** `packages/brepjs-opencascade/src/*.js` and `*.wasm` are **gitignored** (`.gitignore:31-36`); only `.d.ts` files are tracked. A `brepjs_single.js is missing` error means restore them from the published tarball with `bash scripts/ensure-wasm.sh` (version-stamped via `src/.wasm-version`; CI runs it) — **not** a Docker build.
 
-**Tests.** `tests/setup.ts` re-exports `initOC` (alias of `initOCCT`) from `tests/setup-kernel.ts`; `TEST_KERNEL` selects `occt` | `brepkit` | `occt-wasm` | `manifold`, defaulting to `occt-wasm`. Under vitest, `brepkit-wasm` is aliased to its Node CJS entry because the ESM entry uses the unsupported WASM-ESM-integration proposal (`vitest.config.ts:50-53`). See the `writing-tests` skill for the multi-kernel test setup.
+**Tests.** `tests/setup.ts` re-exports `initOC` (alias of `initOCCT`) from `tests/setup-kernel.ts`; `TEST_KERNEL` selects `occt` | `brepkit` | `occt-wasm` | `manifold`, defaulting to `occt-wasm`. Under vitest, `brepkit-wasm` is aliased to its Node CJS entry because the ESM entry uses the unsupported WASM-ESM-integration proposal (`vitest.config.ts`). See the `writing-tests` skill for the multi-kernel test setup.
 
 ## Threading reality
 
 **Every shipped kernel build is single-threaded.** The brepjs-opencascade build compiles without `-pthread` (`packages/brepjs-opencascade/build-config/brepjs.yml`), and occt-wasm's README states "Single WASM thread — each kernel instance is single-threaded." Consequences:
 
-- `op.SetRunParallel(true)` (`src/kernel/occt/booleanOps.ts:44-59`) and the facade's `SetRunParallel(Standard_True)` degrade to sequential in a threadless build — effectively no-ops. Do not expect a speedup from them; the meshing path passes `isInParallel = Standard_False` deliberately.
+- `op.SetRunParallel(true)` (`src/kernel/occt/booleanOps.ts`) and the facade's `SetRunParallel(Standard_True)` degrade to sequential in a threadless build — effectively no-ops. Do not expect a speedup from them; the meshing path passes `isInParallel = Standard_False` deliberately.
 - Off-main-thread work uses **message passing, not shared handles**: brepjs's own `src/worker/` exchanges **BREP strings** across the boundary (`workerHandler.ts` calls `initFn(msg.wasmUrl)` on init), and occt-wasm ships an `occt-wasm/worker` export (`OcctWorker.spawn`, Comlink) whose handles are **worker-local**. A handle from one instance is meaningless in another.
 
 Vitest test-runner config (pool, workers, memory cap, timeout) is owned by the `writing-tests` skill; the WASM-specific reason those knobs stay conservative is that OCCT WASM linear memory grows monotonically across a fork's files, so over-committing workers trips timeouts (#1102).

--- a/.claude/skills/wasm-interop/references/opencascade-build.md
+++ b/.claude/skills/wasm-interop/references/opencascade-build.md
@@ -1,0 +1,77 @@
+# brepjs-opencascade WASM build
+
+Deep reference for the `src/kernel/occt/` backend's native side: the C++ facade classes
+compiled into the WASM module, the emcc flags, and the Docker build flow. Read this only
+when editing `packages/brepjs-opencascade/build-config/brepjs.yml` or reasoning about why a
+facade returns what it does. The default kernel is occt-wasm (an external package); this
+reference is for the brepjs-opencascade fallback only.
+
+## Build flow
+
+- One-command build: `pnpm run buildWasm` (in `packages/brepjs-opencascade/`) =
+  `buildSingle` then `optimizeWasm`.
+- `buildSingle` runs the opencascade.js compiler in Docker
+  (`ghcr.io/andymai/opencascade.js:v8`) over `brepjs.yml`, producing `brepjs_single.*`.
+- `optimizeWasm` runs `wasm-opt -O4 --strip-debug --strip-producers --enable-exception-handling`.
+- **Only `brepjs_single` is built.** `brepjs.yml` declares a single `mainBuild: name:
+brepjs_single.js`; any `brepjs_threaded.*` / `brepjs_with_exceptions.*` files present
+  locally are legacy — package.json exports only `.` / `./single` / `./src/*` with
+  `main: src/brepjs_single.js`.
+- A Docker rebuild is on the order of hours. Land every C++ facade edit and run review
+  before starting. Reproduce suspected kernel bugs in JS/TS against the installed WASM
+  first — a rebuild is the last resort.
+
+## emcc flags (brepjs.yml `emccFlags`)
+
+```
+-flto                     link-time optimization
+-fwasm-exceptions         native WASM exceptions (not JS-based)
+-sEXPORT_ES6=1            ES module output
+-sALLOW_MEMORY_GROWTH=1   heap can grow — WHY heap views go stale after a WASM call
+-sEXPORTED_RUNTIME_METHODS=["FS","HEAP32","HEAPU32","HEAPF32","HEAPF64","HEAPU8"]
+-msimd128 -mrelaxed-simd  SIMD IS enabled (docs/compatibility.md's "SIMD not used" is stale)
+-mtail-call
+-sWASM_BIGINT
+-sEVAL_CTORS=2
+-O3
+-sINITIAL_MEMORY=134217728    128 MB
+-sMAXIMUM_MEMORY=4294967296   4 GB
+```
+
+No `-pthread` flag — the module is single-threaded, so `SetRunParallel(Standard_True)`
+inside the facade degrades to sequential.
+
+The exported heap views (`HEAPF32`, `HEAPU32`, `HEAP32`, …) are how the TS side reads
+facade-returned pointers. Combined with `ALLOW_MEMORY_GROWTH`, this is why
+`src/kernel/occt/meshOps.ts` must `.slice()` a heap view into an owned array _before any
+other WASM call_.
+
+## C++ facade classes (bulk extraction and batch ops)
+
+The facade lives in `brepjs.yml`'s `additionalBindCode` / `additionalCppCode`. Each class
+does a single bulk WASM call to avoid per-element boundary crossings, returns raw
+pointers + sizes, and frees on `.delete()`.
+
+| Facade class                                                | Purpose                                                                                                                                                                                                                                                                                | TS consumer                |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `MeshExtractor` / `MeshData`                                | Mesh a shape; vertices/normals/UVs/face groups in one call                                                                                                                                                                                                                             | `occt/meshOps.ts`          |
+| `EdgeMeshExtractor` / `EdgeMeshData`                        | Tessellate edges                                                                                                                                                                                                                                                                       | `occt/meshOps.ts`          |
+| `MeshBatchExtractor` / `MeshBatchData`                      | Mesh many shapes at once                                                                                                                                                                                                                                                               | `occt/meshOps.ts`          |
+| `BooleanBatch`                                              | Batched booleans (`SetRunParallel` set here)                                                                                                                                                                                                                                           | `occt/booleanOps.ts`       |
+| `BooleanPipeline`                                           | Chained boolean pipeline                                                                                                                                                                                                                                                               | `occt/booleanOps.ts`       |
+| `EvolutionExtractor` / `EvolutionData`                      | Fillet/chamfer generated/modified/deleted tracking                                                                                                                                                                                                                                     | lineage ops                |
+| `TopologyExtractor` / `TopologyResult`                      | Sub-shape enumeration                                                                                                                                                                                                                                                                  | `occt/topologyOps.ts`      |
+| `MeasurementExtractor` / `MeasurementData`                  | Volume/area/inertia in one call                                                                                                                                                                                                                                                        | measure ops                |
+| `TransformBatch`                                            | Batched transforms                                                                                                                                                                                                                                                                     | transform ops              |
+| `LoftBatch` / `ExtrudeBatch` / `ShellBatch` / `FilletBatch` | Batched op families (feature-detected — see `initFromOC` cache resets)                                                                                                                                                                                                                 | operations                 |
+| `TopoDS_Cast`                                               | Downcast a generic `TopoDS_Shape` to its concrete subtype                                                                                                                                                                                                                              | `occt/geometryQueryOps.ts` |
+| `Bnd_Box`                                                   | Manual bounding-box bindings                                                                                                                                                                                                                                                           | query ops                  |
+| `BRepToolsWrapper` / `GeomToolsWrapper`                     | BREP/Geom serialization helpers                                                                                                                                                                                                                                                        | io ops                     |
+| `StepStreamIO`                                              | In-memory STEP read/write                                                                                                                                                                                                                                                              | io ops                     |
+| `Curve2dBatchEval`                                          | 2D curve batch evaluation                                                                                                                                                                                                                                                              | 2d ops                     |
+| `SpatialIndex3D`                                            | 3D spatial queries                                                                                                                                                                                                                                                                     | query ops                  |
+| `HelixWireBuilder`                                          | Native helix wire construction — **not currently compiled** (`brepjs.yml` symbol commented out; `TKHelix` not in the opencascade.js filter, needs a Docker image update). `makeHelixWire` in `occt/extendedConstructorOps.ts` feature-detects it and falls back to manual construction | operations                 |
+
+When a feature-detected batch class (`LoftBatch`, `FilletBatch`, …) is added or removed,
+`initFromOC()` in `src/kernel/index.ts` resets the matching detection cache — keep the two
+in sync or capability flags go stale.

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: writing-tests
+description: This skill should be used when writing, running, or fixing tests in the brepjs repository — when a task says "add a test", "write a regression test", "tests are failing", "test timed out", "coverage threshold failed", "run tests against brepkit/manifold/occt", "skip this test on kernel X", or when a new operation needs test coverage before merge. Covers the test skeleton, geometry assertions, multi-kernel projects, divergence skips, and coverage gates.
+---
+
+# Writing and running tests
+
+## Test file skeleton
+
+Tests live in `/tests/`, named `<moduleName>.test.ts` (e.g. `tests/shapeFns.test.ts`); `api*.test.ts` for public-API surface tests. Extend an existing file for the module before creating a new one.
+
+Exact boilerplate (from `tests/booleanFns.test.ts`):
+
+```ts
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { box, fuse, isOk, unwrap, measureVolume } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+```
+
+Rules:
+
+- Import `initKernel` from `./setup.js` — **not** `initOC`. `initOC` is a backward-compat alias (`tests/setup.ts`) that force-boots the legacy OpenCascade.js kernel regardless of which vitest project is running. `initKernel()` (`tests/helpers/kernelInit.ts`) reads the `TEST_KERNEL` env var set by the vitest project, so the same test runs correctly under all four kernels. CLAUDE.md's "Writing a test" section still names `initOC`; prefer `initKernel`.
+- The `30000` is the `beforeAll` hook timeout (WASM boot can be slow on first run). It is NOT the per-test timeout — that is **90 s** (`testTimeout: 90000` in `vitest.config.ts`; CLAUDE.md's "30s timeout" claim is stale).
+- Import the public surface from `@/index.js`. Cross-directory imports use the `@/` alias (→ `src/`), always with `.js` extensions. Vitest globals are enabled, but files still import `describe`/`it`/`expect` explicitly.
+- Reach for internals (`@/core/shapeTypes.js`, helpers in `tests/helpers/`) only when the public API cannot express the assertion.
+
+## Assertions
+
+- **Result handling**: assert `expect(isOk(result)).toBe(true)` first, then `unwrap(result)` to get the value. Use `isErr()`/`unwrapErr()` for error-path tests. `unwrap` is fine in tests; production code in layers 2–3 uses `isOk()`/`match()` — see the result-error-handling skill.
+- **Floating point**: always `toBeCloseTo(expected, precision)`, never exact equality. Convention for unit-scale geometry: `toBeCloseTo(2000, 0)` (within 0.5 absolute). Round-trip serialization checks use precision 6 (`tests/parity/README.md`).
+- **Shape kinds**: `isSolid()`, `isFace()`, `isWire()`, `isCompound()`, `isShape3D()`, or `getShapeKind()`.
+- **Geometry validity**: assert real measurements — `unwrap(measureVolume(shape))`, `unwrap(measureArea(shape))` — not just "operation returned Ok".
+- **Cross-kernel numeric checks**: `expectClose(actual, expected, relTol?, absTol?)` and `expectKernelsAgree(valA, valB, label)` from `tests/helpers/kernelDivergences.ts` (default relTol `1e-4`).
+
+Worked example:
+
+```ts
+describe('fuse', () => {
+  it('fuses two boxes', () => {
+    const result = fuse(boxA, boxB);
+    expect(isOk(result)).toBe(true);
+    const shape = unwrap(result);
+    expect(isShape3D(shape)).toBe(true);
+    expect(unwrap(measureVolume(shape))).toBeCloseTo(2000, 0);
+  });
+});
+```
+
+## Running tests
+
+| Command                                             | What it runs                                                                    |
+| --------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `npm run test`                                      | occt-wasm project, changed files only, no coverage (the pre-commit tier-2 gate) |
+| `npm run test:full`                                 | occt-wasm project, full suite **with coverage thresholds enforced**             |
+| `npm run test:ci`                                   | occt-wasm project, full suite, no coverage (CI shards this 4-way)               |
+| `npm run test:watch`                                | occt-wasm project, watch mode                                                   |
+| `npm run test:occt` / `npm run test:brepkit`        | legacy OpenCascade.js / brepkit projects                                        |
+| `npx vitest run --project manifold tests/x.test.ts` | manifold project (no npm script exists)                                         |
+| `npm run test:stress`                               | `tests/io-stress.test.ts` only, via `vitest.stress.config.ts`                   |
+| `npm run test:docs`                                 | extracts doc snippets, runs generated `tests/docs/extracted.test.ts`            |
+
+**Single file — always pass `--project`**:
+
+```bash
+npx vitest run --project occt-wasm tests/booleanFns.test.ts
+```
+
+A bare `npx vitest run tests/x.test.ts` fans out to **all four kernel projects** (manifold, occt, brepkit, occt-wasm) and will fail on kernels the test was never gated for. This corrects the bare-run example in CLAUDE.md.
+
+Runner facts (`vitest.config.ts`): `pool: 'forks'` with `--max-old-space-size=6144`; `maxWorkers` defaults to 4 because OCCT WASM linear memory grows monotonically per fork and more forks swap-thrash — raise locally with `VITEST_MAX_WORKERS=<n>`. Pre-commit runs changed-file tests (or the full coverage run with `FULL_TESTS=1`); pre-push runs no tests. See the quality-gates skill for the full gate stack and ci-triage for CI behavior.
+
+## Multi-kernel testing
+
+Four vitest projects are generated from `tests/helpers/kernelRegistry.ts`: `occt`, `brepkit`, `occt-wasm` (**the default and the merge gate**), and `manifold`. Each project sets `TEST_KERNEL=<id>`; `initKernel()` and `currentKernel` (from `./setup.js`) read it.
+
+Decision table for a test that misbehaves on some kernel:
+
+| Situation                                              | Do this                                                                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Feature exists only on some kernels (capability gap)   | Check `getKernelCapabilities(id)` flags in `tests/helpers/kernelRegistry.ts`; gate with `it.skipIf(currentKernel !== 'occt-wasm')(...)` (see `tests/curves.test.ts`) |
+| Kernel produces a genuinely different-but-valid result | Add an entry to the divergence registry in `tests/helpers/kernelDivergences.ts`, then `it('...', (ctx) => { skipIfDiverges(ctx, 'module.case'); ... })`              |
+| A whole describe block diverges                        | `describe.skipIf(shouldSkipSuite('module.case'))(...)`                                                                                                               |
+| Test file cannot run at all on one kernel              | Add it to that kernel's `excludeTests` in `kernelRegistry.ts`                                                                                                        |
+
+Never inline `if (isBrepkit) ctx.skip()` — the registry is the single source of truth, and `docs/kernel-conformance.md` is generated from it (`npm run conformance:generate`). Registry entry format, divergence kinds, capability flags, and the excluded-suite inventory are in `references/multi-kernel.md`.
+
+Kernel-agnostic behavioral specs (closed-form reference values, fast-check invariants) live in `tests/parity/` — read `tests/parity/README.md` before adding one. Note its gate table predates the occt-wasm default; the required gate is now the occt-wasm project.
+
+## Coverage
+
+Root thresholds (`vitest.config.ts`): statements 85, branches 71, functions 91, lines 88. These are **measured floors** for the occt-wasm project, not aspirational targets — new code below the floor fails `npm run test:full` locally. Per-kernel: the `occt` project has its own thresholds; `brepkit`, `occt-wasm`, and `manifold` projects are `'informational'` (thresholds enforced at the root config level for the default kernel). Each kernel's coverage excludes the _other_ kernels' adapter dirs (`coverageExcludesFor()` in `kernelRegistry.ts`).
+
+CI nuance: coverage is **not a PR gate** — the `coverage` job runs only on push to main with `continue-on-error: true` (`.github/workflows/ci.yml`). The enforcement point that bites during development is local `npm run test:full` (also pre-commit with `FULL_TESTS=1`). If a function-coverage miss blocks a commit, add tests for the new code rather than lowering thresholds; only re-floor after re-measuring with `npm run test:full` (and say so in the PR).
+
+## Benchmarks / performance regressions
+
+Performance benches live in `benchmarks/*.bench.test.ts` (~20 files), separate from the correctness suite. They share `benchmarks/harness.ts` (the `bench()` timer + `printResults`/`writeResultsJSON`/`compareResults`) and `benchmarks/setup.ts` (`initBenchKernels()`, driven by the `BENCH_KERNELS` env var). They run under their own config, `vitest.bench.config.ts` (`include: ['benchmarks/**/*.bench.test.ts']`, `testTimeout: 120000`, forks pool) — the root `vitest.config.ts` excludes `benchmarks/` entirely.
+
+**Bench tests do not assert.** Each `it()` runs `bench()` and prints a markdown/JSON table; nothing fails on slowness. Read the numbers by eye against a baseline.
+
+Run commands:
+
+| Command                                                                               | What it runs                                                                                         |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `npm run bench`                                                                       | all bench files; `BENCH_KERNELS` defaults to `occt` (legacy OpenCascade.js), single-kernel for speed |
+| `npm run bench:compare`                                                               | `BENCH_KERNELS=both` — occt + brepkit + occt-wasm side by side                                       |
+| `npm run bench:json`                                                                  | `BENCH_KERNELS=both BENCH_OUTPUT_JSON=1` — emits the JSON block CI parses                            |
+| `npx vitest run benchmarks/gridPattern.bench.test.ts --config vitest.bench.config.ts` | one bench file                                                                                       |
+
+Baselines are committed **markdown reports** under `benchmarks/results/`, not JSON fixtures: `v8-baseline.md` is a frozen snapshot; `latest.md` is auto-generated by `kernel-comparison.bench.test.ts` (`generateReport` writes it, header says "Do not edit manually"). The regression-oriented bench files (`regression.bench.test.ts`, `regression-885.bench.test.ts`, `booleanBatch`, `gridPattern`, `optimization-targets`) each pin a set of named scenarios whose medians are the thing you compare across runs.
+
+Interpreting a regression: `compareResults(current, baseline, threshold = 0.1)` (in `harness.ts`) flags any benchmark whose median grew more than `threshold` (10% default) over the baseline. Match by the exact `name` string. Noise on shared machines runs ±9–15%, so treat a single sub-25% delta as noise and re-run before believing it.
+
+Add or update a baseline:
+
+- **New bench**: create `benchmarks/<name>.bench.test.ts`, import init from `./setup.js` and helpers from `./harness.js`, and follow an existing file (e.g. `gridPattern.bench.test.ts`).
+- **Refresh the kernel-comparison report**: run `npm run bench:compare`, which rewrites `benchmarks/results/latest.md`. Do not hand-edit it.
+- **Freeze a new reference point**: commit a new `<tag>-baseline.md` alongside `v8-baseline.md` rather than overwriting the old frozen snapshot.
+
+**CI blind spot.** Only `regression.bench.test.ts` runs in CI — the dedicated `benchmark` job (`.github/workflows/ci.yml`) runs it PR-only, compares PR-vs-main medians at a 25% threshold, posts a comparison comment, and `core.setFailed`s (it is in the `ci-pass` needs-list, so a >25% regression blocks merge). Every **other** bench file sits in `alwaysExclude` (`vitest.config.ts`) and never runs in CI, so their committed baseline reports rot silently — run the suite locally when touching a hot path. See the `ci-triage` skill's "Blind spots" section.
+
+## Symptom → cause → fix
+
+| Symptom                                                                  | Cause                                                                              | Fix                                                                                                                                          |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Test passes locally, fails in another kernel project in CI-adjacent runs | Ran bare `npx vitest run <file>` or test isn't kernel-portable                     | Pass `--project occt-wasm`; use `initKernel()` not `initOC`; gate via capabilities or the divergence registry                                |
+| Test hangs then fails at 90 s                                            | Per-test `testTimeout` (90000 ms), often memory pressure from too many forks       | Lower/raise `VITEST_MAX_WORKERS`; on CI this is why the test job is sharded (see ci-triage)                                                  |
+| `beforeAll` timeout at 30 s                                              | First WASM boot slow, or the hook timeout argument was omitted                     | Keep the `, 30000` third argument on `beforeAll`                                                                                             |
+| Flaky float comparison                                                   | Exact equality or too-tight precision                                              | `toBeCloseTo(expected, 0)` for unit-scale geometry; `expectClose` with relative tolerance for derived values                                 |
+| New test never runs in CI                                                | File matches `alwaysExclude` in `vitest.config.ts` or a kernel `excludeTests` list | Check both lists; excluded suites (`kernel-agreement`, `brepkit-validation`, …) run only by explicit path — see `references/multi-kernel.md` |
+| Coverage functions threshold fails on `test:full` but CI is green        | Coverage is main-only + non-blocking in CI; local run enforces                     | Add tests for uncovered functions before pushing                                                                                             |
+| fast-check parity test flakes with huge volume error                     | Raw `fc.double` offsets create sub-micron near-coincident solids                   | Use the quantized `fcOffset` generator (`tests/parity/README.md`, "Input generators")                                                        |
+| Import errors like "Cannot find module './foo'"                          | Missing `.js` extension on a `.ts` import                                          | All imports use `.js` extensions; `@/` for cross-directory                                                                                   |
+
+## Checklist before committing a test
+
+1. `initKernel()` in `beforeAll(..., 30000)`, imported from `./setup.js`.
+2. Public API via `@/index.js`; `.js` extensions everywhere.
+3. `isOk` + `unwrap`, `toBeCloseTo`, type guards, `measureVolume`/`measureArea`.
+4. Kernel-specific behavior handled via registry/capabilities, not inline skips.
+5. `npx vitest run --project occt-wasm tests/<file>.test.ts` green.
+6. If the change touches shared geometry code, spot-check one other kernel: `npx vitest run --project brepkit tests/<file>.test.ts`.
+
+## Additional resources
+
+- `references/multi-kernel.md` — divergence registry entry format, capability flags, excluded-suite inventory and how each actually runs, parity-suite pointers.
+- `tests/parity/README.md` — parity philosophy, tolerance policy, input generators.
+- `docs/kernel-conformance.md` — generated capability/divergence matrix (`npm run conformance:generate`).
+- Sibling skills: `adding-operations` (what to test when adding an op), `kernel-abstraction` (adapter/kernel structure), `debugging-geometry` (when an assertion fails for geometric reasons), `result-error-handling` (Result semantics), `quality-gates` (pre-commit/validate stack), `ci-triage` (shard failures, CI-only reds, bench blind spots), `memory-and-disposal` (`using`/handle leaks that surface as test crashes).

--- a/.claude/skills/writing-tests/references/multi-kernel.md
+++ b/.claude/skills/writing-tests/references/multi-kernel.md
@@ -1,0 +1,119 @@
+# Multi-kernel testing reference
+
+## The four vitest projects
+
+Projects are generated in `vitest.config.ts` from `kernelConfigs` in `tests/helpers/kernelRegistry.ts`. Each project sets `env: { TEST_KERNEL: <id> }`, which drives `initKernel()` and `currentKernel`.
+
+| Project     | Kernel                                                                     | Gate status                                                      | Coverage thresholds                                          |
+| ----------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------ |
+| `occt-wasm` | occt-wasm npm package (`OcctKernel.init()` + `OcctWasmAdapter.fromKernel`) | **default; the CI merge gate** (`default: true` in the registry) | `'informational'` at project level; enforced via root config |
+| `occt`      | OpenCascade.js WASM (`brepjs-opencascade`, `initFromOC`)                   | opt-in (`npm run test:occt`)                                     | own thresholds: 84/74/90/84                                  |
+| `brepkit`   | brepkit-wasm (`BrepkitAdapter`)                                            | opt-in (`npm run test:brepkit`); not run in CI                   | `'informational'`                                            |
+| `manifold`  | Manifold mesh kernel (`brepjs-manifold`)                                   | opt-in (`npx vitest run --project manifold ...`); no npm script  | `'informational'`                                            |
+
+`defaultKernelId()` in `kernelRegistry.ts` is the single source of truth for the default. If the default kernel ever changes, re-measure coverage with `npm run test:full` and re-floor the root thresholds (see the comment above `thresholds` in `vitest.config.ts`).
+
+## Capability flags
+
+Per-kernel booleans in `kernelRegistry.ts`, read via `getKernelCapabilities(id)`:
+
+`projection`, `constraintSketch`, `kernel2D`, `variableFillet`, `offsetSolidV2`, `gridPattern`
+
+Use these (or a `currentKernel` comparison) for **feature-existence** gating:
+
+```ts
+import { initKernel, currentKernel } from './setup.js';
+
+it.skipIf(currentKernel !== 'occt-wasm')('unwraps a cylindrical face', () => { ... });
+```
+
+Capability gaps are structural ("this kernel has no HLR projection"). Behavioral differences on a shared feature belong in the divergence registry instead.
+
+## Divergence registry
+
+`tests/helpers/kernelDivergences.ts` is the single source of truth for kernel-specific test differences. Never write inline `if (isBrepkit) ctx.skip()` — add a registry entry so the difference is documented, keyed, and rendered into `docs/kernel-conformance.md` (`npm run conformance:generate`).
+
+### Entry format
+
+The registry is a `DivergenceMap`: kernel id → divergence key → entry. Keys follow `operation.specificCase` (e.g. `booleans.cutFuseRecombine`, `projection.makeProjectedEdges`).
+
+```ts
+export const divergences: DivergenceMap = {
+  manifold: {
+    'projection.makeProjectedEdges': {
+      kind: 'not-implemented',
+      reason: 'manifold is a mesh kernel with no hidden-line-removal projection (projectEdges).',
+    },
+  },
+};
+```
+
+Fields: `kind`, `reason` (mandatory, explain the _geometric_ why), optional `since` and `tracking` (upstream issue URL). Tolerance entries additionally carry `relativeTol`, optional `absoluteTol`, and `metric` (`'volume' | 'area' | 'distance' | 'angle' | 'count'`).
+
+### Kinds and their runtime effect
+
+| Kind               | Meaning                                                            | Effect via `skipIfDiverges`                                                        |
+| ------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `not-implemented`  | Kernel lacks the feature entirely                                  | Test skipped                                                                       |
+| `skip`             | Feature exists but this case is invalid/meaningless on this kernel | Test skipped                                                                       |
+| `tolerance`        | Same result, looser numeric agreement                              | **No-op** — test still runs; entry is informational + feeds `getToleranceFor(key)` |
+| `topology-differs` | Valid result with different topology (e.g. face count)             | **No-op** — informational                                                          |
+
+### Consuming entries in tests
+
+Per-test skip requires the vitest `TestContext`:
+
+```ts
+import { skipIfDiverges } from './helpers/kernelDivergences.js';
+
+it('sections a sphere to a face', (ctx) => {
+  skipIfDiverges(ctx, 'booleanFns.sectionToFaceSphere');
+  // ...
+});
+```
+
+Whole-suite skip (no ctx available at `describe` level):
+
+```ts
+import { shouldSkipSuite } from './helpers/kernelDivergences.js';
+
+describe.skipIf(shouldSkipSuite('booleans.cutFuseRecombine'))('recombine identity', () => { ... });
+```
+
+Other helpers: `getDivergence(key, kernelId?)`, `getAllDivergences()`, `expectClose(actual, expected, relTol = 1e-4, absTol = 1e-10)`, `expectKernelsAgree(valA, valB, label, relTol?, absTol?)`.
+
+Note: `currentKernelId` in `kernelDivergences.ts` falls back to `'occt'` when `TEST_KERNEL` is unset, whereas `currentKernel` in `tests/setup-kernel.ts` falls back to the registry default (`occt-wasm`). Inside vitest this never matters (projects always set `TEST_KERNEL`), but be aware when running helpers outside vitest.
+
+## Excluded suites — what actually runs where
+
+### `alwaysExclude` (`vitest.config.ts`) — excluded from ALL kernel projects
+
+| File/pattern                                                        | Why excluded                                        | How it actually runs                                                                                                                 |
+| ------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `tests/io-stress.test.ts`                                           | Own config with 60 s timeout                        | `npm run test:stress` (`vitest.stress.config.ts`, `TEST_KERNEL=occt`)                                                                |
+| `tests/kernel-agreement.test.ts`                                    | Manages its own dual-kernel init (`initAllKernels`) | Explicit path only: `npx vitest run tests/kernel-agreement.test.ts`. **No npm script, no CI job — rots silently unless run by hand** |
+| `tests/brepkit-adapter.test.ts`, `tests/brepkit-validation.test.ts` | Need a real brepkit-wasm install or local link      | Explicit path only; same silent-rot caveat                                                                                           |
+| `benchmarks/**`                                                     | Own config                                          | `npm run bench` (`vitest.bench.config.ts`)                                                                                           |
+| `packages/brepjs-cad/**`, `packages/brepjs-viewer/**`               | Own `@` alias + own vitest config                   | Dedicated CI jobs via `npm run test --workspace=<pkg>`                                                                               |
+| `apps/**`, `.worktrees/**`, `.claude/worktrees/**`                  | Not part of the library suite                       | apps/playground is gated by `tsc -b` only                                                                                            |
+
+Do not confuse `tests/brepkit-adapter.test.ts` (hyphenated, excluded) with `tests/brepkitAdapter.test.ts` (camelCase, NOT excluded) — the latter drives `BrepkitAdapter` with a pure mock kernel and runs as a unit test in every project.
+
+When touching the excluded suites, run them by explicit path locally before merging; nothing else will.
+
+### occt-wasm project `excludeTests` (`kernelRegistry.ts`)
+
+Excluded from the default gate even though it is the default project: `tests/brepkitExtended.test.ts`, `tests/brepkitSketchArc.test.ts`, `tests/brepkitOffsetV2.test.ts`, `tests/gltfRoundTrip.test.ts`. The brepkit ones run under `npm run test:brepkit`.
+
+Companion packages (`brepjs-sheetmetal`, `brepjs-bim`) test through their own workspace CI jobs, but the root suite aliases their bare specifiers to live `src` (`vitest.config.ts` resolve aliases) so root tests that import them exercise current source, not stale dist.
+
+## Parity suite (`tests/parity/`)
+
+The kernel-agnostic behavioral spec. Rules (full text in `tests/parity/README.md`):
+
+1. Reference values come from closed-form math, never from a kernel's output.
+2. Algebraic invariants (inclusion–exclusion etc.) via `fast-check`, `numRuns: 50`.
+3. Round-trip I/O invariants to precision 6.
+4. Positional offsets must use the quantized `fcOffset` generator, not raw `fc.double` — sub-micron offsets put OCCT booleans in unstable near-coincident configurations and fast-check shrinks straight toward them.
+
+The README's "how parity failure surfaces" table predates the occt-wasm default switch: the required gate is now the occt-wasm project; brepkit/manifold parity failures remain informational.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ Monorepo packages:
 - `packages/brepjs-bim`: IFC/BIM parametric building elements + IFC import/export (experimental, published)
 - `packages/brepjs-sheetmetal`: Sheet-metal authoring + unfold/flat-pattern + DXF (experimental, published)
 - `packages/brepjs-manifold`: Manifold mesh/CSG preview kernel (experimental, unpublished)
-- `packages/brepjs-viewer`: Shared React/R3F renderer (consumed by the playground and brepjs-cad; not yet published)
-- `packages/brepjs-cad`: Agent skill + verify/preview CLI + WASM viewer (not yet published; skill ships via the repo Claude-plugin marketplace)
+- `packages/brepjs-viewer`: Shared React/R3F renderer (consumed by the playground and brepjs-cad; published, manual publish — unmanaged by release-please)
+- `packages/brepjs-cad`: Agent skill + verify/preview CLI + WASM viewer (published; skill also ships via the repo Claude-plugin marketplace)
 
 ## Commands
 


### PR DESCRIPTION
## What

Adds a library of **16 task-triggered skills** under `.claude/skills/` so contributors and smaller AI models can debug, extend, validate, and advance brepjs without relying on tribal knowledge. Each skill is a verified, source-cited playbook — decision tables and `symptom → cause → fix` recipes — that **points to** `CLAUDE.md`/`docs/` rather than duplicating them.

## The skills

| Skill | Covers |
|---|---|
| `architecture-navigation` | where code belongs; layer-boundary rules & violations |
| `adding-operations` | end-to-end recipe for a new op across the six export surfaces |
| `kernel-abstraction` | adapter methods, registry, multi-kernel capability differences |
| `wasm-interop` | raw JS↔WASM mechanics (Emscripten enums, heap, threading) |
| `debugging-geometry` | invalid shapes, failed booleans, healing, kernel divergence, finder mis-selection |
| `memory-and-disposal` | handles, `using`, `DisposalScope`, leak hunting |
| `result-error-handling` | `Result<T,E>`, error codes, throw-vs-return |
| `writing-tests` | test skeleton, geometry assertions, multi-kernel, coverage, benchmarks |
| `quality-gates` | `npm run validate`, ESLint, pattern checker, baseline trap |
| `ci-triage` | each CI job's known failure modes → fixes (incl. OSV scan) |
| `release-publishing` | release-please, npm publish, manifest cascade, breaking-marker rule |
| `git-pr-workflow` | hook tiers, conventional commits, worktrees, PR/merge |
| `companion-packages` | the `packages/`/`apps/` map, publish status, workspace deps |
| `playground-examples` | the three gates (types, geometry, thumbnail) |
| `assembly-solver` | **new coverage** — constraint solver, mates, kinematic joints, IK, DH, URDF |
| `shaperef-lineage` | **new coverage** — topological naming, role tables, history replay |

The last two document subsystems that previously had **no docs page and no skill**.

## How it was built

Authored and reviewed with multi-agent orchestration: every concrete claim (paths, npm scripts, function names, config keys, code snippets) was verified against the live source; each skill passed an adversarial fact-check and a craft review; two cross-library critics resolved overlap, trigger-collisions, and gaps. Descriptions use reciprocal exclusions so a given query routes to exactly one skill.

## Notes

- `docs(skills):` type — does not trigger a version bump.
- Removes the dangling `.claude/skills/brepjs-verify` symlink (target moved to `packages/brepjs-cad/skills`, which ships via the plugin marketplace).
- Markdown only; no source or config changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

