### PR TITLE
chore(ci): raise total JS size budget to 380 kB and ignore typescript majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
       # both ship the same code.) Re-allow once opentype.js supports this lookup format.
       - dependency-name: opentype.js
         versions: ['1.3.5', '2.x']
+      # TypeScript 7 cannot resolve: typescript-eslint (through 8.65.0) declares a peer
+      # range of >=4.8.4 <6.1.0, and typedoc 0.28.x conflicts the same way, so `npm
+      # install` fails with ERESOLVE before any job runs. Re-allow once both widen their
+      # peer ranges to accept 7.x.
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
     groups:
       minor-and-patch:
         update-types:

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,5 +1,5 @@
 [
-  { "name": "total (all JS)", "path": "dist/*.js", "limit": "350 kB" },
+  { "name": "total (all JS)", "path": "dist/*.js", "limit": "380 kB" },
   { "name": "brepjs", "path": "dist/brepjs.js", "limit": "57 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },


### PR DESCRIPTION
## Size budget

The `total (all JS)` budget was 350 kB while `main` measures **349,733 B** — 267 bytes of headroom (0.08% of budget). Any dependency bump trips it.

That is what happened to #1902 (the 12-package `minor-and-patch` group): it measures **350,699 B**, failing by **699 bytes** (0.2%).

| | bytes | vs 350 kB |
|---|---|---|
| `main` (base) | 349,733 | −267 |
| #1902 (head) | 350,699 | **+699** ❌ |

This is budget calibration, not bundle bloat. 380 kB restores ~8% headroom. The 17 per-entrypoint budgets are unchanged — they still catch real per-module regressions, and none of them were close to their limits.

## TypeScript majors

#1903 (`typescript` 6.0.3 → 7.0.2) fails every job at `npm install`:

```
npm error While resolving: typedoc@0.28.20
npm error Found: typescript@7.0.2
npm error peer typescript@">=5" from cosmiconfig-typescript-loader@6.3.0
```

`typescript-eslint` through its latest 8.65.0 still declares `peer typescript >=4.8.4 <6.1.0`, and `typedoc` 0.28.x conflicts the same way. TS 7 cannot resolve in this tree, so the PR is unmergeable until upstream widens those ranges.

Added a `semver-major` ignore for `typescript` following the existing `opentype.js` precedent, with the reason recorded inline so it can be revisited. Minor and patch TypeScript updates still flow normally.

Closes #1903.