### PR TITLE
fix(origins): recover split coplanar face origins across boolean seams

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "340 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "342 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/topology/metadata/originTrackingFns.ts
+++ b/src/topology/metadata/originTrackingFns.ts
@@ -102,7 +102,7 @@ export function propagateOriginsFromEvolution(
 /** Max 3D centroid separation (mm²) for a "near" match — the general case. */
 const MAX_MATCH_DIST_SQ = 100;
 
-/** Min |normal·normal| for two faces to count as sharing a plane's orientation. */
+/** Min |outNormal·inNormal| for two faces to count as sharing a plane's orientation. */
 const COPLANAR_NORMAL_MIN = 0.985;
 
 /**

--- a/src/topology/metadata/originTrackingFns.ts
+++ b/src/topology/metadata/originTrackingFns.ts
@@ -99,9 +99,40 @@ export function propagateOriginsFromEvolution(
 // Geometric matching helper
 // ---------------------------------------------------------------------------
 
+/** Max 3D centroid separation (mm²) for a "near" match — the general case. */
+const MAX_MATCH_DIST_SQ = 100;
+
+/** Min |normal·normal| for two faces to count as sharing a plane's orientation. */
+const COPLANAR_NORMAL_MIN = 0.985;
+
+/**
+ * Max squared perpendicular offset (mm²) from an input face's plane for the
+ * output face to count as *coplanar* with it — i.e. a piece the boolean sliced
+ * off that same planar surface. 0.1mm² tolerates kernel/mesh float noise while
+ * still separating floors that sit even a fraction of a mm apart in depth.
+ */
+const COPLANAR_OFFSET_SQ = 0.1;
+
 /**
  * Find the best origin match for a result face by comparing normals and centroids
  * against input face signatures. Returns `undefined` if no good match exists.
+ *
+ * Two acceptance paths:
+ *  1. Near match — same-facing normal (signed dot ≥ 0.707) and centroids within
+ *     {@link MAX_MATCH_DIST_SQ}. The general case for regenerated seam faces
+ *     (feature tops, flush walls). Unchanged legacy behavior.
+ *  2. Coplanar match — the output face lies on an input face's plane (parallel
+ *     *or* antiparallel normal, tiny perpendicular offset) regardless of how far
+ *     its centroid drifted in-plane. Two cases path 1 misses:
+ *       • A boolean that splits a large planar face — a wide cutout floor sliced
+ *         by an overlapping deeper cutout — leaves pieces >10mm from the parent
+ *         centroid (past path 1's cutoff).
+ *       • A cut flips the cavity face's normal versus the tool face it came from,
+ *         so the floor is antiparallel to its origin's input face.
+ *     Both left the surface tagless → body color in multi-color consumers
+ *     (gridfinity GH #2443). Matching by plane + orientation-agnostic normal
+ *     recovers them. Ranked below every near match (offset by −1) so path 1 wins
+ *     when both apply; among coplanar candidates the nearest in-plane wins.
  */
 function findBestOriginMatch(
   outNormal: readonly [number, number, number],
@@ -117,13 +148,27 @@ function findBestOriginMatch(
   for (const inp of inputSigs) {
     const dot =
       outNormal[0] * inp.normal[0] + outNormal[1] * inp.normal[1] + outNormal[2] * inp.normal[2];
-    if (dot < 0.707) continue;
     const dx = outCentroid[0] - inp.centroid[0];
     const dy = outCentroid[1] - inp.centroid[1];
     const dz = outCentroid[2] - inp.centroid[2];
     const distSq = dx * dx + dy * dy + dz * dz;
-    if (distSq > 100) continue;
-    const score = dot - distSq / 100;
+
+    // Path 1: near match with same-facing normal — legacy behavior, unchanged.
+    if (dot >= 0.707 && distSq <= MAX_MATCH_DIST_SQ) {
+      const score = dot - distSq / MAX_MATCH_DIST_SQ;
+      if (score > bestScore) {
+        bestScore = score;
+        bestOrigin = inp.origin;
+      }
+      continue;
+    }
+
+    // Path 2: coplanar (same plane, orientation-agnostic), any in-plane distance.
+    if (Math.abs(dot) < COPLANAR_NORMAL_MIN) continue;
+    const perp = dx * inp.normal[0] + dy * inp.normal[1] + dz * inp.normal[2];
+    if (perp * perp > COPLANAR_OFFSET_SQ) continue;
+    const inPlaneSq = Math.max(0, distSq - perp * perp);
+    const score = Math.abs(dot) - 1 - inPlaneSq / (inPlaneSq + 1);
     if (score > bestScore) {
       bestScore = score;
       bestOrigin = inp.origin;

--- a/src/topology/metadata/originTrackingFns.ts
+++ b/src/topology/metadata/originTrackingFns.ts
@@ -113,68 +113,85 @@ const COPLANAR_NORMAL_MIN = 0.985;
  */
 const COPLANAR_OFFSET_SQ = 0.1;
 
+interface OriginSig {
+  readonly normal: readonly [number, number, number];
+  readonly centroid: readonly [number, number, number];
+  readonly origin: number;
+  /** True only for planar surfaces — the coplanar fallback requires it. */
+  readonly planar: boolean;
+}
+
 /**
  * Find the best origin match for a result face by comparing normals and centroids
  * against input face signatures. Returns `undefined` if no good match exists.
  *
- * Two acceptance paths:
+ * Two passes, near strictly preferred:
  *  1. Near match — same-facing normal (signed dot ≥ 0.707) and centroids within
  *     {@link MAX_MATCH_DIST_SQ}. The general case for regenerated seam faces
- *     (feature tops, flush walls). Unchanged legacy behavior.
- *  2. Coplanar match — the output face lies on an input face's plane (parallel
- *     *or* antiparallel normal, tiny perpendicular offset) regardless of how far
- *     its centroid drifted in-plane. Two cases path 1 misses:
+ *     (feature tops, flush walls). Unchanged legacy behavior. If any near match
+ *     exists it wins outright — the coplanar pass never runs — so a distant
+ *     coplanar candidate can't outscore a valid near one.
+ *  2. Coplanar match (only when no near match, and only between PLANAR faces) —
+ *     the output face lies on an input face's plane (parallel *or* antiparallel
+ *     normal, tiny perpendicular offset) regardless of how far its centroid
+ *     drifted in-plane. Two cases pass 1 misses:
  *       • A boolean that splits a large planar face — a wide cutout floor sliced
  *         by an overlapping deeper cutout — leaves pieces >10mm from the parent
- *         centroid (past path 1's cutoff).
+ *         centroid (past pass 1's cutoff).
  *       • A cut flips the cavity face's normal versus the tool face it came from,
  *         so the floor is antiparallel to its origin's input face.
  *     Both left the surface tagless → body color in multi-color consumers
- *     (gridfinity GH #2443). Matching by plane + orientation-agnostic normal
- *     recovers them. Ranked below every near match (offset by −1) so path 1 wins
- *     when both apply; among coplanar candidates the nearest in-plane wins.
+ *     (gridfinity GH #2443). The planar gate keeps a curved output face from
+ *     inheriting an origin off an unrelated face that merely shares a sampled
+ *     tangent plane; among coplanar candidates the nearest in-plane wins.
  */
 function findBestOriginMatch(
   outNormal: readonly [number, number, number],
   outCentroid: readonly [number, number, number],
-  inputSigs: ReadonlyArray<{
-    normal: readonly [number, number, number];
-    centroid: readonly [number, number, number];
-    origin: number;
-  }>
+  outPlanar: boolean,
+  inputSigs: readonly OriginSig[]
 ): number | undefined {
-  let bestScore = -Infinity;
-  let bestOrigin: number | undefined;
+  // Pass 1: near match — always wins when present.
+  let bestNearScore = -Infinity;
+  let bestNear: number | undefined;
   for (const inp of inputSigs) {
     const dot =
       outNormal[0] * inp.normal[0] + outNormal[1] * inp.normal[1] + outNormal[2] * inp.normal[2];
+    if (dot < 0.707) continue;
     const dx = outCentroid[0] - inp.centroid[0];
     const dy = outCentroid[1] - inp.centroid[1];
     const dz = outCentroid[2] - inp.centroid[2];
     const distSq = dx * dx + dy * dy + dz * dz;
-
-    // Path 1: near match with same-facing normal — legacy behavior, unchanged.
-    if (dot >= 0.707 && distSq <= MAX_MATCH_DIST_SQ) {
-      const score = dot - distSq / MAX_MATCH_DIST_SQ;
-      if (score > bestScore) {
-        bestScore = score;
-        bestOrigin = inp.origin;
-      }
-      continue;
-    }
-
-    // Path 2: coplanar (same plane, orientation-agnostic), any in-plane distance.
-    if (Math.abs(dot) < COPLANAR_NORMAL_MIN) continue;
-    const perp = dx * inp.normal[0] + dy * inp.normal[1] + dz * inp.normal[2];
-    if (perp * perp > COPLANAR_OFFSET_SQ) continue;
-    const inPlaneSq = Math.max(0, distSq - perp * perp);
-    const score = Math.abs(dot) - 1 - inPlaneSq / (inPlaneSq + 1);
-    if (score > bestScore) {
-      bestScore = score;
-      bestOrigin = inp.origin;
+    if (distSq > MAX_MATCH_DIST_SQ) continue;
+    const score = dot - distSq / MAX_MATCH_DIST_SQ;
+    if (score > bestNearScore) {
+      bestNearScore = score;
+      bestNear = inp.origin;
     }
   }
-  return bestOrigin;
+  if (bestNear !== undefined) return bestNear;
+
+  // Pass 2: coplanar planar-face fallback. Only planar↔planar surfaces qualify.
+  if (!outPlanar) return undefined;
+  let bestInPlaneSq = Infinity;
+  let bestCoplanar: number | undefined;
+  for (const inp of inputSigs) {
+    if (!inp.planar) continue;
+    const dot =
+      outNormal[0] * inp.normal[0] + outNormal[1] * inp.normal[1] + outNormal[2] * inp.normal[2];
+    if (Math.abs(dot) < COPLANAR_NORMAL_MIN) continue;
+    const dx = outCentroid[0] - inp.centroid[0];
+    const dy = outCentroid[1] - inp.centroid[1];
+    const dz = outCentroid[2] - inp.centroid[2];
+    const perp = dx * inp.normal[0] + dy * inp.normal[1] + dz * inp.normal[2];
+    if (perp * perp > COPLANAR_OFFSET_SQ) continue;
+    const inPlaneSq = Math.max(0, dx * dx + dy * dy + dz * dz - perp * perp);
+    if (inPlaneSq < bestInPlaneSq) {
+      bestInPlaneSq = inPlaneSq;
+      bestCoplanar = inp.origin;
+    }
+  }
+  return bestCoplanar;
 }
 
 // ---------------------------------------------------------------------------
@@ -235,11 +252,7 @@ export function propagateOriginsByHash(
   // Geometric pass: recover origins for boolean-regenerated faces by matching
   // surface normal + centroid against the input faces.
   if (unmatched.length > 0) {
-    const inputSigs: {
-      origin: number;
-      normal: [number, number, number];
-      centroid: [number, number, number];
-    }[] = [];
+    const inputSigs: OriginSig[] = [];
     for (const input of inputs) {
       const origins = getFaceOrigins(input);
       if (!origins) continue;
@@ -255,7 +268,8 @@ export function propagateOriginsByHash(
             0.5 * (bounds.vMin + bounds.vMax)
           );
           const centroid = kernel.surfaceCenterOfMass(f.wrapped);
-          inputSigs.push({ origin, normal, centroid });
+          const planar = kernel.surfaceType(f.wrapped) === 'plane';
+          inputSigs.push({ origin, normal, centroid, planar });
         } catch {
           // skip faces that can't compute normal/centroid
         }
@@ -273,8 +287,9 @@ export function propagateOriginsByHash(
             0.5 * (outBounds.vMin + outBounds.vMax)
           );
           const outCentroid = kernel.surfaceCenterOfMass(f.wrapped);
+          const outPlanar = kernel.surfaceType(f.wrapped) === 'plane';
 
-          const bestOrigin = findBestOriginMatch(outNormal, outCentroid, inputSigs);
+          const bestOrigin = findBestOriginMatch(outNormal, outCentroid, outPlanar, inputSigs);
           if (bestOrigin !== undefined) {
             resultMap.set(hash, bestOrigin);
           }

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -52,6 +52,14 @@ export const divergences: DivergenceMap = {
       reason: 'manifold is a mesh kernel with no hidden-line-removal projection (projectEdges).',
     },
     // -----------------------------------------------------------------------
+    // originGeometricFallback.test.ts — mesh CSG splits/attributes faces its own way
+    // -----------------------------------------------------------------------
+    'origins.coplanarSplitMatch': {
+      kind: 'skip',
+      reason:
+        'The mesh CSG kernel re-tessellates and attributes split coplanar faces through its own path, not the B-rep hash/geometric origin fallback; a split floor piece can pick up the neighbour tool origin. Exercised on the B-rep kernels (occt/brepkit/opencascade) that gridfinity ships.',
+    },
+    // -----------------------------------------------------------------------
     // booleans.test.ts — mesh CSG vs exact B-rep
     // -----------------------------------------------------------------------
     'booleans.cutFuseRecombine': {

--- a/tests/originGeometricFallback.test.ts
+++ b/tests/originGeometricFallback.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
+import { skipIfDiverges } from './helpers/kernelDivergences.js';
 import {
   box,
   getFaces,
@@ -9,6 +10,7 @@ import {
   translate,
   fuseAll,
   fuseAllBisect,
+  cutAllBisect,
   unwrap,
   faceCenter,
 } from '@/index.js';
@@ -23,6 +25,12 @@ beforeAll(async () => {
 // propagation used to leave them origin-less (→ 0 / body at mesh time). This
 // is the minimal analogue of the multi-color export bug where a feature's top
 // face printed in the body color.
+/** Tag a shape's faces with an origin and return it (setShapeOrigin is void). */
+function setOrigin<T extends ReturnType<typeof box>>(shape: T, origin: number): T {
+  setShapeOrigin(shape, origin);
+  return shape;
+}
+
 function sideBySide(): [ReturnType<typeof box>, ReturnType<typeof box>] {
   const a = box(10, 10, 10);
   const b = translate(box(10, 10, 10), [10, 0, 0]);
@@ -53,5 +61,75 @@ describe('coplanar boolean-regenerated faces keep their origin', () => {
   it('fuseAllBisect (export primitive): no top face loses its origin', () => {
     const [a, b] = sideBySide();
     assertNoUndefinedTopFace(unwrap(fuseAllBisect([a, b], { simplify: true })).shape);
+  });
+
+  // A long tagged top face split through its middle by a taller divider yields
+  // two pieces whose centroids sit ~16mm from the original face centroid — past
+  // the near-match cutoff — yet still coplanar with it. Both must keep the base
+  // origin instead of falling back to body color. This is the minimal analogue
+  // of gridfinity-layout-tool GH #2443, where a wide cutout floor sliced by an
+  // overlapping deeper cutout printed part of its floor in the body color.
+  it('a long face split far from its centroid keeps its origin via coplanar match', (ctx) => {
+    skipIfDiverges(ctx, 'origins.coplanarSplitMatch');
+    // Base top face: 20 x 60 at z=10, centroid (10, 30, 10).
+    const base = setOrigin(box(20, 60, 10), 1);
+    // Divider rises to z=20 through the base's middle (y 27..33), splitting the
+    // top face into y<27 and y>33 pieces (centroids ~y13 and ~y46 → ~16mm off).
+    const divider = setOrigin(translate(box(20, 6, 20), [0, 27, 0]), 2);
+
+    const result = unwrap(fuseAllBisect([base, divider], { simplify: true })).shape;
+
+    const origins = getFaceOrigins(result);
+    expect(origins).toBeDefined();
+    if (!origins) return;
+    let splitFloorFaces = 0;
+    for (const f of getFaces(result)) {
+      const c = faceCenter(f);
+      // Base top-face pieces: z≈10, off to either side of the divider band.
+      if (Math.abs(c[2] - 10) < 0.1 && (c[1] < 27 || c[1] > 33)) {
+        splitFloorFaces++;
+        expect(origins.get(getHashCode(f))).toBe(1);
+      }
+    }
+    // Two disconnected pieces prove the face actually split (not passed through).
+    expect(splitFloorFaces).toBeGreaterThanOrEqual(2);
+  });
+
+  // The direct #2443 shape: subtract a wide, shallow cavity and an overlapping
+  // deeper cavity from a block. The deep cut slices the shallow cavity's long
+  // floor into two pieces far from its centroid — AND a cut flips that floor's
+  // normal versus the tool face it came from. Both pieces must keep the shallow
+  // cavity's origin (not body). Exercises cutAll's hash+geometric fallback.
+  it('cutAllBisect: a wide cavity floor sliced by an overlapping deeper cut keeps its origin', (ctx) => {
+    skipIfDiverges(ctx, 'origins.coplanarSplitMatch');
+    const body = box(30, 80, 30);
+    // Shallow, long cavity — floor plane at z=18, footprint x[5,25] y[5,75].
+    const shallow = setOrigin(box(20, 70, 12, { at: [15, 40, 24] }), 1);
+    // Deeper cavity crossing the shallow one's middle at full width (y 35..45),
+    // splitting its floor into y[5,35] and y[45,75] pieces (~20mm off-centre).
+    const deep = setOrigin(box(30, 10, 20, { at: [15, 40, 20] }), 2);
+
+    const result = unwrap(cutAllBisect(body, [shallow, deep], { simplify: true })).shape;
+
+    const origins = getFaceOrigins(result);
+    expect(origins).toBeDefined();
+    if (!origins) return;
+    let floorPieces = 0;
+    for (const f of getFaces(result)) {
+      const c = faceCenter(f);
+      // Shallow cavity floor pieces: z≈18, inside its footprint, off the deep band.
+      if (
+        Math.abs(c[2] - 18) < 0.1 &&
+        c[0] > 6 &&
+        c[0] < 24 &&
+        (c[1] < 35 || c[1] > 45) &&
+        c[1] > 6 &&
+        c[1] < 74
+      ) {
+        floorPieces++;
+        expect(origins.get(getHashCode(f))).toBe(1);
+      }
+    }
+    expect(floorPieces).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Problem

The geometric origin-matching fallback (`findBestOriginMatch`) recovers face origins for boolean-regenerated faces by matching surface normal + centroid against input faces. It rejected any candidate whose centroid sat **>10mm away** (`distSq > 100`) or whose **normal was flipped** (`dot < 0.707`). Two real cases slipped through:

- **Split large planar face** — a boolean that splits a wide tagged floor (a cutout floor sliced by an overlapping deeper cutout) leaves pieces whose centroids drift 10–20mm from the parent's, past the near-match cutoff.
- **Cut normal flip** — a cut flips the cavity face's outward normal versus the tool face it came from, so the cavity floor is *antiparallel* to its origin's input face.

Both leave the surface with no origin → it falls back to body color in multi-color consumers.

**Downstream symptom:** gridfinity-layout-tool [#2443](https://github.com/andymai/gridfinity-layout-tool/issues/2443) — overlapping shadow-board cutouts of the same color printed part of a floor in the body color.

## Fix

Add a second acceptance path to `findBestOriginMatch`: a **coplanar match** — the output face lies on an input face's plane (orientation-agnostic normal via `|dot|`, perpendicular offset ≤ 0.1mm²), regardless of in-plane centroid distance.

- Legacy **near match** (signed normal, ≤10mm) is unchanged and always outranks coplanar matches, so existing behavior is preserved.
- Among coplanar candidates the nearest in-plane wins, and the perpendicular-offset gate cleanly separates parallel surfaces at different depths (e.g. a cutout floor vs the bin floor).

## Tests

`tests/originGeometricFallback.test.ts` gains two regression tests — a **fuse-split** face and the direct **cut-split** #2443 shape (block minus a wide shallow cavity minus an overlapping deeper cavity). Both fail on `main` (6 failures across occt/brepkit/opencascade) and pass with the fix. The experimental mesh-CSG (`manifold`) kernel attributes split faces through its own path; that divergence is registered in `kernelDivergences.ts` and the tests skip it there.

Verified end-to-end: building this branch and swapping it into gridfinity-layout-tool makes the #2443 reproduction's previously-untagged floor fully tagged (0 mm² untagged at the cutout depth).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

