### PR TITLE
fix(brepkit): transform compounds in applyMatrix

### DIFF
--- a/src/kernel/brepkit/internalOps.ts
+++ b/src/kernel/brepkit/internalOps.ts
@@ -16,6 +16,10 @@ import {
   faceHandle,
   edgeHandle,
   wireHandle,
+  compoundHandle,
+  syntheticCompounds,
+  nextSyntheticId,
+  toArray,
   unwrap,
   DEFAULT_DEFLECTION,
 } from './helpers.js';
@@ -63,6 +67,24 @@ export function applyMatrix(bk: BrepkitKernel, shape: KernelShape, matrix: numbe
       const copy = bk.copyEdge(h.id);
       bk.transformEdge(copy, matrix);
       return edgeHandle(copy);
+    }
+    case 'compound': {
+      // A compound is either a real brepkit compound (all-solid children, held
+      // in the arena) or a JS-side synthetic one holding wires/faces/edges;
+      // `makeCompound` picks between them, so both have to be handled here.
+      const children = syntheticCompounds.get(h.id);
+      if (children) {
+        const moved = children.map((child) => applyMatrix(bk, child, matrix) as BrepkitHandle);
+        const syntheticId = nextSyntheticId();
+        syntheticCompounds.set(syntheticId, moved);
+        return compoundHandle(syntheticId);
+      }
+      const copies = toArray(bk.getCompoundSolids(h.id)).map((solidId) => {
+        const copy = bk.copySolid(solidId);
+        bk.transformSolid(copy, matrix);
+        return copy;
+      });
+      return compoundHandle(bk.makeCompound(copies));
     }
     default:
       throw new Error(`brepkit: applyMatrix does not support '${h.type}' shapes`);

