### PR TITLE
perf(topology): native adjacency for betweenFaces via adjacentFaceHashes

### DIFF
--- a/src/topology/adjacencyFns.ts
+++ b/src/topology/adjacencyFns.ts
@@ -423,3 +423,40 @@ function sharedEdgesJS<D extends Dimension>(face1: Face<D>, face2: Face<D>): Edg
 
   return shared;
 }
+
+// Per-kernel memo of native kernel.adjacentFaces support (occt-wasm/brepkit native,
+// occt/manifold stub → JS fallback), mirroring nativeSharedEdgesSupported.
+const nativeAdjacentFacesSupported = new Map<string, boolean>();
+
+/**
+ * Hashes of the faces adjacent to `face` within `parent`, keyed like the kernel's
+ * `hashCode(_, HASH_CODE_MAX)` (so they index the parent's cached faces).
+ *
+ * Prefers the kernel-native adjacency (occt-wasm/brepkit) — markedly faster than
+ * the borrowed JS edge-map path, which pays per-call edge extraction + hashing —
+ * and disposes the owned result handles here so none escape. Returns only hashes,
+ * keeping callers clear of the borrowed-vs-owned handle contract; falls back to
+ * the borrowed-view {@link adjacentFaces} where the native op is unsupported.
+ */
+export function adjacentFaceHashes<D extends Dimension>(
+  parent: AnyShape<D>,
+  face: Face<D>
+): number[] {
+  const kernel = getKernel();
+  const kernelId = getActiveKernelId() ?? '';
+  if (nativeAdjacentFacesSupported.get(kernelId) !== false) {
+    try {
+      const raw = kernel.adjacentFaces(parent.wrapped, face.wrapped);
+      nativeAdjacentFacesSupported.set(kernelId, true);
+      try {
+        return raw.map((r) => kernel.hashCode(r, HASH_CODE_MAX));
+      } finally {
+        for (const r of raw) kernel.dispose(r);
+      }
+    } catch (e) {
+      if (!isUnsupportedKernelOperationError(e)) throw e;
+      nativeAdjacentFacesSupported.set(kernelId, false);
+    }
+  }
+  return adjacentFaces(parent, face).map((f) => kernel.hashCode(f.wrapped, HASH_CODE_MAX));
+}

--- a/src/topology/shapeRef/derivedFaceRefFns.ts
+++ b/src/topology/shapeRef/derivedFaceRefFns.ts
@@ -63,6 +63,7 @@ function betweenFaces(shape: Shape3D, aFaces: readonly Face[], bFaces: readonly 
     }
   }
 
+  if (betweenHashes.length === 0) return [];
   const byHash = new Map<number, Face>(getFaces(shape).map((f) => [getHashCode(f), f]));
   return betweenHashes.map((h) => byHash.get(h)).filter((f): f is Face => f !== undefined);
 }

--- a/src/topology/shapeRef/derivedFaceRefFns.ts
+++ b/src/topology/shapeRef/derivedFaceRefFns.ts
@@ -15,7 +15,7 @@ import type { Edge, Face, Shape3D } from '@/core/shapeTypes.js';
 import type { Vec3 } from '@/core/types.js';
 import { getFaces } from '@/topology/topologyQueryFns.js';
 import { getHashCode } from '@/topology/shapeFns.js';
