### PR TITLE
fix(topology): release healed-result arena slots in healingFns

### DIFF
--- a/src/topology/healingFns.ts
+++ b/src/topology/healingFns.ts
@@ -7,7 +7,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { AnyShape, Dimension, Face, Wire, Solid, ValidSolid } from '@/core/shapeTypes.js';
-import { castShape, isSolid, isFace, isWire } from '@/core/shapeTypes.js';
+import { castResultShape, disposeResultShape, isSolid, isFace, isWire } from '@/core/shapeTypes.js';
 import { type Result, ok, err, isOk } from '@/core/result.js';
 import { kernelError, validationError, BrepErrorCode } from '@/core/errors.js';
 import { getWires, getFaces } from './shapeFns.js';
@@ -55,8 +55,11 @@ export function healSolid(solid: Solid): Result<ValidSolid> {
         )
       );
     }
-    const cast = castShape(result);
+    // castResultShape releases the orphaned pre-downcast slot on occt-wasm; the
+    // guard skips in-place kernels (brepkit), where the result is the input.
+    const cast = castResultShape(result);
     if (!isSolid(cast)) {
+      disposeResultShape(cast);
       return err(kernelError('HEAL_RESULT_NOT_SOLID', 'Healed result is not a solid'));
     }
     // Invalidate cached validity — kernels that heal in-place (e.g. brepkit)
