### PR TITLE
chore(deps): hold knip at 6.27.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
       # peer ranges to accept 7.x.
       - dependency-name: typescript
         update-types: ['version-update:semver-major']
+      # knip 6.28.0 (webpro-nl/knip#1895) started reporting unused re-exports when
+      # `ignoreExportsUsedInFile` is set. That flags 74 exports + 42 exported types
+      # across the barrel files that make up the public API surface (src/*/index.ts
+      # re-exported through src/index.ts), so `npm run knip` fails. Adopting the
+      # stricter reporting is a deliberate triage of knip.config.ts, not a bump.
+      # Re-allow once that config work is done.
+      - dependency-name: knip
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-major']
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
#1930 (minor-and-patch group, 10 updates) is red on `npm run knip`. Bisected to the knip 6.27.0 → 6.29.0 bump in that group: knip 6.28.0 ([#1895](https://github.com/webpro-nl/knip/pull/1895)) began reporting unused re-exports when `ignoreExportsUsedInFile` is set.

That surfaces 74 unused exports + 42 unused exported types, essentially all of them re-exports in the barrel files that form the public API (`src/*/index.ts` re-exported through `src/index.ts`). Verified locally: identical tree passes on 6.27.0 and fails on 6.28.0 and 6.29.0. `includeEntryExports: false` and an explicit `entry` list make no difference.

Adopting the stricter reporting is a knip.config.ts triage, not a bump, so this ignores knip minors/majors to unblock the other 9 updates in #1930. Re-allow once that config work lands.