### PR TITLE
fix(core): make using/Symbol.dispose reclaim occt-wasm arena slots

### DIFF
--- a/src/core/disposal.ts
+++ b/src/core/disposal.ts
@@ -9,6 +9,7 @@
  */
 
 import type { KernelShape } from '@/kernel/types.js';
+import { getKernel } from '@/kernel/index.js';
 import type { BrepError } from './errors.js';
 import type { Result } from './result.js';
 
@@ -142,6 +143,13 @@ export interface ShapeHandle {
 
 /** Create a disposable shape handle. */
 export function createHandle(ocShape: KernelShape): ShapeHandle {
+  // Capture the owning kernel now: on the occt-wasm arena kernel a shape's own
+  // `delete()` is a no-op, so the slot is only reclaimed via `kernel.dispose()`
+  // (→ `k.release(id)`). Routing disposal through the kernel makes `using` free
+  // the slot on every kernel. Embind kernels keep their existing `.delete()`
+  // behaviour (`kernel.dispose` falls through to it). `k.release` is idempotent,
+  // so overlap with `disposeResultShape`/`disposeDowncastSource` is safe.
+  const kernel = getKernel();
   let disposed = false;
 
   const dispose = () => {
@@ -150,7 +158,7 @@ export function createHandle(ocShape: KernelShape): ShapeHandle {
       trackHandleDisposed();
       registry.unregister(handle);
       try {
-        ocShape.delete();
+        kernel.dispose(ocShape);
       } catch {
         // Already deleted — ignore
       }
@@ -177,7 +185,18 @@ export function createHandle(ocShape: KernelShape): ShapeHandle {
   };
 
   trackHandleCreated();
-  registry.register(handle, ocShape, handle);
+  // GC safety net: route the finalizer through the kernel too, else arena slots
+  // survive collection on occt-wasm. The closure holds `ocShape`/`kernel` (not
+  // `handle`), so it never keeps the handle itself alive.
+  registry.register(
+    handle,
+    {
+      delete: () => {
+        kernel.dispose(ocShape);
+      },
+    },
+    handle
+  );
   return handle;
 }
 

--- a/src/core/kernelCall.ts
+++ b/src/core/kernelCall.ts
@@ -7,7 +7,7 @@
 
 import type { KernelShape } from '@/kernel/types.js';
 import type { AnyShape } from './shapeTypes.js';
-import { castShape } from './shapeTypes.js';
+import { castResultShape } from './shapeTypes.js';
 import type { Result } from './result.js';
 import { ok, err } from './result.js';
 import type { BrepErrorKind, BrepError } from './errors.js';
@@ -70,7 +70,10 @@ export function kernelCall(
   kind: BrepErrorKind = 'KERNEL_OPERATION'
 ): Result<AnyShape> {
   try {
-    return ok(castShape(fn()));
+    // castResultShape (not castShape): fn() returns a fresh kernel result the
+    // caller owns, so release its orphaned pre-downcast slot on the occt-wasm
+    // arena kernel. Identity-downcast kernels skip the release via the guard.
+    return ok(castResultShape(fn()));
   } catch (e) {
     const rawMessage = e instanceof Error ? e.message : String(e);
     const translatedMessage =

--- a/src/core/shapeTypes.ts
+++ b/src/core/shapeTypes.ts
@@ -382,3 +382,21 @@ export function castShapeWithKnownType<D extends Dimension = '3D'>(
   if (knownType === 'compsolid') return createCompSolid(dc) as AnyShape<D>;
   return createCompound<D>(dc, dim);
 }
+
+/**
+ * The result-owning counterpart to {@link castShapeWithKnownType}: casts a
+ * freshly-iterated sub-shape and releases the orphaned pre-downcast handle.
+ * Use for a raw sub-shape the caller owns outright — e.g. each element of
+ * `iterShapes` — where only the branded downcast result is retained. Identity
+ * downcast kernels (manifold/brepkit) skip the release via the guard in
+ * {@link disposeDowncastSource}.
+ */
+export function castResultShapeWithKnownType<D extends Dimension = '3D'>(
+  ocShape: KernelShape,
+  knownType: ShapeType,
+  dim?: D
+): AnyShape<D> {
+  const cast = castShapeWithKnownType<D>(ocShape, knownType, dim);
+  disposeDowncastSource(ocShape, cast);
+  return cast;
+}

--- a/src/kernel/brepkit/topologyOps.ts
+++ b/src/kernel/brepkit/topologyOps.ts
@@ -274,6 +274,9 @@ export function makeTopologyOps(bk: BrepkitKernel) {
     isSame: (a, b) => isSame(bk, a, b),
     isEqual: (a, b) => isEqual(bk, a, b),
     downcast: (shape, type) => downcast(bk, shape, type),
+    // brepkit never frees handles individually (arena; delete is a no-op), so
+    // the aliased handle is safe to "dispose" independently of the source.
+    copyShape: (shape) => downcast(bk, shape),
     hashCode: (shape, upperBound) => hashCode(bk, shape, upperBound),
     isNull: (shape) => isNull(bk, shape),
     shapeOrientation: (shape) => shapeOrientation(bk, shape),
@@ -289,6 +292,7 @@ export function makeTopologyOps(bk: BrepkitKernel) {
     | 'isSame'
     | 'isEqual'
     | 'downcast'
+    | 'copyShape'
     | 'hashCode'
     | 'isNull'
     | 'shapeOrientation'

--- a/src/kernel/interfaces/topologyOps.ts
+++ b/src/kernel/interfaces/topologyOps.ts
@@ -21,6 +21,18 @@ export interface KernelTopologyOps {
   isEqual(a: KernelShape, b: KernelShape): boolean;
   /** Downcast a shape to a more specific type (e.g., TopoDS_Shape → TopoDS_Edge). */
   downcast(shape: KernelShape, type?: ShapeType): KernelShape;
+  /**
+   * Return an independently-disposable duplicate of a shape.
+   *
+   * `downcast` is a *cast*, not a copy: on the occt-wasm arena kernel a
+   * same-type downcast returns the very same handle id, so disposing the
+   * "copy" would free the source. `copyShape` guarantees a handle that can be
+   * disposed without affecting the source — a real geometric copy where a
+   * primitive exists (occt-wasm `k.copy`), or the safe existing duplicate on
+   * kernels that never free handles individually (brepkit/manifold) or share
+   * refcounted geometry (occt Embind).
+   */
+  copyShape(shape: KernelShape): KernelShape;
   /** Compute a hash code for a shape (used for face tracking). */
   hashCode(shape: KernelShape, upperBound: number): number;
   /** Check if a shape handle is null. */

--- a/src/kernel/manifold/topologyOps.ts
+++ b/src/kernel/manifold/topologyOps.ts
@@ -162,6 +162,9 @@ export function makeTopologyOps(_module: ManifoldModule): KernelTopologyOps {
     isSame,
     isEqual: isSame,
     downcast: (shape) => shape,
+    // Mesh kernel: handles are value-like and never freed individually, so the
+    // identity result is safe to dispose independently of the source.
+    copyShape: (shape) => shape,
     hashCode,
     isNull,
     shapeOrientation: (_shape: KernelShape): ShapeOrientation => 'forward',

--- a/src/kernel/occt/geometryQueryOps.ts
+++ b/src/kernel/occt/geometryQueryOps.ts
@@ -538,6 +538,9 @@ export function makeGeometryQueryOps(oc: KernelInstance) {
     curveParameters: (shape) => curveParameters(oc, shape),
     shapeOrientation: (shape) => shapeOrientation(oc, shape),
     downcast: (shape, type) => downcast(oc, shape, type),
+    // Embind downcast returns a fresh TopoDS wrapper over refcounted geometry,
+    // so it is already safe to dispose independently of the source.
+    copyShape: (shape) => downcast(oc, shape),
     hashCode: (shape, upperBound) => hashCode(oc, shape, upperBound),
     isNull: (shape) => isNull(oc, shape),
     hasTriangulation: (shape) => hasTriangulation(oc, shape),
@@ -569,6 +572,7 @@ export function makeGeometryQueryOps(oc: KernelInstance) {
     | 'curveParameters'
     | 'shapeOrientation'
     | 'downcast'
+    | 'copyShape'
     | 'hashCode'
     | 'isNull'
     | 'hasTriangulation'

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1327,6 +1327,10 @@ export class OcctWasmAdapter implements KernelAdapter {
     return topoOps.downcast(this.k, shape, type);
   }
 
+  copyShape(shape: KernelShape): KernelShape {
+    return topoOps.copyShape(this.k, shape);
+  }
+
   hashCode(shape: KernelShape, upperBound: number): number {
     return topoOps.hashCode(this.k, shape, upperBound);
   }

--- a/src/kernel/occtWasm/topologyOps.ts
+++ b/src/kernel/occtWasm/topologyOps.ts
@@ -52,6 +52,13 @@ export function downcast(k: OcctKernelWasm, shape: KernelShape, type?: ShapeType
   return shape;
 }
 
+export function copyShape(k: OcctKernelWasm, shape: KernelShape): KernelShape {
+  // Real geometric copy into a fresh arena slot. `downcast` would alias the
+  // source id, so a copy is the only way to get an independently-disposable
+  // handle on this kernel.
+  return wrapResult(k, k.copy(unwrap(shape)));
+}
+
 export function hashCode(k: OcctKernelWasm, shape: KernelShape, upperBound: number): number {
   return k.hashCode(unwrap(shape), upperBound);
 }

--- a/src/sketching/draw3d.ts
+++ b/src/sketching/draw3d.ts
@@ -7,7 +7,7 @@ import { createFace } from '@/core/shapeTypes.js';
 import { outerWire } from '@/topology/faceFns.js';
 import { getEdges } from '@/topology/shapeFns.js';
 import { makeFace } from '@/topology/shapeHelpers.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import type Sketch from './sketch.js';
 import type { ProjectionPlane } from '@/projection/projectionPlanes.js';
 import { type Camera, cameraFromPlane, projectEdges } from '@/projection/cameraFns.js';
@@ -63,7 +63,7 @@ export function drawProjection(
  */
 export function drawFaceOutline(face: Face): Drawing {
   using scope = new DisposalScope();
-  const clonedFace = scope.register(createFace(unwrap(downcast(face.wrapped))));
+  const clonedFace = scope.register(createFace(unwrap(copyShape(face.wrapped))));
   const faceOuterWire = scope.register(outerWire(clonedFace));
   const curves = getEdges(faceOuterWire).map((e) => edgeToCurve(e, face));
 

--- a/src/sketching/faceSketcher.ts
+++ b/src/sketching/faceSketcher.ts
@@ -7,7 +7,7 @@ import type { ClosedWire, Wire, Face, PlanarWire } from '@/core/shapeTypes.js';
 import { createEdge, createFace } from '@/core/shapeTypes.js';
 import { uvBounds, pointOnSurface, normalAt } from '@/topology/faceFns.js';
 import { curveStartPoint, curveIsClosed } from '@/topology/curveFns.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import type { GenericSketcher } from '@/2d/blueprints/genericSketcher.js';
 import type { KernelType } from '@/kernel/types.js';
 import type { Curve2D, Point2D } from '@/2d/lib/index.js';
@@ -40,7 +40,7 @@ export default class FaceSketcher extends BaseSketcher2d implements GenericSketc
 
   constructor(face: Face, origin: Point2D = [0, 0]) {
     super(origin);
-    this.face = createFace(unwrap(downcast(face.wrapped)));
+    this.face = createFace(unwrap(copyShape(face.wrapped)));
     this._bounds = uvBounds(face);
   }
 

--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -1,6 +1,6 @@
 import type { Plane } from '@/core/planeTypes.js';
 import { unwrap } from '@/core/result.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
 import type { ExtrusionProfile, SweepOptions } from '@/operations/extrudeUtils.js';
 import type { LoftOptions } from '@/operations/loftFns.js';
@@ -120,7 +120,7 @@ export default class Sketch implements SketchInterface {
 
   set baseFace(newFace: Face | null | undefined) {
     if (this._baseFace) this._baseFace.delete();
-    this._baseFace = newFace ? createFace(unwrap(downcast(newFace.wrapped))) : newFace;
+    this._baseFace = newFace ? createFace(unwrap(copyShape(newFace.wrapped))) : newFace;
   }
 
   /** Release all kernel resources held by this sketch. */
@@ -131,12 +131,12 @@ export default class Sketch implements SketchInterface {
 
   /** Create an independent deep copy of this sketch. */
   clone(): Sketch {
-    const cloned = createWire(unwrap(downcast(this.wire.wrapped))) as ClosedWire & PlanarWire;
+    const cloned = createWire(unwrap(copyShape(this.wire.wrapped))) as ClosedWire & PlanarWire;
     const sketch = new Sketch(cloned, {
       defaultOrigin: this.defaultOrigin,
       defaultDirection: this.defaultDirection,
     });
-    if (this.baseFace) sketch.baseFace = createFace(unwrap(downcast(this.baseFace.wrapped)));
+    if (this.baseFace) sketch.baseFace = createFace(unwrap(copyShape(this.baseFace.wrapped)));
     return sketch;
   }
 

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -15,7 +15,7 @@ import {
   makeSolid,
 } from '@/topology/shapeHelpers.js';
 import { type Result, unwrap } from '@/core/result.js';
-import { downcast } from '@/topology/cast.js';
+import { copyShape } from '@/topology/cast.js';
 import { cutAll } from '@/topology/booleanFns.js';
 import { toVec3, type Vec3, type PointInput } from '@/core/types.js';
 import { vecScale, vecNormalize, vecCross } from '@/core/vecOps.js';
@@ -99,7 +99,7 @@ export function sketchFace(sketch: Sketch): OrientedFace & PlanarFace {
 
 /** Return an independent clone of the sketch's wire. */
 export function sketchWires(sketch: Sketch): Wire {
-  return createWire(unwrap(downcast(sketch.wire.wrapped)));
+  return createWire(unwrap(copyShape(sketch.wire.wrapped)));
 }
 
 /**
@@ -369,7 +369,7 @@ export function compoundSketchLoft(
   });
 
   const baseFaceRaw = compoundSketchFace(sketch);
-  const baseFace = createFace(unwrap(downcast(baseFaceRaw.wrapped)));
+  const baseFace = createFace(unwrap(copyShape(baseFaceRaw.wrapped)));
   shells.push(baseFace, compoundSketchFace(other));
 
   return unwrap(makeSolid(shells));

--- a/src/topology/cast.ts
+++ b/src/topology/cast.ts
@@ -81,6 +81,27 @@ export function downcast(shape: KernelShape): Result<GenericTopo> {
 }
 
 /**
+ * Return an independently-disposable copy of a generic KernelShape.
+ *
+ * Like {@link downcast}, but the result can be disposed without affecting the
+ * source — `downcast` is only a cast and aliases the source handle on the
+ * occt-wasm arena kernel. Use when cloning a shape (e.g. a sketch wire) that
+ * outlives, or is disposed apart from, its origin.
+ *
+ * @returns Ok with the copied shape, or Err if the shape is null.
+ */
+export function copyShape(shape: KernelShape): Result<GenericTopo> {
+  if (getKernel().isNull(shape)) {
+    return err(typeCastError('NULL_SHAPE', 'Cannot copy a null shape'));
+  }
+  try {
+    return ok(getKernel().copyShape(shape));
+  } catch (e) {
+    return err(typeCastError('NO_WRAPPER', 'Could not copy this shape', e));
+  }
+}
+
+/**
  * Cast a raw kernel shape to its corresponding branded brepjs type (Vertex, Edge, Face, etc.).
  *
  * Performs downcast + branded handle creation in one step.

--- a/src/topology/shapeFns.ts
+++ b/src/topology/shapeFns.ts
@@ -18,10 +18,10 @@ import { BrepErrorCode } from '@/core/errors.js';
 // Identity / introspection
 // ---------------------------------------------------------------------------
 
-/** Clone a shape (deep copy via kernel topology downcast). */
+/** Clone a shape (an independently-disposable deep copy). */
 export function clone<T extends AnyShape<Dimension>>(shape: T): Result<T> {
   return kernelCall(
-    () => getKernel().downcast(shape.wrapped),
+    () => getKernel().copyShape(shape.wrapped),
     BrepErrorCode.CLONE_FAILED,
     'Failed to clone shape'
   ) as Result<T>;

--- a/src/topology/topologyQueryFns.ts
+++ b/src/topology/topologyQueryFns.ts
@@ -17,7 +17,7 @@ import type {
   CompSolid,
   ShapeKind,
 } from '@/core/shapeTypes.js';
-import { castShapeWithKnownType } from '@/core/shapeTypes.js';
+import { castResultShapeWithKnownType } from '@/core/shapeTypes.js';
 import { getOrQueryType } from '@/core/shapeTypeCache.js';
 import type { Vec3 } from '@/core/types.js';
 
@@ -35,7 +35,7 @@ function castSubShapes<T>(parentShape: KernelShape, type: ShapeType): T[] {
   const rawShapes = kernel.iterShapes(parentShape, type);
   const result: T[] = new Array(rawShapes.length);
   for (let i = 0; i < rawShapes.length; i++) {
-    result[i] = castShapeWithKnownType(rawShapes[i], type) as T;
+    result[i] = castResultShapeWithKnownType(rawShapes[i], type) as T;
   }
   return result;
 }
@@ -174,49 +174,49 @@ export function getCompSolids(shape: AnyShape<Dimension>): CompSolid[] {
 /** Lazily iterate edges of a shape, yielding branded Edge handles one at a time. */
 export function* iterEdges<D extends Dimension>(shape: AnyShape<D>): Generator<Edge<D>> {
   for (const e of getKernel().iterShapes(shape.wrapped, 'edge')) {
-    yield castShapeWithKnownType(e, 'edge') as Edge<D>;
+    yield castResultShapeWithKnownType(e, 'edge') as Edge<D>;
   }
 }
 
 /** Lazily iterate faces of a shape, yielding branded Face handles one at a time. */
 export function* iterFaces<D extends Dimension>(shape: AnyShape<D>): Generator<Face<D>> {
   for (const f of getKernel().iterShapes(shape.wrapped, 'face')) {
-    yield castShapeWithKnownType(f, 'face') as Face<D>;
+    yield castResultShapeWithKnownType(f, 'face') as Face<D>;
   }
 }
 
 /** Lazily iterate wires of a shape, yielding branded Wire handles one at a time. */
 export function* iterWires<D extends Dimension>(shape: AnyShape<D>): Generator<Wire<D>> {
   for (const w of getKernel().iterShapes(shape.wrapped, 'wire')) {
-    yield castShapeWithKnownType(w, 'wire') as Wire<D>;
+    yield castResultShapeWithKnownType(w, 'wire') as Wire<D>;
   }
 }
 
 /** Lazily iterate vertices of a shape, yielding branded Vertex handles one at a time. */
 export function* iterVertices<D extends Dimension>(shape: AnyShape<D>): Generator<Vertex<D>> {
   for (const v of getKernel().iterShapes(shape.wrapped, 'vertex')) {
-    yield castShapeWithKnownType(v, 'vertex') as Vertex<D>;
+    yield castResultShapeWithKnownType(v, 'vertex') as Vertex<D>;
   }
 }
 
 /** Lazily iterate solids of a shape, yielding branded Solid handles one at a time. */
 export function* iterSolids(shape: AnyShape<Dimension>): Generator<Solid> {
   for (const s of getKernel().iterShapes(shape.wrapped, 'solid')) {
-    yield castShapeWithKnownType(s, 'solid') as Solid;
+    yield castResultShapeWithKnownType(s, 'solid') as Solid;
   }
 }
 
 /** Lazily iterate shells of a shape, yielding branded Shell handles one at a time. */
 export function* iterShells(shape: AnyShape<Dimension>): Generator<Shell> {
   for (const s of getKernel().iterShapes(shape.wrapped, 'shell')) {
-    yield castShapeWithKnownType(s, 'shell') as Shell;
+    yield castResultShapeWithKnownType(s, 'shell') as Shell;
   }
 }
 
 /** Lazily iterate compsolids of a shape, yielding branded CompSolid handles one at a time. */
 export function* iterCompSolids(shape: AnyShape<Dimension>): Generator<CompSolid> {
   for (const s of getKernel().iterShapes(shape.wrapped, 'compsolid')) {
-    yield castShapeWithKnownType(s, 'compsolid') as CompSolid;
+    yield castResultShapeWithKnownType(s, 'compsolid') as CompSolid;
   }
 }
 

--- a/tests/shapeFns.test.ts
+++ b/tests/shapeFns.test.ts
@@ -52,6 +52,21 @@ describe('clone', () => {
     expect(unwrap(measureVolume(box(10, 10, 10)))).toBeCloseTo(1000, 0);
     expect(cloned).toBeDefined();
   });
+
+  it('produces an independently-owned copy, not an alias of the source', () => {
+    // Regression: clone used `downcast`, but on the occt-wasm arena kernel a
+    // same-type downcast returns the *same* handle id — so the "copy" aliased
+    // the source and disposing it would free the original. clone now uses a
+    // real copyShape. Verify same geometry but a distinct kernel entity.
+    const b = box(10, 10, 10);
+    const cloned = unwrap(clone(b));
+    expect(unwrap(measureVolume(cloned))).toBeCloseTo(unwrap(measureVolume(b)), 6);
+    // On the occt-wasm arena kernel a genuine copy occupies a distinct slot.
+    if (process.env['TEST_KERNEL'] === 'occt-wasm') {
+      const idOf = (h: { id?: number }): number | undefined => h.id;
+      expect(idOf(cloned.wrapped as { id?: number })).not.toBe(idOf(b.wrapped as { id?: number }));
+    }
+  });
 });
 
 describe('toBREP', () => {

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -1,0 +1,134 @@
+/**
+ * occt-wasm arena disposal — proves `using`/Symbol.dispose actually reclaims
+ * arena slots on the occt-wasm kernel.
+ *
+ * occt-wasm shapes are arena-allocated: a handle's own `.delete()` is a no-op,
+ * so a slot is only reclaimed via `kernel.dispose()` (→ `k.release(id)`).
+ * `createHandle` routes disposal through the kernel, so a `using`-scoped shape
+ * frees its slot. `getShapeCount()` is the ground-truth oracle — the JS-side
+ * `getDisposalStats().liveHandles` is blind to orphaned pre-downcast slots.
+ *
+ * Gated to occt-wasm: no other kernel exposes the arena counter (brepkit is a
+ * no-free arena; occt/manifold have different memory models).
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import {
+  box,
+  cylinder,
+  sphere,
+  translate,
+  clone,
+  getFaces,
+  getEdges,
+  measureVolume,
+  isOk,
+  unwrap,
+} from '@/index.js';
+import { getKernel } from '@/kernel/index.js';
+
+const isOcctWasm = (process.env['TEST_KERNEL'] ?? 'occt') === 'occt-wasm';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+/** occt-wasm's live-shape arena counter, the ground-truth leak oracle. */
+function arenaCount(): number {
+  const adapter = getKernel() as unknown as {
+    retainedKernelOwner?: { getRawKernel?: () => { getShapeCount?: () => number } };
+  };
+  const raw = adapter.retainedKernelOwner?.getRawKernel?.();
+  const n = typeof raw?.getShapeCount === 'function' ? raw.getShapeCount() : undefined;
+  if (typeof n !== 'number') throw new Error('arena counter unavailable');
+  return n;
+}
+
+/** Run `op` once to warm caches, then N times; return net arena growth per iteration. */
+function perIterationLeak(op: () => void, iterations = 20): number {
+  op();
+  const before = arenaCount();
+  for (let i = 0; i < iterations; i++) op();
+  return (arenaCount() - before) / iterations;
+}
+
+describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
+  describe('using-scoped ops reclaim their arena slots', () => {
+    it('primitives leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          void b;
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using c = cylinder(5, 10);
+          void c;
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using s = sphere(5);
+          void s;
+        })
+      ).toBe(0);
+    });
+
+    it('transform leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          using m = translate(b, [1, 0, 0]);
+          void m;
+        })
+      ).toBe(0);
+    });
+
+    it('sub-shape extraction (getFaces/getEdges) leaks nothing when disposed', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          for (const f of getFaces(b)) f[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          for (const e of getEdges(b)) e[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('clone leaks nothing when disposed', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const r = clone(b);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('disposal is real, not a no-op', () => {
+    it('creating then disposing a box returns the arena to baseline', () => {
+      const before = arenaCount();
+      const b = box(10, 10, 10);
+      expect(arenaCount()).toBeGreaterThan(before);
+      b[Symbol.dispose]();
+      expect(arenaCount()).toBe(before);
+    });
+  });
+
+  describe('clone is independent of its source (PR-1 + PR-2 integration)', () => {
+    it('disposing a clone does not free the original', () => {
+      using original = box(10, 10, 10);
+      const cloned = unwrap(clone(original));
+      cloned[Symbol.dispose]();
+      // Source must survive the clone's disposal — before the copyShape fix the
+      // clone aliased the source's arena slot, so this freed the original.
+      expect(unwrap(measureVolume(original))).toBeCloseTo(1000, 0);
+    });
+  });
+});

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -19,6 +19,11 @@ import {
   sphere,
   translate,
   clone,
+  cut,
+  fuse,
+  intersect,
+  fuseAll,
+  compound,
   getFaces,
   getEdges,
   measureVolume,
@@ -105,6 +110,64 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
         perIterationLeak(() => {
           using b = box(10, 10, 10);
           const r = clone(b);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('booleans leak nothing when inputs and result are disposed', () => {
+      // Every intermediate is `using`-disposed; the only survivor would be a
+      // leak inside the boolean itself. (An undisposed intermediate here would
+      // read as a false "+1" — the arena counter sees the whole arena.)
+      expect(
+        perIterationLeak(() => {
+          using a = box(10, 10, 10);
+          using inner = box(5, 5, 20);
+          using tool = translate(inner, [3, 3, 0]);
+          const r = cut(a, tool);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using a = box(10, 10, 10);
+          using inner = box(5, 5, 20);
+          using tool = translate(inner, [3, 3, 0]);
+          const r = fuse(a, tool);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using a = box(10, 10, 10);
+          using inner = box(5, 5, 20);
+          using tool = translate(inner, [3, 3, 0]);
+          const r = intersect(a, tool);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('N-way and multi-solid-tool booleans leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b1 = box(10, 10, 10);
+          using i2 = box(10, 10, 10);
+          using b2 = translate(i2, [5, 0, 0]);
+          using i3 = box(10, 10, 10);
+          using b3 = translate(i3, [10, 0, 0]);
+          const r = fuseAll([b1, b2, b3]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using a = box(20, 20, 20);
+          using i1 = box(3, 3, 30);
+          using i2 = box(3, 3, 30);
+          using pillar2 = translate(i2, [8, 0, 0]);
+          using tool = compound([i1, pillar2]);
+          const r = cut(a, tool);
           if (isOk(r)) unwrap(r)[Symbol.dispose]();
         })
       ).toBe(0);


### PR DESCRIPTION
## Summary

On **occt-wasm — the default kernel — `using`/`Symbol.dispose` was a silent no-op.** occt-wasm shapes are arena-allocated: a handle's own `.delete()` does nothing, so a slot is only reclaimed via `kernel.dispose()` (→ `k.release(id)`). But `createHandle`'s disposer called `ocShape.delete()` (the no-op), so **every shape leaked its arena slot** unless something explicitly released it. Measured before this change: `using b = box(...)` net **+1 slot leaked**; `getFaces` (6 faces) **+13**; `getEdges` (12) **+25** — all growing unbounded across a session. `getDisposalStats().liveHandles` (JS-side) reads **0** the whole time; it's structurally blind to orphaned arena slots, so the leak was invisible.

This is the foundational half of the WASM-handle-leak work: the prior `castResultShape`/`disposeResultShape` campaign plugged *intermediate* orphans op-by-op, but the base `using`-disposal itself never freed on the default kernel.

## What this does

- **`createHandle` routes disposal through the owning kernel.** It captures `getKernel()` at creation and calls `kernel.dispose(ocShape)` in both `Symbol.dispose` and the FinalizationRegistry (GC) path, instead of `ocShape.delete()`. So `using` frees the slot on every kernel. Embind/brepkit/manifold are unchanged (`kernel.dispose` falls through to `.delete()` there). `k.release` is idempotent, so overlap with the existing `disposeResultShape`/`disposeDowncastSource` helpers cannot double-free.
- **Sub-shape extraction is leak-free.** New `castResultShapeWithKnownType` releases the orphaned pre-downcast slot; `castSubShapes` + the `iter*` generators (backing `getFaces`/`getEdges`/`getWires`/`getVertices`) use it.
- **`kernelCall` uses `castResultShape`** so `clone`/`simplify` no longer orphan their pre-downcast slot.

## After

`using`-scoped primitives, transforms, sub-shape extraction, `clone`, and **all booleans** (`cut`/`fuse`/`intersect`, single- and multi-solid tools, and native N-way `fuseAll`) return the arena to baseline (**0 leak/call**, verified). A new occt-wasm-gated harness `tests/wasmArenaDisposal.test.ts` asserts this per op via the `getShapeCount()` arena oracle, proves disposal is real (create → dispose → back to baseline), and proves clone-dispose independence (disposing a clone leaves the source intact — the integration point with #1767).

## Sequencing

Stacks on **#1767** (`clone` via real `copyShape`), which is a prerequisite: making disposal real would otherwise turn `clone`'s aliasing `downcast` into a use-after-free (disposing a clone freed its source). With #1767 first, this lands with the full occt-wasm suite green.

## Follow-ups (not in scope)

- `adjacencyFns` (the `edgeToFaces`/`vertexToFaces` caches store raw pre-downcast handles) and `healingFns` (in-place heal ownership on brepkit) still hold orphans and need dedicated analysis before release.