### PR TITLE
fix(playground): hoist @react-three/fiber so vercel builds resolve drei

### DIFF
--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -129,9 +129,15 @@ export default defineConfig({
     // may live at the workspace root or nested in apps/playground depending on how npm
     // hoists once sibling workspaces (brepjs-viewer) pull the same React major, so
     // resolve the package dir at config time rather than hardcoding either location.
+    // @react-three/fiber needs the same treatment for a stricter reason: drei only
+    // *peer*-depends on it, so drei's own imports resolve solely by fiber being hoisted
+    // beside it. Vercel installs with --legacy-peer-deps, which drops peer-only entries,
+    // so a bump that de-hoists fiber makes drei unresolvable there while every local
+    // install still works.
     alias: {
       react: dirname(reactRequire.resolve('react/package.json')),
       'react-dom': dirname(reactRequire.resolve('react-dom/package.json')),
+      '@react-three/fiber': dirname(reactRequire.resolve('@react-three/fiber/package.json')),
     },
   },
   build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,54 +137,6 @@
         "typescript": "6.0.3"
       }
     },
-    "apps/playground/node_modules/@react-three/fiber": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
-      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.8",
-        "@types/webxr": "*",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
-        "its-fine": "^2.0.0",
-        "react-use-measure": "^2.1.7",
-        "scheduler": "^0.27.0",
-        "suspend-react": "^0.1.3",
-        "use-sync-external-store": "^1.4.0",
-        "zustand": "^5.0.3"
-      },
-      "peerDependencies": {
-        "expo": ">=43.0",
-        "expo-asset": ">=8.4",
-        "expo-file-system": ">=11.0",
-        "expo-gl": ">=11.0",
-        "react": ">=19 <19.3",
-        "react-dom": ">=19 <19.3",
-        "react-native": ">=0.78",
-        "three": ">=0.156"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        },
-        "expo-asset": {
-          "optional": true
-        },
-        "expo-file-system": {
-          "optional": true
-        },
-        "expo-gl": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "apps/playground/node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -4253,11 +4205,10 @@
       }
     },
     "node_modules/@react-three/fiber": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
-      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
+      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -15214,55 +15165,6 @@
         "puppeteer": "^25.0.4"
       }
     },
-    "packages/brepjs-cad/node_modules/@react-three/fiber": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
-      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.8",
-        "@types/webxr": "*",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
-        "its-fine": "^2.0.0",
-        "react-use-measure": "^2.1.7",
-        "scheduler": "^0.27.0",
-        "suspend-react": "^0.1.3",
-        "use-sync-external-store": "^1.4.0",
-        "zustand": "^5.0.3"
-      },
-      "peerDependencies": {
-        "expo": ">=43.0",
-        "expo-asset": ">=8.4",
-        "expo-file-system": ">=11.0",
-        "expo-gl": ">=11.0",
-        "react": ">=19 <19.3",
-        "react-dom": ">=19 <19.3",
-        "react-native": ">=0.78",
-        "three": ">=0.156"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        },
-        "expo-asset": {
-          "optional": true
-        },
-        "expo-file-system": {
-          "optional": true
-        },
-        "expo-gl": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "packages/brepjs-cad/node_modules/@types/node": {
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
@@ -15399,55 +15301,6 @@
         "three": ">=0.184"
       }
     },
