### PR TITLE
chore(brepjs-cad): pin brepjs dep to "*" to stop node-workspace release churn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,8 +6799,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.118.25"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -14757,7 +14756,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "brepjs": ">=18.118.25",
+        "brepjs": "*",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0",
         "typescript": "^6.0.3"

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "brepjs": ">=18.117.1",
+    "brepjs": "*",
     "commander": "^15.0.0",
     "occt-wasm": "^3.0.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
brepjs-cad has been cutting a release on nearly every core PR (0.71→0.87 across one session, ~103 release commits) even when nothing in `packages/brepjs-cad` changed. Root cause: the release-please `node-workspace` plugin re-pins brepjs-cad's `brepjs` **dependency floor** (`>=18.117.1` → the exact latest version) on every brepjs release, cutting a companion brepjs-cad release each time.

## Fix

Pin the dep to `"*"` (staying in `dependencies`):
```diff
-    "brepjs": ">=18.117.1",
+    "brepjs": "*",
```

node-workspace re-pins `>=`/`^` floors but **leaves `"*"` specs untouched** — proven by brepjs-cad's own `brepjs-viewer: "*"` devDep changing only **3× across 103 release commits** while its `brepjs` `>=` dep re-pinned nearly every one. So `"*"` stops the churn while keeping brepjs a regular dependency (installed on every method).

## Why not `peerDependencies`?

That was the obvious alternative (bim/sheetmetal use it) and I clean-room-tested it — it **regresses standalone installs**: under `--legacy-peer-deps` / `--omit=peer`, npm doesn't auto-install the peer, and the CLI dies with `kernel init failed: Cannot find package 'brepjs'` (the resolve hook's bundled fallback lives in cad's own `node_modules`, which a peer never populates). `"*"` avoids that entirely.

## Verification (clean-room `npm pack` + install)

| Install | `brep verify` a real part |
|---------|---------------------------|
| default `npm install` | ✅ `ok:true`, volume 1000 |
| `--legacy-peer-deps` | ✅ `ok:true`, volume 1000 |

- `npm run smoke:standalone -w brepjs-cad` (the repo's own guard: build → pack → clean install → verify): **passes**
- release-please dry-run against this branch: parses `"*"` fine, anchors brepjs-cad@0.87.0, would open 0 PRs
- **Bonus:** `"*"` is never re-pinned, so it's also immune to the prepared-but-unpublished-version **ETARGET race** that #1711/#1713 fought.

## Tradeoff

`"*"` has no version floor — but the current `>=18.117.1` already has no *upper* bound (permits 19.x too), and the runtime resolve hook prefers the consumer's local brepjs anyway, so for a bundled tool this is acceptable looseness.

> Touches the release pipeline — worth a human eyeball, but the change is one line + lockfile and the evidence is end-to-end.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

