### PR TITLE
docs(kernel): correct MeshOptions.angularTolerance cross-kernel note

### DIFF
--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -90,10 +90,8 @@ export interface MeshOptions {
   /** Linear deflection tolerance for tessellation. */
   tolerance: number;
   /**
-   * Angular deflection tolerance for tessellation.
-   *
-   * **Cross-kernel note**: brepkit only supports linear deflection; this
-   * parameter is ignored (a one-time warning is emitted). OCCT honours both.
+   * Angular deflection tolerance for tessellation. Honoured by both the OCCT
+   * and brepkit kernels; a non-positive value falls back to the kernel default.
    */
   angularTolerance: number;
   skipNormals?: boolean;


### PR DESCRIPTION
## What

Corrects a stale doc comment on `MeshOptions.angularTolerance` in `src/kernel/types.ts`.

## Why

The comment claimed brepkit **ignores** `angularTolerance` and emits a one-time warning. Both halves are wrong:

- `src/kernel/brepkit/meshOps.ts` forwards `angularTolerance` on **every** tessellation path (solid, single-face, edges, grouped/per-face, UV) — a non-positive value maps to `undefined`, which the kernel treats as its default angular cap.
- The only `console.warn` in that file is a grouped-tessellation **failure fallback** (`tessellateSolidGrouped failed … falling back to per-face`), not an "angularTolerance ignored" notice.

Both OCCT and brepkit honour the parameter, so the comment now says so.

## Notes

- Comment-only change; no behavior, types, or API affected. Surfaced while auditing kernel docs for the skill library (#1738); kept separate to keep that PR markdown-only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

