### PR TITLE
fix(2d): free 2D handles stranded by custom corners

### DIFF
--- a/src/2d/README.md
+++ b/src/2d/README.md
@@ -78,3 +78,4 @@ graph TB
 5. **Serialization**: `Curve2D.serialize()` enables persistence; curves can be saved and restored
 6. **Kernel-abstracted**: All 2D curve operations (evaluation, type queries, circle/ellipse data, Bezier poles, bounding boxes) go through `getKernel()` / `getKernel2D()` methods. No direct kernel API calls in this module.
 7. **Disposable**: `Blueprint`, `Curve2D`, and `BoundingBox2d` implement `Symbol.dispose`, enabling `using` keyword for deterministic WASM cleanup: `using bp = new BlueprintSketcher().movePointerTo([0,0]).lineTo([10,0]).close();`
+8. **`boundingBox` is borrowed**: `Curve2D.boundingBox` caches its `BoundingBox2d` and disposes it with the curve, so a box read from a curve must not outlive it. Clone the curve first if you need an independent box.

--- a/src/2d/blueprints/baseSketcher2d.ts
+++ b/src/2d/blueprints/baseSketcher2d.ts
@@ -27,6 +27,17 @@ const cornerModeFns = {
   fillet: filletCurves,
 } as const;
 
