### PR TITLE
docs: state per-repo signing without asserting cross-repo equivalence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 All contributors must sign our [CLA](.github/CLA.md) before their first PR
 can be merged. When you open a PR, a bot will prompt you to sign by posting
 a comment. You sign once per repository: brepkit and brepjs keep separate
-signature stores, and the agreement terms are identical in both.
+signature stores.
 
 ## Getting Started
 


### PR DESCRIPTION
Mirrors the review finding accepted on brepkit#1419: the CONTRIBUTING CLA note asserted the two repos' agreement terms are identical, which goes stale if either CLA text changes independently. Now states only the per-repository signing behavior.