### PR TITLE
fix(csg): copy input arrays in n-ary builders

### DIFF
--- a/src/csg/builders.ts
+++ b/src/csg/builders.ts
@@ -233,11 +233,21 @@ export function intersect(a: SolidNode, b: SolidNode, tolerance?: number): Inter
   };
 }
 
+// N-ary builders copy their input arrays so later caller mutation can't
+// desync the children from the pre-computed structuralHash (same contract
+// as `instance` and `loft`).
 export function fuseAll(shapes: ReadonlyArray<SolidNode>, tolerance?: number): FuseAllNode {
-  let h = fnvMixInt32(startHash('FuseAll'), shapes.length);
-  for (const s of shapes) h = mix(h, s);
+  const copied = [...shapes];
+  let h = fnvMixInt32(startHash('FuseAll'), copied.length);
+  for (const s of copied) h = mix(h, s);
   h = mixOptNumber(h, tolerance);
-  return { kind: 'FuseAll', shapes, tolerance, structuralHash: h, freeParams: depsOf(...shapes) };
+  return {
+    kind: 'FuseAll',
+    shapes: copied,
+    tolerance,
+    structuralHash: h,
+    freeParams: depsOf(...copied),
+  };
 }
 
 export function cutAll(
@@ -245,17 +255,18 @@ export function cutAll(
   tools: ReadonlyArray<SolidNode>,
   tolerance?: number
 ): CutAllNode {
+  const copied = [...tools];
   let h = mix(startHash('CutAll'), base);
-  h = fnvMixInt32(h, tools.length);
-  for (const t of tools) h = mix(h, t);
+  h = fnvMixInt32(h, copied.length);
+  for (const t of copied) h = mix(h, t);
   h = mixOptNumber(h, tolerance);
   return {
     kind: 'CutAll',
     base,
-    tools,
+    tools: copied,
     tolerance,
     structuralHash: h,
-    freeParams: depsOf(base, ...tools),
+    freeParams: depsOf(base, ...copied),
   };
 }
 
@@ -415,9 +426,15 @@ export function revolve(
 // ---------------------------------------------------------------------------
 
 export function compound(children: ReadonlyArray<IRNode>): CompoundNode {
-  let h = fnvMixInt32(startHash('Compound'), children.length);
-  for (const c of children) h = mix(h, c);
-  return { kind: 'Compound', children, structuralHash: h, freeParams: depsOf(...children) };
+  const copied = [...children];
+  let h = fnvMixInt32(startHash('Compound'), copied.length);
+  for (const c of copied) h = mix(h, c);
+  return {
+    kind: 'Compound',
+    children: copied,
+    structuralHash: h,
+    freeParams: depsOf(...copied),
+  };
 }
 
 export function instance(

--- a/tests/csg/csgBuilderImmutability.test.ts
+++ b/tests/csg/csgBuilderImmutability.test.ts
@@ -1,0 +1,52 @@
+/**
+ * N-ary builders must decouple from their input arrays: mutating the array
+ * after construction cannot change the node's children, which would desync
+ * them from the pre-computed structuralHash. Pure tests, no kernel needed.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { box, sphere, fuseAll, cutAll, compound, loft, polygon, type IRNode } from '@/csg/index.js';
+
+function rect() {
+  return polygon([
+    [0, 0, 0],
+    [10, 0, 0],
+    [10, 10, 0],
+    [0, 10, 0],
+  ]);
+}
+
+describe('n-ary builders copy their input arrays', () => {
+  it('fuseAll', () => {
+    const shapes = [box(1, 1, 1), box(2, 2, 2)];
+    const node = fuseAll(shapes);
+    shapes.push(sphere(3));
+    shapes[0] = sphere(9);
+    expect(node.shapes).toHaveLength(2);
+    expect(node.structuralHash).toBe(fuseAll([box(1, 1, 1), box(2, 2, 2)]).structuralHash);
+  });
+
+  it('cutAll', () => {
+    const tools = [box(1, 1, 1)];
+    const node = cutAll(box(5, 5, 5), tools);
+    tools.push(sphere(2));
+    expect(node.tools).toHaveLength(1);
+    expect(node.structuralHash).toBe(cutAll(box(5, 5, 5), [box(1, 1, 1)]).structuralHash);
+  });
+
+  it('compound', () => {
+    const children: IRNode[] = [box(1, 1, 1), sphere(2)];
+    const node = compound(children);
+    children.length = 0;
+    expect(node.children).toHaveLength(2);
+    expect(node.structuralHash).toBe(compound([box(1, 1, 1), sphere(2)]).structuralHash);
+  });
+
+  it('loft', () => {
+    const sections = [rect(), rect()];
+    const node = loft(sections);
+    sections.push(rect());
+    expect(node.sections).toHaveLength(2);
+    expect(node.structuralHash).toBe(loft([rect(), rect()]).structuralHash);
+  });
+});


### PR DESCRIPTION
Follow-up hardening from the review of #2030: `fuseAll`, `cutAll`, and `compound` stored the caller's input array by reference, so mutating that array after construction changed the node's children while `structuralHash` and `freeParams` kept their original values — stale cached geometry on later evaluations. `instance` (and now `loft`) already copy for exactly this reason; this brings the remaining n-ary builders onto the same contract.

New pure test suite `tests/csg/csgBuilderImmutability.test.ts` locks the contract for all four n-ary builders: post-construction push/replace/clear of the input array leaves the node's children and hash identical to a fresh build.
