### PR TITLE
fix: plug arena leaks in the projection path (makeProjectedEdges, drawProjection)

### DIFF
--- a/src/projection/makeProjectedEdges.ts
+++ b/src/projection/makeProjectedEdges.ts
@@ -41,13 +41,22 @@ export function makeProjectedEdges(
     ...getEdgesFromOc(projected.visible.outline),
   ];
 
-  const hidden = withHiddenLines
-    ? [
-        ...getEdgesFromOc(projected.hidden.sharp),
-        ...getEdgesFromOc(projected.hidden.smooth),
-        ...getEdgesFromOc(projected.hidden.outline),
-      ]
-    : [];
+  // projectEdges always allocates all six result compounds; getEdgesFromOc is the
+  // only thing that disposes them (via `using compound`). So extract the hidden
+  // compounds even when unwanted — then dispose the clones — rather than skipping
+  // the calls and leaking the three hidden compounds' arena slots.
+  const hiddenEdges = [
+    ...getEdgesFromOc(projected.hidden.sharp),
+    ...getEdgesFromOc(projected.hidden.smooth),
+    ...getEdgesFromOc(projected.hidden.outline),
+  ];
+  let hidden: Edge[];
+  if (withHiddenLines) {
+    hidden = hiddenEdges;
+  } else {
+    for (const e of hiddenEdges) e[Symbol.dispose]();
+    hidden = [];
+  }
 
   return { visible, hidden };
 }

--- a/src/projection/makeProjectedEdges.ts
+++ b/src/projection/makeProjectedEdges.ts
@@ -1,13 +1,19 @@
 import { getKernel } from '@/kernel/index.js';
 import type { KernelType } from '@/kernel/types.js';
 import type { Edge, AnyShape } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