-    "packages/brepjs-viewer/node_modules/@react-three/fiber": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
-      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.8",
-        "@types/webxr": "*",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
-        "its-fine": "^2.0.0",
-        "react-use-measure": "^2.1.7",
-        "scheduler": "^0.27.0",
-        "suspend-react": "^0.1.3",
-        "use-sync-external-store": "^1.4.0",
-        "zustand": "^5.0.3"
-      },
-      "peerDependencies": {
-        "expo": ">=43.0",
-        "expo-asset": ">=8.4",
-        "expo-file-system": ">=11.0",
-        "expo-gl": ">=11.0",
-        "react": ">=19 <19.3",
-        "react-dom": ">=19 <19.3",
-        "react-native": ">=0.78",
-        "three": ">=0.156"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        },
-        "expo-asset": {
-          "optional": true
-        },
-        "expo-file-system": {
-          "optional": true
-        },
-        "expo-gl": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "packages/brepjs-viewer/node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -15506,55 +15359,6 @@
       "engines": {
         "node": ">=24",
         "vscode": "^1.87.0"
-      }
-    },
-    "packages/brepjs-vscode/node_modules/@react-three/fiber": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.7.0.tgz",
-      "integrity": "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.8",
-        "@types/webxr": "*",
-        "base64-js": "^1.5.1",
-        "buffer": "^6.0.3",
-        "its-fine": "^2.0.0",
-        "react-use-measure": "^2.1.7",
-        "scheduler": "^0.27.0",
-        "suspend-react": "^0.1.3",
-        "use-sync-external-store": "^1.4.0",
-        "zustand": "^5.0.3"
-      },
-      "peerDependencies": {
-        "expo": ">=43.0",
-        "expo-asset": ">=8.4",
-        "expo-file-system": ">=11.0",
-        "expo-gl": ">=11.0",
-        "react": ">=19 <19.3",
-        "react-dom": ">=19 <19.3",
-        "react-native": ">=0.78",
-        "three": ">=0.156"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        },
-        "expo-asset": {
-          "optional": true
-        },
-        "expo-file-system": {
-          "optional": true
-        },
-        "expo-gl": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
       }
     },
     "packages/brepjs-vscode/node_modules/@types/node": {


### PR DESCRIPTION
Vercel production deploys have failed since #1986. Every deploy from `455c10a8` onward errors with:

```
Rolldown failed to resolve import "@react-three/fiber"
from /vercel/path0/node_modules/@react-three/drei/web/Facemesh.js
```

## Cause

`@react-three/drei` does not depend on `@react-three/fiber`, it *peer*-depends on it (`^9.0.0`). So drei's own `import '@react-three/fiber'` has no dependency edge backing it and resolves only by fiber happening to sit hoisted beside it in the root `node_modules`.

Before #1986 there was a single hoisted `@react-three/fiber@9.6.1` serving both the workspaces and drei's peer requirement. #1986 bumped the four workspaces to `9.7.0` and nested a copy under each, but left the root entry at `9.6.1` flagged `"peer": true`, an orphan nothing declares anymore.

Vercel's `installCommand` is `npm install --legacy-peer-deps`. That flag makes npm skip peer resolution entirely, so peer-only entries are exactly the ones it drops. Nothing was left at the root for drei to resolve against.

Local installs and `npm ci` both materialize the lockfile verbatim, orphan included, so the failure only ever appeared on Vercel.

## Fix

**Lockfile:** bump the root entry to `9.7.0`, drop its now-inaccurate `"peer": true` marker, and remove the four nested duplicates. Back to one hoisted copy. Edited surgically rather than via `npm dedupe`, which re-resolves the whole tree (it downgraded `dompurify` 3.4.13 to 3.4.8, `internmap` 2.0.3 to 1.0.1, and vitepress's `vite` 6.4.3 to 5.4.21 in a 1200-line diff).

**Playground vite config:** alias `@react-three/fiber` to that single physical copy, next to the existing `react`/`react-dom` aliases added for this same hoisting hazard. The lockfile edit alone regresses on the next fiber bump, since the trigger is Dependabot's de-hoisting, not this particular version. The alias makes the build independent of where npm places the package.

## Verification

Reproduced the failure locally by moving the root copy aside and nesting one under `apps/playground`:

- without the alias: fails with the same Rolldown error
- with the alias: builds clean

Also confirmed `npm install --legacy-peer-deps` (Vercel's exact command) now leaves fiber hoisted, and `npm run build:site` completes from that tree.

`npm ci` validates the lockfile without rewriting it. Typecheck, lint, and format all pass.
