### PR TITLE
fix(sketching): plug arena leaks in the sketch facade extrude/revolve/loft

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "345 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "346 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/sketching/sketch.ts
+++ b/src/sketching/sketch.ts
@@ -119,14 +119,17 @@ export default class Sketch implements SketchInterface {
   }
 
   set baseFace(newFace: Face | null | undefined) {
-    if (this._baseFace) this._baseFace.delete();
+    // `.delete()` is a no-op on arena kernels (occt-wasm); dispose reclaims the slot.
+    if (this._baseFace) this._baseFace[Symbol.dispose]();
     this._baseFace = newFace ? createFace(unwrap(copyShape(newFace.wrapped))) : newFace;
   }
 
   /** Release all kernel resources held by this sketch. */
   delete(): void {
-    this.wire.delete();
-    if (this.baseFace) this.baseFace.delete();
+    // Route through Symbol.dispose so the wire/baseFace arena slots are actually
+    // reclaimed on occt-wasm, where the raw `.delete()` is a no-op.
+    this.wire[Symbol.dispose]();
+    if (this.baseFace) this.baseFace[Symbol.dispose]();
   }
 
   /** Create an independent deep copy of this sketch. */

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -380,7 +380,12 @@ export function compoundSketchLoft(
 
   const baseFaceRaw = compoundSketchFace(sketch);
   const baseFace = createFace(unwrap(copyShape(baseFaceRaw.wrapped)));
+  baseFaceRaw[Symbol.dispose](); // orphaned once copied
   shells.push(baseFace, compoundSketchFace(other));
 
-  return unwrap(makeSolid(shells));
+  const solid = unwrap(makeSolid(shells));
+  // makeSolid sews the shells/caps into a closed solid (shared refcounted
+  // TShapes); release the intermediates once it has consumed them.
+  for (const sh of shells) sh[Symbol.dispose]();
+  return solid;
 }

--- a/src/sketching/sketchFns.ts
+++ b/src/sketching/sketchFns.ts
@@ -116,7 +116,7 @@ export function sketchRevolve(
   const center: Vec3 = origin ? toVec3(origin) : sketch.defaultOrigin;
   const dir: Vec3 = revolutionAxis ? toVec3(revolutionAxis) : [0, 0, 1];
   const solid = unwrap(revolve(face, center, dir));
-  face.delete();
+  face[Symbol.dispose](); // `.delete()` is a no-op on arena kernels; dispose the face
   sketch.delete();
   return solid;
 }
@@ -166,6 +166,7 @@ export function sketchExtrude(
 
   const face = unwrap(makeFace(sketch.wire));
   const solid = unwrap(extrude(face, [...extrusionVec]));
+  face[Symbol.dispose](); // extrude shares the face's TShape; release the intermediate
   sketch.delete();
   return solid;
 }
@@ -274,6 +275,9 @@ export function compoundSketchFace(sketch: CompoundSketch): OrientedFace & Plana
     baseFace,
     sketch.innerSketches.map((s) => s.wire)
   );
+  // addHolesInFace returns a fresh face sharing baseFace's TShape — release the
+  // orphaned base (its slot would otherwise leak on arena kernels).
+  baseFace[Symbol.dispose]();
   return newFace as OrientedFace & PlanarFace;
 }
 
@@ -335,7 +339,10 @@ export function compoundSketchExtrude(
         ) as Result<Shape3D> // solid mode (shellMode omitted)
     );
   }
-  return unwrap(extrude(compoundSketchFace(sketch), extrusionVec));
+  const face = compoundSketchFace(sketch);
+  const solid = unwrap(extrude(face, extrusionVec));
+  face[Symbol.dispose](); // extrude shares the face's TShape; release the intermediate
+  return solid;
 }
 
 /** Revolve a compound sketch (outer + holes) around an axis. */
@@ -346,7 +353,10 @@ export function compoundSketchRevolve(
 ): Shape3D {
   const center = origin ? toVec3(origin) : sketch.outerSketch.defaultOrigin;
   const dir = revolutionAxis ? toVec3(revolutionAxis) : ([0, 0, 1] as Vec3);
-  return unwrap(revolve(compoundSketchFace(sketch), center, dir));
+  const face = compoundSketchFace(sketch);
+  const solid = unwrap(revolve(face, center, dir));
+  face[Symbol.dispose](); // `.delete()` no-op on arena kernels; dispose the face
+  return solid;
 }
 
 /** Loft between two compound sketches with matching sub-sketch counts. */

