### PR TITLE
revert: restore brepjs-cad brepjs dep floor — "*" did not fix the release churn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14756,7 +14756,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "brepjs": "*",
+        "brepjs": ">=18.117.1",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0",
         "typescript": "^6.0.3"

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "brepjs": "*",
+    "brepjs": ">=18.117.1",
     "commander": "^15.0.0",
     "occt-wasm": "^3.0.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Reverts #1852.

## Why

#1852 pinned brepjs-cad's `brepjs` dep to `"*"` on the premise that node-workspace leaves `"*"` specs alone, so the release churn would stop. **That premise was wrong**, caught by a simulate-the-next-core-PR release-please dry-run (a throwaway branch with a real `fix(core):` commit run through the actual node-workspace logic):

| Package | dep spec | dry-run outcome |
|---------|----------|-----------------|
| **brepjs-cad** | `dependency: "*"` | `version: 0.87.1 **forced bump**` → release fires |
| brepjs-bim / sheetmetal | `peerDependency` | "No candidate pull request" → no release |

→ **"Would open 2 pull requests"** (brepjs + brepjs-cad) even with `"*"`.

node-workspace **force-bumps** every managed *dependency*-dependent when a dep releases. The spec (`"*"` vs `>=`) only controls whether the dep *line* is re-pinned, not whether a release fires. The `"*"`-is-immune corroboration was confounded: brepjs-cad's `brepjs-viewer: "*"` devDep never churns because **brepjs-viewer is unmanaged by release-please** (#1430) — nothing to do with `"*"`.

## Conclusion

The per-core-PR brepjs-cad release is **by design**: cad is a standalone CLI that needs brepjs at runtime, so brepjs must be a real `dependency` → node-workspace force-bumps it. The only thing that stops it is `peerDependencies`, which **breaks the standalone CLI under `--legacy-peer-deps`** (clean-room proven — `Cannot find package 'brepjs'`).

This restores `>=18.117.1` for an accurate history; the churn is identical either way. **#1853 stays** — the `smoke:standalone` guard now covers both `--legacy-peer-deps` and default installs, which is the durable value from this investigation (it would catch a future peer regression).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

