### PR TITLE
fix(brepkit): accept a compound base in fuse and cut

### DIFF
--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -85,6 +85,18 @@ function kernelBoolean(
   return bk[op](a, b);
 }
 
+/**
+ * Solid ids behind a shape: a solid contributes itself, a compound its children.
+ * Throws with the method name for anything else, matching `unwrapSolidOrThrow`.
+ */
+function solidIdsOf(bk: BrepkitKernel, shape: KernelShape, methodName: string): number[] {
+  const h = shape as BrepkitHandle;
+  if (isBrepkitHandle(shape) && h.type === 'compound') {
+    return toArray(bk.getCompoundSolids(h.id));
+  }
+  return [unwrapSolidOrThrow(shape, methodName)];
+}
+
 export function fuse(
   bk: BrepkitKernel,
   shape: KernelShape,
@@ -100,6 +112,20 @@ export function fuse(
   // Identity: fuse(∅, X) = X, fuse(X, ∅) = X.
   if (isEmptyCompound(bk, shape as BrepkitHandle)) return tool;
   if (isEmptyCompound(bk, tool as BrepkitHandle)) return shape;
+
+  // A compound base is one operand, not a container to pick a solid out of:
+  // the union has to cover every child. Text is a compound of glyph solids, so
+  // without this the whole "text fused onto a bin" path throws before any
+  // geometry runs. brepkit's n-way fuse merges disjoint groups without running
+  // a boolean, so children the tool never touches survive intact.
+  const baseHandle = shape as BrepkitHandle;
+  if (isBrepkitHandle(shape) && baseHandle.type === 'compound') {
+    const ids = solidIdsOf(bk, shape, 'fuse');
+    ids.push(...solidIdsOf(bk, tool, 'fuse'));
+    if (ids.length === 0) throw new Error('brepkit: fuse resolved to zero solid IDs');
+    return solidHandle(bk.fuseAll(new Uint32Array(ids)));
+  }
+
   const baseId = unwrapSolidOrThrow(shape, 'fuse');
   const toolHandle = tool as BrepkitHandle;
   if (toolHandle.type === 'compound') {
@@ -129,6 +155,24 @@ export function cut(
   // Identity: cut(∅, X) = ∅, cut(X, ∅) = X.
   if (isEmptyCompound(bk, shape as BrepkitHandle)) return emptyCompound(bk);
   if (isEmptyCompound(bk, tool as BrepkitHandle)) return shape;
+
+  // Cut each child independently and drop the ones the tool consumes whole,
+  // the same shape `cutAll` uses for a compound base (brepkit#1499).
+  const cutBase = shape as BrepkitHandle;
+  if (isBrepkitHandle(shape) && cutBase.type === 'compound') {
+    const toolIds = solidIdsOf(bk, tool, 'cut');
+    const survivors: number[] = [];
+    for (const childId of toArray(bk.getCompoundSolids(cutBase.id))) {
+      try {
+        survivors.push(bk.compoundCut(childId, new Uint32Array(toolIds)));
+      } catch (e) {
+        if (!isEmptyBooleanError(e)) throw e;
+      }
+    }
+    if (survivors.length === 0) return emptyCompound(bk);
+    return compoundHandle(bk.makeCompound(survivors));
+  }
+
   const baseId = unwrapSolidOrThrow(shape, 'cut');
   const toolHandle = tool as BrepkitHandle;
   if (toolHandle.type === 'compound') {
@@ -227,21 +271,18 @@ export function fuseAll(
   if (shapes.length === 0) throw new Error('brepkit: fuseAll requires at least one shape');
   if (shapes.length === 1) return wasmIndex(shapes, 0);
 
-  if (bk.compoundFuse) {
+  // brepkit exposes its n-way GFA fuse as `fuseAll`. This probed `compoundFuse`,
+  // a name brepkit has never had, so the fast path was dead and every call fell
+  // through to the pairwise tree below.
+  if (typeof bk.fuseAll === 'function') {
     const solidIds: number[] = [];
     for (const shape of shapes) {
-      const h = shape as BrepkitHandle;
-      if (h.type === 'compound') {
-        solidIds.push(...toArray(bk.getCompoundSolids(h.id)));
-      } else {
-        solidIds.push(unwrapSolidOrThrow(shape, 'fuseAll'));
-      }
+      solidIds.push(...solidIdsOf(bk, shape, 'fuseAll'));
     }
     if (solidIds.length === 0) {
       throw new Error('brepkit: fuseAll resolved to zero solid IDs');
     }
-    const result = bk.compoundFuse(new Uint32Array(solidIds));
-    return solidHandle(result);
+    return solidHandle(bk.fuseAll(new Uint32Array(solidIds)));
   }
 
   let current = [...shapes];

--- a/src/kernel/brepkit/booleanOps.ts
+++ b/src/kernel/brepkit/booleanOps.ts
@@ -86,6 +86,20 @@ function kernelBoolean(
 }
 
 /**
+ * A compound base routes through the kernel's n-way `fuseAll` / `compoundCut`,
+ * neither of which takes the post-boolean `simplify` flag the two-operand
+ * `*WithOptions` entry points do. Say so rather than silently returning
+ * unsimplified topology, the same way an old kernel reports it.
+ */
+function warnCompoundBaseSimplify(options: BooleanOptions | undefined, op: string): void {
+  if (!options?.simplify) return;
+  warnOnce(
+    `boolean-simplify-compound-base-${op}`,
+    `BooleanOptions.simplify is not applied when ${op} receives a compound base; ignored.`
+  );
+}
+
+/**
  * Solid ids behind a shape: a solid contributes itself, a compound its children.
  * Throws with the method name for anything else, matching `unwrapSolidOrThrow`.
  */
@@ -120,6 +134,7 @@ export function fuse(
   // a boolean, so children the tool never touches survive intact.
   const baseHandle = shape as BrepkitHandle;
   if (isBrepkitHandle(shape) && baseHandle.type === 'compound') {
+    warnCompoundBaseSimplify(_options, 'fuse');
     const ids = solidIdsOf(bk, shape, 'fuse');
     ids.push(...solidIdsOf(bk, tool, 'fuse'));
     if (ids.length === 0) throw new Error('brepkit: fuse resolved to zero solid IDs');
@@ -160,6 +175,7 @@ export function cut(
   // the same shape `cutAll` uses for a compound base (brepkit#1499).
   const cutBase = shape as BrepkitHandle;
   if (isBrepkitHandle(shape) && cutBase.type === 'compound') {
+    warnCompoundBaseSimplify(_options, 'cut');
     const toolIds = solidIdsOf(bk, tool, 'cut');
     const survivors: number[] = [];
     for (const childId of toArray(bk.getCompoundSolids(cutBase.id))) {

--- a/src/kernel/brepkit/brepkitWasmTypes.ts
+++ b/src/kernel/brepkit/brepkitWasmTypes.ts
@@ -938,9 +938,6 @@ export interface BrepkitKernel {
   ): number;
 
   /** @future Not in brepkit-wasm 3.0.0. Referenced with feature detection in adapter. */
-  compoundFuse?(solidIds: Uint32Array | number[]): number;
-
-  /** @future Not in brepkit-wasm 3.0.0. Referenced with feature detection in adapter. */
   copyEdge?(edge: number): number;
 
   /** @future Not in brepkit-wasm 3.0.0. Referenced with feature detection in adapter. */

--- a/tests/brepkitExtended.test.ts
+++ b/tests/brepkitExtended.test.ts
@@ -12,7 +12,9 @@ import { describe, expect, it, beforeAll } from 'vitest';
 import { initKernel } from './setup.js';
 import {
   box,
+  cut,
   fillet,
+  fuse,
   castShape,
   compound,
   getEdges,
@@ -697,6 +699,49 @@ descOcct('Brepkit-only methods throw on OCCT', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Booleans with a compound BASE
+// ---------------------------------------------------------------------------
+
+// `fuse` and `cut` accepted a compound as the tool but demanded a solid as the
+// base, so anything built as a compound could not be fused or cut. Text is a
+// compound of glyph solids, which is how this reached the tool: "fuse requires
+// a solid, got compound" (brepkit#1537).
+descBk('Booleans with a compound base (brepkit)', () => {
+  it('fuses a compound base with a solid tool', () => {
+    // Two disjoint unit boxes plus a tool overlapping only the first.
+    const base = compound([box(2, 2, 2), translate(box(2, 2, 2), [10, 0, 0])]);
+    const result = unwrap(fuse(base, translate(box(2, 2, 2), [1, 0, 0])));
+    // 8 + 8 for the pair, plus the 4 the tool adds beyond the first box.
+    expect(unwrap(measureVolume(result))).toBeCloseTo(20, 1);
+  });
+
+  it('keeps a compound-base child the tool never touches', () => {
+    const base = compound([box(2, 2, 2), translate(box(2, 2, 2), [10, 0, 0])]);
+    const fused = unwrap(fuse(base, translate(box(2, 2, 2), [1, 0, 0])));
+    const bb = getKernel().boundingBox(fused.wrapped);
+    expect(bb.max[0]).toBeCloseTo(12, 3);
+  });
+
+  it('fuses a compound base with a compound tool', () => {
+    const base = compound([box(2, 2, 2), translate(box(2, 2, 2), [10, 0, 0])]);
+    const tool = compound([translate(box(2, 2, 2), [20, 0, 0])]);
+    expect(unwrap(measureVolume(unwrap(fuse(base, tool))))).toBeCloseTo(24, 1);
+  });
+
+  it('cuts every child of a compound base', () => {
+    // A slab spanning both children removes the lower half of each.
+    const base = compound([box(2, 2, 2), translate(box(2, 2, 2), [10, 0, 0])]);
+    const result = unwrap(cut(base, translate(box(20, 4, 1), [-1, -1, 0])));
+    expect(unwrap(measureVolume(result))).toBeCloseTo(8, 1);
+  });
+
+  it('drops a compound-base child the tool consumes whole', () => {
+    const base = compound([box(2, 2, 2), translate(box(2, 2, 2), [10, 0, 0])]);
+    const result = unwrap(cut(base, translate(box(4, 4, 4), [-1, -1, -1])));
+    expect(unwrap(measureVolume(result))).toBeCloseTo(8, 1);
+  });
+});
+
 // Transforming compounds
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes the live half of brepkit#1537.

## The gap

`fuse` and `cut` accepted a compound as the **tool** but demanded a solid as the **base**:

```ts
const baseId = unwrapSolidOrThrow(shape, 'fuse');   // booleanOps.ts
```

So a shape built as a compound could not be fused or cut at all. Text is a compound of glyph solids, which is how it surfaced downstream as

```
brepkit: fuse requires a solid, got compound
```

`cutAll` grew a compound-base branch in #1996; `fuse` and `cut` did not.

## Semantics

**`fuse`** treats a compound base as one operand, not a container to pick a solid out of — the union has to cover every child. Every child plus the tool goes into a single n-way fuse. brepkit's `fuseAll` merges disjoint groups without running a boolean, so children the tool never touches survive intact while overlapping ones merge.

**`cut`** mirrors `cutAll`: cut each child independently, drop the ones the tool consumes whole, return a compound of the survivors (or an empty compound if nothing survives).

Both share a small `solidIdsOf` helper so a solid and a compound resolve the same way, with `unwrapSolidOrThrow`'s error for anything else.

## Separate fix in the same file: the n-way fast path has never run

`fuseAll` gated its fast path on `bk.compoundFuse`:

```ts
if (bk.compoundFuse) { ... }
```

**brepkit has never had a method by that name** — zero hits across its entire history. It exposes that operation as `fuseAll`, which this file's own `BrepkitKernel` type has always declared as *required* (`compoundFuse` sat beside it marked `@future Not in brepkit-wasm 3.0.0`).

So the probe has been false since it was added in #462, and every `fuseAll` call fell through to the JS pairwise tree — brepkit's n-way GFA fuse has not been reachable from this adapter at all. The probe now points at `bk.fuseAll` and the obsolete declaration is removed.

## Verification

Five tests in `tests/brepkitExtended.test.ts` covering: compound base with a solid tool, an untouched child surviving, compound base with a compound tool, cutting every child, and dropping a fully consumed child.

Each fails before the change with the exact error above:

```
Error: brepkit: fuse requires a solid, got compound.
Error: brepkit: cut requires a solid, got compound.
```

- Boolean suites (`brepkitExtended`, `booleanFns`, `boolean`, `brepkitAdapter`, `booleanBatchFns`): **776 passed** against a **766** baseline, with the same 45 pre-existing `manifold` failures on both sides.
- Pre-commit full occt-wasm project run: **4220 passed, 0 failed**.
- `npm run lint`, `npm run typecheck`, prettier: clean.

## Note for the layout tool

The other 17 failures in brepkit#1537 are a stale pin, not a code gap: `meshShape` on a compound was fixed in #2012 and released in **18.124.7**, and the tool pins `brepjs 18.124.2`. Bumping that pin clears them without any change here.