-import { adjacentFaces, facesOfEdge, verticesOfEdge } from '@/topology/adjacencyFns.js';
+import { adjacentFaceHashes, facesOfEdge, verticesOfEdge } from '@/topology/adjacencyFns.js';
 import { normalAt, faceCenter } from '@/topology/faceFns.js';
 import { distance, facesForRole, roleOfFace, vertexCentroid } from './roleLookup.js';
 import type {
@@ -42,27 +42,29 @@ function facesByNormal(shape: Shape3D, normal: Vec3): Face[] {
 }
 
 /**
- * Faces adjacent to BOTH face sets, excluding the sets themselves. Uses the
- * cached edge→faces adjacency (`adjacentFaces`) rather than an O(F·N) per-pair
- * `sharedEdges` scan.
+ * Faces adjacent to BOTH face sets, excluding the sets themselves. Works purely
+ * in face-hash space via `adjacentFaceHashes` (kernel-native adjacency where
+ * available, no per-call edge extraction), then maps the surviving hashes back to
+ * the parent's borrowed cache faces — so the returned handles keep the same
+ * borrowed lifetime (freed with `shape`) the resolution path already assumes.
  */
 function betweenFaces(shape: Shape3D, aFaces: readonly Face[], bFaces: readonly Face[]): Face[] {
   const exclude = new Set([...aFaces, ...bFaces].map(getHashCode));
   const adjacentToA = new Set<number>();
-  for (const a of aFaces) {
-    for (const f of adjacentFaces(shape, a)) adjacentToA.add(getHashCode(f));
-  }
-  const result: Face[] = [];
+  for (const a of aFaces) for (const h of adjacentFaceHashes(shape, a)) adjacentToA.add(h);
+
+  const betweenHashes: number[] = [];
   const seen = new Set<number>();
   for (const b of bFaces) {
-    for (const f of adjacentFaces(shape, b)) {
-      const h = getHashCode(f);
+    for (const h of adjacentFaceHashes(shape, b)) {
       if (exclude.has(h) || seen.has(h) || !adjacentToA.has(h)) continue;
       seen.add(h);
-      result.push(f);
+      betweenHashes.push(h);
     }
   }
-  return result;
+
+  const byHash = new Map<number, Face>(getFaces(shape).map((f) => [getHashCode(f), f]));
+  return betweenHashes.map((h) => byHash.get(h)).filter((f): f is Face => f !== undefined);
 }
 
 /** Face whose center is nearest `point`; undefined on a tie (→ ambiguous). */

--- a/tests/adjacencyFns.test.ts
+++ b/tests/adjacencyFns.test.ts
@@ -13,6 +13,8 @@ import {
   sharedEdges,
   isSameShape,
 } from '@/index.js';
+import { adjacentFaceHashes } from '@/topology/adjacencyFns.js';
+import { getHashCode } from '@/topology/shapeFns.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -132,5 +134,20 @@ describe('sharedEdges', () => {
       const shared = sharedEdges(face0, oppositeFace);
       expect(shared).toHaveLength(0);
     }
+  });
+});
+
+describe('adjacentFaceHashes', () => {
+  it('returns the hashes of the adjacent faces (agrees with adjacentFaces)', () => {
+    const b = box(10, 10, 10);
+    const faces = getFaces(b);
+    const face0 = faces[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    const expected = new Set(adjacentFaces(b, face0).map(getHashCode));
+    const hashes = adjacentFaceHashes(b, face0);
+    expect(hashes).toHaveLength(4); // a box face borders 4 others
+    expect(new Set(hashes)).toEqual(expected);
+    // every returned hash indexes an actual face of the parent
+    const parentFaceHashes = new Set(faces.map(getHashCode));
+    expect(hashes.every((h) => parentFaceHashes.has(h))).toBe(true);
   });
 });

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -103,6 +103,7 @@ import {
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
 import { subShapeCount, subShapeHashes } from '@/topology/topologyQueryFns.js';
+import { adjacentFaceHashes } from '@/topology/adjacencyFns.js';
 import { checkInterference, checkAllInterferences } from '@/measurement/interferenceFns.js';
 import { DisposalScope } from '@/core/disposal.js';
 import { makeExternalGear } from '@/gear/index.js';
@@ -216,6 +217,19 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       expect(
         perIterationLeak(() => {
           checkAllInterferences([a, b]);
+        })
+      ).toBe(0);
+    });
+
+    it('adjacentFaceHashes leaks nothing (native path disposes its owned results)', () => {
+      // The native kernel.adjacentFaces returns owned fresh slots; adjacentFaceHashes
+      // reads their hashes and disposes them, so nothing survives per call.
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const f0 = getFaces(b)[0];
+          if (!f0) throw new Error('box must have a face');
+          adjacentFaceHashes(b, f0);
         })
       ).toBe(0);
     });


### PR DESCRIPTION
A scoped fast path for the toponaming derived-face resolution (`betweenFaces`), landing the native-adjacency perf win **without touching the public `adjacentFaces` contract**.

## Why scoped (not a full public migration)

Benchmark: native `kernel.adjacentFaces` is **~4.5× faster** than the borrowed JS edge-map path (66ms vs 302ms over 2000×6 calls on a box) — the JS path pays per-call edge extraction + hashing + `wrapAll` that native does in one C++ call. (This corrects my #1824 "no gain" note, which wrongly assumed the cached map made it cheap.)

But native returns **owned** slots, and public `adjacentFaces`'s result flows through the ShapeRef resolution chain (`betweenFaces` → `resolveRef` → resolved ref `.face`/`.candidates`) as **borrowed** handles. Migrating it wholesale would ripple the ownership contract through the public toponaming surface and break external callers who don't dispose. Per discussion, this takes the contained path.

## Change

- **`adjacentFaceHashes(parent, face)`** — returns only the neighbor face **hashes** (keyed like `hashCode(_, HASH_CODE_MAX)`), computed via the native fast path with owned handles disposed internally (none escape), and a borrowed-view `adjacentFaces` fallback where native is unsupported (occt/manifold). Memoised per kernel, like `sharedEdges`.
- **`betweenFaces`** now works purely in hash space and maps survivors back to the parent's borrowed cache faces, so its returned handles keep the exact borrowed lifetime the resolution path already assumes. Public `adjacentFaces` is untouched.

## Verification

- Native path exercised + **0** arena residue (`getShapeCount` oracle)
- `adjacentFaceHashes` agrees with `adjacentFaces` hashes on occt-wasm (native) **and** occt (fallback)
- Full ShapeRef/replay suite **39/39**; public `adjacentFaces` + its arena tests unchanged
- Full occt-wasm suite: **4737 pass / 0 fail**
- typecheck / lint / check:patterns / check:boundaries / format / knip: clean

This closes the `adjacentFaces` follow-up from #1824 — capturing the perf benefit on the hot path while leaving the public borrowed contract (and external callers) intact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

