### PR TITLE
feat(kernel): route BooleanOptions.simplify through brepkit boolean WithOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "@vitest/coverage-v8": "4.1.10",
         "brepjs-opencascade": "*",
-        "brepkit-wasm": "3.0.2",
+        "brepkit-wasm": "3.2.1",
         "eslint": "10.8.0",
         "fast-check": "4.9.0",
         "husky": "9.1.7",
@@ -7275,9 +7275,9 @@
       "link": true
     },
     "node_modules/brepkit-wasm": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-3.0.2.tgz",
-      "integrity": "sha512-gCBV3rtv6L5Hl3aJJdDyBEnLGSyccDOEh0Hz2xW9hQ2fa11pSfGOwhcA5srazIqH15BqdWqNsc2o3jMoEpGDDA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/brepkit-wasm/-/brepkit-wasm-3.2.1.tgz",
+      "integrity": "sha512-KYxzfVtwSbYRWUd+lejltkC4VGrTT07zvCOmL8j+TURn/ORiT/PicUGIXKlHw3ZN7d102ZSIIl6fgscgYcAAzw==",
       "dev": true,
       "license": "AGPL-3.0-only"
     },

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@vitest/coverage-v8": "4.1.10",
     "brepjs-opencascade": "*",
-    "brepkit-wasm": "3.0.2",
+    "brepkit-wasm": "3.2.1",
     "eslint": "10.8.0",
     "fast-check": "4.9.0",
     "husky": "9.1.7",

--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -23,7 +23,7 @@ import {
   isBrepkitHandle,
   toArray,
   warnOnce,
-  hasBooleanOptions,
+  hasIgnoredBooleanOptions,
   nextSyntheticId,
   syntheticCompounds,
 } from './helpers.js';
@@ -59,16 +59,42 @@ function emptyCompound(bk: BrepkitKernel): KernelShape {
   return compoundHandle(bk.makeCompound([]));
 }
 
