### PR TITLE
fix(ci): verify release PRs still install before they auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,13 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       site: ${{ steps.filter.outputs.site }}
       voxel: ${{ steps.filter.outputs.voxel }}
+      release_please: ${{ steps.release-please.outputs.skip }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Release-please PRs only touch CHANGELOG.md, package.json versions,
       # and .release-please-manifest.json — no code changes to validate.
+      # They are not unconditionally safe though: node-workspace rewrites
+      # cross-package dependency ranges, so release-install-check still runs.
       - name: Skip release-please PRs
         id: release-please
         env:
@@ -124,6 +127,32 @@ jobs:
       - run: npm run docs:generate-lookup
       - run: npx prettier --write docs/function-lookup.md
       - run: git diff --exit-code docs/function-lookup.md
+
+  release-install-check:
+    # The one thing worth proving on a release-please PR, which skips the rest
+    # of CI. release-please's node-workspace plugin rewrites cross-package
+    # dependency ranges as it bumps versions — in #1711 it re-pinned
+    # brepjs-cad to `brepjs@^18.117.1` while only 18.117.0 was published, and
+    # auto-merge landed it on main. Every deploy then died on ETARGET at
+    # install, before any build ran, and so did every other PR's `npm ci`.
+    #
+    # `npm ci` reproduces that failure exactly (verified: an unsatisfiable
+    # floor exits 1 with the same ETARGET), so installing the tree the PR
+    # proposes is a sufficient guard. Nothing is built — a release PR changes
+    # only versions, changelogs and the ranges checked here.
+    needs: changes
+    if: needs.changes.outputs.release_please == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+      # --ignore-scripts skips the root `prepare` (husky + ensure-wasm); this
+      # job only needs resolution to succeed, not a usable build environment.
+      - run: npm ci --ignore-scripts --no-audit --no-fund
 
   site-build:
     # Runs Vercel's exact buildCommand (`npm run build:site`) on the exact tree
@@ -447,6 +476,7 @@ jobs:
     needs:
       [
         changes,
+        release-install-check,
         typecheck,
         lint,
         quality,


### PR DESCRIPTION
Investigating the release-please desync turned up something more useful than the desync itself, so this PR fixes that and leaves the cosmetic drift alone deliberately.

## What the desync actually is

`packages/brepjs-cad/package.json` declares `brepjs: ">=18.122.0"`; `package-lock.json` records `">=18.124.4"` for the same dependency.

The two drift because release-please writes the re-pinned range into each file on a different PR:

- **root brepjs releases** advance the range in `package-lock.json` (every cut)
- **leaf brepjs-cad releases** now update only the `version` field, never the range

The last time `package.json`'s range moved was 0.119.1, six releases ago, so the gap widens with each root release rather than closing.

## Why it is not currently dangerous

The drift always leaves `package.json` **trailing** the lockfile and the local workspace version, and a lower floor is always satisfiable. Verified: `npm ci` installs this tree cleanly and does not rewrite the lockfile.

The direction that *is* dangerous is the floor running **ahead** of the available brepjs. That is #1711: node-workspace re-pinned brepjs-cad to `^18.117.1` while only 18.117.0 was published, auto-merge landed it on main, and every deploy died on ETARGET before any build ran. I reproduced that failure mode directly — an unsatisfiable floor makes `npm ci` exit 1 with the identical ETARGET.

## The real gap

Release-please PRs skip **every** CI job, on the premise that they only touch versions and changelogs. They also rewrite cross-package dependency ranges, which is precisely the input that broke production in #1711 — and nothing verifies it.

The repo already serializes root-before-leaf merges to prevent that ordering. This adds a check of the *result* rather than trusting the sequencing.

## Change

A `release-install-check` job that runs `npm ci` on release PRs and is wired into `ci-pass`, so an unsatisfiable range blocks auto-merge. Nothing is built: versions, changelogs and these ranges are all a release PR changes.

Gating verified by simulating both paths — release PRs run only this job; normal PRs run the usual 14 and skip it.

## What this does not do

It does not stop the drift. Making the range stop moving means either pinning it to `"*"` (tried in #1852, reverted in #1854) or taking brepjs-cad's `brepjs` dependency out of node-workspace's management. Both change the published package's contract and both have broken things before, so they are worth deciding deliberately rather than folding into a CI fix.
