### PR TITLE
fix(scripts): format the generated kernel types in the sync itself

### DIFF
--- a/scripts/sync-brepkit-types.ts
+++ b/scripts/sync-brepkit-types.ts
@@ -12,6 +12,7 @@
  *   4. Generates the types file with `@unwired` tags for unused methods
  */
 
+import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
@@ -544,7 +545,7 @@ function generate(): void {
   lines.push('  /** Triangle indices (groups of 3). */');
   lines.push('  readonly indices: Uint32Array;');
   lines.push(
-    "  /** Per-face start offsets into `indices`; last element equals `indices.length`. */"
+    '  /** Per-face start offsets into `indices`; last element equals `indices.length`. */'
   );
   lines.push('  readonly faceOffsets: Uint32Array;');
   lines.push('}');
@@ -637,6 +638,10 @@ function generate(): void {
   lines.push('');
 
   writeFileSync(OUTPUT_FILE, lines.join('\n'));
+  // The generated file must satisfy the repo's format gate directly; a sync
+  // that leaves prettier violations turns every kernel bump into a two-step
+  // edit.
+  execFileSync('npx', ['prettier', '--write', OUTPUT_FILE], { stdio: 'inherit' });
 
   const wiredCount = methods.filter((m) => wired.has(m.name)).length;
   const totalCount = methods.length;


### PR DESCRIPTION
The type sync wrote prettier-nonconforming output, so every kernel bump tripped the format gate and needed a manual prettier pass (the 2.129.13 bump in #1946 did). The sync now runs prettier on its own output.

Also serves as the release-triggering commit for the 2.129.13 kernel pin: #1946 landed as `chore(deps)`, which release-please does not release, so the pin is sitting unpublished on main. This `fix:` cuts the version that carries it (the published package's consumers get the fuse same-sense fix, the 47x volume path, and the loft concave-corner orientation fix).