### PR TITLE
perf(kernel): implement occt-wasm arena checkpoint/releaseSince bulk-free

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -43,6 +43,7 @@
 import type { KernelCapabilities } from '@/kernel/capabilities.js';
 import { EXACT_BREP_CAPABILITIES } from '@/kernel/capabilities.js';
 import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
+import { BrepBugError } from '@/utils/bug.js';
 import type {
   BooleanOpType,
   BooleanOptions,
@@ -210,12 +211,22 @@ export class OcctWasmAdapter implements KernelAdapter {
   }
 
   restoreCheckpoint(cp: number): void {
+    // Validate BEFORE releaseSince: a stale/bogus mark would otherwise erase
+    // every live handle above that arena position, not just this scope's.
+    const idx = this.openCheckpoints.lastIndexOf(cp);
+    if (idx === -1) {
+      throw new BrepBugError(
+        'occtWasmAdapter.restoreCheckpoint',
+        `checkpoint ${cp} is not open — releaseSince would erase unrelated live handles`
+      );
+    }
     this.k.releaseSince(cp);
-    this.closeCheckpoint(cp);
+    this.openCheckpoints.length = idx;
   }
 
   discardCheckpoint(cp: number): void {
     // Keep every handle; just forget the mark (occt-wasm marks hold no state).
+    // Tolerant of an unknown cp — discarding frees nothing, so there's no risk.
     this.closeCheckpoint(cp);
   }
 

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -192,21 +192,37 @@ export class OcctWasmAdapter implements KernelAdapter {
     notImplemented('executeBatch');
   }
 
+  // occt-wasm >= 3.7.0 exposes stateless arena marks (checkpoint/releaseSince);
+  // brepjs's interface also reports checkpointCount, so track open marks JS-side.
+  // Bulk-free contract: every handle allocated after a checkpoint is invalidated
+  // by restoreCheckpoint — copy out (as mesh/data) or allocate before the mark
+  // anything that must survive; a live handle used afterward is a use-after-free.
+  private readonly openCheckpoints: number[] = [];
+
   checkpoint(): number {
-    // occt-wasm doesn't have checkpoint support yet
-    notImplemented('checkpoint');
+    const mark = this.k.checkpoint();
+    this.openCheckpoints.push(mark);
+    return mark;
   }
 
   checkpointCount(): number {
-    notImplemented('checkpointCount');
+    return this.openCheckpoints.length;
   }
 
-  restoreCheckpoint(_cp: number): void {
-    notImplemented('restoreCheckpoint');
+  restoreCheckpoint(cp: number): void {
+    this.k.releaseSince(cp);
+    this.closeCheckpoint(cp);
   }
 
-  discardCheckpoint(_cp: number): void {
-    notImplemented('discardCheckpoint');
+  discardCheckpoint(cp: number): void {
+    // Keep every handle; just forget the mark (occt-wasm marks hold no state).
+    this.closeCheckpoint(cp);
+  }
+
+  /** Drop `cp` and any marks nested inside it (LIFO), so the depth stays honest. */
+  private closeCheckpoint(cp: number): void {
+    const idx = this.openCheckpoints.lastIndexOf(cp);
+    if (idx !== -1) this.openCheckpoints.length = idx;
   }
 
   // =========================================================================

--- a/src/kernel/occtWasm/occtWasmTypes.ts
+++ b/src/kernel/occtWasm/occtWasmTypes.ts
@@ -147,6 +147,10 @@ export interface OcctKernelWasm {
   release(id: number): void;
   releaseAll(): void;
   getShapeCount(): number;
+  /** Mark the current arena high-water point (occt-wasm >= 3.7.0). */
+  checkpoint(): number;
+  /** Free every handle allocated at or after `mark` in one call (occt-wasm >= 3.7.0). */
+  releaseSince(mark: number): void;
 
   // --- Primitives ---
   makeBox(dx: number, dy: number, dz: number): number;

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -368,7 +368,7 @@ export const divergences: DivergenceMap = {
     brepkitExtended: {
       kind: 'not-implemented',
       reason:
-        'Extended I/O, advanced modeling, validation, point classification, mesh boolean, batch execution, arena checkpoint are brepkit-only',
+        'Extended I/O, advanced modeling, validation, point classification, mesh boolean, batch execution are brepkit-only (occt-wasm >= 3.7.0 also has arena checkpoint/releaseSince — covered in wasmArenaDisposal.test.ts)',
     },
     gltfRoundTrip: {
       kind: 'not-implemented',

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -1322,4 +1322,18 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena checkpoint / releaseSince bulk-fre
     expect(arenaCount()).toBe(baseline);
     expect(kernel.checkpointCount()).toBe(before);
   });
+
+  it('restoreCheckpoint rejects a stale/unknown mark instead of erasing live handles', () => {
+    const kernel = getKernel();
+    const cp = kernel.checkpoint();
+    kernel.restoreCheckpoint(cp); // cp is now closed
+    // Restoring it again — or any fabricated mark — must throw, not silently
+    // releaseSince over unrelated live arena handles.
+    expect(() => {
+      kernel.restoreCheckpoint(cp);
+    }).toThrow();
+    expect(() => {
+      kernel.restoreCheckpoint(-1);
+    }).toThrow();
+  });
 });

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -1278,3 +1278,48 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
     });
   });
 });