-import { getEdges as _getEdges } from '@/topology/shapeFns.js';
+import { castResultShape } from '@/core/shapeTypes.js';
+import { unwrap } from '@/core/result.js';
+import { getEdges as _getEdges, clone } from '@/topology/shapeFns.js';
 import type { Camera } from './cameraFns.js';
 
 const getEdgesFromOc = (shape: KernelType): Edge[] => {
   if (shape.IsNull()) return [];
-  return _getEdges(castShape(shape));
+  // Each projected sub-result is a fresh arena compound; manage it so its slot
+  // (and the borrowed edges cached on it) are freed, and return independent
+  // clones the caller owns. Without this every projectEdges() leaks its result
+  // compounds.
+  using compound = castResultShape(shape);
+  return _getEdges(compound).map((e) => unwrap(clone(e)));
 };
 
 /**

--- a/src/sketching/draw3d.ts
+++ b/src/sketching/draw3d.ts
@@ -19,6 +19,9 @@ const edgesToDrawing = (edges: Edge[]): Drawing => {
   using scope = new DisposalScope();
   // drawRectangle always produces a single closed planar wire — narrow safely.
   const planeSketch = drawRectangle(1000, 1000).sketchOnPlane() as Sketch;
+  // The throwaway plane wire is consumed by makeFace; dispose it too so it does
+  // not leak an arena slot per call.
+  scope.register(planeSketch.wire);
   const planeFace = scope.register(unwrap(makeFace(planeSketch.wire)));
 
   const curves = edges.map((e) => edgeToCurve(e, planeFace));
@@ -50,10 +53,17 @@ export function drawProjection(
 
   const { visible, hidden } = projectEdges(shape, camera);
 
-  return {
-    visible: edgesToDrawing(visible),
-    hidden: edgesToDrawing(hidden),
-  };
+  // projectEdges returns independent edges the caller owns; they are only needed
+  // to build the 2D drawings, so dispose them once converted.
+  try {
+    return {
+      visible: edgesToDrawing(visible),
+      hidden: edgesToDrawing(hidden),
+    };
+  } finally {
+    for (const e of visible) e[Symbol.dispose]();
+    for (const e of hidden) e[Symbol.dispose]();
+  }
 }
 
 /**

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -63,6 +63,14 @@ import {
   section,
   roof,
   surfaceFromGrid,
+  createCamera,
+  makeProjectedEdges,
+  drawProjection,
+  createAssemblyNode,
+  addChild,
+  addMate,
+  solveAssembly,
+  faceCenter,
   getWires,
   getFaces,
   getEdges,
@@ -879,6 +887,60 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           s.wire[Symbol.dispose]();
         })
       ).toBe(0);
+    });
+  });
+
+  describe('projection + assembly ops leak nothing', () => {
+    // makeProjectedEdges leaked its 6 HLR result compounds (returned edges were
+    // borrowed from them); it now manages them and returns independent clones.
+    // drawProjection additionally leaked the edges + edgesToDrawing's plane wire.
+    // solveAssembly is pure transform math and allocates no shapes.
+    it('makeProjectedEdges leaks nothing', () => {
+      const cam = unwrap(createCamera([0, 0, 100], [0, 0, 1]));
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10, { centered: true });
+          const { visible, hidden } = makeProjectedEdges(b, cam, true);
+          for (const e of visible) e[Symbol.dispose]();
+          for (const e of hidden) e[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('drawProjection leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10, { centered: true });
+          drawProjection(b, 'front');
+        })
+      ).toBe(0);
+    });
+
+    it('solveAssembly leaks nothing', () => {
+      using b1 = box(10, 10, 10);
+      using b2 = box(6, 6, 6);
+      const topByZ = (fs: ReturnType<typeof getFaces>, top: boolean) =>
+        fs.reduce((best, f) =>
+          (top ? faceCenter(f)[2] > faceCenter(best)[2] : faceCenter(f)[2] < faceCenter(best)[2])
+            ? f
+            : best
+        );
+      const f1 = getFaces(b1);
+      const f2 = getFaces(b2);
+      const topB1 = topByZ(f1, true);
+      const botB2 = topByZ(f2, false);
+      let asm = createAssemblyNode('root');
+      asm = addChild(asm, createAssemblyNode('base', { shape: b1 }));
+      asm = addChild(asm, createAssemblyNode('top', { shape: b2 }));
+      asm = addMate(asm, { type: 'fixed', entity: { node: 'base' } });
+      asm = addMate(asm, {
+        type: 'coincident',
+        entityA: { node: 'base', face: topB1 },
+        entityB: { node: 'top', face: botB2 },
+      });
+      expect(perIterationLeak(() => void solveAssembly(asm))).toBe(0);
+      for (const f of f1) f[Symbol.dispose]();
+      for (const f of f2) f[Symbol.dispose]();
     });
   });
 

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -895,7 +895,7 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
     // borrowed from them); it now manages them and returns independent clones.
     // drawProjection additionally leaked the edges + edgesToDrawing's plane wire.
     // solveAssembly is pure transform math and allocates no shapes.
-    it('makeProjectedEdges leaks nothing', () => {
+    it('makeProjectedEdges leaks nothing (with and without hidden lines)', () => {
       const cam = unwrap(createCamera([0, 0, 100], [0, 0, 1]));
       expect(
         perIterationLeak(() => {
@@ -903,6 +903,15 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
           const { visible, hidden } = makeProjectedEdges(b, cam, true);
           for (const e of visible) e[Symbol.dispose]();
           for (const e of hidden) e[Symbol.dispose]();
+        })
+      ).toBe(0);
+      // withHiddenLines=false must still dispose the (always-allocated) hidden
+      // result compounds — the `hidden` array is empty and needs no disposal.
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10, { centered: true });
+          const { visible } = makeProjectedEdges(b, cam, false);
+          for (const e of visible) e[Symbol.dispose]();
         })
       ).toBe(0);
     });


### PR DESCRIPTION
Continues the arena-leak sweep into the **assembly / projection / text** families (probed all three). The leaks were in **projection**; assembly and base text were already clean. Oracle now **51 tests**.

## Fixed (measured via `getShapeCount()`)

| Op | Before → after | Root cause |
|---|---|---|
| **makeProjectedEdges** | 12 → 0 | the 6 HLR result compounds from `projectEdges` were never disposed; returned edges were *borrowed* from their (leaked) topology caches. Now manages each compound with `using` and returns independent **clones** the caller owns. |
| **drawProjection** | 22 → 0 | never disposed the projected edges it consumes, and `edgesToDrawing` leaked the throwaway `drawRectangle().sketchOnPlane()` plane wire per call. |

## Already clean (verified, no change)
- `solveAssembly` — pure transform math, allocates no shapes (0/call)
- `textBlueprints`, `drawText`, and `sketchText` for straight/open glyphs (I, C, LT) — 0/call

## Known residual (documented, not fixed)
`sketchText` leaks **1 slot for a glyph that contains a hole** (B, O, …) — an intermediate in the 2D hole-contour wire path, independent of the returned contour wires (disposing every returned wire/face still leaves 1). Straight/open glyphs are clean. Left as a documented follow-up; it needs a font to reproduce so it's not in the arena oracle.

## Verification
- `vitest run --project occt-wasm tests/wasmArenaDisposal.test.ts` → 51/51
- 85 tests pass across projection/draw3d/text/assembly suites
- typecheck / eslint / prettier / pattern-check clean; total-JS 344.6 kB (within 345 kB)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

