### PR TITLE
chore(tooling): run workspace typechecks on native TypeScript 7

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -10,7 +10,7 @@
     "prebuild": "npm run build:deps",
     "build": "tsc -b && npm run check:examples && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b",
+    "typecheck": "tsgo -b",
     "check:examples": "npx tsx scripts/checkExamples.ts",
     "smoke": "npx tsx scripts/smoke.ts",
     "shoot": "npx tsx scripts/shootExamples.ts",

--- a/packages/brepjs-bim/package.json
+++ b/packages/brepjs-bim/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "lint": "eslint src tests"
   },

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "build": "node scripts/copyReference.mjs && vite build && vite build --config viewer/vite.config.ts && node -e \"require('fs').chmodSync('dist/cli/main.js',0o755);require('fs').chmodSync('dist/cli/main.cjs',0o755);require('fs').chmodSync('dist/mcp/server.js',0o755)\"",
-    "typecheck": "tsc --noEmit && tsc -p viewer/tsconfig.json --noEmit && tsc -p bench/tsconfig.json",
+    "typecheck": "tsgo --noEmit && tsgo -p viewer/tsconfig.json --noEmit && tsgo -p bench/tsconfig.json",
     "lint": "eslint src tests viewer bench",
     "test": "vitest run",
     "eval": "tsx bench/run.ts",

--- a/packages/brepjs-sheetmetal/package.json
+++ b/packages/brepjs-sheetmetal/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "snapshot": "tsx harness/snapshot.ts",
     "lint": "eslint src tests"

--- a/packages/brepjs-viewer/package.json
+++ b/packages/brepjs-viewer/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/brepjs-vscode/package.json
+++ b/packages/brepjs-vscode/package.json
@@ -100,7 +100,7 @@
     "build": "node esbuild.mjs && vite build --config webview/vite.config.ts",
     "build:ext": "node esbuild.mjs",
     "build:webview": "vite build --config webview/vite.config.ts",
-    "typecheck": "tsc --noEmit && tsc -p webview/tsconfig.json --noEmit"
+    "typecheck": "tsgo --noEmit && tsgo -p webview/tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@react-three/drei": "*",


### PR DESCRIPTION
## What

Migrate every workspace \`typecheck\` script from \`tsc\` to \`tsgo\` (native TypeScript 7), completing the migration started at the root in #1764.

| Workspace | Script variant | tsgo result |
|---|---|---|
| brepjs-sheetmetal / viewer / bim | \`--noEmit\` | ✅ |
| brepjs-cad | \`--noEmit\` + \`-p viewer\` + emitting \`-p bench\` | ✅ |
| brepjs-vscode | \`--noEmit\` + \`-p webview\` | ✅ |
| apps/playground | \`-b\` (build mode) | ✅ |

The native dev build handles all four variants — plain \`--noEmit\`, \`-p <config>\`, an emitting \`-p\`, and \`-b\` build mode. \`tsgo\` resolves via the root \`@typescript/native-preview\` \`.bin\` in every workspace (no per-package dep needed — its only versions are \`-dev\` prereleases a \`"*"\` range wouldn't resolve, and workspace bin resolution walks up to root).

## Validation

All six pass via the exact CI invocation \`npm run typecheck --workspace=<name>\` (EXIT 0, 0 errors). Emitting variants (cad bench, playground \`-b\`) write only to gitignored output.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

