### PR TITLE
fix: plug occt-wasm arena leaks in imports/modifiers and fuseAll pairwise simplify

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "348 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "349 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },

--- a/src/io/gltfImportFns.ts
+++ b/src/io/gltfImportFns.ts
@@ -4,7 +4,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { UnknownDimShape } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castResultShape } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { ioError, BrepErrorCode } from '@/core/errors.js';
 
@@ -26,7 +26,7 @@ export async function importGLB(blob: Blob): Promise<Result<UnknownDimShape>> {
   try {
     const data = await blob.arrayBuffer();
     const shape = getKernel().importGLB(data);
-    return ok(castShape(shape));
+    return ok(castResultShape(shape));
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return err(ioError(BrepErrorCode.GLB_IMPORT_FAILED, `Failed to import GLB: ${msg}`, e));

--- a/src/io/importFns.ts
+++ b/src/io/importFns.ts
@@ -5,7 +5,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { UnknownDimShape } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castResultShape } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { ioError } from '@/core/errors.js';
 
@@ -34,7 +34,13 @@ export async function importSTEP(blob: Blob): Promise<Result<UnknownDimShape>> {
       return err(ioError('STEP_IMPORT_FAILED', 'STEP file contains no valid geometry'));
     }
 
-    return ok(castShape(shapes[0]));
+    // Multi-root files yield several top-level shapes; only the first is
+    // returned, so release the rest to avoid leaking their arena slots.
+    for (let i = 1; i < shapes.length; i++) {
+      const extra = shapes[i];
+      if (extra) getKernel().dispose(extra);
+    }
+    return ok(castResultShape(shapes[0]));
   } catch (e) {
     return err(ioError('STEP_IMPORT_FAILED', 'Failed to load STEP file', e));
   }
@@ -63,7 +69,7 @@ export async function importSTL(blob: Blob): Promise<Result<UnknownDimShape>> {
     if (shape.IsNull()) {
       return err(ioError('STL_IMPORT_FAILED', 'Failed to create solid from STL mesh'));
     }
-    return ok(castShape(shape));
+    return ok(castResultShape(shape));
   } catch (e) {
     return err(ioError('STL_IMPORT_FAILED', 'Failed to load STL file', e));
   }
@@ -90,7 +96,13 @@ export async function importIGES(blob: Blob): Promise<Result<UnknownDimShape>> {
       return err(ioError('IGES_IMPORT_FAILED', 'IGES file contains no valid geometry'));
     }
 
-    return ok(castShape(shapes[0]));
+    // Multi-root files yield several top-level shapes; only the first is
+    // returned, so release the rest to avoid leaking their arena slots.
+    for (let i = 1; i < shapes.length; i++) {
+      const extra = shapes[i];
+      if (extra) getKernel().dispose(extra);
+    }
+    return ok(castResultShape(shapes[0]));
   } catch (e) {
     return err(ioError('IGES_IMPORT_FAILED', 'Failed to load IGES file', e));
   }

--- a/src/io/ioUtils.ts
+++ b/src/io/ioUtils.ts
@@ -8,7 +8,7 @@
 import { getKernel } from '@/kernel/index.js';
 import type { KernelShape } from '@/kernel/types.js';
 import type { UnknownDimShape } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castShape, castResultShape } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { ioError } from '@/core/errors.js';
 
