### PR TITLE
fix(kernel): make manifold copyShape a real copy, not an alias

### DIFF
--- a/src/kernel/manifold/meshHandle.ts
+++ b/src/kernel/manifold/meshHandle.ts
@@ -20,6 +20,13 @@ export function unwrap(shape: ManifoldShape): ManifoldSolid {
   return shape.manifold;
 }
 
+// A pass-through op (no geometric change available) must still yield a distinct
+// manifold object so two handles never alias the same one — otherwise the
+// adapter's dispose() double-frees. translate by zero returns a fresh Manifold.
+export function cloneSolid(solid: ManifoldSolid): ManifoldSolid {
+  return typeof solid?.translate === 'function' ? solid.translate([0, 0, 0]) : solid;
+}
+
 export function nodeOf(shape: ManifoldShape): OpNode {
   return shape.node;
 }

--- a/src/kernel/manifold/modifierOps.ts
+++ b/src/kernel/manifold/modifierOps.ts
@@ -3,18 +3,11 @@ import type { KernelShape } from '@/kernel/types.js';
 import type { ManifoldModule } from './helpers.js';
 import { notImplemented } from './helpers.js';
 import type { ManifoldShape, ManifoldSolid } from './meshHandle.js';
-import { nodeOf, unwrap, wrap } from './meshHandle.js';
+import { cloneSolid, nodeOf, unwrap, wrap } from './meshHandle.js';
 import { makeNode } from './opGraph.js';
 import { orientPositive } from './approximations.js';
 
 const ROUNDING_BALL_SEGMENTS = 16;
-
-// A pass-through op (no geometric change available) must still yield a distinct
-// manifold object so two handles never alias the same one — otherwise the
-// adapter's dispose() double-frees. translate by zero returns a fresh Manifold.
-function cloneSolid(solid: ManifoldSolid): ManifoldSolid {
-  return typeof solid?.translate === 'function' ? solid.translate([0, 0, 0]) : solid;
-}
 
 // Rolling-ball preview: Minkowski shrink-then-grow rounds convex edges by
 // `radius`. Falls back to a clone of the input solid when the build lacks

--- a/src/kernel/manifold/topologyOps.ts
+++ b/src/kernel/manifold/topologyOps.ts
@@ -2,7 +2,16 @@ import type { KernelTopologyOps } from '@/kernel/interfaces/topologyOps.js';
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
 import type { KernelShape, ShapeOrientation, ShapeType } from '@/kernel/types.js';
 import type { ManifoldModule } from './helpers.js';
-import { asManifoldShape, brepCache, occtOrThrow, resolveOcct, unwrap } from './meshHandle.js';
+import {
+  asManifoldShape,
+  brepCache,
+  cloneSolid,
+  occtOrThrow,
+  resolveOcct,
+  unwrap,
+  wrap,
+} from './meshHandle.js';
+import { makeNode } from './opGraph.js';
 import { replay } from './replay.js';
 import { extractFaces } from './nativeFaces.js';
 import { extractEdges, extractVertices } from './nativeEdges.js';
@@ -162,9 +171,18 @@ export function makeTopologyOps(_module: ManifoldModule): KernelTopologyOps {
     isSame,
     isEqual: isSame,
     downcast: (shape) => shape,
-    // Mesh kernel: handles are value-like and never freed individually, so the
-    // identity result is safe to dispose independently of the source.
-    copyShape: (shape) => shape,
+    // dispose() frees the native solid, so a copy must own a distinct one — an
+    // identity result would free the source's solid when the copy is disposed.
+    // The zero-translate node keeps the copy replayable while isolating its
+    // brepCache entry (dispose frees the cached B-rep by node).
+    copyShape: (shape) => {
+      const s = asManifoldShape(shape);
+      if (!s) return shape;
+      return wrap(
+        cloneSolid(unwrap(s)),
+        makeNode('translateShape', { x: 0, y: 0, z: 0 }, [s.node])
+      );
+    },
     hashCode,
     isNull,
     shapeOrientation: (_shape: KernelShape): ShapeOrientation => 'forward',

--- a/tests/manifoldCopyShape.test.ts
+++ b/tests/manifoldCopyShape.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+/**
+ * Manifold copyShape independence — clone() must not alias the native solid.
+ *
+ * The adapter's dispose() frees `handle.manifold`, so an identity copyShape
+ * makes clone-then-delete a use-after-free on the source (surfaced as
+ * "Cannot pass deleted object as a pointer of type Manifold" the first time
+ * a boolean or mesh() materializes the source, e.g. via subShapeHashes).
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initKernel, initOCCT } from './setup.js';
+import { withKernel, box, clone, mesh, unwrap } from '@/index.js';
+
+let haveManifold = false;
+beforeAll(async () => {
+  await initOCCT();
+  try {
+    await initKernel('manifold');
+    haveManifold = true;
+  } catch {
+    haveManifold = false;
+  }
+}, 60_000);
+
+describe('manifold copyShape', () => {
+  it('disposing a clone leaves the source usable', () => {
+    if (!haveManifold) return;
+    withKernel('manifold', () => {
+      const source = box(10, 10, 10);
+      const copy = unwrap(clone(source));
+      copy.delete();
+      expect(mesh(source).vertices.length).toBeGreaterThan(0);
+      source.delete();
+    });
+  });
+
+  it('disposing the source leaves the clone usable', () => {
+    if (!haveManifold) return;
+    withKernel('manifold', () => {
+      const source = box(10, 10, 10);
+      const copy = unwrap(clone(source));
+      source.delete();
+      expect(mesh(copy).vertices.length).toBeGreaterThan(0);
+      copy.delete();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1857

## Problem

On the Manifold kernel `copyShape` was identity, so `clone()` returned a wrapper sharing the source's native `Manifold` — while the adapter's `dispose()` unconditionally calls `manifold.delete()`. Any clone-then-delete freed the solid out from under the other handle. Latent until 18.118.25, whose `collectInputFaceHashes` → `subShapeHashes` → `iterShapes('face')` → `getMesh()` became the first path inside a boolean to materialize a possibly-deleted input (`BindingError: Cannot pass deleted object as a pointer of type Manifold`, hit in gridfinity's split preview — andymai/gridfinity-layout-tool#2625).

## Fix

- `copyShape` now returns `wrap(cloneSolid(unwrap(s)), makeNode('translateShape', {x:0,y:0,z:0}, [s.node]))` — a distinct native solid under its own op-node, so the copy stays replayable and dispose only touches its own `brepCache` entry (sharing the source's node would let a disposed copy free the source's cached OCCT replay and dangle its outstanding sub-shape witnesses).
- `cloneSolid` hoisted from `modifierOps.ts` to `meshHandle.ts` (it already existed precisely to avoid this aliasing in pass-through modifier ops).
- Non-manifold handles (sub-shape witnesses) keep identity behavior.

This is the Manifold-side counterpart of #1767, which fixed the same aliasing-clone bug on OCCT.

## Verification

- New `tests/manifoldCopyShape.test.ts`: clone→delete→use-source and source→delete→use-clone. Both fail with the BindingError before the fix, pass after.
- `npm run validate` green: typecheck, lint, boundaries, format, 283 test files / 4181 tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

