### PR TITLE
fix(deps): drop redundant brace-expansion override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6826,16 +6826,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brepjs": {

--- a/package.json
+++ b/package.json
@@ -311,7 +311,6 @@
   },
   "overrides": {
     "dompurify": "^3.4.11",
-    "brace-expansion": "^5.0.7",
     "esbuild@<0.25.0": "^0.25.0",
     "esbuild@>=0.26.0 <0.28.1": "^0.28.1",
     "js-yaml": "^4.2.0",


### PR DESCRIPTION
## Summary

`brace-expansion` cannot be removed from the tree: its only path in is `minimatch`, required by `eslint`, `@typescript-eslint/typescript-estree`, `@eslint/config-array`, and `typedoc`. All dev, none droppable.

What can go is the **override**, which is what actually caused the recurring alert.

The override was added in #1056 (May 2026), when the tree still had older `minimatch` pulling `brace-expansion` 1.x/2.x, and forcing `^5` was the only way up. Every `minimatch` in the tree is now 10.x, which already declares `^5.0.2` / `^5.0.5` natively. The override no longer raises any floor.

What it *did* do is freeze resolution. An npm `override` stops npm re-resolving that package against consumer ranges, so the entry only moves when a human edits it. That is why it sat at 5.0.7 while 5.0.9 shipped, and why it needed a manual bump per advisory (`^5.0.6` → `^5.0.7` → would have been `^5.0.8`).

Clears **GHSA-mh99-v99m-4gvg** (7.5 High).

## Why the lockfile is hand-edited

`npm install` on 11.15.0 produces version skew against the npm that generated this lockfile:

- strips/adds `"peer": true` on ~40 unrelated packages
- drops `"version"` from the `node_modules/brepjs` link entry
- rewrites `packages/brepjs-cad`'s `brepjs` range from `>=18.119.4` to `>=18.117.1`

Decisively, it also does not fix the target: npm keeps a satisfying lockfile entry rather than re-resolving, so 5.0.7 stayed put either way.

On that third bullet, npm is arguably the correct one and it is worth a separate look. `packages/brepjs-cad/package.json` declares `"brepjs": ">=18.117.1"`, but release-please's `db8248dd` bumped that range to `>=18.119.4` **in the lockfile only**, leaving the two out of sync. Any `npm install` will keep reconciling the lockfile back to the package.json, and the next release will flip it again. Not addressed here.

So this is a 4-field surgical edit (`version`, `resolved`, `integrity`, `engines`) with `integrity` taken from the registry. Every CI job installs with `npm ci`, which validates integrity and never rewrites the lockfile.

`engines` tightens from `18 || 20 || >=22` to `20 || >=22`; root `engines` is `>=24` and CI is Node 24, so this is a non-issue. `dependencies` are unchanged (`balanced-match ^4.0.2`, already resolved at 4.0.4), so nothing cascades.

## Verification

- [x] `npm ci` clean, integrity hash validated
- [x] `npm ls brace-expansion` shows a single deduped 5.0.9 under both `minimatch` 10.2.4 and 10.2.5
- [x] `npm audit` high count 4 → 3; `brace-expansion` no longer listed
- [x] `npm run lint` (eslint, the main minimatch consumer) clean
- [x] `npm run docs:api` (typedoc, the other consumer) 0 errors
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run check:boundaries` passed
- [x] lockfile diff is 4 lines, `package.json` diff is 1 line

## Not in scope

`main`'s OSV job stays red on the remaining 7 findings (`dompurify` ×3, `sharp`, `@hono/node-server`, `body-parser`, `postcss`). Note `dompurify` is the same staleness pattern: the override says `^3.4.11` but `monaco-editor` pins a nested `dompurify@3.4.8` exactly, so the hoisted copy being 3.4.12 does not clear those alerts.