@@ -44,9 +44,16 @@ export function sewMeshToSolid(
   }
 
   try {
-    return ok(castShape(kernel.sewAndSolidify(triFaces, tolerance)));
+    // sewAndSolidify copies the faces into a fresh solid, so the tri-face slots
+    // can be released and the orphaned pre-downcast handle cast away.
+    const solid = kernel.sewAndSolidify(triFaces, tolerance);
+    const cast = castResultShape(solid);
+    for (const triFace of triFaces) kernel.dispose(triFace);
+    return ok(cast);
   } catch {
-    // If sewing/solid fails, try sewing alone
+    // Open/degenerate surface: sew alone into a shell/compound. On arena kernels
+    // the sewn shell shares the input face slots, so leave the tri-faces and the
+    // pre-downcast handle untouched (castShape, no dispose) to avoid freeing them.
     try {
       return ok(castShape(kernel.sew(triFaces, tolerance)));
     } catch (e) {

--- a/src/io/threemfImportFns.ts
+++ b/src/io/threemfImportFns.ts
@@ -4,7 +4,7 @@
 
 import { getKernel } from '@/kernel/index.js';
 import type { UnknownDimShape } from '@/core/shapeTypes.js';
-import { castShape } from '@/core/shapeTypes.js';
+import { castResultShape } from '@/core/shapeTypes.js';
 import { type Result, ok, err } from '@/core/result.js';
 import { ioError, BrepErrorCode } from '@/core/errors.js';
 import { sewMeshToSolid } from './ioUtils.js';
@@ -318,7 +318,7 @@ function buildSolidFromMesh(mesh: ParsedMesh): Result<UnknownDimShape> {
 
   try {
     const solid = kernel.buildSolidFromFaces(points, faces, 1e-6);
-    return ok(castShape(solid));
+    return ok(castResultShape(solid));
   } catch {
     // Fallback: resolve indexed triangles to vertex triples and sew
     const triangles: Array<

--- a/src/topology/booleanFns.ts
+++ b/src/topology/booleanFns.ts
@@ -360,7 +360,22 @@ export function intersect(
 // ---------------------------------------------------------------------------
 
 /**
+ * Result of a pairwise fuse subtree. `owned` is true when `shape` is a fresh
+ * fused solid this recursion produced (the parent must dispose it once consumed)
+ * and false when it is a passthrough of a caller-owned input (a `count === 1`
+ * leaf) that must never be disposed here.
+ */
+interface PairwiseNode {
+  shape: Shape3D;
+  owned: boolean;
+}
+
+/**
  * Internal helper for pairwise fuse using index ranges to avoid array allocations.
+ *
+ * `isFinal` marks the subtree whose output is the overall result; only then does
+ * a two-input leaf apply `simplify` (with 3+ inputs the top-level combine already
+ * does, but a two-input fuse is a lone leaf with no combine to reapply it).
  */
 function fuseAllPairwise(
   shapes: Shape3D[],
@@ -368,22 +383,25 @@ function fuseAllPairwise(
   end: number,
   optimisation: 'none' | 'commonFace' | 'sameFace',
   simplify: boolean,
+  isFinal: boolean,
   trackEvolution: boolean,
   signal?: AbortSignal,
   fuzzyValue?: number
-): Result<Shape3D> {
+): Result<PairwiseNode> {
   if (signal?.aborted) throw signal.reason;
   const count = end - start;
-  if (count === 1) return ok(getAtOrThrow(shapes, start));
+  if (count === 1) return ok({ shape: getAtOrThrow(shapes, start), owned: false });
   if (count === 2) {
-    return fuse(getAtOrThrow(shapes, start), getAtOrThrow(shapes, start + 1), {
+    const pair = fuse(getAtOrThrow(shapes, start), getAtOrThrow(shapes, start + 1), {
       optimisation,
-      simplify: false,
+      simplify: isFinal ? simplify : false,
       trackEvolution,
       fuzzyValue,
       unsafe: true,
       ...(signal ? { signal } : {}),
     });
+    if (isErr(pair)) return pair;
+    return ok({ shape: pair.value, owned: true });
   }
 
   const mid = start + Math.ceil(count / 2);
@@ -393,6 +411,7 @@ function fuseAllPairwise(
     mid,
     optimisation,
     simplify,
+    false,
     trackEvolution,
     signal,
     fuzzyValue
@@ -404,13 +423,17 @@ function fuseAllPairwise(
     end,
     optimisation,
     simplify,
+    false,
     trackEvolution,
     signal,
     fuzzyValue
   );
-  if (isErr(rightResult)) return rightResult;
+  if (isErr(rightResult)) {
+    if (leftResult.value.owned) disposeResultShape(leftResult.value.shape);
+    return rightResult;
+  }
 
-  return fuse(leftResult.value, rightResult.value, {
+  const combined = fuse(leftResult.value.shape, rightResult.value.shape, {
     optimisation,
     simplify,
     trackEvolution,
@@ -418,6 +441,12 @@ function fuseAllPairwise(
     unsafe: true,
     ...(signal ? { signal } : {}),
   });
+  // The two operands are consumed by the combine; release the ones this
+  // recursion owns (never the caller-owned leaf passthroughs).
+  if (leftResult.value.owned) disposeResultShape(leftResult.value.shape);
+  if (rightResult.value.owned) disposeResultShape(rightResult.value.shape);
+  if (isErr(combined)) return combined;
+  return ok({ shape: combined.value, owned: true });
 }
 
 /**
@@ -490,16 +519,19 @@ export function fuseAll(
 
   // Pairwise fallback: recursive divide-and-conquer with index ranges
   // Uses index ranges instead of slice() to avoid array allocations
-  return fuseAllPairwise(
+  const pairwise = fuseAllPairwise(
     shapes,
     0,
     shapes.length,
     optimisation,
     simplify,
+    true,
     trackEvolution,
     signal,
     fuzzyValue
   );
+  if (isErr(pairwise)) return pairwise;
+  return ok(pairwise.value.shape);
 }
 
 /**

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -279,6 +279,7 @@ export function fillet(
       const resultShape = getKernel().fillet(shape.wrapped, edgeShapes, kernelRadius);
       const cast = castResultShape(resultShape);
       if (!isShape3D(cast)) {
+        disposeResultShape(cast);
         return err(kernelError(BrepErrorCode.FILLET_NOT_3D, 'Fillet result is not a 3D shape'));
       }
       return ok(cast as ValidSolid);
@@ -429,6 +430,7 @@ export function shell(
       );
       const cast = castResultShape(resultShape);
       if (!isShape3D(cast)) {
+        disposeResultShape(cast);
         return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
       }
       return ok(cast as ValidSolid);
@@ -445,6 +447,7 @@ export function shell(
     );
     const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
+      disposeResultShape(cast);
       return err(kernelError('SHELL_RESULT_NOT_3D', 'Shell result is not a 3D shape'));
     }
     propagateAllMetadata(evolution, [shape], cast);
@@ -490,6 +493,7 @@ export function offset(shape: ValidSolid, distance: number, tolerance = 1e-6): R
     );
     const cast = castResultShape(resultShape);
     if (!isShape3D(cast)) {
+      disposeResultShape(cast);
       return err(kernelError('OFFSET_RESULT_NOT_3D', 'Offset result is not a 3D shape'));
     }
     propagateAllMetadata(evolution, [shape], cast);

--- a/tests/booleanFns.test.ts
+++ b/tests/booleanFns.test.ts
@@ -24,6 +24,7 @@ import {
   isShape3D,
   getShapeKind,
   getEdges,
+  getFaces,
   getKernel,
   createSolid,
   measureVolume,
@@ -207,6 +208,28 @@ describe('boolean edge cases', () => {
       );
       expect(isOk(result)).toBe(true);
       expect(unwrap(measureVolume(unwrap(result)))).toBeCloseTo(3000, 0);
+    });
+
+    it('pairwise strategy honors simplify for a two-shape fuse (regression)', (ctx) => {
+      // Two face-adjacent boxes fuse into a 20x10x10 solid whose four side faces
+      // stay split at x=10 until simplify (BRepAlgoAPI_Fuse::SimplifyResult) merges
+      // them, dropping the face count from 10 to 6. The pairwise leaf previously
+      // hard-coded simplify:false for the two-input case, silently dropping the
+      // caller's request — with 3+ inputs the top-level combine reapplies it, but a
+      // two-input fuse is a lone leaf with no combine downstream. Only the occt
+      // (opencascade.js) kernel applies the option on fuse; the others ignore it.
+      skipIfDiverges(ctx, 'booleanFns.pairwiseSimplifyFaceMerge');
+      const boxes = (): [Shape3D, Shape3D] => [
+        boxAt(0, 0, 0, 10, 10, 10),
+        boxAt(10, 0, 0, 20, 10, 10),
+      ];
+      const plain = fuseAll(boxes(), { strategy: 'pairwise', simplify: false });
+      const simplified = fuseAll(boxes(), { strategy: 'pairwise', simplify: true });
+      expect(isOk(plain)).toBe(true);
+      expect(isOk(simplified)).toBe(true);
+      const simplifiedShape = unwrap(simplified);
+      expect(unwrap(measureVolume(simplifiedShape))).toBeCloseTo(2000, 0);
+      expect(getFaces(simplifiedShape).length).toBeLessThan(getFaces(unwrap(plain)).length);
     });
 
     it('fuseAll with native strategy (default)', () => {

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -60,8 +60,13 @@ export const divergences: DivergenceMap = {
         'The mesh CSG kernel re-tessellates and attributes split coplanar faces through its own path, not the B-rep hash/geometric origin fallback; a split floor piece can pick up the neighbour tool origin. Exercised on the B-rep kernels (occt/brepkit/opencascade) that gridfinity ships.',
     },
     // -----------------------------------------------------------------------
-    // booleans.test.ts — mesh CSG vs exact B-rep
+    // booleanFns.test.ts — simplify (SimplifyResult) is occt-only on fuse
     // -----------------------------------------------------------------------
+    'booleanFns.pairwiseSimplifyFaceMerge': {
+      kind: 'skip',
+      reason:
+        'fuse ignores the simplify option on manifold; only the occt (opencascade.js) kernel applies SimplifyResult to merge coplanar faces, so the fused solid face count is unchanged by simplify:true.',
+    },
     'booleans.cutFuseRecombine': {
       kind: 'skip',
       reason:
@@ -121,6 +126,14 @@ export const divergences: DivergenceMap = {
     },
   },
   brepkit: {
+    // -----------------------------------------------------------------------
+    // booleanFns.test.ts — brepkit fuse ignores BooleanOptions (incl. simplify)
+    // -----------------------------------------------------------------------
+    'booleanFns.pairwiseSimplifyFaceMerge': {
+      kind: 'skip',
+      reason:
+        'brepkit fuse warns and ignores BooleanOptions (optimisation/simplify/strategy/fuzzyValue); only the occt (opencascade.js) kernel applies SimplifyResult, so the fused solid face count is unchanged by simplify:true.',
+    },
     // -----------------------------------------------------------------------
     // projection.test.ts — brepkit HLR (projectEdges) is partial
     // -----------------------------------------------------------------------
@@ -427,6 +440,14 @@ export const divergences: DivergenceMap = {
   // excludeTests in kernelRegistry.ts. Add entries here when specific
   // tests need per-test skipping rather than whole-file exclusion.
   'occt-wasm': {
+    // ---------------------------------------------------------------------
+    // booleanFns.test.ts — occt-wasm fuse ignores the simplify option
+    // ---------------------------------------------------------------------
+    'booleanFns.pairwiseSimplifyFaceMerge': {
+      kind: 'skip',
+      reason:
+        'occt-wasm fuse does not apply the simplify option (no SimplifyResult); only the occt (opencascade.js) kernel merges coplanar faces, so the fused solid face count is unchanged by simplify:true.',
+    },
     // ---------------------------------------------------------------------
     // Raw-OCCT-API tests: exercise the Emscripten `oc` object (gp_Vec,
     // TopoDS_*, FS.readFile, raw BREP) that occt-wasm does not expose by

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -1081,6 +1081,28 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
         })
       ).toBe(0);
     });
+
+    it('fuseAll pairwise strategy disposes intermediate solids (regression)', () => {
+      // Divide-and-conquer over 4 inputs produces two owned intermediate solids
+      // (fuse(b0,b1) and fuse(b2,b3)) that the combine step consumes; the pairwise
+      // helper previously returned the combined result without disposing those
+      // operands, leaking ~N-2 arena slots per call. Only the caller-owned leaf
+      // inputs must survive — the guard here is that they, and the result, are
+      // disposed so any residual growth is a genuine intermediate leak.
+      expect(
+        perIterationLeak(() => {
+          using b0 = box(10, 10, 10);
+          using s1 = box(10, 10, 10);
+          using b1 = translate(s1, [10, 0, 0]);
+          using s2 = box(10, 10, 10);
+          using b2 = translate(s2, [20, 0, 0]);
+          using s3 = box(10, 10, 10);
+          using b3 = translate(s3, [30, 0, 0]);
+          const r = fuseAll([b0, b1, b2, b3], { strategy: 'pairwise' });
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
   });
 
   describe('sweep / loft variants leak nothing', () => {


### PR DESCRIPTION
## Problem

On the arena-allocator kernel (occt-wasm) every shape is a slot reclaimed only via `getKernel().dispose()`. A parallel audit of the geometry/IO surface found several fresh-result paths that leaked slots, plus one silent boolean-correctness bug.

## Fixes

- **`modifierFns` fillet/shell/offset** — dispose the cast result on the non-3D error branch, matching `finalizeShape3D` (was leaking the downcast slot every failed modify).
- **`io/ioUtils` `sewMeshToSolid`** — release the tri-face slots and cast the fresh solid with `castResultShape` on the `sewAndSolidify` path (faces are **copied** into the solid). The **`sew` fallback** returns a shell that *aliases* the input face slots on arena kernels, so it keeps `castShape` and leaves the tri-faces untouched — this is the highest-frequency leak (every closed-mesh OBJ/3MF import leaked ~triangle-count slots).
- **`io/importFns` STEP/STL/IGES + `gltf`/`threemf` importers** — `castResultShape` on fresh results; STEP/IGES also dispose the unreturned extra roots of multi-root files.
- **`booleanFns` `fuseAllPairwise`** — thread an `isFinal` flag so a two-input fuse honors `simplify` (a lone leaf with no combine to reapply it — previously `fuseAll([a,b], {strategy:'pairwise', simplify:true})` silently dropped `simplify`), and track per-node ownership to dispose owned intermediates without freeing caller-owned inputs.

## Why the `sew`-fallback nuance matters

`castShape → castResultShape` cannot be applied blindly: `sewAndSolidify` copies faces into a fresh solid (safe to dispose + re-cast), but `sew` returns a shell that shares the input face slots on the arena kernel — re-casting/disposing its source corrupts it. A stash-based apples-to-apples baseline caught 2 `occt-wasm` OBJ-import regressions from the naive version and drove the split fix.

## Tests

Two regressions for the `fuseAllPairwise` change:

- **`booleanFns` — simplify honored on the two-shape pairwise leaf.** A face-adjacent pair fused with `simplify:true` drops from 10 faces to 6. `simplify` on `fuse` is applied **only by the `occt` (opencascade.js) kernel** — occt-wasm/brepkit/manifold take `_options` and ignore it — so the test is gated to `occt` via a `booleanFns.pairwiseSimplifyFaceMerge` divergence registered on the other three (with accurate reasons). Runs under `npm run test:occt`.
- **`wasmArenaDisposal` (occt-wasm, CI-gated) — intermediate solids are disposed.** A 4-input pairwise fuse produces two owned intermediate solids that the combine consumes; the `getShapeCount()` oracle confirms `perIterationLeak == 0`. Verified the guard has teeth: reverting the disposal makes it report a 2-slot/call leak.

## Verification

- typecheck, eslint, prettier, `check:boundaries`, `check:patterns` — all green
- **occt-wasm and brepkit** pass across `booleanFns`, `modifierFns`, `importFns`, `objImport`, `threemfImport`, `import-export`, `gltfRoundTrip`, `castResultShapeMigration`, `errorPathDisposal`, and the **`wasmArenaDisposal` leak oracle**
- Remaining failures in the suite are pre-existing `|manifold|` B-Rep-import gaps (a mesh kernel can't round-trip STEP/STL/OBJ/3MF), identical to the pristine baseline