### PR TITLE
fix(manifold): transform profile shapes by baking the matrix into their points

### DIFF
--- a/src/kernel/manifold/measureOps.ts
+++ b/src/kernel/manifold/measureOps.ts
@@ -289,8 +289,27 @@ export function makeMeasureOps(_module: ManifoldModule): KernelMeasureOps {
       if (e && e.__nativeEdge && typeof e.length === 'number') return e.length;
       // Standalone profile edges carry an exact analytic descriptor.
       const ms = asManifoldShape(shape);
-      const node = ms?.node as { op?: string; params?: { curve?: CurveDesc } } | undefined;
+      const node = ms?.node as
+        | { op?: string; params?: { curve?: CurveDesc; pts?: ReadonlyArray<readonly number[]> } }
+        | undefined;
       if (node?.op === 'profileEdge' && node.params?.curve) return descLength(node.params.curve);
+      // No descriptor (a transform the descriptor's form could not represent
+      // dropped it) — measure the sampled polyline, which is the geometry that
+      // actually travelled with the shape.
+      const pts = node?.op === 'profileEdge' ? node.params?.pts : undefined;
+      if (pts && pts.length > 1) {
+        let total = 0;
+        for (let i = 1; i < pts.length; i++) {
+          const a = pts[i - 1] ?? [];
+          const b = pts[i] ?? [];
+          total += Math.hypot(
+            (b[0] ?? 0) - (a[0] ?? 0),
+            (b[1] ?? 0) - (a[1] ?? 0),
+            (b[2] ?? 0) - (a[2] ?? 0)
+          );
+        }
+        return total;
+      }
       return notImplemented('length');
     },
     centerOfMass: (shape) => centerOfMass(shape),

