### PR TITLE
fix(brepkit): cutAll accepts a compound base so its output can be chained

### DIFF
--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -266,9 +266,7 @@ export function cutAll(
   options?: BooleanOptions
 ): KernelShape {
   if (tools.length === 0) return shape;
-  if (tools.length === 1) return cut(bk, shape, tools[0], options);
 
-  const baseId = unwrapSolidOrThrow(shape, 'cutAll');
   const toolIds: number[] = [];
   for (const tool of tools) {
     const h = tool as BrepkitHandle;
@@ -280,8 +278,31 @@ export function cutAll(
   }
   if (toolIds.length === 0) return shape;
 
-  const result = bk.compoundCut(baseId, new Uint32Array(toolIds));
-  return solidHandle(result);
+  // cutAll's own output is a compound whenever a cut disconnects or empties
+  // the base, so the base must be consumable as one (brepkit#1499). Cut each
+  // child solid; a child fully consumed by the tools is dropped.
+  const baseHandle = shape as BrepkitHandle;
+  if (isBrepkitHandle(shape) && baseHandle.type === 'compound') {
+    const survivors: number[] = [];
+    for (const childId of toArray(bk.getCompoundSolids(baseHandle.id))) {
+      try {
+        survivors.push(bk.compoundCut(childId, new Uint32Array(toolIds)));
+      } catch (e) {
+        if (!isEmptyBooleanError(e)) throw e;
+      }
+    }
+    return compoundHandle(bk.makeCompound(survivors));
+  }
+
+  if (tools.length === 1) return cut(bk, shape, tools[0], options);
+
+  const baseId = unwrapSolidOrThrow(shape, 'cutAll');
+  try {
+    return solidHandle(bk.compoundCut(baseId, new Uint32Array(toolIds)));
+  } catch (e) {
+    if (isEmptyBooleanError(e)) return emptyCompound(bk);
+    throw e;
+  }
 }
 
 export function split(bk: BrepkitKernel, shape: KernelShape, tools: KernelShape[]): KernelShape {

--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -286,7 +286,7 @@ export function cutAll(
     const survivors: number[] = [];
     for (const childId of toArray(bk.getCompoundSolids(baseHandle.id))) {
       try {
-        survivors.push(bk.compoundCut(childId, new Uint32Array(toolIds)));
+        survivors.push(bk.compoundCut(childId, toolIds));
       } catch (e) {
         if (!isEmptyBooleanError(e)) throw e;
       }

--- a/tests/brepkitAdapter.test.ts
+++ b/tests/brepkitAdapter.test.ts
@@ -404,6 +404,56 @@ describe('BrepkitAdapter', () => {
       const toolIds = Array.from(mock.compoundCut.mock.calls[0]?.[1] as ArrayLike<number>);
       expect(toolIds).toHaveLength(2);
     });
+
+    it('cutAll accepts a compound base by cutting each child solid (brepkit#1499)', () => {
+      const mock = createMockBrepKernel();
+      mock.getCompoundSolids = vi.fn(() => [11, 12]);
+      const adapter = new BrepkitAdapter(mock);
+      const a = adapter.makeBox(2, 2, 2);
+      const b = adapter.makeBox(2, 2, 2);
+      const base = adapter.makeCompound([a, b]);
+      const tools = [adapter.makeBox(1, 1, 1), adapter.makeBox(1, 1, 1)];
+
+      const result = adapter.cutAll(base, tools);
+
+      expect(mock.compoundCut).toHaveBeenCalledTimes(2);
+      expect(mock.compoundCut.mock.calls.map((c) => c[0])).toEqual([11, 12]);
+      expect((result as BrepkitHandle).type).toBe('compound');
+    });
+
+    it('cutAll drops a compound-base child fully consumed by the tools', () => {
+      const mock = createMockBrepKernel();
+      mock.getCompoundSolids = vi.fn(() => [11, 12]);
+      mock.compoundCut = vi.fn((target: number) => {
+        if (target === 11) throw new Error('empty result: Cut with target fully contained in tool');
+        return 99;
+      });
+      const adapter = new BrepkitAdapter(mock);
+      const a = adapter.makeBox(2, 2, 2);
+      const b = adapter.makeBox(2, 2, 2);
+      const base = adapter.makeCompound([a, b]);
+      const tools = [adapter.makeBox(3, 3, 3), adapter.makeBox(1, 1, 1)];
+
+      const result = adapter.cutAll(base, tools);
+
+      expect((result as BrepkitHandle).type).toBe('compound');
+      const survivors = mock.makeCompound.mock.calls.at(-1)?.[0] as number[];
+      expect(Array.from(survivors)).toEqual([99]);
+    });
+
+    it('cutAll on a solid base returns an empty compound when the batch empties it', () => {
+      const mock = createMockBrepKernel();
+      mock.compoundCut = vi.fn(() => {
+        throw new Error('empty result: Cut with target fully contained in tool');
+      });
+      const adapter = new BrepkitAdapter(mock);
+      const base = adapter.makeBox(1, 1, 1);
+      const tools = [adapter.makeBox(3, 3, 3), adapter.makeBox(3, 3, 3)];
+
+      const result = adapter.cutAll(base, tools);
+
+      expect((result as BrepkitHandle).type).toBe('compound');
+    });
   });
 
   describe('transforms', () => {


### PR DESCRIPTION
## Summary

Adapter side of brepkit#1499. `cutAll` returns a compound whenever a cut disconnects or empties the base, but rejected compounds as input, so carving loops that feed the result back in died on the second iteration:

```
Error: brepkit: cutAll requires a solid, got compound.
```

## Change

- A compound base now cuts each child solid through the batched `compoundCut`, drops children fully consumed by the tools (kernel empty-result), and recombines the survivors with `makeCompound`. An empty compound base flows through and stays empty.
- The solid-base multi-tool path converts a kernel empty-result into an empty compound instead of throwing, matching the single-tool path's existing behavior.

The kernel-side root that spuriously minted the empty compound in the reporting scenario (false "target fully contained in tool" on thin revolved cutters) is fixed separately in brepkit#1501; this PR makes the API composable regardless, since legitimately-emptying and disconnecting cuts exist.

## Verification

- 3 new mock-kernel unit tests in `tests/brepkitAdapter.test.ts` (compound base fans out per child, consumed child dropped, emptied solid base returns empty compound).
- `npm run test:brepkit` (real wasm, 4578 tests): green.
- typecheck + eslint on changed files: clean.