### PR TITLE
perf(measurement): bulk-free distance scratch in interference checks via checkpoint

### DIFF
--- a/src/core/disposal.ts
+++ b/src/core/disposal.ts
@@ -10,6 +10,7 @@
 
 import type { KernelShape } from '@/kernel/types.js';
 import { getKernel } from '@/kernel/index.js';
+import { isUnsupportedKernelOperationError } from '@/kernel/unsupported.js';
 import type { BrepError } from './errors.js';
 import type { Result } from './result.js';
 
@@ -260,6 +261,36 @@ export function createBorrowedHandle(ocShape: KernelShape): ShapeHandle {
     // never fire. Tie dependent lifetimes to the owning parent's handle instead.
     onDispose: noop,
   };
+}
+
+/**
+ * Run `fn` between an arena checkpoint and restore, reclaiming every slot it
+ * allocates — including kernel-internal query temporaries brepjs holds no handle
+ * for (e.g. `distance`/`boundingBox` scratch) — in a single `restoreCheckpoint`.
+ *
+ * **SAFE ONLY when `fn` returns plain data** (numbers, points, arrays): restore
+ * frees *every* slot allocated after the checkpoint, so a live shape handle in
+ * the return value would dangle. Use for data-returning batch analysis over many
+ * bodies; never to wrap a shape builder. Inputs allocated before the call are
+ * untouched (restore only frees from the mark forward).
+ *
+ * No-op wrapper on kernels without arena checkpoints (occt/manifold): `fn` runs
+ * directly and those kernels' own disposal applies.
+ */
+export function withArenaCheckpoint<T>(fn: () => T): T {
+  const kernel = getKernel();
+  let cp: number;
+  try {
+    cp = kernel.checkpoint();
+  } catch (e) {
+    if (!isUnsupportedKernelOperationError(e)) throw e;
+    return fn();
+  }
+  try {
+    return fn();
+  } finally {
+    kernel.restoreCheckpoint(cp);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/disposal.ts
+++ b/src/core/disposal.ts
@@ -286,11 +286,22 @@ export function withArenaCheckpoint<T>(fn: () => T): T {
     if (!isUnsupportedKernelOperationError(e)) throw e;
     return fn();
   }
+  let result: T;
   try {
-    return fn();
-  } finally {
-    kernel.restoreCheckpoint(cp);
+    result = fn();
+  } catch (e) {
+    // fn's error is primary: still restore, but never let a restore failure mask
+    // it (a plain `finally { restore() }` would swallow the original throw).
+    try {
+      kernel.restoreCheckpoint(cp);
+    } catch {
+      /* surface fn's error instead */
+    }
+    throw e;
   }
+  // Success path: a restore failure here is a genuine bug — let it surface.
+  kernel.restoreCheckpoint(cp);
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/measurement/interferenceFns.ts
+++ b/src/measurement/interferenceFns.ts
@@ -11,6 +11,7 @@ import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { type Result, ok, err, unwrap } from '@/core/result.js';
 import { validationError, BrepErrorCode } from '@/core/errors.js';
 import { getBounds, type Bounds3D } from '@/topology/shapeFns.js';
+import { withArenaCheckpoint } from '@/core/disposal.js';
 import { wasmIndex } from '@/utils/vec3.js';
 
 // ---------------------------------------------------------------------------
@@ -84,13 +85,20 @@ export function checkInterference(
       )
     );
   }
-  const dist = getKernel().distance(shape1.wrapped, shape2.wrapped);
 
-  return ok({
-    hasInterference: dist.value <= tolerance,
-    minDistance: dist.value,
-    pointOnShape1: dist.point1,
-    pointOnShape2: dist.point2,
+  // The kernel's distance computation leaves internal scratch handles brepjs
+  // holds no reference to — a per-call arena residue that compounds to O(N^2)
+  // across checkAllInterferences. We return only plain data (distance + points),
+  // so bulk-freeing the whole call with a checkpoint is safe and keeps the arena
+  // flat even under heavy pairwise batches.
+  return withArenaCheckpoint(() => {
+    const dist = getKernel().distance(shape1.wrapped, shape2.wrapped);
+    return ok({
+      hasInterference: dist.value <= tolerance,
+      minDistance: dist.value,
+      pointOnShape1: dist.point1,
+      pointOnShape2: dist.point2,
+    });
   });
 }
 

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -103,6 +103,7 @@ import {
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
 import { subShapeCount, subShapeHashes } from '@/topology/topologyQueryFns.js';
+import { checkInterference, checkAllInterferences } from '@/measurement/interferenceFns.js';
 import { DisposalScope } from '@/core/disposal.js';
 import { makeExternalGear } from '@/gear/index.js';
 
@@ -196,6 +197,25 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
         perIterationLeak(() => {
           using b = box(10, 10, 10);
           for (const e of getEdges(b)) e[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('checkInterference / checkAllInterferences leave no arena residue (checkpoint bulk-free)', () => {
+      // distance() leaves kernel-internal scratch handles brepjs can't free
+      // individually; withArenaCheckpoint reclaims them. Without it this grew
+      // ~16 slots per pair, O(N^2) across the batch.
+      using a = box(10, 10, 10);
+      using b0 = box(10, 10, 10);
+      using b = translate(b0, [5, 0, 0]);
+      expect(
+        perIterationLeak(() => {
+          checkInterference(a, b);
+        })
+      ).toBe(0);
+      expect(
+        perIterationLeak(() => {
+          checkAllInterferences([a, b]);
         })
       ).toBe(0);
     });


### PR DESCRIPTION
The first real consumer of occt-wasm 3.7.0's arena `checkpoint`/`releaseSince` (wired in #1830), which had been landed as a capability without an adopter.

## Why this is the right fit

The kernel's `distance()` computation leaves **~16 internal scratch handles per call that brepjs holds no reference to** (probed with the `getShapeCount` oracle). brepjs can't free them with `release()` — it has no handles. Only a checkpoint restore, which reclaims **by arena position**, can. Across `checkAllInterferences` (N·(N−1)/2 pairs) that residue compounds to **O(N²)** arena growth.

Interference checks return only plain data (distance + points, no shape handles), which is exactly the precondition that makes `checkpoint`/`releaseSince` safe here.

## Change

- **`withArenaCheckpoint(fn)`** (`core/disposal.ts`): runs `fn` between a checkpoint and restore, reclaiming everything it allocates in one call. **Safe only for data-returning `fn`** — restore frees every post-mark slot, so a returned shape handle would dangle; documented at the call site. No-op on kernels without checkpoints (occt/manifold), detected via the `UnsupportedKernelOperationError` marker from #1829.
- Wrap **`checkInterference`** (returns only distance + points) in it. This makes the single call leak-free **and** gives `checkAllInterferences` a flat **O(1)** arena for free — each pair self-cleans — instead of O(N²·16).

## Verification

- Probe: single `16/call → 0`, batch `16/pair → 0`
- New arena-oracle regression test pins both at 0
- Interference results unchanged: `interferenceFns` **14/14** on occt-wasm (native) and occt (no-op fallback)
- Full occt-wasm suite: **4735 pass / 0 fail**
- typecheck / lint / check:patterns / check:boundaries / format / knip: clean

`withArenaCheckpoint` is a reusable helper for any future data-returning batch analysis; this closes the checkpoint-consumer follow-up from #1830.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