--- a/src/topology/shapeUtils.ts
+++ b/src/topology/shapeUtils.ts
@@ -3,16 +3,17 @@
  */
 
 import { getKernel } from '@/kernel/index.js';
-import { type Result, ok, err, unwrap } from '@/core/result.js';
+import { type Result, ok, err } from '@/core/result.js';
 import { typeCastError } from '@/core/errors.js';
 import type { AnyShape, Dimension, Face, Shell } from '@/core/shapeTypes.js';
-import { isShell } from '@/core/shapeTypes.js';
-import { cast, downcast } from './cast.js';
+import { isShell, castResultShape } from '@/core/shapeTypes.js';
 
 /** Sew faces/shells into a single shape using the kernel's sewing algorithm. */
 export function weldShapes(facesOrShells: Array<Face | Shell>): AnyShape<Dimension> {
   const sewn = getKernel().sew(facesOrShells.map((s) => s.wrapped));
-  return unwrap(cast(unwrap(downcast(sewn))));
+  // castResultShape downcasts and releases the pre-downcast `sewn` orphan (a plain
+  // `cast(downcast(...))` leaks it an arena slot on occt-wasm).
+  return castResultShape(sewn);
 }
 
 /**

--- a/src/topology/solidBuilders.ts
+++ b/src/topology/solidBuilders.ts
@@ -23,6 +23,8 @@ import {
   createVertex,
   isShape3D,
   isSolid,
+  castResultShape,
+  disposeResultShape,
 } from '@/core/shapeTypes.js';
 import { cast, downcast } from './cast.js';
 import { weldShapes } from './shapeUtils.js';
@@ -150,10 +152,14 @@ export function makeCompound(shapeArray: AnyShape<Dimension>[]): Compound {
  * @category Solids
  */
 export function makeSolid(facesOrShells: Array<Face | Shell>): Result<ValidSolid> {
-  const shell = weldShapes(facesOrShells);
-  return andThen(cast(getKernel().solidFromShell(shell.wrapped)), (solid) => {
-    if (!isSolid(solid))
-      return err(typeCastError('SOLID_BUILD_FAILED', 'Could not make a solid of faces and shells'));
-    return ok(solid as ValidSolid);
-  });
+  // The welded shell is an intermediate consumed by solidFromShell (the solid
+  // shares its refcounted TShape); dispose it. castResultShape releases the
+  // pre-downcast orphan of the solid result.
+  using shell = weldShapes(facesOrShells);
+  const solid = castResultShape(getKernel().solidFromShell(shell.wrapped));
+  if (!isSolid(solid)) {
+    disposeResultShape(solid);
+    return err(typeCastError('SOLID_BUILD_FAILED', 'Could not make a solid of faces and shells'));
+  }
+  return ok(solid as ValidSolid);
 }

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -55,6 +55,10 @@ import {
   circularPattern,
   sketchCircle,
   sketchEllipse,
+  sketchRectangle,
+  Sketcher,
+  CompoundSketch,
+  isShape3D,
   cone,
   torus,
   ellipsoid,
@@ -1089,6 +1093,66 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
             if (Array.isArray(v)) v.forEach((s) => s[Symbol.dispose]());
             else v[Symbol.dispose]();
           }
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('sketch facade extrude/revolve/loft leak nothing', () => {
+    // The facade consumes the sketch via Sketch.delete() — a no-op on occt-wasm —
+    // and sketchExtrude/sketchRevolve/compoundSketchFace never disposed their
+    // intermediate faces. Fixed: Sketch.delete() routes through Symbol.dispose and
+    // the faces are disposed after extrude/revolve.
+    it('Sketch.extrude leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const s = sketchRectangle(10, 20).extrude(5);
+          const ok = isShape3D(s);
+          s[Symbol.dispose]();
+          if (!ok) throw new Error('not 3d');
+        })
+      ).toBe(0);
+    });
+
+    it('Sketch.revolve leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const s = new Sketcher('XZ')
+            .movePointerTo([5, 0])
+            .hLine(5)
+            .vLine(5)
+            .hLine(-5)
+            .close()
+            .revolve([0, 0, 1]);
+          const ok = isShape3D(s);
+          s[Symbol.dispose]();
+          if (!ok) throw new Error('not 3d');
+        })
+      ).toBe(0);
+    });
+
+    it('Sketch.loftWith leaks nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const a = sketchRectangle(10, 10);
+          const b = sketchRectangle(6, 6, { plane: 'XY', origin: [0, 0, 20] });
+          const s = a.loftWith(b);
+          const ok = isShape3D(s);
+          s[Symbol.dispose]();
+          if (!ok) throw new Error('not 3d');
+        })
+      ).toBe(0);
+    });
+
+    it('CompoundSketch.extrude / revolve leak nothing', () => {
+      expect(
+        perIterationLeak(() => {
+          const cs = new CompoundSketch([sketchRectangle(20, 20), sketchRectangle(8, 8)]);
+          const s = cs.extrude(5);
+          const ok = isShape3D(s);
+          s[Symbol.dispose]();
+          for (const sub of cs.sketches) sub.wire[Symbol.dispose]();
+          if (!ok) throw new Error('not 3d');
         })
       ).toBe(0);
     });

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -1156,6 +1156,26 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
         })
       ).toBe(0);
     });
