### PR TITLE
fix: plug arena leaks in pocket/boss, mirrorJoin, twist/complexExtrude, blueprint sketches

### DIFF
--- a/src/2d/blueprints/blueprint.ts
+++ b/src/2d/blueprints/blueprint.ts
@@ -245,6 +245,9 @@ export default class Blueprint implements DrawingInterface {
 
     const edges = curvesAsEdgesOnPlane(this.curves, plane);
     const wire = assembleWire(edges);
+    // Edges are consumed into the wire (shared refcounted TShape); dispose the
+    // per-curve edge handles so they don't leak an arena slot each.
+    for (const e of edges) e[Symbol.dispose]();
 
     return {
       wire,
@@ -265,10 +268,12 @@ export default class Blueprint implements DrawingInterface {
 
     const edges = unwrap(curvesAsEdgesOnFace(this.curves, face, scaleMode));
     const wire = assembleWire(edges);
+    for (const e of edges) e[Symbol.dispose]();
 
     kernel.buildCurves3d(wire.wrapped);
     const fixedWire = kernel.fixWireOnFace(wire.wrapped, face.wrapped, 1e-9);
-    wire.delete();
+    // `.delete()` is a no-op on arena kernels; dispose reclaims the intermediate wire.
+    wire[Symbol.dispose]();
 
     return { wire: createWire(fixedWire), baseFace: face };
   }

--- a/src/operations/compoundOpsFns.ts
+++ b/src/operations/compoundOpsFns.ts
@@ -23,6 +23,7 @@ import type {
 import { resolve } from '@/topology/apiTypes.js';
 import { getBounds, getFaces, translate, mirror } from '@/topology/shapeFns.js';
 import { fuse, cut, fuseAll } from '@/topology/booleanFns.js';
+import { DisposalScope } from '@/core/disposal.js';
 import { extrude } from './extrudeFns.js';
 import { faceFinder } from '@/query/finderFns.js';
 import { normalAt, faceCenter } from '@/topology/faceFns.js';
@@ -75,15 +76,19 @@ function resolveTargetFace(
   return ok(faceSpec);
 }
 
-/** Convert a DrawingLike or Wire to a ClosedWire & PlanarWire (profiles are always closed and planar). */
-function toWire(profile: DrawingLike | Wire): ClosedWire & PlanarWire {
+/**
+ * Convert a DrawingLike or Wire to a ClosedWire & PlanarWire (profiles are always
+ * closed and planar). `owned` is true when we materialised a fresh sketch wire
+ * (the caller must dispose it); false when the caller's own Wire is passed through.
+ */
+function toWire(profile: DrawingLike | Wire): { wire: ClosedWire & PlanarWire; owned: boolean } {
   if ('sketchOnPlane' in profile && typeof profile.sketchOnPlane === 'function') {
     // planar by construction: sketch operates on XY plane
-    return profile.sketchOnPlane('XY').wire as ClosedWire & PlanarWire;
+    return { wire: profile.sketchOnPlane('XY').wire as ClosedWire & PlanarWire, owned: true };
   }
   // planar by construction: remaining cases are either DrawingLike 2D profiles
   // or Wire inputs — callers are expected to pass closed, planar profiles here.
-  return profile as ClosedWire & PlanarWire;
+  return { wire: profile as ClosedWire & PlanarWire, owned: false };
 }
 
 // ---------------------------------------------------------------------------
@@ -180,16 +185,23 @@ export function pocket<T extends Shape3D>(shape: Shapeable<T>, options: PocketOp
   const targetFace = targetResult.value;
   const normal = normalAt(targetFace);
   const center = faceCenter(targetFace);
-  const w = toWire(profile);
+
+  // The profile wire (if materialised here), its face, the positioned face, and
+  // the extruded tool are all intermediates consumed by cut — dispose them.
+  using scope = new DisposalScope();
+  const { wire: w, owned } = toWire(profile);
+  if (owned) scope.register(w);
 
   const faceResult = _makeFace(w);
   if (isErr(faceResult)) return faceResult;
+  scope.register(faceResult.value);
 
   // Position the profile on the target face before extruding
-  const positioned = translate(faceResult.value, center);
+  const positioned = scope.register(translate(faceResult.value, center));
   const extDir = vecScale(vecNormalize(normal), -depth);
   const toolResult = extrude(positioned, extDir);
   if (isErr(toolResult)) return toolResult;
+  scope.register(toolResult.value);
 
   return cut(s, toolResult.value, { unsafe: true }) as Result<T>;
 }
@@ -217,16 +229,23 @@ export function boss<T extends Shape3D>(shape: Shapeable<T>, options: BossOption
   const targetFace = targetResult.value;
   const normal = normalAt(targetFace);
   const center = faceCenter(targetFace);
-  const w = toWire(profile);
+
+  // The profile wire (if materialised here), its face, the positioned face, and
+  // the extruded tool are all intermediates consumed by fuse — dispose them.
+  using scope = new DisposalScope();
+  const { wire: w, owned } = toWire(profile);
+  if (owned) scope.register(w);
 
   const faceResult = _makeFace(w);
   if (isErr(faceResult)) return faceResult;
+  scope.register(faceResult.value);
 
   // Position the profile on the target face before extruding
-  const positioned = translate(faceResult.value, center);
+  const positioned = scope.register(translate(faceResult.value, center));
   const extDir = vecScale(vecNormalize(normal), height);
   const toolResult = extrude(positioned, extDir);
   if (isErr(toolResult)) return toolResult;
+  scope.register(toolResult.value);
 
   return fuse(s, toolResult.value, { unsafe: true }) as Result<T>;
 }
@@ -252,7 +271,7 @@ export function mirrorJoin<T extends Shape3D>(
     return err(validationError('MIRROR_ZERO_NORMAL', 'Mirror plane normal cannot be zero'));
   }
 
-  const mirrored = mirror(s, normal, planeOrigin);
+  using mirrored = mirror(s, normal, planeOrigin);
   return fuse(s, mirrored, { unsafe: true }) as Result<T>;
 }
 

--- a/src/operations/sweepFns.ts
+++ b/src/operations/sweepFns.ts
@@ -66,6 +66,9 @@ function makeSpineWire(start: Vec3, end: Vec3): Wire {
   const kernel = getKernel();
   const edge = kernel.makeLineEdge([...start], [...end]);
   const wire = kernel.makeWire([edge]);
+  // The edge is consumed into the wire (shared refcounted TShape); `.delete()` is
+  // a no-op on arena kernels, so release its slot through kernel.dispose.
+  kernel.dispose(edge);
   return castResultShape(wire) as Wire;
 }
 
@@ -248,7 +251,8 @@ export function complexExtrude(
     );
   }
   const endPoint = vecAdd(center, normal);
-  const spine = makeSpineWire(center, endPoint);
+  // sweep is immutable and does not consume the spine — dispose it on every exit.
+  using spine = makeSpineWire(center, endPoint);
   let law = null;
   if (profileShape) {
     const lawResult = buildLawFromProfile(extrusionLength, profileShape);
@@ -292,11 +296,12 @@ export function twistExtrude(
   }
 
   const endPoint = vecAdd(center, normal);
-  const spine = makeSpineWire(center, endPoint);
+  // sweep is immutable and consumes neither spine — dispose both on every exit.
+  using spine = makeSpineWire(center, endPoint);
 
   const leftHanded = angleDegrees < 0;
   const pitch = (360.0 / Math.abs(angleDegrees)) * extrusionLength;
-  const auxiliarySpine = makeHelixWire(pitch, extrusionLength, 1, center, normal, leftHanded);
+  using auxiliarySpine = makeHelixWire(pitch, extrusionLength, 1, center, normal, leftHanded);
 
   let law = null;
   if (profileShape) {

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -53,6 +53,13 @@ import {
   torus,
   ellipsoid,
   drill,
+  pocket,
+  boss,
+  mirrorJoin,
+  complexExtrude,
+  twistExtrude,
+  sketchRoundedRectangle,
+  drawCircle,
   section,
   roof,
   surfaceFromGrid,
@@ -787,6 +794,91 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           if (isOk(r)) unwrap(r)[Symbol.dispose]();
         })
       ).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('compound-op + sweep-variant + blueprint-sketch ops leak nothing', () => {
+    // Follow-up sweep: pocket/boss leaked profile-wire + face + positioned + tool;
+    // mirrorJoin leaked the mirrored half; complex/twistExtrude leaked their spine
+    // (+ helix + makeSpineWire's edge); blueprint sketchOnPlane leaked every
+    // per-curve edge (fixed sketchRoundedRectangle and the pocket/boss profiles).
+    it('mirrorJoin leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 5, 5);
+          const r = mirrorJoin(b, { normal: [1, 0, 0] });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('pocket / boss leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(20, 20, 10, { centered: true });
+          const r = pocket(b, { profile: drawCircle(3), depth: 3 });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using b = box(20, 20, 10, { centered: true });
+          const r = boss(b, { profile: drawCircle(3), height: 3 });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('complexExtrude / twistExtrude leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using f = unwrap(
+            polygon([
+              [-5, -5, 0],
+              [5, -5, 0],
+              [5, 5, 0],
+              [-5, 5, 0],
+            ])
+          );
+          const w = getWires(f)[0];
+          if (!w) throw new Error('polygon face must have a wire');
+          const cw = unwrap(closedWire(w));
+          const r = complexExtrude(cw, [0, 0, 0], [0, 0, 10]);
+          if (isOk(r)) {
+            const v = unwrap(r);
+            if (!Array.isArray(v)) v[Symbol.dispose]();
+          }
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          using f = unwrap(
+            polygon([
+              [-5, -5, 0],
+              [5, -5, 0],
+              [5, 5, 0],
+              [-5, 5, 0],
+            ])
+          );
+          const w = getWires(f)[0];
+          if (!w) throw new Error('polygon face must have a wire');
+          const cw = unwrap(closedWire(w));
+          const r = twistExtrude(cw, 90, [0, 0, 0], [0, 0, 10]);
+          if (isOk(r)) {
+            const v = unwrap(r);
+            if (!Array.isArray(v)) v[Symbol.dispose]();
+          }
+        })
+      ).toBe(0);
+    });
+
+    it('sketchRoundedRectangle (blueprint sketchOnPlane) leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const s = sketchRoundedRectangle(10, 8, 2);
+          s.wire[Symbol.dispose]();
+        })
+      ).toBe(0);
     });
   });
 