+/**
+ * Delete the curves a corner function consumed. Corner functions return their
+ * inputs untouched when they bail (collinear curves, failed offset), so only
+ * the ones absent from the result are ours to free.
+ */
+function disposeConsumedCurves(consumed: Curve2D[], produced: Curve2D[]): void {
+  consumed.forEach((curve) => {
+    if (!produced.includes(curve)) curve.delete();
+  });
+}
+
 function buildCornerFunction(
   radius: number | ((first: Curve2D, second: Curve2D) => Curve2D[]),
   mode: 'chamfer' | 'fillet' | 'dogbone'
@@ -131,7 +142,9 @@ export class BaseSketcher2d {
     if (!previousCurve)
       bug('Sketcher2d.saveCurve', 'No previous curve available for custom corner');
 
-    this.pendingCurves.push(...this._nextCorner(previousCurve, curve));
+    const cornered = this._nextCorner(previousCurve, curve);
+    disposeConsumedCurves([previousCurve, curve], cornered);
+    this.pendingCurves.push(...cornered);
     this._nextCorner = null;
   }
 
@@ -435,7 +448,9 @@ export class BaseSketcher2d {
     if (!previousCurve || !curve)
       bug('Sketcher2d._customCornerLastWithFirst', 'Not enough curves to close and fillet');
 
-    this.pendingCurves.push(...buildCornerFunction(radius, mode)(previousCurve, curve));
+    const cornered = buildCornerFunction(radius, mode)(previousCurve, curve);
+    disposeConsumedCurves([previousCurve, curve], cornered);
+    this.pendingCurves.push(...cornered);
   }
 
   protected _closeSketch(): void {

--- a/src/2d/lib/curve2D.ts
+++ b/src/2d/lib/curve2D.ts
@@ -58,6 +58,10 @@ export class Curve2D {
   delete(): void {
     if (!this._deleted) {
       this._deleted = true;
+      if (this._boundingBox) {
+        this._boundingBox.delete();
+        this._boundingBox = null;
+      }
       if (typeof this._wrapped.delete === 'function') {
         unregisterFromCleanup(this._wrapped);
         this._wrapped.delete();
@@ -69,7 +73,12 @@ export class Curve2D {
     this.delete();
   }
 
-  /** Compute (and cache) the 2D bounding box of this curve. */
+  /**
+   * Compute (and cache) the 2D bounding box of this curve.
+   *
+   * @remarks The returned box is owned by the curve and is disposed when the
+   * curve is deleted. Clone it if it must outlive the curve.
+   */
   get boundingBox() {
     if (this._boundingBox) return this._boundingBox;
     const kernel = getKernel();

--- a/src/2d/lib/curve2dFns.ts
+++ b/src/2d/lib/curve2dFns.ts
@@ -23,7 +23,12 @@ export function reverseCurve(curve: Curve2D): Curve2D {
   return cloned;
 }
 
-/** Get the bounding box of a 2D curve. */
+/**
+ * Get the bounding box of a 2D curve.
+ *
+ * @remarks The box is borrowed from the curve's cache and is disposed with the
+ * curve. Clone it if it must outlive the curve.
+ */
 export function curve2dBoundingBox(curve: Curve2D): BoundingBox2d {
   return curve.boundingBox;
 }

--- a/src/2d/lib/customCorners.ts
+++ b/src/2d/lib/customCorners.ts
@@ -1,4 +1,5 @@
 import { Curve2D } from './curve2D.js';
+import type { Point2D } from './definitions.js';
 import { isPoint2D } from './definitions.js';
 import { intersectCurves } from './intersections.js';
 import { unwrap, isOk } from '@/core/result.js';
@@ -12,6 +13,22 @@ import { make2dOffset } from './offset.js';
 import { add2d, crossProduct2d, normalize2d, scalarMultiply2d } from './vectorOperations.js';
 import { wasmIndex } from '@/utils/vec3.js';
 
+/** Unwrap an intersection, discarding the common-segment curves the caller does not use. */
+function intersectionPoints(first: Curve2D, second: Curve2D): Point2D[] {
+  const result = unwrap(intersectCurves(first, second));
+  result.commonSegments.forEach((c) => {
+    c.delete();
+  });
+  return result.intersections;
+}
+
+/** Delete every split piece that is neither kept nor the curve that was split. */
+function disposeUnusedSplits(pieces: Curve2D[], kept: Curve2D, source: Curve2D): void {
+  pieces.forEach((piece) => {
+    if (piece !== kept && piece !== source) piece.delete();
+  });
+}
+
 function removeCorner(firstCurve: Curve2D, secondCurve: Curve2D, radius: number) {
   const sinAngle = crossProduct2d(firstCurve.tangentAt(1), secondCurve.tangentAt(0));
 
@@ -24,34 +41,44 @@ function removeCorner(firstCurve: Curve2D, secondCurve: Curve2D, radius: number)
   const firstOffset = make2dOffset(firstCurve, offset);
   const secondOffset = make2dOffset(secondCurve, offset);
 
-  if (!(firstOffset instanceof Curve2D) || !(secondOffset instanceof Curve2D)) {
-    return null;
+  try {
+    if (!(firstOffset instanceof Curve2D) || !(secondOffset instanceof Curve2D)) {
+      return null;
+    }
+
+    const intersectionResult = intersectCurves(firstOffset, secondOffset, 1e-9);
+    if (!isOk(intersectionResult)) {
+      return null;
+    }
+    intersectionResult.value.commonSegments.forEach((c) => {
+      c.delete();
+    });
+
+    const potentialCenter = intersectionResult.value.intersections.at(-1);
+    if (!isPoint2D(potentialCenter)) {
+      return null;
+    }
+    const center = potentialCenter;
+
+    const splitForFillet = (curve: Curve2D, offsetCurve: Curve2D) => {
+      const [x, y] = offsetCurve.tangentAt(center);
+      const normal = normalize2d([-y, x]);
+      const splitPoint = add2d(center, scalarMultiply2d(normal, offset));
+      const splitParam = unwrap(curve.parameter(splitPoint, 1e-6));
+      return curve.splitAt([splitParam]);
+    };
+
+    const firstSplit = splitForFillet(firstCurve, firstOffset);
+    const secondSplit = splitForFillet(secondCurve, secondOffset);
+    const first = wasmIndex(firstSplit, 0);
+    const second = wasmIndex(secondSplit, 1);
+    disposeUnusedSplits(firstSplit, first, firstCurve);
+    disposeUnusedSplits(secondSplit, second, secondCurve);
+    return { first, second, center };
+  } finally {
+    if (firstOffset instanceof Curve2D) firstOffset.delete();
+    if (secondOffset instanceof Curve2D) secondOffset.delete();
   }
-
-  const intersectionResult = intersectCurves(firstOffset, secondOffset, 1e-9);
-  if (!isOk(intersectionResult)) {
-    return null;
-  }
-
-  const potentialCenter = intersectionResult.value.intersections.at(-1);
-  if (!isPoint2D(potentialCenter)) {
-    return null;
-  }
-  const center = potentialCenter;
-
-  const splitForFillet = (curve: Curve2D, offsetCurve: Curve2D) => {
-    const [x, y] = offsetCurve.tangentAt(center);
-    const normal = normalize2d([-y, x]);
-    const splitPoint = add2d(center, scalarMultiply2d(normal, offset));
-    const splitParam = unwrap(curve.parameter(splitPoint, 1e-6));
-    return curve.splitAt([splitParam]);
-  };
-
-  const firstSplit = splitForFillet(firstCurve, firstOffset);
-  const secondSplit = splitForFillet(secondCurve, secondOffset);
-  const first = wasmIndex(firstSplit, 0);
-  const second = wasmIndex(secondSplit, 1);
-  return { first, second, center };
 }
 
 /**
@@ -114,38 +141,52 @@ export function dogboneFilletCurves(firstCurve: Curve2D, secondCurve: Curve2D, r
 
   const firstOffset = make2dOffset(firstCurve, offset);
   const secondOffset = make2dOffset(secondCurve, offset);
-
-  if (!(firstOffset instanceof Curve2D) || !(secondOffset instanceof Curve2D)) {
-    return [firstCurve, secondCurve];
-  }
-
-  const intersectionResult2 = intersectCurves(firstOffset, secondOffset, 1e-9);
-  if (!isOk(intersectionResult2)) {
-    return [firstCurve, secondCurve];
-  }
-  const potentialCenter = intersectionResult2.value.intersections.at(-1);
-  if (!isPoint2D(potentialCenter)) {
-    return [firstCurve, secondCurve];
-  }
-
-  const circle = make2dCircle(radius, potentialCenter);
-  const firstInt = unwrap(intersectCurves(firstCurve, circle)).intersections[0];
-  const secondInt = unwrap(intersectCurves(secondCurve, circle)).intersections.at(-1);
-
-  if (!firstInt || !secondInt) return [firstCurve, secondCurve];
-
-  const firstSplit = firstCurve.splitAt([firstInt]);
-  const secondSplit = secondCurve.splitAt([secondInt]);
-  const firstPart = wasmIndex(firstSplit, 0);
-  const secondPart = wasmIndex(secondSplit, secondSplit.length - 1);
+  let circle: Curve2D | null = null;
 
   try {
-    return [
-      firstPart,
-      make2dThreePointArc(firstPart.lastPoint, firstCurve.lastPoint, secondPart.firstPoint),
-      secondPart,
-    ];
-  } catch {
-    return [firstCurve, secondCurve];
+    if (!(firstOffset instanceof Curve2D) || !(secondOffset instanceof Curve2D)) {
+      return [firstCurve, secondCurve];
+    }
+
+    const intersectionResult2 = intersectCurves(firstOffset, secondOffset, 1e-9);
+    if (!isOk(intersectionResult2)) {
+      return [firstCurve, secondCurve];
+    }
+    intersectionResult2.value.commonSegments.forEach((c) => {
+      c.delete();
+    });
+    const potentialCenter = intersectionResult2.value.intersections.at(-1);
+    if (!isPoint2D(potentialCenter)) {
+      return [firstCurve, secondCurve];
+    }
+
+    circle = make2dCircle(radius, potentialCenter);
+    const firstInt = intersectionPoints(firstCurve, circle)[0];
+    const secondInt = intersectionPoints(secondCurve, circle).at(-1);
+
+    if (!firstInt || !secondInt) return [firstCurve, secondCurve];
+
+    const firstSplit = firstCurve.splitAt([firstInt]);
+    const secondSplit = secondCurve.splitAt([secondInt]);
+    const firstPart = wasmIndex(firstSplit, 0);
+    const secondPart = wasmIndex(secondSplit, secondSplit.length - 1);
+    disposeUnusedSplits(firstSplit, firstPart, firstCurve);
+    disposeUnusedSplits(secondSplit, secondPart, secondCurve);
+
+    try {
+      return [
+        firstPart,
+        make2dThreePointArc(firstPart.lastPoint, firstCurve.lastPoint, secondPart.firstPoint),
+        secondPart,
+      ];
+    } catch {
+      if (firstPart !== firstCurve) firstPart.delete();
+      if (secondPart !== secondCurve) secondPart.delete();
+      return [firstCurve, secondCurve];
+    }
+  } finally {
+    if (firstOffset instanceof Curve2D) firstOffset.delete();
+    if (secondOffset instanceof Curve2D) secondOffset.delete();
+    circle?.delete();
   }
 }

--- a/src/2d/lib/customCorners.ts
+++ b/src/2d/lib/customCorners.ts
@@ -11,7 +11,6 @@ import {
 } from './makeCurves.js';
 import { make2dOffset } from './offset.js';
 import { add2d, crossProduct2d, normalize2d, scalarMultiply2d } from './vectorOperations.js';
-import { wasmIndex } from '@/utils/vec3.js';
 
 /** Unwrap an intersection, discarding the common-segment curves the caller does not use. */
 function intersectionPoints(first: Curve2D, second: Curve2D): Point2D[] {
@@ -22,11 +21,51 @@ function intersectionPoints(first: Curve2D, second: Curve2D): Point2D[] {
   return result.intersections;
 }
 
-/** Delete every split piece that is neither kept nor the curve that was split. */
-function disposeUnusedSplits(pieces: Curve2D[], kept: Curve2D, source: Curve2D): void {
+/**
+ * Delete the split pieces the caller is discarding. `splitAt` returns the curve
+ * itself when there is nothing to split, so the source is never deleted here.
+ */
+function disposeSplitPieces(pieces: Curve2D[], source: Curve2D, kept?: Curve2D): void {
   pieces.forEach((piece) => {
-    if (piece !== kept && piece !== source) piece.delete();
+    if (piece !== source && piece !== kept) piece.delete();
   });
+}
+
+/**
+ * Run `split` and, if it throws, dispose the pieces an earlier split already
+ * produced. Splitting the second curve of a corner can fail (its parameter may
+ * not project onto the offset), stranding the first curve's pieces.
+ */
+function splitOrDiscard(
+  split: () => Curve2D[],
+  earlier: { pieces: Curve2D[]; source: Curve2D }
+): Curve2D[] {
+  try {
+    return split();
+  } catch (e) {
+    disposeSplitPieces(earlier.pieces, earlier.source);
+    throw e;
+  }
+}
+
+/**
+ * Build the corner result, disposing the trimmed halves if the connecting curve
+ * cannot be built. They are unreachable once the error propagates.
+ */
+function discardTrimsOnError(
+  firstCurve: Curve2D,
+  secondCurve: Curve2D,
+  first: Curve2D,
+  second: Curve2D,
+  build: () => Curve2D[]
+): Curve2D[] {
+  try {
+    return build();
+  } catch (e) {
+    if (first !== firstCurve) first.delete();
+    if (second !== secondCurve) second.delete();
+    throw e;
+  }
 }
 
 function removeCorner(firstCurve: Curve2D, secondCurve: Curve2D, radius: number) {
@@ -38,15 +77,20 @@ function removeCorner(firstCurve: Curve2D, secondCurve: Curve2D, radius: number)
   const orientationCorrection = sinAngle > 0 ? -1 : 1;
   const offset = Math.abs(radius) * orientationCorrection;
 
-  const firstOffset = make2dOffset(firstCurve, offset);
-  const secondOffset = make2dOffset(secondCurve, offset);
+  let firstOffset: ReturnType<typeof make2dOffset> | null = null;
+  let secondOffset: ReturnType<typeof make2dOffset> | null = null;
 
   try {
+    firstOffset = make2dOffset(firstCurve, offset);
+    secondOffset = make2dOffset(secondCurve, offset);
+
     if (!(firstOffset instanceof Curve2D) || !(secondOffset instanceof Curve2D)) {
       return null;
     }
+    const firstOffsetCurve: Curve2D = firstOffset;
+    const secondOffsetCurve: Curve2D = secondOffset;
 
-    const intersectionResult = intersectCurves(firstOffset, secondOffset, 1e-9);
+    const intersectionResult = intersectCurves(firstOffsetCurve, secondOffsetCurve, 1e-9);
     if (!isOk(intersectionResult)) {
       return null;
     }
@@ -68,12 +112,24 @@ function removeCorner(firstCurve: Curve2D, secondCurve: Curve2D, radius: number)
       return curve.splitAt([splitParam]);
     };
 
-    const firstSplit = splitForFillet(firstCurve, firstOffset);
-    const secondSplit = splitForFillet(secondCurve, secondOffset);
-    const first = wasmIndex(firstSplit, 0);
-    const second = wasmIndex(secondSplit, 1);
-    disposeUnusedSplits(firstSplit, first, firstCurve);
-    disposeUnusedSplits(secondSplit, second, secondCurve);
+    const firstSplit = splitForFillet(firstCurve, firstOffsetCurve);
+    const secondSplit = splitOrDiscard(() => splitForFillet(secondCurve, secondOffsetCurve), {
+      pieces: firstSplit,
+      source: firstCurve,
+    });
+    const first = firstSplit[0];
+    const second = secondSplit[1];
+
+    // A radius that consumes a whole segment splits it at its own endpoint, so
+    // splitAt hands back the curve itself and there is no trimmed half to keep.
+    if (!first || !second) {
+      disposeSplitPieces(firstSplit, firstCurve);
+      disposeSplitPieces(secondSplit, secondCurve);
+      return null;
+    }
+
+    disposeSplitPieces(firstSplit, firstCurve, first);
+    disposeSplitPieces(secondSplit, secondCurve, second);
     return { first, second, center };
   } finally {
     if (firstOffset instanceof Curve2D) firstOffset.delete();
@@ -101,7 +157,11 @@ export function filletCurves(firstCurve: Curve2D, secondCurve: Curve2D, radius: 
 
   const { first, second, center } = cornerRemoved;
 
-  return [first, make2dArcFromCenter(first.lastPoint, second.firstPoint, center), second];
+  return discardTrimsOnError(firstCurve, secondCurve, first, second, () => [
+    first,
+    make2dArcFromCenter(first.lastPoint, second.firstPoint, center),
+    second,
+  ]);
 }
 
 /**
@@ -118,7 +178,11 @@ export function chamferCurves(firstCurve: Curve2D, secondCurve: Curve2D, radius:
 
   const { first, second } = cornerRemoved;
 
-  return [first, make2dSegmentCurve(first.lastPoint, second.firstPoint), second];
+  return discardTrimsOnError(firstCurve, secondCurve, first, second, () => [
+    first,
+    make2dSegmentCurve(first.lastPoint, second.firstPoint),
+    second,
+  ]);
 }
 
 /**
@@ -139,11 +203,14 @@ export function dogboneFilletCurves(firstCurve: Curve2D, secondCurve: Curve2D, r
 
   const offset = Math.abs(radius) * Math.sin(a / 2) * orientationCorrection;
 
-  const firstOffset = make2dOffset(firstCurve, offset);
-  const secondOffset = make2dOffset(secondCurve, offset);
+  let firstOffset: ReturnType<typeof make2dOffset> | null = null;
+  let secondOffset: ReturnType<typeof make2dOffset> | null = null;
   let circle: Curve2D | null = null;
 
   try {
+    firstOffset = make2dOffset(firstCurve, offset);
+    secondOffset = make2dOffset(secondCurve, offset);
+
     if (!(firstOffset instanceof Curve2D) || !(secondOffset instanceof Curve2D)) {
       return [firstCurve, secondCurve];
     }
@@ -167,11 +234,21 @@ export function dogboneFilletCurves(firstCurve: Curve2D, secondCurve: Curve2D, r
     if (!firstInt || !secondInt) return [firstCurve, secondCurve];
 
     const firstSplit = firstCurve.splitAt([firstInt]);
-    const secondSplit = secondCurve.splitAt([secondInt]);
-    const firstPart = wasmIndex(firstSplit, 0);
-    const secondPart = wasmIndex(secondSplit, secondSplit.length - 1);
-    disposeUnusedSplits(firstSplit, firstPart, firstCurve);
-    disposeUnusedSplits(secondSplit, secondPart, secondCurve);
+    const secondSplit = splitOrDiscard(() => secondCurve.splitAt([secondInt]), {
+      pieces: firstSplit,
+      source: firstCurve,
+    });
+    const firstPart = firstSplit[0];
+    const secondPart = secondSplit[secondSplit.length - 1];
+
+    if (!firstPart || !secondPart) {
+      disposeSplitPieces(firstSplit, firstCurve);
+      disposeSplitPieces(secondSplit, secondCurve);
+      return [firstCurve, secondCurve];
+    }
+
+    disposeSplitPieces(firstSplit, firstCurve, firstPart);
+    disposeSplitPieces(secondSplit, secondCurve, secondPart);
 
     try {
       return [

--- a/tests/curve2dFns.test.ts
+++ b/tests/curve2dFns.test.ts
@@ -12,6 +12,7 @@ import {
   curve2dIsOnCurve,
   curve2dDistanceFrom,
 } from '@/2d/lib/curve2dFns.js';
+import { intersectCurves } from '@/2d/lib/intersections.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -24,7 +25,7 @@ function getLineCurve() {
 }
 
 /** Get a circular curve */
-function _getCircleCurve() {
+function getCircleCurve() {
   const drawing = drawCircle(5);
   return drawing.blueprint.curves[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
 }
@@ -123,6 +124,51 @@ describe('curve2dDistanceFrom', () => {
   it('distant point has large distance', () => {
     const curve = getLineCurve();
     expect(curve2dDistanceFrom(curve, [1000, 1000])).toBeGreaterThan(10);
+  });
+});
+
+describe('Curve2D disposal', () => {
+  it('frees the cached bounding box when the curve is deleted', () => {
+    const curve = getLineCurve();
+    const box = curve2dBoundingBox(curve);
+    expect(box.width).toBeGreaterThan(0);
+
+    curve.delete();
+
+    expect(() => box.wrapped).toThrow();
+    expect(curve._boundingBox).toBeNull();
+  });
+
+  it('is idempotent after the bounding box has been read', () => {
+    const curve = getLineCurve();
+    curve2dBoundingBox(curve);
+    curve.delete();
+    expect(() => {
+      curve.delete();
+    }).not.toThrow();
+  });
+
+  it('intersectCurves leaves no box behind once its operands are disposed', () => {
+    const first = getLineCurve();
+    const second = getCircleCurve();
+
+    const result = intersectCurves(first, second);
+    expect(result.ok).toBe(true);
+    if (result.ok)
+      result.value.commonSegments.forEach((c) => {
+        c.delete();
+      });
+
+    const firstBox = first._boundingBox;
+    const secondBox = second._boundingBox;
+    expect(firstBox).not.toBeNull();
+    expect(secondBox).not.toBeNull();
+
+    first.delete();
+    second.delete();
+
+    expect(() => firstBox?.wrapped).toThrow();
+    expect(() => secondBox?.wrapped).toThrow();
   });
 });
 

--- a/tests/customCornerHandleLeaks.test.ts
+++ b/tests/customCornerHandleLeaks.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests for gh #1906 — 2D handle leaks on the custom-corner path.
+ *
+ * `Curve2D.boundingBox` caches a `BoundingBox2d`, and `intersectCurves` reads
+ * both operands' boxes. `removeCorner` / `dogboneFilletCurves` built offset
+ * curves purely to locate the corner centre and dropped them, so every rounded
+ * corner stranded those curves and their cached boxes in the
+ * FinalizationRegistry: reclaimed on GC, never by disposal.
+ *
+ * The probes force collection and count `gcCollected` deltas, so a handle that
+ * is only reachable by the registry reads as a leak. Requires --expose-gc
+ * (set in vitest.config.ts execArgv).
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from './setup.js';
+import { getKernelCapabilities } from './helpers/kernelRegistry.js';
+import { draw, drawRectangle } from '@/index.js';
+import { getDisposalStats } from '@/core/disposal.js';
+import { filletCurves, chamferCurves, dogboneFilletCurves } from '@/2d/lib/customCorners.js';
+import { curve2dBoundingBox } from '@/2d/lib/curve2dFns.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+const forceGc = (globalThis as { gc?: () => void }).gc;
+
+async function drainGc(): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    forceGc?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/** Average number of GC-reclaimed (i.e. never explicitly disposed) handles per call. */
+async function leakPerCall(build: () => void, n = 20): Promise<number> {
+  build();
+  await drainGc();
+  const start = getDisposalStats().gcCollected;
+  for (let i = 0; i < n; i++) build();
+  await drainGc();
+  return (getDisposalStats().gcCollected - start) / n;
+}
+
+const gcIt = forceGc ? it : it.skip;
+
+describe('custom corner handle leaks', () => {
+  gcIt(
+    'a sharp-cornered drawing leaks nothing (baseline)',
+    async () => {
+      const leak = await leakPerCall(() => {
+        draw([0, 0]).lineTo([10, 0]).lineTo([10, 10]).lineTo([0, 10]).close();
+      });
+      expect(leak).toBeLessThan(0.5);
+    },
+    60000
+  );
+
+  gcIt(
+    'a filleted corner leaks nothing',
+    async () => {
+      const leak = await leakPerCall(() => {
+        draw([0, 0]).lineTo([10, 0]).customCorner(2).lineTo([10, 10]).lineTo([0, 10]).close();
+      });
+      expect(leak).toBeLessThan(0.5);
+    },
+    60000
+  );
+
+  gcIt(
+    'a chamfered corner leaks nothing',
+    async () => {
+      const leak = await leakPerCall(() => {
+        draw([0, 0])
+          .lineTo([10, 0])
+          .customCorner(2, 'chamfer')
+          .lineTo([10, 10])
+          .lineTo([0, 10])
+          .close();
+      });
+      expect(leak).toBeLessThan(0.5);
+    },
+    60000
+  );
+
+  gcIt(
+    'a dogbone corner leaks nothing',
+    async () => {
+      const leak = await leakPerCall(() => {
+        draw([0, 0])
+          .lineTo([10, 0])
+          .lineTo([10, 10])
+          .lineTo([0, 10])
+          .closeWithCustomCorner(2, 'dogbone');
+      });
+      expect(leak).toBeLessThan(0.5);
+    },
+    60000
+  );
+});
+
+// Corner treatments need 2D offsets, which manifold does not provide: it bails
+// out and returns the two input curves untouched.
+describe.skipIf(!getKernelCapabilities(currentKernel).kernel2D)(
+  'custom corner geometry is unchanged',
+  () => {
+    const cornerCurves = () => {
+      const curves = drawRectangle(10, 10).blueprint.curves;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return [curves[0]!, curves[1]!] as const;
+    };
+
+    it.each([
+      ['fillet', filletCurves],
+      ['chamfer', chamferCurves],
+      ['dogbone', dogboneFilletCurves],
+    ])('%s returns three connected curves', (_name, cornerFn) => {
+      const [first, second] = cornerCurves();
+      const result = cornerFn(first, second, 2);
+
+      expect(result).toHaveLength(3);
+      for (let i = 0; i < result.length - 1; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const end = result[i]!.lastPoint;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const start = result[i + 1]!.firstPoint;
+        expect(start[0]).toBeCloseTo(end[0], 6);
+        expect(start[1]).toBeCloseTo(end[1], 6);
+      }
+    });
+
+    it('collinear curves are returned untouched and still usable', () => {
+      const first = drawRectangle(10, 10).blueprint.curves[0];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const result = filletCurves(first!, first!, 2);
+
+      expect(result).toHaveLength(2);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(curve2dBoundingBox(result[0]!).width).toBeGreaterThanOrEqual(0);
+    });
+  }
+);

--- a/tests/customCornerHandleLeaks.test.ts
+++ b/tests/customCornerHandleLeaks.test.ts
@@ -57,6 +57,18 @@ describe('custom corner handle leaks', () => {
   );
 
   gcIt(
+    'a corner that bails on a degenerate radius leaks nothing',
+    async () => {
+      const leak = await leakPerCall(() => {
+        // 10 consumes the whole 10-long segment, so the trim produces no halves
+        draw([0, 0]).lineTo([10, 0]).customCorner(10).lineTo([10, 10]).lineTo([0, 10]).close();
+      });
+      expect(leak).toBeLessThan(0.5);
+    },
+    60000
+  );
+
+  gcIt(
     'a filleted corner leaks nothing',
     async () => {
       const leak = await leakPerCall(() => {
@@ -127,6 +139,15 @@ describe.skipIf(!getKernelCapabilities(currentKernel).kernel2D)(
         expect(start[0]).toBeCloseTo(end[0], 6);
         expect(start[1]).toBeCloseTo(end[1], 6);
       }
+    });
+
+    it('a radius that consumes a whole segment bails instead of throwing', () => {
+      const [first, second] = cornerCurves();
+
+      const result = filletCurves(first, second, 10);
+
+      expect(result).toEqual([first, second]);
+      expect(curve2dBoundingBox(first).width).toBeGreaterThan(0);
     });
 
     it('collinear curves are returned untouched and still usable', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,7 +68,9 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     testTimeout: 90000,
     pool: 'forks',
-    execArgv: ['--max-old-space-size=6144'],
+    // --expose-gc lets the handle-leak probes force collection so a
+    // FinalizationRegistry-only reclaim reads as a leak instead of passing.
+    execArgv: ['--max-old-space-size=6144', '--expose-gc'],
     maxWorkers,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Fixes #1906.

## What leaked

`Curve2D.boundingBox` lazily creates **and caches** a `BoundingBox2d`, but `Curve2D` disposal never freed the cache, so every `intersectCurves` caller stranded two boxes in the `FinalizationRegistry`.

Fixing only the cache was not enough. Measuring with a `gcCollected` probe showed a filleted corner still leaking 2 handles per call, because the custom-corner path never disposed the curves whose boxes those were:

- `removeCorner` / `dogboneFilletCurves` build offset curves (and, for dogbone, a locator circle) purely to find the corner centre, then drop them.
- `intersectCurves` returns `commonSegments` as `Curve2D` handles that these callers discard.
- `splitAt` returns both halves; only one is kept per side.
- `BaseSketcher2d` pops the two curves a corner function consumes and pushes the replacements without deleting the originals.

## Changes

- `Curve2D.delete()` disposes and clears its cached bounding box.
- `removeCorner` / `dogboneFilletCurves` dispose their offsets, locator circle, unused split pieces, and common segments on every exit path (`try`/`finally`, so the early-bail branches are covered too).
- `BaseSketcher2d` deletes the curves a corner function consumed, skipping any the function returned untouched (corner functions return their inputs verbatim when they bail on collinear curves or a failed offset).
- `--expose-gc` added to the vitest `execArgv` so leak probes can force collection.

I did not take the issue's suggested fix #2 (clearing the operands' cache inside `intersectCurves`). `boolean2D` intersects each curve against every other, so per-call invalidation would turn O(n) box builds into O(n²). Ownership at the producer is both cheaper and more general.

## Verification

`gcCollected` delta per call, 20 iterations, occt-wasm:

| drawing | before | after |
| --- | --- | --- |
| sharp corners (baseline) | 0 | 0 |
| `customCorner(2)` fillet | 2 | 0 |
| `customCorner(2, 'chamfer')` | 2 | 0 |
| `closeWithCustomCorner(2, 'dogbone')` | 2 | 0 |

- `tests/customCornerHandleLeaks.test.ts` (new): the four probes above, plus geometry assertions that fillet/chamfer/dogbone still return three connected curves and that the collinear bail path returns usable curves. Geometry block is skipped on manifold, which has no 2D offset.
- `tests/curve2dFns.test.ts`: deterministic (no-GC) assertions that a box read from a curve is disposed with it and that `delete()` stays idempotent.
- Full occt-wasm suite green (3941 passed). The 2D suites were also run across all four kernel projects: the only failures are the 86 pre-existing manifold ones, identical on `main`.

## Behavior note

`Curve2D.boundingBox` is now **borrowed**: it is disposed with the curve. Documented on the getter, on `curve2dBoundingBox`, and in `src/2d/README.md`. Callers needing an independent box should clone the curve first.

The sketcher now deletes curves it hands to a *user-supplied* corner function (`customCorner` accepts a callback). A callback that retains its input curves past the call would see them disposed; returning them in the result array opts out.

## Downstream

`gridfinity-layout-tool`'s `pnpm patch` on `dist/blueprintSketcher-*` can be retired once this ships.
