### PR TITLE
fix(topology): stop adjacency queries leaking occt-wasm arena slots

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "343 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "344 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/topology/adjacencyFns.ts
+++ b/src/topology/adjacencyFns.ts
@@ -8,14 +8,19 @@
 import { getKernel } from '@/kernel/index.js';
 import type { KernelShape, ShapeType } from '@/kernel/types.js';
 import type { AnyShape, ClosedWire, Dimension, Edge, Face, Vertex } from '@/core/shapeTypes.js';
-import { castShapeWithKnownType } from '@/core/shapeTypes.js';
+import { castShapeWithKnownType, castResultShapeWithKnownType } from '@/core/shapeTypes.js';
 import { HASH_CODE_MAX } from '@/core/constants.js';
-import { getOrCreateCache } from './topologyQueryFns.js';
+import { getOrCreateCache, getFaces, getEdges, getVertices } from './topologyQueryFns.js';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Brand cache-owned raw sub-shapes (from the edge/face adjacency maps) without
+ * consuming them. Each cast allocates a fresh downcast the caller disposes; the
+ * cached source stays intact — so this must NOT release its input.
+ */
 function wrapAll<T extends AnyShape<Dimension>>(shapes: KernelShape[], type: ShapeType): T[] {
   return shapes.map((s) => castShapeWithKnownType(s, type) as T);
 }
