### PR TITLE
fix(topology): reject array passed as mirror/rotate options object

### DIFF
--- a/apps/docs/getting-started/cheat-sheet.md
+++ b/apps/docs/getting-started/cheat-sheet.md
@@ -52,7 +52,7 @@ import { translate, rotate, scale, box } from 'brepjs/quick';
 
 const b = box(10, 10, 10);
 translate(b, [10, 0, 0]);
-rotate(b, 45, { axis: [0, 0, 1], origin: [0, 0, 0] }); // degrees
+rotate(b, 45, { axis: [0, 0, 1], at: [0, 0, 0] }); // degrees
 scale(b, 2); // uniform
 scale(b, [2, 1, 1]); // per-axis
 ```

--- a/apps/docs/tasks/primitives.md
+++ b/apps/docs/tasks/primitives.md
@@ -89,7 +89,7 @@ import { translate, rotate, scale, box, measureVolume, unwrap } from 'brepjs/qui
 const b = box(10, 10, 10);
 
 const moved = translate(b, [10, 0, 0]); // [dx, dy, dz]
-const rotated = rotate(b, 45, { axis: [0, 0, 1], origin: [0, 0, 0] }); // degrees
+const rotated = rotate(b, 45, { axis: [0, 0, 1], at: [0, 0, 0] }); // degrees
 const scaled = scale(b, 2); // uniform 2x
 const stretched = scale(b, [2, 1, 1]); // per-axis
 

--- a/src/topology/api.ts
+++ b/src/topology/api.ts
@@ -37,6 +37,18 @@ export function translate<T extends AnyShape<Dimension>>(shape: Shapeable<T>, v:
   return transforms.translate(resolve(shape), v);
 }
 
+// An array passed where an options object is expected resolves option keys to
+// `Array.prototype` methods — notably `at`, which becomes a function instead of
+// `undefined` and corrupts a plane/pivot origin into NaN, silently producing
+// degenerate geometry rather than an error. Reject it loudly. See issue #1881.
+function assertNotPositionalOptions(options: unknown, fn: string): void {
+  if (Array.isArray(options)) {
+    throw new Error(
+      `${fn}() expects an options object, e.g. ${fn}(shape, { ... }), not an array of coordinates.`
+    );
+  }
+}
+
 /** Options for {@link rotate}. */
 export interface RotateOptions {
   /** Pivot point. Default: [0, 0, 0]. */
@@ -51,6 +63,7 @@ export function rotate<T extends AnyShape<Dimension>>(
   angle: number,
   options?: RotateOptions
 ): T {
+  assertNotPositionalOptions(options, 'rotate');
   const pivotPoint = options?.at;
   return transforms.rotate(resolve(shape), angle, pivotPoint, options?.axis);
 }
@@ -68,6 +81,7 @@ export function mirror<T extends AnyShape<Dimension>>(
   shape: Shapeable<T>,
   options?: MirrorOptions
 ): T {
+  assertNotPositionalOptions(options, 'mirror');
   const planeOrigin = options?.at;
   return transforms.mirror(resolve(shape), options?.normal ?? [1, 0, 0], planeOrigin);
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -279,7 +279,7 @@ describe('rotate()', () => {
 
   it('supports axis and around options', () => {
     const b = box(10, 10, 10);
-    const rotated = rotate(b, 90, { axis: [1, 0, 0], around: [5, 5, 5] });
+    const rotated = rotate(b, 90, { axis: [1, 0, 0], at: [5, 5, 5] });
     expect(unwrap(measureVolume(rotated))).toBeCloseTo(1000, 0);
   });
 });
@@ -291,9 +291,9 @@ describe('mirror()', () => {
     expect(unwrap(measureVolume(mirrored))).toBeCloseTo(1000, 0);
   });
 
-  it('supports normal and origin options', () => {
+  it('supports normal and at options', () => {
     const b = box(10, 10, 10);
-    const mirrored = mirror(b, { normal: [0, 1, 0], origin: [0, 5, 0] });
+    const mirrored = mirror(b, { normal: [0, 1, 0], at: [0, 5, 0] });
     expect(unwrap(measureVolume(mirrored))).toBeCloseTo(1000, 0);
   });
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -66,7 +66,10 @@ import {
   measureArea,
   faceFinder,
   sketchCircle,
+  getFaces,
+  getKernel,
 } from '@/index.js';
+import { faceGeomType } from '@/topology/faceFns.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -292,6 +295,35 @@ describe('mirror()', () => {
     const b = box(10, 10, 10);
     const mirrored = mirror(b, { normal: [0, 1, 0], origin: [0, 5, 0] });
     expect(unwrap(measureVolume(mirrored))).toBeCloseTo(1000, 0);
+  });
+
+  // Regression for #1881: a correctly-mirrored cylinder is a valid (indirect)
+  // solid — non-degenerate volume, a finite analytic radius, and a finite
+  // surface evaluation. The issue's "radius: NaN" symptom came from a malformed
+  // call (an array passed where the options object goes), not from the geometry.
+  it('produces a valid indirect cylinder that keeps a finite radius', () => {
+    const mirrored = mirror(cylinder(5, 10), { normal: [1, 0, 0] });
+    expect(unwrap(measureVolume(mirrored))).toBeCloseTo(Math.PI * 25 * 10, 0);
+
+    const cylFace = getFaces(mirrored).find((f) => faceGeomType(f) === 'CYLINDRE');
+    expect(cylFace).toBeDefined();
+    if (!cylFace) return;
+    const kernel = getKernel();
+    const cylData = kernel.getSurfaceCylinderData(kernel.extractSurfaceFromFace(cylFace.wrapped));
+    expect(cylData?.radius).toBeCloseTo(5, 6);
+    const p = kernel.pointOnSurface(cylFace.wrapped, 1, 5);
+    expect(p.every((c: number) => Number.isFinite(c))).toBe(true);
+  });
+
+  // Regression for #1881: passing positional coordinates where the options
+  // object is expected must fail loudly. An array's `at` key resolves to
+  // `Array.prototype.at`, which previously corrupted the origin into NaN and
+  // silently built a degenerate zero-volume shape.
+  it('rejects an array passed in place of the options object', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberate misuse
+    expect(() => mirror(box(10, 10, 10), [0, 0, 0] as any)).toThrow(/options object/);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberate misuse
+    expect(() => rotate(box(10, 10, 10), 90, [0, 0, 1] as any)).toThrow(/options object/);
   });
 });
 

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -200,13 +200,13 @@ describe('Shape transformations', () => {
 
   it('mirror with Plane object', () => {
     const plane = unwrap(resolvePlane('YZ'));
-    const b = mirror(box(10, 10, 10), { normal: plane.zDir, origin: plane.origin });
+    const b = mirror(box(10, 10, 10), { normal: plane.zDir, at: plane.origin });
     expect(unwrap(measureVolume(b))).toBeCloseTo(1000, 0);
   });
 
   it('mirror with Plane and custom origin', () => {
     const plane = unwrap(resolvePlane('YZ'));
-    const b = mirror(box(10, 10, 10), { normal: plane.zDir, origin: [5, 0, 0] });
+    const b = mirror(box(10, 10, 10), { normal: plane.zDir, at: [5, 0, 0] });
     expect(unwrap(measureVolume(b))).toBeCloseTo(1000, 0);
   });
 

--- a/tests/shapeFns.test.ts
+++ b/tests/shapeFns.test.ts
@@ -125,7 +125,7 @@ describe('translate', () => {
 describe('rotate', () => {
   it('rotates without changing volume', () => {
     const b = box(10, 10, 10);
-    const rotated = rotate(b, 90, { around: [0, 0, 0], axis: [0, 0, 1] });
+    const rotated = rotate(b, 90, { at: [0, 0, 0], axis: [0, 0, 1] });
     expect(rotated).toBeDefined();
     expect(isSolid(rotated)).toBe(true);
   });
@@ -134,7 +134,7 @@ describe('rotate', () => {
 describe('mirror', () => {
   it('mirrors without changing volume', () => {
     const b = box(10, 10, 10);
-    const mirrored = mirror(b, { normal: [0, 1, 0], origin: [0, 0, 0] });
+    const mirrored = mirror(b, { normal: [0, 1, 0], at: [0, 0, 0] });
     expect(mirrored).toBeDefined();
     expect(isSolid(mirrored)).toBe(true);
   });

--- a/tests/topology.test.ts
+++ b/tests/topology.test.ts
@@ -140,12 +140,12 @@ describe('Shape transforms', () => {
   });
   it('rotate', () => {
     expect(
-      unwrap(measureVolume(rotate(box(10, 10, 10), 90, { around: [0, 0, 0], axis: [1, 0, 0] })))
+      unwrap(measureVolume(rotate(box(10, 10, 10), 90, { at: [0, 0, 0], axis: [1, 0, 0] })))
     ).toBeCloseTo(1000, 0);
   });
   it('mirror', () => {
     expect(
-      unwrap(measureVolume(mirror(box(10, 10, 10), { normal: [0, 1, 0], origin: [0, 0, 0] })))
+      unwrap(measureVolume(mirror(box(10, 10, 10), { normal: [0, 1, 0], at: [0, 0, 0] })))
     ).toBeCloseTo(1000, 0);
   });
   it('scale', () => {

--- a/tests/wasmArenaDisposal.test.ts
+++ b/tests/wasmArenaDisposal.test.ts
@@ -519,7 +519,7 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       expect(
         perIterationLeak(() => {
           using b = box(10, 10, 10);
-          using r = rotate(b, 30, [0, 0, 0], [0, 0, 1]);
+          using r = rotate(b, 30, { at: [0, 0, 0], axis: [0, 0, 1] });
           void r;
         })
       ).toBe(0);
@@ -529,7 +529,7 @@ describe.skipIf(!isOcctWasm)('occt-wasm arena disposal', () => {
       expect(
         perIterationLeak(() => {
           using b = box(10, 10, 10);
-          using r = mirror(b, [0, 1, 0], [0, 0, 0]);
+          using r = mirror(b, { normal: [0, 1, 0], at: [0, 0, 0] });
           void r;
         })
       ).toBe(0);


### PR DESCRIPTION
## What

`mirror(shape, options)` and `rotate(shape, angle, options)` now throw a clear error when handed an **array** in place of the options object.

## Why

While investigating #1881 I found its reproduction was a silent API misuse:

```ts
mirror(cylinder(5, 10), [0, 0, 0], [1, 0, 0])   // positional — wrong
```

The public signature is `mirror(shape, { normal?, at? })`. When an array is passed as `options`:

- `options?.normal` → `undefined` → harmless default.
- `options?.at` → **`Array.prototype.at`** (a *function*, since every array has that method) → passed as the plane origin → spreads into `gp_Pnt` as `NaN` → a **degenerate, zero-volume "mirror."**

Every symptom in #1881 (`pointOnSurface` → NaN, `deriveCylinder` radius → NaN, volume 0) traces to that garbage solid — not to the geometry code. `rotate` shares the same `at` option and the same footgun.

## Change

- Add `assertNotPositionalOptions()` guard to `mirror()` and `rotate()` — reject arrays loudly instead of silently corrupting geometry.
- Fix two arena-leak tests that were themselves passing arrays positionally (`rotate(b, 30, [0,0,0], [0,0,1])`, `mirror(b, [0,1,0], [0,0,0])`) → options-object form. The guard caught these real misuses.
- Add a regression test: a correctly-mirrored cylinder stays a valid indirect solid with a finite analytic radius (guards against a *real* future `deriveCylinder` regression), and the array-as-options form throws.

## Notes on #1881

- **Blocker #2 (NaN radius) is a phantom** — an artifact of this misuse; with a correct call `getSurfaceCylinderData` returns `radius: 5` on all kernels. No `deriveCylinder` fix needed.
- **Blocker #1 (occt-wasm `reverseSurfaceU`) is real** and still needs WASM-side work; a pure-TS fold of the u-reversal works on occt but produces wrong geometry on occt-wasm. This PR does not attempt that.

Refs #1881

## Test plan

- `mirror`/`rotate` tests pass on occt, occt-wasm, brepkit.
- Arena-leak suite passes (rotate/mirror/scale leak nothing).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

