### PR TITLE
fix(ci): deploy vercel from npm ci so production matches the tested tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
-      playground: ${{ steps.filter.outputs.playground }}
+      site: ${{ steps.filter.outputs.site }}
       voxel: ${{ steps.filter.outputs.voxel }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,12 +54,14 @@ jobs:
               - '.prettierrc*'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
-            playground:
+            site:
               - 'src/**'
               - 'packages/**'
               - 'apps/playground/**'
+              - 'apps/docs/**'
               - 'package.json'
               - 'package-lock.json'
+              - 'vercel.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
             voxel:
@@ -116,25 +118,30 @@ jobs:
       - run: npx prettier --write docs/function-lookup.md
       - run: git diff --exit-code docs/function-lookup.md
 
-  playground-build:
-    # Mirrors what Vercel runs (`npm run build --workspace=apps/playground`).
-    # Catches type-resolution and bundler regressions in the playground
-    # before they break Preview deploys — e.g. the duplicate `@types/three`
-    # install in #963 that broke `tsc -b` only inside apps/playground.
+  site-build:
+    # Runs Vercel's exact buildCommand (`npm run build:site`) on the exact tree
+    # its installCommand produces, so a broken deploy fails the PR instead of
+    # only production. Both halves matter: this job previously ran a subset of
+    # build:site and still went green while every deploy failed, because Vercel
+    # installed with `npm install --legacy-peer-deps` while CI used `npm ci` —
+    # the flag drops peer-only packages, so the two trees differed (#1998).
+    # Keep this in step with vercel.json; divergence is what hid that outage.
+    #
+    # Also catches type-resolution and bundler regressions in the playground —
+    # e.g. the duplicate `@types/three` install in #963 that broke `tsc -b`
+    # only inside apps/playground.
     needs: changes
-    if: needs.changes.outputs.playground == 'true'
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
-      # The playground resolves `brepjs` (and the brepjs-bim / brepjs-sheetmetal
-      # domain packages its worker imports) via package exports → `dist/`. Build
-      # the libraries first so `tsc -b` and `vite build` see real type/runtime files.
-      - run: npm run build
-      - run: npm run build --workspace=brepjs-bim
-      - run: npm run build --workspace=brepjs-sheetmetal
-      - run: npm run build --workspace=apps/playground
+      # build:site chains the library builds that the playground and docs
+      # resolve via package exports → `dist/`, then the vitepress build and the
+      # playground → `.vitepress/dist/playground` copy that Vercel serves.
+      # provision-fonts is a no-op without FONT_BLOB_URLS, so it is CI-safe.
+      - run: npm run build:site
 
   packages-viewer:
     # Shared React/R3F renderer extracted from the playground; gated on its own
@@ -437,7 +444,7 @@ jobs:
         lint,
         quality,
         build,
-        playground-build,
+        site-build,
         packages-viewer,
         packages-verify,
         packages-sheetmetal,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,20 @@ jobs:
               - '.prettierrc*'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'
+            # Must cover every input `npm run build:site` reads, or a change to
+            # one skips site-build and still gets a green required check — the
+            # false-green this job exists to prevent. That includes the root
+            # library build it chains through: scripts/, vite.config.ts, tsconfig.
             site:
               - 'src/**'
               - 'packages/**'
               - 'apps/playground/**'
               - 'apps/docs/**'
+              - 'scripts/**'
               - 'package.json'
               - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'vite.config.ts'
               - 'vercel.json'
               - '.github/workflows/ci.yml'
               - '.github/actions/**'

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "framework": "vitepress",
   "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in *components--brepjs-cad) exit 0 ;; *) exit 1 ;; esac",
-  "installCommand": "npm install --legacy-peer-deps",
+  "installCommand": "npm ci",
   "buildCommand": "npm run build:site",
   "outputDirectory": "apps/docs/.vitepress/dist",
   "cleanUrls": true,


### PR DESCRIPTION
#1998 fixed the broken deploy. This fixes the mechanism that let it happen and kept CI green while every production deploy failed.

## The real defect

All of CI installs with `npm ci`. Vercel alone installed with `npm install --legacy-peer-deps`, so **production built a tree no CI job had ever tested**. The flag traces back to the pre-monorepo `site/vercel.json` (before #151) and was carried through every refactor since. Nothing depends on it today: `npm ci` resolves this lockfile cleanly.

`--legacy-peer-deps` makes npm skip peer resolution, which silently drops every package present only to satisfy a peer range. Measured against the current lockfile, Vercel's install was dropping:

| package | why it was there |
| --- | --- |
| `react` 19.2.6 | peer-only |
| `react-dom` 18.3.1 | peer-only |
| `esbuild-wasm` 0.27.7 | peer of `manifold-3d` |
| `search-insights` 2.17.3 | peer of `@docsearch/react` |
| `@react-three/fiber` | peer of `@react-three/drei` — the one that finally broke the build |

So this was never really about fiber. Deploys were already running without Algolia's `search-insights`; the `react`/`react-dom` aliases in the playground vite config were masking the rest. fiber was simply the first one with no alias covering it.

## Changes

**`vercel.json`: `installCommand` → `npm ci`.** Production now builds exactly what the lockfile pins and CI tested. A lockfile that drifts out of sync now fails the install loudly instead of silently producing a different tree.

**CI: `playground-build` → `site-build`, running the real `npm run build:site`.** The old job's comment claimed it mirrored Vercel, but it ran a subset (`npm run build --workspace=apps/playground`) and stayed green through every failed deploy. It now runs Vercel's exact `buildCommand`, so the docs build and the `.vitepress/dist/playground` copy are covered too. Its paths filter widens to `apps/docs/**` and `vercel.json` to match. `ci-pass` is the only required status check, so the rename is contained to `ci.yml`.

## Verification

Ran the new deploy path end to end locally:

- `npm ci` succeeds and does not rewrite the lockfile
- it tolerates the standing release-please range desync (`packages/brepjs-cad` declares `brepjs: >=18.122.0`, lockfile records `>=18.124.2`) — worth checking explicitly, since release-please PRs skip the `changes` filter but still deploy
- `npm run build:site` completes
- all four peer-only packages are present in the resulting tree

`provision-fonts.mjs` is a no-op without `FONT_BLOB_URLS`, so `build:site` is safe on fork PRs and in CI.
