### PR TITLE
fix(core): compare by slot id in disposeDowncastSource (occt-wasm 3.7 readiness)

### DIFF
--- a/src/core/shapeTypes.ts
+++ b/src/core/shapeTypes.ts
@@ -311,7 +311,16 @@ export function castShape3D(ocShape: KernelShape): AnyShape {
  * received from elsewhere.
  */
 export function disposeDowncastSource(source: KernelShape, cast: ShapeHandle): void {
-  if (cast.wrapped !== source) getKernel().dispose(source);
+  // On arena kernels (occt-wasm) a handle carries a slot `id`. An identity
+  // downcast (occt-wasm >= 3.7.0) returns the SAME id wrapped in a fresh object,
+  // so compare by id: a plain `!==` on the wrappers would dispose the slot the
+  // returned shape still points to (use-after-free). Kernels whose shapes carry
+  // no `id` fall back to object identity (the original behavior).
+  const srcId = (source as { id?: unknown }).id;
+  const dstId = (cast.wrapped as { id?: unknown }).id;
+  const sameSlot =
+    srcId !== undefined && dstId !== undefined ? srcId === dstId : cast.wrapped === source;
+  if (!sameSlot) getKernel().dispose(source);
 }
 
 /**


### PR DESCRIPTION
Standalone hardening extracted from the occt-wasm 3.7.0 bump investigation (#1811). **No dependency bump here** — the bump itself is deferred (its blast radius is much larger; see #1811). This lands only the safe, forward-compatible piece.

## The fix
`disposeDowncastSource` released the pre-downcast source using **object identity**:

```ts
if (cast.wrapped !== source) getKernel().dispose(source);
```

That's correct on occt-wasm **3.6.1**, where an identity `downcast` allocates a fresh duplicate slot (so the wrappers genuinely differ). But occt-wasm **3.7.0** (occt-wasm#205) makes an identity downcast return the **same slot id** in a fresh wrapper object — so `!==` is true even though both point at the same slot, and `dispose(source)` would free the id the returned shape still uses (**use-after-free**).

Now it compares by slot `id` (occt-wasm handles carry one), falling back to object identity for kernels whose shapes don't:

```ts
const srcId = (source as { id?: unknown }).id;
const dstId = (cast.wrapped as { id?: unknown }).id;
const sameSlot =
  srcId !== undefined && dstId !== undefined ? srcId === dstId : cast.wrapped === source;
if (!sameSlot) getKernel().dispose(source);
```

## Why it's safe now
- **Behavior-identical on 3.6.1**: distinct duplicate ids → `srcId !== dstId` → dispose fires, exactly as before.
- **Forward-compatible**: when occt-wasm is bumped to 3.7.0, this prevents the identity-downcast UAF across every `castResultShape`/`castResultShapeWithKnownType` path.

## Verification (on current occt-wasm 3.6.1)
- Arena disposal suite 64/64, plus the adjacency + ShapeRef/history-replay suites (the ones that break on 3.7.0) all green — 92 tests, confirming no behavior change.
- typecheck / eslint / prettier clean.

## Follow-up
The full 3.7.0 migration (adjacency `wrapAll`→copyShape, the ShapeRef/toponaming re-identification path, the bump, and tightening `section`/`roof` to `=== 0`) is scoped as a checklist in #1811.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

