### PR TITLE
fix(kernel): implement linear variable fillet on occt-wasm

### DIFF
--- a/src/kernel/occtWasm/modifierOps.ts
+++ b/src/kernel/occtWasm/modifierOps.ts
@@ -7,6 +7,13 @@
 import type { KernelShape } from '@/kernel/types.js';
 import type { OcctKernelWasm, OcctWasmModule } from './occtWasmTypes.js';
 import { makeVecU32, resolveUniformRadius, unwrap, wrapResult } from './helpers.js';
+import { UnsupportedKernelOperationError } from '@/kernel/unsupported.js';
+
+// occt's hashCode upper bound (INT_MAX). Mirrors core's HASH_CODE_MAX but is kept
+// kernel-local so this layer-0 file need not import from core (layer 1); the
+// kernel-agnostic filletVariable spec stores edge hashes at this bound, so the
+// resolution below must hash with the same value.
+const HASH_UPPER_BOUND = 2147483647;
 
 export function fillet(
   k: OcctKernelWasm,
@@ -87,20 +94,95 @@ export function offset(
   return wrapResult(k, k.offset(unwrap(shape), distance, tolerance ?? 1e-6));
 }
 
+/**
+ * Run occt-wasm's variable-fillet primitive and return the resulting solid.
+ * The primitive wraps its result in a single-solid compound (uniform fillet
+ * returns a bare solid); getSubShapes copies that solid into its own arena slot,
+ * so keep it and release the compound wrapper. An unexpected topology (zero or
+ * several solids) is returned as-is for the caller to reject.
+ */
+function runFilletVariable(
+  k: OcctKernelWasm,
+  shapeId: number,
+  edgeId: number,
+  startRadius: number,
+  endRadius: number
+): KernelShape {
+  const resultId = k.filletVariable(shapeId, edgeId, startRadius, endRadius);
+  const solids = k.getSubShapes(resultId, 'solid');
+  const kept = solids.size() === 1 ? solids.get(0) : -1;
+  try {
+    return wrapResult(k, kept === -1 ? resultId : kept);
+  } finally {
+    for (let i = 0, n = solids.size(); i < n; i++) {
+      const id = solids.get(i);
+      if (id !== kept) k.release(id);
+    }
+    solids.delete();
+    if (kept !== -1) k.release(resultId);
+  }
+}
+
 export function filletVariable(k: OcctKernelWasm, shape: KernelShape, spec: string): KernelShape {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON parse
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON parse of a kernel-agnostic spec
   const parsed: any = JSON.parse(spec);
+
+  // Legacy explicit form: { edgeId, startRadius, endRadius }.
   if (
     parsed.edgeId !== undefined &&
     parsed.startRadius !== undefined &&
     parsed.endRadius !== undefined
   ) {
-    return wrapResult(
-      k,
-      k.filletVariable(unwrap(shape), parsed.edgeId, parsed.startRadius, parsed.endRadius)
-    );
+    return runFilletVariable(k, unwrap(shape), parsed.edgeId, parsed.startRadius, parsed.endRadius);
   }
-  throw new Error('occt-wasm: filletVariable (complex spec) not implemented');
+
+  // Form emitted by the high-level variableFillet: { edge: hashCode, radii: [{param, radius}] }.
+  // occt-wasm's primitive builds a single linear start->end taper on one edge, so a constant
+  // (1-point) or linear (2-point) profile maps directly onto it. A genuine multi-point profile
+  // can't be represented and stays unsupported rather than being silently flattened to a line.
+  if (parsed.edge !== undefined && Array.isArray(parsed.radii) && parsed.radii.length > 0) {
+    const radii = parsed.radii;
+    if (radii.length > 2) {
+      throw new UnsupportedKernelOperationError(
+        'occt-wasm: filletVariable supports only a linear (<=2-point) radius profile; ' +
+          'a multi-point variable radius requires the brepkit kernel'
+      );
+    }
+    const startRadius = radii[0].radius;
+    const endRadius = radii[radii.length - 1].radius;
+    // The spec is kernel-agnostic and identifies the edge by stable hash (brepkit resolves it
+    // natively); occt-wasm's primitive takes the edge's arena slot id, so resolve the hash
+    // against the solid's edges. getSubShapes copies each edge into its own slot, so release
+    // every queried copy except the matched one (freed after the fillet runs).
+    const shapeId = unwrap(shape);
+    const edgeVec = k.getSubShapes(shapeId, 'edge');
+    let matchedEdgeId = -1;
+    try {
+      for (let i = 0, n = edgeVec.size(); i < n; i++) {
+        if (matchedEdgeId === -1 && k.hashCode(edgeVec.get(i), HASH_UPPER_BOUND) === parsed.edge) {
+          matchedEdgeId = edgeVec.get(i);
+        }
+      }
+    } finally {
+      for (let i = 0, n = edgeVec.size(); i < n; i++) {
+        const id = edgeVec.get(i);
+        if (id !== matchedEdgeId) k.release(id);
+      }
+      edgeVec.delete();
+    }
+    if (matchedEdgeId === -1) {
+      throw new UnsupportedKernelOperationError(
+        'occt-wasm: filletVariable: target edge not found on the shape'
+      );
+    }
+    try {
+      return runFilletVariable(k, shapeId, matchedEdgeId, startRadius, endRadius);
+    } finally {
+      k.release(matchedEdgeId);
+    }
+  }
+
+  throw new UnsupportedKernelOperationError('occt-wasm: filletVariable: unrecognized spec');
 }
 
 export function draft(

--- a/src/kernel/occtWasm/modifierOps.ts
+++ b/src/kernel/occtWasm/modifierOps.ts
@@ -109,17 +109,28 @@ function runFilletVariable(
   endRadius: number
 ): KernelShape {
   const resultId = k.filletVariable(shapeId, edgeId, startRadius, endRadius);
-  const solids = k.getSubShapes(resultId, 'solid');
-  const kept = solids.size() === 1 ? solids.get(0) : -1;
+  // Release resultId on any failure before it is either handed to the caller
+  // (unexpected topology) or released as the compound wrapper below — otherwise a
+  // throw from getSubShapes would leak it.
+  let releaseResult = true;
   try {
-    return wrapResult(k, kept === -1 ? resultId : kept);
-  } finally {
-    for (let i = 0, n = solids.size(); i < n; i++) {
-      const id = solids.get(i);
-      if (id !== kept) k.release(id);
+    const solids = k.getSubShapes(resultId, 'solid');
+    try {
+      const kept = solids.size() === 1 ? solids.get(0) : -1;
+      for (let i = 0, n = solids.size(); i < n; i++) {
+        const id = solids.get(i);
+        if (id !== kept) k.release(id);
+      }
+      if (kept === -1) {
+        releaseResult = false;
+        return wrapResult(k, resultId);
+      }
+      return wrapResult(k, kept);
+    } finally {
+      solids.delete();
     }
-    solids.delete();
-    if (kept !== -1) k.release(resultId);
+  } finally {
+    if (releaseResult) k.release(resultId);
   }
 }
 
@@ -159,8 +170,10 @@ export function filletVariable(k: OcctKernelWasm, shape: KernelShape, spec: stri
     let matchedEdgeId = -1;
     try {
       for (let i = 0, n = edgeVec.size(); i < n; i++) {
-        if (matchedEdgeId === -1 && k.hashCode(edgeVec.get(i), HASH_UPPER_BOUND) === parsed.edge) {
-          matchedEdgeId = edgeVec.get(i);
+        const id = edgeVec.get(i);
+        if (k.hashCode(id, HASH_UPPER_BOUND) === parsed.edge) {
+          matchedEdgeId = id;
+          break;
         }
       }
     } finally {

--- a/src/topology/modifierFns.ts
+++ b/src/topology/modifierFns.ts
@@ -642,8 +642,9 @@ export interface VariableFilletRadius {
  * The radius varies along the edge according to the provided spec points.
  * Each point specifies a normalized parameter (0 = start, 1 = end) and radius.
  *
- * **Cross-kernel note:** Only brepkit supports variable-radius fillet.
- * Returns UNSUPPORTED_CAPABILITY error on OCCT.
+ * **Cross-kernel note:** brepkit supports arbitrary multi-point radius profiles.
+ * occt-wasm supports a linear (start/end, <=2-point) profile and returns
+ * UNSUPPORTED for multi-point; the opencascade.js kernel does not implement it.
  */
 export function variableFillet(
   shape: ValidSolid,

--- a/tests/modifierFns.test.ts
+++ b/tests/modifierFns.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion -- test array indexing */
 import { describe, expect, it, beforeAll } from 'vitest';
-import { initKernel } from './setup.js';
+import { initKernel, currentKernel } from './setup.js';
 import { skipIfDiverges } from './helpers/kernelDivergences.js';
 import {
   sketchRectangle,
@@ -327,6 +327,51 @@ describe('variableFillet validation', () => {
     const b = box(10, 10, 10);
     const edges = getEdges(b);
     const result = variableFillet(b, edges[0]!, [{ param: 0, radius: 0 }]);
+    expect(isErr(result)).toBe(true);
+    expect(unwrapErr(result).code).toBe('VARIABLE_FILLET_FAILED');
+  });
+});
+
+// occt-wasm gained a linear (<=2-point) variable fillet: its primitive takes an
+// edge arena id (the caller passes a stable hash to resolve) and wraps the result
+// in a single-solid compound (uniform fillet returns a bare solid). Gated to
+// occt-wasm — occt (opencascade.js) doesn't implement it and brepkit's variable
+// fillet reports a physically-impossible volume (its own divergence).
+describe.skipIf(currentKernel !== 'occt-wasm')('variableFillet on occt-wasm', () => {
+  it('applies a linear (2-point) taper, yielding a valid smaller solid', () => {
+    const b = box(10, 10, 10);
+    const result = variableFillet(b, getEdges(b)[0]!, [
+      { param: 0, radius: 1 },
+      { param: 1, radius: 3 },
+    ]);
+    expect(isOk(result)).toBe(true);
+    const solid = unwrap(result);
+    expect(isSolid(solid)).toBe(true);
+    const vol = unwrap(measureVolume(solid));
+    expect(vol).toBeLessThan(1000);
+    expect(vol).toBeGreaterThan(900);
+  });
+
+  it('a constant profile matches a uniform fillet of the same radius', () => {
+    const b = box(10, 10, 10);
+    const edge = getEdges(b)[0]!;
+    const variable = variableFillet(b, edge, [{ param: 0, radius: 2 }]);
+    const uniform = fillet(b, [edge], 2);
+    expect(isOk(variable)).toBe(true);
+    expect(isOk(uniform)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(variable)))).toBeCloseTo(
+      unwrap(measureVolume(unwrap(uniform))),
+      3
+    );
+  });
+
+  it('rejects a multi-point (>2) profile as unsupported', () => {
+    const b = box(10, 10, 10);
+    const result = variableFillet(b, getEdges(b)[0]!, [
+      { param: 0, radius: 1 },
+      { param: 0.5, radius: 5 },
+      { param: 1, radius: 1 },
+    ]);
     expect(isErr(result)).toBe(true);
     expect(unwrapErr(result).code).toBe('VARIABLE_FILLET_FAILED');
   });

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -86,6 +86,7 @@ import {
   getWires,
   getFaces,
   getEdges,
+  variableFillet,
   getVertices,
   getShells,
   fixShape,
@@ -436,13 +437,30 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
     // Modifiers return a fresh solid whose orphaned pre-downcast slot is released
     // by castResultShape/finalizeShape3D; the caller disposes the final result and
     // the source box. Any survivor is a leak inside the modifier itself.
-    // draft/variableFillet are excluded: they don't run on occt-wasm (brepkit-only
-    // / divergent), so their success path can't be exercised by this oracle.
+    // draft is excluded: it doesn't run on occt-wasm (brepkit-only / divergent),
+    // so its success path can't be exercised by this oracle.
     it('fillet leaks nothing', () => {
       expect(
         perIterationLeak(() => {
           using b = box(10, 10, 10);
           const r = fillet(b, 1);
+          if (isOk(r)) unwrap(r)[Symbol.dispose]();
+        })
+      ).toBe(0);
+    });
+
+    it('variableFillet leaks nothing', () => {
+      // Resolves the edge hash via getSubShapes (per-edge arena copies) and unwraps
+      // the primitive's single-solid compound — both release their queried slots.
+      expect(
+        perIterationLeak(() => {
+          using b = box(10, 10, 10);
+          const edge = getEdges(b)[0];
+          if (!edge) return;
+          const r = variableFillet(b, edge, [
+            { param: 0, radius: 1 },
+            { param: 1, radius: 3 },
+          ]);
           if (isOk(r)) unwrap(r)[Symbol.dispose]();
         })
       ).toBe(0);


### PR DESCRIPTION
## Problem

`variableFillet` **always threw on the default kernel**. occt-wasm's handler only recognized a legacy `{ edgeId, startRadius, endRadius }` spec, but the kernel-agnostic caller (`variableFillet` in `modifierFns.ts`) emits `{ edge: hashCode, radii: [{ param, radius }] }`. The keys never matched, so even a linear taper — which occt-wasm's `k.filletVariable` primitive *can* build — was rejected with a plain `Error` (documented as "brepkit-only").

## Diagnosis (empirical)

The primitive works; three separate mismatches blocked it, each verified with a probe:

1. **Spec shape** — the `{ edge, radii }` form was never parsed.
2. **Edge identity** — the spec identifies the edge by *stable hash* (brepkit resolves it natively), but occt-wasm's primitive takes the edge's **arena slot id**. Passing the hash threw a `WebAssembly.Exception`; passing the arena id produced a valid result.
3. **Result topology** — occt-wasm's `filletVariable` wraps the filleted solid in a **single-solid compound** (uniform `fillet` returns a bare solid), so the caller's `isSolid` check rejected it as "did not produce a solid".

## Fix

- Parse `{ edge, radii }`. Map a constant (1-point) or linear (2-point) profile onto the primitive; a genuine multi-point profile stays **UNSUPPORTED** (`UnsupportedKernelOperationError`, correctly routed) rather than being silently flattened to a line.
- Resolve the edge hash against the solid's edges (`getSubShapes` + `hashCode`), releasing the per-edge arena copies.
- Unwrap the single-solid compound and release the wrapper.
- Kernel-local `HASH_UPPER_BOUND` constant (mirrors core's `HASH_CODE_MAX`) so this layer-0 file doesn't import from core (layer 1).
- Corrected the doc note: occt-wasm now supports linear; opencascade.js still returns UNSUPPORTED.

## Verification

- **Constant profile == uniform fillet** of the same radius (990.52 vs 991.42 sanity; constant-2 exactly matches uniform-2) — a strong correctness signal.
- Linear taper yields a valid smaller solid; multi-point is rejected.
- **Arena oracle: 0 leak/call** despite the `getSubShapes`-copy juggling.
- occt-wasm regressions added (`modifierFns.test.ts` gated to occt-wasm) + a `wasmArenaDisposal` leak check; occt-wasm project **112/112**.
- typecheck, eslint, prettier, `check:patterns`, `check:boundaries`, `size` all green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

