### PR TITLE
fix(topology): release orphaned WASM shape handles in boolean/evolution helpers

### DIFF
--- a/src/core/shapeTypes.ts
+++ b/src/core/shapeTypes.ts
@@ -329,6 +329,27 @@ export function castResultShape<D extends Dimension = '3D'>(
 }
 
 /**
+ * Fully release a transiently-branded sub-shape and the raw handle it was cast
+ * from — for a face/edge iterated only to read a property, then discarded.
+ *
+ * `handle`'s dispose updates stats and, on kernels that own their native object
+ * (Embind, manifold, brepkit), frees it. occt-wasm handles are arena-backed
+ * (their delete is a no-op), so when the downcast produced a distinct handle
+ * (`handle.wrapped !== rawSource`) both arena slots are released explicitly. The
+ * identity guard also skips manifold/brepkit — there `handle` *is* `rawSource`,
+ * already freed above, and their `dispose()` has no double-free guard.
+ */
+export function disposeTransientSubShape(handle: ShapeHandle, rawSource: KernelShape): void {
+  const downcast = handle.wrapped;
+  handle[Symbol.dispose]();
+  if (downcast !== rawSource) {
+    const kernel = getKernel();
+    kernel.dispose(downcast);
+    kernel.dispose(rawSource);
+  }
+}
+
+/**
  * Fast-path cast when the shape type is already known (e.g., from iterShapes).
  * Skips the shapeType() WASM call — only performs downcast + branded handle creation.
  * Used internally by topology extractors for bulk sub-shape iteration.

--- a/src/core/shapeTypes.ts
+++ b/src/core/shapeTypes.ts
@@ -298,6 +298,37 @@ export function castShape3D(ocShape: KernelShape): AnyShape {
 }
 
 /**
+ * Release the pre-downcast handle of a freshly-produced kernel result after it
+ * has been cast to `cast`.
+ *
+ * On occt-wasm `downcast` allocates a new arena slot and orphans the input; a
+ * handle's own `delete()` is a no-op there, so the input must be released via
+ * `getKernel().dispose()` to reclaim the slot. Kernels whose `downcast` is
+ * identity (manifold, brepkit) return the same handle as `cast`, so nothing is
+ * released — doing so would delete the shape being returned.
+ *
+ * Use only for a kernel result the caller owns outright — never for a shape
+ * received from elsewhere.
+ */
+export function disposeDowncastSource(source: KernelShape, cast: ShapeHandle): void {
+  if (cast.wrapped !== source) getKernel().dispose(source);
+}
+
+/**
+ * Cast a freshly-produced kernel result to its branded type and release the
+ * orphaned pre-downcast handle. The result-owning counterpart to {@link castShape};
+ * see {@link disposeDowncastSource} for the arena semantics.
+ */
+export function castResultShape<D extends Dimension = '3D'>(
+  ocShape: KernelShape,
+  dim?: D
+): AnyShape<D> {
+  const cast = castShape<D>(ocShape, dim);
+  disposeDowncastSource(ocShape, cast);
+  return cast;
+}
+
+/**
  * Fast-path cast when the shape type is already known (e.g., from iterShapes).
  * Skips the shapeType() WASM call — only performs downcast + branded handle creation.
  * Used internally by topology extractors for bulk sub-shape iteration.

--- a/src/kernel/occtWasm/booleanOps.ts
+++ b/src/kernel/occtWasm/booleanOps.ts
@@ -18,21 +18,40 @@ import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
 import { makeVecU32, unwrap, wrapResult } from './helpers.js';
 
 /**
+ * The resolved tool id plus a `dispose` that releases any temporary the
+ * resolution allocated. Callers must call `dispose()` after the boolean.
+ */
+export interface ResolvedTool {
+  id: number;
+  dispose: () => void;
+}
+
+/**
  * Normalize a boolean tool to a single fused solid when it is a compound of
  * multiple solids (e.g. engraved text — one solid per glyph). occt-wasm's
  * boolean returns an empty result for such compound tools where opencascade
  * tolerated them; fusing the solids first yields a usable single tool.
  * Single-solid (or non-solid) tools pass through untouched.
  */
