### PR TITLE
fix(core): comprehensive occt-wasm arena-leak sweep (wire building, positioned primitives, hull, patterns, gear, section, drill, roof)

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "344 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "345 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/core/disposal.ts
+++ b/src/core/disposal.ts
@@ -292,7 +292,13 @@ export class DisposalScope implements Disposable {
   register<T extends Deletable>(resource: T): T {
     this.handles.push(() => {
       try {
-        resource.delete();
+        // A shape handle's `.delete()` is a no-op on arena kernels (occt-wasm);
+        // its slot is only reclaimed through `Symbol.dispose` → `kernel.dispose`.
+        // Prefer that when present, so a shape registered here is actually freed;
+        // raw WASM objects (no `Symbol.dispose`) fall back to `.delete()`.
+        const disposer = (resource as Partial<Disposable>)[Symbol.dispose];
+        if (typeof disposer === 'function') disposer.call(resource);
+        else resource.delete();
       } catch {
         // Already deleted
       }

--- a/src/gear/gearFns.ts
+++ b/src/gear/gearFns.ts
@@ -446,14 +446,21 @@ function finalizeExternalSolid(
   geom: ReturnType<typeof gearGeometry>,
   diagnostics: GearDiagnostic[]
 ): Result<GearResult> {
+  // The profile wire and its face are consumed by makeFace/extrude (which share
+  // their refcounted TShape); dispose them once the solid is built. The solid is
+  // NOT registered here — it is the returned value on the no-bore path.
+  using profileScope = new DisposalScope();
+  profileScope.register(wire);
   const faceResult = makeFace(wire);
   if (isErr(faceResult)) return faceResult;
+  profileScope.register(faceResult.value);
   const solidResult = extrude(faceResult.value, [0, 0, thickness]);
   if (isErr(solidResult)) return solidResult;
   if (bore <= 0) return ok(buildGearResult(solidResult.value, geom, diagnostics));
 
   // Bore overshoots both ends (z = -0.5 to thickness + 0.5) so no faces are coplanar.
   using boreScope = new DisposalScope();
+  boreScope.register(solidResult.value); // un-bored gear, consumed by cut below
   const boreFaceResult = makeBoreFace(bore / 2);
   if (isErr(boreFaceResult)) return boreFaceResult;
   boreScope.register(boreFaceResult.value);

--- a/src/kernel/occtWasm/constructionOps.ts
+++ b/src/kernel/occtWasm/constructionOps.ts
@@ -265,11 +265,16 @@ export function buildSolidFromFaces(
   }
   const vec = makeVecU32(Module, faceIds);
   try {
-    let sewn = k.sewAndSolidify(vec, tolerance);
-    sewn = k.fixFaceOrientations(sewn);
+    const sewn0 = k.sewAndSolidify(vec, tolerance);
+    const sewn = k.fixFaceOrientations(sewn0);
+    // fixFaceOrientations returns a fresh slot; release the pre-fix intermediate.
+    if (sewn !== sewn0) k.release(sewn0);
     return wrapResult(k, sewn);
   } finally {
     vec.delete();
+    // Each buildTriFace is a fresh arena slot consumed into the sewn solid
+    // (shared refcounted TShape); release the triangles once sewing is done.
+    for (const id of faceIds) k.release(id);
   }
 }
 

--- a/src/kernel/occtWasm/constructionOps.ts
+++ b/src/kernel/occtWasm/constructionOps.ts
@@ -385,6 +385,9 @@ export function triangulatedSurface(
     return wrapResult(k, k.sewAndSolidify(vec, 1e-3));
   } finally {
     vec.delete();
+    // Each buildTriFace is a fresh arena slot consumed into the sewn surface
+    // (shared refcounted TShape); release the triangles once sewing is done.
+    for (const id of faceIds) k.release(id);
   }
 }
 
@@ -407,8 +410,11 @@ export function sewAndSolidify(
 ): KernelShape {
   const vec = makeVecU32(Module, faces.map(unwrap));
   try {
-    let sewn = k.sewAndSolidify(vec, tolerance);
-    sewn = k.fixFaceOrientations(sewn);
+    const sewn0 = k.sewAndSolidify(vec, tolerance);
+    const sewn = k.fixFaceOrientations(sewn0);
+    // fixFaceOrientations returns a fresh slot; release the pre-fix intermediate.
+    // (The input `faces` are caller-owned and intentionally left untouched.)
+    if (sewn !== sewn0) k.release(sewn0);
     return handle('solid', sewn);
   } finally {
     vec.delete();

--- a/src/kernel/occtWasm/constructionOps.ts
+++ b/src/kernel/occtWasm/constructionOps.ts
@@ -50,6 +50,7 @@ export function makeWireFromMixed(
   // throws. Explode each item to its edges first (an edge yields itself),
   // which lets a mix of edges and wires assemble into one wire.
   const edgeIds: number[] = [];
+  const inputIds = new Set(items.map((it) => unwrap(it)));
   for (const item of items) {
     const sub = k.getSubShapes(unwrap(item), 'edge');
     try {
@@ -64,6 +65,10 @@ export function makeWireFromMixed(
     return handle('wire', k.makeWire(vec));
   } finally {
     vec.delete();
+    // getSubShapes copies each edge into its own arena slot; makeWire shares
+    // their refcounted TShape, so release the copies once it has consumed them.
+    // Skip any id that is an input itself (getSubShapes yields an edge as-is).
+    for (const id of edgeIds) if (!inputIds.has(id)) k.release(id);
   }
 }
 

--- a/src/kernel/occtWasm/primitiveOps.ts
+++ b/src/kernel/occtWasm/primitiveOps.ts
@@ -8,6 +8,17 @@ import type { KernelShape } from '@/kernel/types.js';
 import type { OcctKernelWasm } from './occtWasmTypes.js';
 import { handle, rotateZToDirection } from './helpers.js';
 
+/**
+ * Apply an id-remapping positioning step (rotate/translate), releasing the
+ * orphaned source slot. rotate/translate return fresh arena slots on occt-wasm;
+ * the repositioned result shares the source's refcounted TShape and survives, so
+ * releasing the pre-move id here plugs a per-positioned-primitive slot leak.
+ */
+function remap(k: OcctKernelWasm, id: number, next: number): number {
+  if (next !== id) k.release(id);
+  return next;
+}
+
 export function makeBox(
   k: OcctKernelWasm,
   width: number,
@@ -25,11 +36,9 @@ export function makeCylinder(
   direction?: [number, number, number]
 ): KernelShape {
   let id = k.makeCylinder(radius, height);
-  if (direction) {
-    id = rotateZToDirection(k, id, direction);
-  }
+  if (direction) id = remap(k, id, rotateZToDirection(k, id, direction));
   if (center && (center[0] !== 0 || center[1] !== 0 || center[2] !== 0)) {
-    id = k.translate(id, center[0], center[1], center[2]);
+    id = remap(k, id, k.translate(id, center[0], center[1], center[2]));
   }
   return handle('solid', id);
 }
@@ -41,7 +50,7 @@ export function makeSphere(
 ): KernelShape {
   let id = k.makeSphere(radius);
   if (center && (center[0] !== 0 || center[1] !== 0 || center[2] !== 0)) {
-    id = k.translate(id, center[0], center[1], center[2]);
+    id = remap(k, id, k.translate(id, center[0], center[1], center[2]));
   }
   return handle('solid', id);
 }
@@ -55,11 +64,9 @@ export function makeCone(
   direction?: [number, number, number]
 ): KernelShape {
   let id = k.makeCone(radius1, radius2, height);
-  if (direction) {
-    id = rotateZToDirection(k, id, direction);
-  }
+  if (direction) id = remap(k, id, rotateZToDirection(k, id, direction));
   if (center && (center[0] !== 0 || center[1] !== 0 || center[2] !== 0)) {
-    id = k.translate(id, center[0], center[1], center[2]);
+    id = remap(k, id, k.translate(id, center[0], center[1], center[2]));
   }
   return handle('solid', id);
 }
@@ -72,11 +79,9 @@ export function makeTorus(
   direction?: [number, number, number]
 ): KernelShape {
   let id = k.makeTorus(majorRadius, minorRadius);
-  if (direction) {
-    id = rotateZToDirection(k, id, direction);
-  }
+  if (direction) id = remap(k, id, rotateZToDirection(k, id, direction));
   if (center && (center[0] !== 0 || center[1] !== 0 || center[2] !== 0)) {
-    id = k.translate(id, center[0], center[1], center[2]);
+    id = remap(k, id, k.translate(id, center[0], center[1], center[2]));
   }
   return handle('solid', id);
 }

--- a/src/kernel/occtWasm/transformOps.ts
+++ b/src/kernel/occtWasm/transformOps.ts
@@ -295,6 +295,9 @@ export function linearPattern(
       iter.delete();
     }
   }
+  // The extracted solids are fresh slots sharing the compound's refcounted
+  // TShape; release the compound container now that they are wrapped.
+  k.release(compoundId);
   return results;
 }
 
@@ -338,6 +341,9 @@ export function circularPattern(
       iter.delete();
     }
   }
+  // The extracted solids are fresh slots sharing the compound's refcounted
+  // TShape; release the compound container now that they are wrapped.
+  k.release(compoundId);
   return results;
 }
 

--- a/src/operations/compoundOpsFns.ts
+++ b/src/operations/compoundOpsFns.ts
@@ -149,7 +149,12 @@ export function drill<T extends Shape3D>(shape: Shapeable<T>, options: DrillOpti
     tool = _makeCylinder(radius, depth, startPos, dir);
   }
 
-  return cut(s, tool, { unsafe: true }) as Result<T>;
+  try {
+    return cut(s, tool, { unsafe: true }) as Result<T>;
+  } finally {
+    // cut is immutable and does not consume the tool — dispose it.
+    tool[Symbol.dispose]();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/operations/patternFns.ts
+++ b/src/operations/patternFns.ts
@@ -42,11 +42,16 @@ export function linearPattern(
 
   // Pattern copies share exact face geometry — sameFace glue lets OCCT skip
   // expensive intersection calculations (default unless caller overrides)
-  return fuseAll(copies, {
-    optimisation: 'sameFace',
-    ...options,
-    unsafe: true,
-  });
+  try {
+    return fuseAll(copies, {
+      optimisation: 'sameFace',
+      ...options,
+      unsafe: true,
+    });
+  } finally {
+    // fuseAll is immutable and does not consume its inputs — dispose the copies.
+    for (const c of copies) c[Symbol.dispose]();
+  }
 }
 
 /**
@@ -86,11 +91,16 @@ export function circularPattern(
 
   // Pattern copies share exact face geometry — sameFace glue lets OCCT skip
   // expensive intersection calculations (default unless caller overrides)
-  return fuseAll(copies, {
-    optimisation: 'sameFace',
-    ...options,
-    unsafe: true,
-  });
+  try {
+    return fuseAll(copies, {
+      optimisation: 'sameFace',
+      ...options,
+      unsafe: true,
+    });
+  } finally {
+    // fuseAll is immutable and does not consume its inputs — dispose the copies.
+    for (const c of copies) c[Symbol.dispose]();
+  }
 }
 
 /**
@@ -145,5 +155,12 @@ export function gridPattern(
   // Fallback: nested linearPattern
   const rowResult = linearPattern(shape, directionX, countX, spacingX, options);
   if (!rowResult.ok) return rowResult;
-  return linearPattern(rowResult.value, directionY, countY, spacingY, options);
+  const row = rowResult.value;
+  const out = linearPattern(row, directionY, countY, spacingY, options);
+  // Dispose the intermediate row unless linearPattern short-circuited: countX===1
+  // hands back the caller's own shape, and countY===1 passes `row` straight
+  // through as the result — disposing either would be a use-after-free.
+  const passthrough = out.ok && out.value === row;
+  if (row !== shape && !passthrough) row[Symbol.dispose]();
+  return out;
 }

--- a/src/operations/roofFns.ts
+++ b/src/operations/roofFns.ts
@@ -267,6 +267,8 @@ export function roof(
     try {
       const solid = kernel.sewAndSolidify(triFaces, 1e-6);
       const fixed = kernel.fixShape(solid);
+      // fixShape returns a fresh slot on arena kernels; release the pre-fix solid.
+      if (fixed !== solid) kernel.dispose(solid);
       return ok(createSolid(fixed) as ValidSolid);
     } catch (solidifyErr) {
       try {
@@ -279,6 +281,10 @@ export function roof(
       } catch (sewErr) {
         return err(kernelError(BrepErrorCode.ROOF_FAILED, 'Failed to sew roof faces', sewErr));
       }
+    } finally {
+      // Each buildTriFace is a fresh arena slot consumed into the sewn solid
+      // (shared refcounted TShape); release the triangles once sewing is done.
+      for (const tf of triFaces) kernel.dispose(tf);
     }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/sketching/cannedSketches.ts
+++ b/src/sketching/cannedSketches.ts
@@ -49,7 +49,10 @@ export const sketchCircle = (radius: number, planeConfig: PlaneConfig = {}): Ske
       ? { ...planeConfig.plane }
       : unwrap(resolvePlane(planeConfig.plane ?? 'XY', planeConfig.origin));
 
-  const wire = unwrap(assembleWire([makeCircle(radius, plane.origin, plane.zDir)]));
+  // The circle edge is consumed by assembleWire (the wire shares its refcounted
+  // TShape); dispose it once the wire is built so it doesn't leak an arena slot.
+  using scope = new DisposalScope();
+  const wire = unwrap(assembleWire([scope.register(makeCircle(radius, plane.origin, plane.zDir))]));
   const sketch = new Sketch(wire as ClosedWire & PlanarWire, {
     defaultOrigin: [...plane.origin],
     defaultDirection: [...plane.zDir],
@@ -83,8 +86,11 @@ export const sketchEllipse = (xRadius = 1, yRadius = 2, planeConfig: PlaneConfig
     minR = xRadius;
   }
 
+  // The ellipse edge is consumed by assembleWire (the wire shares its refcounted
+  // TShape); dispose it once the wire is built so it doesn't leak an arena slot.
+  using scope = new DisposalScope();
   const wire = unwrap(
-    assembleWire([unwrap(makeEllipse(majR, minR, plane.origin, plane.zDir, xDir))])
+    assembleWire([scope.register(unwrap(makeEllipse(majR, minR, plane.origin, plane.zDir, xDir)))])
   );
 
   const sketch = new Sketch(wire as ClosedWire & PlanarWire, {

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -593,9 +593,11 @@ function makeSectionFace(plane: Plane, size: number): KernelType {
   const wire = kernel.makeWire(edges);
   const face = kernel.makeFace(wire, true);
 
-  // Cleanup temporaries
-  for (const e of edges) e.delete();
-  wire.delete();
+  // Cleanup temporaries. `.delete()` is a no-op on arena kernels (occt-wasm) —
+  // route through kernel.dispose so the edge/wire slots are actually reclaimed
+  // (the face shares their refcounted TShape and survives).
+  for (const e of edges) kernel.dispose(e);
+  kernel.dispose(wire);
 
   return face;
 }
@@ -640,7 +642,8 @@ export function section(
       )
     );
   } finally {
-    sectionFace.delete();
+    // `.delete()` is a no-op on arena kernels; dispose reclaims the slot.
+    getKernel().dispose(sectionFace);
   }
 }
 

--- a/src/topology/primitiveFns.ts
+++ b/src/topology/primitiveFns.ts
@@ -218,9 +218,10 @@ export function ellipsoid(
   rz: number,
   options?: EllipsoidOptions
 ): ValidSolid {
-  let solid = _makeEllipsoid(rx, ry, rz);
+  const solid = _makeEllipsoid(rx, ry, rz);
   if (options?.at) {
-    solid = translate(solid, options.at);
+    using base = solid; // dispose the origin ellipsoid; translate returns a fresh one
+    return translate(base, options.at);
   }
   return solid;
 }

--- a/src/topology/primitiveFns.ts
+++ b/src/topology/primitiveFns.ts
@@ -89,7 +89,8 @@ export function box(
 
   const center = options?.at ?? (options?.centered ? ([0, 0, 0] as Vec3) : undefined);
   if (center) {
-    return translate(solid, [center[0] - width / 2, center[1] - depth / 2, center[2] - height / 2]);
+    using base = solid; // dispose the corner-origin box; translate returns a fresh one
+    return translate(base, [center[0] - width / 2, center[1] - depth / 2, center[2] - height / 2]);
   }
   return solid;
 }
@@ -110,14 +111,15 @@ export interface CylinderOptions {
 export function cylinder(radius: number, height: number, options?: CylinderOptions): ValidSolid {
   const at = options?.at ?? [0, 0, 0];
   const axis = options?.axis ?? [0, 0, 1];
-  let solid = _makeCylinder(radius, height, at, axis);
+  const solid = _makeCylinder(radius, height, at, axis);
   if (options?.centered) {
     const halfShift: Vec3 = [
       -axis[0] * height * 0.5,
       -axis[1] * height * 0.5,
       -axis[2] * height * 0.5,
     ];
-    solid = translate(solid, halfShift);
+    using base = solid; // dispose the pre-translate solid; translate returns a fresh one
+    return translate(base, halfShift);
   }
   return solid;
 }
@@ -132,9 +134,10 @@ export interface SphereOptions {
  * Create a sphere with the given radius.
  */
 export function sphere(radius: number, options?: SphereOptions): ValidSolid {
-  let solid = _makeSphere(radius);
+  const solid = _makeSphere(radius);
   if (options?.at) {
-    solid = translate(solid, options.at);
+    using base = solid; // dispose the origin sphere; translate returns a fresh one
+    return translate(base, options.at);
   }
   return solid;
 }
@@ -164,14 +167,15 @@ export function cone(
 ): ValidSolid {
   const at = options?.at ?? [0, 0, 0];
   const axis = options?.axis ?? [0, 0, 1];
-  let solid = _makeCone(bottomRadius, topRadius, height, at, axis);
+  const solid = _makeCone(bottomRadius, topRadius, height, at, axis);
   if (options?.centered) {
     const halfShift: Vec3 = [
       -axis[0] * height * 0.5,
       -axis[1] * height * 0.5,
       -axis[2] * height * 0.5,
     ];
-    solid = translate(solid, halfShift);
+    using base = solid; // dispose the pre-translate cone; translate returns a fresh one
+    return translate(base, halfShift);
   }
   return solid;
 }

--- a/src/topology/surfaceBuilders.ts
+++ b/src/topology/surfaceBuilders.ts
@@ -7,6 +7,7 @@ import { getKernel } from '@/kernel/index.js';
 import type { Vec3 } from '@/core/types.js';
 import { type Result, ok, err, andThen } from '@/core/result.js';
 import { validationError, kernelError } from '@/core/errors.js';
+import { DisposalScope } from '@/core/disposal.js';
 import type { Dimension, ClosedWire, Face, OrientedFace } from '@/core/shapeTypes.js';
 import { createFace, isFace } from '@/core/shapeTypes.js';
 import type { PlanarFace, PlanarWire } from '@/core/validityTypes.js';
@@ -146,7 +147,15 @@ export function makePolygon(points: Vec3[]): Result<OrientedFace & PlanarFace> {
 
   // points.length >= 3 is guaranteed above, so the wrap-around point is defined.
   const closing = [...points.slice(1), points[0]] as Vec3[];
-  const edges = zip([points, closing] as [Vec3[], Vec3[]]).map(([p1, p2]) => makeLine(p1, p2));
+  // The per-edge lines and the assembled wire are consumed by makeFace (the face
+  // shares their refcounted TShape), so dispose them once the face is built —
+  // otherwise every polygon() leaks its edges + wire on an arena kernel.
+  using scope = new DisposalScope();
+  const edges = zip([points, closing] as [Vec3[], Vec3[]]).map(([p1, p2]) =>
+    scope.register(makeLine(p1, p2))
+  );
   // Polygon edges always form a closed, coplanar loop — safe to narrow
-  return andThen(assembleWire(edges), (wire) => makeFace(wire as ClosedWire & PlanarWire));
+  return andThen(assembleWire(edges), (wire) =>
+    makeFace(scope.register(wire) as ClosedWire & PlanarWire)
+  );
 }

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -51,9 +51,11 @@ import {
   sketchEllipse,
   cone,
   torus,
+  ellipsoid,
   drill,
   section,
   roof,
+  surfaceFromGrid,
   getWires,
   getFaces,
   getEdges,
@@ -683,7 +685,7 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       ).toBe(0);
     });
 
-    it('sphere / cone with position leak nothing', () => {
+    it('sphere / cone / ellipsoid with position leak nothing', () => {
       expect(
         perIterationLeak(() => {
           using s = sphere(5, { at: [3, 0, 0] });
@@ -694,6 +696,12 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
         perIterationLeak(() => {
           using c = cone(5, 2, 10, { at: [1, 1, 0], axis: [0, 1, 0] });
           void c;
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using e = ellipsoid(5, 3, 2, { at: [1, 0, 0] });
+          void e;
         })
       ).toBe(0);
     });
@@ -746,6 +754,20 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           if (isOk(r)) unwrap(r)[Symbol.dispose]();
         })
       ).toBeLessThanOrEqual(1);
+    });
+
+    it('surfaceFromGrid leaks nothing (triangulatedSurface tri-faces)', () => {
+      const heights = [
+        [0, 1, 0],
+        [1, 2, 1],
+        [0, 1, 0],
+      ];
+      expect(
+        perIterationLeak(() => {
+          const r = surfaceFromGrid(heights, { width: 10, depth: 10 });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
     });
 
     it('roof leaks at most its kernel residual', () => {

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -34,6 +34,16 @@ import {
   scale,
   applyMatrix,
   locate,
+  polygon,
+  line,
+  wire,
+  closedWire,
+  extrude,
+  revolve,
+  loft,
+  sweep,
+  thread,
+  getWires,
   getFaces,
   getEdges,
   getVertices,
@@ -52,6 +62,7 @@ import {
 } from '@/index.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
+import { DisposalScope } from '@/core/disposal.js';
 
 const isOcctWasm = (process.env['TEST_KERNEL'] ?? 'occt') === 'occt-wasm';
 
@@ -421,7 +432,160 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
     });
   });
 
+  describe('profile builders leak nothing when disposed', () => {
+    // Regression: makePolygon built its edges + wire and disposed neither, and
+    // makeWireFromMixed (kernel) exploded each input into edge sub-shape slots it
+    // never released — 1 leaked slot per edge in *every* wire built from edges.
+    it('polygon leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using f = unwrap(
+            polygon([
+              [0, 0, 0],
+              [10, 0, 0],
+              [10, 10, 0],
+              [0, 10, 0],
+            ])
+          );
+          void f;
+        })
+      ).toBe(0);
+    });
+
+    it('wire (assembleWire) leaks nothing per edge', () => {
+      expect(
+        perIterationLeak(() => {
+          using e1 = line([0, 0, 0], [10, 0, 0]);
+          using e2 = line([10, 0, 0], [10, 10, 0]);
+          using e3 = line([10, 10, 0], [0, 0, 0]);
+          const r = wire([e1, e2, e3]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('construction ops leak nothing when inputs and result are disposed', () => {
+    // extrude/revolve/loft/sweep were already clean (castResultShape); these lock
+    // that together with the profile-builder fixes above. thread leaked 183/call
+    // pre-fix (its ~60 tooth sections × 3 edges each, via makeWireFromMixed +
+    // DisposalScope.register calling the no-op .delete() instead of Symbol.dispose).
+    it('extrude leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using f = unwrap(
+            polygon([
+              [0, 0, 0],
+              [10, 0, 0],
+              [10, 10, 0],
+              [0, 10, 0],
+            ])
+          );
+          const r = extrude(f, [0, 0, 10]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('revolve leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using f = unwrap(
+            polygon([
+              [5, 0, 0],
+              [10, 0, 0],
+              [10, 0, 10],
+              [5, 0, 10],
+            ])
+          );
+          const r = revolve(f, { axis: [0, 0, 1], at: [0, 0, 0] });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('loft leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using f1 = unwrap(
+            polygon([
+              [0, 0, 0],
+              [10, 0, 0],
+              [10, 10, 0],
+              [0, 10, 0],
+            ])
+          );
+          using f2 = unwrap(
+            polygon([
+              [0, 0, 20],
+              [10, 0, 20],
+              [10, 10, 20],
+              [0, 10, 20],
+            ])
+          );
+          const w1 = getWires(f1)[0];
+          const w2 = getWires(f2)[0];
+          if (!w1 || !w2) throw new Error('polygon faces must have wires');
+          const r = loft([w1, w2]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('sweep leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using pf = unwrap(
+            polygon([
+              [-1, -1, 0],
+              [1, -1, 0],
+              [1, 1, 0],
+              [-1, 1, 0],
+            ])
+          );
+          const pw = getWires(pf)[0];
+          if (!pw) throw new Error('polygon face must have a wire');
+          const profile = unwrap(closedWire(pw));
+          using e = line([0, 0, 0], [0, 0, 20]);
+          using spine = unwrap(wire([e]));
+          const r = sweep(profile, spine);
+          if (isOk(r)) {
+            const v = unwrap(r);
+            if (Array.isArray(v)) {
+              v.forEach((s) => {
+                s[Symbol.dispose]();
+              });
+            } else {
+              v[Symbol.dispose]();
+            }
+          }
+        })
+      ).toBe(0);
+    });
+
+    it('thread leaks nothing (was 183 slots/call)', () => {
+      expect(
+        perIterationLeak(() => {
+          const r = thread({ radius: 6, pitch: 2.5, height: 7.5 });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+  });
+
   describe('disposal is real, not a no-op', () => {
+    it('DisposalScope.register frees a registered shape via kernel.dispose', () => {
+      // register() historically called the no-op .delete(); a shape registered
+      // for scope cleanup leaked on occt-wasm. It now routes through Symbol.dispose.
+      const before = arenaCount();
+      {
+        using scope = new DisposalScope();
+        scope.register(box(10, 10, 10));
+        expect(arenaCount()).toBeGreaterThan(before);
+      }
+      expect(arenaCount()).toBe(before);
+    });
+
     it('creating then disposing a box returns the arena to baseline', () => {
       const before = arenaCount();
       const b = box(10, 10, 10);

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -43,6 +43,12 @@ import {
   loft,
   sweep,
   thread,
+  convexHull,
+  hull,
+  linearPattern,
+  circularPattern,
+  sketchCircle,
+  sketchEllipse,
   getWires,
   getFaces,
   getEdges,
@@ -63,6 +69,7 @@ import {
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
 import { DisposalScope } from '@/core/disposal.js';
+import { makeExternalGear } from '@/gear/index.js';
 
 const isOcctWasm = (process.env['TEST_KERNEL'] ?? 'occt') === 'occt-wasm';
 
@@ -568,6 +575,82 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
         perIterationLeak(() => {
           const r = thread({ radius: 6, pitch: 2.5, height: 7.5 });
           if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('hull / pattern / gear / canned-sketch ops leak nothing', () => {
+    // buildSolidFromFaces (hull/convexHull) leaked each triangle face slot + the
+    // pre-orientation intermediate; the pattern fns never disposed their fused
+    // copies and the kernel leaked the pattern compound; gear + circle/ellipse
+    // sketches leaked their profile wire/edge. All fixed.
+    it('convexHull leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const r = convexHull([
+            [0, 0, 0],
+            [10, 0, 0],
+            [0, 10, 0],
+            [0, 0, 10],
+            [10, 10, 10],
+          ]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('hull leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using a = box(5, 5, 5);
+          using b = box(5, 5, 5);
+          const r = hull([a, b]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('linearPattern leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(2, 2, 2);
+          const r = linearPattern(b, [1, 0, 0], 3, 5);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('circularPattern leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(2, 2, 2);
+          const r = circularPattern(b, [0, 0, 1], 4, 360, [10, 0, 0]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('makeExternalGear leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const r = makeExternalGear({ teeth: 12, moduleSize: 2, thickness: 5 });
+          if (isOk(r)) r.value.solid[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('sketchCircle / sketchEllipse leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const s = sketchCircle(5);
+          s.wire[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          const s = sketchEllipse(5, 3);
+          s.wire[Symbol.dispose]();
         })
       ).toBe(0);
     });

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -49,6 +49,11 @@ import {
   circularPattern,
   sketchCircle,
   sketchEllipse,
+  cone,
+  torus,
+  drill,
+  section,
+  roof,
   getWires,
   getFaces,
   getEdges,
@@ -653,6 +658,113 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           s.wire[Symbol.dispose]();
         })
       ).toBe(0);
+    });
+  });
+
+  describe('positioned primitives + drill leak nothing', () => {
+    // A positioned primitive rotates/translates the base solid; occt-wasm returns
+    // a fresh slot per move and orphaned the pre-move id (a leak in every non-origin
+    // cylinder/sphere/cone/torus). drill never disposed its tool cylinder.
+    it('cylinder with at/axis leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using c = cylinder(1, 10, { at: [5, 5, 0], axis: [0, 1, 0] });
+          void c;
+        })
+      ).toBe(0);
+    });
+
+    it('centered cylinder leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using c = cylinder(1, 10, { centered: true });
+          void c;
+        })
+      ).toBe(0);
+    });
+
+    it('sphere / cone with position leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using s = sphere(5, { at: [3, 0, 0] });
+          void s;
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using c = cone(5, 2, 10, { at: [1, 1, 0], axis: [0, 1, 0] });
+          void c;
+        })
+      ).toBe(0);
+    });
+
+    it('box with at / centered leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10, { centered: true });
+          void b;
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10, { at: [5, 5, 5] });
+          void b;
+        })
+      ).toBe(0);
+    });
+
+    it('torus with position leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using t = torus(10, 2, { at: [1, 0, 0], axis: [0, 1, 0] });
+          void t;
+        })
+      ).toBe(0);
+    });
+
+    it('drill leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const r = drill(b, { at: [5, 5, 0], radius: 1, axis: [0, 0, 1] });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('section / roof shed their JS-side intermediates', () => {
+    // section's cutting-plane face (4 edges + wire + face) and roof's tooth
+    // triangles are now disposed. A single kernel-internal slot remains per call
+    // (BRepAlgoAPI_Section / sewAndSolidify refcount artifact) — a bounded, known
+    // residual, not the pre-fix per-edge/per-triangle growth (section 7, roof 12).
+    it('section leaks at most its kernel residual', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10, { centered: true });
+          const r = section(b, 'XY');
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBeLessThanOrEqual(1);
+    });
+
+    it('roof leaks at most its kernel residual', () => {
+      expect(
+        perIterationLeak(() => {
+          using f = unwrap(
+            polygon([
+              [0, 0, 0],
+              [10, 0, 0],
+              [10, 10, 0],
+              [0, 10, 0],
+            ])
+          );
+          const w = getWires(f)[0];
+          if (!w) throw new Error('polygon face must have a wire');
+          const r = roof(unwrap(closedWire(w)));
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBeLessThanOrEqual(1);
     });
   });
 


### PR DESCRIPTION
Supersedes #1793 (auto-closed when its stacked base branch #1792 merged + was deleted; identical content, rebased onto `main`).

## What

A comprehensive **occt-wasm arena-leak sweep**. Extends `tests/wasmArenaDisposal.test.ts` to 44 assertions and fixes **~18 distinct arena-slot leaks**, all empirically measured via `getShapeCount()`.

## Highest-impact fixes

| Fix | Leak (before → after) | Blast radius |
|---|---|---|
| `makeWireFromMixed` (kernel) | **1 slot / edge** | every wire built from edges — sketches, profiles, drawings, polygons, thread |
| positioned primitives (kernel `remap` + wrappers) | 1 / call | **every non-origin** box / cylinder / sphere / cone / torus / ellipsoid |
| `DisposalScope.register` (core) | every registered shape | gear, faceSketcher, draw3d, sketcher, cannedSketches, thread |
| `buildSolidFromFaces` / `triangulatedSurface` (kernel) | 1 / triangle | hull (13→0), convexHull (7→0), surfaceFromGrid |
| `thread` | **183 → 0** | screw threads |
| `linearPattern`/`circularPattern` (+kernel compound) | copies + container | patterns |
| `gear` finalizeExternalSolid | profile wire + face | gears |
| `section` / `roof` | 7→1 / 12→1 | (residual = documented kernel-internal artifact) |
| `drill`, `makePolygon`, `sketchCircle`/`sketchEllipse`, `gridPattern`, `sewAndSolidify` | 1–9 / call | assorted |

## Root-cause themes
1. **`.delete()` is a no-op on occt-wasm** — code freeing shapes/temporaries via `.delete()` (DisposalScope.register, makeSectionFace) freed nothing. Routed through `Symbol.dispose` / `kernel.dispose`.
2. **`getSubShapes`/`buildTriFace` copy into fresh arena slots** callers never released (makeWireFromMixed, buildSolidFromFaces, triangulatedSurface, roof).
3. **id-reassign without release** — positioned primitives and the pattern kernel op overwrote a slot id through rotate/translate, orphaning the pre-move slot.
4. **immutable functional API doesn't consume inputs** — pattern copies, drill's tool, gear/polygon/sketch profile wires were never disposed by the caller.

## Residuals (documented, bounded)
`section` and `roof` retain **1 kernel-internal slot/call** (BRepAlgoAPI_Section / sewAndSolidify refcount artifacts) after all JS-side intermediates are freed — asserted `<= 1`. Fixing these needs a kernel-side change.

## Review
Greptile reviewed the pre-rebase branch **5/5 "Safe to merge"** and flagged three sibling functions (`ellipsoid`, `triangulatedSurface`, `sewAndSolidify`) — all fixed here.

## Verification
- `vitest run --project occt-wasm tests/wasmArenaDisposal.test.ts` → 44/44
- typecheck / eslint / prettier clean; rebased onto current `main`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

