### PR TITLE
test(manifold): register a B-rep kernel alongside manifold in the test gate

### DIFF
--- a/tests/helpers/kernelInit.ts
+++ b/tests/helpers/kernelInit.ts
@@ -59,6 +59,15 @@ export async function initKernel(id?: string): Promise<void> {
     (module as { setCircularSegments?: (n: number) => void }).setCircularSegments?.(512);
     initFromManifold(module);
     _available.push('manifold');
+    // The manifold adapter is a hybrid: mesh CSG runs natively, but exact
+    // geometry/topology queries replay the op-graph onto a registered B-rep
+    // kernel (see replay.ts, meshHandle.resolveOcct). Manifold alone is not a
+    // configuration the adapter targets — production pairs it with occt-wasm —
+    // so register one or every exact query fails on "no B-rep kernel
+    // registered" rather than on anything the mesh kernel actually does.
+    // Registered after initFromManifold because registerKernel() hands the
+    // default to whichever kernel registers first, and manifold must stay it.
+    await initKernel('occt-wasm');
   } else if (kernel === 'occt') {
     await initOCCT();
   } else {


### PR DESCRIPTION
## Problem

The manifold adapter is a hybrid. Mesh CSG runs natively on manifold-3d, but exact geometry and topology queries replay the recorded op-graph onto a registered B-rep kernel (`replay.ts`, `meshHandle.resolveOcct`). Manifold on its own is not a configuration the adapter targets, and `meshHandle.ts:43` names the production pairing: gridfinity registers occt-wasm alongside manifold.

The test gate initialised manifold alone, so `resolveOcct()` returned `undefined` and every exact query failed on "no B-rep kernel registered" before reaching any manifold code. A large share of the manifold suite was failing on an unsupported setup rather than on kernel behaviour.

## Fix

Register occt-wasm in the manifold branch of `initKernel`, **after** `initFromManifold`. Order is load-bearing: `registerKernel` hands the default to whichever kernel registers first, so registering occt-wasm first makes it the default and silently redirects the whole gate onto OCCT. That misconfiguration reads as a spectacular result (632 to 65 failures) because most tests stop exercising manifold at all.

## Verification

| configuration | manifold failures |
| --- | --- |
| baseline | 632 |
| registered first (occt-wasm becomes default) | 65, but the gate is no longer testing manifold |
| **registered after (manifold stays default)** | **496** |

Suite size is unchanged at 5237 tests in every run, so this is tests passing rather than tests disappearing.

## One test moves from green to red

`adjacencyFns > sharedEdges returns 0 shared edges between opposite box faces` was passing vacuously: the manifold path returned an empty list and the test asserts zero. It now fails honestly, exposing a pre-existing bug where `adjacentFaces` and `sharedEdges` pass manifold sub-shape witnesses straight to OCCT, which rejects them.

I attempted the fix here and backed it out. Translating witnesses by nearest bounding-box center (the re-identification `resolveSelection` uses) cleared the crashes but made `sharedEdges` on opposite faces return 4 edges instead of 0, since both witnesses resolved to the same OCCT face. A confidently wrong answer is worse than a loud failure, so that work belongs in its own PR with a proper diagnosis.

The manifold project is not part of the blocking gate: `test:ci` runs `--project occt-wasm`.

Default occt-wasm gate: 3838 passed, 0 failed.