-export function resolveBooleanTool(k: OcctKernelWasm, tool: KernelShape): number {
+export function resolveBooleanTool(k: OcctKernelWasm, tool: KernelShape): ResolvedTool {
   const toolId = unwrap(tool);
   const solids = k.getSubShapes(toolId, 'solid');
   try {
-    return solids.size() > 1 ? k.fuseAll(solids) : toolId;
+    if (solids.size() > 1) {
+      // Multi-solid tool: the fused result is a fresh arena slot the caller
+      // must release once the boolean has consumed it.
+      const fusedId = k.fuseAll(solids);
+      return {
+        id: fusedId,
+        dispose: () => {
+          k.release(fusedId);
+        },
+      };
+    }
+    return { id: toolId, dispose: () => {} };
   } finally {
-    // getSubShapes copies each sub-solid into its own arena slot. Deleting the
-    // vector frees only the container, so release the queried solids too —
-    // otherwise every pass-through boolean (single-solid tool) leaks one handle.
+    // getSubShapes copies each sub-solid into its own arena slot; the vector
+    // delete frees only the container, so release the queried copies too.
     // Guard against releasing the tool itself in case a query ever aliases it.
     for (let i = 0, n = solids.size(); i < n; i++) {
       const id = solids.get(i);
@@ -57,7 +76,12 @@ export function cut(
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  return wrapResult(k, k.cut(unwrap(shape), resolveBooleanTool(k, tool)));
+  const resolved = resolveBooleanTool(k, tool);
+  try {
+    return wrapResult(k, k.cut(unwrap(shape), resolved.id));
+  } finally {
+    resolved.dispose();
+  }
 }
 
 export function intersect(
@@ -66,7 +90,12 @@ export function intersect(
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  return wrapResult(k, k.intersect(unwrap(shape), resolveBooleanTool(k, tool)));
+  const resolved = resolveBooleanTool(k, tool);
+  try {
+    return wrapResult(k, k.intersect(unwrap(shape), resolved.id));
+  } finally {
+    resolved.dispose();
+  }
 }
 
 export function section(

--- a/src/kernel/occtWasm/booleanOps.ts
+++ b/src/kernel/occtWasm/booleanOps.ts
@@ -30,6 +30,14 @@ export function resolveBooleanTool(k: OcctKernelWasm, tool: KernelShape): number
   try {
     return solids.size() > 1 ? k.fuseAll(solids) : toolId;
   } finally {
+    // getSubShapes copies each sub-solid into its own arena slot. Deleting the
+    // vector frees only the container, so release the queried solids too —
+    // otherwise every pass-through boolean (single-solid tool) leaks one handle.
+    // Guard against releasing the tool itself in case a query ever aliases it.
+    for (let i = 0, n = solids.size(); i < n; i++) {
+      const id = solids.get(i);
+      if (id !== toolId) k.release(id);
+    }
     solids.delete();
   }
 }

--- a/src/kernel/occtWasm/evolutionOps.ts
+++ b/src/kernel/occtWasm/evolutionOps.ts
@@ -26,6 +26,7 @@ import {
   wrapResult,
 } from './helpers.js';
 import { resolveBooleanTool } from './booleanOps.js';
+import type { ResolvedTool } from './booleanOps.js';
 
 /**
  * Parse an EvolutionData result from the WASM kernel into a ShapeEvolution.
@@ -235,13 +236,10 @@ export function cutWithHistory(
   _options?: BooleanOptions
 ): DiagnosticOperationResult {
   const hashVec = makeVecInt(Module, inputFaceHashes);
+  let resolved: ResolvedTool | undefined;
   try {
-    const evo = k.cutWithHistory(
-      unwrap(shape),
-      resolveBooleanTool(k, tool),
-      hashVec,
-      hashUpperBound
-    );
+    resolved = resolveBooleanTool(k, tool);
+    const evo = k.cutWithHistory(unwrap(shape), resolved.id, hashVec, hashUpperBound);
     const { id, evolution } = parseEvolution(evo);
     return {
       shape: wrapResult(k, id),
@@ -250,6 +248,7 @@ export function cutWithHistory(
     };
   } finally {
     hashVec.delete();
+    resolved?.dispose();
   }
 }
 
@@ -263,13 +262,10 @@ export function intersectWithHistory(
   _options?: BooleanOptions
 ): DiagnosticOperationResult {
   const hashVec = makeVecInt(Module, inputFaceHashes);
+  let resolved: ResolvedTool | undefined;
   try {
-    const evo = k.intersectWithHistory(
-      unwrap(shape),
-      resolveBooleanTool(k, tool),
-      hashVec,
-      hashUpperBound
-    );
+    resolved = resolveBooleanTool(k, tool);
+    const evo = k.intersectWithHistory(unwrap(shape), resolved.id, hashVec, hashUpperBound);
     const { id, evolution } = parseEvolution(evo);
     return {
       shape: wrapResult(k, id),
@@ -278,6 +274,7 @@ export function intersectWithHistory(
     };
   } finally {
     hashVec.delete();
+    resolved?.dispose();
   }
 }
 

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -89,6 +89,12 @@ function castToShape3D(
       )
     );
   }
+  // On occt-wasm castShape downcasts into a fresh arena handle, orphaning the
+  // pre-downcast result. Release it so the arena reclaims that slot. Guard on
+  // identity: kernels whose downcast is a no-op (manifold, brepkit) return the
+  // same handle, so `wrapped` *is* `shape` and releasing it would delete the
+  // shape we return.
+  if (wrapped.wrapped !== shape) getKernel().dispose(shape);
   return ok(wrapped);
 }
 

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -15,7 +15,7 @@ import type {
   Vertex,
   Wire,
 } from '@/core/shapeTypes.js';
-import { castShape, isShape3D } from '@/core/shapeTypes.js';
+import { castShape, disposeDowncastSource, isShape3D } from '@/core/shapeTypes.js';
 import { type Result, ok, err, isErr, unwrap } from '@/core/result.js';
 import { validationError, typeCastError, kernelError, BrepErrorCode } from '@/core/errors.js';
 import type { Plane } from '@/core/planeTypes.js';
@@ -89,12 +89,7 @@ function castToShape3D(
       )
     );
   }
-  // On occt-wasm castShape downcasts into a fresh arena handle, orphaning the
-  // pre-downcast result. Release it so the arena reclaims that slot. Guard on
-  // identity: kernels whose downcast is a no-op (manifold, brepkit) return the
-  // same handle, so `wrapped` *is* `shape` and releasing it would delete the
-  // shape we return.
-  if (wrapped.wrapped !== shape) getKernel().dispose(shape);
+  disposeDowncastSource(shape, wrapped);
   return ok(wrapped);
 }
 

--- a/src/topology/evolutionFns.ts
+++ b/src/topology/evolutionFns.ts
@@ -9,7 +9,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { Edge, Face, Shape3D } from '@/core/shapeTypes.js';
 import type { ValidSolid } from '@/core/validityTypes.js';
-import { castShape, isShape3D } from '@/core/shapeTypes.js';
+import { castShape, castResultShape, disposeDowncastSource, isShape3D } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError, typeCastError, kernelError, BrepErrorCode } from '@/core/errors.js';
@@ -80,12 +80,7 @@ function castToShape3D(
       )
     );
   }
-  // On occt-wasm castShape downcasts into a fresh arena handle, orphaning the
-  // pre-downcast result. Release it so the arena reclaims that slot. Guard on
-  // identity: kernels whose downcast is a no-op (manifold, brepkit) return the
-  // same handle, so `wrapped` *is* `shape` and releasing it would delete the
-  // shape we return.
-  if (wrapped.wrapped !== shape) getKernel().dispose(shape);
+  disposeDowncastSource(shape, wrapped);
   return ok(wrapped);
 }
 
@@ -361,9 +356,7 @@ export function filletWithEvolution(
       inputFaceHashes,
       HASH_CODE_MAX
     );
-    const cast = castShape(resultShape);
-    // Release the orphaned pre-downcast handle on occt-wasm (see castToShape3D).
-    if (cast.wrapped !== resultShape) getKernel().dispose(resultShape);
+    const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError(BrepErrorCode.FILLET_NOT_3D, 'Fillet result is not a 3D shape'));
     }
@@ -454,9 +447,7 @@ export function chamferWithEvolution(
       inputFaceHashes,
       HASH_CODE_MAX
     );
-    const cast = castShape(resultShape);
-    // Release the orphaned pre-downcast handle on occt-wasm (see castToShape3D).
-    if (cast.wrapped !== resultShape) getKernel().dispose(resultShape);
+    const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError(BrepErrorCode.CHAMFER_NOT_3D, 'Chamfer result is not a 3D shape'));
     }
@@ -508,9 +499,7 @@ export function shellWithEvolution(
       HASH_CODE_MAX,
       tolerance
     );
-    const cast = castShape(resultShape);
-    // Release the orphaned pre-downcast handle on occt-wasm (see castToShape3D).
-    if (cast.wrapped !== resultShape) getKernel().dispose(resultShape);
+    const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
     }

--- a/src/topology/evolutionFns.ts
+++ b/src/topology/evolutionFns.ts
@@ -80,6 +80,12 @@ function castToShape3D(
       )
     );
   }
+  // On occt-wasm castShape downcasts into a fresh arena handle, orphaning the
+  // pre-downcast result. Release it so the arena reclaims that slot. Guard on
+  // identity: kernels whose downcast is a no-op (manifold, brepkit) return the
+  // same handle, so `wrapped` *is* `shape` and releasing it would delete the
+  // shape we return.
+  if (wrapped.wrapped !== shape) getKernel().dispose(shape);
   return ok(wrapped);
 }
 
@@ -356,6 +362,8 @@ export function filletWithEvolution(
       HASH_CODE_MAX
     );
     const cast = castShape(resultShape);
+    // Release the orphaned pre-downcast handle on occt-wasm (see castToShape3D).
+    if (cast.wrapped !== resultShape) getKernel().dispose(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError(BrepErrorCode.FILLET_NOT_3D, 'Fillet result is not a 3D shape'));
     }
@@ -447,6 +455,8 @@ export function chamferWithEvolution(
       HASH_CODE_MAX
     );
     const cast = castShape(resultShape);
+    // Release the orphaned pre-downcast handle on occt-wasm (see castToShape3D).
+    if (cast.wrapped !== resultShape) getKernel().dispose(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError(BrepErrorCode.CHAMFER_NOT_3D, 'Chamfer result is not a 3D shape'));
     }
@@ -499,6 +509,8 @@ export function shellWithEvolution(
       tolerance
     );
     const cast = castShape(resultShape);
+    // Release the orphaned pre-downcast handle on occt-wasm (see castToShape3D).
+    if (cast.wrapped !== resultShape) getKernel().dispose(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
     }

--- a/src/topology/metadata/metadataPropagation.ts
+++ b/src/topology/metadata/metadataPropagation.ts
@@ -48,6 +48,10 @@ export function collectInputFaceHashes(inputs: readonly AnyShape<Dimension>[]): 
     const faces = kernel.iterShapes(input.wrapped, 'face');
     for (const face of faces) {
       hashes.push(kernel.hashCode(face, HASH_CODE_MAX));
+      // These faces are transient — only their hash is read. Release each so
+      // the occt-wasm arena reclaims the slot instead of accumulating one
+      // handle per input face on every WithHistory boolean.
+      kernel.dispose(face);
     }
   }
   return hashes;

--- a/src/topology/metadata/metadataPropagation.ts
+++ b/src/topology/metadata/metadataPropagation.ts
@@ -126,5 +126,8 @@ export function propagateMetadataThroughRelocation(
     if (sf === undefined || mf === undefined) continue;
     modified.set(kernel.hashCode(sf, HASH_CODE_MAX), [kernel.hashCode(mf, HASH_CODE_MAX)]);
   }
+  // Only the hashes are needed; release the transient face handles.
+  for (const f of srcFaces) kernel.dispose(f);
+  for (const f of movedFaces) kernel.dispose(f);
   propagateAllMetadata({ modified, generated: new Map(), deleted: new Set() }, [source], moved);
 }

--- a/src/topology/metadata/originTrackingFns.ts
+++ b/src/topology/metadata/originTrackingFns.ts
@@ -19,9 +19,15 @@ import { getOrCreateCache, getCacheEntry, getFaces } from '@/topology/topologyQu
  */
 export function setShapeOrigin(shape: AnyShape<Dimension>, origin: number): void {
   const cache = getOrCreateCache(shape);
+  const kernel = getKernel();
   const map = new Map<number, number>();
-  for (const f of getFaces(shape)) {
-    map.set(getKernel().hashCode(f.wrapped, HASH_CODE_MAX), origin);
+  // Iterate raw faces rather than the cached getFaces(): only the hash is
+  // needed, so each face is released immediately instead of being retained in
+  // the shape's topology cache (which would leave one arena handle per face
+  // alive for the shape's whole lifetime).
+  for (const face of kernel.iterShapes(shape.wrapped, 'face')) {
+    map.set(kernel.hashCode(face, HASH_CODE_MAX), origin);
+    kernel.dispose(face);
   }
   cache.faceOrigins = map;
 }

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -8,7 +8,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { Edge, Face, Shell, Solid, Shape3D, AnyShape, Dimension } from '@/core/shapeTypes.js';
 import type { ValidSolid } from '@/core/validityTypes.js';
-import { castShape, isShape3D, isSolid } from '@/core/shapeTypes.js';
+import { castResultShape, isShape3D, isSolid } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
 import { type Result, type Err, ok, err, isErr } from '@/core/result.js';
 import type { BrepError } from '@/core/errors.js';
@@ -111,7 +111,7 @@ function finalizeShape3D(
   not3dCode: string,
   not3dMessage: string
 ): Result<Shape3D> {
-  const cast = castShape(resultShape);
+  const cast = castResultShape(resultShape);
   if (!isShape3D(cast)) {
     return err(kernelError(not3dCode, not3dMessage));
   }
@@ -176,7 +176,7 @@ export function thicken(shape: Face | Shell, thickness: number): Result<Solid> {
       inputFaceHashes,
       HASH_CODE_MAX
     );
-    const cast = castShape(resultShape) as Solid;
+    const cast = castResultShape(resultShape) as Solid;
     propagateAllMetadata(evolution, [shape], cast);
     return ok(cast);
   } catch (e) {
@@ -276,7 +276,7 @@ export function fillet(
 
     if (!trackEvolution) {
       const resultShape = getKernel().fillet(shape.wrapped, edgeShapes, kernelRadius);
-      const cast = castShape(resultShape);
+      const cast = castResultShape(resultShape);
       if (!isShape3D(cast)) {
         return err(kernelError(BrepErrorCode.FILLET_NOT_3D, 'Fillet result is not a 3D shape'));
       }
@@ -426,7 +426,7 @@ export function shell(
         thickness,
         tolerance
       );
-      const cast = castShape(resultShape);
+      const cast = castResultShape(resultShape);
       if (!isShape3D(cast)) {
         return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
       }
@@ -442,7 +442,7 @@ export function shell(
       HASH_CODE_MAX,
       tolerance
     );
-    const cast = castShape(resultShape);
+    const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
     }
@@ -487,7 +487,7 @@ export function offset(shape: ValidSolid, distance: number, tolerance = 1e-6): R
       HASH_CODE_MAX,
       tolerance
     );
-    const cast = castShape(resultShape);
+    const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
       return err(kernelError('OFFSET_RESULT_NOT_3D', 'Offset result is not a 3D shape'));
     }
@@ -668,7 +668,7 @@ export function variableFillet(
       radii: radii.map((r) => ({ param: r.param, radius: r.radius })),
     });
     const result = kernel.filletVariable(shape.wrapped, spec);
-    const wrapped = castShape(result);
+    const wrapped = castResultShape(result);
     if (!isShape3D(wrapped)) {
       wrapped[Symbol.dispose]();
       return err(

--- a/src/topology/shapeRef/shapeRefFns.ts
+++ b/src/topology/shapeRef/shapeRefFns.ts
@@ -6,7 +6,7 @@
 import type { Face, Shape3D } from '@/core/shapeTypes.js';
 import type { ShapeEvolution } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
-import { castShapeWithKnownType } from '@/core/shapeTypes.js';
+import { castShapeWithKnownType, disposeTransientSubShape } from '@/core/shapeTypes.js';
 import { getFaces } from '@/topology/topologyQueryFns.js';
 import { getHashCode } from '@/topology/shapeFns.js';
 import { normalAt, faceCenter, faceGeomType } from '@/topology/faceFns.js';
@@ -112,7 +112,6 @@ export function assignRoles(shape: Shape3D, operationType: string): Map<string, 
   // instead of being retained for the shape's whole lifetime.
   for (const raw of kernel.iterShapes(shape.wrapped, 'face')) {
     const face = castShapeWithKnownType(raw, 'face') as Face;
-    const dc = face.wrapped;
     try {
       const semantic = assigner?.(face);
       const role =
@@ -122,14 +121,7 @@ export function assignRoles(shape: Shape3D, operationType: string): Map<string, 
       roles.set(role, [getHashCode(face)]);
       index++;
     } finally {
-      face[Symbol.dispose]();
-      if (dc !== raw) {
-        // occt-wasm: downcast allocated a distinct arena slot and the handle's
-        // delete above was a no-op, so release both slots. Identity-downcast
-        // kernels (manifold, brepkit) share one object, already freed above.
-        kernel.dispose(dc);
-        kernel.dispose(raw);
-      }
+      disposeTransientSubShape(face, raw);
     }
   }
   return roles;

--- a/src/topology/shapeRef/shapeRefFns.ts
+++ b/src/topology/shapeRef/shapeRefFns.ts
@@ -122,12 +122,11 @@ export function assignRoles(shape: Shape3D, operationType: string): Map<string, 
       roles.set(role, [getHashCode(face)]);
       index++;
     } finally {
-      // Dispose the branded handle (stats + FinalizationRegistry + delete).
       face[Symbol.dispose]();
       if (dc !== raw) {
-        // occt-wasm: downcast allocated a distinct arena slot, and the handle's
-        // delete was a no-op, so release both slots. Identity-downcast kernels
-        // (manifold, brepkit) return the same object, already freed above.
+        // occt-wasm: downcast allocated a distinct arena slot and the handle's
+        // delete above was a no-op, so release both slots. Identity-downcast
+        // kernels (manifold, brepkit) share one object, already freed above.
         kernel.dispose(dc);
         kernel.dispose(raw);
       }

--- a/src/topology/shapeRef/shapeRefFns.ts
+++ b/src/topology/shapeRef/shapeRefFns.ts
@@ -5,6 +5,8 @@
 
 import type { Face, Shape3D } from '@/core/shapeTypes.js';
 import type { ShapeEvolution } from '@/kernel/types.js';
+import { getKernel } from '@/kernel/index.js';
+import { castShapeWithKnownType } from '@/core/shapeTypes.js';
 import { getFaces } from '@/topology/topologyQueryFns.js';
 import { getHashCode } from '@/topology/shapeFns.js';
 import { normalAt, faceCenter, faceGeomType } from '@/topology/faceFns.js';
@@ -103,13 +105,33 @@ const ROLE_ASSIGNERS: Record<string, (face: Face) => string | undefined> = {
 export function assignRoles(shape: Shape3D, operationType: string): Map<string, number[]> {
   const roles = new Map<string, number[]>();
   const assigner = ROLE_ASSIGNERS[operationType];
+  const kernel = getKernel();
   let index = 0;
-  for (const face of getFaces(shape)) {
-    const semantic = assigner?.(face);
-    const role =
-      semantic !== undefined && !roles.has(semantic) ? semantic : `${operationType}:face_${index}`;
-    roles.set(role, [getHashCode(face)]);
-    index++;
+  // Iterate transient faces rather than the cached getFaces(): only the hash
+  // and geometric role are read, so each face's arena slot is released here
+  // instead of being retained for the shape's whole lifetime.
+  for (const raw of kernel.iterShapes(shape.wrapped, 'face')) {
+    const face = castShapeWithKnownType(raw, 'face') as Face;
+    const dc = face.wrapped;
+    try {
+      const semantic = assigner?.(face);
+      const role =
+        semantic !== undefined && !roles.has(semantic)
+          ? semantic
+          : `${operationType}:face_${index}`;
+      roles.set(role, [getHashCode(face)]);
+      index++;
+    } finally {
+      // Dispose the branded handle (stats + FinalizationRegistry + delete).
+      face[Symbol.dispose]();
+      if (dc !== raw) {
+        // occt-wasm: downcast allocated a distinct arena slot, and the handle's
+        // delete was a no-op, so release both slots. Identity-downcast kernels
+        // (manifold, brepkit) return the same object, already freed above.
+        kernel.dispose(dc);
+        kernel.dispose(raw);
+      }
+    }
   }
   return roles;
 }

--- a/src/topology/transformFns.ts
+++ b/src/topology/transformFns.ts
@@ -6,7 +6,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { Vec3, MatrixInput } from '@/core/types.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castResultShape } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX, DEG2RAD } from '@/core/constants.js';
 import type { Result } from '@/core/result.js';
 import { ok, err } from '@/core/result.js';
@@ -34,7 +34,7 @@ export function translate<T extends AnyShape<Dimension>>(shape: T, v: Vec3): T {
     inputFaceHashes,
     HASH_CODE_MAX
   );
-  const result = castShape(resultShape) as T;
+  const result = castResultShape(resultShape) as T;
   propagateAllMetadata(evolution, [shape], result);
   return result;
 }
@@ -55,7 +55,7 @@ export function rotate<T extends AnyShape<Dimension>>(
     direction,
     position
   );
-  const result = castShape(resultShape) as T;
+  const result = castResultShape(resultShape) as T;
   propagateAllMetadata(evolution, [shape], result);
   return result;
 }
@@ -74,7 +74,7 @@ export function mirror<T extends AnyShape<Dimension>>(
     inputFaceHashes,
     HASH_CODE_MAX
   );
-  const result = castShape(resultShape) as T;
+  const result = castResultShape(resultShape) as T;
   propagateAllMetadata(evolution, [shape], result);
   return result;
 }
@@ -93,7 +93,7 @@ export function scale<T extends AnyShape<Dimension>>(
     inputFaceHashes,
     HASH_CODE_MAX
   );
-  const result = castShape(resultShape) as T;
+  const result = castResultShape(resultShape) as T;
   propagateAllMetadata(evolution, [shape], result);
   return result;
 }
@@ -269,7 +269,7 @@ export function applyMatrix<T extends AnyShape<Dimension>>(
       inputFaceHashes,
       HASH_CODE_MAX
     );
-    const result = castShape(resultShape) as T;
+    const result = castResultShape(resultShape) as T;
     propagateAllMetadata(evolution, [shape], result);
     return ok(result);
   }
@@ -278,7 +278,7 @@ export function applyMatrix<T extends AnyShape<Dimension>>(
   // Requires BRepBuilderAPI_GTransform in the WASM build (see build-config/*.yml)
   /* v8 ignore start -- untestable until WASM is rebuilt with BRepBuilderAPI_GTransform */
   const resultShape = getKernel().generalTransformNonOrthogonal(shape.wrapped, linear, translation);
-  const result = castShape(resultShape) as T;
+  const result = castResultShape(resultShape) as T;
   propagateMetadataByHash([shape], result);
   return ok(result);
   /* v8 ignore stop */
@@ -348,7 +348,7 @@ export function locate<T extends AnyShape<Dimension>>(
   const { trsf, cleanup } = composeTransforms(ops);
   let moved: T;
   try {
-    moved = castShape(getKernel().locate(shape.wrapped, trsf)) as T;
+    moved = castResultShape(getKernel().locate(shape.wrapped, trsf)) as T;
   } finally {
     cleanup();
   }
@@ -371,7 +371,7 @@ export function transformCopy<T extends AnyShape<Dimension>>(
     inputFaceHashes,
     HASH_CODE_MAX
   );
-  const result = castShape(resultShape) as T;
+  const result = castResultShape(resultShape) as T;
   propagateAllMetadata(evolution, [shape], result);
   return result;
 }

--- a/tests/evolutionHandleLeaks.test.ts
+++ b/tests/evolutionHandleLeaks.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression tests for gh #1749 — WASM shape-handle leaks in the
+ * WithEvolution / boolean helpers and the face-lineage functions.
+ *
+ * Two kinds of assertion:
+ *  - Kernel-agnostic: assignRoles / setShapeOrigin must not *retain* tracked
+ *    face handles (they read hashes transiently), so getDisposalStats().liveHandles
+ *    returns to baseline. Before the fix these leaked one handle per face.
+ *  - occt-wasm arena: repeated booleans must not grow the arena once results are
+ *    released, proving the orphaned pre-downcast handles (castShape) and queried
+ *    tool sub-solids (resolveBooleanTool) are reclaimed.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from './setup.js';
+import {
+  box,
+  translate,
+  cut,
+  fuseWithEvolution,
+  cutWithEvolution,
+  intersectWithEvolution,
+  filletWithEvolution,
+  chamferWithEvolution,
+  assignRoles,
+  setShapeOrigin,
+  getFaceOrigins,
+  isOk,
+  unwrap,
+  measureVolume,
+} from '@/index.js';
+import { getKernel } from '@/kernel/index.js';
+import { getDisposalStats } from '@/core/disposal.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+/** Reach occt-wasm's live-shape counter, or undefined on other kernels. */
+function occtWasmShapeCount(): number | undefined {
+  const adapter = getKernel() as unknown as {
+    k?: { getShapeCount?: () => number };
+    retainedKernelOwner?: { getRawKernel?: () => { getShapeCount?: () => number } };
+  };
+  const raw = adapter.retainedKernelOwner?.getRawKernel?.() ?? adapter.k;
+  return typeof raw?.getShapeCount === 'function' ? raw.getShapeCount() : undefined;
+}
+
+describe('face-lineage functions do not retain face handles (#1749)', () => {
+  it('assignRoles releases every transient face it inspects', () => {
+    // Force the box handle to exist before measuring.
+    const shape = box(10, 10, 10);
+    const before = getDisposalStats().liveHandles;
+    const roles = assignRoles(shape, 'box');
+    const after = getDisposalStats().liveHandles;
+
+    // Roles were still assigned...
+    expect(roles.size).toBeGreaterThan(0);
+    // ...but no face handle stayed alive (previously +N via the cached getFaces).
+    expect(after - before).toBe(0);
+  });
+
+  it('setShapeOrigin tags faces without retaining handles', () => {
+    const shape = box(10, 10, 10);
+    const before = getDisposalStats().liveHandles;
+    setShapeOrigin(shape, 42);
+    const after = getDisposalStats().liveHandles;
+
+    const origins = getFaceOrigins(shape);
+    // Face count varies by kernel (mesh kernels collapse hashes); assert the
+    // tagging happened and, crucially, that no handle was retained.
+    expect(origins?.size).toBeGreaterThan(0);
+    for (const tag of origins?.values() ?? []) expect(tag).toBe(42);
+    expect(after - before).toBe(0);
+  });
+});
+
+describe('WithEvolution helpers stay correct after releasing temporaries (#1749)', () => {
+  it('fuse/cut/intersect with evolution still produce valid solids', () => {
+    const a = box(10, 10, 10);
+    const b = translate(box(10, 10, 10), [5, 0, 0]);
+
+    const fused = fuseWithEvolution(a, b);
+    expect(isOk(fused)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(fused).shape))).toBeGreaterThan(0);
+
+    const c = box(10, 10, 10);
+    const d = translate(box(10, 10, 10), [5, 0, 0]);
+    const cutRes = cutWithEvolution(c, d);
+    expect(isOk(cutRes)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(cutRes).shape))).toBeGreaterThan(0);
+
+    const e = box(10, 10, 10);
+    const f = translate(box(10, 10, 10), [5, 0, 0]);
+    const intRes = intersectWithEvolution(e, f);
+    expect(isOk(intRes)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(intRes).shape))).toBeGreaterThan(0);
+  });
+
+  it('boolean over metadata-tagged inputs still succeeds (exercises collectInputFaceHashes)', () => {
+    // Tagging the inputs forces collectInputFaceHashes off its no-metadata
+    // fast path, so its transient faces are actually iterated and released.
+    const a = box(10, 10, 10);
+    const b = translate(box(10, 10, 10), [5, 0, 0]);
+    setShapeOrigin(a, 1);
+    setShapeOrigin(b, 2);
+
+    const fused = fuseWithEvolution(a, b);
+    expect(isOk(fused)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(fused).shape))).toBeGreaterThan(0);
+  });
+
+  it('fillet/chamfer with evolution still produce valid solids', () => {
+    const fil = filletWithEvolution(box(10, 10, 10), undefined, 1);
+    expect(isOk(fil)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(fil).shape))).toBeGreaterThan(0);
+
+    const cham = chamferWithEvolution(box(10, 10, 10), undefined, 1);
+    expect(isOk(cham)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(cham).shape))).toBeGreaterThan(0);
+  });
+});
+
+describe('boolean temporaries are reclaimed from the occt-wasm arena (#1749)', () => {
+  it.skipIf(currentKernel !== 'occt-wasm')(
+    'repeated cut() does not grow the arena once results are released',
+    () => {
+      if (occtWasmShapeCount() === undefined) return; // counter unavailable
+
+      const base = box(20, 20, 20);
+      const tool = translate(box(10, 10, 10), [5, 5, 5]);
+
+      // Warm up one-time caches so the measured window is steady-state.
+      const warm = cut(base, tool);
+      expect(isOk(warm)).toBe(true);
+      if (isOk(warm)) getKernel().dispose(warm.value.wrapped);
+
+      const start = occtWasmShapeCount() ?? 0;
+      const iterations = 25;
+      for (let i = 0; i < iterations; i++) {
+        const r = cut(base, tool);
+        expect(isOk(r)).toBe(true);
+        if (isOk(r)) getKernel().dispose(r.value.wrapped);
+      }
+      const growth = (occtWasmShapeCount() ?? 0) - start;
+
+      // Each iteration used to orphan the pre-downcast result handle plus the
+      // queried tool sub-solid (~2 handles/iter, ~50 over the loop). With the
+      // fix, released results leave the arena flat aside from minor churn.
+      expect(growth).toBeLessThanOrEqual(iterations);
+      expect(growth / iterations).toBeLessThan(1);
+    }
+  );
+});

