### PR TITLE
feat(kernel): sketch on indirect cylindrical faces (occt-wasm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "knip": "6.26.0",
         "lint-staged": "17.0.8",
         "lz-string": "1.5.0",
-        "occt-wasm": "3.7.0",
+        "occt-wasm": "3.8.0",
         "prettier": "3.9.5",
         "puppeteer": "25.3.0",
         "size-limit": "12.1.0",
@@ -62,7 +62,7 @@
         "brepjs-manifold": "^0.1.0",
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-        "occt-wasm": "^3.7.0"
+        "occt-wasm": "^3.8.0"
       },
       "peerDependenciesMeta": {
         "brepjs-manifold": {
@@ -140,7 +140,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -318,7 +317,6 @@
       "integrity": "sha512-Ds16IyPm/dNJPCU8OzApo2gwGrgWT5BYHhE3NFwZbpCveqyvPDB9sZDDkJ5DsdOGT2aC+R3i0/M1OVXF2qdgPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.53.0",
         "@algolia/requester-browser-xhr": "5.53.0",
@@ -1083,7 +1081,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1132,7 +1129,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2321,7 +2317,6 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2375,7 +2370,6 @@
       "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2554,7 +2548,6 @@
       "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.9.0",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
@@ -2834,7 +2827,6 @@
       "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.9.0",
         "@opentelemetry/resources": "2.9.0",
@@ -3786,7 +3778,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -5423,7 +5414,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -5446,7 +5436,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5481,7 +5470,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
       "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -5570,7 +5558,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -6569,7 +6556,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6626,7 +6612,6 @@
       "integrity": "sha512-OGW1q6b91CRSSeiOnM8LxuR5NYJ2esvw66jUZ4IIvdv+ItNkx3pwLuyR+jaCdbGee4ov5WgUnyPryyh11xvByQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.19.0",
         "@algolia/client-abtesting": "5.53.0",
@@ -7392,7 +7377,6 @@
       "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -7499,7 +7483,6 @@
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7944,7 +7927,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8164,8 +8146,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
       "integrity": "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==",
       "devOptional": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
       "version": "3.4.11",
@@ -8423,7 +8404,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8659,7 +8639,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8953,7 +8932,6 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -9233,7 +9211,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9628,7 +9605,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -10377,6 +10353,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -10388,7 +10365,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "11.5.1",
@@ -10891,7 +10869,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "^3.4.10",
         "marked": "14.0.0"
@@ -11051,9 +11028,9 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.7.0.tgz",
-      "integrity": "sha512-k18t7mwcyFrSEZbAIVl3pl5J/dKE3AOUAWuvyB/tWW9FHcN/Imf1Kjh9cJGbfuR/3uBEu1K/a4hATgQyT/abjg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.8.0.tgz",
+      "integrity": "sha512-foHJyvhQNOjRlXHiENaMObLsfO31Eg9qa7N8f/107Jk5hSTxlC9kgBjvzZqP8fjy95G+l+IY2953+zEWnxwQ6A==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "comlink": "^4.4.2"
@@ -11795,6 +11772,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -11941,7 +11919,6 @@
       "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -12316,7 +12293,6 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -12688,8 +12664,7 @@
       "version": "0.185.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -13064,7 +13039,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13383,7 +13357,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -14122,7 +14095,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -14295,7 +14267,6 @@
       "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.39",
         "@vue/compiler-sfc": "3.5.39",
@@ -14648,7 +14619,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -14794,7 +14764,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14910,7 +14879,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14979,7 +14947,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "knip": "6.26.0",
     "lint-staged": "17.0.8",
     "lz-string": "1.5.0",
-    "occt-wasm": "3.7.0",
+    "occt-wasm": "3.8.0",
     "prettier": "3.9.5",
     "puppeteer": "25.3.0",
     "size-limit": "12.1.0",
@@ -287,7 +287,7 @@
     "brepjs-manifold": "^0.1.0",
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
     "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0",
-    "occt-wasm": "^3.7.0"
+    "occt-wasm": "^3.8.0"
   },
   "peerDependenciesMeta": {
     "brepjs-manifold": {

--- a/src/kernel/occtWasm/occtWasmAdapter.ts
+++ b/src/kernel/occtWasm/occtWasmAdapter.ts
@@ -1568,8 +1568,8 @@ export class OcctWasmAdapter implements KernelAdapter {
     return surfaceOps.getSurfaceAxis(this.k, face);
   }
 
-  reverseSurfaceU(_surface: KernelType): KernelType {
-    notImplemented('reverseSurfaceU');
+  reverseSurfaceU(surface: KernelType): KernelType {
+    return surfaceOps.reverseSurfaceU(this.k, surface);
   }
 
   detectSmallFeatures(

--- a/src/kernel/occtWasm/occtWasmTypes.ts
+++ b/src/kernel/occtWasm/occtWasmTypes.ts
@@ -442,7 +442,9 @@ export interface OcctKernelWasm {
   surfaceNormal(faceId: number, u: number, v: number): EmVectorDouble;
   pointOnSurface(faceId: number, u: number, v: number): EmVectorDouble;
   outerWire(faceId: number): number;
+  reverseSurfaceU(faceId: number): number;
   uvBounds(faceId: number): EmVectorDouble;
+  getFaceCylinderData(faceId: number): EmVectorDouble;
   uvFromPoint(faceId: number, x: number, y: number, z: number): EmVectorDouble;
   projectPointOnFace(faceId: number, x: number, y: number, z: number): EmVectorDouble;
   classifyPointOnFace(faceId: number, u: number, v: number): string;

--- a/src/kernel/occtWasm/surfaceOps.ts
+++ b/src/kernel/occtWasm/surfaceOps.ts
@@ -38,6 +38,15 @@ export function outerWire(k: OcctKernelWasm, face: KernelShape): KernelShape {
   return handle('wire', k.outerWire(unwrap(face)));
 }
 
+/**
+ * Reverse a surface's U parametrization. Surfaces are face proxies here, so this
+ * returns a new face carrying the U-reversed geometric surface — evaluating
+ * `pointOnSurface` on it yields the original surface at `UReversedParameter(u)`.
+ */
+export function reverseSurfaceU(k: OcctKernelWasm, surface: KernelShape): KernelShape {
+  return handle('face', k.reverseSurfaceU(unwrap(surface)));
+}
+
 export function surfaceNormal(
   k: OcctKernelWasm,
   face: KernelShape,
@@ -229,8 +238,15 @@ export function getSurfaceCylinderData(
   k: OcctKernelWasm,
   surface: KernelShape
 ): { radius: number; isDirect: boolean } | null {
-  const cyl = deriveCylinder(k, surface);
-  return cyl ? { radius: cyl.radius, isDirect: cyl.isDirect } : null;
+  // OCCT's exact gp_Cylinder accessor (radius + Direct()) — cheaper and more
+  // robust than sampling the surface, which returned NaN for degenerate inputs.
+  const vec = k.getFaceCylinderData(unwrap(surface));
+  try {
+    if (vec.size() < 2) return null; // non-cylinder → facade returns an empty vector
+    return { radius: vec.get(0), isDirect: vec.get(1) === 1 };
+  } finally {
+    vec.delete();
+  }
 }
 
 export function uvFromPoint(

--- a/tests/curves.test.ts
+++ b/tests/curves.test.ts
@@ -8,7 +8,19 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initKernel, currentKernel } from './setup.js';
-import { box, cylinder, cut, getFaces, getEdges, isOk, isErr, unwrap, castShape } from '@/index.js';
+import {
+  box,
+  cylinder,
+  cut,
+  mirror,
+  getFaces,
+  getEdges,
+  meshEdges,
+  isOk,
+  isErr,
+  unwrap,
+  castShape,
+} from '@/index.js';
 import {
   curvesAsEdgesOnFace,
   curvesAsEdgesOnPlane,
@@ -86,9 +98,46 @@ describe('curvesAsEdgesOnFace', () => {
     expect(isOk(result)).toBe(true);
   });
 
-  // occt-wasm-specific: it derives isDirect from the (orientation-aware) face
-  // normal. occt reads gp_Cylinder::Direct() directly and brepkit hardcodes true,
-  // so neither exercises the orientation-compensation path this guards.
+  // Regression for occt-wasm reverseSurfaceU (brepjs#1881): sketching onto an
+  // indirect (left-handed) cylindrical face — produced by mirroring a cylinder —
+  // previously threw `reverseSurfaceU is not yet implemented`. It must now map
+  // the profile onto a small finite patch, not NaN or the full circumference.
+  it.skipIf(currentKernel === 'brepkit' || currentKernel === 'manifold')(
+    'projects curves onto an indirect (mirrored) cylindrical face',
+    () => {
+      const kernel = getKernel();
+      const mcyl = mirror(cylinder(5, 10), { normal: [1, 0, 0] });
+      const cylFace = getFaces(mcyl).find((f) => kernel.surfaceType(f.wrapped) === 'cylinder');
+      expect(cylFace).toBeDefined();
+      if (!cylFace) return;
+
+      const cylData = kernel.getSurfaceCylinderData(kernel.extractSurfaceFromFace(cylFace.wrapped));
+      expect(cylData?.radius).toBeCloseTo(5, 6);
+      expect(cylData?.isDirect).toBe(false); // genuinely indirect → reversal path
+
+      const curve = new Curve2D(kernel.makeLine2d(8, 2, 14, 6));
+      const result = curvesAsEdgesOnFace([curve], cylFace, 'original');
+      expect(isOk(result)).toBe(true);
+
+      const edges = unwrap(result);
+      expect(edges.length).toBeGreaterThan(0);
+      const m = meshEdges(edges[0]);
+      expect(m.lines.length).toBeGreaterThan(0);
+      let maxAbsXY = 0;
+      for (let i = 0; i < m.lines.length; i += 3) {
+        expect(Number.isFinite(m.lines[i])).toBe(true);
+        maxAbsXY = Math.max(maxAbsXY, Math.hypot(m.lines[i], m.lines[i + 1]));
+      }
+      // Points lie on the radius-5 cylinder, not scattered/NaN.
+      expect(maxAbsXY).toBeCloseTo(5, 1);
+      for (const e of edges) e[Symbol.dispose]();
+    }
+  );
+
+  // occt-wasm reads gp_Cylinder::Direct() via the facade's getFaceCylinderData;
+  // occt reads it directly and brepkit hardcodes true. This guards that
+  // occt-wasm reports the surface's true handedness for a reversed face rather
+  // than being thrown off by face orientation.
   it.skipIf(currentKernel !== 'occt-wasm')(
     'reports isDirect independent of face orientation (reversed bore)',
     () => {


### PR DESCRIPTION
## What

Closes #1881. Sketching a 2D profile onto an **indirect (left-handed) cylindrical face** — e.g. the cylindrical face of a mirrored cylinder — now works on the default occt-wasm kernel instead of throwing `UnsupportedKernelOperationError: reverseSurfaceU is not yet implemented`.

## How

- **Wire `reverseSurfaceU`** in `occtWasmAdapter` to occt-wasm 3.8.0's new facade primitive ([andymai/occt-wasm#217](https://github.com/andymai/occt-wasm/pull/217)), removing the `notImplemented` stub. occt-wasm represents surfaces as face proxies, so the primitive returns a face carrying the `UReverse()`'d `Geom_Surface`; `pointOnSurface` on it then evaluates the original at `UReversedParameter(u)`.
- **Fold `getSurfaceCylinderData` onto OCCT's exact `gp_Cylinder` accessor** (the facade's `getFaceCylinderData`: radius + `Direct()`) instead of sampling the surface. The sampled derivation returned `NaN` for degenerate inputs; this is exact, cheaper, and NaN-proof. (`deriveCylinder` stays for the axis origin/direction in `getSurfaceAxis`.)
- Bump `occt-wasm` 3.7.0 → 3.8.0.

## Verification

The sketch on a mirrored cylinder now lands the profile on a small finite patch **byte-identical to opencascade.js's native reversal** (`bbox [0.15,-5,2, 4.71,-1.67,6]`), not NaN or the full circumference (the earlier broken-fold symptom).

## Test plan

- New regression test in `curves.test.ts`: projecting curves onto an indirect (mirrored) cylindrical face returns Ok and maps onto the radius-5 cylinder. Passes on occt-wasm and occt; skipped on brepkit/manifold (brepkit represents the mirror as direct).
- The existing reversed-bore `isDirect` test still passes with the exact-accessor fold-in (its stale comment updated).
- Full `curves`/`2d`/`blueprint`/`surface`/`api`/`sweep`/arena-disposal suites green across kernels; typecheck, lint, boundaries, format, knip all clean.

## Background

occt-wasm PR #217 (merged, released as 3.8.0) added the WASM-side `reverseSurfaceU`; this PR is the brepjs-side wiring. A pure-TS fold of the reversal was equivalent to native on opencascade.js but produced wrong geometry on occt-wasm, so the kernel primitive was genuinely required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/brepjs/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

