### PR TITLE
perf(metadata): collect input face hashes via subShapeHashes (no per-face handle)

### DIFF
--- a/src/topology/metadata/metadataPropagation.ts
+++ b/src/topology/metadata/metadataPropagation.ts
@@ -18,6 +18,7 @@ import {
 } from './originTrackingFns.js';
 import { propagateFaceTagsFromEvolution, hasFaceTags } from './faceTagFns.js';
 import { propagateColorsFromEvolution, hasColorMetadata } from './colorFns.js';
+import { subShapeHashes } from '@/topology/topologyQueryFns.js';
 
 // ---------------------------------------------------------------------------
 // Face hash collection
@@ -42,18 +43,12 @@ export function collectInputFaceHashes(inputs: readonly AnyShape<Dimension>[]): 
   // O(1) check: skip expensive face iteration when no metadata exists
   if (!inputs.some(hasAnyMetadata)) return [];
 
-  const kernel = getKernel();
+  // Only the face hashes are needed (a membership set for metadata matching), so
+  // use subShapeHashes — the native occt-wasm 3.7.0 path reads them without
+  // allocating a handle per face, avoiding per-face arena churn on every
+  // WithHistory boolean/transform/modifier.
   const hashes: number[] = [];
-  for (const input of inputs) {
-    const faces = kernel.iterShapes(input.wrapped, 'face');
-    for (const face of faces) {
-      hashes.push(kernel.hashCode(face, HASH_CODE_MAX));
-      // These faces are transient — only their hash is read. Release each so
-      // the occt-wasm arena reclaims the slot instead of accumulating one
-      // handle per input face on every WithHistory boolean.
-      kernel.dispose(face);
-    }
-  }
+  for (const input of inputs) hashes.push(...subShapeHashes(input, 'face'));
   return hashes;
 }
 

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -104,6 +104,8 @@ import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import { getKernel } from '@/kernel/index.js';
 import { subShapeCount, subShapeHashes } from '@/topology/topologyQueryFns.js';
 import { adjacentFaceHashes } from '@/topology/adjacencyFns.js';
+import { collectInputFaceHashes } from '@/topology/metadata/metadataPropagation.js';
+import { setShapeOrigin } from '@/topology/metadata/originTrackingFns.js';
 import { checkInterference, checkAllInterferences } from '@/measurement/interferenceFns.js';
 import { DisposalScope } from '@/core/disposal.js';
 import { makeExternalGear } from '@/gear/index.js';
@@ -217,6 +219,18 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       expect(
         perIterationLeak(() => {
           checkAllInterferences([a, b]);
+        })
+      ).toBe(0);
+    });
+
+    it('collectInputFaceHashes (metadata propagation) allocates no face handles', () => {
+      // Runs on every WithHistory boolean/transform when inputs carry metadata.
+      // Now backed by subShapeHashes, so it reads face hashes without a handle each.
+      using b = box(10, 10, 10);
+      setShapeOrigin(b, 1); // give it metadata so the collection actually iterates
+      expect(
+        perIterationLeak(() => {
+          collectInputFaceHashes([b]);
         })
       ).toBe(0);
     });


### PR DESCRIPTION
Extends the `subShapeHashes` wiring (#1834) into the metadata-propagation path.

## Where the win actually is

`collectInputFaceHashes` is the shared metadata-propagation input step run on **every** WithHistory boolean / transform / modifier / evolution op (~25 call sites) — it feeds face-**tag**, **color**, and **origin** propagation. It iterated every input face via `iterShapes` just to read (and immediately dispose) their hashes, allocating one arena handle per face on occt-wasm each time.

Now it uses `subShapeHashes`: the native occt-wasm 3.7.0 path reads the deduplicated face hashes with **no per-face handle**, iterate-and-release fallback elsewhere. The result is unchanged — a face-hash membership set for metadata matching (per-input `iterShapes` faces are already unique, so dedup is a no-op there).

## Not converted (no clean fit — verified)

The literal face-tag/color leaf functions don't match the "collect all sub-shape hashes" pattern:
- **`faceTagFns`** builds hash→handle maps and returns the matching face **handles** — it needs the handles (which `getFaces` caches anyway).
- **`colorFns`** hashes a specific *given* face, not a collection.
- **`propagateMetadataThroughRelocation`** pairs source/moved faces **positionally** by `iterShapes` index — dedup would break the 1:1 correspondence.

## Verification

- New arena regression test pins `collectInputFaceHashes` at **0** handle allocation on occt-wasm (`getShapeCount` oracle)
- Full occt-wasm suite: **4738 pass / 0 fail**
- metadata / boolean / faceTag suites green on occt-wasm and occt
- typecheck / lint / check:patterns / check:boundaries / format / knip: clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

