### PR TITLE
chore(deps): bump occt-wasm to 4.0.0 and brepkit-wasm to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,14 +37,14 @@
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "@vitest/coverage-v8": "4.1.10",
         "brepjs-opencascade": "*",
-        "brepkit-wasm": "3.0.0",
+        "brepkit-wasm": "3.0.2",
         "eslint": "10.8.0",
         "fast-check": "4.9.0",
         "husky": "9.1.7",
         "knip": "6.27.0",
         "lint-staged": "17.2.0",
         "lz-string": "1.5.0",
-        "occt-wasm": "3.8.3",
+        "occt-wasm": "4.0.0",
         "prettier": "3.9.6",
         "puppeteer": "25.4.0",
         "size-limit": "12.1.0",
@@ -64,7 +64,7 @@
         "brepjs-manifold": "^0.1.0",
         "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
         "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0 || ^3.0.0",
-        "occt-wasm": "^3.8.0"
+        "occt-wasm": "^3.8.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "brepjs-manifold": {
@@ -7228,8 +7228,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.120.0"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -7276,9 +7275,9 @@
       "link": true
     },
     "node_modules/brepkit-wasm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-3.0.0.tgz",
-      "integrity": "sha512-xlHJcJpbtvE6F87wdfZQ/a8KWiV6SLF1yk7AeLJUpGqc4bBkdifCMNu7tH6r04C1+pu7H8H1M/E1F7Xru1L82A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-3.0.2.tgz",
+      "integrity": "sha512-gCBV3rtv6L5Hl3aJJdDyBEnLGSyccDOEh0Hz2xW9hQ2fa11pSfGOwhcA5srazIqH15BqdWqNsc2o3jMoEpGDDA==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },
@@ -11273,9 +11272,9 @@
       "license": "MIT"
     },
     "node_modules/occt-wasm": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-3.8.3.tgz",
-      "integrity": "sha512-UF8Ej2vP0GZNySw8qGwFX29TbspaQAgust64fzq8QewEskCQmHhmlux7ib7a/h+yu2ib8nmRiUkUZQgbjsi9wA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/occt-wasm/-/occt-wasm-4.0.0.tgz",
+      "integrity": "sha512-4FDlN8VVeYuYSOc7AooSrtWrvqGO7jML/tECkCJf9YMUMGLZFuA/FJGDTlQk4IOT62E70Ag1lQ2Jcx0CC66wwg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "comlink": "^4.4.2"
@@ -14885,9 +14884,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
-        "brepjs": ">=18.120.0",
+        "brepjs": ">=18.117.1",
         "commander": "^15.0.0",
-        "occt-wasm": "^3.0.0",
+        "occt-wasm": "^3.0.0 || ^4.0.0",
         "typescript": "^6.0.3"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -265,14 +265,14 @@
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@vitest/coverage-v8": "4.1.10",
     "brepjs-opencascade": "*",
-    "brepkit-wasm": "3.0.0",
+    "brepkit-wasm": "3.0.2",
     "eslint": "10.8.0",
     "fast-check": "4.9.0",
     "husky": "9.1.7",
     "knip": "6.27.0",
     "lint-staged": "17.2.0",
     "lz-string": "1.5.0",
-    "occt-wasm": "3.8.3",
+    "occt-wasm": "4.0.0",
     "prettier": "3.9.6",
     "puppeteer": "25.4.0",
     "size-limit": "12.1.0",
@@ -289,7 +289,7 @@
     "brepjs-manifold": "^0.1.0",
     "brepjs-opencascade": "^0.5.1 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
     "brepkit-wasm": "^0.10.1 || ^1.0.0 || ^2.0.0 || ^3.0.0",
-    "occt-wasm": "^3.8.0"
+    "occt-wasm": "^3.8.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "brepjs-manifold": {

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -59,7 +59,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "brepjs": ">=18.117.1",
     "commander": "^15.0.0",
-    "occt-wasm": "^3.0.0",
+    "occt-wasm": "^3.0.0 || ^4.0.0",
     "typescript": "^6.0.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Brings the three pluggable kernels to their latest published releases.

| package | before | after |
| --- | --- | --- |
| `occt-wasm` | 3.8.3 | 4.0.0 |
| `brepkit-wasm` | 3.0.0 | 3.0.2 |
| `manifold-3d` | 3.5.1 | already latest |

## occt-wasm 4.0.0 major

The break is `SweepMode.Auxiliary` no longer forcing `CurvilinearEquivalence=true` on `BRepOffsetAPI_MakePipeShell::SetMode`. That path is unreachable from brepjs: nothing here calls `sweepOriented`, and the occt-wasm adapter's `sweepPipeShell` drops the `auxiliary` option before it reaches the facade.

The new default also matches the other kernel. `src/kernel/occt/advancedOps.ts` already calls `SetMode_5(auxiliary, false, NoContact)`, so occt-wasm now agrees with what the opencascade adapter was doing.

Peer range widened to `^3.8.0 || ^4.0.0` so downstream consumers on 3.x keep resolving; same for brepjs-cad's `occt-wasm` dependency.

## Verification

- `test:ci` (occt-wasm): 4778 passed, 373 skipped
- `test:brepkit`: 4576 passed, 658 skipped
- typecheck, format:check, check:boundaries clean

The two extra lockfile lines are npm reconciling the lock to the committed `package.json` (brepjs-cad's `brepjs` range, the linked-workspace `version` field), not a revert.