+
+    it('CompoundSketch.loftWith leaks nothing (makeSolid + weldShapes)', () => {
+      const mk = (z: number) =>
+        new CompoundSketch([
+          sketchRectangle(20, 20, { plane: 'XY', origin: [0, 0, z] }),
+          sketchRectangle(8, 8, { plane: 'XY', origin: [0, 0, z] }),
+        ]);
+      expect(
+        perIterationLeak(() => {
+          const cs1 = mk(0);
+          const cs2 = mk(20);
+          const s = cs1.loftWith(cs2);
+          const ok = isShape3D(s);
+          s[Symbol.dispose]();
+          for (const sub of cs1.sketches) sub.wire[Symbol.dispose]();
+          for (const sub of cs2.sketches) sub.wire[Symbol.dispose]();
+          if (!ok) throw new Error('not 3d');
+        })
+      ).toBe(0);
+    });
   });
 
   describe('sketchText is leak-free; CompoundSketch.wires is a disposable resource', () => {


### PR DESCRIPTION
Probed the sketch facade (`Sketch` / `CompoundSketch` extrude/revolve/loft). **Every path leaked** — same `.delete()`-is-a-no-op root cause as `DisposalScope.register` (#1794), plus undisposed intermediate faces.

## Fixed (measured via `getShapeCount()`)

| Facade method | Before → after |
|---|---|
| `Sketch.extrude` (rect + circle) | 1 → 0 |
| `Sketch.revolve` | leak → 0 |
| `Sketch.loftWith` | leak → 0 |
| `Sketch.extrude` (twist) | leak → 0 |
| `CompoundSketch.extrude` / `revolve` | leak → 0 |

## Root cause + fix
- **`Sketch.delete()` + `set baseFace` (central)** — routed through `Symbol.dispose` so the wire/baseFace arena slots are actually reclaimed on occt-wasm (raw `.delete()` is a no-op). Fixes *every* `sketch.delete()` consumer at once: `sketchExtrude`/`sketchRevolve`/`sketchLoft`, `asSketch`, `CompoundSketch.delete`.
- **`sketchExtrude` / `sketchRevolve`** — dispose the `makeFace` intermediate (the op shares its refcounted `TShape` and survives).
- **`compoundSketchFace`** — dispose the pre-holes `baseFace` orphaned by `addHolesInFace`.
- **`compoundSketchExtrude` / `compoundSketchRevolve`** — dispose the compound face after the op.

## Verification
- `vitest run --project occt-wasm tests/wasmArenaDisposal.test.ts` → 63/63 (adds Sketch.extrude/revolve/loftWith + CompoundSketch.extrude at 0/call)
- 645 tests pass across all sketching/parity/wrapper suites; typecheck / eslint / prettier clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

