### PR TITLE
fix(kernel): implement occt-wasm fixSelfIntersection via healWire

### DIFF
--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1639,8 +1639,10 @@ export class OcctWasmAdapter implements KernelAdapter {
     return repairOps.fixShape(this.k, shape);
   }
 
-  fixSelfIntersection(_wire: KernelShape): KernelShape {
-    notImplemented('fixSelfIntersection');
+  fixSelfIntersection(wire: KernelShape): KernelShape {
+    // occt-wasm exposes no standalone ShapeFix_Wire::FixSelfIntersection; healWire
+    // runs the ShapeFix_Wire heal (which includes self-intersection repair).
+    return repairOps.healWire(this.k, wire);
   }
 
   // =========================================================================

--- a/tests/healingFns.test.ts
+++ b/tests/healingFns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { initKernel } from './setup.js';
+import { initKernel, currentKernel } from './setup.js';
 import {
   box,
   sphere,
@@ -305,6 +305,22 @@ describe('autoHeal', () => {
       // so we just confirm no crash and the result is ok.
       const result = autoHeal(b, { fixSelfIntersection: true });
       expect(isOk(result)).toBe(true);
+    });
+
+    // autoHeal short-circuits valid shapes, so it never invokes the kernel's
+    // fixSelfIntersection above. occt-wasm previously threw notImplemented there
+    // (making the public wrapper return Err); it now delegates to healWire
+    // (ShapeFix_Wire), so a direct call heals a well-formed wire to a valid wire.
+    it.skipIf(currentKernel !== 'occt-wasm')('fixSelfIntersection heals a wire directly', () => {
+      const face = getFaces(box(10, 10, 10))[0];
+      expect(face).toBeDefined();
+      if (!face) return;
+      const wire = getWires(face)[0];
+      expect(wire).toBeDefined();
+      if (!wire) return;
+      const result = fixSelfIntersection(wire);
+      expect(isOk(result)).toBe(true);
+      expect(isWire(unwrap(result))).toBe(true);
     });
 
     it('all options explicitly true returns ok for a valid box', () => {


### PR DESCRIPTION
Addresses two adapter gaps flagged in the audit. One is cleanly fixable; the other turned out to need WASM-side work, documented below.

## `fixSelfIntersection` — FIXED

`fixSelfIntersection` threw `notImplemented` on occt-wasm, so the public `fixSelfIntersection()` wrapper returned `Err` and `autoHeal({ fixSelfIntersection: true })` **silently did nothing** once a shape actually reached that step. (The existing tests never caught it: `autoHeal` short-circuits *valid* shapes via `alreadyValid`, so the kernel call was never invoked.)

Delegate to **`healWire`**, which runs occt-wasm's `ShapeFix_Wire` heal — self-intersection repair included — at the shared heal tolerance.

**Verified:** a well-formed wire heals to a valid wire; `autoHeal` no longer throws. Added a **direct occt-wasm regression** (`healingFns.test.ts`) that calls `fixSelfIntersection(wire)` — the `autoHeal`-based tests can't reach the kernel call because a valid box short-circuits.

## `reverseSurfaceU` — left unimplemented (needs WASM + a `deriveCylinder` fix)

Investigated and deliberately **not** changed. It is only reached for genuinely **indirect (left-handed)** cylinder surfaces (`!cylData.isDirect`), which I could reproduce on occt-wasm via `mirror(cylinder(...))`. Two blockers make a safe TS-only fix impossible:

1. occt-wasm exposes no `Geom_Surface::UReversed` equivalent (surfaces are face proxies; `reverseShape` flips orientation, which is a different operation).
2. For that same indirect cylinder, `getSurfaceCylinderData` returns **`radius = NaN`**, so the caller (`2d/curves.ts`) would compute a `1/NaN` scale even if the reversal worked.

So the indirect-cylinder unwrap path needs both a WASM-side `UReversed` primitive **and** a `deriveCylinder` NaN fix. Forcing an identity or transform-compensation here would risk silently-wrong (mirrored/rotated) sketch geometry, so it stays a loud `UnsupportedKernelOperationError`.

## Verification

- typecheck, eslint, prettier, `check:patterns`, `check:boundaries`, `size` — all green
- `healingFns.test.ts` on occt-wasm passes incl. the new direct `fixSelfIntersection` regression

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

