### PR TITLE
chore(hooks): skip pre-commit changed-file tests when no code is staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,10 +20,19 @@ wait $PID3 || exit 1
 # Tier 2: Tests (only if Tier 1 passes)
 # Default: run only tests affected by changed files (fast, no coverage thresholds).
 # FULL_TESTS=1: run full suite with coverage thresholds (same as pre-push).
-if [ "${FULL_TESTS:-0}" = "1" ]; then
-  npm run test:full
+#
+# Skip entirely when no code is staged: vitest's forceRerunTriggers treat a
+# package.json/lockfile/vitest-config change as "everything changed", so a
+# manifest-only commit would boot the WASM kernel for the whole suite. CI's
+# test:ci is the full gate regardless.
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '^(src/|tests/|vitest\.)'; then
+  if [ "${FULL_TESTS:-0}" = "1" ]; then
+    npm run test:full
+  else
+    npm run test
+  fi
 else
-  npm run test
+  echo "⏭  No src/ or tests/ changes staged — skipping changed-file tests (CI runs the full suite)."
 fi
 
 # Tier 3: Non-blocking reminders


### PR DESCRIPTION
## Problem

Committing a manifest-only change (e.g. a \`package.json\`/\`package-lock.json\` bump) makes the pre-commit hook boot the WASM kernel and run the **entire** test suite, which routinely exceeds the commit timeout and gets reaped. This forced \`--no-verify\` on the TS 7 typecheck PR (#1764).

## Root cause

\`npm run test\` = \`vitest run --project occt-wasm --changed\`. Vitest's default \`forceRerunTriggers\` include \`**/package.json/**\` and \`**/vitest.config.*\`, so a manifest/config change is treated as "everything changed" → full-suite rerun under \`--changed\`.

## Fix

Gate the Tier 2 test step on whether any \`src/\`, \`tests/\`, or \`vitest.*\` path is staged. Manifest/docs/config-only commits skip the changed-file tests (Tier 1 typecheck + lint-staged + boundaries still run); \`test:ci\` in CI remains the full gate. \`FULL_TESTS=1\` override preserved.

\`\`\`
if git diff --cached --name-only --diff-filter=ACMR | grep -qE '^(src/|tests/|vitest\.)'; then
  ... run tests ...
else
  echo "⏭  No src/ or tests/ changes staged — skipping changed-file tests (CI runs the full suite)."
fi
\`\`\`

## Validation

This PR's own commit (touches only \`.husky/pre-commit\`) ran through the hook with tests **skipped** and completed cleanly with hooks enabled — no \`--no-verify\`, no reaping.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

