### PR TITLE
fix(topology): plug error-path handle leaks in not-3D reject branches

### DIFF
--- a/src/core/shapeTypes.ts
+++ b/src/core/shapeTypes.ts
@@ -350,6 +350,18 @@ export function disposeTransientSubShape(handle: ShapeHandle, rawSource: KernelS
 }
 
 /**
+ * Release a branded shape on an error path — when a cast result is rejected and
+ * discarded. Releases the arena slot (occt-wasm's own `delete` is a no-op) then
+ * runs the handle's disposer for stats/registry. Safe on every kernel: the
+ * disposer's `delete()` runs inside createHandle's try/catch, so the repeated
+ * free after `getKernel().dispose()` is swallowed.
+ */
+export function disposeResultShape(handle: ShapeHandle): void {
+  getKernel().dispose(handle.wrapped);
+  handle[Symbol.dispose]();
+}
+
+/**
  * Fast-path cast when the shape type is already known (e.g., from iterShapes).
  * Skips the shapeType() WASM call — only performs downcast + branded handle creation.
  * Used internally by topology extractors for bulk sub-shape iteration.

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -15,7 +15,13 @@ import type {
   Vertex,
   Wire,
 } from '@/core/shapeTypes.js';
-import { castShape, disposeDowncastSource, isShape3D } from '@/core/shapeTypes.js';
+import {
+  castShape,
+  disposeDowncastSource,
+  disposeResultShape,
+  getShapeKind,
+  isShape3D,
+} from '@/core/shapeTypes.js';
 import { type Result, ok, err, isErr, unwrap } from '@/core/result.js';
 import { validationError, typeCastError, kernelError, BrepErrorCode } from '@/core/errors.js';
 import type { Plane } from '@/core/planeTypes.js';
@@ -64,21 +70,9 @@ function castToShape3D(
 ): Result<Shape3D> {
   const wrapped = castShape(shape);
   if (!isShape3D(wrapped)) {
-    // Include actual shape type in error for debugging
-    const shapeType = shape.ShapeType();
-    const typeNames = [
-      'COMPOUND',
-      'COMPSOLID',
-      'SOLID',
-      'SHELL',
-      'FACE',
-      'WIRE',
-      'EDGE',
-      'VERTEX',
-      'SHAPE',
-    ];
-    const typeName = typeNames[shapeType] ?? `UNKNOWN(${shapeType})`;
-    wrapped[Symbol.dispose]();
+    const typeName = getShapeKind(wrapped).toUpperCase();
+    disposeDowncastSource(shape, wrapped);
+    disposeResultShape(wrapped);
     return err(
       typeCastError(
         errorCode,

--- a/src/topology/evolutionFns.ts
+++ b/src/topology/evolutionFns.ts
@@ -9,7 +9,14 @@
 import { getKernel } from '@/kernel/index.js';
 import type { Edge, Face, Shape3D } from '@/core/shapeTypes.js';
 import type { ValidSolid } from '@/core/validityTypes.js';
-import { castShape, castResultShape, disposeDowncastSource, isShape3D } from '@/core/shapeTypes.js';
+import {
+  castShape,
+  castResultShape,
+  disposeDowncastSource,
+  disposeResultShape,
+  getShapeKind,
+  isShape3D,
+} from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError, typeCastError, kernelError, BrepErrorCode } from '@/core/errors.js';
@@ -56,20 +63,9 @@ function castToShape3D(
 ): Result<Shape3D> {
   const wrapped = castShape(shape);
   if (!isShape3D(wrapped)) {
-    const shapeType = shape.ShapeType();
-    const typeNames = [
-      'COMPOUND',
-      'COMPSOLID',
-      'SOLID',
-      'SHELL',
-      'FACE',
-      'WIRE',
-      'EDGE',
-      'VERTEX',
-      'SHAPE',
-    ];
-    const typeName = typeNames[shapeType] ?? `UNKNOWN(${shapeType})`;
-    wrapped[Symbol.dispose]();
+    const typeName = getShapeKind(wrapped).toUpperCase();
+    disposeDowncastSource(shape, wrapped);
+    disposeResultShape(wrapped);
     return err(
       typeCastError(
         errorCode,
@@ -358,6 +354,7 @@ export function filletWithEvolution(
     );
     const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
+      disposeResultShape(cast);
       return err(kernelError(BrepErrorCode.FILLET_NOT_3D, 'Fillet result is not a 3D shape'));
     }
     propagateAllMetadata(evolution, [shape], cast);
@@ -449,6 +446,7 @@ export function chamferWithEvolution(
     );
     const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
+      disposeResultShape(cast);
       return err(kernelError(BrepErrorCode.CHAMFER_NOT_3D, 'Chamfer result is not a 3D shape'));
     }
     propagateAllMetadata(evolution, [shape], cast);
@@ -501,6 +499,7 @@ export function shellWithEvolution(
     );
     const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
+      disposeResultShape(cast);
       return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
     }
     propagateAllMetadata(evolution, [shape], cast);

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -8,7 +8,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { Edge, Face, Shell, Solid, Shape3D, AnyShape, Dimension } from '@/core/shapeTypes.js';
 import type { ValidSolid } from '@/core/validityTypes.js';
-import { castResultShape, isShape3D, isSolid } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isShape3D, isSolid } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
 import { type Result, type Err, ok, err, isErr } from '@/core/result.js';
 import type { BrepError } from '@/core/errors.js';
@@ -113,6 +113,7 @@ function finalizeShape3D(
 ): Result<Shape3D> {
   const cast = castResultShape(resultShape);
   if (!isShape3D(cast)) {
+    disposeResultShape(cast);
     return err(kernelError(not3dCode, not3dMessage));
   }
   propagateAllMetadata(evolution, inputs, cast);
@@ -670,7 +671,7 @@ export function variableFillet(
     const result = kernel.filletVariable(shape.wrapped, spec);
     const wrapped = castResultShape(result);
     if (!isShape3D(wrapped)) {
-      wrapped[Symbol.dispose]();
+      disposeResultShape(wrapped);
       return err(
         kernelError(
           BrepErrorCode.VARIABLE_FILLET_FAILED,
@@ -679,7 +680,7 @@ export function variableFillet(
       );
     }
     if (!isSolid(wrapped)) {
-      wrapped[Symbol.dispose]();
+      disposeResultShape(wrapped);
       return err(
         kernelError(
           BrepErrorCode.VARIABLE_FILLET_FAILED,

--- a/tests/errorPathDisposal.test.ts
+++ b/tests/errorPathDisposal.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression tests for gh #1753 — the not-3D / not-Solid error branches of the
+ * boolean/evolution/modifier ops leaked the rejected cast result on occt-wasm
+ * (a handle's own delete() is a no-op there). The fix routes those branches
+ * through disposeResultShape(), which releases the arena slot.
+ *
+ * The not-3D branches can't be triggered deterministically from geometry (valid
+ * booleans/fillets always produce 3D), so these tests exercise the disposal
+ * mechanism directly: arena reclamation on occt-wasm, and cross-kernel safety.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from './setup.js';
+import { box } from '@/index.js';
+import { getKernel } from '@/kernel/index.js';
+import { disposeResultShape } from '@/core/shapeTypes.js';
+import { getDisposalStats } from '@/core/disposal.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+/** Reach occt-wasm's live-shape counter, or undefined on other kernels. */
+function occtWasmShapeCount(): number | undefined {
+  const adapter = getKernel() as unknown as {
+    k?: { getShapeCount?: () => number };
+    retainedKernelOwner?: { getRawKernel?: () => { getShapeCount?: () => number } };
+  };
+  const raw = adapter.retainedKernelOwner?.getRawKernel?.() ?? adapter.k;
+  return typeof raw?.getShapeCount === 'function' ? raw.getShapeCount() : undefined;
+}
+
+describe('disposeResultShape (#1753)', () => {
+  it('marks the handle disposed and updates stats, on every kernel', () => {
+    const s = box(5, 5, 5);
+    const before = getDisposalStats().liveHandles;
+    disposeResultShape(s);
+    expect(s.disposed).toBe(true);
+    expect(getDisposalStats().liveHandles).toBe(before - 1);
+  });
+
+  it.skipIf(currentKernel !== 'occt-wasm')('reclaims the arena slot on occt-wasm', () => {
+    const before = occtWasmShapeCount();
+    if (before === undefined) return;
+
+    const s = box(5, 5, 5);
+    expect((occtWasmShapeCount() ?? 0) > before).toBe(true); // slot allocated
+
+    disposeResultShape(s);
+    expect(occtWasmShapeCount()).toBe(before); // slot reclaimed
+  });
+
+  it.skipIf(currentKernel !== 'occt-wasm')(
+    'repeated allocate + disposeResultShape does not grow the arena',
+    () => {
+      if (occtWasmShapeCount() === undefined) return;
+      const start = occtWasmShapeCount() ?? 0;
+      for (let i = 0; i < 25; i++) disposeResultShape(box(3, 3, 3));
+      expect((occtWasmShapeCount() ?? 0) - start).toBeLessThanOrEqual(1);
+    }
+  );
+});


