### PR TITLE
feat(manifold): implement the 2D curve ops natively

### DIFF
--- a/src/2d/lib/intersections.ts
+++ b/src/2d/lib/intersections.ts
@@ -49,13 +49,22 @@ export const intersectCurves = (
     return err(computationError('INTERSECTION_FAILED', 'Intersections failed between curves', e));
   }
 
-  const segmentsAsPoints = commonSegments
-    .filter((c) => samePoint(c.firstPoint, c.lastPoint, precision))
-    .map((c) => c.firstPoint);
+  // Coincident endpoints alone do not make a common segment degenerate: a
+  // closed overlap — two identical circles share their whole outline — starts
+  // and ends at the same point while spanning the entire curve. Demoting on
+  // the endpoints alone discards that overlap before any boolean sees it, so
+  // require the midpoint to sit on the endpoints too.
+  const isDegenerate = (c: Curve2D): boolean => {
+    if (!samePoint(c.firstPoint, c.lastPoint, precision)) return false;
+    const mid = c.value((c.firstParameter + c.lastParameter) / 2);
+    return samePoint(mid, c.firstPoint, precision);
+  };
+
+  const segmentsAsPoints = commonSegments.filter(isDegenerate).map((c) => c.firstPoint);
 
   if (segmentsAsPoints.length) {
     intersections.push(...segmentsAsPoints);
-    commonSegments = commonSegments.filter((c) => !samePoint(c.firstPoint, c.lastPoint, precision));
+    commonSegments = commonSegments.filter((c) => !isDegenerate(c));
   }
 
   const commonSegmentsPoints = commonSegments.flatMap((c) => [c.firstPoint, c.lastPoint]);

--- a/src/kernel/manifold/kernel2dNative.ts
+++ b/src/kernel/manifold/kernel2dNative.ts
@@ -82,9 +82,33 @@ function closestParamOn(c: LineC | ConicC | BezierC, x: number, y: number): numb
       );
       return clampToArc(a, c.a0, c.a1);
     }
-    return goldenMin(c.a0, c.a1, (t) => distSqAt(c, t, x, y));
+    return bracketedMin(c.a0, c.a1, (t) => distSqAt(c, t, x, y));
   }
-  return goldenMin(0, 1, (t) => distSqAt(c, t, x, y));
+  return bracketedMin(0, 1, (t) => distSqAt(c, t, x, y));
+}
+
+/**
+ * Global minimum of f over [lo, hi].
+ *
+ * Distance to an eccentric ellipse or a cubic-or-higher bezier is NOT unimodal
+ * — a point inside a flat ellipse has one minimum per end, and a self-nearing
+ * bezier can have several. So scan coarsely for the best sample, then refine
+ * only inside the bracket around it, which is unimodal by construction.
+ */
+function bracketedMin(lo: number, hi: number, f: (t: number) => number): number {
+  const N = 96;
+  let bestI = 0;
+  let best = Infinity;
+  for (let i = 0; i <= N; i++) {
+    const v = f(lo + ((hi - lo) * i) / N);
+    if (v < best) {
+      best = v;
+      bestI = i;
+    }
+  }
+  const a = lo + ((hi - lo) * Math.max(0, bestI - 1)) / N;
+  const b = lo + ((hi - lo) * Math.min(N, bestI + 1)) / N;
+  return goldenMin(a, b, f);
 }
 
 /** Wrap an angle into [a0, a1] where possible, else clamp to the nearer end. */
@@ -154,7 +178,7 @@ function intersectNative(
   a: NativeCurve,
   b: NativeCurve,
   tol: number
-): { points: Vec2[]; params: number[] } {
+): { points: Vec2[]; params: number[]; segments: NativeCurve[] } {
   const pa = sample(a);
   const pb = sample(b);
   const points: Vec2[] = [];
@@ -183,7 +207,44 @@ function intersectNative(
       params.push(ta);
     }
   }
