### PR TITLE
fix(operations): stop rectangularPattern leaking its translated copies

### DIFF
--- a/src/operations/compoundOpsFns.ts
+++ b/src/operations/compoundOpsFns.ts
@@ -311,6 +311,7 @@ export function rectangularPattern<T extends Shape3D>(
   // This replaces sequential fuse() (N-1 pairwise operations on growing shapes)
   // with a single BRepAlgoAPI_BuilderAlgo call.
   const copies: Shape3D[] = [s];
+  const owned: Shape3D[] = []; // the translated copies we allocate (not the caller's `s`)
   for (let xi = 0; xi < xCount; xi++) {
     for (let yi = 0; yi < yCount; yi++) {
       if (xi === 0 && yi === 0) continue; // skip original
@@ -319,9 +320,17 @@ export function rectangularPattern<T extends Shape3D>(
         xNorm[1] * xSpacing * xi + yNorm[1] * ySpacing * yi,
         xNorm[2] * xSpacing * xi + yNorm[2] * ySpacing * yi,
       ];
-      copies.push(translate(s, offset));
+      const c = translate(s, offset);
+      copies.push(c);
+      owned.push(c);
     }
   }
 
-  return fuseAll(copies, { unsafe: true }) as Result<T>;
+  try {
+    return fuseAll(copies, { unsafe: true }) as Result<T>;
+  } finally {
+    // fuseAll is immutable and does not consume its inputs — dispose the copies
+    // we created (never `s`, which the caller owns).
+    for (const c of owned) c[Symbol.dispose]();
+  }
 }

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -24,6 +24,8 @@ import {
   fuse,
   intersect,
   fuseAll,
+  cutAll,
+  rectangularPattern,
   compound,
   fillet,
   chamfer,
@@ -973,6 +975,43 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       expect(perIterationLeak(() => void solveAssembly(asm))).toBe(0);
       for (const f of f1) f[Symbol.dispose]();
       for (const f of f2) f[Symbol.dispose]();
+    });
+  });
+
+  describe('boolean variants leak nothing', () => {
+    // fuseAll + drill are covered above. cutAll (batch cut) routes through
+    // castToShape3D, which disposes the downcast source on both paths — clean.
+    // rectangularPattern leaked its translated copies (3/call for a 2x2 grid),
+    // handed to the immutable fuseAll but never disposed — now released.
+    it('cutAll leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using base = box(20, 20, 20);
+          using i1 = box(3, 3, 30);
+          using t1 = translate(i1, [5, 5, 0]);
+          using i2 = box(3, 3, 30);
+          using t2 = translate(i2, [12, 12, 0]);
+          const r = cutAll(base, [t1, t2]);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('rectangularPattern leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          using b = box(2, 2, 2);
+          const r = rectangularPattern(b, {
+            xDir: [1, 0, 0],
+            xCount: 2,
+            xSpacing: 5,
+            yDir: [0, 1, 0],
+            yCount: 2,
+            ySpacing: 5,
+          });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
     });
   });
 


### PR DESCRIPTION
Probed the boolean variants (`fuseAll`, `cutAll`, `drill`) for arena leaks, plus `rectangularPattern` (another batch-fuse compound op). One real leak found and fixed.

## Results (measured via `getShapeCount()`)

| Variant | Leak/call | Status |
|---|---|---|
| `fuseAll` | 0 | already clean |
| `cutAll` | 0 | already clean — `castToShape3D` disposes the downcast source on both paths |
| `drill` | 0 | already clean (fixed in #1798) |
| **`rectangularPattern`** | **3 → 0** | **fixed** |

## The rectangularPattern leak
It builds `translate(s, offset)` copies for the grid and hands them to the immutable `fuseAll` — which doesn't consume its inputs — so every translated copy leaked (3 for a 2×2 grid). This is the identical bug already fixed in `linearPattern`/`circularPattern`; `rectangularPattern` in `compoundOpsFns` was missed. Now the allocated copies are disposed in a `finally` (never `s`, which the caller owns).

## Verification
- `vitest run --project occt-wasm tests/wasmArenaDisposal.test.ts` → 59/59 (adds cutAll, rectangularPattern at 0/call)
- 202 tests pass across compound/pattern/boolean suites; typecheck / eslint / prettier clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

