### PR TITLE
test(brepjs-cad): run the standalone smoke under --legacy-peer-deps too

### DIFF
--- a/packages/brepjs-cad/scripts/smokeStandalone.mjs
+++ b/packages/brepjs-cad/scripts/smokeStandalone.mjs
@@ -8,6 +8,14 @@
 // kernel realm. This packs the tarball, installs it into a throwaway project that adds NO
 // brepjs of its own, authors a .brep.ts that `import`s 'brepjs', runs the installed
 // `brep` bin, and asserts ok:true + volume>0 — the full standalone chain end to end.
+//
+// Runs the install+verify under BOTH default npm and `--legacy-peer-deps`. The two diverge
+// only for `peerDependencies`: default npm auto-installs peers, `--legacy-peer-deps` does
+// NOT. Declaring brepjs as a regular `dependency` (currently `"brepjs": "*"`) keeps it in
+// the install tree either way; a regression to `peerDependencies` would leave brepjs
+// dangling under `--legacy-peer-deps` and break the CLI — which the default-only path is
+// blind to (that gap is exactly what shipped #1852's rejected peer-dep variant undetected
+// in local default-install testing).
 
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
@@ -23,57 +31,57 @@ function run(cmd, args, cwd) {
   return execFileSync(cmd, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
 }
 
-try {
-  // 1. Build, then pack. Build first (its vite logs go to stdout) so `npm pack` can run with
-  //    --ignore-scripts — that skips the prepack rebuild and keeps the pack's stdout a clean
-  //    JSON document. --pack-destination keeps the tarball out of the repo.
-  process.stderr.write('building brepjs-cad...\n');
-  run('npm', ['run', 'build'], pkgRoot);
-  process.stderr.write('packing brepjs-cad...\n');
-  const packJson = run('npm', ['pack', '--json', '--ignore-scripts', '--pack-destination', workRoot], pkgRoot);
-  const tarball = join(workRoot, JSON.parse(packJson)[0].filename);
-  if (!existsSync(tarball)) throw new Error(`pack produced no tarball at ${tarball}`);
-
-  // 2. Empty consumer project with NO brepjs of its own. "type":"module" so the .ts part
-  //    loads via Node's native ESM type-stripping (engines requires >=24), matching a real
-  //    ESM author project. node_modules here holds ONLY the installed tool.
-  const proj = join(workRoot, 'consumer');
+// Install the tarball into a fresh consumer project that adds NO brepjs of its own, author a
+// part that imports bare 'brepjs', run the installed `brep` bin, and assert a valid solid.
+// `extraInstallArgs` lets the caller vary the install mode (e.g. --legacy-peer-deps). This is
+// exactly a real `npm i brepjs-cad && brep verify part.brep.ts` with zero setup: it proves the
+// install resolves every runtime dep (nothing dangling), the resolve hook lands the CLI's
+// brepjs and the part's `import 'brepjs'` on one kernel realm, the .ts part loads via native
+// ESM type-stripping, the kernel runs, and measure produces a valid solid — none of which is
+// reachable from the in-repo tsx/vitest path.
+function installAndVerify(label, extraInstallArgs) {
+  const proj = join(workRoot, `consumer-${label}`);
   run('mkdir', ['-p', proj], workRoot);
+  // "type":"module" so the .ts part loads via Node's native ESM type-stripping (engines >=24),
+  // matching a real ESM author project.
   writeFileSync(
     join(proj, 'package.json'),
-    JSON.stringify({ name: 'consumer', version: '0.0.0', private: true, type: 'module' }, null, 2)
+    JSON.stringify({ name: `consumer-${label}`, version: '0.0.0', private: true, type: 'module' }, null, 2)
   );
 
-  process.stderr.write('installing tarball into clean project...\n');
+  process.stderr.write(`installing tarball into clean project (${label})...\n`);
   // No optional deps (puppeteer/Chrome) — proves the default verify path needs none, and that
   // the snapshot path degrades gracefully (lazy) rather than crashing when puppeteer is absent.
-  run('npm', ['install', '--no-save', '--omit=optional', tarball], proj);
+  run('npm', ['install', '--no-save', '--omit=optional', ...extraInstallArgs, tarball], proj);
 
-  // 3. A part that imports bare 'brepjs' — resolved by the tool's hook to ONE realm.
   const part = join(proj, 'box.brep.ts');
   writeFileSync(part, "import { box } from 'brepjs';\nexport default () => box(10, 10, 10);\n");
   const bin = join(proj, 'node_modules', '.bin', 'brep');
 
-  function verify(label) {
-    process.stderr.write(`running installed brep (${label})...\n`);
-    const outFile = join(proj, `report-${label}.json`);
-    run(bin, ['verify', part, '--json', outFile], proj);
-    const report = JSON.parse(readFileSync(outFile, 'utf8'));
-    if (report.ok !== true) throw new Error(`[${label}] expected ok:true, got ok:${report.ok}`);
-    const volume = report.measurements && report.measurements.volume;
-    if (!(volume > 0)) throw new Error(`[${label}] expected volume>0, got ${volume}`);
-    process.stderr.write(`[${label}] ok:true, volume:${volume}\n`);
-  }
+  process.stderr.write(`running installed brep (${label})...\n`);
+  const outFile = join(proj, 'report.json');
+  run(bin, ['verify', part, '--json', outFile], proj);
+  const report = JSON.parse(readFileSync(outFile, 'utf8'));
+  if (report.ok !== true) throw new Error(`[${label}] expected ok:true, got ok:${report.ok}`);
+  const volume = report.measurements && report.measurements.volume;
+  if (!(volume > 0)) throw new Error(`[${label}] expected volume>0, got ${volume}`);
+  process.stderr.write(`[${label}] ok:true, volume:${volume}\n`);
+}
 
-  // 4. As installed: the consumer added NO brepjs of its own — the only brepjs/occt-wasm present
-  //    are the ones npm pulled in as the tool's own declared deps. This is exactly a real
-  //    `npm i brepjs-cad && brep verify part.brep.ts` with zero setup, and it proves
-  //    the full chain end to end: the package install resolves all runtime deps (nothing was left
-  //    dangling), the resolve hook governs both the CLI's `brepjs` and the part's `import 'brepjs'`
-  //    onto one initialized kernel realm, the .ts part loads via native ESM type-stripping, the
-  //    kernel runs, and STEP/measure produce a valid solid. None of this is reachable from the
-  //    in-repo tsx/vitest path, which has the whole monorepo on disk.
-  verify('standalone');
+let tarball;
+try {
+  // Build, then pack. Build first (its vite logs go to stdout) so `npm pack` can run with
+  // --ignore-scripts — that skips the prepack rebuild and keeps the pack's stdout a clean JSON
+  // document. --pack-destination keeps the tarball out of the repo.
+  process.stderr.write('building brepjs-cad...\n');
+  run('npm', ['run', 'build'], pkgRoot);
+  process.stderr.write('packing brepjs-cad...\n');
+  const packJson = run('npm', ['pack', '--json', '--ignore-scripts', '--pack-destination', workRoot], pkgRoot);
+  tarball = join(workRoot, JSON.parse(packJson)[0].filename);
+  if (!existsSync(tarball)) throw new Error(`pack produced no tarball at ${tarball}`);
+
+  installAndVerify('default', []);
+  installAndVerify('legacy-peer-deps', ['--legacy-peer-deps']);
 
   process.stderr.write('standalone smoke OK\n');
 } catch (err) {


### PR DESCRIPTION
Closes the blind spot that let #1852's rejected peerDependencies variant pass local testing while actually breaking legacy installs.

## Problem

`smoke:standalone` (the clean-room pack → install → `brep verify` guard) only installed the tarball with **default npm**, which auto-installs `peerDependencies`. So it couldn't see the failure mode that `--legacy-peer-deps` / `--omit=peer` exposes: a runtime dep declared as a **peer** (rather than a regular `dependency`) is left dangling, and the CLI dies with `kernel init failed: Cannot find package 'brepjs'`.

## Change

Refactor the install+verify into a helper and run it **twice** — `default` and `--legacy-peer-deps` — each in its own clean consumer project. This guards the current `"brepjs": "*"` dependency choice (#1852) against a regression back to `peerDependencies`.

## No workflow change needed

`smoke:standalone` already runs in the `packages-verify` CI job (a `ci-pass` dependency, `ci.yml:180`), so extending the script automatically extends the gated coverage.

## Verified locally

```
[default] ok:true, volume:999.99...
[legacy-peer-deps] ok:true, volume:999.99...
standalone smoke OK
```

Both pass with `"brepjs": "*"`. If brepjs were moved back to `peerDependencies`, the `legacy-peer-deps` case would fail — exactly the regression this catches.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