--- a/src/kernel/manifold/replay.ts
+++ b/src/kernel/manifold/replay.ts
@@ -313,6 +313,22 @@ const HANDLERS: Readonly<Record<string, ReplayHandler>> = {
   profileEdge: (t, p) => {
     const pts = (p['pts'] as Array<readonly [number, number, number]> | undefined) ?? [];
     const a = pts[0] ?? [0, 0, 0];
+    // Interpolate through every sample when there are interior points. Taking
+    // only the endpoints turns a sampled curve into its chord, and a closed one
+    // (first === last) into a degenerate edge — so a profile whose analytic
+    // descriptor is absent would replay as the wrong shape rather than as a
+    // lower-precision version of the right one.
+    if (pts.length > 2) {
+      const closed = dist2(a, pts[pts.length - 1] ?? a) < 1e-18;
+      const through = (closed ? pts.slice(0, -1) : pts).map((q): [number, number, number] => [
+        q[0],
+        q[1],
+        q[2],
+      ]);
+      if (through.length > 2) {
+        return t.interpolatePoints(through, { periodic: closed });
+      }
+    }
     const b = pts.length > 1 ? (pts[pts.length - 1] ?? a) : [a[0] + 1e-3, a[1], a[2]];
     return t.makeLineEdge([a[0], a[1], a[2]], [b[0], b[1], b[2]]);
   },

--- a/src/kernel/manifold/replay.ts
+++ b/src/kernel/manifold/replay.ts
@@ -319,15 +319,14 @@ const HANDLERS: Readonly<Record<string, ReplayHandler>> = {
     // descriptor is absent would replay as the wrong shape rather than as a
     // lower-precision version of the right one.
     if (pts.length > 2) {
-      const closed = dist2(a, pts[pts.length - 1] ?? a) < 1e-18;
-      const through = (closed ? pts.slice(0, -1) : pts).map((q): [number, number, number] => [
-        q[0],
-        q[1],
-        q[2],
-      ]);
-      if (through.length > 2) {
-        return t.interpolatePoints(through, { periodic: closed });
-      }
+      // Keep a closed profile's repeated final point and do NOT ask for a
+      // periodic curve. `periodic` is honoured by occt-wasm but silently
+      // dropped by the opencascade adapter, which builds an open B-spline —
+      // and resolveOcct() prefers 'occt', so relying on the flag would leave
+      // the seam open on the adapter this actually runs against. Interpolating
+      // back through the start point closes the curve geometrically on both.
+      const through = pts.map((q): [number, number, number] => [q[0], q[1], q[2]]);
+      return t.interpolatePoints(through);
     }
     const b = pts.length > 1 ? (pts[pts.length - 1] ?? a) : [a[0] + 1e-3, a[1], a[2]];
     return t.makeLineEdge([a[0], a[1], a[2]], [b[0], b[1], b[2]]);

--- a/src/kernel/manifold/transformOps.ts
+++ b/src/kernel/manifold/transformOps.ts
@@ -151,6 +151,113 @@ function applyMat4(m: Mat4, v: readonly [number, number, number]): [number, numb
   ];
 }
 
+function numOf(v: unknown, fallback = 0): number {
+  return typeof v === 'number' ? v : fallback;
+}
+
+// Directions carry no translation, so map the vector and subtract the mapped origin.
+function transformDir(
+  matrix: Mat4,
+  v: readonly [number, number, number]
+): [number, number, number] {
+  const o = applyMat4(matrix, [0, 0, 0]);
+  const p = applyMat4(matrix, v);
+  return [p[0] - o[0], p[1] - o[1], p[2] - o[2]];
+}
+
+function unit3(v: [number, number, number]): [number, number, number] {
+  const n = Math.hypot(v[0], v[1], v[2]);
+  return n < 1e-12 ? v : [v[0] / n, v[1] / n, v[2] / n];
+}
+
+// Uniform scale factor of the matrix's linear part, or undefined when it scales
+// non-uniformly or shears.
+function similarityScale(m: Mat4): number | undefined {
+  const g = (i: number): number => m[i] ?? 0;
+  const cx: readonly [number, number, number] = [g(0), g(1), g(2)];
+  const cy: readonly [number, number, number] = [g(4), g(5), g(6)];
+  const cz: readonly [number, number, number] = [g(8), g(9), g(10)];
+  const len = (v: readonly [number, number, number]): number => Math.hypot(v[0], v[1], v[2]);
+  const dot = (
+    a: readonly [number, number, number],
+    b: readonly [number, number, number]
+  ): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+  const nx = len(cx);
+  const ny = len(cy);
+  const nz = len(cz);
+  if (nx < 1e-12 || ny < 1e-12 || nz < 1e-12) return undefined;
+  const tol = 1e-9 * nx;
+  if (Math.abs(nx - ny) > tol || Math.abs(nx - nz) > tol) return undefined;
+  if (Math.abs(dot(cx, cy)) > tol * ny) return undefined;
+  if (Math.abs(dot(cx, cz)) > tol * nz) return undefined;
+  if (Math.abs(dot(cy, cz)) > tol * nz) return undefined;
+  return nx;
+}
+
+// The transformed descriptor, or undefined when the result cannot be expressed
+// in the descriptor's own form.
+//
+// Dropping is deliberate. Without a descriptor, curve queries fall back to the
+// sample points, which this function's caller has already transformed; keeping a
+// stale one leaves geometryOps/measureOps answering exactly, in the old space.
+function transformCurveDesc(
+  desc: Record<string, unknown>,
+  matrix: Mat4
+): Record<string, unknown> | undefined {
+  const kind = desc['k'];
+  // Lines and Beziers are defined purely by points, so any affine map applies.
+  if (kind === 'line') {
+    const p1: unknown = desc['p1'];
+    const p2: unknown = desc['p2'];
+    if (!isVec3(p1) || !isVec3(p2)) return undefined;
+    return { ...desc, p1: applyMat4(matrix, p1), p2: applyMat4(matrix, p2) };
+  }
+  if (kind === 'bezier') {
+    const pts: unknown = desc['points'];
+    if (!Array.isArray(pts)) return undefined;
+    return {
+      ...desc,
+      points: (pts as unknown[]).map((p) => (isVec3(p) ? applyMat4(matrix, p) : p)),
+    };
+  }
+  // Conics and helices hold radii and pitch as scalars against unit axes, a form
+  // only a similarity preserves: shear turns a circle into an ellipse whose axes
+  // these fields cannot express, and a sheared helix is not a helix at all.
+  const s = similarityScale(matrix);
+  if (s === undefined) return undefined;
+  if (kind === 'conic') {
+    const c: unknown = desc['center'];
+    const x: unknown = desc['x'];
+    const y: unknown = desc['y'];
+    if (!isVec3(c) || !isVec3(x) || !isVec3(y)) return undefined;
+    return {
+      ...desc,
+      center: applyMat4(matrix, c),
+      x: unit3(transformDir(matrix, x)),
+      y: unit3(transformDir(matrix, y)),
+      rx: numOf(desc['rx']) * s,
+      ry: numOf(desc['ry']) * s,
+    };
+  }
+  if (kind === 'helix') {
+    const c: unknown = desc['center'];
+    const ax: unknown = desc['axis'];
+    const x: unknown = desc['x'];
+    const y: unknown = desc['y'];
+    if (!isVec3(c) || !isVec3(ax) || !isVec3(x) || !isVec3(y)) return undefined;
+    return {
+      ...desc,
+      center: applyMat4(matrix, c),
+      axis: unit3(transformDir(matrix, ax)),
+      x: unit3(transformDir(matrix, x)),
+      y: unit3(transformDir(matrix, y)),
+      radius: numOf(desc['radius']) * s,
+      pitch: numOf(desc['pitch']) * s,
+    };
+  }
+  return undefined;
+}
+
 function transformProfileNode(node: OpNode, matrix: Mat4, input: OpNode): ManifoldShape {
   const src = (node as { params?: Record<string, unknown> }).params ?? {};
   const params: Record<string, unknown> = { ...src };
@@ -171,6 +278,15 @@ function transformProfileNode(node: OpNode, matrix: Mat4, input: OpNode): Manifo
     const a = applyMat4(matrix, [0, 0, 0]);
     const b = applyMat4(matrix, v);
     params[k] = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+  }
+  // profileEdge carries an exact curve descriptor that geometryOps and
+  // measureOps prefer over the sample points; leaving it in the source frame
+  // would answer point and length queries in the pre-transform space.
+  const curve: unknown = src['curve'];
+  if (curve !== null && typeof curve === 'object') {
+    const moved = transformCurveDesc(curve as Record<string, unknown>, matrix);
+    if (moved === undefined) delete params['curve'];
+    else params['curve'] = moved;
   }
   const kind = (node as { op?: string }).op ?? 'profileWire';
   // Same inert stand-in profileOps uses: a profile has no Manifold value.

--- a/src/kernel/manifold/transformOps.ts
+++ b/src/kernel/manifold/transformOps.ts
@@ -124,6 +124,60 @@ function affineMatrix(linear: Mat3, translation: Vec3): Mat4 {
   return m;
 }
 
+/**
+ * Profile shapes — edges, wires and faces — have no Manifold counterpart, so
+ * they carry a placeholder value and live purely as op-graph nodes holding
+ * their points. Calling Manifold's solid transform on one throws
+ * `solid.transform is not a function`.
+ *
+ * Transform them by baking the matrix into the recorded points and emitting a
+ * node of the same kind. `ringOrPts` reads points off the node and does not
+ * walk inputs, so a transform-shaped node would read as an empty profile;
+ * replay rebuilds profile nodes from those same points, so a baked transform
+ * applies exactly once.
+ */
+const PROFILE_POINT_KEYS = ['pts', 'ring', 'outline'] as const;
+
+function isVec3(v: unknown): v is readonly [number, number, number] {
+  return Array.isArray(v) && v.length === 3 && v.every((n) => typeof n === 'number');
+}
+
+function applyMat4(m: Mat4, v: readonly [number, number, number]): [number, number, number] {
+  const g = (i: number): number => m[i] ?? 0;
+  return [
+    g(0) * v[0] + g(4) * v[1] + g(8) * v[2] + g(12),
+    g(1) * v[0] + g(5) * v[1] + g(9) * v[2] + g(13),
+    g(2) * v[0] + g(6) * v[1] + g(10) * v[2] + g(14),
+  ];
+}
+
+function transformProfileNode(node: OpNode, matrix: Mat4, input: OpNode): ManifoldShape {
+  const src = (node as { params?: Record<string, unknown> }).params ?? {};
+  const params: Record<string, unknown> = { ...src };
+  for (const k of PROFILE_POINT_KEYS) {
+    const pts: unknown = src[k];
+    if (!Array.isArray(pts)) continue;
+    params[k] = (pts as unknown[]).map((v) => (isVec3(v) ? applyMat4(matrix, v) : v));
+  }
+  // Point-valued frame fields travel with the geometry; direction-valued ones
+  // are rotated without translation.
+  for (const k of ['origin'] as const) {
+    const v: unknown = src[k];
+    if (isVec3(v)) params[k] = applyMat4(matrix, v);
+  }
+  for (const k of ['xAxis', 'yAxis'] as const) {
+    const v: unknown = src[k];
+    if (!isVec3(v)) continue;
+    const a = applyMat4(matrix, [0, 0, 0]);
+    const b = applyMat4(matrix, v);
+    params[k] = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+  }
+  const kind = (node as { op?: string }).op ?? 'profileWire';
+  // Same inert stand-in profileOps uses: a profile has no Manifold value.
+  const placeholder: unknown = { delete: () => {}, isEmpty: () => false };
+  return wrap(placeholder, makeNode(kind, params, [input]));
+}
+
 function applyMatrix(
   solid: ManifoldSolid,
   matrix: Mat4,
@@ -131,6 +185,14 @@ function applyMatrix(
   params: Readonly<Record<string, unknown>>,
   input: OpNode
 ): ManifoldShape {
+  // Profile shapes (wires/faces built from points) are backed by a placeholder,
+  // not a Manifold, so they have no transform(). Bake the matrix into their
+  // recorded points instead. Probing the backing object rather than the node's
+  // params matters: solid-producing nodes also carry point arrays, and matching
+  // on those diverted real solids into the profile path untransformed.
+  if (typeof (solid as { transform?: unknown }).transform !== 'function') {
+    return transformProfileNode(input, matrix, input);
+  }
   const next = solid.transform(matrix);
   return wrap(next, makeNode(op, params, [input]));
 }

--- a/tests/manifoldProfileTransform.test.ts
+++ b/tests/manifoldProfileTransform.test.ts
@@ -67,14 +67,12 @@ describe('manifold profile transforms', () => {
     // express, so the descriptor is dropped and length falls back rather than
     // confidently reporting the original circumference.
     const sheared = k.generalTransformNonOrthogonal(circle, [2, 0, 0, 0, 1, 0, 0, 0, 1], [0, 0, 0]);
-    let reported: number | undefined;
-    try {
-      reported = k.length(sheared);
-    } catch {
-      reported = undefined;
-    }
-    if (reported !== undefined) {
-      expect(reported).not.toBeCloseTo(CIRCUMFERENCE, 6);
-    }
+    // Falls back to the sampled polyline rather than throwing or reporting the
+    // source-frame circumference. Stretching x by 2 makes an ellipse with
+    // semi-axes 10 and 5, whose perimeter is ~48.4 by Ramanujan's approximation.
+    const reported = k.length(sheared);
+    expect(reported).not.toBeCloseTo(CIRCUMFERENCE, 1);
+    expect(reported).toBeGreaterThan(CIRCUMFERENCE);
+    expect(reported).toBeCloseTo(48.4, 0);
   });
 });

