### PR TITLE
fix(topology): register cache-cleanup onDispose once per shape handle

### DIFF
--- a/src/topology/topologyQueryFns.ts
+++ b/src/topology/topologyQueryFns.ts
@@ -90,6 +90,9 @@ function disposeCacheEntry(key: object): void {
   }
 }
 
+/** Handles whose disposal is already wired to release their cache entry. */
+const cleanupRegistered = new WeakSet();
+
 /** @internal Get or create a cache entry for a shape. Used by originTrackingFns. */
 export function getOrCreateCache(shape: AnyShape<Dimension>): TopoCacheEntry {
   const key = shape.wrapped;
@@ -97,9 +100,14 @@ export function getOrCreateCache(shape: AnyShape<Dimension>): TopoCacheEntry {
   if (!entry) {
     entry = {};
     topoCache.set(key, entry);
-    // Release the cached sub-shape handles when the parent shape is disposed,
-    // so its arena slots don't outlive it. (GC of an undisposed parent drops
-    // the WeakMap entry, letting the handles' own finalizers reclaim them.)
+  }
+  // Release the cached sub-shape handles when the parent shape is disposed, so
+  // its arena slots don't outlive it. (GC of an undisposed parent drops the
+  // WeakMap entry, letting the handles' own finalizers reclaim them.) Register
+  // once per handle — keyed on the handle, not the entry, so a re-query after
+  // invalidateShapeCache rebuilds the entry without stacking dead callbacks.
+  if (!cleanupRegistered.has(shape)) {
+    cleanupRegistered.add(shape);
     shape.onDispose(() => {
       disposeCacheEntry(key);
     });

--- a/tests/topologyCaching.test.ts
+++ b/tests/topologyCaching.test.ts
@@ -100,6 +100,19 @@ describe('topology cache — invalidation', () => {
     expect(edges2).toHaveLength(len);
     expect(edges2[0]?.disposed).toBe(false);
   });
+
+  it('survives repeated invalidate + re-query without stacking cleanup', () => {
+    const b = box(10, 10, 10);
+    getEdges(b); // warm the cache
+    // Repeated invalidation registers cleanup once per handle (not once per
+    // rebuild), so re-extraction stays correct across many cycles.
+    for (let i = 0; i < 5; i++) {
+      invalidateShapeCache(b);
+      const edges = getEdges(b);
+      expect(edges).toHaveLength(12);
+      expect(edges[0]?.disposed).toBe(false);
+    }
+  });
 });
 
 describe('finder cache integration', () => {


### PR DESCRIPTION
Follow-up to #1779 (Greptile finding).

`getOrCreateCache` registered the `onDispose` cache-cleanup callback inside the `if (!entry)` branch, so each `invalidateShapeCache` + re-query re-entered it and pushed **another** closure onto the parent handle. The stale closures became no-ops (their `disposeCacheEntry(key)` finds nothing) but were never pruned — one dead closure accumulated per invalidation cycle, each retaining the cache key until the handle was disposed.

Guard registration with a `WeakSet` keyed on the **handle**: register cleanup once per handle, decoupled from entry (re)creation. The captured `key` is stable across rebuilds, so the single callback disposes whatever entry is current at disposal time.

Adds a regression test exercising repeated invalidate + re-query.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