+/** Kernel boolean honoring `simplify` when the kernel supports it (brepkit-wasm >= 3.2). */
+function kernelBoolean(
+  bk: BrepkitKernel,
+  op: 'fuse' | 'cut' | 'intersect',
+  a: number,
+  b: number,
+  options?: BooleanOptions
+): number {
+  if (options?.simplify) {
+    if (op === 'fuse' && typeof bk.fuseWithOptions === 'function') {
+      return bk.fuseWithOptions(a, b, true);
+    }
+    if (op === 'cut' && typeof bk.cutWithOptions === 'function') {
+      return bk.cutWithOptions(a, b, true);
+    }
+    if (op === 'intersect' && typeof bk.intersectWithOptions === 'function') {
+      return bk.intersectWithOptions(a, b, true);
+    }
+    warnOnce(
+      'boolean-simplify',
+      'BooleanOptions.simplify needs brepkit-wasm >= 3.2; ignored on this kernel.'
+    );
+  }
+  return bk[op](a, b);
+}
+
 export function fuse(
   bk: BrepkitKernel,
   shape: KernelShape,
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  if (_options && hasBooleanOptions(_options)) {
+  if (_options && hasIgnoredBooleanOptions(_options)) {
     warnOnce(
       'boolean-options',
-      'BooleanOptions (optimisation, simplify, strategy, fuzzyValue) not supported; ignored.'
+      'BooleanOptions (optimisation, strategy, fuzzyValue) not supported; ignored.'
     );
   }
   // Identity: fuse(∅, X) = X, fuse(X, ∅) = X.
@@ -80,11 +106,11 @@ export function fuse(
     const toolSolidIds: number[] = toArray(bk.getCompoundSolids(toolHandle.id));
     let currentId = baseId;
     for (const toolSolidId of toolSolidIds) {
-      currentId = bk.fuse(currentId, toolSolidId);
+      currentId = kernelBoolean(bk, 'fuse', currentId, toolSolidId, _options);
     }
     return solidHandle(currentId);
   }
-  const result = bk.fuse(baseId, unwrapSolidOrThrow(tool, 'fuse'));
+  const result = kernelBoolean(bk, 'fuse', baseId, unwrapSolidOrThrow(tool, 'fuse'), _options);
   return solidHandle(result);
 }
 
@@ -94,10 +120,10 @@ export function cut(
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  if (_options && hasBooleanOptions(_options)) {
+  if (_options && hasIgnoredBooleanOptions(_options)) {
     warnOnce(
       'boolean-options',
-      'BooleanOptions (optimisation, simplify, strategy, fuzzyValue) not supported; ignored.'
+      'BooleanOptions (optimisation, strategy, fuzzyValue) not supported; ignored.'
     );
   }
   // Identity: cut(∅, X) = ∅, cut(X, ∅) = X.
@@ -110,7 +136,7 @@ export function cut(
     let currentId = baseId;
     for (const toolSolidId of toolSolidIds) {
       try {
-        currentId = bk.cut(currentId, toolSolidId);
+        currentId = kernelBoolean(bk, 'cut', currentId, toolSolidId, _options);
       } catch (e) {
         if (isEmptyBooleanError(e)) return emptyCompound(bk);
         throw e;
@@ -119,7 +145,7 @@ export function cut(
     return solidHandle(currentId);
   }
   try {
-    const result = bk.cut(baseId, unwrapSolidOrThrow(tool, 'cut'));
+    const result = kernelBoolean(bk, 'cut', baseId, unwrapSolidOrThrow(tool, 'cut'), _options);
     return solidHandle(result);
   } catch (e) {
     if (isEmptyBooleanError(e)) return emptyCompound(bk);
@@ -133,10 +159,10 @@ export function intersect(
   tool: KernelShape,
   _options?: BooleanOptions
 ): KernelShape {
-  if (_options && hasBooleanOptions(_options)) {
+  if (_options && hasIgnoredBooleanOptions(_options)) {
     warnOnce(
       'boolean-options',
-      'BooleanOptions (optimisation, simplify, strategy, fuzzyValue) not supported; ignored.'
+      'BooleanOptions (optimisation, strategy, fuzzyValue) not supported; ignored.'
     );
   }
   // Identity: intersect(∅, _) = ∅, intersect(_, ∅) = ∅.
@@ -144,9 +170,12 @@ export function intersect(
     return emptyCompound(bk);
   }
   try {
-    const result = bk.intersect(
+    const result = kernelBoolean(
+      bk,
+      'intersect',
       unwrapSolidOrThrow(shape, 'intersect'),
-      unwrapSolidOrThrow(tool, 'intersect')
+      unwrapSolidOrThrow(tool, 'intersect'),
+      _options
     );
     return solidHandle(result);
   } catch (e) {

--- a/src/kernel/brepkit/brepkitWasmTypes.ts
+++ b/src/kernel/brepkit/brepkitWasmTypes.ts
@@ -161,6 +161,20 @@ export interface BrepkitKernel {
 
   intersect(a: number, b: number): number;
 
+  /** brepkit-wasm >= 3.2: boolean with post-processing (simplify = unify co-surface fragments). */
+  fuseWithOptions?(a: number, b: number, simplify: boolean): number;
+
+  cutWithOptions?(a: number, b: number, simplify: boolean): number;
+
+  intersectWithOptions?(a: number, b: number, simplify: boolean): number;
+
+  /**
+   * brepkit-wasm >= 3.2: process-wide count of booleans that used the mesh
+   * (co-refinement) fallback. Snapshot around a chain; growth means at least
+   * one approximate, possibly non-watertight result.
+   */
+  meshFallbackCount?(): number;
+
   compoundCut(target: number, toolIds: Uint32Array | number[]): number;
 
   convexHull(coords: Float64Array | number[]): number;

--- a/src/kernel/brepkit/helpers.ts
+++ b/src/kernel/brepkit/helpers.ts
@@ -378,21 +378,6 @@ export function hasIgnoredBooleanOptions(opts: {
   );
 }
 
-/** Check if a BooleanOptions object has any meaningful (non-signal) property set. */
-export function hasBooleanOptions(opts: {
-  optimisation?: unknown;
-  simplify?: unknown;
-  strategy?: unknown;
-  fuzzyValue?: unknown;
-}): boolean {
-  return (
-    opts.optimisation !== undefined ||
-    opts.simplify !== undefined ||
-    opts.strategy !== undefined ||
-    opts.fuzzyValue !== undefined
-  );
-}
-
 // ---------------------------------------------------------------------------
 // 2D handle casts
 // ---------------------------------------------------------------------------

--- a/src/kernel/brepkit/helpers.ts
+++ b/src/kernel/brepkit/helpers.ts
@@ -367,6 +367,17 @@ export function warnOnce(key: string, message: string): void {
   console.warn(`brepkit: ${message}`);
 }
 
+/** Check if a BooleanOptions object sets an option brepkit still ignores. */
+export function hasIgnoredBooleanOptions(opts: {
+  optimisation?: unknown;
+  strategy?: unknown;
+  fuzzyValue?: unknown;
+}): boolean {
+  return (
+    opts.optimisation !== undefined || opts.strategy !== undefined || opts.fuzzyValue !== undefined
+  );
+}
+
 /** Check if a BooleanOptions object has any meaningful (non-signal) property set. */
 export function hasBooleanOptions(opts: {
   optimisation?: unknown;

--- a/tests/booleanSimplify.test.ts
+++ b/tests/booleanSimplify.test.ts
@@ -1,0 +1,32 @@
+/**
+ * BooleanOptions.simplify passthrough (brepkit >= 3.2): the option routes to
+ * the kernel's *WithOptions entry points instead of being warn-dropped.
+ * Runs on whichever kernel BREPJS_KERNEL selects; on kernels without the
+ * entry points the option degrades to a plain boolean, so the volume
+ * assertions hold everywhere.
+ */
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { box, measureVolume, unwrap, translate, fuse, cut } from '@/index.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+describe('BooleanOptions.simplify', () => {
+  it('fuse with simplify produces the correct solid', () => {
+    const box1 = box(10, 10, 10);
+    const box2 = translate(box1, [5, 0, 0]);
+    const fused = unwrap(fuse(box1, box2, { simplify: true }));
+    const vol = unwrap(measureVolume(fused));
+    expect(vol).toBeCloseTo(1500, 0);
+  });
+
+  it('cut with simplify produces the correct solid', () => {
+    const box1 = box(10, 10, 10);
+    const box2 = translate(box1, [5, 0, 0]);
+    const c = unwrap(cut(box1, box2, { simplify: true }));
+    const vol = unwrap(measureVolume(c));
+    expect(vol).toBeCloseTo(500, 0);
+  });
+});

--- a/tests/brepkitAdapter.test.ts
+++ b/tests/brepkitAdapter.test.ts
@@ -33,6 +33,9 @@ function createMockBrepKernel() {
 
     // Booleans
     fuse: vi.fn((_a: number, _b: number) => allocId()),
+    fuseWithOptions: vi.fn((_a: number, _b: number, _simplify: boolean) => allocId()),
+    cutWithOptions: vi.fn((_a: number, _b: number, _simplify: boolean) => allocId()),
+    intersectWithOptions: vi.fn((_a: number, _b: number, _simplify: boolean) => allocId()),
     cut: vi.fn((_a: number, _b: number) => allocId()),
     compoundCut: vi.fn((_target: number, _toolIds: Uint32Array | number[]) => allocId()),
     intersect: vi.fn((_a: number, _b: number) => allocId()),
@@ -331,6 +334,33 @@ describe('BrepkitAdapter', () => {
 
       expect(mock.fuse).toHaveBeenCalledWith((a as BrepkitHandle).id, (b as BrepkitHandle).id);
       expect((result as BrepkitHandle).type).toBe('solid');
+    });
+
+    it('fuse with simplify routes through fuseWithOptions', () => {
+      const mock = createMockBrepKernel();
+      const adapter = new BrepkitAdapter(mock);
+      const a = adapter.makeBox(1, 1, 1);
+      const b = adapter.makeBox(1, 1, 1);
+      adapter.fuse(a, b, { simplify: true });
+
+      expect(mock.fuseWithOptions).toHaveBeenCalledWith(
+        (a as BrepkitHandle).id,
+        (b as BrepkitHandle).id,
+        true
+      );
+      expect(mock.fuse).not.toHaveBeenCalled();
+    });
+
+    it('fuse with simplify falls back to plain fuse on kernels without fuseWithOptions', () => {
+      const mock = createMockBrepKernel();
+      // Simulate an older brepkit-wasm without the options entry point.
+      (mock as { fuseWithOptions?: unknown }).fuseWithOptions = undefined;
+      const adapter = new BrepkitAdapter(mock);
+      const a = adapter.makeBox(1, 1, 1);
+      const b = adapter.makeBox(1, 1, 1);
+      adapter.fuse(a, b, { simplify: true });
+
+      expect(mock.fuse).toHaveBeenCalled();
     });
 
     it('cut delegates to kernel', () => {


### PR DESCRIPTION
Completes the brepjs side of brepkit#1447 (`BooleanOptions` accepted then silently ignored).

- `fuse`/`cut`/`intersect` feature-detect the brepkit-wasm 3.2+ `*WithOptions` entry points and route `simplify` through them (kernel-side it unifies co-surface fragments after the boolean). Kernels without the entry points degrade to a plain boolean with a one-time warning.
- The ignored-options warning narrows to what is actually still ignored: `optimisation`, `strategy`, `fuzzyValue`.
- Types gain optional `fuseWithOptions`/`cutWithOptions`/`intersectWithOptions`/`meshFallbackCount` declarations (`meshFallbackCount` is the brepkit#1445 export guard: snapshot around a chain, refuse the output when it grew).
- Bumps brepkit-wasm to 3.2.1 — also carries the slots wall-pattern watertightness fix (brepkit#1446: the tool-side slots case went 53.7 s → 3.07 s with fully analytic output on this kernel).

Verification: adapter unit tests 404/404 (incl. new routing + old-kernel-fallback tests), new live `booleanSimplify` tests green on both kernels, typecheck + knip clean, full brepkit consumer project **4568 passed / 362 skipped**.