### PR TITLE
fix(ci): install the playground smoke runner with npm ci

### DIFF
--- a/.github/workflows/playground-smoke.yml
+++ b/.github/workflows/playground-smoke.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+          cache: npm
 
       - name: Cache puppeteer browser download
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -41,13 +42,16 @@ jobs:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json', 'apps/playground/package.json') }}
 
-      - name: Install playground dependencies
-        working-directory: apps/playground
-        # --ignore-scripts skips the root `prepare` (husky + ensure-wasm)
-        # which we don't need in a smoke runner. We then run puppeteer's
-        # browser install explicitly below since --ignore-scripts also
-        # suppressed it.
-        run: npm install --legacy-peer-deps --no-audit --no-fund --ignore-scripts
+      - name: Install dependencies
+        # Root `npm ci` pins the smoke runner to the lockfile, matching every
+        # other workflow. The previous `npm install --legacy-peer-deps` re-resolved
+        # the tree on each run and silently dropped peer-only packages, the same
+        # install divergence that hid the broken production deploy in #2001.
+        #
+        # --ignore-scripts skips the root `prepare` (husky + ensure-wasm), which a
+        # smoke runner doesn't need. It also suppresses puppeteer's browser
+        # download, so that runs explicitly below.
+        run: npm ci --no-audit --no-fund --ignore-scripts
 
       - name: Install Chrome for Puppeteer
         working-directory: apps/playground


### PR DESCRIPTION
Follow-up to #2001. `playground-smoke.yml` was the last workflow still installing with `npm install --legacy-peer-deps`.

It re-resolved the dependency tree on every run instead of honouring the lockfile, so the smoke runner's `puppeteer` and `tsx` were whatever npm picked that day, and the flag dropped peer-only packages exactly as it did on Vercel.

This one could not have caused that outage: the smoke test loads an already-deployed URL rather than building anything. It was simply the last instance of the pattern.

## Changes

- Install with `npm ci` from the repo root instead of `npm install --legacy-peer-deps` from `apps/playground`, matching every other workflow.
- Add setup-node's `cache: npm` so the fuller install stays comfortably inside the job's 5 minute timeout.

The puppeteer and smoke steps still run from `apps/playground`; both binaries resolve from the root tree.

## Verification

Reproduced the CI conditions locally and ran the real smoke against the live production deployment (`e9928e12`, the first built under `npm ci`):

- `npm ci --ignore-scripts --no-audit --no-fund` at the root completes in ~8s warm
- from `apps/playground`, that tree resolves `tsx` 4.23.4 and `puppeteer` 25.4.0
- `npm run smoke -- <production URL>` prints `✓ Engine reached Ready`

So the deployed site built by `npm ci` doesn't just build, it boots the WASM kernel.
