### PR TITLE
perf(topology): use the kernel-native sharedEdges when available

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "346 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "347 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/topology/adjacencyFns.ts
+++ b/src/topology/adjacencyFns.ts
@@ -378,11 +378,18 @@ export function sharedEdges<D extends Dimension>(face1: Face<D>, face2: Face<D>)
   const kernel = getKernel();
   const kernelId = getActiveKernelId() ?? '';
   if (nativeSharedEdgesSupported.get(kernelId) !== false) {
+    let raw: KernelShape[] | undefined;
     try {
-      const raw = kernel.sharedEdges(face1.wrapped, face2.wrapped);
+      raw = kernel.sharedEdges(face1.wrapped, face2.wrapped);
+      const result = raw.map((e) => castResultShapeWithKnownType(e, 'edge') as Edge<D>);
       nativeSharedEdgesSupported.set(kernelId, true);
-      return raw.map((e) => castResultShapeWithKnownType(e, 'edge') as Edge<D>);
+      return result;
     } catch (e) {
+      // On a mid-map cast failure the native slots aren't all owned yet — release
+      // the whole batch so nothing leaks (dispose is idempotent for any the cast
+      // already adopted). Then classify: only fall back on the unsupported
+      // sentinels, else re-throw a genuine error.
+      if (raw) for (const r of raw) kernel.dispose(r);
       if (!isUnsupportedKernelError(e)) throw e;
       nativeSharedEdgesSupported.set(kernelId, false);
     }

--- a/src/topology/adjacencyFns.ts
+++ b/src/topology/adjacencyFns.ts
@@ -5,7 +5,7 @@
  * (built once per parent shape and cached) to avoid redundant WASM calls.
  */
 
-import { getKernel } from '@/kernel/index.js';
+import { getKernel, getActiveKernelId } from '@/kernel/index.js';
 import type { KernelShape, ShapeType } from '@/kernel/types.js';
 import type { AnyShape, ClosedWire, Dimension, Edge, Face, Vertex } from '@/core/shapeTypes.js';
 import { castResultShapeWithKnownType, borrowShapeWithKnownType } from '@/core/shapeTypes.js';
@@ -347,14 +347,51 @@ export function adjacentFaces<D extends Dimension>(parent: AnyShape<D>, face: Fa
   return wrapAll<Face<D>>(neighborRaw, 'face');
 }
 
+// Per-kernel memo of whether kernel.sharedEdges is a real implementation. occt-wasm
+// and brepkit compute shared edges natively (kernel-side edge-to-face map); the occt
+// (OpenCascade) adapter stubs it, and manifold has no exact topology of its own. We
+// probe once per kernel, matching only the codebase's three canonical "unsupported
+// operation" sentinels so a genuine geometry error still propagates instead of
+// silently degrading to the JS path.
+const nativeSharedEdgesSupported = new Map<string, boolean>();
+
+function isUnsupportedKernelError(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : '';
+  // occt stub | occt-wasm notImplemented | manifold occtOrThrow
+  return /is only available with the|is not yet implemented|requires a registered occt kernel/.test(
+    msg
+  );
+}
+
 /**
  * Get all edges shared between two faces.
+ *
+ * Prefers the kernel's native `sharedEdges` (computed from its internal
+ * edge-to-face adjacency) and falls back to {@link sharedEdgesJS} on kernels
+ * that don't implement it. Both return fresh, caller-owned edge handles.
  *
  * @param face1 - The first face.
  * @param face2 - The second face.
  * @returns Array of edges present in both faces (via isSame comparison).
  */
 export function sharedEdges<D extends Dimension>(face1: Face<D>, face2: Face<D>): Edge<D>[] {
+  const kernel = getKernel();
+  const kernelId = getActiveKernelId() ?? '';
+  if (nativeSharedEdgesSupported.get(kernelId) !== false) {
+    try {
+      const raw = kernel.sharedEdges(face1.wrapped, face2.wrapped);
+      nativeSharedEdgesSupported.set(kernelId, true);
+      return raw.map((e) => castResultShapeWithKnownType(e, 'edge') as Edge<D>);
+    } catch (e) {
+      if (!isUnsupportedKernelError(e)) throw e;
+      nativeSharedEdgesSupported.set(kernelId, false);
+    }
+  }
+  return sharedEdgesJS(face1, face2);
+}
+
+/** JS fallback for {@link sharedEdges}: match edges of both faces by hash + isSame. */
+function sharedEdgesJS<D extends Dimension>(face1: Face<D>, face2: Face<D>): Edge<D>[] {
   const kernel = getKernel();
   const edges1 = kernel.iterShapes(face1.wrapped, 'edge');
   const edges2 = kernel.iterShapes(face2.wrapped, 'edge');


### PR DESCRIPTION
occt-wasm 3.7.0 (and brepkit) compute shared edges kernel-side from their internal edge-to-face adjacency map. This wires `sharedEdges` to that native path, with the previous JS scan retained as a fallback.

## What changed

`sharedEdges(face1, face2)` now delegates to `kernel.sharedEdges` and falls back to the JS hash+isSame scan (`sharedEdgesJS`) on kernels that stub it (`occt`) or lack exact topology of their own (`manifold`). Native support is **probed once per kernel** and memoized, matching only the codebase's three canonical "unsupported operation" sentinels (occt's `makeBrepkitOnlyStubs`, occt-wasm's `notImplemented`, manifold's `occtOrThrow`) — so a genuine geometry error still propagates instead of silently degrading to JS.

`sharedEdges` was the most expensive adjacency path: uncached, O(F²·E) with `iterShapes` on both faces every call (`derivedFaceRefFns.betweenFaces` even routes around it, calling it "an O(F·N) per-pair `sharedEdges` scan"). Both paths return fresh, caller-owned edge handles, so the **ownership contract is unchanged** — a drop-in.

## Deliberately not wired

I probed all three native methods before scoping this, and two aren't safe substitutes:

- **Raw `edgeToFaceMap`** returns hashes at the kernel's own `HASH_UPPER` (1e6) and keyed **per-face-occurrence**, so they match **0/12** of `hashCode(edge, HASH_CODE_MAX)` on a box. It can't build the isSame-verified `facesOfEdge` cache without breaking lookups (and the toponaming that depends on them). The native adjacency methods consume it correctly kernel-side; the raw JSON is not a compatible substitute.
- **`adjacentFaces`** stays on its cached borrowed-view path. The native version returns *owned* slots, which would ripple the borrowed→owned ownership change through `derivedFaceRefFns.betweenFaces` and the toponaming derived-face path — real risk, no gain over the existing cache.

## Verification

- Full occt-wasm suite: **4724 pass / 0 fail**
- Adjacency + ShapeRef replay: green on occt-wasm (native) and brepkit (native)
- occt (JS fallback) and manifold: at baseline parity (manifold's 9 standalone adjacency failures pre-exist this change)
- Confirmed via a spy probe: native invoked on occt-wasm/brepkit, fallback after one probe on occt — all producing identical results
- typecheck / lint / check:patterns / check:boundaries / format / knip: clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