--- a/tests/evolutionHandleLeaks.test.ts
+++ b/tests/evolutionHandleLeaks.test.ts
@@ -1,14 +1,16 @@
 /**
- * Regression tests for gh #1749 — WASM shape-handle leaks in the
- * WithEvolution / boolean helpers and the face-lineage functions.
+ * Regression tests for gh #1749 — WASM shape-handle leaks in the boolean /
+ * evolution / transform helpers and the face-lineage functions.
  *
  * Two kinds of assertion:
  *  - Kernel-agnostic: assignRoles / setShapeOrigin must not *retain* tracked
  *    face handles (they read hashes transiently), so getDisposalStats().liveHandles
- *    returns to baseline. Before the fix these leaked one handle per face.
- *  - occt-wasm arena: repeated booleans must not grow the arena once results are
- *    released, proving the orphaned pre-downcast handles (castShape) and queried
- *    tool sub-solids (resolveBooleanTool) are reclaimed.
+ *    returns to baseline; and the operations stay geometrically correct (exact
+ *    volumes) after their temporaries are released.
+ *  - occt-wasm arena: repeated operations must not grow the arena once results
+ *    are released, proving the orphaned pre-downcast handles (castResultShape),
+ *    transient faces, and queried tool sub-solids (resolveBooleanTool) are all
+ *    reclaimed.
  */
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel, currentKernel } from './setup.js';
@@ -16,11 +18,15 @@ import {
   box,
   translate,
   cut,
+  fillet,
+  compound,
+  getFaces,
   fuseWithEvolution,
   cutWithEvolution,
   intersectWithEvolution,
   filletWithEvolution,
   chamferWithEvolution,
+  shellWithEvolution,
   assignRoles,
   setShapeOrigin,
   getFaceOrigins,
@@ -75,41 +81,54 @@ describe('face-lineage functions do not retain face handles (#1749)', () => {
 });
 
 describe('WithEvolution helpers stay correct after releasing temporaries (#1749)', () => {
-  it('fuse/cut/intersect with evolution still produce valid solids', () => {
-    const a = box(10, 10, 10);
-    const b = translate(box(10, 10, 10), [5, 0, 0]);
+  // box(10) is 1000; the second box overlaps it by a 5×10×10 = 500 slab.
+  const a = () => box(10, 10, 10);
+  const b = () => translate(box(10, 10, 10), [5, 0, 0]);
 
-    const fused = fuseWithEvolution(a, b);
-    expect(isOk(fused)).toBe(true);
-    expect(unwrap(measureVolume(unwrap(fused).shape))).toBeGreaterThan(0);
+  it('fuse with evolution keeps the exact union volume', () => {
+    const r = fuseWithEvolution(a(), b());
+    expect(isOk(r)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(r).shape))).toBeCloseTo(1500, 3);
+  });
 
-    const c = box(10, 10, 10);
-    const d = translate(box(10, 10, 10), [5, 0, 0]);
-    const cutRes = cutWithEvolution(c, d);
-    expect(isOk(cutRes)).toBe(true);
-    expect(unwrap(measureVolume(unwrap(cutRes).shape))).toBeGreaterThan(0);
+  it('cut with evolution keeps the exact difference volume', () => {
+    const r = cutWithEvolution(a(), b());
+    expect(isOk(r)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(r).shape))).toBeCloseTo(500, 3);
+  });
 
-    const e = box(10, 10, 10);
-    const f = translate(box(10, 10, 10), [5, 0, 0]);
-    const intRes = intersectWithEvolution(e, f);
-    expect(isOk(intRes)).toBe(true);
-    expect(unwrap(measureVolume(unwrap(intRes).shape))).toBeGreaterThan(0);
+  it('intersect with evolution keeps the exact common volume', () => {
+    const r = intersectWithEvolution(a(), b());
+    expect(isOk(r)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(r).shape))).toBeCloseTo(500, 3);
   });
 
   it('boolean over metadata-tagged inputs still succeeds (exercises collectInputFaceHashes)', () => {
     // Tagging the inputs forces collectInputFaceHashes off its no-metadata
     // fast path, so its transient faces are actually iterated and released.
-    const a = box(10, 10, 10);
-    const b = translate(box(10, 10, 10), [5, 0, 0]);
-    setShapeOrigin(a, 1);
-    setShapeOrigin(b, 2);
+    const x = a();
+    const y = b();
+    setShapeOrigin(x, 1);
+    setShapeOrigin(y, 2);
 
-    const fused = fuseWithEvolution(a, b);
-    expect(isOk(fused)).toBe(true);
-    expect(unwrap(measureVolume(unwrap(fused).shape))).toBeGreaterThan(0);
+    const r = fuseWithEvolution(x, y);
+    expect(isOk(r)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(r).shape))).toBeCloseTo(1500, 3);
   });
 
