### PR TITLE
fix(deps): bump dompurify to 3.4.12 for GHSA-c2j3-45gr-mqc4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8168,9 +8168,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
Resolves Dependabot alert #134 (low): [GHSA-c2j3-45gr-mqc4](https://github.com/advisories/GHSA-c2j3-45gr-mqc4), `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements.

`dompurify` is transitive, reached through `mermaid` and `posthog-js` (apps/docs) and `monaco-editor` and `posthog-js` (apps/playground). It is not a dependency of the published `brepjs` package.

3.4.12 satisfies every declaring range already in the tree (`^3.3.3`, `^3.4.10`, `^3.3.2`), so this is a lockfile-only bump with no `package.json` change and no other resolution movement.

## Diff scope

Hand-applied rather than regenerated. A full `npm update dompurify` produces the same 3-line dompurify change plus ~40 lines of unrelated `"peer": true` removals, which is metadata drift from the local npm version rather than anything to do with this bump. Only the semantic delta is committed: version, resolved URL, and integrity hash.

Verified with `npm ci --dry-run --ignore-scripts` (exit 0), which confirms the integrity hash resolves.

## Not addressed here

The other two open alerts are blocked upstream and cannot be fixed by a bump:

- **#135 sharp (high)** needs `>=0.35.0`, but the latest `ndarray-pixels` (5.0.1) still pins `sharp: ^0.34.0`. Reached only via `packages/brepjs-manifold`, which is unpublished, so no consumer is affected.
- **#128 @hono/node-server (medium)** needs `>=2.0.5`, but the latest `@modelcontextprotocol/sdk` (1.29.0) still pins `^1.19.9`. The advisory covers path traversal in `serve-static`, which neither the SDK (it uses the package only for Node/Web-Standard conversion in `streamableHttp`) nor `brepjs-cad` invokes.

Both are being dismissed rather than forced via `overrides` that would cross their parents' declared compatibility ranges.
