### PR TITLE
fix(playground): bundle monaco locally instead of loading from a CDN

### DIFF
--- a/apps/playground/src/components/playground/EditorPanel.tsx
+++ b/apps/playground/src/components/playground/EditorPanel.tsx
@@ -1,3 +1,4 @@
+import '../../lib/monacoLoader';
 import Editor, { type BeforeMount, type OnMount } from '@monaco-editor/react';
 import { useCallback, useEffect, useRef } from 'react';
 import { usePlaygroundStore } from '../../stores/playgroundStore';

--- a/apps/playground/src/lib/monacoLoader.ts
+++ b/apps/playground/src/lib/monacoLoader.ts
@@ -1,0 +1,14 @@
+import * as monaco from 'monaco-editor';
+import { loader } from '@monaco-editor/react';
+
+// Without this, @monaco-editor/react falls back to its default loader, which
+// fetches the editor from cdn.jsdelivr.net at runtime. That made the
+// monaco-editor version in package.json cosmetic: the pin only supplied types
+// while users ran whatever version the loader defaulted to, which lagged the
+// pin and shipped an older bundled DOMPurify. It also put editor execution
+// outside the lockfile, where no dependency scanner could see it.
+//
+// No MonacoEnvironment.getWorker shim is needed: monaco 0.56 spawns its own
+// workers with `new Worker(new URL('...', import.meta.url), {type:'module'})`,
+// which Vite resolves and emits at build time.
+loader.config({ monaco });

--- a/apps/playground/src/lib/monacoSetup.ts
+++ b/apps/playground/src/lib/monacoSetup.ts
@@ -38,21 +38,24 @@ export function setupMonaco(monaco: Monaco) {
   // explicitly hits a Monaco bug where the reference isn't expanded
   // transitively, leaving user code with "Cannot find name 'Math'" errors
   // (issue #761).
-  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-    target: monaco.languages.typescript.ScriptTarget.ES2022,
-    module: monaco.languages.typescript.ModuleKind.ESNext,
-    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+  // monaco 0.56 moved the TypeScript language service off `languages.typescript`
+  // to a top-level `typescript` namespace. The old path silently reads
+  // undefined, so setupMonaco throws and the editor never mounts.
+  monaco.typescript.typescriptDefaults.setCompilerOptions({
+    target: monaco.typescript.ScriptTarget.ES2022,
+    module: monaco.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.typescript.ModuleResolutionKind.NodeJs,
     strict: true,
     noEmit: true,
     allowJs: true,
   });
 
-  monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+  monaco.typescript.typescriptDefaults.setDiagnosticsOptions({
     noSemanticValidation: false,
     noSyntaxValidation: false,
   });
 
-  monaco.languages.typescript.typescriptDefaults.addExtraLib(
+  monaco.typescript.typescriptDefaults.addExtraLib(
     buildBrepjsModuleDts(ambientTypes, sheetmetalAmbientTypes, bimAmbientTypes),
     'file:///node_modules/@types/brepjs/index.d.ts'
   );


### PR DESCRIPTION
## Summary

Follow-up to #1917. The playground loaded its editor from a third-party CDN at runtime, which meant the `monaco-editor` pin in `apps/playground/package.json` had no effect on what users actually ran.

`@monaco-editor/react` is used with no `loader.config()` override anywhere, so `@monaco-editor/loader`'s default applied and monaco was fetched from `cdn.jsdelivr.net`. Consequences:

- The editor actually executing was the **loader's default (0.55.1)**, not the **0.56.0** pinned in `package.json`. Two different editors; the pin only supplied build-time types.
- 0.55.1 vendors **DOMPurify 3.2.7**, older than the 3.4.8 that OSV was flagging in #1917.
- Editor execution sat outside `package-lock.json`, so no dependency scanner could see the version that ran.

`loader.config({ monaco })` makes the pin real.

No `MonacoEnvironment.getWorker` shim is required: monaco 0.56 spawns its own workers with `new Worker(new URL('...', import.meta.url), { type: 'module' })`, which Vite resolves and emits at build time. (`worker: { format: 'es' }` was already set in the vite config.)

## Bundling surfaced a latent break

**The pin was never API-compatible with this code.** `monacoSetup.ts` was written against the 0.55.x the CDN served. monaco 0.56 moved the TypeScript language service off `languages.typescript` to a top-level `typescript` namespace, so `monaco.languages.typescript.typescriptDefaults` reads `undefined`:

```
pageerror: Cannot read properties of undefined (reading 'typescriptDefaults')
```

`setupMonaco` threw and the editor never mounted. Four references migrated to `monaco.typescript.*`. This break was invisible before precisely because the pin was inert — nobody was running 0.56.

Worth noting the build passed at every step here; only running the page caught it.

## Verification

Headless puppeteer run against `vite preview` of the production build:

| check | result |
| --- | --- |
| editor mounts | ✅ `.monaco-editor` present, 41 view lines rendered |
| requests to jsdelivr / unpkg / cdnjs | ✅ **none** |
| `ts.worker` origin | ✅ served from localhost, not CDN |
| TS language service after migration | ✅ typing `const n: number = "definitely not a number"` produces a `.squiggly-error` |
| page errors | ✅ none |
| playground smoke (`scripts/smoke.ts`) | ✅ `Engine reached Ready` |

Also confirmed statically: in `@monaco-editor/loader`, `injectScripts`/`getMonacoLoaderScript` — the only CDN consumers — sit after the `if (state.monaco) { resolve; return }` early exit, so the path is unreachable once `monaco` is supplied. The `cdn.jsdelivr.net` string that remains in the bundle is that module's dead default config.

Plus: root `typecheck`, playground `tsc -b`, `check:examples`, and `prettier --check` all clean.

## Tradeoff: bundle size

Monaco now ships from our origin instead of jsdelivr:

```
monaco-*.js      4,392 kB  (1,122 kB gzip)
monaco-*.css       162 kB  (   25 kB gzip)
ts.worker-*.js   6,916 kB  (fetched on first TS model)
```

The existing `manualChunks` rule already isolates monaco, so the entry bundle is unaffected (`index-*.js` is unchanged at ~1,329 kB). This is a real change in first-load characteristics — previously these bytes came from a shared, possibly-warm CDN cache. The upside is that the version is now pinned, auditable, and offline-capable.

Vite also emits `css.worker`, `html.worker` and `json.worker` (~2.3 MB combined) because monaco's own language contributions reference them via `import.meta.url`. They are never fetched — the editor mounts with `defaultLanguage="typescript"` and no model of those languages is ever created — but they do occupy build output. Removing them would mean bypassing monaco's barrel entry, which trades away editor capability; not done here.

## Net security effect

Users move from monaco 0.55.1 (bundled DOMPurify **3.2.7**) to 0.56.0 (**3.4.8**), and the running version is now covered by the lockfile the scanner reads. The three `dompurify` entries in `osv-scanner.toml` from #1917 are unaffected and still accurate: monaco vendors its own copy, and the `node_modules` copy the scanner matches remains unimported.
