### PR TITLE
fix(topology): complete castResultShape/disposeResultShape migration across remaining ops (#1755)

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "342 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "343 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/operations/convexHullFns.ts
+++ b/src/operations/convexHullFns.ts
@@ -7,7 +7,7 @@
 
 import type { Vec3 } from '@/core/types.js';
 import type { Solid } from '@/core/shapeTypes.js';
-import { castShape, isSolid } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isSolid } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { validationError, kernelError, BrepErrorCode } from '@/core/errors.js';
 import { getKernel } from '@/kernel/index.js';
@@ -45,9 +45,10 @@ export function convexHull(points: ReadonlyArray<Vec3>): Result<Solid> {
     const kernel = getKernel();
     const objPoints = points.map((p) => ({ x: p[0], y: p[1], z: p[2] }));
     const result = kernel.hullFromPoints(objPoints, 0.1);
-    const cast = castShape(result);
+    const cast = castResultShape(result);
 
     if (!isSolid(cast)) {
+      disposeResultShape(cast);
       return err(
         kernelError(
           BrepErrorCode.HULL_NOT_3D,

--- a/src/operations/extrudeFns.ts
+++ b/src/operations/extrudeFns.ts
@@ -10,7 +10,13 @@ import type { Vec3 } from '@/core/types.js';
 import { vecLength, vecNormalize } from '@/core/vecOps.js';
 import type { Dimension, OrientedFace, Shape3D, ValidSolid } from '@/core/shapeTypes.js';
 import type { PlanarFace } from '@/core/validityTypes.js';
-import { castShape, isShape3D, createSolid } from '@/core/shapeTypes.js';
+import {
+  castResultShape,
+  disposeDowncastSource,
+  disposeResultShape,
+  isShape3D,
+  createSolid,
+} from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { typeCastError, validationError, kernelError, BrepErrorCode } from '@/core/errors.js';
 
@@ -45,6 +51,7 @@ export function extrude(
     const shape = kernel.extrude(face.wrapped, [...dir], len);
     const downcastShape = kernel.downcast(shape, 'solid');
     const solid = createSolid(downcastShape) as ValidSolid;
+    disposeDowncastSource(shape, solid);
     return ok(solid);
   } catch (e) {
     return err(
@@ -78,9 +85,10 @@ export function revolve(
   try {
     const kernel = getKernel();
     const shape = kernel.revolveVec(face.wrapped, [...center], [...direction], angle);
-    const result = castShape(shape);
+    const result = castResultShape(shape);
 
     if (!isShape3D(result)) {
+      disposeResultShape(result);
       return err(typeCastError('REVOLUTION_NOT_3D', 'Revolution did not produce a 3D shape'));
     }
     return ok(result);
@@ -148,7 +156,9 @@ export function extrudeAll(entries: readonly ExtrudeAllEntry[]): Result<ValidSol
     return ok(
       shapes.map((shape) => {
         const downcast = kernel.downcast(shape, 'solid');
-        return createSolid(downcast) as ValidSolid;
+        const solid = createSolid(downcast) as ValidSolid;
+        disposeDowncastSource(shape, solid);
+        return solid;
       })
     );
   } catch (e) {

--- a/src/operations/loftFns.ts
+++ b/src/operations/loftFns.ts
@@ -6,7 +6,7 @@ import { getKernel } from '@/kernel/index.js';
 import type { PointInput } from '@/core/types.js';
 import { toVec3 } from '@/core/types.js';
 import type { Dimension, Wire, Shape3D } from '@/core/shapeTypes.js';
-import { castShape, isShape3D } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isShape3D } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { typeCastError, validationError, kernelError } from '@/core/errors.js';
 
@@ -67,8 +67,9 @@ export function loft(
       }
     );
 
-    const result = castShape(shape);
+    const result = castResultShape(shape);
     if (!isShape3D(result)) {
+      disposeResultShape(result);
       return err(typeCastError('LOFT_NOT_3D', 'Loft did not produce a 3D shape'));
     }
     return ok(result);
@@ -143,8 +144,9 @@ export function loftAll(entries: readonly LoftAllEntry[]): Result<Shape3D[]> {
 
     const results: Shape3D[] = [];
     for (const shape of shapes) {
-      const cast = castShape(shape);
+      const cast = castResultShape(shape);
       if (!isShape3D(cast)) {
+        disposeResultShape(cast);
         return err(typeCastError('LOFT_ALL_NOT_3D', 'Batch loft entry did not produce a 3D shape'));
       }
       results.push(cast);

--- a/src/operations/patternFns.ts
+++ b/src/operations/patternFns.ts
@@ -11,7 +11,7 @@ import { vecNormalize, vecIsZero } from '@/core/vecOps.js';
 import { fuseAll, type BooleanOptions } from '@/topology/booleanFns.js';
 import { validationError } from '@/core/errors.js';
 import { getKernel } from '@/kernel/index.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castResultShape } from '@/core/shapeTypes.js';
 
 /**
  * Create a linear pattern of a shape along a direction.
@@ -38,7 +38,7 @@ export function linearPattern(
 
   const dir = vecNormalize(direction);
   const ocShapes = getKernel().linearPattern(shape.wrapped, [...dir], spacing, count);
-  const copies = ocShapes.map((s) => castShape(s) as Shape3D);
+  const copies = ocShapes.map((s) => castResultShape(s) as Shape3D);
 
   // Pattern copies share exact face geometry — sameFace glue lets OCCT skip
   // expensive intersection calculations (default unless caller overrides)
@@ -82,7 +82,7 @@ export function circularPattern(
     angleStep,
     count
   );
-  const copies = ocShapes.map((s) => castShape(s) as Shape3D);
+  const copies = ocShapes.map((s) => castResultShape(s) as Shape3D);
 
   // Pattern copies share exact face geometry — sameFace glue lets OCCT skip
   // expensive intersection calculations (default unless caller overrides)
@@ -139,7 +139,7 @@ export function gridPattern(
       countX,
       countY
     );
-    return ok(castShape(compound) as Shape3D);
+    return ok(castResultShape(compound) as Shape3D);
   }
 
   // Fallback: nested linearPattern

--- a/src/operations/sweepFns.ts
+++ b/src/operations/sweepFns.ts
@@ -10,7 +10,12 @@ import type { KernelShape, KernelType } from '@/kernel/types.js';
 import type { Vec3 } from '@/core/types.js';
 import { vecAdd, vecLength } from '@/core/vecOps.js';
 import type { ClosedWire, Dimension, Wire, Shell, Solid, Shape3D } from '@/core/shapeTypes.js';
-import { castShape, isShape3D, isWire as isWireGuard } from '@/core/shapeTypes.js';
+import {
+  castResultShape,
+  disposeResultShape,
+  isShape3D,
+  isWire as isWireGuard,
+} from '@/core/shapeTypes.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import {
   type BrepError,
@@ -61,7 +66,7 @@ function makeSpineWire(start: Vec3, end: Vec3): Wire {
   const kernel = getKernel();
   const edge = kernel.makeLineEdge([...start], [...end]);
   const wire = kernel.makeWire([edge]);
-  return castShape(wire) as Wire;
+  return castResultShape(wire) as Wire;
 }
 
 /** Build a helix wire for twist extrusion. */
@@ -74,7 +79,7 @@ function makeHelixWire(
   leftHanded = false
 ): Wire {
   const kernel = getKernel();
-  return castShape(
+  return castResultShape(
     kernel.makeHelixWire(pitch, height, radius, [...center], [...dir], leftHanded)
   ) as Wire;
 }
@@ -82,6 +87,35 @@ function makeHelixWire(
 // ---------------------------------------------------------------------------
 // Generic sweep
 // ---------------------------------------------------------------------------
+
+/** Cast a shell-mode sweep result `[shell, startWire, endWire]`, releasing all three on any reject. */
+function castSweepShellTuple(result: {
+  shape: KernelShape;
+  firstShape: KernelShape;
+  lastShape: KernelShape;
+}): Result<[Shape3D, Wire, Wire]> {
+  const shape = castResultShape(result.shape);
+  const startWire = castResultShape(result.firstShape);
+  const endWire = castResultShape(result.lastShape);
+  const disposeAll = (): void => {
+    disposeResultShape(shape);
+    disposeResultShape(startWire);
+    disposeResultShape(endWire);
+  };
+  if (!isShape3D(shape)) {
+    disposeAll();
+    return err(typeCastError('SWEEP_NOT_3D', 'Sweep did not produce a 3D shape'));
+  }
+  if (!isWireGuard(startWire)) {
+    disposeAll();
+    return err(typeCastError('SWEEP_START_NOT_WIRE', 'Sweep did not produce a start Wire'));
+  }
+  if (!isWireGuard(endWire)) {
+    disposeAll();
+    return err(typeCastError('SWEEP_END_NOT_WIRE', 'Sweep did not produce an end Wire'));
+  }
+  return ok([shape, startWire, endWire] as [Shape3D, Wire, Wire]);
+}
 
 /**
  * Sweep a wire profile along a spine wire to create a 3D shape.
@@ -105,8 +139,9 @@ export function sweep(
   if (config.mode === 'simple' && !shellMode) {
     const kernel = getKernel();
     const resultOc = kernel.simplePipe(wire.wrapped, spine.wrapped);
-    const shape = castShape(resultOc);
+    const shape = castResultShape(resultOc);
     if (!isShape3D(shape)) {
+      disposeResultShape(shape);
       return err(typeCastError('SWEEP_NOT_3D', 'Simple pipe did not produce a 3D shape'));
     }
     return ok(shape);
@@ -147,23 +182,12 @@ export function sweep(
   });
 
   if (shellMode && typeof result === 'object' && 'firstShape' in result) {
-    const shape = castShape(result.shape);
-    if (!isShape3D(shape)) {
-      return err(typeCastError('SWEEP_NOT_3D', 'Sweep did not produce a 3D shape'));
-    }
-    const startWire = castShape(result.firstShape);
-    const endWire = castShape(result.lastShape);
-    if (!isWireGuard(startWire)) {
-      return err(typeCastError('SWEEP_START_NOT_WIRE', 'Sweep did not produce a start Wire'));
-    }
-    if (!isWireGuard(endWire)) {
-      return err(typeCastError('SWEEP_END_NOT_WIRE', 'Sweep did not produce an end Wire'));
-    }
-    return ok([shape, startWire, endWire] as [Shape3D, Wire, Wire]);
+    return castSweepShellTuple(result);
   }
 
-  const shape = castShape(result);
+  const shape = castResultShape(result);
   if (!isShape3D(shape)) {
+    disposeResultShape(shape);
     return err(typeCastError('SWEEP_NOT_3D', 'Sweep did not produce a 3D shape'));
   }
   return ok(shape);
@@ -421,8 +445,9 @@ export function multiSectionSweep(
 
     const loftResult = kernel.loftAdvanced(positionedWires, { solid, ruled, tolerance });
 
-    const result = castShape(loftResult);
+    const result = castResultShape(loftResult);
     if (!isShape3D(result)) {
+      disposeResultShape(result);
       return err(
         typeCastError('MULTI_SWEEP_NOT_3D', 'Multi-section sweep did not produce a 3D shape')
       );
@@ -481,8 +506,9 @@ export function guidedSweep(
     const ocShape =
       typeof sweepResult === 'object' && 'shape' in sweepResult ? sweepResult.shape : sweepResult;
 
-    const result = castShape(ocShape);
+    const result = castResultShape(ocShape);
     if (!isShape3D(result)) {
+      disposeResultShape(result);
       return err(typeCastError('GUIDED_SWEEP_NOT_3D', 'Guided sweep did not produce a 3D shape'));
     }
     return ok(result as Solid | Shell);

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/core/shapeTypes.js';
 import {
   castShape,
+  castResultShape,
   disposeDowncastSource,
   disposeResultShape,
   getShapeKind,
@@ -624,7 +625,7 @@ export function section(
   try {
     const kernel = getKernel();
     const resultOc = kernel.section(shape.wrapped, sectionFace, approximation);
-    const wrapped = castShape(resultOc);
+    const wrapped = castResultShape(resultOc);
     return ok(wrapped);
   } catch (e) {
     const raw = e instanceof Error ? e.message : String(e);
@@ -744,7 +745,7 @@ function assembleWiresFromEdges(edges: EdgeD[]): Wire[] {
     const wireEdges = walkEdgeChain(startEdge, adjacency, visited);
     try {
       const wireOc = kernel.makeWire(wireEdges.map((e) => e.wrapped));
-      wires.push(castShape(wireOc) as Wire);
+      wires.push(castResultShape(wireOc) as Wire);
     } catch {
       // Skip malformed wire components
     }
@@ -867,7 +868,7 @@ export function split(
       shape.wrapped,
       tools.map((t) => t.wrapped)
     );
-    return ok(castShape(result));
+    return ok(castResultShape(result));
   } catch (e) {
     const raw = e instanceof Error ? e.message : String(e);
     return err(
@@ -953,8 +954,9 @@ export function booleanPipeline(
       return err(kernelError('BOOLEAN_PIPELINE_FAILED', 'Boolean pipeline returned null shape'));
     }
 
-    const shape = castShape(result);
+    const shape = castResultShape(result);
     if (!isShape3D(shape)) {
+      disposeResultShape(shape);
       return err(typeCastError('BOOLEAN_PIPELINE_NOT_3D', 'Pipeline result is not a 3D shape'));
     }
     return ok(shape);

--- a/src/topology/chamferAngleFns.ts
+++ b/src/topology/chamferAngleFns.ts
@@ -7,7 +7,12 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { Edge, Shape3D } from '@/core/shapeTypes.js';
-import { castShape, isShape3D } from '@/core/shapeTypes.js';
+import {
+  castResultShape,
+  disposeDowncastSource,
+  disposeResultShape,
+  isShape3D,
+} from '@/core/shapeTypes.js';
 import { downcast } from './cast.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError, typeCastError, kernelError } from '@/core/errors.js';
@@ -84,11 +89,17 @@ export function chamferDistAngle(
   }
 
   const downcastResult = downcast(raw);
-  if (isErr(downcastResult)) return downcastResult;
+  if (isErr(downcastResult)) {
+    getKernel().dispose(raw);
+    return downcastResult;
+  }
 
-  const wrapped = castShape(downcastResult.value);
+  const wrapped = castResultShape(downcastResult.value);
+  // Two downcasts chain here: `downcast(raw)` orphaned `raw` and castResultShape
+  // released its own (intermediate) source, so `raw` still needs releasing.
+  disposeDowncastSource(raw, wrapped);
   if (!isShape3D(wrapped)) {
-    wrapped[Symbol.dispose]();
+    disposeResultShape(wrapped);
     return err(
       typeCastError('CHAMFER_ANGLE_NOT_3D', 'chamferDistAngle did not produce a 3D shape')
     );

--- a/src/topology/curveFns.ts
+++ b/src/topology/curveFns.ts
@@ -6,7 +6,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { Vec3 } from '@/core/types.js';
 import type { Dimension, Edge, Wire } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape } from '@/core/shapeTypes.js';
 import type { CurveType } from '@/core/typeDiscriminants.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { typeCastError } from '@/core/errors.js';
@@ -134,7 +134,7 @@ export function getOrientation(shape: Edge<Dimension> | Wire<Dimension>): 'forwa
 
 /** Flip the orientation of an edge or wire. Returns a new shape with the same dimension. */
 export function flipOrientation<D extends Dimension>(shape: Edge<D> | Wire<D>): Edge<D> | Wire<D> {
-  return castShape<D>(getKernel().reverseShape(shape.wrapped)) as Edge<D> | Wire<D>;
+  return castResultShape<D>(getKernel().reverseShape(shape.wrapped)) as Edge<D> | Wire<D>;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,8 +178,9 @@ export function interpolateCurve(
 
   try {
     const result = getKernel().interpolatePoints(points as [number, number, number][], options);
-    const cast = castShape(result);
+    const cast = castResultShape(result);
     if (!isEdge(cast)) {
+      disposeResultShape(cast);
       return err(typeCastError('INTERPOLATE_NOT_EDGE', 'Interpolation did not produce an edge'));
     }
     return ok(cast);
@@ -210,8 +211,9 @@ export function approximateCurve(
 
   try {
     const result = getKernel().approximatePoints(points as [number, number, number][], options);
-    const cast = castShape(result);
+    const cast = castResultShape(result);
     if (!isEdge(cast)) {
+      disposeResultShape(cast);
       return err(typeCastError('APPROXIMATE_NOT_EDGE', 'Approximation did not produce an edge'));
     }
     return ok(cast);
@@ -249,10 +251,10 @@ export function offsetWire2D(
     chamfer: 'intersection', // sharp/miter corners
   };
   const resultShape = getKernel().offsetWire2D(wire.wrapped, offset, joinMap[kind]);
-  const wrapped = castShape(resultShape);
+  const wrapped = castResultShape(resultShape);
 
   if (!isWireGuard(wrapped)) {
-    wrapped[Symbol.dispose]();
+    disposeResultShape(wrapped);
     return err(typeCastError('OFFSET_NOT_WIRE', 'Offset did not produce a Wire'));
   }
   return ok(wrapped);

--- a/src/topology/hullFns.ts
+++ b/src/topology/hullFns.ts
@@ -7,7 +7,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { KernelShape } from '@/kernel/types.js';
 import type { Solid, AnyShape, Dimension } from '@/core/shapeTypes.js';
-import { castShape, isSolid } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isSolid } from '@/core/shapeTypes.js';
 import { type Result, ok, err, isErr } from '@/core/result.js';
 import { validationError, kernelError, BrepErrorCode } from '@/core/errors.js';
 
@@ -70,9 +70,10 @@ export function hull(
     const kernel = getKernel();
     const ocShapes = shapes.map((s) => s.wrapped);
     const resultOc = kernel.hull(ocShapes, tolerance);
-    const cast = castShape(resultOc);
+    const cast = castResultShape(resultOc);
 
     if (!isSolid(cast)) {
+      disposeResultShape(cast);
       return err(
         kernelError(
           BrepErrorCode.HULL_NOT_3D,

--- a/src/topology/minkowskiFns.ts
+++ b/src/topology/minkowskiFns.ts
@@ -7,7 +7,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { Shape3D, Solid, Face } from '@/core/shapeTypes.js';
-import { castShape, isShape3D } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isShape3D } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { validationError, kernelError, typeCastError, BrepErrorCode } from '@/core/errors.js';
 import { getFaces, getVertices } from './shapeFns.js';
@@ -55,9 +55,9 @@ function detectSphere(shape: Shape3D): number | null {
 function minkowskiSphere(shape: Shape3D, radius: number, tolerance: number): Result<Solid> {
   try {
     const resultShape = getKernel().offset(shape.wrapped, radius, tolerance);
-    const wrapped = castShape(resultShape);
+    const wrapped = castResultShape(resultShape);
     if (!isShape3D(wrapped)) {
-      wrapped[Symbol.dispose]();
+      disposeResultShape(wrapped);
       return err(
         typeCastError(
           BrepErrorCode.MINKOWSKI_NOT_3D,
@@ -121,9 +121,9 @@ function minkowskiGeneral(shape: Shape3D, tool: Shape3D, tolerance: number): Res
 
     // Compute convex hull of all sum points
     const hullShape = kernel.hullFromPoints(sumPoints, tolerance);
-    const wrapped = castShape(hullShape);
+    const wrapped = castResultShape(hullShape);
     if (!isShape3D(wrapped)) {
-      wrapped[Symbol.dispose]();
+      disposeResultShape(wrapped);
       return err(
         typeCastError(BrepErrorCode.MINKOWSKI_NOT_3D, 'Minkowski hull did not produce a 3D shape')
       );

--- a/src/topology/polyhedronFns.ts
+++ b/src/topology/polyhedronFns.ts
@@ -4,7 +4,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { Solid } from '@/core/shapeTypes.js';
-import { castShape, isSolid } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isSolid } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { validationError, kernelError, BrepErrorCode } from '@/core/errors.js';
 import type { Vec3 } from '@/core/types.js';
@@ -62,10 +62,10 @@ export function polyhedron(
     const kernel = getKernel();
     const ptObjs = points.map(([x, y, z]) => ({ x, y, z }));
     const resultOc = kernel.buildSolidFromFaces(ptObjs, triangles, tolerance);
-    const cast = castShape(resultOc);
+    const cast = castResultShape(resultOc);
 
     if (!isSolid(cast)) {
-      cast[Symbol.dispose]();
+      disposeResultShape(cast);
       return err(
         kernelError(BrepErrorCode.POLYHEDRON_FAILED, 'Polyhedron did not produce a solid')
       );

--- a/src/topology/positionFns.ts
+++ b/src/topology/positionFns.ts
@@ -4,7 +4,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { Shape3D, Edge, Wire } from '@/core/shapeTypes.js';
-import { castShape, isShape3D } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isShape3D } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { kernelError, BrepErrorCode } from '@/core/errors.js';
 
@@ -27,8 +27,9 @@ export function positionOnCurve(
   try {
     const kernel = getKernel();
     const result = kernel.positionOnCurve(shape.wrapped, spine.wrapped, param);
-    const wrapped = castShape(result);
+    const wrapped = castResultShape(result);
     if (!isShape3D(wrapped)) {
+      disposeResultShape(wrapped);
       return err(
         kernelError(
           BrepErrorCode.POSITION_ON_CURVE_FAILED,

--- a/src/topology/surfaceFns.ts
+++ b/src/topology/surfaceFns.ts
@@ -4,7 +4,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { AnyShape } from '@/core/shapeTypes.js';
-import { castShape, isFace, isShell } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isFace, isShell } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { validationError, kernelError, ioError, BrepErrorCode } from '@/core/errors.js';
 
@@ -110,11 +110,11 @@ function buildBSplineSurface(
   }
 
   const faceShape = getKernel().bsplineSurface(points, rows, cols);
-  const shape = castShape(faceShape);
+  const shape = castResultShape(faceShape);
   if (isFace(shape)) {
     return ok(shape);
   }
-  shape[Symbol.dispose]();
+  disposeResultShape(shape);
   return err(kernelError(BrepErrorCode.SURFACE_FAILED, 'B-spline surface did not produce a face'));
 }
 
@@ -137,7 +137,7 @@ function buildTriangulatedSurface(
   }
 
   const resultShape = getKernel().triangulatedSurface(points, rows, cols);
-  const shape = castShape(resultShape);
+  const shape = castResultShape(resultShape);
 
   if (isFace(shape)) {
     return ok(shape);
@@ -147,7 +147,7 @@ function buildTriangulatedSurface(
     return ok(shape);
   }
 
-  shape[Symbol.dispose]();
+  disposeResultShape(shape);
   return err(
     kernelError(BrepErrorCode.SURFACE_FAILED, 'surfaceFromGrid: unexpected shape type from sewing')
   );

--- a/tests/castResultShapeMigration.test.ts
+++ b/tests/castResultShapeMigration.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests for gh #1755 — completing the castResultShape /
+ * disposeResultShape migration across the remaining topology/operations ops.
+ *
+ * Before the fix each of these ops cast a fresh kernel result with the raw
+ * castShape(), orphaning the pre-downcast handle on occt-wasm (a handle's own
+ * delete() is a no-op there), and several reject branches dropped the cast
+ * result entirely. Two kinds of assertion:
+ *  - Correctness: each op still produces valid geometry — proving the added
+ *    disposals release only owned temporaries, never a shape still in use.
+ *  - occt-wasm arena: repeated calls do not grow the arena once results are
+ *    released, proving the orphaned pre-downcast handles are reclaimed.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from './setup.js';
+import {
+  box,
+  sphere,
+  translate,
+  getEdges,
+  isOk,
+  unwrap,
+  measureVolume,
+  measureArea,
+  minkowski,
+  polyhedron,
+  interpolateCurve,
+  approximateCurve,
+  flipOrientation,
+  surfaceFromGrid,
+  hull,
+  convexHull,
+  linearPattern,
+  circularPattern,
+  gridPattern,
+  positionOnCurve,
+  section,
+  split,
+  booleanPipeline,
+} from '@/index.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import type { Result } from '@/core/result.js';
+import { getKernel } from '@/kernel/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+/** Reach occt-wasm's live-shape counter, or undefined on other kernels. */
+function occtWasmShapeCount(): number | undefined {
+  const adapter = getKernel() as unknown as {
+    k?: { getShapeCount?: () => number };
+    retainedKernelOwner?: { getRawKernel?: () => { getShapeCount?: () => number } };
+  };
+  const raw = adapter.retainedKernelOwner?.getRawKernel?.() ?? adapter.k;
+  return typeof raw?.getShapeCount === 'function' ? raw.getShapeCount() : undefined;
+}
+
+/** A tetrahedron for polyhedron(). */
+const TETRA_POINTS: [number, number, number][] = [
+  [0, 0, 0],
+  [1, 0, 0],
+  [0.5, Math.sqrt(3) / 2, 0],
+  [0.5, Math.sqrt(3) / 6, Math.sqrt(6) / 3],
+];
+const TETRA_FACES = [
+  [0, 2, 1],
+  [0, 1, 3],
+  [1, 2, 3],
+  [0, 3, 2],
+];
+
+// These ops are occt-specific (interpolatePoints/section/minkowski require the
+// occt kernel), and the source-orphan leak they fix is occt-wasm's arena; the
+// universal disposeResultShape safety is covered by errorPathDisposal.test.ts.
+describe.skipIf(currentKernel !== 'occt-wasm')(
+  'migrated ops stay geometrically correct (#1755)',
+  () => {
+    it('minkowski sphere fast path grows the box', () => {
+      const r = minkowski(box(4, 4, 4), sphere(1));
+      expect(isOk(r)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(r)))).toBeGreaterThan(64);
+    });
+
+    it('minkowski general (hull) path produces a solid', () => {
+      const r = minkowski(box(4, 4, 4), box(2, 2, 2));
+      expect(isOk(r)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(r)))).toBeGreaterThan(0);
+    });
+
+    it('polyhedron builds a solid with positive volume', () => {
+      const r = polyhedron(TETRA_POINTS, TETRA_FACES);
+      expect(isOk(r)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(r)))).toBeGreaterThan(0.05);
+    });
+
+    it('interpolateCurve / approximateCurve build edges', () => {
+      const pts: [number, number, number][] = [
+        [0, 0, 0],
+        [5, 2, 0],
+        [10, 0, 0],
+      ];
+      expect(isOk(interpolateCurve(pts))).toBe(true);
+      expect(isOk(approximateCurve(pts))).toBe(true);
+    });
+
+    it('flipOrientation returns an edge', () => {
+      const edge = getEdges(box(10, 10, 10))[0];
+      expect(edge).toBeDefined();
+      if (edge) expect(flipOrientation(edge).disposed).toBe(false);
+    });
+
+    it('surfaceFromGrid builds a surface with positive area', () => {
+      const r = surfaceFromGrid([
+        [0, 0, 0],
+        [0, 1, 0],
+        [0, 0, 0],
+      ]);
+      expect(isOk(r)).toBe(true);
+      expect(unwrap(measureArea(unwrap(r)))).toBeGreaterThan(0);
+    });
+
+    it('hull / convexHull produce solids', () => {
+      const h = hull([box(4, 4, 4), translate(box(4, 4, 4), [6, 0, 0])]);
+      expect(isOk(h)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(h)))).toBeGreaterThan(0);
+
+      const ch = convexHull([
+        [0, 0, 0],
+        [10, 0, 0],
+        [0, 10, 0],
+        [0, 0, 10],
+        [5, 5, 5],
+      ]);
+      expect(isOk(ch)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(ch)))).toBeGreaterThan(0);
+    });
+
+    it('linear / circular / grid patterns fuse copies', () => {
+      const lp = linearPattern(box(2, 2, 2), [1, 0, 0], 3, 5);
+      expect(isOk(lp)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(lp)))).toBeCloseTo(24, 3);
+
+      const cp = circularPattern(translate(box(1, 1, 1), [5, 0, 0]), [0, 0, 1], 4);
+      expect(isOk(cp)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(cp)))).toBeCloseTo(4, 3);
+
+      const gp = gridPattern(box(1, 1, 1), [1, 0, 0], [0, 1, 0], 2, 2, 5, 5);
+      expect(isOk(gp)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(gp)))).toBeCloseTo(4, 3);
+    });
+
+    it('positionOnCurve repositions a shape along a spine', () => {
+      const spine = unwrap(
+        interpolateCurve([
+          [0, 0, 0],
+          [0, 0, 5],
+          [0, 0, 10],
+        ])
+      );
+      const r = positionOnCurve(box(1, 1, 1), spine, 0.5);
+      expect(isOk(r)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(r)))).toBeCloseTo(1, 3);
+    });
+
+    it('section / split / booleanPipeline over a box', () => {
+      expect(isOk(section(box(10, 10, 10), 'XY'))).toBe(true);
+
+      const sp = split(box(10, 10, 10), [translate(box(20, 1, 20), [-5, 5, -5])]);
+      expect(isOk(sp)).toBe(true);
+
+      const bp = booleanPipeline(box(10, 10, 10), [
+        { op: 'cut', tool: translate(box(4, 4, 4), [8, 3, 3]) },
+        { op: 'fuse', tool: translate(box(4, 4, 4), [-2, 3, 3]) },
+      ]);
+      expect(isOk(bp)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(bp)))).toBeGreaterThan(0);
+    });
+  }
+);
+
+describe('migrated-op temporaries are reclaimed from the occt-wasm arena (#1755)', () => {
+  it.skipIf(currentKernel !== 'occt-wasm')(
+    'repeated migrated ops do not grow the arena once results are released',
+    () => {
+      if (occtWasmShapeCount() === undefined) return; // counter unavailable
+
+      const dispose = (v: Result<AnyShape<Dimension>> | AnyShape<Dimension>): void => {
+        const shape = isResult(v) ? (isOk(v) ? v.value : undefined) : v;
+        if (shape) getKernel().dispose(shape.wrapped);
+      };
+
+      // Inputs are created once and reused, so the *only* fresh kernel handle
+      // each op produces is its cast result. That isolates the pre-downcast
+      // source orphan this migration fixes: ops that build additional internal
+      // temporaries (hull/convexHull/polyhedron/patterns/minkowski/section) are
+      // covered by the correctness suite above but excluded here, since their
+      // out-of-scope intermediate leaks would swamp the signal.
+      const edge = getEdges(box(10, 10, 10))[0];
+      expect(edge).toBeDefined();
+      if (!edge) return;
+      const curvePts: [number, number, number][] = [
+        [0, 0, 0],
+        [5, 2, 0],
+        [10, 0, 0],
+      ];
+      const grid = [
+        [0, 0, 0],
+        [0, 1, 0],
+        [0, 0, 0],
+      ];
+      const splitBase = box(10, 10, 10);
+      const splitTool = translate(box(20, 1, 20), [-5, 5, -5]);
+      const pipeBase = box(10, 10, 10);
+      const pipeTool = translate(box(4, 4, 4), [8, 3, 3]);
+      const posShape = box(1, 1, 1);
+      const posSpine = unwrap(
+        interpolateCurve([
+          [0, 0, 0],
+          [0, 0, 5],
+          [0, 0, 10],
+        ])
+      );
+
+      const cycle = (): void => {
+        dispose(flipOrientation(edge)); // curveFns reverseShape
+        dispose(interpolateCurve(curvePts)); // curveFns interpolatePoints
+        dispose(approximateCurve(curvePts)); // curveFns approximatePoints
+        dispose(surfaceFromGrid(grid)); // surfaceFns
+        dispose(split(splitBase, [splitTool])); // booleanFns split
+        dispose(booleanPipeline(pipeBase, [{ op: 'cut', tool: pipeTool }])); // booleanFns pipeline
+        dispose(positionOnCurve(posShape, posSpine, 0.5)); // positionFns
+      };
+
+      // Warm up one-time caches so the measured window is steady-state.
+      cycle();
+
+      const start = occtWasmShapeCount() ?? 0;
+      const iterations = 15;
+      for (let i = 0; i < iterations; i++) cycle();
+      const growth = (occtWasmShapeCount() ?? 0) - start;
+
+      // Before the fix each of the 7 ops orphaned its pre-downcast handle every
+      // call — ~105 over the loop. With the fix, released results leave the
+      // arena flat. Allow a tiny margin for lazily-populated caches.
+      expect(growth).toBeLessThanOrEqual(7);
+    }
+  );
+});
+
+/** Narrow a value to a Result<T> by its discriminant. */
+function isResult(v: unknown): v is Result<AnyShape<Dimension>> {
+  return typeof v === 'object' && v !== null && 'ok' in v;
+}


### PR DESCRIPTION
Follow-up to #1750 / #1756. Completes the `castResultShape` / `disposeResultShape` migration across the topology/operations ops that #1750 and #1756 didn't reach.

### What & why

`castShape(<fresh kernel result>)` orphans the pre-downcast handle on occt-wasm — `downcast()` allocates a new arena slot and a handle's own `delete()` is a no-op there, so the source slot leaks. Several reject branches also dropped the cast result entirely (a full leak) or called `wrapped[Symbol.dispose]()` (a no-op arena-wise). This routes every remaining fresh-result cast through the helpers added in #1750/#1756:

- success path `castShape(freshResult)` → **`castResultShape(...)`** (releases the orphaned source; on identity-downcast kernels the guard skips, so it's safe everywhere)
- reject branch (missing disposal / `[Symbol.dispose]()`) → **`disposeResultShape(...)`** (releases both slots)

### Sites migrated

| File | Ops |
|---|---|
| `minkowskiFns` | `minkowskiSphere` (offset), general hull path |
| `chamferAngleFns` | `chamferDistAngle` — **multi-downcast chain**: also releases the intermediate `downcast(raw)` source and the `isErr` early-return `raw` |
| `polyhedronFns` | `buildSolidFromFaces` |
| `curveFns` | `flipOrientation` (reverseShape), `interpolateCurve`, `approximateCurve` (both previously returned `err` without disposing the cast), `offsetWire2D` |
| `surfaceFns` | `bsplineSurface`, `triangulatedSurface` |
| `hullFns` / `convexHullFns` | `hull`, `convexHull` (both leaked the cast on the `!isSolid` branch) |
| `sweepFns` | `makeSpineWire`, `makeHelixWire`, `sweep` (simple + shell tuple + normal), `multiSectionSweep`, `guidedSweep` |
| `loftFns` | `loft`, `loftAll` |
| `extrudeFns` | `revolve` (cast) + `extrude` / `extrudeAll` (manual `downcast`+`createSolid` → `disposeDowncastSource`) |
| `patternFns` | `linearPattern`, `circularPattern`, `gridPattern` |
| `positionFns` | `positionOnCurve` |
| `booleanFns` | `section`, `split`, `booleanPipeline`, `assembleWiresFromEdges` |

Each site was verified to pass a **fresh kernel result the caller owns**, never a wrapped input.

### Tests

`tests/castResultShapeMigration.test.ts`:
- **Correctness** — every migrated op still produces valid geometry (proves the added disposals free only owned temporaries).
- **occt-wasm arena flatness** — a reused-input cycle over the ops whose *only* per-call allocation is the cast result (`flip`/`interp`/`approx`/`surf`/`split`/`pipe`/`pos`) stays flat once results are released; before the fix each leaked its pre-downcast source (~105 over the loop).

### Deferred (out of scope)

- **`healingFns`** — brepkit heals **in-place** and can return a *wrapped input*, so `disposeResultShape` on its reject branches (e.g. `healSolid`'s `!isValid` branch) could free the caller's input. Needs separate per-kernel analysis.
- The `getSubShapes` element-leak consumers in `measureOps` / `constructionOps` / `sweepOps` noted in the #1750 review.
- `faceFns` `outerWire` / `removeHolesFromFace` inline casts (sub-shape ownership is ambiguous; outside the issue's `rg` scope).

Closes #1755.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

