### PR TITLE
build(deps): pin @emnapi packages to stop npm pruning them from the lockfile

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -25,7 +25,17 @@ const config: KnipConfig = {
       // the lockfile with sharp's platform binaries for no runtime/CI benefit.
       // brepjs-voxel-wasm is a sibling workspace package imported only by the
       // out-of-src test suite (tests/voxel*.test.ts), which root `project` excludes.
-      ignoreDependencies: ['@types/react', 'sharp', 'brepjs-voxel-wasm'],
+      // @emnapi/core + @emnapi/runtime are never imported: they are declared only to
+      // stop npm < 11.11 pruning them from the lockfile (they are otherwise reachable
+      // just as hoisted optional peer deps of the *-wasm32-wasi binaries), which made
+      // CI's npm fail every Dependabot PR with "Missing: @emnapi/... from lock file".
+      ignoreDependencies: [
+        '@types/react',
+        'sharp',
+        'brepjs-voxel-wasm',
+        '@emnapi/core',
+        '@emnapi/runtime',
+      ],
     },
     // examples/ holds runnable demos (entry points, not imported by src); the
     // IfcOpenShell validator under scripts/ is Python. src/ stays fully checked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
       "devDependencies": {
         "@commitlint/cli": "21.2.1",
         "@commitlint/config-conventional": "21.2.0",
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
         "@eslint/js": "10.0.1",
         "@size-limit/file": "12.1.0",
         "@types/opentype.js": "1.3.9",
@@ -1200,7 +1202,6 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -1212,7 +1213,6 @@
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -256,6 +256,8 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
     "@commitlint/config-conventional": "21.2.0",
+    "@emnapi/core": "1.11.2",
+    "@emnapi/runtime": "1.11.2",
     "@eslint/js": "10.0.1",
     "@size-limit/file": "12.1.0",
     "@types/opentype.js": "1.3.9",


### PR DESCRIPTION
## Problem

Every Dependabot PR fails **all** CI jobs at the shared `npm ci` setup step:

```
npm error code EUSAGE
npm error Missing: @emnapi/core@1.11.2 from lock file
npm error Missing: @emnapi/runtime@1.11.2 from lock file
```

`@emnapi/core` and `@emnapi/runtime` are reachable only as *hoisted optional peer deps* of the `*-wasm32-wasi` platform binaries (`@tailwindcss/oxide`, `@rolldown/binding`, `@oxc-parser/binding`, `@oxc-resolver/binding`), which never install on linux-x64. npm versions older than 11.11 therefore prune the two package nodes as "optional and not strictly required", while leaving the `peerDependencies` references pointing at them. CI's npm validates strictly and rejects the resulting dangling graph.

Dependabot regenerates lockfiles with an older npm, so it reproduces this on every bump. `@dependabot rebase` does not help: it regenerates with the same npm and emits the same broken lockfile. The lockfile has to be hand-patched on each PR, which has now been done for #807, #808, #813, #814, #815, #998, and most recently #1888, #1889, #1890.

## Fix

Declare both packages as direct root `devDependencies`. npm only prunes packages reachable *solely* as optional peer deps; promoting them to direct dependencies makes them unconditionally required, so every npm version emits the package nodes and Dependabot's lockfiles come out valid on the first try.

## Verification

Reproduced and fixed with npm 11.6.1 (an older-npm stand-in for Dependabot's runner), `npm install --package-lock-only`:

| lockfile state | `@emnapi/core` + `@emnapi/runtime` |
| --- | --- |
| `main` as-is | **dropped** (reproduces the CI failure) |
| with this change | **kept** |

`npm ci --dry-run --ignore-scripts` exits 0 and now reports `add @emnapi/core 1.11.2`, confirming the packages are genuinely installed rather than skipped as optional.

## Notes on the diff

The lockfile change is hand-applied rather than regenerated. A full `npm install` also stripped `"peer": true` from ~35 unrelated packages, which is metadata drift from my local npm version, exactly the kind of churn that causes this class of desync. The committed diff is only the semantic delta: two entries in the root `devDependencies` block, and dropping `"optional": true` from the two package nodes.

Versions are exact-pinned to `1.11.2` to match the other 28 root devDependencies and the version already resolved on `main`.

The two packages are dev-only, MIT, and tiny. They are added to knip's `ignoreDependencies` since nothing imports them; they exist purely to pin the lockfile.