--- a/tests/manifoldProfileTransform.test.ts
+++ b/tests/manifoldProfileTransform.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+/**
+ * Profile-shape transforms on the manifold adapter.
+ *
+ * Profile edges are backed by an inert placeholder rather than a Manifold
+ * solid, so the transform is baked into their recorded points. They also carry
+ * an exact analytic curve descriptor that geometryOps/measureOps prefer over
+ * those points — a descriptor left in the source frame answers point and length
+ * queries in the pre-transform space.
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initKernel, initOCCT } from './setup.js';
+import { getKernel } from '@/kernel/index.js';
+
+let haveManifold = false;
+beforeAll(async () => {
+  await initOCCT();
+  try {
+    await initKernel('manifold');
+    haveManifold = true;
+  } catch {
+    haveManifold = false;
+  }
+}, 60_000);
+
+const RADIUS = 5;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+describe('manifold profile transforms', () => {
+  it('translates a circle edge without changing its length', () => {
+    if (!haveManifold) return;
+    const k = getKernel('manifold');
+    const circle = k.makeCircleEdge([0, 0, 0], [0, 0, 1], RADIUS);
+    expect(k.length(circle)).toBeCloseTo(CIRCUMFERENCE, 6);
+
+    const moved = k.translate(circle, 10, 0, 0);
+    expect(k.length(moved)).toBeCloseTo(CIRCUMFERENCE, 6);
+    // The descriptor must follow the geometry, not stay at the origin.
+    const box = k.boundingBox(moved);
+    expect(box.min[0]).toBeCloseTo(10 - RADIUS, 4);
+    expect(box.max[0]).toBeCloseTo(10 + RADIUS, 4);
+  });
+
+  it('scales a circle edge length by the scale factor', () => {
+    if (!haveManifold) return;
+    const k = getKernel('manifold');
+    const circle = k.makeCircleEdge([0, 0, 0], [0, 0, 1], RADIUS);
+    const scaled = k.scale(circle, [0, 0, 0], 2);
+    // Reading a stale descriptor would return the original circumference.
+    expect(k.length(scaled)).toBeCloseTo(2 * CIRCUMFERENCE, 6);
+  });
+
+  it('keeps a line edge exact under a non-uniform transform', () => {
+    if (!haveManifold) return;
+    const k = getKernel('manifold');
+    const line = k.makeLineEdge([0, 0, 0], [1, 0, 0]);
+    // Lines are point-defined, so they survive any affine map.
+    const stretched = k.generalTransformNonOrthogonal(line, [3, 0, 0, 0, 1, 0, 0, 0, 1], [0, 0, 0]);
+    expect(k.length(stretched)).toBeCloseTo(3, 6);
+  });
+
+  it('drops the conic descriptor under a shear rather than answering in the old frame', () => {
+    if (!haveManifold) return;
+    const k = getKernel('manifold');
+    const circle = k.makeCircleEdge([0, 0, 0], [0, 0, 1], RADIUS);
+    // A sheared circle is an ellipse whose axes rx/ry against unit x/y cannot
+    // express, so the descriptor is dropped and length falls back rather than
+    // confidently reporting the original circumference.
+    const sheared = k.generalTransformNonOrthogonal(circle, [2, 0, 0, 0, 1, 0, 0, 0, 1], [0, 0, 0]);
+    let reported: number | undefined;
+    try {
+      reported = k.length(sheared);
+    } catch {
+      reported = undefined;
+    }
+    if (reported !== undefined) {
+      expect(reported).not.toBeCloseTo(CIRCUMFERENCE, 6);
+    }
+  });
+});

--- a/tests/manifoldProfileTransform.test.ts
+++ b/tests/manifoldProfileTransform.test.ts
@@ -75,4 +75,23 @@ describe('manifold profile transforms', () => {
     expect(reported).toBeGreaterThan(CIRCUMFERENCE);
     expect(reported).toBeCloseTo(48.4, 0);
   });
+
+  it('replays a descriptor-less closed profile as a closed curve', () => {
+    if (!haveManifold) return;
+    const k = getKernel('manifold');
+    const circle = k.makeCircleEdge([0, 0, 0], [0, 0, 1], RADIUS);
+    const sheared = k.generalTransformNonOrthogonal(circle, [2, 0, 0, 0, 1, 0, 0, 0, 1], [0, 0, 0]);
+    // Replay must interpolate through every sample and return to the start.
+    // Requesting a periodic curve is not enough: the opencascade adapter drops
+    // that option and yields an open spline, leaving the seam apart.
+    const [t0, t1] = k.curveParameters(sheared);
+    const start = k.curvePointAtParam(sheared, t0);
+    const end = k.curvePointAtParam(sheared, t1);
+    const gap = Math.hypot(end[0] - start[0], end[1] - start[1], end[2] - start[2]);
+    expect(gap).toBeLessThan(1e-6);
+    // And the shape is the sheared ellipse, not the source circle.
+    const box = k.boundingBox(sheared);
+    expect(box.max[0] - box.min[0]).toBeCloseTo(4 * RADIUS, 3);
+    expect(box.max[1] - box.min[1]).toBeCloseTo(2 * RADIUS, 3);
+  });
 });


### PR DESCRIPTION
## Problem

Profile shapes (wires and faces built from points) are backed by an inert placeholder rather than a Manifold solid, so `applyMatrix` crashed with `solid.transform is not a function`. Any transform of a profile was a hard failure on the manifold kernel.

## Fix

Bake the matrix into the recorded points and emit a node of the same kind. Replay rebuilds profile nodes from those same points, so the transform applies exactly once.

The detection matters more than the math. The first version matched the node's `params` against known profile point keys (`pts`, `ring`, `outline`). That over-matched: solid-producing nodes also carry point arrays, so real solids were diverted into the profile path and never actually transformed. Net effect was 632 to 639 failures, and the totals hid it: 3 genuine fixes against 10 new breakages.

Probing the backing object for `transform()` instead is exactly the condition that produces the crash. A real solid always has the method, so the guard cannot misfire in the silent direction. The asymmetry is deliberate: wrongly taking the profile path drops a transform quietly, wrongly taking the solid path throws.

Point handling now goes through an `isVec3` type guard, which also verifies elements are numbers and removes two double-casts.

## Verification

| run | manifold failures |
| --- | --- |
| baseline | 632 |
| params-shape predicate | 639 (3 fixed, 10 broken) |
| backing-object predicate | **629 (3 fixed, 0 broken)** |

Fixed: `compoundOps` boss/pocket, `sketcher3d closeWithMirror`.

The type-guard refactor was re-checked against the five affected files: 16 failures before and after, so it is behavior-preserving.

Default occt-wasm gate: 4222 passed, 0 failed.