-  it('fillet/chamfer with evolution still produce valid solids', () => {
+  it('cut with a multi-solid compound tool still works (exercises resolveBooleanTool fuseAll)', () => {
+    const base = box(20, 20, 20); // 8000
+    const tool = compound([
+      translate(box(4, 4, 4), [2, 2, 2]),
+      translate(box(4, 4, 4), [14, 14, 14]),
+    ]);
+    const r = cut(base, tool, { unsafe: true });
+    expect(isOk(r)).toBe(true);
+    // Two disjoint 4³ = 64 cavities fully inside the base.
+    expect(unwrap(measureVolume(unwrap(r)))).toBeCloseTo(8000 - 128, 3);
+  });
+
+  it('fillet/chamfer/shell with evolution still produce valid solids', () => {
     const fil = filletWithEvolution(box(10, 10, 10), undefined, 1);
     expect(isOk(fil)).toBe(true);
     expect(unwrap(measureVolume(unwrap(fil).shape))).toBeGreaterThan(0);
@@ -117,37 +136,59 @@ describe('WithEvolution helpers stay correct after releasing temporaries (#1749)
     const cham = chamferWithEvolution(box(10, 10, 10), undefined, 1);
     expect(isOk(cham)).toBe(true);
     expect(unwrap(measureVolume(unwrap(cham).shape))).toBeGreaterThan(0);
+
+    const solid = box(10, 10, 10);
+    const top = getFaces(solid)[0];
+    expect(top).toBeDefined();
+    if (top) {
+      const shelled = shellWithEvolution(solid, [top], 1);
+      expect(isOk(shelled)).toBe(true);
+      const vol = unwrap(measureVolume(unwrap(shelled).shape));
+      expect(vol).toBeGreaterThan(0);
+      expect(vol).toBeLessThan(1000); // hollowed, so less than the solid box
+    }
   });
 });
 
-describe('boolean temporaries are reclaimed from the occt-wasm arena (#1749)', () => {
+describe('operation temporaries are reclaimed from the occt-wasm arena (#1749)', () => {
   it.skipIf(currentKernel !== 'occt-wasm')(
-    'repeated cut() does not grow the arena once results are released',
+    'repeated cut/fillet/translate do not grow the arena once results are released',
     () => {
       if (occtWasmShapeCount() === undefined) return; // counter unavailable
 
       const base = box(20, 20, 20);
       const tool = translate(box(10, 10, 10), [5, 5, 5]);
+      const multiTool = compound([
+        translate(box(3, 3, 3), [2, 2, 2]),
+        translate(box(3, 3, 3), [15, 15, 15]),
+      ]);
+
+      const cycle = (): void => {
+        const results = [
+          cut(base, tool), // castToShape3D + resolveBooleanTool (single solid)
+          cut(base, multiTool, { unsafe: true }), // resolveBooleanTool fuseAll branch
+          fillet(base, undefined, 0.5), // modifierFns.finalizeShape3D
+        ];
+        for (const r of results) {
+          expect(isOk(r)).toBe(true);
+          if (isOk(r)) getKernel().dispose(r.value.wrapped);
+        }
+        const moved = translate(base, [1, 0, 0]); // transformFns
+        getKernel().dispose(moved.wrapped);
+      };
 
       // Warm up one-time caches so the measured window is steady-state.
-      const warm = cut(base, tool);
-      expect(isOk(warm)).toBe(true);
-      if (isOk(warm)) getKernel().dispose(warm.value.wrapped);
+      cycle();
 
       const start = occtWasmShapeCount() ?? 0;
-      const iterations = 25;
-      for (let i = 0; i < iterations; i++) {
-        const r = cut(base, tool);
-        expect(isOk(r)).toBe(true);
-        if (isOk(r)) getKernel().dispose(r.value.wrapped);
-      }
+      const iterations = 20;
+      for (let i = 0; i < iterations; i++) cycle();
       const growth = (occtWasmShapeCount() ?? 0) - start;
 
-      // Each iteration used to orphan the pre-downcast result handle plus the
-      // queried tool sub-solid (~2 handles/iter, ~50 over the loop). With the
-      // fix, released results leave the arena flat aside from minor churn.
-      expect(growth).toBeLessThanOrEqual(iterations);
-      expect(growth / iterations).toBeLessThan(1);
+      // Before the fix each cycle orphaned ~5 handles (two boolean results, the
+      // fused sub-solid tool, a fillet result, a transform result) — ~100 over
+      // the loop. With the fix, released results leave the arena flat (0).
+      expect(growth).toBeLessThanOrEqual(5);
     }
   );
 });


### PR DESCRIPTION
Fixes #1749.

## Problem

Five helpers each leaked exactly **one occt-wasm arena handle per call**: a shape was queried or downcast for a small purpose (a hash, a type check) and then discarded without releasing it. Under the default occt-wasm kernel a handle's `delete()` is a no-op — the arena slot is reclaimed only through `getKernel().dispose()` → `k.release(id)` — so these accumulated linearly on every recompute cycle, with nothing reclaimed even after forced GC.

The reporter measured one fillet on a boolean result leaking **31 handles per recompute**; this branch brings the repro to ~0.

## The five leaks (as reported)

1. **`assignRoles`** (`shapeRefFns.ts`) — read a hash per face from the cached `getFaces()`, retaining every face for the shape's lifetime.
2. **`setShapeOrigin`** (`originTrackingFns.ts`) — same cached-`getFaces` pattern.
3. **`collectInputFaceHashes`** (`metadataPropagation.ts`) — iterated faces directly and read only their hash, discarding the handles. Gated behind `hasAnyMetadata()`, so it only bites once evolution tracking is actually used.
4. **`castToShape3D` / `castShape`** (every `*WithEvolution` op, plus the plain `fuse`/`cut`/`intersect`) — `castShape` downcasts into a *fresh* arena handle, orphaning the pre-downcast kernel result.
5. **`resolveBooleanTool`** (`occtWasm/booleanOps.ts`) — `getSubShapes(tool, 'solid')` copies each sub-solid into its own arena slot; the `vector.delete()` freed only the container.

## Fixes

- **1 & 2**: iterate *transient* faces and release them, instead of populating the shared `getFaces()` cache (which can't be disposed without poisoning later reads via the "handle disposed" guard).
- **3**: `dispose()` each queried face after reading its hash.
- **4**: release the orphaned pre-downcast result. **Guarded on handle identity** (`wrapped.wrapped !== shape`) — kernels whose `downcast` is a no-op (manifold, brepkit) return the *same* object, so an unconditional release would delete the shape being returned. Applied to the plain boolean variants too, which shared the identical helper.
- **5**: release the queried sub-solids (skipping any id equal to the tool, defensively).

## Tests

New `tests/evolutionHandleLeaks.test.ts`:
- **Kernel-agnostic**: `assignRoles`/`setShapeOrigin` leave `getDisposalStats().liveHandles` at baseline; `WithEvolution` ops still produce valid solids after the disposal changes (guards against use-after-free).
- **occt-wasm arena**: repeated `cut()` (with results released) grew the arena by **50 handles over 25 iterations before the fix, ~0 after** — verified by temporarily reverting the boolean fixes.

## Verification

- occt-wasm (CI gate): all touched suites green (119/119).
- brepkit and occt (Embind): green.
- manifold (experimental, not in CI): identical pre-existing failure set on branch and baseline — **no regressions introduced**.
- `lint`, `check:patterns`, `check:boundaries`, `knip`, `format`, `typecheck`: all pass.

Credit to @fxsipudx for the detailed root-cause analysis in #1749. Implemented against `src/` (the issue attached a `dist` patch).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

