### PR TITLE
ci: unblock the OSV push scan and stop merged PRs being locked

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,3 +28,13 @@ jobs:
           # commits carry it as the committer, so it must be allowlisted or
           # every release PR fails the CLA check.
           allowlist: 'andymai,web-flow,dependabot[bot],github-actions[bot],brepkit[bot],*[bot]'
+          # Defaults to true, which locks every PR the moment it merges.
+          # release-please comments on the release PR right after tagging it,
+          # so a locked PR fails that comment, and the failure propagates: the
+          # action's outputs never publish, `publish-brepjs` is skipped on its
+          # `brepjs_release_created` gate, and the release ends up tagged on
+          # GitHub but absent from npm (18.121.0 landed this way).
+          # Locking only stops contributors deleting their signature *comment*;
+          # the authoritative record is signatures/cla.json on the
+          # cla-signatures branch, which locking does not protect.
+          lock-pullrequest-aftermerge: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -7228,8 +7228,7 @@
     },
     "node_modules/brepjs": {
       "resolved": "",
-      "link": true,
-      "version": "18.121.0"
+      "link": true
     },
     "node_modules/brepjs-bim": {
       "resolved": "packages/brepjs-bim",
@@ -11147,9 +11146,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "devOptional": true,
       "funding": [
         {
@@ -14881,11 +14880,11 @@
       }
     },
     "packages/brepjs-cad": {
-      "version": "0.119.1",
+      "version": "0.119.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
-        "brepjs": ">=18.121.0",
+        "brepjs": ">=18.117.1",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0 || ^4.0.0",
         "typescript": "^6.0.3"


### PR DESCRIPTION
Two CI defects that both hid behind the same asymmetry: they only manifest on pushes to `main`, and no pull request ever showed them.

## The blocking OSV scan has been failing on every push to main

`nanoid` 3.3.16 carries GHSA-2v37-7h3g-55p8 (High, 8.2). The scan passes on pull requests because that variant is report-only; the push variant blocks. So `main` sat red by default and every PR looked clean.

It arrives through `vite -> postcss`, which asks for `^3.3.16`, so 3.3.18 satisfies it and a plain lockfile update is enough. Deliberately not an override — those pin a resolution and become a per-advisory treadmill once upstream moves.

Dev-only dependency: nothing changes in the published package, hence `chore` rather than `fix`. No release is warranted.

## Every merged PR is locked, which strands every release

`contributor-assistant/github-action` defaults `lock-pullrequest-aftermerge` to `true`, and nothing overrode it. Confirmed against the action's own `action.yml`, and every merged PR checked is `locked=true` by `github-actions[bot]` (#1955, #1958, #1960, #1961, #1962, #1963, #1965).

The consequence is not cosmetic. release-please comments on the release PR immediately after tagging it, so:

1. the tag and GitHub release are created
2. the comment hits the lock and the action step fails
3. its outputs never publish
4. `publish-brepjs` is skipped on its `brepjs_release_created` gate
5. the release is tagged on GitHub but absent from npm

18.121.0 landed in exactly that state an hour ago and needed a manual `republish` dispatch to reach npm. Left alone this recurs on every release, and the failure is quiet — the red X reads as "release-please failed", not "your package never published".

Fixed at the root rather than by making the release step tolerant: `continue-on-error` there would let a genuinely failed release publish anyway.

Disabling the lock is safe here. It only stops a contributor deleting their signature *comment* after merge; the authoritative record is `signatures/cla.json` on the `cla-signatures` branch, which locking does not protect. Every current contributor is allowlisted (`andymai,web-flow,dependabot[bot],github-actions[bot],brepkit[bot],*[bot]`), so no signature comment is posted in the first place.

## Verification

The nanoid change is lockfile-only (`3.3.16 -> 3.3.18`, plus npm reconciling the linked-workspace version field). The CLA change adds one input.

Neither can be fully proven until this merges — the OSV push variant and the CLA lock both only run on `main`. The next release after this is the real test of the second fix.
