### PR TITLE
refactor(kernel): mark unsupported-operation errors instead of matching messages

### DIFF
--- a/src/kernel/manifold/geometryOps.ts
+++ b/src/kernel/manifold/geometryOps.ts
@@ -15,6 +15,7 @@
 import type { KernelCurveOps } from '@/kernel/interfaces/curveOps.js';
 import type { KernelSurfaceOps } from '@/kernel/interfaces/surfaceOps.js';
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
+import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 import type { KernelShape } from '@/kernel/types.js';
 import type { ManifoldModule } from './helpers.js';
 import { asManifoldShape, brepCache, occtOrThrow, resolveOcct, unwrap } from './meshHandle.js';
@@ -64,7 +65,9 @@ function viaOcct<T>(
   if (witness && witness.__manifoldSub && witness.occt) {
     const occt = resolveOcct();
     if (!occt) {
-      throw new Error('manifold: sub-shape geometry query requires a registered occt kernel');
+      throw new UnsupportedKernelOperationError(
+        'manifold: sub-shape geometry query requires a registered occt kernel'
+      );
     }
     return query(witness.occt, occt);
   }
@@ -74,7 +77,7 @@ function viaOcct<T>(
   }
   const occt = resolveOcct();
   if (!occt) {
-    throw new Error(
+    throw new UnsupportedKernelOperationError(
       'manifold: exact geometry query unsupported on manifold kernel; no B-rep kernel registered'
     );
   }

--- a/src/kernel/manifold/measureOps.ts
+++ b/src/kernel/manifold/measureOps.ts
@@ -13,6 +13,7 @@
 
 import type { BulkMeasurement, KernelMeasureOps } from '@/kernel/interfaces/measureOps.js';
 import type { DistanceResult, KernelShape } from '@/kernel/types.js';
+import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 import type { ManifoldModule } from './helpers.js';
 import { notImplemented } from './helpers.js';
 import {
@@ -255,7 +256,7 @@ function surfaceCurvature(
 ): ReturnType<KernelMeasureOps['surfaceCurvature']> {
   const occt = resolveOcct();
   if (!occt) {
-    throw new Error(
+    throw new UnsupportedKernelOperationError(
       'manifold: surfaceCurvature requires a registered occt kernel; none is available'
     );
   }

--- a/src/kernel/manifold/meshHandle.ts
+++ b/src/kernel/manifold/meshHandle.ts
@@ -1,6 +1,7 @@
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
 import type { KernelShape } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
+import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 import type { OpNode } from './opGraph.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- manifold-3d object type gap
@@ -50,7 +51,9 @@ export function resolveOcct(): KernelAdapter | undefined {
 export function occtOrThrow(method: string): KernelAdapter {
   const occt = resolveOcct();
   if (!occt) {
-    throw new Error(`manifold: ${method} requires a registered occt kernel; none is available`);
+    throw new UnsupportedKernelOperationError(
+      `manifold: ${method} requires a registered occt kernel; none is available`
+    );
   }
   return occt;
 }

--- a/src/kernel/occt/defaultAdapter.ts
+++ b/src/kernel/occt/defaultAdapter.ts
@@ -18,6 +18,7 @@ import type { KernelCapabilities } from '@/kernel/capabilities.js';
 import { EXACT_BREP_CAPABILITIES } from '@/kernel/capabilities.js';
 import type { KernelAdapter, KernelMeshResult, KernelInstance } from '@/kernel/types.js';
 import type { Kernel2DCapability } from '@/kernel/kernel2dTypes.js';
+import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 
 import { makeBooleanOps } from './booleanOps.js';
 import { makeBooleanPipelineOps } from './booleanPipelineOps.js';
@@ -50,7 +51,7 @@ import { draftWithHistory } from './historyOps.js';
 // brepjs-patterns-disable: max-function-lines
 function makeBrepkitOnlyStubs() {
   const u = (name: string) => () => {
-    throw new Error(`${name} is only available with the brepkit kernel`);
+    throw new UnsupportedKernelOperationError(`${name} is only available with the brepkit kernel`);
   };
   return {
     export3MF: u('export3MF'),
@@ -67,7 +68,9 @@ function makeBrepkitOnlyStubs() {
     detectSmallFeatures: u('detectSmallFeatures'),
     recognizeFeatures: u('recognizeFeatures'),
     meshBoolean: ((): KernelMeshResult => {
-      throw new Error('meshBoolean is only available with the brepkit kernel');
+      throw new UnsupportedKernelOperationError(
+        'meshBoolean is only available with the brepkit kernel'
+      );
     }) as KernelAdapter['meshBoolean'],
     edgeToFaceMap: u('edgeToFaceMap'),
     sharedEdges: u('sharedEdges'),

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -42,6 +42,7 @@
 
 import type { KernelCapabilities } from '@/kernel/capabilities.js';
 import { EXACT_BREP_CAPABILITIES } from '@/kernel/capabilities.js';
+import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 import type {
   BooleanOpType,
   BooleanOptions,
@@ -110,7 +111,7 @@ import * as hullOps from './hullOps.js';
 // parseEvolution moved to evolutionOps.ts
 
 function notImplemented(method: string): never {
-  throw new Error(`occt-wasm: ${method} is not yet implemented`);
+  throw new UnsupportedKernelOperationError(`occt-wasm: ${method} is not yet implemented`);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/kernel/unsupported.ts
+++ b/src/kernel/unsupported.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared error for "this kernel doesn't implement this operation" — a stubbed
+ * adapter method (occt's brepkit-only stubs, occt-wasm's not-yet-implemented) or
+ * a manifold op that needs an absent occt replay. Feature-detection recognises it
+ * structurally via {@link isUnsupportedKernelOperationError} instead of matching
+ * each adapter's message text, so a native-vs-fallback probe stays decoupled from
+ * wording. Adapters keep their existing messages; this only adds the marker.
+ */
+
+const UNSUPPORTED_MARKER = Symbol.for('brepjs.kernel.unsupportedOperation');
+
+/** Thrown by a kernel adapter asked to perform an operation it doesn't support. */
+export class UnsupportedKernelOperationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedKernelOperationError';
+    // Global-registry symbol, checked in place of `instanceof`, so the marker
+    // still matches across a bundle boundary that loaded a second copy of this
+    // class (e.g. a consumer bundling its own brepjs).
+    Object.defineProperty(this, UNSUPPORTED_MARKER, { value: true });
+  }
+}
+
+/** True if `error` is an {@link UnsupportedKernelOperationError} from any kernel adapter. */
+export function isUnsupportedKernelOperationError(error: unknown): boolean {
+  return error instanceof Error && Reflect.get(error, UNSUPPORTED_MARKER) === true;
+}

--- a/src/topology/adjacencyFns.ts
+++ b/src/topology/adjacencyFns.ts
@@ -6,6 +6,7 @@
  */
 
 import { getKernel, getActiveKernelId } from '@/kernel/index.js';
+import { isUnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 import type { KernelShape, ShapeType } from '@/kernel/types.js';
 import type { AnyShape, ClosedWire, Dimension, Edge, Face, Vertex } from '@/core/shapeTypes.js';
 import { castResultShapeWithKnownType, borrowShapeWithKnownType } from '@/core/shapeTypes.js';
@@ -350,18 +351,9 @@ export function adjacentFaces<D extends Dimension>(parent: AnyShape<D>, face: Fa
 // Per-kernel memo of whether kernel.sharedEdges is a real implementation. occt-wasm
 // and brepkit compute shared edges natively (kernel-side edge-to-face map); the occt
 // (OpenCascade) adapter stubs it, and manifold has no exact topology of its own. We
-// probe once per kernel, matching only the codebase's three canonical "unsupported
-// operation" sentinels so a genuine geometry error still propagates instead of
-// silently degrading to the JS path.
+// probe once per kernel and fall back only for a marked UnsupportedKernelOperationError,
+// so a genuine geometry error still propagates instead of silently degrading to JS.
 const nativeSharedEdgesSupported = new Map<string, boolean>();
-
-function isUnsupportedKernelError(e: unknown): boolean {
-  const msg = e instanceof Error ? e.message : '';
-  // occt stub | occt-wasm notImplemented | manifold occtOrThrow
-  return /is only available with the|is not yet implemented|requires a registered occt kernel/.test(
-    msg
-  );
-}
 
 /**
  * Get all edges shared between two faces.
@@ -390,7 +382,7 @@ export function sharedEdges<D extends Dimension>(face1: Face<D>, face2: Face<D>)
       // already adopted). Then classify: only fall back on the unsupported
       // sentinels, else re-throw a genuine error.
       if (raw) for (const r of raw) kernel.dispose(r);
-      if (!isUnsupportedKernelError(e)) throw e;
+      if (!isUnsupportedKernelOperationError(e)) throw e;
       nativeSharedEdgesSupported.set(kernelId, false);
     }
   }

--- a/tests/kernelCapabilityGuards.test.ts
+++ b/tests/kernelCapabilityGuards.test.ts
@@ -8,7 +8,13 @@ import { describe, expect, it, beforeAll } from 'vitest';
 import { initOC } from './setup.js';
 import { getKernel } from '@/kernel/index.js';
 import { supportsProjection, supportsConstraintSketch } from '@/kernel/index.js';
+import {
+  UnsupportedKernelOperationError,
+  isUnsupportedKernelOperationError,
+} from '@/kernel/unsupported.js';
 import { importGLB } from '@/io/gltfImportFns.js';
+import { box } from '@/index.js';
+import { getFaces } from '@/topology/topologyQueryFns.js';
 import { isErr } from '@/core/result.js';
 
 beforeAll(async () => {
@@ -39,5 +45,34 @@ describe('importGLB error handling', () => {
     const blob = new Blob([new Uint8Array([0, 1, 2, 3])]);
     const result = await importGLB(blob);
     expect(isErr(result)).toBe(true);
+  });
+});
+
+describe('UnsupportedKernelOperationError', () => {
+  it('the guard recognizes the marked error and rejects lookalikes', () => {
+    expect(isUnsupportedKernelOperationError(new UnsupportedKernelOperationError('x'))).toBe(true);
+    // A plain error that merely *reads* like the old sentinels must not match —
+    // this is the whole point of moving off message-substring detection.
+    expect(isUnsupportedKernelOperationError(new Error('sharedEdges is not yet implemented'))).toBe(
+      false
+    );
+    expect(isUnsupportedKernelOperationError('is only available with the brepkit kernel')).toBe(
+      false
+    );
+    expect(isUnsupportedKernelOperationError(undefined)).toBe(false);
+  });
+
+  it('a stubbed kernel op throws an error the guard recognizes', () => {
+    // This suite runs on the occt (OpenCascade) kernel, which stubs sharedEdges.
+    using b = box(10, 10, 10);
+    const face = getFaces(b)[0];
+    if (!face) throw new Error('box must have a face');
+    let caught: unknown;
+    try {
+      getKernel().sharedEdges(face.wrapped, face.wrapped);
+    } catch (e) {
+      caught = e;
+    }
+    expect(isUnsupportedKernelOperationError(caught)).toBe(true);
   });
 });


### PR DESCRIPTION
Follow-up to #1824. **Closes #1825.**

## Problem

Feature-detecting a native kernel op vs its JS fallback (in `adjacencyFns.sharedEdges`) was done by matching three adapter error-message substrings. Greptile flagged this as fragile: a reworded message silently breaks the probe, and a genuine geometry error containing one of the phrases would be misclassified as "unsupported" and swallowed into the fallback.

## Change

New `src/kernel/unsupported.ts`:
- **`UnsupportedKernelOperationError`** — carries a `Symbol.for('brepjs.kernel.unsupportedOperation')` marker.
- **`isUnsupportedKernelOperationError(e)`** — checks the marker via `Reflect.get`, **not `instanceof`** (which is unreliable across the multi-entry Vite build's separate dist chunks, where a second copy of the class could be bundled).

The three canonical stub sites now throw it, **messages unchanged** (only the marker is added, so any user or code reading the text is unaffected):
- occt `makeBrepkitOnlyStubs` (`u()`) + inline `meshBoolean`
- occt-wasm `notImplemented`
- manifold `occtOrThrow`

`adjacencyFns` drops the substring regex for the structural guard. "Unsupported operation" is now a first-class, reusable signal for any future feature-detected native op.

## Verification

- Full occt-wasm suite: **4726 pass / 0 fail** (+2 new)
- Adjacency **12/12** on occt-wasm/occt/brepkit — native path on occt-wasm/brepkit, marker-driven JS fallback on occt
- New guard tests assert the marked error is recognized **and** that a plain `Error` merely *reading* like the old sentinels is **not** misclassified (the exact fragility this removes)
- typecheck / lint / check:patterns / check:boundaries / format / knip: clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