### PR DESCRIPTION
Follow-up to #1794 (the comprehensive arena-leak sweep) — plugs the remaining leaks in op families the first pass didn't probe. Oracle now **48 tests**, all 0 slots/call.

## Leaks fixed (measured via `getShapeCount()`)

| Fix | Leak (before → after) | Notes |
|---|---|---|
| **blueprint `sketchOnPlane` / `sketchOnFace`** (2d) | per-curve edge (8 for a rounded rect) | the wire path for **all** blueprint sketches — cascaded to `sketchRoundedRectangle` (8→0) and pocket/boss profiles |
| **pocket / boss** (operations) | 6 → 0 | never disposed the profile wire, its face, the positioned face, or the extruded tool |
| **complexExtrude / twistExtrude** (sweepFns) | 2/3 → 0 | disposed the spine (+ helix aux spine); `makeSpineWire` now releases its consumed edge |
| **mirrorJoin** | 1 → 0 | disposed the mirrored half |

`split`, `slice`, and `sketchPolysides` were already clean.

## Notes
- `toWire` now reports whether it materialised a fresh sketch wire (caller disposes) vs. passing through a caller-owned Wire — so pocket/boss don't free an input they don't own.
- Same root-cause themes as #1794: immutable API not consuming inputs, and `getSubShapes`/edge copies never released.
- `section`/`roof`'s ≤1 residuals are unchanged — confirmed C++-side (`k.section` / `sewAndSolidify` bindings; the JS adapter `wrapResult` just re-wraps the id, no orphan). Those need an external occt-wasm change.

## Verification
- `vitest run --project occt-wasm tests/wasmArenaDisposal.test.ts` → 48/48
- 578 tests pass across compound/sweep/blueprint/sketch suites
- typecheck / eslint / prettier clean; total-JS size 344.4 kB (within the 345 kB budget)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

