### PR TITLE
chore(security): drop the withdrawn esbuild ignore

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,17 +2,6 @@
 # OSV Scan workflow (.github/workflows/osv-scan.yml). Each entry must carry a
 # reason and a review date so exceptions don't outlive their justification.
 
-[[IgnoredVulns]]
-id = "GHSA-gv7w-rqvm-qjhr"
-ignoreUntil = 2026-09-15
-# esbuild 0.25.10 reaches the tree only via vitepress -> vite@6.4.x, a dev-only
-# docs-site build dependency. The advisory is the Deno install path trusting a
-# malicious NPM_CONFIG_REGISTRY; not reachable from our Node-only trusted CI
-# build. The fix (esbuild 0.28.1) drops destructuring->es2020 transform support
-# and breaks the vitepress build, and vitepress' stable line still pins vite
-# 6.x. Re-evaluate once vitepress 2.x (newer vite/esbuild) ships.
-reason = "esbuild dev-only via vitepress; Deno/NPM_CONFIG_REGISTRY vector not reachable in Node CI; fix breaks docs build"
-
 # --- dompurify via monaco-editor (3 advisories) ---------------------------
 # monaco-editor 0.56.0 declares `dompurify: 3.4.8` as an exact pin, which is
 # what the scanner matches on. That copy is never executed, for two reasons.


### PR DESCRIPTION
## Summary

`osv-scanner` was reporting this entry as an **unused ignore** on every run:

```
/var/home/andy/Git/brepjs/osv-scanner.toml has unused ignores:
 - GHSA-gv7w-rqvm-qjhr
```

The cause is not that our tree got fixed. **The advisory was withdrawn upstream** — `api.osv.dev` returns it as:

> Withdrawn Advisory: esbuild: Missing binary integrity verification in Deno module enables remote code execution via NPM_CONFIG_REGISTRY

`vitepress` still carries `esbuild@0.25.10`, which sits squarely inside the advisory's stated range (`introduced 0.17.0`, `fixed 0.28.1`). It stopped matching only because the advisory no longer exists, not because the dependency moved.

So the entry filters nothing. Its `ignoreUntil` of 2026-09-15 would have forced a scheduled re-look at an advisory that had been retracted, and the reasoning it documents (the fix breaking the docs build) is no longer a live tradeoff.

If the advisory is ever reinstated, the scan flags it again — which is the behaviour we want, rather than a standing exception nobody re-examines.

## Verification

- [x] `osv-scanner scan --lockfile=package-lock.json` → **No issues found**
- [x] the `unused ignores` warning is gone
- [x] the three `dompurify` entries still filter correctly (unchanged)

Docs-only change to `osv-scanner.toml`; no lockfile or source changes.