--- a/src/kernel/brepkit/internalOps.ts
+++ b/src/kernel/brepkit/internalOps.ts
@@ -16,6 +16,7 @@ import {
   faceHandle,
   edgeHandle,
   wireHandle,
+  vertexHandle,
   compoundHandle,
   syntheticCompounds,
   nextSyntheticId,
@@ -67,6 +68,22 @@ export function applyMatrix(bk: BrepkitKernel, shape: KernelShape, matrix: numbe
       const copy = bk.copyEdge(h.id);
       bk.transformEdge(copy, matrix);
       return edgeHandle(copy);
+    }
+    case 'vertex': {
+      // A vertex has no surface to offset, just a point to move. It reaches
+      // here through the compound branch below: the public `compound()`
+      // accepts vertices, so a synthetic compound can hold them, and without
+      // this arm transforming such a compound throws.
+      const p = bk.getVertexPosition(h.id);
+      const m = matrix;
+      const [x, y, z] = [p[0] ?? 0, p[1] ?? 0, p[2] ?? 0];
+      return vertexHandle(
+        bk.makeVertex(
+          (m[0] ?? 0) * x + (m[1] ?? 0) * y + (m[2] ?? 0) * z + (m[3] ?? 0),
+          (m[4] ?? 0) * x + (m[5] ?? 0) * y + (m[6] ?? 0) * z + (m[7] ?? 0),
+          (m[8] ?? 0) * x + (m[9] ?? 0) * y + (m[10] ?? 0) * z + (m[11] ?? 0)
+        )
+      );
     }
     case 'compound': {
       // A compound is either a real brepkit compound (all-solid children, held

--- a/tests/brepkitExtended.test.ts
+++ b/tests/brepkitExtended.test.ts
@@ -10,7 +10,19 @@
 
 import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
-import { box, fillet, castShape, getEdges, getFaces, isSolid, unwrap } from '@/index.js';
+import {
+  box,
+  fillet,
+  castShape,
+  compound,
+  getEdges,
+  getFaces,
+  isSolid,
+  measureVolume,
+  rotate,
+  translate,
+  unwrap,
+} from '@/index.js';
 import { getKernel } from '@/kernel/index.js';
 import { shouldSkipSuite } from './helpers/kernelDivergences.js';
 
@@ -678,5 +690,41 @@ descOcct('Brepkit-only methods throw on OCCT', () => {
   it('meshBoolean throws', () => {
     const kernel = getKernel();
     expect(() => kernel.meshBoolean([], [], [], [], 'union', 1e-6)).toThrow(/brepkit/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transforming compounds
+// ---------------------------------------------------------------------------
+
+// A compound reaches applyMatrix whenever a caller rotates or translates a
+// multi-part shape. The gridfinity floor and divider pattern builders both lay
+// out a panel compound exactly that way, and every scenario in both families
+// failed outright on "applyMatrix does not support 'compound' shapes".
+descBk('Transforming compounds (brepkit)', () => {
+  it('translates an all-solid compound', () => {
+    const c = compound([box(1, 1, 1), translate(box(1, 1, 1), [5, 0, 0])]);
+    const bb = getKernel().boundingBox(translate(c, [0, 0, 10]).wrapped);
+    expect(bb.min[2]).toBeCloseTo(10, 3);
+    expect(bb.max[2]).toBeCloseTo(11, 3);
+    expect(bb.max[0]).toBeCloseTo(6, 3);
+  });
+
+  it('leaves the source compound where it was', () => {
+    const c = compound([box(1, 1, 1), translate(box(1, 1, 1), [5, 0, 0])]);
+    translate(c, [0, 0, 10]);
+    expect(getKernel().boundingBox(c.wrapped).min[2]).toBeCloseTo(0, 3);
+  });
+
+  it('preserves every member, not just the first', () => {
+    const c = compound([box(2, 2, 2), translate(box(2, 2, 2), [5, 0, 0])]);
+    const moved = translate(c, [0, 0, 3]);
+    expect(unwrap(measureVolume(moved))).toBeCloseTo(16, 1);
+  });
+
+  it('rotates a compound about Z', () => {
+    const c = compound([box(4, 1, 1), translate(box(4, 1, 1), [0, 3, 0])]);
+    const bb = getKernel().boundingBox(rotate(c, 90, { axis: [0, 0, 1] }).wrapped);
+    expect(bb.max[1] - bb.min[1]).toBeCloseTo(4, 2);
   });
 });

--- a/tests/brepkitExtended.test.ts
+++ b/tests/brepkitExtended.test.ts
@@ -19,7 +19,9 @@ import {
   getFaces,
   isSolid,
   measureVolume,
+  polygon,
   rotate,
+  vertex,
   translate,
   unwrap,
 } from '@/index.js';
@@ -720,6 +722,31 @@ descBk('Transforming compounds (brepkit)', () => {
     const c = compound([box(2, 2, 2), translate(box(2, 2, 2), [5, 0, 0])]);
     const moved = translate(c, [0, 0, 3]);
     expect(unwrap(measureVolume(moved))).toBeCloseTo(16, 1);
+  });
+
+  // The all-solid cases above take the ARENA path. A compound with any
+  // non-solid child is stored JS-side instead and transformed by recursing
+  // per child, which is a different code path and was previously uncovered.
+  it('translates a synthetic compound holding a face', () => {
+    const face = unwrap(
+      polygon([
+        [0, 0, 0],
+        [2, 0, 0],
+        [2, 2, 0],
+      ])
+    );
+    const c = compound([box(1, 1, 1), face]);
+    const bb = getKernel().boundingBox(translate(c, [0, 0, 7]).wrapped);
+    expect(bb.min[2]).toBeCloseTo(7, 3);
+  });
+
+  it('translates a synthetic compound holding a vertex', () => {
+    // `compound()` accepts vertices, so the recursive path must be able to
+    // move one; without a vertex arm in applyMatrix this threw.
+    const c = compound([box(1, 1, 1), vertex([0, 0, 0])]);
+    const bb = getKernel().boundingBox(translate(c, [0, 0, 5]).wrapped);
+    expect(bb.min[2]).toBeCloseTo(5, 3);
+    expect(bb.max[2]).toBeCloseTo(6, 3);
   });
 
   it('rotates a compound about Z', () => {


### PR DESCRIPTION
## What

Rotating or translating a compound threw `brepkit: applyMatrix does not support 'compound' shapes`. `applyMatrix` handled solid/face/wire/edge and fell through to a throw for compounds.

## Why it matters

This accounted for **18 of the 21 failures** across two whole gridfinity scenario families. Both builders hit it the same way — `floorPatternBuilder` does `rotate(panel, -90, …)` then `translate(laid, …)`, and `dividerPatternBuilder` the same, where `panel` is a compound of cutter parts. The floor builder explicitly reuses the divider builder's panel factory, which is why one gap took out both families.

The throw happens *before any geometry runs*, so no boolean was ever reached — the floor file was failing 9 of 11 tests in 5.4 seconds.

## Fix

Handle both compound flavours, because `makeCompound` chooses between them:

- **all-solid** → a real arena compound: `getCompoundSolids` → `copySolid` + `transformSolid` → `makeCompound`
- **anything else** → a JS-side `syntheticCompounds` entry: transform each child and re-register under a fresh synthetic id

Covering only the arena case would silently drop wire and face children.

## Measured, tool-side

With the built `dist/` overlaid into the tool's resolved `brepjs`:

| family | before | after |
|---|---|---|
| floor patterns | 9 failed / 2 passed | **1 failed / 10 passed** |
| divider patterns | 12 failed / 3 passed | **3 failed / 12 passed** |

**21 failures → 4.** Almost none was hiding a second defect: 17 pass outright once they reach the kernel and export watertight. The floor file's runtime goes 5.4 s → 71 s for exactly that reason — those tests previously threw before doing any work.

The 4 remaining are genuine geometry defects, now unblocked and visible.

## Verification

Four tests in `tests/brepkitExtended.test.ts` (which runs under the `brepkit` project), covering both compound flavours, non-mutation of the source, and that every member survives — all differentially verified to fail with the exact production error without the fix.

Suite A/B on `--project brepkit`: **identical failure set**, treatment +4 passing (3595 vs 3591). The 86 pre-existing file-level failures are untouched.

Note: `tests/brepkit-adapter.test.ts` looks like the natural home for these but is excluded from every vitest project, so tests added there never run.