+
+describe.skipIf(!isOcctWasm)('occt-wasm arena checkpoint / releaseSince bulk-free', () => {
+  it('restoreCheckpoint frees every slot allocated since the mark in one call', () => {
+    const kernel = getKernel();
+    const baseline = arenaCount();
+    const cp = kernel.checkpoint();
+    expect(cp).toBeGreaterThanOrEqual(0);
+    // Allocate a batch of intermediates, disposing none of them.
+    for (let i = 0; i < 15; i++) box(1 + i, 1, 1);
+    expect(arenaCount()).toBeGreaterThan(baseline);
+    // A single releaseSince reclaims the whole batch.
+    kernel.restoreCheckpoint(cp);
+    expect(arenaCount()).toBe(baseline);
+  });
+
+  it('checkpointCount tracks open marks; discardCheckpoint keeps the handles', () => {
+    const kernel = getKernel();
+    const before = kernel.checkpointCount();
+    const cp = kernel.checkpoint();
+    expect(kernel.checkpointCount()).toBe(before + 1);
+    using b = box(10, 10, 10);
+    const held = arenaCount();
+    kernel.discardCheckpoint(cp);
+    expect(kernel.checkpointCount()).toBe(before);
+    // Discard reclaims nothing — the shape stays live and meshable.
+    expect(arenaCount()).toBe(held);
+    expect(getFaces(b).length).toBe(6);
+  });
+
+  it('nested checkpoints restore independently (LIFO)', () => {
+    const kernel = getKernel();
+    const before = kernel.checkpointCount();
+    const baseline = arenaCount();
+    const outer = kernel.checkpoint();
+    box(2, 2, 2);
+    const inner = kernel.checkpoint();
+    box(3, 3, 3);
+    kernel.restoreCheckpoint(inner); // frees only the inner box
+    expect(arenaCount()).toBeGreaterThan(baseline);
+    expect(kernel.checkpointCount()).toBe(before + 1);
+    kernel.restoreCheckpoint(outer); // frees the outer box too
+    expect(arenaCount()).toBe(baseline);
+    expect(kernel.checkpointCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
occt-wasm 3.7.0 adds native arena bulk-free primitives (`checkpoint()` → mark, `releaseSince(mark)` → free everything since it). brepjs's kernel interface **already** declares `checkpoint`/`checkpointCount`/`restoreCheckpoint`/`discardCheckpoint` (brepkit implements them natively); occt-wasm stubbed all four as `notImplemented`. This wires them to the native 3.7.0 primitives.

## Change

- `checkpoint()` → `k.checkpoint()`, pushing the mark onto a JS-side stack so `checkpointCount()` can report open marks (occt-wasm marks are stateless).
- `restoreCheckpoint(cp)` → `k.releaseSince(cp)` — one call reclaims every slot allocated since the mark.
- `discardCheckpoint(cp)` → drop the mark, free nothing.
- Both closers truncate the stack LIFO so the reported depth stays honest under nesting.

New occt-wasm-gated tests use the `getShapeCount` arena oracle to prove `restoreCheckpoint` reclaims a 15-shape batch in **one** call, `discardCheckpoint` keeps handles live, and nested marks restore LIFO. Corrected the stale "arena checkpoint is brepkit-only" divergence note.

## Scope & the DisposalScope incompatibility

The bulk-free contract (documented at the call site): **every handle allocated after a checkpoint is invalidated by `restoreCheckpoint`** — copy out as mesh/data, or allocate before the mark, anything that must survive.

This is why it **cannot** back the general `DisposalScope`: that helper's documented "return a shape from the scope and it survives" contract (regression #723, `tests/withScope-disposal.test.ts`) depends on freeing *only registered* handles, whereas `releaseSince` frees the whole range including the returned shape. It's safe only for scopes returning non-arena data (mesh/measurement/export).

No such consumer exists in `src/` today (the capability is dormant even on brepkit), so this PR lands the **capability + proof** and achieves occt-wasm/brepkit parity; adoption for a specific hot path is left as a follow-up.

## Verification

- Full occt-wasm suite: **4729 pass / 0 fail** (+3 new)
- brepkit checkpoint suite: unchanged
- typecheck / lint / check:patterns / check:boundaries / format: clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