@@ -25,7 +30,11 @@ function wrapAll<T extends AnyShape<Dimension>>(shapes: KernelShape[], type: Sha
  * hash+isSame, and return branded handles of type `T`.
  *
  * Used by edgesOfFace, wiresOfFace, and verticesOfEdge — all of which need
- * the same deduplicated-children pattern on a raw KernelShape.
+ * the same deduplicated-children pattern on a raw KernelShape. Each iterated
+ * sub-shape is a fresh arena slot the caller owns: uniques are cast with
+ * `castResultShapeWithKnownType` (releasing the orphaned pre-downcast source),
+ * and duplicates are released outright — otherwise every call leaks one slot
+ * per sub-shape on the occt-wasm arena kernel.
  */
 function deduplicatedSubShapes<T extends AnyShape<Dimension>>(
   parentKernel: KernelShape,
@@ -34,22 +43,25 @@ function deduplicatedSubShapes<T extends AnyShape<Dimension>>(
   const kernel = getKernel();
   const items = kernel.iterShapes(parentKernel, type);
 
-  const results: KernelShape[] = [];
+  const results: T[] = [];
+  // Store the branded downcast (its `.wrapped` shares the source TShape) for
+  // isSame dedup, so we can release the raw iterated slot immediately.
   const seen = new Map<number, KernelShape[]>();
 
   for (const item of items) {
     const hash = kernel.hashCode(item, HASH_CODE_MAX);
     const bucket = seen.get(hash);
-    if (!bucket) {
-      seen.set(hash, [item]);
-      results.push(item);
-    } else if (!bucket.some((r) => kernel.isSame(r, item))) {
-      bucket.push(item);
-      results.push(item);
+    if (bucket?.some((r) => kernel.isSame(r, item))) {
+      kernel.dispose(item);
+      continue;
     }
+    const casted = castResultShapeWithKnownType(item, type) as T;
+    results.push(casted);
+    if (bucket) bucket.push(casted.wrapped);
+    else seen.set(hash, [casted.wrapped]);
   }
 
-  return wrapAll<T>(results, type);
+  return results;
 }
 
 /** Edge-face pair stored in the adjacency map. */
@@ -58,31 +70,67 @@ interface EdgeFaceEntry {
   readonly face: KernelShape;
 }
 
+/** Hash-index branded sub-shapes for isSame lookup by hash code. */
+function indexByHash<T extends AnyShape<Dimension>>(items: readonly T[]): Map<number, T[]> {
+  const kernel = getKernel();
+  const index = new Map<number, T[]>();
+  for (const item of items) {
+    const hash = kernel.hashCode(item.wrapped, HASH_CODE_MAX);
+    const bucket = index.get(hash);
+    if (bucket) bucket.push(item);
+    else index.set(hash, [item]);
+  }
+  return index;
+}
+
+/** The managed handle matching a raw sub-shape by hash + isSame, or undefined. */
+function findManaged<T extends AnyShape<Dimension>>(
+  index: Map<number, T[]>,
+  raw: KernelShape,
+  hash: number
+): T | undefined {
+  const kernel = getKernel();
+  return index.get(hash)?.find((m) => kernel.isSame(m.wrapped, raw));
+}
+
 /**
  * Build or retrieve the cached edge→faces adjacency map for a parent shape.
  * Maps edge hash codes to edge-face pairs, storing the edge alongside each
  * face so facesOfEdge can verify via isSame without re-extracting face edges.
+ *
+ * The stored handles are the parent's **managed** `getEdges`/`getFaces` handles
+ * (owned by the topology cache), never fresh iterated slots — so the map holds
+ * no arena slots of its own. The transient per-face edges used only for
+ * matching are released immediately.
  */
 function getEdgeToFacesMap(parent: AnyShape<Dimension>): Map<number, EdgeFaceEntry[]> {
   const cache = getOrCreateCache(parent);
   if (cache.edgeToFaces) return cache.edgeToFaces;
 
   const kernel = getKernel();
+  const faces = getFaces(parent);
+  const edgeIndex = indexByHash(getEdges(parent));
   const edgeToFaces = new Map<number, EdgeFaceEntry[]>();
-  const allFaces = kernel.iterShapes(parent.wrapped, 'face');
 
-  for (const f of allFaces) {
-    const edges = kernel.iterShapes(f, 'edge');
-    for (const e of edges) {
-      const hash = kernel.hashCode(e, HASH_CODE_MAX);
+  for (const face of faces) {
+    for (const rawEdge of kernel.iterShapes(face.wrapped, 'edge')) {
+      const hash = kernel.hashCode(rawEdge, HASH_CODE_MAX);
+      const managedEdge = findManaged(edgeIndex, rawEdge, hash);
+      kernel.dispose(rawEdge);
+      if (!managedEdge) continue;
       let bucket = edgeToFaces.get(hash);
       if (!bucket) {
         bucket = [];
         edgeToFaces.set(hash, bucket);
       }
-      // Store each edge-face pair; dedup faces within same edge identity
-      if (!bucket.some((entry) => kernel.isSame(entry.edge, e) && kernel.isSame(entry.face, f))) {
-        bucket.push({ edge: e, face: f });
+      if (
+        !bucket.some(
+          (entry) =>
+            kernel.isSame(entry.edge, managedEdge.wrapped) &&
+            kernel.isSame(entry.face, face.wrapped)
+        )
+      ) {
+        bucket.push({ edge: managedEdge.wrapped, face: face.wrapped });
       }
     }
   }
@@ -99,24 +147,37 @@ interface VertexFaceEntry {
 
 /**
  * Build or retrieve the cached vertex→faces adjacency map for a parent shape —
- * the vertex analogue of {@link getEdgeToFacesMap}.
+ * the vertex analogue of {@link getEdgeToFacesMap}. Stores the parent's managed
+ * `getVertices`/`getFaces` handles and releases the transient per-face vertices.
  */
 function getVertexToFacesMap(parent: AnyShape<Dimension>): Map<number, VertexFaceEntry[]> {
   const cache = getOrCreateCache(parent);
   if (cache.vertexToFaces) return cache.vertexToFaces;
 
   const kernel = getKernel();
+  const faces = getFaces(parent);
+  const vertexIndex = indexByHash(getVertices(parent));
   const vertexToFaces = new Map<number, VertexFaceEntry[]>();
-  for (const f of kernel.iterShapes(parent.wrapped, 'face')) {
-    for (const v of kernel.iterShapes(f, 'vertex')) {
-      const hash = kernel.hashCode(v, HASH_CODE_MAX);
+
+  for (const face of faces) {
+    for (const rawVertex of kernel.iterShapes(face.wrapped, 'vertex')) {
+      const hash = kernel.hashCode(rawVertex, HASH_CODE_MAX);
+      const managedVertex = findManaged(vertexIndex, rawVertex, hash);
+      kernel.dispose(rawVertex);
+      if (!managedVertex) continue;
       let bucket = vertexToFaces.get(hash);
       if (!bucket) {
         bucket = [];
         vertexToFaces.set(hash, bucket);
       }
-      if (!bucket.some((entry) => kernel.isSame(entry.vertex, v) && kernel.isSame(entry.face, f))) {
-        bucket.push({ vertex: v, face: f });
+      if (
+        !bucket.some(
+          (entry) =>
+            kernel.isSame(entry.vertex, managedVertex.wrapped) &&
+            kernel.isSame(entry.face, face.wrapped)
+        )
+      ) {
+        bucket.push({ vertex: managedVertex.wrapped, face: face.wrapped });
       }
     }
   }
@@ -275,6 +336,9 @@ export function adjacentFaces<D extends Dimension>(parent: AnyShape<D>, face: Fa
     }
   }
 
+  // faceEdgeHandles were extracted only to key into the map; release them.
+  // neighborRaw are cache-owned face handles — wrapAll copies, never consumes.
+  for (const e of faceEdgeHandles) e[Symbol.dispose]();
   return wrapAll<Face<D>>(neighborRaw, 'face');
 }
 
@@ -302,13 +366,19 @@ export function sharedEdges<D extends Dimension>(face1: Face<D>, face2: Face<D>)
     bucket.push(e2);
   }
 
-  const shared: KernelShape[] = [];
+  // edges1/edges2 are fresh arena slots owned here: cast the matches (releasing
+  // their pre-downcast source) and release every other transient, so the query
+  // leaks nothing per call.
+  const shared: Edge<D>[] = [];
   for (const e1 of edges1) {
     const bucket = edge2Map.get(kernel.hashCode(e1, HASH_CODE_MAX));
     if (bucket?.some((e2) => kernel.isSame(e1, e2))) {
-      shared.push(e1);
+      shared.push(castResultShapeWithKnownType(e1, 'edge') as Edge<D>);
+    } else {
+      kernel.dispose(e1);
     }
   }
+  for (const e2 of edges2) kernel.dispose(e2);
 
-  return wrapAll<Edge<D>>(shared, 'edge');
+  return shared;
 }

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -26,10 +26,16 @@ import {
   compound,
   getFaces,
   getEdges,
+  edgesOfFace,
+  verticesOfFace,
+  facesOfEdge,
+  adjacentFaces,
+  sharedEdges,
   measureVolume,
   isOk,
   unwrap,
 } from '@/index.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
 
 const isOcctWasm = (process.env['TEST_KERNEL'] ?? 'occt') === 'occt-wasm';
@@ -171,6 +177,52 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           if (isOk(r)) unwrap(r)[Symbol.dispose]();
         })
       ).toBe(0);
+    });
+
+    it('adjacency queries leak nothing per call (warm cache)', () => {
+      // Shared parent with a warm adjacency cache: each query's per-call
+      // allocation must return to baseline. The parent + borrowed sub-shape
+      // handles are intentionally kept alive for the duration.
+      const parent = box(10, 10, 10);
+      const faces = getFaces(parent);
+      const edges = getEdges(parent);
+      const disposeAll = (arr: AnyShape<Dimension>[]): void => {
+        for (const h of arr) h[Symbol.dispose]();
+      };
+      const f0 = faces[0];
+      const f1 = faces[1];
+      const e0 = edges[0];
+      if (!f0 || !f1 || !e0) throw new Error('box must have faces and edges');
+
+      expect(
+        perIterationLeak(() => {
+          disposeAll(edgesOfFace(f0));
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          disposeAll(verticesOfFace(f0));
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          disposeAll(facesOfEdge(parent, e0));
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          disposeAll(adjacentFaces(parent, f0));
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          disposeAll(sharedEdges(f0, f1));
+        })
+      ).toBe(0);
+
+      disposeAll(faces);
+      disposeAll(edges);
+      parent[Symbol.dispose]();
     });
   });
 


### PR DESCRIPTION
## Summary

`adjacencyFns` leaked occt-wasm arena slots two ways — a **per-call** leak on every query and a **one-time** retention per shape:

| query | before | after |
|---|---|---|
| `edgesOfFace` / `verticesOfFace` / `wiresOfFace` / `verticesOfEdge` | 4/call | **0** |
| `adjacentFaces` | 8/call | **0** |
| `sharedEdges` | 8/call | **0** |
| `edgeToFaces` / `vertexToFaces` map build | ~30/shape retained | **0** |

Both are the same root issue #1768 exposed: `iterShapes` hands back fresh arena slots, and adjacency either discarded them (dedup duplicates, non-matching edges) or stashed them raw in a cache that never released them.

## What this does

- **Per-call transients are released.** `deduplicatedSubShapes` now casts uniques with `castResultShapeWithKnownType` (freeing the orphaned pre-downcast source) and `dispose`s duplicates; `sharedEdges` disposes every non-matching / lookup-only edge; `adjacentFaces` disposes the edge handles it extracted only to key into the map.
- **The adjacency maps hold no arena slots of their own.** `getEdgeToFacesMap` / `getVertexToFacesMap` now store the parent's **managed** `getEdges`/`getVertices`/`getFaces` handles (already owned by the topology cache, matched via a hash index) instead of fresh iterated slots, and release the transient per-face sub-shapes used only for matching.

Verified via the `getShapeCount()` arena oracle: every query returns to baseline. New coverage in `tests/wasmArenaDisposal.test.ts` asserts each adjacency query is leak-free per call with a warm cache.

## Correctness

`isSame` matching is unchanged in behavior — a face's coedge and the parent's canonical edge share a `TShape`, so the managed-handle match resolves identically. Validated across the adjacency, topology-caching, and ShapeRef/history-replay suites (which lean on adjacency for lineage) plus the full occt-wasm suite.

## Not in scope (follow-up)

The residual retention is now purely the **general topology cache** (`getFaces`/`getEdges`/`getVertices` cache their handles and never release them on eviction or parent disposal) — a broader `topoCache` lifecycle issue affecting all cached extractors, not adjacency-specific.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

