### PR TITLE
fix(kernel): expand brepkit edge polylines into segment pairs

### DIFF
--- a/src/kernel/brepkit/meshOps.test.ts
+++ b/src/kernel/brepkit/meshOps.test.ts
@@ -55,6 +55,19 @@ describe('brepkit meshEdges', () => {
     }
   });
 
+  it('drops degenerate pairs, matching the occtWasm adapter', () => {
+    const partial: Partial<BrepkitKernel> = {
+      meshEdgesAll: () => ({
+        // A repeated point mid-polyline yields a zero-length segment.
+        positions: new Float64Array([0, 0, 0, 1, 0, 0, 1, 0, 0, 2, 0, 0]),
+        offsets: new Uint32Array([0]),
+        edgeCount: 1,
+      }),
+    };
+    const { lines } = meshEdges(partial as BrepkitKernel, shape, 0.1, 0.35);
+    expect(Array.from(lines)).toEqual([0, 0, 0, 1, 0, 0, 1, 0, 0, 2, 0, 0]);
+  });
+
   it('reports edgeGroups indexing the expanded buffer', () => {
     const { lines, edgeGroups } = meshEdges(stubKernel(), shape, 0.1, 0.35);
     expect(edgeGroups).toEqual([

--- a/src/kernel/brepkit/meshOps.test.ts
+++ b/src/kernel/brepkit/meshOps.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { meshEdges } from './meshOps.js';
+import type { BrepkitKernel } from './brepkitWasmTypes.js';
+import type { KernelShape } from '../types.js';
+
+/**
+ * brepkit returns one polyline per edge; `lines` is consumed as GL_LINES.
+ * Two edges: a 2-point straight edge and a 3-point (odd) polyline. The odd
+ * count is what used to leak a segment across the edge boundary.
+ */
+function stubKernel(): BrepkitKernel {
+  return {
+    meshEdgesAll: () => ({
+      positions: new Float32Array([
+        0, 0, 0, 1, 0, 0, // edge 0: straight, 2 points
+        5, 0, 0, 5, 1, 0, 5, 2, 0, // edge 1: 3 points (odd)
+      ]),
+      offsets: new Uint32Array([0, 6]),
+      edgeCount: 2,
+    }),
+  } as unknown as BrepkitKernel;
+}
+
+describe('brepkit meshEdges', () => {
+  const shape = { __brepkit: true, type: 'solid', id: 1 } as unknown as KernelShape;
+
+  it('expands per-edge polylines into disjoint segment pairs', () => {
+    const { lines } = meshEdges(stubKernel(), shape, 0.1, 0.35);
+    // edge 0 -> 1 segment, edge 1 -> 2 segments; 3 segments = 6 vertices.
+    expect(Array.from(lines)).toEqual([
+      0, 0, 0, 1, 0, 0,
+      5, 0, 0, 5, 1, 0,
+      5, 1, 0, 5, 2, 0,
+    ]);
+  });
+
+  it('never joins one edge to the next', () => {
+    const { lines } = meshEdges(stubKernel(), shape, 0.1, 0.35);
+    for (let i = 0; i < lines.length; i += 6) {
+      const [ax, ay, az, bx, by, bz] = [
+        lines[i]!, lines[i + 1]!, lines[i + 2]!,
+        lines[i + 3]!, lines[i + 4]!, lines[i + 5]!,
+      ];
+      const len = Math.hypot(bx - ax, by - ay, bz - az);
+      // The stray segment would run from (1,0,0) to (5,0,0): length 4.
+      expect(len).toBeLessThan(2);
+    }
+  });
+
+  it('reports edgeGroups indexing the expanded buffer', () => {
+    const { lines, edgeGroups } = meshEdges(stubKernel(), shape, 0.1, 0.35);
+    expect(edgeGroups).toEqual([
+      { start: 0, count: 2, edgeHash: 0 },
+      { start: 2, count: 4, edgeHash: 1 },
+    ]);
+    const last = edgeGroups[edgeGroups.length - 1]!;
+    expect(last.start + last.count).toBe(lines.length / 3);
+  });
+});

--- a/src/kernel/brepkit/meshOps.test.ts
+++ b/src/kernel/brepkit/meshOps.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { meshEdges } from './meshOps.js';
 import type { BrepkitKernel } from './brepkitWasmTypes.js';
-import type { KernelShape } from '../types.js';
+import { vec3At } from '@/utils/vec3.js';
 
 /**
  * brepkit returns one polyline per edge; `lines` is consumed as GL_LINES.
- * Two edges: a 2-point straight edge and a 3-point (odd) polyline. The odd
- * count is what used to leak a segment across the edge boundary.
+ * Two edges here: a 2-point straight edge and a 3-point (odd) polyline. The
+ * odd count is what used to leak a segment across the edge boundary.
  */
 function stubKernel(): BrepkitKernel {
-  return {
+  const partial: Partial<BrepkitKernel> = {
     meshEdgesAll: () => ({
       positions: new Float32Array([
         0, 0, 0, 1, 0, 0, // edge 0: straight, 2 points
@@ -18,12 +18,14 @@ function stubKernel(): BrepkitKernel {
       offsets: new Uint32Array([0, 6]),
       edgeCount: 2,
     }),
-  } as unknown as BrepkitKernel;
+  };
+  return partial as BrepkitKernel;
 }
 
-describe('brepkit meshEdges', () => {
-  const shape = { __brepkit: true, type: 'solid', id: 1 } as unknown as KernelShape;
+// `KernelShape` is an opaque `any`, so the handle needs no assertion.
+const shape = { __brepkit: true, type: 'solid', id: 1 };
 
+describe('brepkit meshEdges', () => {
   it('expands per-edge polylines into disjoint segment pairs', () => {
     const { lines } = meshEdges(stubKernel(), shape, 0.1, 0.35);
     // edge 0 -> 1 segment, edge 1 -> 2 segments; 3 segments = 6 vertices.
@@ -34,16 +36,13 @@ describe('brepkit meshEdges', () => {
     ]);
   });
 
-  it('never joins one edge to the next', () => {
+  it('never joins the end of one edge to the start of the next', () => {
     const { lines } = meshEdges(stubKernel(), shape, 0.1, 0.35);
     for (let i = 0; i < lines.length; i += 6) {
-      const [ax, ay, az, bx, by, bz] = [
-        lines[i]!, lines[i + 1]!, lines[i + 2]!,
-        lines[i + 3]!, lines[i + 4]!, lines[i + 5]!,
-      ];
-      const len = Math.hypot(bx - ax, by - ay, bz - az);
-      // The stray segment would run from (1,0,0) to (5,0,0): length 4.
-      expect(len).toBeLessThan(2);
+      const [ax, ay, az] = vec3At(lines, i);
+      const [bx, by, bz] = vec3At(lines, i + 3);
+      // The leaked segment ran from (1,0,0) to (5,0,0): length 4.
+      expect(Math.hypot(bx - ax, by - ay, bz - az)).toBeLessThan(2);
     }
   });
 
@@ -53,7 +52,7 @@ describe('brepkit meshEdges', () => {
       { start: 0, count: 2, edgeHash: 0 },
       { start: 2, count: 4, edgeHash: 1 },
     ]);
-    const last = edgeGroups[edgeGroups.length - 1]!;
-    expect(last.start + last.count).toBe(lines.length / 3);
+    const last = edgeGroups[edgeGroups.length - 1];
+    expect((last?.start ?? 0) + (last?.count ?? 0)).toBe(lines.length / 3);
   });
 });

--- a/src/kernel/brepkit/meshOps.test.ts
+++ b/src/kernel/brepkit/meshOps.test.ts
@@ -11,9 +11,22 @@ import { vec3At } from '@/utils/vec3.js';
 function stubKernel(): BrepkitKernel {
   const partial: Partial<BrepkitKernel> = {
     meshEdgesAll: () => ({
-      positions: new Float32Array([
-        0, 0, 0, 1, 0, 0, // edge 0: straight, 2 points
-        5, 0, 0, 5, 1, 0, 5, 2, 0, // edge 1: 3 points (odd)
+      positions: new Float64Array([
+        0,
+        0,
+        0,
+        1,
+        0,
+        0, // edge 0: straight, 2 points
+        5,
+        0,
+        0,
+        5,
+        1,
+        0,
+        5,
+        2,
+        0, // edge 1: 3 points (odd)
       ]),
       offsets: new Uint32Array([0, 6]),
       edgeCount: 2,
@@ -29,11 +42,7 @@ describe('brepkit meshEdges', () => {
   it('expands per-edge polylines into disjoint segment pairs', () => {
     const { lines } = meshEdges(stubKernel(), shape, 0.1, 0.35);
     // edge 0 -> 1 segment, edge 1 -> 2 segments; 3 segments = 6 vertices.
-    expect(Array.from(lines)).toEqual([
-      0, 0, 0, 1, 0, 0,
-      5, 0, 0, 5, 1, 0,
-      5, 1, 0, 5, 2, 0,
-    ]);
+    expect(Array.from(lines)).toEqual([0, 0, 0, 1, 0, 0, 5, 0, 0, 5, 1, 0, 5, 1, 0, 5, 2, 0]);
   });
 
   it('never joins the end of one edge to the start of the next', () => {

--- a/src/kernel/brepkit/meshOps.ts
+++ b/src/kernel/brepkit/meshOps.ts
@@ -64,16 +64,35 @@ export function meshEdges(
   const offsets = edgeLines.offsets;
   const edgeCount = edgeLines.edgeCount;
 
+  // brepkit returns one POLYLINE per edge (`offsets` indexes each edge's first
+  // point). `lines` is consumed as GL_LINES — disjoint vertex pairs — so the
+  // polylines must be expanded, two vertices per segment, the way OCCT's native
+  // buffer already arrives. Passing the polylines through unchanged both drops
+  // every other segment and, wherever an edge has an odd point count, emits one
+  // segment running from that edge's last point to the next edge's first point:
+  // a stray line between unrelated parts of the model.
+  const segments: number[] = [];
   const edgeGroups: Array<{ start: number; count: number; edgeHash: number }> = [];
   for (let i = 0; i < edgeCount; i++) {
     const startIdx = wasmIndex(offsets, i);
     const endIdx = i + 1 < edgeCount ? wasmIndex(offsets, i + 1) : positions.length;
     const pointCount = (endIdx - startIdx) / 3;
-    edgeGroups.push({ start: startIdx / 3, count: pointCount, edgeHash: i });
+    const segStart = segments.length / 3;
+    for (let p = 0; p + 1 < pointCount; p++) {
+      const a = startIdx + p * 3;
+      const b = a + 3;
+      segments.push(positions[a]!, positions[a + 1]!, positions[a + 2]!);
+      segments.push(positions[b]!, positions[b + 1]!, positions[b + 2]!);
+    }
+    edgeGroups.push({
+      start: segStart,
+      count: segments.length / 3 - segStart,
+      edgeHash: i,
+    });
   }
 
   return {
-    lines: new Float32Array(positions),
+    lines: new Float32Array(segments),
     edgeGroups,
   };
 }

--- a/src/kernel/brepkit/meshOps.ts
+++ b/src/kernel/brepkit/meshOps.ts
@@ -65,12 +65,12 @@ export function meshEdges(
   const edgeCount = edgeLines.edgeCount;
 
   // brepkit returns one POLYLINE per edge (`offsets` indexes each edge's first
-  // point). `lines` is consumed as GL_LINES — disjoint vertex pairs — so the
-  // polylines must be expanded, two vertices per segment, the way OCCT's native
-  // buffer already arrives. Passing the polylines through unchanged both drops
-  // every other segment and, wherever an edge has an odd point count, emits one
-  // segment running from that edge's last point to the next edge's first point:
-  // a stray line between unrelated parts of the model.
+  // point, already ×3). `lines` is a flat line list — consecutive point pairs,
+  // one per segment, for THREE.LineSegments — so each polyline has to be
+  // expanded into pairs. Emitting the raw polyline as a line list draws every
+  // other segment and joins the end of one edge to the start of the next,
+  // putting a stray line across empty space wherever those points differ.
+  // Same expansion the occtWasm adapter does; manifold emits pairs directly.
   const segments: number[] = [];
   const edgeGroups: Array<{ start: number; count: number; edgeHash: number }> = [];
   for (let i = 0; i < edgeCount; i++) {
@@ -80,7 +80,10 @@ export function meshEdges(
     const segStart = segments.length / 3;
     for (let p = 0; p + 1 < pointCount; p++) {
       const a = startIdx + p * 3;
-      segments.push(...vec3At(positions, a), ...vec3At(positions, a + 3));
+      const [x0, y0, z0] = vec3At(positions, a);
+      const [x1, y1, z1] = vec3At(positions, a + 3);
+      if (x0 === x1 && y0 === y1 && z0 === z1) continue; // degenerate pair
+      segments.push(x0, y0, z0, x1, y1, z1);
     }
     edgeGroups.push({
       start: segStart,

--- a/src/kernel/brepkit/meshOps.ts
+++ b/src/kernel/brepkit/meshOps.ts
@@ -12,7 +12,7 @@ import type {
 } from '@/kernel/types.js';
 import type { KernelAdapter } from '@/kernel/interfaces/index.js';
 import { type BrepkitHandle, unwrap, toArray, DEFAULT_DEFLECTION } from './helpers.js';
-import { wasmIndex } from '@/utils/vec3.js';
+import { wasmIndex, vec3At } from '@/utils/vec3.js';
 
 export function mesh(
   bk: BrepkitKernel,
@@ -80,9 +80,7 @@ export function meshEdges(
     const segStart = segments.length / 3;
     for (let p = 0; p + 1 < pointCount; p++) {
       const a = startIdx + p * 3;
-      const b = a + 3;
-      segments.push(positions[a]!, positions[a + 1]!, positions[a + 2]!);
-      segments.push(positions[b]!, positions[b + 1]!, positions[b + 2]!);
+      segments.push(...vec3At(positions, a), ...vec3At(positions, a + 3));
     }
     edgeGroups.push({
       start: segStart,


### PR DESCRIPTION
## What

`meshEdges` in the brepkit adapter passed the kernel's per-edge **polylines** straight into `KernelEdgeMeshResult.lines`, which is consumed as **GL_LINES** — disjoint vertex pairs. OCCT's native buffer already arrives pair-expanded; brepkit's does not, so it has to be expanded here.

## Symptom

Spurious straight lines drawn across unrelated parts of the model, reported against the gridfinity layout tool's bin preview.

Two distinct effects, both from the same misread:

1. **Every second segment of each edge was dropped** — a polyline `p0 p1 p2 p3` renders as `(p0,p1)` and `(p2,p3)`, losing `(p1,p2)`. Curved edges came out broken.
2. **Odd point counts leaked across the edge boundary** — the pairing straddled into the next edge, emitting a segment from one edge's last point to the next edge's first point. Those endpoints can be anywhere on the model.

## Measurements

Same 2×1 gridfinity bin, long (>2 mm) non-axis-aligned segments:

| | long skew segments | vertical segments | interior-point repeats |
|---|---|---|---|
| OCCT (control) | 40 | 112 | 6326 / 6679 |
| brepkit, before | **163** | 67 | **11 / 9871** |
| brepkit, after | **40** | **112** | 18866 / 19291 |

The repeats column is the format signature: a pair-expanded buffer repeats interior points, a polyline never does. Before the fix brepkit's buffer was unambiguously polyline-shaped.

Examples of the stray segments, all now gone:

```
len=76.05  (-41.75,-38.00,25.30) -> (-39.85, 38.00,23.40)
len=76.02  (-39.85,-38.00,23.40) -> (-39.85, 38.00,21.60)
```

Each joins the top of the lip chamfer at one corner to the bottom of it 76 mm away. After the fix the 40 remaining skew segments are exactly OCCT's — genuine chamfer rungs like `(38.00,-39.85,23.40) -> (38.00,-41.75,25.30)` — and the vertical count matches OCCT exactly as the dropped segments come back.

## Precedent: occtWasm already fixes this

`src/kernel/occtWasm/meshOps.ts` does exactly this expansion, and its comment describes the same failure almost verbatim:

> `KernelEdgeMeshResult.lines` is a flat *line list* (consecutive point pairs, one per segment) for THREE.LineSegments — so expand each polyline into pairs. Emitting the raw polyline as a line list draws every other segment and joins the end of one edge to the start of the next: zero-length pairs where edges share a vertex, spurious diagonals across empty space where they don't.

So the contract was already settled; brepkit was the only adapter still passing polylines through. This change adopts the same `edgeGroups` semantics (start/count indexing the expanded buffer) and the same skip of degenerate pairs. Manifold emits pairs directly and already agreed.

## Not a geometry bug

Worth stating since it looked like one at first: these were never real B-rep edges. brepkit's own topology has no such edges — probing the lofted lip profile and the full 1×1 bin natively finds zero long diagonals, and the tessellated mesh is structurally valid throughout. The defect was purely in how this adapter framed the buffer.

## Tests

`src/kernel/brepkit/meshOps.test.ts` stubs the kernel with two edges — one straight 2-point edge and one 3-point (odd) polyline, the case that used to leak — and asserts the expanded pairs, that no segment spans an edge boundary, and that `edgeGroups` indexes the expanded buffer.

## Follow-up, not in this PR

This function calls `meshEdgesAll`, which brepkit documents as "useful for debugging topology", rather than `meshEdges`, whose docs say it filters edges that "arise from boolean face-splitting and don't represent visible creases". On a 1×1 bin that is 16 extra edges — two full rings of co-surface lip-junction seams. The existing comment justifies it as "for OCCT parity" and I could not find the original reasoning in history, so I left it alone rather than bundle a behaviour change with a clear bug fix.
