### PR TITLE
fix(security): document GHSA-55q2-fjhq-7xh7 as unreachable via monaco

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,7 +2,7 @@
 # OSV Scan workflow (.github/workflows/osv-scan.yml). Each entry must carry a
 # reason and a review date so exceptions don't outlive their justification.
 
-# --- dompurify via monaco-editor (3 advisories) ---------------------------
+# --- dompurify via monaco-editor (4 advisories) ---------------------------
 # monaco-editor 0.56.0 declares `dompurify: 3.4.8` as an exact pin, which is
 # what the scanner matches on. That copy is never executed, for two reasons.
 #
@@ -61,3 +61,18 @@ ignoreUntil = 2026-11-01
 # clearConfig occurrence in esm/ is DOMPurify's own definition; monaco never
 # calls it, so no config survives between sanitize() calls.
 reason = "monaco vendors its own DOMPurify; flagged node_modules copy is never imported; clearConfig() never called"
+
+[[IgnoredVulns]]
+id = "GHSA-55q2-fjhq-7xh7"
+ignoreUntil = 2026-11-01
+# Needs IN_PLACE sanitization plus a hook that removes a containing element, so
+# that _sanitizeElements() returns after the hook detaches a node without
+# neutralizing its descendants. monaco has the hook half — domSanitize.js
+# registers replaceWithPlainTextHook on uponSanitizeElement — but never the
+# IN_PLACE half: both sanitize() call sites pass RETURN_DOM_FRAGMENT or
+# RETURN_TRUSTED_TYPE, and outside DOMPurify's own definition IN_PLACE appears
+# nowhere in monaco's esm/ or min/. The vendored copy also forces it off for
+# string input (`typeof dirty == "string" && (IN_PLACE = false)`), which is what
+# monaco passes. Without IN_PLACE, sanitize builds a fresh document rather than
+# mutating the input, so the detached-subtree path is unreachable.
+reason = "monaco vendors its own DOMPurify; flagged node_modules copy is never imported; IN_PLACE never set, so the detached-subtree path is unreachable"


### PR DESCRIPTION
## Problem

`OSV Scan (blocking)` has been failing on main. One medium vulnerability, `GHSA-55q2-fjhq-7xh7`, dompurify 3.4.8 (fixed in 3.4.13).

It is the same monaco-vendored copy as the three DOMPurify advisories already suppressed here:

- `node_modules/dompurify` is **3.4.13**, already patched. That is what mermaid and posthog-js resolve to.
- `node_modules/monaco-editor/node_modules/dompurify` is **3.4.8**, pinned exactly by monaco, so npm cannot dedupe it.

## Why it is unreachable

Exploitation needs two things together: `IN_PLACE` sanitization **and** a `beforeSanitizeElements`/`uponSanitizeElement` hook that removes a containing element. The bug is that `_sanitizeElements()` returns after a hook detaches a node without neutralizing its descendants, leaving event handlers live on a detached subtree.

monaco has the hook half. `domSanitize.js:213` registers `replaceWithPlainTextHook` on `uponSanitizeElement`, and it does remove nodes.

It never has the `IN_PLACE` half:

- Both `purify.sanitize()` call sites in `domSanitize.js` pass `RETURN_DOM_FRAGMENT: true` or `RETURN_TRUSTED_TYPE: true`. Neither passes `IN_PLACE`.
- Outside DOMPurify's own definition, `IN_PLACE` appears nowhere in monaco's `esm/` or `min/` output.
- The vendored copy forces it off for string input regardless (`typeof dirty == "string" && (IN_PLACE = false)`), and strings are what monaco passes.

Without `IN_PLACE`, sanitize builds a fresh document instead of mutating the input, so the detached-subtree path is never taken.

This is on top of the reachability argument the existing entries already record: monaco imports its own vendored DOMPurify at `esm/vs/base/browser/dompurify/dompurify.js`, never the bare `dompurify` package, and the playground CDN-loads monaco rather than bundling it.

## Note

No override. As the file header already argues, an override would raise a copy that is neither imported nor shipped, turning the table green without changing a byte of what executes. Bumping monaco is the real fix and upstream has not shipped one. Entry carries the same `ignoreUntil = 2026-11-01` review date as its siblings.
