### PR TITLE
fix(topology): release the topology cache when its shape is disposed

### DIFF
--- a/src/core/disposal.ts
+++ b/src/core/disposal.ts
@@ -139,6 +139,15 @@ export interface ShapeHandle {
 
   /** Check if this handle has been disposed */
   readonly disposed: boolean;
+
+  /**
+   * Register a callback to run when this handle is disposed, before its kernel
+   * slot is released. Used to release dependent resources tied to this shape's
+   * lifetime (e.g. its cached sub-shape handles). Callbacks are invoked once,
+   * in registration order; a callback that throws is swallowed. Registering on
+   * an already-disposed handle runs the callback immediately.
+   */
+  onDispose(callback: () => void): void;
 }
 
 /** Create a disposable shape handle. */
@@ -151,12 +160,27 @@ export function createHandle(ocShape: KernelShape): ShapeHandle {
   // so overlap with `disposeResultShape`/`disposeDowncastSource` is safe.
   const kernel = getKernel();
   let disposed = false;
+  let onDisposeCallbacks: (() => void)[] | undefined;
+
+  const runOnDispose = () => {
+    if (!onDisposeCallbacks) return;
+    for (const cb of onDisposeCallbacks) {
+      try {
+        cb();
+      } catch {
+        // A dependent-cleanup failure must not abort disposal.
+      }
+    }
+    onDisposeCallbacks = undefined;
+  };
 
   const dispose = () => {
     if (!disposed) {
       disposed = true;
       trackHandleDisposed();
       registry.unregister(handle);
+      // Release dependents (e.g. cached sub-shapes) before this slot goes.
+      runOnDispose();
       try {
         kernel.dispose(ocShape);
       } catch {
@@ -181,6 +205,14 @@ export function createHandle(ocShape: KernelShape): ShapeHandle {
 
     delete() {
       dispose();
+    },
+
+    onDispose(callback: () => void) {
+      if (disposed) {
+        callback();
+        return;
+      }
+      (onDisposeCallbacks ??= []).push(callback);
     },
   };
 

--- a/src/topology/topologyQueryFns.ts
+++ b/src/topology/topologyQueryFns.ts
@@ -66,12 +66,43 @@ export interface TopoCacheEntry {
 
 const topoCache = new WeakMap<object, TopoCacheEntry>();
 
+/**
+ * Release the cached sub-shape handles for a cache entry and drop it. The
+ * extractor arrays own arena slots (their branded downcast handles); the
+ * adjacency maps only alias those same handles, so dropping the maps is enough.
+ * Disposal is idempotent, so a manually-disposed handle here is a safe no-op.
+ */
+function disposeCacheEntry(key: object): void {
+  const entry = topoCache.get(key);
+  if (!entry) return;
+  topoCache.delete(key);
+  const arrays = [
+    entry.edges,
+    entry.faces,
+    entry.wires,
+    entry.vertices,
+    entry.shells,
+    entry.solids,
+    entry.compSolids,
+  ];
+  for (const arr of arrays) {
+    if (arr) for (const handle of arr) handle[Symbol.dispose]();
+  }
+}
+
 /** @internal Get or create a cache entry for a shape. Used by originTrackingFns. */
 export function getOrCreateCache(shape: AnyShape<Dimension>): TopoCacheEntry {
-  let entry = topoCache.get(shape.wrapped);
+  const key = shape.wrapped;
+  let entry = topoCache.get(key);
   if (!entry) {
     entry = {};
-    topoCache.set(shape.wrapped, entry);
+    topoCache.set(key, entry);
+    // Release the cached sub-shape handles when the parent shape is disposed,
+    // so its arena slots don't outlive it. (GC of an undisposed parent drops
+    // the WeakMap entry, letting the handles' own finalizers reclaim them.)
+    shape.onDispose(() => {
+      disposeCacheEntry(key);
+    });
   }
   return entry;
 }
@@ -82,11 +113,12 @@ export function getCacheEntry(shape: AnyShape<Dimension>): TopoCacheEntry | unde
 }
 
 /**
- * Invalidate cached topology data for a shape.
- * Call this after operations that modify a shape in-place (e.g., unifyFaces).
+ * Invalidate cached topology data for a shape, releasing its cached sub-shape
+ * handles. Call this after operations that modify a shape in-place (e.g.,
+ * unifyFaces).
  */
 export function invalidateShapeCache(shape: AnyShape<Dimension>): void {
-  topoCache.delete(shape.wrapped);
+  disposeCacheEntry(shape.wrapped);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/topologyCaching.test.ts
+++ b/tests/topologyCaching.test.ts
@@ -84,15 +84,21 @@ describe('topology cache — getCachedShapeKind', () => {
 });
 
 describe('topology cache — invalidation', () => {
-  it('invalidateShapeCache forces re-extraction', () => {
+  it('invalidateShapeCache releases the stale handles and forces re-extraction', () => {
     const b = box(10, 10, 10);
     const edges1 = getEdges(b);
+    const len = edges1.length;
+    expect(edges1[0]?.disposed).toBe(false);
+
     invalidateShapeCache(b);
+    // The stale cached handles are released (they reference pre-modification
+    // topology); do not touch their `.wrapped` after this point.
+    expect(edges1[0]?.disposed).toBe(true);
+
+    // Re-extraction yields a fresh, live array of the same length.
     const edges2 = getEdges(b);
-    // Different array reference after invalidation
-    expect(edges1).not.toBe(edges2);
-    // But same contents
-    expect(edges2).toHaveLength(edges1.length);
+    expect(edges2).toHaveLength(len);
+    expect(edges2[0]?.disposed).toBe(false);
   });
 });
 

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -26,6 +26,7 @@ import {
   compound,
   getFaces,
   getEdges,
+  getVertices,
   edgesOfFace,
   verticesOfFace,
   facesOfEdge,
@@ -53,6 +54,10 @@ function arenaCount(): number {
   const n = typeof raw?.getShapeCount === 'function' ? raw.getShapeCount() : undefined;
   if (typeof n !== 'number') throw new Error('arena counter unavailable');
   return n;
+}
+
+function disposeAll(arr: AnyShape<Dimension>[]): void {
+  for (const h of arr) h[Symbol.dispose]();
 }
 
 /** Run `op` once to warm caches, then N times; return net arena growth per iteration. */
@@ -186,9 +191,6 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       const parent = box(10, 10, 10);
       const faces = getFaces(parent);
       const edges = getEdges(parent);
-      const disposeAll = (arr: AnyShape<Dimension>[]): void => {
-        for (const h of arr) h[Symbol.dispose]();
-      };
       const f0 = faces[0];
       const f1 = faces[1];
       const e0 = edges[0];
@@ -223,6 +225,33 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       disposeAll(faces);
       disposeAll(edges);
       parent[Symbol.dispose]();
+    });
+  });
+
+  describe('disposing a parent releases its cached topology', () => {
+    it('a warm topology + adjacency cache is freed with the parent', () => {
+      // No manual disposal of the borrowed sub-shape handles — the parent's
+      // disposal must release the whole cache (extractors + adjacency maps).
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          getFaces(b);
+          getEdges(b);
+          getVertices(b);
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const es = getEdges(b);
+          const fs = getFaces(b);
+          const e0 = es[0];
+          const f0 = fs[0];
+          if (!e0 || !f0) throw new Error('box must have edges and faces');
+          disposeAll(facesOfEdge(b, e0));
+          disposeAll(adjacentFaces(b, f0));
+        })
+      ).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

The topology cache (`topoCache`, a `WeakMap` in `topologyQueryFns`) caches a shape's sub-shape handles — `getFaces`/`getEdges`/`getWires`/`getVertices` and the edge/vertex→faces adjacency maps. Those handles own occt-wasm arena slots, but nothing ever released them: `invalidateShapeCache` just dropped the entry, and disposing the parent shape freed only the parent's slot, never its cache. So querying topology on many transient shapes leaked their whole cached topology (≈6 faces + 12 edges + 8 vertices per box, held for the parent's lifetime and beyond).

This is the root behind the adjacency-map retention noted in the previous PR — adjacency now references these cached handles, so fixing the cache's lifecycle fixes the last of it.

## What this does

- **`ShapeHandle` gains an `onDispose(cb)` hook** (core): callbacks run once, deterministically, when the handle is disposed, just before its kernel slot is released.
- **The topology cache registers cleanup per shape**: the first time a cache entry is built for a shape, `getOrCreateCache` registers `onDispose` to release that entry's cached sub-shape handles. So `using solid = box(...)` now reclaims *everything* derived from it, not just the solid's own slot.
- **`invalidateShapeCache` now releases the stale handles** it drops (they reference pre-modification topology).

Both lifecycle paths are covered: explicit disposal → `onDispose` → deterministic release; GC of an undisposed parent → the `WeakMap` entry drops → the cached handles' own finalizers reclaim their slots.

## Behavior change

Disposing a shape (or calling `invalidateShapeCache` on it) now **disposes its cached sub-shape handles**. Code must not retain a borrowed `getFaces`/`getEdges`/… handle past its parent's disposal — `clone()`/`copyShape` such a handle first if it needs to outlive the parent. This matched the whole suite except one cache test that asserted the old (leaky) behavior, updated here to assert the correct semantics. The sole internal `invalidateShapeCache` caller (`healingFns`) re-derives after invalidating and never reuses the stale handles.

## Verification

New harness coverage in `tests/wasmArenaDisposal.test.ts`: a warm topology + adjacency cache returns the arena to baseline when the parent is disposed. Full occt-wasm suite green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

