### PR TITLE
fix(topology): clone via a real copyShape, not an aliasing downcast

### DIFF
--- a/src/kernel/brepkit/topologyOps.ts
+++ b/src/kernel/brepkit/topologyOps.ts
@@ -274,6 +274,9 @@ export function makeTopologyOps(bk: BrepkitKernel) {
     isSame: (a, b) => isSame(bk, a, b),
     isEqual: (a, b) => isEqual(bk, a, b),
     downcast: (shape, type) => downcast(bk, shape, type),
+    // brepkit never frees handles individually (arena; delete is a no-op), so
+    // the aliased handle is safe to "dispose" independently of the source.
+    copyShape: (shape) => downcast(bk, shape),
     hashCode: (shape, upperBound) => hashCode(bk, shape, upperBound),
     isNull: (shape) => isNull(bk, shape),
     shapeOrientation: (shape) => shapeOrientation(bk, shape),
@@ -289,6 +292,7 @@ export function makeTopologyOps(bk: BrepkitKernel) {
     | 'isSame'
     | 'isEqual'
     | 'downcast'
+    | 'copyShape'
     | 'hashCode'
     | 'isNull'
     | 'shapeOrientation'

--- a/src/kernel/interfaces/topologyOps.ts
+++ b/src/kernel/interfaces/topologyOps.ts
@@ -21,6 +21,18 @@ export interface KernelTopologyOps {
   isEqual(a: KernelShape, b: KernelShape): boolean;
   /** Downcast a shape to a more specific type (e.g., TopoDS_Shape → TopoDS_Edge). */
   downcast(shape: KernelShape, type?: ShapeType): KernelShape;
+  /**
+   * Return an independently-disposable duplicate of a shape.
+   *
+   * `downcast` is a *cast*, not a copy: on the occt-wasm arena kernel a
+   * same-type downcast returns the very same handle id, so disposing the
+   * "copy" would free the source. `copyShape` guarantees a handle that can be
+   * disposed without affecting the source — a real geometric copy where a
+   * primitive exists (occt-wasm `k.copy`), or the safe existing duplicate on
+   * kernels that never free handles individually (brepkit/manifold) or share
+   * refcounted geometry (occt Embind).
+   */
+  copyShape(shape: KernelShape): KernelShape;
   /** Compute a hash code for a shape (used for face tracking). */
   hashCode(shape: KernelShape, upperBound: number): number;
   /** Check if a shape handle is null. */

--- a/src/kernel/manifold/topologyOps.ts
+++ b/src/kernel/manifold/topologyOps.ts
@@ -162,6 +162,9 @@ export function makeTopologyOps(_module: ManifoldModule): KernelTopologyOps {
     isSame,
     isEqual: isSame,
     downcast: (shape) => shape,
+    // Mesh kernel: handles are value-like and never freed individually, so the
+    // identity result is safe to dispose independently of the source.
+    copyShape: (shape) => shape,
     hashCode,
     isNull,
     shapeOrientation: (_shape: KernelShape): ShapeOrientation => 'forward',

--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -538,6 +538,9 @@ export function makeGeometryQueryOps(oc: KernelInstance) {
     curveParameters: (shape) => curveParameters(oc, shape),
     shapeOrientation: (shape) => shapeOrientation(oc, shape),
     downcast: (shape, type) => downcast(oc, shape, type),
+    // Embind downcast returns a fresh TopoDS wrapper over refcounted geometry,
+    // so it is already safe to dispose independently of the source.
+    copyShape: (shape) => downcast(oc, shape),
     hashCode: (shape, upperBound) => hashCode(oc, shape, upperBound),
     isNull: (shape) => isNull(oc, shape),
     hasTriangulation: (shape) => hasTriangulation(oc, shape),
@@ -569,6 +572,7 @@ export function makeGeometryQueryOps(oc: KernelInstance) {
     | 'curveParameters'
     | 'shapeOrientation'
     | 'downcast'
+    | 'copyShape'
     | 'hashCode'
     | 'isNull'
     | 'hasTriangulation'

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1327,6 +1327,10 @@ export class OcctWasmAdapter implements KernelAdapter {
     return topoOps.downcast(this.k, shape, type);
   }
 
+  copyShape(shape: KernelShape): KernelShape {
+    return topoOps.copyShape(this.k, shape);
+  }
+
   hashCode(shape: KernelShape, upperBound: number): number {
     return topoOps.hashCode(this.k, shape, upperBound);
   }

--- a/src/kernel/occtWasm/topologyOps.ts
+++ b/src/kernel/occtWasm/topologyOps.ts
@@ -52,6 +52,13 @@ export function downcast(k: OcctKernelWasm, shape: KernelShape, type?: ShapeType
   return shape;
 }
 
+export function copyShape(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  // Real geometric copy into a fresh arena slot. `downcast` would alias the
+  // source id, so a copy is the only way to get an independently-disposable
+  // handle on this kernel.
+  return wrapResult(k, k.copy(unwrap(shape)));
+}
+
 export function hashCode(k: OcctKernelWasm, shape: KernelShape, upperBound: number): number {
   return k.hashCode(unwrap(shape), upperBound);
 }

--- a/src/sketching/draw3d.ts
+++ b/src/sketching/draw3d.ts
@@ -7,7 +7,7 @@ import { createFace } from '@/core/shapeTypes.js';
 import { outerWire } from '@/topology/faceFns.js';
 import { getEdges } from '@/topology/shapeFns.js';
 import { makeFace } from '@/topology/shapeHelpers.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import type Sketch from './sketch.js';
 import type { ProjectionPlane } from '@/projection/projectionPlanes.js';
 import { type Camera, cameraFromPlane, projectEdges } from '@/projection/cameraFns.js';
@@ -63,7 +63,7 @@ export function drawProjection(
  */
 export function drawFaceOutline(face: Face): Drawing {
   using scope = new DisposalScope();
-  const clonedFace = scope.register(createFace(unwrap(downcast(face.wrapped))));
+  const clonedFace = scope.register(createFace(unwrap(copyShape(face.wrapped))));
   const faceOuterWire = scope.register(outerWire(clonedFace));
   const curves = getEdges(faceOuterWire).map((e) => edgeToCurve(e, face));
 

--- a/src/sketching/faceSketcher.ts
+++ b/src/sketching/faceSketcher.ts
@@ -7,7 +7,7 @@ import type { ClosedWire, Wire, Face, PlanarWire } from '@/core/shapeTypes.js';
 import { createEdge, createFace } from '@/core/shapeTypes.js';
 import { uvBounds, pointOnSurface, normalAt } from '@/topology/faceFns.js';
 import { curveStartPoint, curveIsClosed } from '@/topology/curveFns.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import type { GenericSketcher } from '@/2d/blueprints/genericSketcher.js';
 import type { KernelType } from '@/kernel/types.js';
 import type { Curve2D, Point2D } from '@/2d/lib/index.js';
@@ -40,7 +40,7 @@ export default class FaceSketcher extends BaseSketcher2d implements GenericSketc
 
   constructor(face: Face, origin: Point2D = [0, 0]) {
     super(origin);
-    this.face = createFace(unwrap(downcast(face.wrapped)));
+    this.face = createFace(unwrap(copyShape(face.wrapped)));
     this._bounds = uvBounds(face);
   }
 

--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -1,6 +1,6 @@
 import type { Plane } from '@/core/planeTypes.js';
 import { unwrap } from '@/core/result.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
 import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
 import type { LoftOptions } from '@/operations/loftFns.js';
@@ -120,7 +120,7 @@ export default class Sketch implements SketchInterface {
 
   set baseFace(newFace: Face | null | undefined) {
     if (this._baseFace) this._baseFace.delete();
-    this._baseFace = newFace ? createFace(unwrap(downcast(newFace.wrapped))) : newFace;
+    this._baseFace = newFace ? createFace(unwrap(copyShape(newFace.wrapped))) : newFace;
   }
 
   /** Release all kernel resources held by this sketch. */
@@ -131,12 +131,12 @@ export default class Sketch implements SketchInterface {
 
   /** Create an independent deep copy of this sketch. */
   clone(): Sketch {
-    const cloned = createWire(unwrap(downcast(this.wire.wrapped))) as ClosedWire & PlanarWire;
+    const cloned = createWire(unwrap(copyShape(this.wire.wrapped))) as ClosedWire & PlanarWire;
     const sketch = new Sketch(cloned, {
       defaultOrigin: this.defaultOrigin,
       defaultDirection: this.defaultDirection,
     });
-    if (this.baseFace) sketch.baseFace = createFace(unwrap(downcast(this.baseFace.wrapped)));
+    if (this.baseFace) sketch.baseFace = createFace(unwrap(copyShape(this.baseFace.wrapped)));
     return sketch;
   }
 

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -15,7 +15,7 @@ import {
   makeSolid,
 } from '@/topology/shapeHelpers.js';
 import { type Result, unwrap } from '@/core/result.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import { cutAll } from '@/topology/booleanFns.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
 import { vecScale, vecNormalize, vecCross } from '@/core/vecOps.js';
@@ -99,7 +99,7 @@ export function sketchFace(sketch: Sketch): OrientedFace & PlanarFace {
 
 /** Return an independent clone of the sketch's wire. */
 export function sketchWires(sketch: Sketch): Wire {
-  return createWire(unwrap(downcast(sketch.wire.wrapped)));
+  return createWire(unwrap(copyShape(sketch.wire.wrapped)));
 }
 
 /**
@@ -369,7 +369,7 @@ export function compoundSketchLoft(
   });
 
   const baseFaceRaw = compoundSketchFace(sketch);
-  const baseFace = createFace(unwrap(downcast(baseFaceRaw.wrapped)));
+  const baseFace = createFace(unwrap(copyShape(baseFaceRaw.wrapped)));
   shells.push(baseFace, compoundSketchFace(other));
 
   return unwrap(makeSolid(shells));

--- a/src/topology/cast.ts
+++ b/src/topology/cast.ts
@@ -81,6 +81,27 @@ export function downcast(shape: KernelShape): Result<GenericTopo> {
 }
 
 /**
+ * Return an independently-disposable copy of a generic KernelShape.
+ *
+ * Like {@link downcast}, but the result can be disposed without affecting the
+ * source — `downcast` is only a cast and aliases the source handle on the
+ * occt-wasm arena kernel. Use when cloning a shape (e.g. a sketch wire) that
+ * outlives, or is disposed apart from, its origin.
+ *
+ * @returns Ok with the copied shape, or Err if the shape is null.
+ */
+export function copyShape(shape: KernelShape): Result<GenericTopo> {
+  if (getKernel().isNull(shape)) {
+    return err(typeCastError('NULL_SHAPE', 'Cannot copy a null shape'));
+  }
+  try {
+    return ok(getKernel().copyShape(shape));
+  } catch (e) {
+    return err(typeCastError('NO_WRAPPER', 'Could not copy this shape', e));
+  }
+}
+
+/**
  * Cast a raw kernel shape to its corresponding branded brepjs type (Vertex, Edge, Face, etc.).
  *
  * Performs downcast + branded handle creation in one step.

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -18,10 +18,10 @@ import { BrepErrorCode } from '@/core/errors.js';
 // Identity / introspection
 // ---------------------------------------------------------------------------
 
-/** Clone a shape (deep copy via kernel topology downcast). */
+/** Clone a shape (an independently-disposable deep copy). */
 export function clone<T extends AnyShape<Dimension>>(shape: T): Result<T> {
   return kernelCall(
-    () => getKernel().downcast(shape.wrapped),
+    () => getKernel().copyShape(shape.wrapped),
     BrepErrorCode.CLONE_FAILED,
     'Failed to clone shape'
   ) as Result<T>;

--- a/tests/shapeFns.test.ts
+++ b/tests/shapeFns.test.ts
@@ -52,6 +52,21 @@ describe('clone', () => {
     expect(unwrap(measureVolume(box(10, 10, 10)))).toBeCloseTo(1000, 0);
     expect(cloned).toBeDefined();
   });
+
+  it('produces an independently-owned copy, not an alias of the source', () => {
+    // Regression: clone used `downcast`, but on the occt-wasm arena kernel a
+    // same-type downcast returns the *same* handle id — so the "copy" aliased
+    // the source and disposing it would free the original. clone now uses a
+    // real copyShape. Verify same geometry but a distinct kernel entity.
+    const b = box(10, 10, 10);
+    const cloned = unwrap(clone(b));
+    expect(unwrap(measureVolume(cloned))).toBeCloseTo(unwrap(measureVolume(b)), 6);
+    // On the occt-wasm arena kernel a genuine copy occupies a distinct slot.
+    if (process.env['TEST_KERNEL'] === 'occt-wasm') {
+      const idOf = (h: { id?: number }): number | undefined => h.id;
+      expect(idOf(cloned.wrapped as { id?: number })).not.toBe(idOf(b.wrapped as { id?: number }));
+    }
+  });
 });
 
 describe('toBREP', () => {


### PR DESCRIPTION
## Summary

`clone()` (and the sketch-subsystem copies it underlies) duplicated a shape via `downcast(x.wrapped)`. But `downcast` is a **cast, not a copy**: on the occt-wasm arena kernel a same-type downcast returns the *same* handle id, and brepkit's `downcast` returns the identical handle. So a brepjs "clone" **aliased its source** rather than copying it.

Today this is masked because those kernels never free a handle individually (`delete` is a no-op). But it's a latent correctness bug — a clone is supposed to be independent — and it blocks making WASM handle disposal actually reclaim arena slots (a follow-up): once disposal is real, disposing a clone would free the original (use-after-free).

## What this does

Adds a first-class `copyShape(shape)` to the kernel abstraction — "return an independently-disposable duplicate":

- **occt-wasm**: real geometric copy via `k.copy` (a fresh arena slot).
- **occt (Embind)**: delegates to `downcast` — already a fresh `TopoDS` wrapper over refcounted geometry, safe to dispose independently.
- **brepkit / manifold**: delegates to their existing `downcast` — these never free handles individually, so the aliased handle is already safe.

Routes the 8 clone/copy call sites through it: the `clone` primitive (`shapeFns`), `Sketch.clone` + `baseFace`, `sketchWire`, the compound-loft base face, `draw3d`, and `faceSketcher`. Left untouched the two `sketcher.ts` `downcast` calls, which cast a fresh op result / feed `mirror` and are never disposed independently.

## Behavior change

Only on occt-wasm: `clone` now yields a distinct kernel entity (a real copy) instead of an alias of the source. Geometry is preserved. The other three kernels are byte-for-byte unchanged (their `copyShape` delegates to the pre-existing `downcast`).

## Validation

- Full occt-wasm suite green.
- occt / brepkit: the 5 clone/sketch/shaperef suites green (0 failures).
- New regression test in `shapeFns.test.ts`: clone preserves geometry cross-kernel and is a distinct arena slot on occt-wasm.

Prerequisite for the WASM-arena disposal fix (`using`/`Symbol.dispose` currently a no-op on occt-wasm), which lands separately on top.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