@@ -65,6 +68,7 @@ export function healSolid(solid: Solid): Result<ValidSolid> {
     // Verify the healed solid actually passes BRepCheck — ShapeFix_Solid
     // makes a best-effort attempt but does not guarantee full repair.
     if (!isValid(cast)) {
+      disposeResultShape(cast);
       return err(
         kernelError('HEAL_SOLID_INCOMPLETE', 'Healed result is still invalid after ShapeFix_Solid')
       );
@@ -87,8 +91,9 @@ export function healFace<D extends Dimension>(face: Face<D>): Result<Face<D>> {
 
   try {
     const result = getKernel().healFace(face.wrapped);
-    const cast = castShape<D>(result);
+    const cast = castResultShape<D>(result);
     if (!isFace(cast)) {
+      disposeResultShape(cast);
       return err(kernelError('HEAL_RESULT_NOT_FACE', 'Healed result is not a face'));
     }
     return ok(cast);
@@ -110,8 +115,9 @@ export function healWire<D extends Dimension>(wire: Wire<D>, face?: Face<D>): Re
 
   try {
     const result = getKernel().healWire(wire.wrapped, face?.wrapped);
-    const cast = castShape<D>(result);
+    const cast = castResultShape<D>(result);
     if (!isWire(cast)) {
+      disposeResultShape(cast);
       return err(kernelError('HEAL_RESULT_NOT_WIRE', 'Healed result is not a wire'));
     }
     return ok(cast);
@@ -224,11 +230,20 @@ export function autoHeal(
   let current: AnyShape<Dimension> = shape;
   let solidHealed = false;
 
+  // Advance the pipeline, releasing the previous intermediate — but never the
+  // caller's input `shape`, and never an in-place result (same handle).
+  const setCurrent = (next: AnyShape<Dimension>): void => {
+    const prev = current;
+    current = next;
+    if (prev !== shape && prev.wrapped !== next.wrapped) {
+      disposeResultShape(prev);
+    }
+  };
+
   // Sewing step (if tolerance provided)
   if (sewTolerance !== undefined) {
     try {
-      const sewResult = castShape(getKernel().sew([current.wrapped], sewTolerance));
-      current = sewResult;
+      setCurrent(castResultShape(getKernel().sew([current.wrapped], sewTolerance)));
       steps.push(`Applied sewing with tolerance ${sewTolerance}`);
       diagnostics.push({
         name: 'sew',
@@ -273,7 +288,7 @@ export function autoHeal(
   if (shouldHealShape) {
     const healResult = heal(current);
     if (isOk(healResult)) {
-      current = healResult.value;
+      setCurrent(healResult.value);
       if (isSolid(shape)) {
         solidHealed = true;
         steps.push('Applied ShapeFix_Solid');
@@ -338,7 +353,7 @@ export function fixShape<D extends Dimension>(shape: AnyShape<D>): Result<AnySha
   try {
     const kernel = getKernel();
     const fixed = kernel.fixShape(shape.wrapped);
-    return ok(castShape<D>(fixed));
+    return ok(castResultShape<D>(fixed));
   } catch (e) {
     return err(kernelError(BrepErrorCode.FIX_SHAPE_FAILED, 'ShapeFix_Shape failed', e));
   }
@@ -353,13 +368,15 @@ export function solidFromShell(shell: AnyShape): Result<ValidSolid> {
   try {
     const kernel = getKernel();
     const solidShape = kernel.solidFromShell(shell.wrapped);
-    const wrapped = castShape(solidShape);
+    const wrapped = castResultShape(solidShape);
     if (!isSolid(wrapped)) {
+      disposeResultShape(wrapped);
       return err(
         kernelError(BrepErrorCode.SOLID_FROM_SHELL_FAILED, 'solidFromShell did not produce a solid')
       );
     }
     if (!isValid(wrapped)) {
+      disposeResultShape(wrapped);
       return err(
         kernelError(
           BrepErrorCode.SOLID_FROM_SHELL_FAILED,
@@ -384,8 +401,9 @@ export function fixSelfIntersection(wire: Wire): Result<Wire> {
   try {
     const kernel = getKernel();
     const fixed = kernel.fixSelfIntersection(wire.wrapped);
-    const wrapped = castShape(fixed);
+    const wrapped = castResultShape(fixed);
     if (!isWire(wrapped)) {
+      disposeResultShape(wrapped);
       return err(kernelError(BrepErrorCode.FIX_SELF_INTERSECTION_FAILED, 'Result is not a wire'));
     }
     return ok(wrapped);

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -27,6 +27,10 @@ import {
   getFaces,
   getEdges,
   getVertices,
+  getShells,
+  fixShape,
+  solidFromShell,
+  autoHeal,
   edgesOfFace,
   verticesOfFace,
   facesOfEdge,
@@ -250,6 +254,37 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           if (!e0 || !f0) throw new Error('box must have edges and faces');
           disposeAll(facesOfEdge(b, e0));
           disposeAll(adjacentFaces(b, f0));
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('healing ops leak nothing', () => {
+    it('fixShape / solidFromShell / autoHeal return the arena to baseline', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const r = fixShape(b);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const shells = getShells(b);
+          const s0 = shells[0];
+          if (s0) {
+            const r = solidFromShell(s0);
+            if (isOk(r)) unwrap(r)[Symbol.dispose]();
+          }
+          disposeAll(shells);
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const r = autoHeal(b);
+          if (isOk(r)) r.value.shape[Symbol.dispose]();
         })
       ).toBe(0);
     });


### PR DESCRIPTION
## Summary

`healingFns` cast healed results with plain `castShape`, so on the occt-wasm arena kernel every heal leaked its pre-downcast slot (measured 1/call on `fixShape`/`solidFromShell`), and the type/validity **reject** branches leaked both the pre-downcast and the downcast slot. This was the last deferred piece of the WASM-leak work — deferred because a healer can return the input *healed in place* (brepkit), so a naive `disposeResultShape` on a reject path was feared to free the caller's input.

## Why it's actually safe

Verified empirically across kernels:
- **occt-wasm** returns a *distinct* arena slot for the heal result (id differs from the input even when `isSame` is true because they share a refcounted `TShape`). Disposing that slot decrements the shared `TShape` refcount but never destroys it while the input still holds a reference — the input survives (measured: 1000 → 1000 after disposing a heal result).
- **brepkit** heals in place, but its per-handle `dispose` is a no-op (no-free arena), so `disposeResultShape` frees nothing — the input is untouched.
- **occt (Embind)** is refcounted; same safety.

So `castResultShape` on success (its `disposeDowncastSource` guard already skips identity-downcast kernels) and `disposeResultShape` on reject are safe everywhere.

## What this does

- `healSolid` / `healFace` / `healWire` / `fixShape` / `fixSelfIntersection` / `solidFromShell`: cast with `castResultShape`, and release the cast on every reject branch.
- `autoHeal`: the pipeline reassigns `current` (sew → heal), orphaning intermediates. A `setCurrent` helper releases the replaced intermediate — but never the caller's input `shape`, and never an in-place result (same handle). Combined with the topology-cache-disposal fix, disposing an intermediate also releases its cached sub-shapes.

## Verification

`fixShape`/`solidFromShell` go 1 → 0 leak/call; `autoHeal` stays 0 — via the `getShapeCount()` arena oracle, added to `tests/wasmArenaDisposal.test.ts`. The full `healingFns` suite (165 tests) passes on occt-wasm, occt, and brepkit — exercising the reject paths and the brepkit in-place behavior, which would fail if an input were corrupted. Full occt-wasm suite green.

## Completes the initiative

This closes the WASM `using`-disposal leak work: primitives, transforms, sub-shape extraction, clone, booleans, adjacency, the topology cache, and now healing all return the occt-wasm arena to baseline.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