### PR DESCRIPTION
Fixes #1753 (follow-up to #1749 / #1750).

## Problem

#1750 released the orphaned pre-downcast handle on the **success** path of the boolean/evolution/modifier ops, but their **not-3D / not-Solid reject branches** still leaked:

- `wrapped[Symbol.dispose]()` is a **no-op on occt-wasm's arena**, so the rejected downcast (and, in `castToShape3D`, the pre-downcast source, which is only released on success) leaked one handle each.
- `castToShape3D` built its error message with `shape.ShapeType()` on the **raw** kernel result — an occt-wasm arena handle has **no `ShapeType` method**, so if that branch were ever reached it threw `TypeError: shape.ShapeType is not a function` instead of returning the intended `typeCastError`.

## Fix

- Add **`disposeResultShape(handle)`** (`core/shapeTypes.ts`): release the arena slot via `getKernel().dispose(handle.wrapped)`, then run the handle's disposer for stats/registry. Safe on every kernel (the disposer's `delete()` runs inside `createHandle`'s try/catch).
- **`castToShape3D`** (`booleanFns`, `evolutionFns`): release both the source (`disposeDowncastSource`) and the downcast (`disposeResultShape`) on the reject branch, and derive the type name from **`getShapeKind(wrapped)`** (kernel-agnostic, cached) instead of `shape.ShapeType()`.
- **`fillet`/`chamfer`/`shell` WithEvolution**, **`finalizeShape3D`** (plain fillet/chamfer/draft), and **`filletVariable`**: dispose the rejected cast via `disposeResultShape`.

## Tests

The not-3D branches aren't reachable from valid geometry (booleans/fillets always produce 3D; I verified a face-touching intersect returns an empty-but-valid 3D compound, not a face). So `tests/errorPathDisposal.test.ts` exercises the mechanism directly: `disposeResultShape` reclaims the occt-wasm arena slot, keeps `liveHandles` balanced, and is safe on all four kernels.

## Verification

- Full occt-wasm suite green (**4647 passed**); brepkit + occt(Embind) green.
- lint / check:patterns / check:boundaries / knip / format / typecheck all pass.

## Scope

This PR finishes the ops #1750 already made success-safe. The **broader migration** — the remaining ops (`minkowskiFns`, `chamferAngleFns`, `polyhedronFns`, `curveFns`, `surfaceFns`, and the pure success-path orphans in `sweepFns`/`loftFns`/`extrudeFns`/`hullFns`/…) that still use raw `castShape` — is tracked in **#1755**.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

