### PR TITLE
fix(operations): stop multiSectionSweep leaking its per-section positioned wires

### DIFF
--- a/src/operations/sweepFns.ts
+++ b/src/operations/sweepFns.ts
@@ -437,27 +437,38 @@ export function multiSectionSweep(
     if (isErr(paramsResult)) return paramsResult;
     const params = paramsResult.value;
 
-    // Position each profile wire along the spine and loft
+    // Position each profile wire along the spine and loft. positionOnCurve and
+    // downcast each allocate a fresh arena slot per section that loftAdvanced only
+    // consumes (never frees) — track and release them once the loft is built.
+    const positioned: KernelShape[] = [];
     const positionedWires: KernelShape[] = [];
-    for (let i = 0; i < sections.length; i++) {
-      const param = params[i];
-      const section = sections[i];
-      if (param === undefined || section === undefined) continue;
+    try {
+      for (let i = 0; i < sections.length; i++) {
+        const param = params[i];
+        const section = sections[i];
+        if (param === undefined || section === undefined) continue;
 
-      const positioned = kernel.positionOnCurve(section.wire.wrapped, spine.wrapped, param);
-      positionedWires.push(kernel.downcast(positioned, 'wire'));
+        const p = kernel.positionOnCurve(section.wire.wrapped, spine.wrapped, param);
+        positioned.push(p);
+        positionedWires.push(kernel.downcast(p, 'wire'));
+      }
+
+      const loftResult = kernel.loftAdvanced(positionedWires, { solid, ruled, tolerance });
+
+      const result = castResultShape(loftResult);
+      if (!isShape3D(result)) {
+        disposeResultShape(result);
+        return err(
+          typeCastError('MULTI_SWEEP_NOT_3D', 'Multi-section sweep did not produce a 3D shape')
+        );
+      }
+      return ok(result as Solid | Shell);
+    } finally {
+      // The loft result shares these wires' refcounted TShapes and survives.
+      // release() is idempotent, so an aliased downcast (occt-wasm) is safe.
+      for (const w of positionedWires) kernel.dispose(w);
+      for (const p of positioned) kernel.dispose(p);
     }
-
-    const loftResult = kernel.loftAdvanced(positionedWires, { solid, ruled, tolerance });
-
-    const result = castResultShape(loftResult);
-    if (!isShape3D(result)) {
-      disposeResultShape(result);
-      return err(
-        typeCastError('MULTI_SWEEP_NOT_3D', 'Multi-section sweep did not produce a 3D shape')
-      );
-    }
-    return ok(result as Solid | Shell);
   } catch (e: unknown) {
     const raw = e instanceof Error ? e.message : String(e);
     return err(

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -42,7 +42,10 @@ import {
   extrude,
   revolve,
   loft,
+  loftAll,
   sweep,
+  guidedSweep,
+  multiSectionSweep,
   thread,
   convexHull,
   hull,
@@ -970,6 +973,85 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       expect(perIterationLeak(() => void solveAssembly(asm))).toBe(0);
       for (const f of f1) f[Symbol.dispose]();
       for (const f of f2) f[Symbol.dispose]();
+    });
+  });
+
+  describe('sweep / loft variants leak nothing', () => {
+    // guidedSweep + loftAll were already clean (castResultShape; loftAll disposes
+    // its makeVertex temporaries via kernel.dispose). multiSectionSweep leaked its
+    // per-section positionOnCurve + downcast wires (4/call for 2 sections) — now
+    // released once loftAdvanced has consumed them.
+    const squareWire = (z: number, r: number) => {
+      const f = unwrap(
+        polygon([
+          [-r, -r, z],
+          [r, -r, z],
+          [r, r, z],
+          [-r, r, z],
+        ])
+      );
+      const w = getWires(f)[0];
+      if (!w) throw new Error('polygon face must have a wire');
+      return { face: f, wire: w };
+    };
+
+    it('guidedSweep leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using pf = squareWire(0, 1).face;
+          const pw = getWires(pf)[0];
+          if (!pw) throw new Error('no wire');
+          const profile = unwrap(closedWire(pw));
+          using se = line([0, 0, 0], [0, 0, 20]);
+          using spine = unwrap(wire([se]));
+          using ge = line([3, 0, 0], [3, 0, 20]);
+          using guide = unwrap(wire([ge]));
+          const r = guidedSweep(profile, spine, [guide]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('loftAll leaks nothing (with start/end points)', () => {
+      expect(
+        perIterationLeak(() => {
+          using f1 = squareWire(0, 5).face;
+          using f2 = squareWire(20, 5).face;
+          const w1 = getWires(f1)[0];
+          const w2 = getWires(f2)[0];
+          if (!w1 || !w2) throw new Error('no wires');
+          const r = loftAll([
+            { wires: [w1, w2], ruled: true, startPoint: [0, 0, -5], endPoint: [0, 0, 25] },
+          ]);
+          if (isOk(r)) for (const s of unwrap(r)) s[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('multiSectionSweep leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using f1 = squareWire(0, 2).face;
+          using f2 = squareWire(0, 3).face;
+          const w1 = getWires(f1)[0];
+          const w2 = getWires(f2)[0];
+          if (!w1 || !w2) throw new Error('no wires');
+          using se = line([0, 0, 0], [0, 0, 20]);
+          using spine = unwrap(wire([se]));
+          const r = multiSectionSweep(
+            [
+              { wire: w1, location: 0 },
+              { wire: w2, location: 1 },
+            ],
+            spine
+          );
+          if (isOk(r)) {
+            const v = unwrap(r);
+            if (Array.isArray(v)) v.forEach((s) => s[Symbol.dispose]());
+            else v[Symbol.dispose]();
+          }
+        })
+      ).toBe(0);
     });
   });
 


### PR DESCRIPTION
Probed the remaining sweep/loft variants for arena leaks. One real leak found and fixed.

## Results (measured via `getShapeCount()`)

| Variant | Leak/call | Status |
|---|---|---|
| `guidedSweep` | 0 | already clean (`castResultShape` + `disposeResultShape`) |
| `loftAll` | 0 | already clean (disposes `makeVertex` start/end temporaries via `kernel.dispose`) |
| `loftAll` + start/end points | 0 | already clean |
| **`multiSectionSweep`** | **4 → 0** | **fixed** |

## The multiSectionSweep leak
For each section it calls `kernel.positionOnCurve` (a fresh positioned wire) and `kernel.downcast(_, 'wire')` (another slot), pushes them into the loft input, and never releases them — `loftAdvanced` only *consumes* them. That's 2 slots/section (4 for a 2-section sweep). Now tracked and disposed in a `finally` once the loft is built: the result shares their refcounted `TShape` and survives, and `release()` is idempotent so an aliased occt-wasm `downcast` is safe.

## Verification
- `vitest run --project occt-wasm tests/wasmArenaDisposal.test.ts` → 57/57 (adds guidedSweep, loftAll+points, multiSectionSweep at 0/call)
- 30 tests pass across sweep/loft suites; typecheck / eslint / prettier clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