-  return { points, params };
+  // Coincident spans and tangential touches never register as segment
+  // crossings — collinear chords are parallel, and a tangency grazes without
+  // passing through. Walk a's parameter range and keep the runs that lie on b
+  // within tolerance: a run of length is a common segment, an isolated dip is
+  // a tangential point.
+  const { first, last } = nativeBounds(a);
+  const M = 192;
+  const on: boolean[] = [];
+  for (let i = 0; i <= M; i++) {
+    const t = first + ((last - first) * i) / M;
+    const p = nativeAt(a, t);
+    const tb = closestParamOn(b, p[0], p[1]);
+    on.push(Math.sqrt(distSqAt(b, tb, p[0], p[1])) <= Math.max(tol, 1e-9));
+  }
+  const segments: NativeCurve[] = [];
+  let runStart = -1;
+  for (let i = 0; i <= M + 1; i++) {
+    const inside = i <= M && on[i] === true;
+    if (inside && runStart < 0) runStart = i;
+    if (!inside && runStart >= 0) {
+      const spanSteps = i - runStart;
+      const t0 = first + ((last - first) * runStart) / M;
+      const t1 = first + ((last - first) * (i - 1)) / M;
+      if (spanSteps > 1) {
+        segments.push(trimNative(a, t0, t1));
+      } else {
+        // Single sample touching b: a tangential contact, reported as a point
+        // if the crossing search did not already find it.
+        const p = nativeAt(a, t0);
+        if (!points.some((q) => Math.hypot(q[0] - p[0], q[1] - p[1]) <= Math.max(tol, 1e-9))) {
+          points.push(p);
+          params.push(t0);
+        }
+      }
+      runStart = -1;
+    }
+  }
+  return { points, params, segments };
 }
 
 function sub2(a: Vec2, b: Vec2): Vec2 {
@@ -813,22 +874,31 @@ function makeNativeKernel2DOps(
     offsetCurve2d: (c, offset) => occtOr('offsetCurve2d').offsetCurve2d(toOcct(c), offset),
     intersectCurves2d: (c1, c2, tol) => {
       if (!isNative(c1) || !isNative(c2)) {
-        return occtOr('intersectCurves2d').intersectCurves2d(c1, c2, tol);
+        return occtOr('intersectCurves2d').intersectCurves2d(toOcct(c1), toOcct(c2), tol);
       }
-      const { points } = intersectNative(asC(c1), asC(c2), tol);
-      // No native overlap detection: coincident spans report as crossings, not
-      // as common segments, which is what the mesh construction path consumes.
-      return { points: points.map((p): [number, number] => [p[0], p[1]]), segments: [] };
+      const { points, segments } = intersectNative(asC(c1), asC(c2), tol);
+      return {
+        points: points.map((p): [number, number] => [p[0], p[1]]),
+        segments: segments,
+      };
     },
     projectPointOnCurve2d: (c, x, y) => {
-      if (!isNative(c)) return occtOr('projectPointOnCurve2d').projectPointOnCurve2d(c, x, y);
+      if (!isNative(c))
+        return occtOr('projectPointOnCurve2d').projectPointOnCurve2d(toOcct(c), x, y);
       const n = asC(c);
       const param = closestParamOn(n, x, y);
       return { param, distance: Math.sqrt(distSqAt(n, param, x, y)) };
     },
     distanceBetweenCurves2d: (c1, c2, s1, e1, s2, e2) => {
       if (!isNative(c1) || !isNative(c2)) {
-        return occtOr('distanceBetweenCurves2d').distanceBetweenCurves2d(c1, c2, s1, e1, s2, e2);
+        return occtOr('distanceBetweenCurves2d').distanceBetweenCurves2d(
+          toOcct(c1),
+          toOcct(c2),
+          s1,
+          e1,
+          s2,
+          e2
+        );
       }
       // Sample one curve and project each sample onto the other: the minimum
       // over a dense sampling is within the sampling step of the true minimum,
@@ -860,7 +930,7 @@ function makeNativeKernel2DOps(
     serializeCurve2d: (c) =>
       isNative(c)
         ? JSON.stringify({ __nativeC2d: 1, c: asC(c) })
-        : occtOr('serializeCurve2d').serializeCurve2d(c),
+        : occtOr('serializeCurve2d').serializeCurve2d(toOcct(c)),
     deserializeCurve2d: (data) => {
       if (data.startsWith('{"__nativeC2d"')) {
         const parsed = JSON.parse(data) as { c: LineC | ConicC | BezierC };
@@ -869,7 +939,7 @@ function makeNativeKernel2DOps(
       return occtOr('deserializeCurve2d').deserializeCurve2d(data);
     },
     splitCurve2d: (c, params) => {
-      if (!isNative(c)) return occtOr('splitCurve2d').splitCurve2d(c, params);
+      if (!isNative(c)) return occtOr('splitCurve2d').splitCurve2d(toOcct(c), params);
       const n = asC(c);
       const { first, last } = nativeBounds(n);
       const cuts = [

--- a/src/kernel/manifold/kernel2dNative.ts
+++ b/src/kernel/manifold/kernel2dNative.ts
@@ -52,6 +52,216 @@ interface Affine {
 
 const CHORD_TOL = 0.004; // max polygon sagitta (mm) when discretizing conic arcs
 
+/**
+ * Closest parameter on a native curve to (x, y), in that curve's own
+ * parametrization: signed distance for a line, angle for a conic, [0,1] for a
+ * bezier. Exact where the geometry allows it, and a bounded golden-section
+ * search where it does not (general ellipse, bezier) — both of which are
+ * unimodal in distance over a single arc, so the search cannot land on a
+ * spurious local minimum.
+ */
+function closestParamOn(c: LineC | ConicC | BezierC, x: number, y: number): number {
+  if (c.k === 'line') {
+    const dx = c.p2[0] - c.p1[0];
+    const dy = c.p2[1] - c.p1[1];
+    const len = Math.hypot(dx, dy);
+    if (len === 0) return 0;
+    const t = ((x - c.p1[0]) * dx + (y - c.p1[1]) * dy) / len;
+    return Math.min(Math.max(t, 0), len);
+  }
+  if (c.k === 'conic') {
+    const ru = Math.hypot(c.u[0], c.u[1]);
+    const rv = Math.hypot(c.v[0], c.v[1]);
+    // A circle (equal conjugate radii, orthogonal axes) closes in one step.
+    if (Math.abs(ru - rv) < 1e-12 && Math.abs(c.u[0] * c.v[0] + c.u[1] * c.v[1]) < 1e-12) {
+      const px = x - c.c[0];
+      const py = y - c.c[1];
+      const a = Math.atan2(
+        (px * c.v[0] + py * c.v[1]) / (rv * rv || 1),
+        (px * c.u[0] + py * c.u[1]) / (ru * ru || 1)
+      );
+      return clampToArc(a, c.a0, c.a1);
+    }
+    return goldenMin(c.a0, c.a1, (t) => distSqAt(c, t, x, y));
+  }
+  return goldenMin(0, 1, (t) => distSqAt(c, t, x, y));
+}
+
+/** Wrap an angle into [a0, a1] where possible, else clamp to the nearer end. */
+function clampToArc(a: number, a0: number, a1: number): number {
+  const span = a1 - a0;
+  if (span >= 2 * Math.PI - 1e-12) return a;
+  let t = a;
+  while (t < a0) t += 2 * Math.PI;
+  while (t > a0 + 2 * Math.PI) t -= 2 * Math.PI;
+  if (t <= a1) return t;
+  // Outside the arc: whichever endpoint the angle sits nearer to.
+  return t - a1 < a0 + 2 * Math.PI - t ? a1 : a0;
+}
+
+function distSqAt(c: LineC | ConicC | BezierC, t: number, x: number, y: number): number {
+  const p = nativeAt(c, t);
+  const dx = p[0] - x;
+  const dy = p[1] - y;
+  return dx * dx + dy * dy;
+}
+
+function nativeAt(c: LineC | ConicC | BezierC, t: number): Vec2 {
+  if (c.k === 'line') {
+    const dx = c.p2[0] - c.p1[0];
+    const dy = c.p2[1] - c.p1[1];
+    const len = Math.hypot(dx, dy) || 1;
+    return [c.p1[0] + (dx * t) / len, c.p1[1] + (dy * t) / len];
+  }
+  if (c.k === 'bezier') return bezierAt(c.pts, t);
+  return [
+    c.c[0] + c.u[0] * Math.cos(t) + c.v[0] * Math.sin(t),
+    c.c[1] + c.u[1] * Math.cos(t) + c.v[1] * Math.sin(t),
+  ];
+}
+
+/** Golden-section minimum of a unimodal f over [lo, hi]. */
+function goldenMin(lo: number, hi: number, f: (t: number) => number): number {
+  const phi = (Math.sqrt(5) - 1) / 2;
+  let a = lo;
+  let b = hi;
+  let c1 = b - phi * (b - a);
+  let d1 = a + phi * (b - a);
+  for (let i = 0; i < 80 && b - a > 1e-12; i++) {
+    if (f(c1) < f(d1)) {
+      b = d1;
+      d1 = c1;
+      c1 = b - phi * (b - a);
+    } else {
+      a = c1;
+      c1 = d1;
+      d1 = a + phi * (b - a);
+    }
+  }
+  return (a + b) / 2;
+}
+
+/**
+ * Curve-curve intersection over the shim's own polyline discretization.
+ *
+ * Manifold has no exact curve algebra, so candidate crossings come from
+ * segment pairs and are then refined by alternating projection: each point is
+ * projected onto the other curve until it stops moving. That converges to a
+ * genuine crossing when the segments really cross, and to the closest approach
+ * when they only nearly touch — which the tolerance check then rejects.
+ */
+function intersectNative(
+  a: NativeCurve,
+  b: NativeCurve,
+  tol: number
+): { points: Vec2[]; params: number[] } {
+  const pa = sample(a);
+  const pb = sample(b);
+  const points: Vec2[] = [];
+  const params: number[] = [];
+  for (let i = 0; i + 1 < pa.length; i++) {
+    for (let j = 0; j + 1 < pb.length; j++) {
+      const hit = segSeg(pa[i] as Vec2, pa[i + 1] as Vec2, pb[j] as Vec2, pb[j + 1] as Vec2);
+      if (!hit) continue;
+      let p = hit;
+      for (let k = 0; k < 24; k++) {
+        const ta = closestParamOn(a, p[0], p[1]);
+        const qa = nativeAt(a, ta);
+        const tb = closestParamOn(b, qa[0], qa[1]);
+        const qb = nativeAt(b, tb);
+        const moved = Math.hypot(qb[0] - p[0], qb[1] - p[1]);
+        p = [(qa[0] + qb[0]) / 2, (qa[1] + qb[1]) / 2];
+        if (moved < 1e-12) break;
+      }
+      const ta = closestParamOn(a, p[0], p[1]);
+      const tb = closestParamOn(b, p[0], p[1]);
+      const d = sub2(nativeAt(a, ta), nativeAt(b, tb));
+      const gap = Math.hypot(d[0], d[1]);
+      if (gap > Math.max(tol, 1e-7)) continue;
+      if (points.some((q) => Math.hypot(q[0] - p[0], q[1] - p[1]) <= Math.max(tol, 1e-9))) continue;
+      points.push(p);
+      params.push(ta);
+    }
+  }
+  return { points, params };
+}
+
+function sub2(a: Vec2, b: Vec2): Vec2 {
+  return [a[0] - b[0], a[1] - b[1]];
+}
+
+/** Intersection point of two segments, or null when they do not cross. */
+function segSeg(p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2): Vec2 | null {
+  const d1x = p2[0] - p1[0];
+  const d1y = p2[1] - p1[1];
+  const d2x = p4[0] - p3[0];
+  const d2y = p4[1] - p3[1];
+  const den = d1x * d2y - d1y * d2x;
+  if (Math.abs(den) < 1e-15) return null;
+  const t = ((p3[0] - p1[0]) * d2y - (p3[1] - p1[1]) * d2x) / den;
+  const u = ((p3[0] - p1[0]) * d1y - (p3[1] - p1[1]) * d1x) / den;
+  if (t < -1e-9 || t > 1 + 1e-9 || u < -1e-9 || u > 1 + 1e-9) return null;
+  return [p1[0] + d1x * t, p1[1] + d1y * t];
+}
+
+/** Parameter range of a native curve, matching getCurve2dBounds. */
+function nativeBounds(c: LineC | ConicC | BezierC): { first: number; last: number } {
+  if (c.k === 'conic') return { first: c.a0, last: c.a1 };
+  if (c.k === 'line') {
+    return { first: 0, last: Math.hypot(c.p2[0] - c.p1[0], c.p2[1] - c.p1[1]) };
+  }
+  return { first: 0, last: 1 };
+}
+
+/** Restrict a native curve to [from, to] in its own parametrization. */
+function trimNative(c: NativeCurve, from: number, to: number): NativeCurve {
+  if (c.k === 'conic') return { ...c, a0: from, a1: to };
+  if (c.k === 'line') {
+    const p1 = nativeAt(c, from);
+    const p2 = nativeAt(c, to);
+    return { ...c, p1, p2 };
+  }
+  // de Casteljau twice: drop [0,from], then rescale and drop the tail.
+  const right = deCasteljauRight(c.pts, from);
+  const span = 1 - from;
+  const t2 = span <= 1e-15 ? 1 : (to - from) / span;
+  return { ...c, pts: deCasteljauLeft(right, t2) };
+}
+
+function deCasteljauLeft(pts: Vec2[], t: number): Vec2[] {
+  const out: Vec2[] = [];
+  let cur = pts.map((p): Vec2 => [p[0], p[1]]);
+  out.push(cur[0] as Vec2);
+  while (cur.length > 1) {
+    const next: Vec2[] = [];
+    for (let i = 0; i + 1 < cur.length; i++) {
+      const a = cur[i] as Vec2;
+      const b = cur[i + 1] as Vec2;
+      next.push([a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]);
+    }
+    cur = next;
+    out.push(cur[0] as Vec2);
+  }
+  return out;
+}
+
+function deCasteljauRight(pts: Vec2[], t: number): Vec2[] {
+  const out: Vec2[] = [];
+  let cur = pts.map((p): Vec2 => [p[0], p[1]]);
+  out.push(cur[cur.length - 1] as Vec2);
+  while (cur.length > 1) {
+    const next: Vec2[] = [];
+    for (let i = 0; i + 1 < cur.length; i++) {
+      const a = cur[i] as Vec2;
+      const b = cur[i + 1] as Vec2;
+      next.push([a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]);
+    }
+    cur = next;
+    out.push(cur[cur.length - 1] as Vec2);
+  }
+  return out.reverse();
+}
+
 function isNative(x: unknown): x is NativeCurve {
   return !!x && typeof x === 'object' && (x as { __nativeC2d?: boolean }).__nativeC2d === true;
 }
@@ -601,19 +811,41 @@ function makeNativeKernel2DOps(
     // first (toOcct) so the genuinely-OCCT engine receives real B-rep curves.
     makeBSpline2d: (points, options) => occtOr('makeBSpline2d').makeBSpline2d(points, options),
     offsetCurve2d: (c, offset) => occtOr('offsetCurve2d').offsetCurve2d(toOcct(c), offset),
-    intersectCurves2d: (c1, c2, tol) =>
-      occtOr('intersectCurves2d').intersectCurves2d(toOcct(c1), toOcct(c2), tol),
-    projectPointOnCurve2d: (c, x, y) =>
-      occtOr('projectPointOnCurve2d').projectPointOnCurve2d(toOcct(c), x, y),
-    distanceBetweenCurves2d: (c1, c2, s1, e1, s2, e2) =>
-      occtOr('distanceBetweenCurves2d').distanceBetweenCurves2d(
-        toOcct(c1),
-        toOcct(c2),
-        s1,
-        e1,
-        s2,
-        e2
-      ),
+    intersectCurves2d: (c1, c2, tol) => {
+      if (!isNative(c1) || !isNative(c2)) {
+        return occtOr('intersectCurves2d').intersectCurves2d(c1, c2, tol);
+      }
+      const { points } = intersectNative(asC(c1), asC(c2), tol);
+      // No native overlap detection: coincident spans report as crossings, not
+      // as common segments, which is what the mesh construction path consumes.
+      return { points: points.map((p): [number, number] => [p[0], p[1]]), segments: [] };
+    },
+    projectPointOnCurve2d: (c, x, y) => {
+      if (!isNative(c)) return occtOr('projectPointOnCurve2d').projectPointOnCurve2d(c, x, y);
+      const n = asC(c);
+      const param = closestParamOn(n, x, y);
+      return { param, distance: Math.sqrt(distSqAt(n, param, x, y)) };
+    },
+    distanceBetweenCurves2d: (c1, c2, s1, e1, s2, e2) => {
+      if (!isNative(c1) || !isNative(c2)) {
+        return occtOr('distanceBetweenCurves2d').distanceBetweenCurves2d(c1, c2, s1, e1, s2, e2);
+      }
+      // Sample one curve and project each sample onto the other: the minimum
+      // over a dense sampling is within the sampling step of the true minimum,
+      // which is the same accuracy class as the shim's chord tolerance.
+      const a = asC(c1);
+      const b = asC(c2);
+      const N = 256;
+      let best = Infinity;
+      for (let i = 0; i <= N; i++) {
+        const t = s1 + ((e1 - s1) * i) / N;
+        const p = nativeAt(a, t);
+        const q = closestParamOn(b, p[0], p[1]);
+        const qc = Math.min(Math.max(q, Math.min(s2, e2)), Math.max(s2, e2));
+        best = Math.min(best, Math.sqrt(distSqAt(b, qc, p[0], p[1])));
+      }
+      return best;
+    },
     approximateCurve2dAsBSpline: (c, tol, cont, maxSeg) =>
       occtOr('approximateCurve2dAsBSpline').approximateCurve2dAsBSpline(
         toOcct(c),
@@ -623,9 +855,34 @@ function makeNativeKernel2DOps(
       ),
     decomposeBSpline2dToBeziers: (c) =>
       occtOr('decomposeBSpline2dToBeziers').decomposeBSpline2dToBeziers(toOcct(c)),
-    serializeCurve2d: (c) => occtOr('serializeCurve2d').serializeCurve2d(toOcct(c)),
-    deserializeCurve2d: (data) => occtOr('deserializeCurve2d').deserializeCurve2d(data),
-    splitCurve2d: (c, params) => occtOr('splitCurve2d').splitCurve2d(toOcct(c), params),
+    // The native descriptor is already a closed value form, so round-tripping
+    // it needs no OCCT. Tagged so deserialize can tell it from OCCT payloads.
+    serializeCurve2d: (c) =>
+      isNative(c)
+        ? JSON.stringify({ __nativeC2d: 1, c: asC(c) })
+        : occtOr('serializeCurve2d').serializeCurve2d(c),
+    deserializeCurve2d: (data) => {
+      if (data.startsWith('{"__nativeC2d"')) {
+        const parsed = JSON.parse(data) as { c: LineC | ConicC | BezierC };
+        return { __nativeC2d: true, ...parsed.c };
+      }
+      return occtOr('deserializeCurve2d').deserializeCurve2d(data);
+    },
+    splitCurve2d: (c, params) => {
+      if (!isNative(c)) return occtOr('splitCurve2d').splitCurve2d(c, params);
+      const n = asC(c);
+      const { first, last } = nativeBounds(n);
+      const cuts = [
+        first,
+        ...params.filter((t) => t > first && t < last).sort((a, b) => a - b),
+        last,
+      ];
+      const out: Curve2dHandle[] = [];
+      for (let i = 0; i + 1 < cuts.length; i++) {
+        out.push(trimNative(n, cuts[i] ?? 0, cuts[i + 1] ?? 0));
+      }
+      return out;
+    },
     getCurve2dEllipseData: (c) => occtOr('getCurve2dEllipseData').getCurve2dEllipseData(toOcct(c)),
     getCurve2dBezierPoles: (c) => occtOr('getCurve2dBezierPoles').getCurve2dBezierPoles(toOcct(c)),
     getCurve2dBezierDegree: (c) =>

--- a/src/kernel/manifold/kernel2dNative.ts
+++ b/src/kernel/manifold/kernel2dNative.ts
@@ -216,15 +216,29 @@ function intersectNative(
       params.push(ta);
     }
   }
-  // Coincident spans and tangential touches never register as segment
-  // crossings — collinear chords are parallel, and a tangency grazes without
-  // passing through. Walk a's parameter range and keep the runs that lie on b
-  // within tolerance: a run of length is a common segment, an isolated dip is
-  // a tangential point.
+  const contacts = contactRuns(a, b, tol, points, params);
+  return dropOverlapPoints(points, params, contacts, tol);
+}
+
+/**
+ * Spans of `a` that lie on `b` within tolerance.
+ *
+ * Coincident spans and tangential touches never register as segment crossings —
+ * collinear chords are parallel, and a tangency grazes without passing through.
+ * Walking a's parameter range finds both: a run with length is a common
+ * segment, an isolated dip is a tangential point (appended to `points`).
+ */
+function contactRuns(
+  a: NativeCurve,
+  b: NativeCurve,
+  tol: number,
+  points: Vec2[],
+  params: number[]
+): NativeCurve[] {
   const { first, last } = nativeBounds(a);
   // Deliberately at the shim's discretization resolution, not the caller's
   // tolerance. Raising it does find more genuine coincidences, but the 2D
-  // boolean downstream cannot yet absorb them: at tolerance-derived density the
+  // boolean downstream cannot absorb them: at tolerance-derived density the
   // shared-segment cases in boolean2dRegression (issue #712) collapse to
   // degenerate output (`expected -Infinity to be greater than 0`). Detecting
   // more contacts than the consumer can handle is a net loss, so this stays put
@@ -242,31 +256,58 @@ function intersectNative(
   for (let i = 0; i <= M + 1; i++) {
     const inside = i <= M && on[i] === true;
     if (inside && runStart < 0) runStart = i;
-    if (!inside && runStart >= 0) {
-      const t0 = first + ((last - first) * runStart) / M;
-      const t1 = first + ((last - first) * (i - 1)) / M;
-      // Classify by how long the contact physically is, not by how many
-      // samples landed on it: a sample-count test makes the segment/point
-      // answer move with the sampling density, which is exactly the coupling
-      // that made a denser scan reclassify contacts it had called points.
-      const p0 = nativeAt(a, t0);
-      const p1 = nativeAt(a, t1);
-      const physical = Math.hypot(p1[0] - p0[0], p1[1] - p0[1]);
-      if (physical > Math.max(tol, CHORD_TOL)) {
-        segments.push(trimNative(a, t0, t1));
-      } else {
-        // Single sample touching b: a tangential contact, reported as a point
-        // if the crossing search did not already find it.
-        const p = nativeAt(a, t0);
-        if (!points.some((q) => Math.hypot(q[0] - p[0], q[1] - p[1]) <= Math.max(tol, 1e-9))) {
-          points.push(p);
-          params.push(t0);
-        }
-      }
-      runStart = -1;
+    if (inside || runStart < 0) continue;
+    const t0 = first + ((last - first) * runStart) / M;
+    const t1 = first + ((last - first) * (i - 1)) / M;
+    // Length ALONG the run, not end to end: a closed curve coincident over its
+    // whole length returns to its start, so an endpoint chord is zero and a
+    // fully shared circle would be reported as a single point.
+    let physical = 0;
+    for (let k = runStart; k < i - 1; k++) {
+      const q0 = nativeAt(a, first + ((last - first) * k) / M);
+      const q1 = nativeAt(a, first + ((last - first) * (k + 1)) / M);
+      physical += Math.hypot(q1[0] - q0[0], q1[1] - q0[1]);
     }
+    if (physical > Math.max(tol, CHORD_TOL)) {
+      segments.push(trimNative(a, t0, t1));
+    } else {
+      const p = nativeAt(a, t0);
+      if (!points.some((q) => Math.hypot(q[0] - p[0], q[1] - p[1]) <= Math.max(tol, 1e-9))) {
+        points.push(p);
+        params.push(t0);
+      }
+    }
+    runStart = -1;
   }
-  return { points, params, segments };
+  return segments;
+}
+
+/**
+ * A coincident span makes the crossing search fire at every sampled chord pair
+ * along it — 79 "intersections" for two identical circles. Those points are the
+ * overlap, not isolated crossings, so drop any that land on a reported segment.
+ */
+function dropOverlapPoints(
+  points: Vec2[],
+  params: number[],
+  segments: NativeCurve[],
+  tol: number
+): { points: Vec2[]; params: number[]; segments: NativeCurve[] } {
+  if (segments.length === 0) return { points, params, segments };
+  const keep: number[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i] as Vec2;
+    const onSeg = segments.some((seg) => {
+      const t = closestParamOn(seg, p[0], p[1]);
+      return Math.sqrt(distSqAt(seg, t, p[0], p[1])) <= Math.max(tol, CHORD_TOL);
+    });
+    if (!onSeg) keep.push(i);
+  }
+  return {
+    points: keep.map((i) => points[i] as Vec2),
+    params: keep.map((i) => params[i] as number),
+    segments,
+  };
 }
 
 function sub2(a: Vec2, b: Vec2): Vec2 {

--- a/src/kernel/manifold/kernel2dNative.ts
+++ b/src/kernel/manifold/kernel2dNative.ts
@@ -9,6 +9,15 @@
  * onto the 3D plane and emits a native manifold edge (a `profileEdge` op-node,
  * consumed by makeWire/makeFace). Exact/NURBS/introspection ops that have no
  * native form fall back to OCCT (see kernel2dOps).
+ *
+ * Accuracy: the query ops (projection, intersection, curve distance) are
+ * sampling-based, with the step count derived from each curve's extent and the
+ * caller's tolerance rather than fixed. That bounds the error to the tolerance
+ * for ordinary geometry, but it cannot promise to catch a feature narrower than
+ * its own step — a hairline tangency on a wiggly high-degree bezier can still be
+ * missed. Resolving those exactly means root-finding on the distance polynomial,
+ * which belongs to a real curve engine; callers needing that guarantee should
+ * register an OCCT kernel, which these ops then delegate to.
  * @module
  */
 
@@ -82,9 +91,9 @@ function closestParamOn(c: LineC | ConicC | BezierC, x: number, y: number): numb
       );
       return clampToArc(a, c.a0, c.a1);
     }
-    return bracketedMin(c.a0, c.a1, (t) => distSqAt(c, t, x, y));
+    return bracketedMin(c.a0, c.a1, (t) => distSqAt(c, t, x, y), stepsFor(c, CHORD_TOL));
   }
-  return bracketedMin(0, 1, (t) => distSqAt(c, t, x, y));
+  return bracketedMin(0, 1, (t) => distSqAt(c, t, x, y), stepsFor(c, CHORD_TOL));
 }
 
 /**
@@ -95,8 +104,8 @@ function closestParamOn(c: LineC | ConicC | BezierC, x: number, y: number): numb
  * bezier can have several. So scan coarsely for the best sample, then refine
  * only inside the bracket around it, which is unimodal by construction.
  */
-function bracketedMin(lo: number, hi: number, f: (t: number) => number): number {
-  const N = 96;
+function bracketedMin(lo: number, hi: number, f: (t: number) => number, steps: number): number {
+  const N = Math.max(8, steps);
   let bestI = 0;
   let best = Infinity;
   for (let i = 0; i <= N; i++) {
@@ -213,6 +222,13 @@ function intersectNative(
   // within tolerance: a run of length is a common segment, an isolated dip is
   // a tangential point.
   const { first, last } = nativeBounds(a);
+  // Deliberately at the shim's discretization resolution, not the caller's
+  // tolerance. Raising it does find more genuine coincidences, but the 2D
+  // boolean downstream cannot yet absorb them: at tolerance-derived density the
+  // shared-segment cases in boolean2dRegression (issue #712) collapse to
+  // degenerate output (`expected -Infinity to be greater than 0`). Detecting
+  // more contacts than the consumer can handle is a net loss, so this stays put
+  // until that path is hardened.
   const M = 192;
   const on: boolean[] = [];
   for (let i = 0; i <= M; i++) {
@@ -227,10 +243,16 @@ function intersectNative(
     const inside = i <= M && on[i] === true;
     if (inside && runStart < 0) runStart = i;
     if (!inside && runStart >= 0) {
-      const spanSteps = i - runStart;
       const t0 = first + ((last - first) * runStart) / M;
       const t1 = first + ((last - first) * (i - 1)) / M;
-      if (spanSteps > 1) {
+      // Classify by how long the contact physically is, not by how many
+      // samples landed on it: a sample-count test makes the segment/point
+      // answer move with the sampling density, which is exactly the coupling
+      // that made a denser scan reclassify contacts it had called points.
+      const p0 = nativeAt(a, t0);
+      const p1 = nativeAt(a, t1);
+      const physical = Math.hypot(p1[0] - p0[0], p1[1] - p0[1]);
+      if (physical > Math.max(tol, CHORD_TOL)) {
         segments.push(trimNative(a, t0, t1));
       } else {
         // Single sample touching b: a tangential contact, reported as a point
@@ -263,6 +285,40 @@ function segSeg(p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2): Vec2 | null {
   const u = ((p3[0] - p1[0]) * d1y - (p3[1] - p1[1]) * d1x) / den;
   if (t < -1e-9 || t > 1 + 1e-9 || u < -1e-9 || u > 1 + 1e-9) return null;
   return [p1[0] + d1x * t, p1[1] + d1y * t];
+}
+
+/**
+ * How many parameter steps resolve `c` to within `tol`.
+ *
+ * A fixed step count is wrong at both ends: wasteful on a short line and blind
+ * to a feature narrower than one interval on a long or wiggly curve. Deriving
+ * it from the curve's own extent — control-polygon length for a bezier, arc
+ * length for a conic — ties the resolution to the geometry and the caller's
+ * tolerance, the same way conicSegments already does for discretization.
+ *
+ * This bounds the miss, it does not remove it: any sampling scheme can still
+ * step over a feature narrower than its own interval. Exactly resolving that
+ * needs polynomial root-finding on the distance function, which is a different
+ * and much larger piece of machinery than this shim carries.
+ */
+function stepsFor(c: LineC | ConicC | BezierC, tol: number): number {
+  const t = Math.max(tol, 1e-9);
+  if (c.k === 'line') return 2;
+  let extent: number;
+  if (c.k === 'conic') {
+    const r = Math.max(Math.hypot(c.u[0], c.u[1]), Math.hypot(c.v[0], c.v[1]));
+    extent = Math.abs(c.a1 - c.a0) * r;
+  } else {
+    extent = 0;
+    for (let i = 0; i + 1 < c.pts.length; i++) {
+      const a = c.pts[i] as Vec2;
+      const b = c.pts[i + 1] as Vec2;
+      extent += Math.hypot(b[0] - a[0], b[1] - a[1]);
+    }
+  }
+  // Two steps per tolerance-width feature, so a contact of width `tol` spans an
+  // interval rather than falling between two samples.
+  return Math.min(20000, Math.max(64, Math.ceil((2 * extent) / t)));
 }
 
 /** Parameter range of a native curve, matching getCurve2dBounds. */


### PR DESCRIPTION
Five 2D ops delegated to OCCT and threw `manifold 2D: <op> needs an OCCT kernel (none registered)` whenever manifold ran alone — which is how the manifold test project runs it.

The shim already carries a native curve algebra (lines, conics, beziers) for the construction path. These ops simply had not been written against it, so this is missing code rather than a missing kernel.

## What was implemented

| op | approach |
| --- | --- |
| `projectPointOnCurve2d` | exact on lines and circles; golden-section on general ellipses and beziers, which are unimodal in distance over a single arc so the search cannot land on a spurious minimum |
| `intersectCurves2d` | polyline candidates from the shim's own discretization, refined by alternating projection, then gated on tolerance so a near miss is rejected rather than reported as a crossing |
| `splitCurve2d` | exact trim per type; de Casteljau twice for a bezier |
| `serializeCurve2d` / `deserializeCurve2d` | tagged JSON of the native descriptor, tagged so deserialize can distinguish it from an OCCT payload |
| `distanceBetweenCurves2d` | dense sampling plus projection — the same accuracy class as the shim's existing chord tolerance |

Each keeps its OCCT path for a non-native handle, so a registered OCCT kernel still serves the exact engine and nothing regresses for callers who have one.

## Result

Manifold's suite: **707 → 643 failures, +64 passing.**

Intersection accounts for most of that, and for more than its own count. A large share of the 2D suite is downstream of it and was failing as `unwrap() on Err: INTERSECTION` rather than as a missing op, so those were filed under a different heading until the op existed.

Combined with the spine-path and extrusion-law fixes earlier in this sequence, manifold is down from 738 to 643.

## Not addressed

Two categories remain that this approach cannot reach, and they are worth naming rather than leaving to be rediscovered:

- `approximateCurve2dAsBSpline` and `makeBSpline2d` need a native B-spline representation the shim does not have. Adding one is a real piece of work, not a wiring change.
- `extractSurfaceFromFace` and the analytic surface-type queries (`CYLINDRE` and friends) have no correct answer from a tessellation: a meshed cylinder genuinely is a set of planes.

## Verification

occt-wasm 4785 passed / 371 skipped and brepkit 4580 passed / 659 skipped, both unchanged — this file is manifold-only. typecheck, lint, format and the pattern checker clean.

## Review fixes (three P1s)

All three were real, and all three were introduced by the first commit rather than pre-existing.

**Every delegated path dropped `toOcct`.** Rewriting the fallbacks as `if (!isNative(...)) return occtOr(...)(c1, c2, ...)` handed a native descriptor straight to the OCCT engine whenever operands were mixed, where the original converted both. A regression, not a gap: the exact engine would have thrown or produced NaN geometry.

**Projection assumed a single minimum.** Distance to an eccentric ellipse or a cubic-or-higher bezier is not unimodal — a point inside a flat ellipse has a minimum at each end — so one golden-section over the whole interval can return a local answer and then reject valid intersections downstream. It now scans coarsely for the global bracket and refines only inside it, where unimodality holds by construction.

**Coincident and tangential contacts were discarded.** Collinear chords are parallel, so `segSeg` rejects them on a near-zero determinant, and a tangency grazes without crossing at all. On top of that the return path hardcoded `segments: []`. Both now come from walking one curve's parameter range and keeping the runs that lie on the other within tolerance: a run is a common segment, an isolated dip is a tangential point. Blueprint boolean logic consumes those segments, which made the empty array the most load-bearing of the three.

The fixes gain rather than cost: **643 → 632 failures, +11 passing.** Manifold is down from 738 to 632 across this sequence. occt-wasm (4785) and brepkit (4580) remain unchanged.

## Second review pass: fixed-resolution scans

Review then flagged both scans as fixed-resolution — a minimum basin or a contact narrower than one interval is stepped over. Both are true.

**Projection resolution is now derived** from the curve's own extent and the tolerance, the way `conicSegments` already does for discretization, so the bracket is tied to geometry rather than a constant.

**Contact classification no longer counts samples.** A run was called a segment when it spanned more than one sample, which made the segment-or-point answer move with sampling density. It now measures how long the contact physically is, which is density-independent — a real flaw, independent of what the resolution is set to.

**The coincidence scan stays at the shim's discretization resolution, deliberately.** Deriving it from the caller's tolerance does find more genuine coincidences, but the 2D boolean downstream cannot absorb them: at that density the three shared-segment cases in `boolean2dRegression` (issue #712) collapse to degenerate output, `expected -Infinity to be greater than 0`.

That was measured by diffing the failing sets between the two configurations rather than inferred from the totals — the regression was exactly those three tests and nothing else. Detecting more contacts than the consumer can handle is a net loss, so this holds until that path is hardened. The constant carries that evidence in a comment so the experiment is not repeated blind.

**The module doc now states the contract these ops offer**: sampling-based, bounded by tolerance for ordinary geometry, unable to promise a feature narrower than its own step. Resolving that exactly needs root-finding on the distance polynomial, which belongs to a real curve engine; callers needing that guarantee should register an OCCT kernel, which these ops delegate to.

Final: manifold 632 failures / 4031 passing, from 738 / 3926 at the start of this sequence. occt-wasm 4785 and brepkit 4580 unchanged throughout.

## Third review pass: closed coincident curves

Contact length was measured end to end. A closed curve coincident over its whole length returns to its start, so the chord is zero and two identical circles reported their entire shared outline as a single point. It is now measured along the run, which is what "how long is this contact" means for a curve that comes back on itself.

That exposed a second problem underneath it: the crossing search fires at every sampled chord pair along a coincident span, so the same two circles also produced 79 spurious intersection points. Those are the overlap, not isolated crossings, so points landing on a reported segment are now dropped.

Verified directly, since no test covers the case:

| | points | segments |
| --- | --- | --- |
| before | 79 | 0 |
| arc-length classification | 79 | 1 |
| plus overlap filtering | **0** | **1** |

`intersectNative` reached 70 lines doing all of this, so the contact scan and the point filter were extracted to `contactRuns` and `dropOverlapPoints` rather than baselining the limit.

## Relationship to Manifold's own 2D

Worth recording, since it explains why these ops are computed rather than delegated. manifold-3d ships `CrossSection`, which its docs describe as "use of the Clipper2 library for polygon clipping (boolean) and offsetting" — filled polygonal regions.

brepjs already uses it for exactly that: `sweepOps.ts` (15 references), `approximations.ts`, `profileOps.ts`, `modifierOps.ts`, `replay.ts`.

What `CrossSection` cannot provide is curve parametrization. `CrossSection.circle(radius, circularSegments)` is discretized at construction, so there is no parameter to project onto, split at, or return from an intersection. That is precisely what `projectPointOnCurve2d`, `splitCurve2d` and `intersectCurves2d` are asked for, which is why the shim carries its own curve algebra and why these had to be implemented against it.

## Fourth review pass: the overlap was lost downstream

The remaining finding said closed coincident curves "lose their common-segment representation **before blueprint boolean processing**". The native op was already returning the segment, so the loss was downstream of this file.

`intersectCurves` (`src/2d/lib/intersections.ts`) treated any common segment whose endpoints coincide as degenerate and rewrote it as a single intersection point. That is correct for a segment with no extent and wrong for a closed one: two identical circles share their entire outline while starting and ending at the same place. Degeneracy now also requires the midpoint to sit on the endpoints, so a closed overlap with real extent survives.

This is shared-layer code every kernel runs, but it was unreachable until now — the OCCT kernels do not report a closed overlap at all. Measured with two identical circles:

| kernel | intersections | commonSegments |
| --- | --- | --- |
| occt-wasm | 0 | 0 |
| occt (opencascade) | 0 | 0 |
| manifold, before this fix | 1 | 0 |
| manifold, after | 0 | **1** |

So the native implementation is stricter here than OCCT, and the shared-layer fix is load-bearing rather than defensive — verified by stashing it and re-running.

occt-wasm (4785), brepkit (4580) and the opencascade 2D suites (129) are unchanged.
