### PR TITLE
feat(csg): add path node and segment vocabulary

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   { "name": "total (all JS)", "path": "dist/*.js", "limit": "380 kB" },
-  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "59 kB" },
+  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "61 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },
   { "name": "brepjs/vectors", "path": "dist/vectors.js", "limit": "1 kB" },

--- a/src/csg/builders.ts
+++ b/src/csg/builders.ts
@@ -2,11 +2,14 @@
 // literal inputs to expressions and pre-compute structuralHash + freeParams.
 import {
   asScalarExpr,
+  asVec2Expr,
   asVec3Expr,
   type Expr,
   type ScalarInput,
+  type Vec2Input,
   type Vec3Input,
 } from './expressions.js';
+import { hashSegments, segmentFreeParams, type Segment2D } from './segments.js';
 import {
   fnvInit,
   fnvMixString,
@@ -39,6 +42,7 @@ import type {
   ExtrudeNode,
   RevolveNode,
   LoftNode,
+  PathNode,
   CompoundNode,
   InstanceNode,
   IRNode,
@@ -366,6 +370,23 @@ export function extrude(profile: FaceNode, vector: Vec3Input): ExtrudeNode {
     vector: ve,
     structuralHash: h,
     freeParams: depsOf(profile, ve),
+  };
+}
+
+/** Open (or incidentally closed) planar path in the XY plane at z = 0,
+ *  producing a Wire. Segments come from `lineTo`/`arcTo`/`bezierTo`/
+ *  `ellipseArcTo`. */
+export function path(start: Vec2Input, segments: ReadonlyArray<Segment2D>): PathNode {
+  const se = asVec2Expr(start);
+  const copied = [...segments];
+  let h = mix(startHash('Path'), se);
+  h = hashSegments(h, copied);
+  return {
+    kind: 'Path',
+    start: se,
+    segments: copied,
+    structuralHash: h,
+    freeParams: depsOf(se, ...segmentFreeParams(copied)),
   };
 }
 

--- a/src/csg/edit.ts
+++ b/src/csg/edit.ts
@@ -26,6 +26,7 @@ function rebuildChildren(n: IRNode, pred: NodePredicate, repl: IRNode): IRNode {
     case 'Line':
     case 'Vertex':
     case 'Empty':
+    case 'Path':
       return n;
     case 'Fuse':
       return B.fuse(walk(n.a, pred, repl), walk(n.b, pred, repl), n.tolerance);
@@ -85,6 +86,7 @@ function childrenOf(n: IRNode): readonly IRNode[] {
     case 'Line':
     case 'Vertex':
     case 'Empty':
+    case 'Path':
       return [];
     case 'Fuse':
     case 'Cut':

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -45,6 +45,7 @@ import { evalInstance } from './evaluators/instance.js';
 import { evalExtrude } from './evaluators/extrude.js';
 import { evalRevolve } from './evaluators/revolve.js';
 import { evalLoft } from './evaluators/loft.js';
+import { evalPath } from './evaluators/path.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -145,6 +146,8 @@ function dispatch(node: IRNode, ctx: EvalContext): Result<AnyShape<Dimension>> {
       return evalRevolve(node, ctx);
     case 'Loft':
       return evalLoft(node, ctx);
+    case 'Path':
+      return evalPath(node, ctx);
   }
 }
 

--- a/src/csg/evaluators/path.ts
+++ b/src/csg/evaluators/path.ts
@@ -1,0 +1,203 @@
+import {
+  makeLine,
+  makeThreePointArc,
+  makeBezierCurve,
+  makeEllipseArc,
+  assembleWire,
+} from '@/topology/curveBuilders.js';
+import { DisposalScope } from '@/core/disposal.js';
+import { ok, err, type Result } from '@/core/result.js';
+import { validationError } from '@/core/errors.js';
+import type { AnyShape, Dimension, Edge } from '@/core/shapeTypes.js';
+import type { Vec2, Vec3 } from '@/core/types.js';
+import { evalScalar, evalVec2 } from '../expressions.js';
+import type { Segment2D } from '../segments.js';
+import type { PathNode } from '../types.js';
+import type { EvalContext } from './context.js';
+
+const EPS = 1e-9;
+
+function v3(p: Vec2): Vec3 {
+  return [p[0], p[1], 0];
+}
+
+function fail(msg: string): Result<never> {
+  return err(validationError('CSG_PATH_SEGMENT', `Path: ${msg}`));
+}
+
+/** SVG-style endpoint circular arc: recover the on-arc midpoint so the edge
+ *  can be built as a three-point arc. */
+function circularArcMidpoint(
+  from: Vec2,
+  to: Vec2,
+  r: number,
+  largeArc: boolean,
+  clockwise: boolean
+): Result<Vec2> {
+  const [x1, y1] = from;
+  const [x2, y2] = to;
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const d = Math.hypot(dx, dy);
+  if (d < EPS) return fail('Arc: coincident endpoints');
+  if (d > 2 * r + 1e-6) return fail(`Arc: radius ${r} too small for chord ${d}`);
+  const h = Math.sqrt(Math.max(0, r * r - (d / 2) * (d / 2)));
+  const ux = dx / d;
+  const uy = dy / d;
+  // A ccw small arc has its center on the left of the directed chord; the
+  // side flips with each of the two flags.
+  const sign = clockwise === largeArc ? 1 : -1;
+  const cx = (x1 + x2) / 2 + sign * h * -uy;
+  const cy = (y1 + y2) / 2 + sign * h * ux;
+  const a0 = Math.atan2(y1 - cy, x1 - cx);
+  let a1 = Math.atan2(y2 - cy, x2 - cx);
+  if (clockwise) {
+    while (a1 >= a0 - EPS) a1 -= 2 * Math.PI;
+  } else {
+    while (a1 <= a0 + EPS) a1 += 2 * Math.PI;
+  }
+  const amid = (a0 + a1) / 2;
+  return ok([cx + r * Math.cos(amid), cy + r * Math.sin(amid)]);
+}
+
+interface EllipseParams {
+  readonly center: Vec2;
+  readonly theta1: number;
+  readonly theta2: number;
+  readonly rx: number;
+  readonly ry: number;
+}
+
+/** SVG F.6.5 endpoint-to-center conversion (math y-up; sweep = !clockwise).
+ *  Angles are relative to the rotated x-axis. */
+function ellipseArcParams(
+  from: Vec2,
+  to: Vec2,
+  radii: Vec2,
+  phi: number,
+  largeArc: boolean,
+  clockwise: boolean
+): Result<EllipseParams> {
+  const sweep = !clockwise;
+  let [rx, ry] = radii;
+  if (rx <= 0 || ry <= 0) return fail('EllipseArc: non-positive radius');
+  const cosPhi = Math.cos(phi);
+  const sinPhi = Math.sin(phi);
+  const hx = (from[0] - to[0]) / 2;
+  const hy = (from[1] - to[1]) / 2;
+  const x1p = cosPhi * hx + sinPhi * hy;
+  const y1p = -sinPhi * hx + cosPhi * hy;
+  const lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+  if (lambda > 1) {
+    const s = Math.sqrt(lambda);
+    rx *= s;
+    ry *= s;
+  }
+  const num = rx * rx * ry * ry - rx * rx * y1p * y1p - ry * ry * x1p * x1p;
+  const den = rx * rx * y1p * y1p + ry * ry * x1p * x1p;
+  if (den < EPS) return fail('EllipseArc: coincident endpoints');
+  const coef = (largeArc !== sweep ? 1 : -1) * Math.sqrt(Math.max(0, num / den));
+  const cxp = coef * ((rx * y1p) / ry);
+  const cyp = coef * (-(ry * x1p) / rx);
+  const cx = cosPhi * cxp - sinPhi * cyp + (from[0] + to[0]) / 2;
+  const cy = sinPhi * cxp + cosPhi * cyp + (from[1] + to[1]) / 2;
+  const theta1 = Math.atan2((y1p - cyp) / ry, (x1p - cxp) / rx);
+  let dTheta = Math.atan2((-y1p - cyp) / ry, (-x1p - cxp) / rx) - theta1;
+  if (!sweep && dTheta > 0) dTheta -= 2 * Math.PI;
+  if (sweep && dTheta < 0) dTheta += 2 * Math.PI;
+  // The kernel draws ccw from theta1 to theta2; a clockwise arc is the same
+  // point set traversed backwards, so swap.
+  const t1 = dTheta >= 0 ? theta1 : theta1 + dTheta;
+  const t2 = dTheta >= 0 ? theta1 + dTheta : theta1;
+  return ok({ center: [cx, cy], theta1: t1, theta2: t2, rx, ry });
+}
+
+function ellipseEdge(from: Vec2, seg: Segment2D, ctx: EvalContext): Result<Edge> {
+  if (seg.kind !== 'EllipseArc') return fail('internal: not an ellipse segment');
+  const to = evalVec2(seg.to, ctx.env, 'Path.EllipseArc.to');
+  if (!to.ok) return to;
+  const radii = evalVec2(seg.radii, ctx.env, 'Path.EllipseArc.radii');
+  if (!radii.ok) return radii;
+  const rotDeg = evalScalar(seg.rotation, ctx.env, 'Path.EllipseArc.rotation');
+  if (!rotDeg.ok) return rotDeg;
+  const phi = (rotDeg.value * Math.PI) / 180;
+  const p = ellipseArcParams(from, to.value, radii.value, phi, seg.largeArc, seg.clockwise);
+  if (!p.ok) return p;
+  const { center, theta1, theta2, rx, ry } = p.value;
+  if (rx >= ry) {
+    const xDir: Vec3 = [Math.cos(phi), Math.sin(phi), 0];
+    return makeEllipseArc(rx, ry, theta1, theta2, v3(center), [0, 0, 1], xDir);
+  }
+  // Kernel wants major >= minor: swap axes (major along the rotated y-axis)
+  // and shift angles by -90 deg relative to the new major axis.
+  const yDir: Vec3 = [-Math.sin(phi), Math.cos(phi), 0];
+  return makeEllipseArc(
+    ry,
+    rx,
+    theta1 - Math.PI / 2,
+    theta2 - Math.PI / 2,
+    v3(center),
+    [0, 0, 1],
+    yDir
+  );
+}
+
+function segmentEnd(seg: Segment2D, ctx: EvalContext): Result<Vec2> {
+  return evalVec2(seg.to, ctx.env, `Path.${seg.kind}.to`);
+}
+
+function segmentToEdge(from: Vec2, seg: Segment2D, ctx: EvalContext): Result<Edge> {
+  switch (seg.kind) {
+    case 'Line': {
+      const to = segmentEnd(seg, ctx);
+      if (!to.ok) return to;
+      if (Math.hypot(to.value[0] - from[0], to.value[1] - from[1]) < EPS) {
+        return fail('Line: zero length');
+      }
+      return ok(makeLine(v3(from), v3(to.value)));
+    }
+    case 'Arc': {
+      const to = segmentEnd(seg, ctx);
+      if (!to.ok) return to;
+      const r = evalScalar(seg.radius, ctx.env, 'Path.Arc.radius');
+      if (!r.ok) return r;
+      const mid = circularArcMidpoint(from, to.value, r.value, seg.largeArc, seg.clockwise);
+      if (!mid.ok) return mid;
+      return ok(makeThreePointArc(v3(from), v3(mid.value), v3(to.value)));
+    }
+    case 'Bezier': {
+      const to = segmentEnd(seg, ctx);
+      if (!to.ok) return to;
+      const controls: Vec3[] = [];
+      for (const c of seg.controls) {
+        const cv = evalVec2(c, ctx.env, 'Path.Bezier.control');
+        if (!cv.ok) return cv;
+        controls.push(v3(cv.value));
+      }
+      return makeBezierCurve([v3(from), ...controls, v3(to.value)]);
+    }
+    case 'EllipseArc':
+      return ellipseEdge(from, seg, ctx);
+  }
+}
+
+export function evalPath(node: PathNode, ctx: EvalContext): Result<AnyShape<Dimension>> {
+  if (node.segments.length === 0) return fail('at least one segment required');
+  const start = evalVec2(node.start, ctx.env, 'Path.start');
+  if (!start.ok) return start;
+  // Edges are intermediates consumed by wire assembly; the wire is the fresh
+  // handle handed to the evaluator cache.
+  using scope = new DisposalScope();
+  const edges: Edge[] = [];
+  let cur = start.value;
+  for (const seg of node.segments) {
+    const e = segmentToEdge(cur, seg, ctx);
+    if (!e.ok) return e;
+    scope.register(e.value);
+    edges.push(e.value);
+    const end = segmentEnd(seg, ctx);
+    if (!end.ok) return end;
+    cur = end.value;
+  }
+  return assembleWire(edges);
+}

--- a/src/csg/evaluators/path.ts
+++ b/src/csg/evaluators/path.ts
@@ -5,10 +5,12 @@ import {
   makeEllipseArc,
   assembleWire,
 } from '@/topology/curveBuilders.js';
+import { flipOrientation } from '@/topology/curveFns.js';
+import { getKernel } from '@/kernel/index.js';
 import { DisposalScope } from '@/core/disposal.js';
 import { ok, err, type Result } from '@/core/result.js';
-import { validationError } from '@/core/errors.js';
-import type { AnyShape, Dimension, Edge } from '@/core/shapeTypes.js';
+import { validationError, kernelError } from '@/core/errors.js';
+import { castShape, type AnyShape, type Dimension, type Edge } from '@/core/shapeTypes.js';
 import type { Vec2, Vec3 } from '@/core/types.js';
 import { evalScalar, evalVec2 } from '../expressions.js';
 import type { Segment2D } from '../segments.js';
@@ -124,22 +126,56 @@ function ellipseEdge(from: Vec2, seg: Segment2D, ctx: EvalContext): Result<Edge>
   const p = ellipseArcParams(from, to.value, radii.value, phi, seg.largeArc, seg.clockwise);
   if (!p.ok) return p;
   const { center, theta1, theta2, rx, ry } = p.value;
+  // Build AXIS-ALIGNED (no xDir: the kernel's makeEllipseArc silently ignores
+  // it on occt-wasm) and rotate the edge into the true frame afterwards. The
+  // major axis must come first, so a tall ellipse builds major-along-X with
+  // angles shifted by -90 deg and picks up the extra quarter turn here.
+  let arc: Result<Edge>;
+  let psi: number;
   if (rx >= ry) {
-    const xDir: Vec3 = [Math.cos(phi), Math.sin(phi), 0];
-    return makeEllipseArc(rx, ry, theta1, theta2, v3(center), [0, 0, 1], xDir);
+    arc = makeEllipseArc(rx, ry, theta1, theta2, v3(center), [0, 0, 1]);
+    psi = phi;
+  } else {
+    arc = makeEllipseArc(ry, rx, theta1 - Math.PI / 2, theta2 - Math.PI / 2, v3(center), [0, 0, 1]);
+    psi = phi + Math.PI / 2;
   }
-  // Kernel wants major >= minor: swap axes (major along the rotated y-axis)
-  // and shift angles by -90 deg relative to the new major axis.
-  const yDir: Vec3 = [-Math.sin(phi), Math.cos(phi), 0];
-  return makeEllipseArc(
-    ry,
-    rx,
-    theta1 - Math.PI / 2,
-    theta2 - Math.PI / 2,
-    v3(center),
-    [0, 0, 1],
-    yDir
-  );
+  if (!arc.ok) return arc;
+  let edge = arc.value;
+  if (Math.abs(psi) > EPS) {
+    using tmp = edge;
+    const rotated = rotateEdgeAbout(tmp, (psi * 180) / Math.PI, center);
+    if (!rotated.ok) return rotated;
+    edge = rotated.value;
+  }
+  if (seg.clockwise) {
+    // The kernel draws ccw, so a clockwise segment was built with swapped
+    // angles: right point set, reversed parametric direction. Flip so the
+    // edge runs from -> to in path order (spine direction depends on it).
+    using tmp = edge;
+    edge = flipOrientation(tmp) as Edge;
+  }
+  return ok(edge);
+}
+
+/** Rotate an edge about the Z axis at `center` (degrees) via a cheap location
+ *  re-tag; returns a fresh, independently-disposable handle. Kernels without
+ *  an edge-relocation path (brepkit) surface as a Result error, not a throw. */
+function rotateEdgeAbout(edge: Edge, angleDeg: number, center: Vec2): Result<Edge> {
+  const kernel = getKernel();
+  const { handle, dispose } = kernel.composeTransform([
+    { type: 'rotate', angle: angleDeg, axis: [0, 0, 1], center: [center[0], center[1], 0] },
+  ]);
+  try {
+    return ok(castShape(kernel.locate(edge.wrapped, handle)) as Edge);
+  } catch (e) {
+    return err(
+      kernelError('CSG_PATH_ELLIPSE_ROTATE', 'Path: kernel cannot relocate ellipse-arc edges', e, {
+        operation: 'evalPath',
+      })
+    );
+  } finally {
+    dispose();
+  }
 }
 
 function segmentEnd(seg: Segment2D, ctx: EvalContext): Result<Vec2> {

--- a/src/csg/expressions.ts
+++ b/src/csg/expressions.ts
@@ -355,6 +355,15 @@ export function evalVec3(expr: Expr, env: Env, where: string): Result<Vec3> {
   return ok([a as number, b as number, c as number]);
 }
 
+export function evalVec2(expr: Expr, env: Env, where: string): Result<Vec2> {
+  const r = evalExpr(expr, env);
+  if (!r.ok) return r;
+  const v = expectVecLen(r.value, 2, where);
+  if (!v.ok) return v;
+  const [a, b] = v.value;
+  return ok([a as number, b as number]);
+}
+
 // ---------------------------------------------------------------------------
 // Projection — restrict env to the keys a node actually depends on, so cache
 // keys are insensitive to unrelated env changes.

--- a/src/csg/index.ts
+++ b/src/csg/index.ts
@@ -33,6 +33,7 @@ export {
   extrude,
   revolve,
   loft,
+  path,
   compound,
   instance,
   type RevolveOptions,
@@ -78,6 +79,7 @@ export type {
   ExtrudeNode,
   RevolveNode,
   LoftNode,
+  PathNode,
   InstanceNode,
   SolidNode,
   FaceNode,
@@ -86,6 +88,17 @@ export type {
   AnyNode,
 } from './types.js';
 export { outputKindOf } from './types.js';
+
+// Segments (shared by Path now, Profile later)
+export {
+  lineTo,
+  arcTo,
+  bezierTo,
+  ellipseArcTo,
+  type Segment2D,
+  type SegmentOptions,
+  type EllipseArcOptions,
+} from './segments.js';
 
 // Evaluator
 export {

--- a/src/csg/optimize.ts
+++ b/src/csg/optimize.ts
@@ -12,7 +12,8 @@ import {
   buildVec,
   type Expr,
 } from './expressions.js';
-import type { IRNode, ExtrudeNode, RevolveNode, LoftNode } from './types.js';
+import { foldSegment } from './segments.js';
+import type { IRNode, ExtrudeNode, RevolveNode, LoftNode, PathNode } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -162,11 +163,12 @@ function optimizeNode(n: IRNode): IRNode {
     case 'Extrude':
     case 'Revolve':
     case 'Loft':
+    case 'Path':
       return optimizeFeature(n);
   }
 }
 
-function optimizeFeature(n: ExtrudeNode | RevolveNode | LoftNode): IRNode {
+function optimizeFeature(n: ExtrudeNode | RevolveNode | LoftNode | PathNode): IRNode {
   switch (n.kind) {
     case 'Extrude':
       return B.extrude(optimizeNode(n.profile), foldExpr(n.vector));
@@ -177,6 +179,11 @@ function optimizeFeature(n: ExtrudeNode | RevolveNode | LoftNode): IRNode {
       });
     case 'Loft':
       return B.loft(n.sections.map(optimizeNode), { ruled: n.ruled });
+    case 'Path':
+      return B.path(
+        foldExpr(n.start),
+        n.segments.map((s) => foldSegment(s, foldExpr))
+      );
   }
 }
 

--- a/src/csg/segments.ts
+++ b/src/csg/segments.ts
@@ -1,0 +1,159 @@
+/**
+ * Serializable 2D segment vocabulary — endpoint-parametrized (SVG-style)
+ * curve segments shared by the Path node (open spines) and, later, Profile
+ * contours. Positions and radii are expressions, so `freeParams` propagates
+ * and segment data hashes with the same FNV machinery as every node field.
+ */
+
+import {
+  asScalarExpr,
+  asVec2Expr,
+  type Expr,
+  type ScalarInput,
+  type Vec2Input,
+} from './expressions.js';
+import { fnvMixString, fnvMixBool, fnvMixInt32, fnvMixHash } from './hash.js';
+
+// ---------------------------------------------------------------------------
+// Node-side segment data (expressions, canonicalized flags)
+// ---------------------------------------------------------------------------
+
+export interface LineSegment {
+  readonly kind: 'Line';
+  /** Vec2 endpoint. */
+  readonly to: Expr;
+}
+
+export interface ArcSegment {
+  readonly kind: 'Arc';
+  readonly to: Expr;
+  readonly radius: Expr;
+  readonly largeArc: boolean;
+  readonly clockwise: boolean;
+}
+
+export interface BezierSegment {
+  readonly kind: 'Bezier';
+  /** Control poles (SVG Q/C semantics), 1 or 2 entries. */
+  readonly controls: readonly Expr[];
+  readonly to: Expr;
+}
+
+export interface EllipseArcSegment {
+  readonly kind: 'EllipseArc';
+  readonly to: Expr;
+  /** Vec2 (rx, ry). */
+  readonly radii: Expr;
+  /** Rotation of the ellipse x-axis, degrees (matching Rotate). */
+  readonly rotation: Expr;
+  readonly largeArc: boolean;
+  readonly clockwise: boolean;
+}
+
+export type Segment2D = LineSegment | ArcSegment | BezierSegment | EllipseArcSegment;
+
+// ---------------------------------------------------------------------------
+// Authoring inputs (plain numbers accepted, flags optional)
+// ---------------------------------------------------------------------------
+
+export interface SegmentOptions {
+  readonly largeArc?: boolean | undefined;
+  readonly clockwise?: boolean | undefined;
+}
+
+export interface EllipseArcOptions extends SegmentOptions {
+  readonly rotation?: ScalarInput | undefined;
+}
+
+export function lineTo(to: Vec2Input): Segment2D {
+  return { kind: 'Line', to: asVec2Expr(to) };
+}
+
+export function arcTo(to: Vec2Input, radius: ScalarInput, options?: SegmentOptions): Segment2D {
+  return {
+    kind: 'Arc',
+    to: asVec2Expr(to),
+    radius: asScalarExpr(radius),
+    largeArc: options?.largeArc ?? false,
+    clockwise: options?.clockwise ?? false,
+  };
+}
+
+export function bezierTo(controls: ReadonlyArray<Vec2Input>, to: Vec2Input): Segment2D {
+  return { kind: 'Bezier', controls: controls.map(asVec2Expr), to: asVec2Expr(to) };
+}
+
+export function ellipseArcTo(
+  to: Vec2Input,
+  radii: Vec2Input,
+  options?: EllipseArcOptions
+): Segment2D {
+  return {
+    kind: 'EllipseArc',
+    to: asVec2Expr(to),
+    radii: asVec2Expr(radii),
+    rotation: asScalarExpr(options?.rotation ?? 0),
+    largeArc: options?.largeArc ?? false,
+    clockwise: options?.clockwise ?? false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hashing and dependency collection
+// ---------------------------------------------------------------------------
+
+export function hashSegments(h0: bigint, segments: readonly Segment2D[]): bigint {
+  let h = fnvMixInt32(h0, segments.length);
+  const mix = (acc: bigint, e: Expr): bigint => fnvMixHash(acc, e.structuralHash);
+  for (const s of segments) {
+    h = fnvMixString(h, s.kind);
+    h = mix(h, s.to);
+    if (s.kind === 'Arc') {
+      h = mix(h, s.radius);
+      h = fnvMixBool(fnvMixBool(h, s.largeArc), s.clockwise);
+    } else if (s.kind === 'Bezier') {
+      h = fnvMixInt32(h, s.controls.length);
+      for (const c of s.controls) h = mix(h, c);
+    } else if (s.kind === 'EllipseArc') {
+      h = mix(h, s.radii);
+      h = mix(h, s.rotation);
+      h = fnvMixBool(fnvMixBool(h, s.largeArc), s.clockwise);
+    }
+  }
+  return h;
+}
+
+export function segmentFreeParams(segments: readonly Segment2D[]): Expr[] {
+  const out: Expr[] = [];
+  for (const s of segments) {
+    out.push(s.to);
+    if (s.kind === 'Arc') out.push(s.radius);
+    else if (s.kind === 'Bezier') out.push(...s.controls);
+    else if (s.kind === 'EllipseArc') out.push(s.radii, s.rotation);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Folding (used by optimize)
+// ---------------------------------------------------------------------------
+
+export function foldSegment(s: Segment2D, foldExpr: (e: Expr) => Expr): Segment2D {
+  switch (s.kind) {
+    case 'Line':
+      return lineTo(foldExpr(s.to));
+    case 'Arc':
+      return arcTo(foldExpr(s.to), foldExpr(s.radius), {
+        largeArc: s.largeArc,
+        clockwise: s.clockwise,
+      });
+    case 'Bezier':
+      return bezierTo(s.controls.map(foldExpr), foldExpr(s.to));
+    case 'EllipseArc':
+      return ellipseArcTo(foldExpr(s.to), foldExpr(s.radii), {
+        rotation: foldExpr(s.rotation),
+        largeArc: s.largeArc,
+        clockwise: s.clockwise,
+      });
+  }
+}

--- a/src/csg/serialize.ts
+++ b/src/csg/serialize.ts
@@ -17,6 +17,7 @@ import {
   type UnaryOp,
 } from './expressions.js';
 import * as B from './builders.js';
+import { lineTo, arcTo, bezierTo, ellipseArcTo, type Segment2D } from './segments.js';
 import type { IRNode } from './types.js';
 
 export const CSG_VERSION = 1;
@@ -115,6 +116,32 @@ function optExprToJson(e: Expr | undefined): unknown {
   return e ? exprToJson(e) : undefined;
 }
 
+function segmentToJson(s: Segment2D): unknown {
+  switch (s.kind) {
+    case 'Line':
+      return { kind: 'Line', to: exprToJson(s.to) };
+    case 'Arc':
+      return {
+        kind: 'Arc',
+        to: exprToJson(s.to),
+        radius: exprToJson(s.radius),
+        largeArc: s.largeArc,
+        clockwise: s.clockwise,
+      };
+    case 'Bezier':
+      return { kind: 'Bezier', controls: s.controls.map(exprToJson), to: exprToJson(s.to) };
+    case 'EllipseArc':
+      return {
+        kind: 'EllipseArc',
+        to: exprToJson(s.to),
+        radii: exprToJson(s.radii),
+        rotation: exprToJson(s.rotation),
+        largeArc: s.largeArc,
+        clockwise: s.clockwise,
+      };
+  }
+}
+
 function transformToJson(n: IRNode): unknown {
   switch (n.kind) {
     case 'Translate':
@@ -161,6 +188,9 @@ function nodeToJson(n: IRNode): unknown {
   }
   if (n.kind === 'Loft') {
     return { kind: 'Loft', sections: n.sections.map(nodeToJson), ruled: n.ruled };
+  }
+  if (n.kind === 'Path') {
+    return { kind: 'Path', start: exprToJson(n.start), segments: n.segments.map(segmentToJson) };
   }
   if (n.kind === 'Compound') return { kind: 'Compound', children: n.children.map(nodeToJson) };
   if (n.kind === 'Instance') {
@@ -345,6 +375,8 @@ function readNode(j: unknown): Result<IRNode> {
       return readRevolve(j);
     case 'Loft':
       return readLoft(j);
+    case 'Path':
+      return readPath(j);
     default:
       return bad(`unknown node kind: ${String(kind)}`);
   }
@@ -571,6 +603,78 @@ function readLoft(j: Record<string, unknown>): Result<IRNode> {
     return bad('Loft.ruled: not a boolean');
   }
   return ok(B.loft(sections.value, { ruled }));
+}
+
+function readFlag(j: Record<string, unknown>, key: string): Result<boolean> {
+  const v = j[key];
+  if (v === undefined) return ok(false);
+  return typeof v === 'boolean' ? ok(v) : bad(`${key}: not a boolean`);
+}
+
+function readSegment(j: unknown): Result<Segment2D> {
+  if (!isObj(j)) return bad('segment: not an object');
+  const to = readExpr(j['to']);
+  if (!to.ok) return to;
+  const kind = j['kind'];
+  switch (kind) {
+    case 'Line':
+      return ok(lineTo(to.value));
+    case 'Arc': {
+      const radius = readExpr(j['radius']);
+      if (!radius.ok) return radius;
+      const largeArc = readFlag(j, 'largeArc');
+      if (!largeArc.ok) return largeArc;
+      const clockwise = readFlag(j, 'clockwise');
+      if (!clockwise.ok) return clockwise;
+      return ok(
+        arcTo(to.value, radius.value, { largeArc: largeArc.value, clockwise: clockwise.value })
+      );
+    }
+    case 'Bezier': {
+      const raw = j['controls'];
+      if (!Array.isArray(raw)) return bad('Bezier.controls: not array');
+      const controls: Expr[] = [];
+      for (const c of raw) {
+        const r = readExpr(c);
+        if (!r.ok) return r;
+        controls.push(r.value);
+      }
+      return ok(bezierTo(controls, to.value));
+    }
+    case 'EllipseArc': {
+      const radii = readExpr(j['radii']);
+      if (!radii.ok) return radii;
+      const rotation = readExpr(j['rotation']);
+      if (!rotation.ok) return rotation;
+      const largeArc = readFlag(j, 'largeArc');
+      if (!largeArc.ok) return largeArc;
+      const clockwise = readFlag(j, 'clockwise');
+      if (!clockwise.ok) return clockwise;
+      return ok(
+        ellipseArcTo(to.value, radii.value, {
+          rotation: rotation.value,
+          largeArc: largeArc.value,
+          clockwise: clockwise.value,
+        })
+      );
+    }
+    default:
+      return bad(`unknown segment kind: ${String(kind)}`);
+  }
+}
+
+function readPath(j: Record<string, unknown>): Result<IRNode> {
+  const start = readExpr(j['start']);
+  if (!start.ok) return start;
+  const raw = j['segments'];
+  if (!Array.isArray(raw)) return bad('Path.segments: not array');
+  const segments: Segment2D[] = [];
+  for (const s of raw) {
+    const r = readSegment(s);
+    if (!r.ok) return r;
+    segments.push(r.value);
+  }
+  return ok(B.path(start.value, segments));
 }
 
 function readCompound(j: Record<string, unknown>): Result<IRNode> {

--- a/src/csg/types.ts
+++ b/src/csg/types.ts
@@ -3,6 +3,7 @@
 // invalidation is scoped to subtrees that actually depend on a changed param.
 
 import type { Expr } from './expressions.js';
+import type { Segment2D } from './segments.js';
 import type { Matrix4x4 } from '@/core/types.js';
 
 // ---------------------------------------------------------------------------
@@ -176,6 +177,14 @@ export interface RevolveNode extends IRNodeBase {
   readonly at?: Expr | undefined;
 }
 
+export interface PathNode extends IRNodeBase {
+  readonly kind: 'Path';
+  /** Vec2 start point; the path lies in the XY plane (z = 0) and is lifted
+   *  into 3D by transform nodes. */
+  readonly start: Expr;
+  readonly segments: readonly Segment2D[];
+}
+
 export interface LoftNode extends IRNodeBase {
   readonly kind: 'Loft';
   /** Each section must produce OutputKind 'Face'; at least two required. */
@@ -230,6 +239,7 @@ export type IRNode =
   | ExtrudeNode
   | RevolveNode
   | LoftNode
+  | PathNode
   | CompoundNode
   | InstanceNode;
 
@@ -294,6 +304,8 @@ export function outputKindOf(node: IRNode): OutputKind {
     case 'Revolve':
     case 'Loft':
       return 'Solid';
+    case 'Path':
+      return 'Wire';
     case 'Compound':
       return 'Compound';
     case 'Instance':

--- a/tests/csg/csgPath.test.ts
+++ b/tests/csg/csgPath.test.ts
@@ -24,7 +24,8 @@ import {
   type Segment2D,
 } from '@/csg/index.js';
 import { isOk, unwrap, measureLength } from '@/index.js';
-import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import { curvePointAt, curveStartPoint, curveEndPoint } from '@/topology/curveFns.js';
+import type { AnyShape, Dimension, Edge, Wire } from '@/core/shapeTypes.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -37,6 +38,11 @@ function len(s: AnyShape<Dimension>): number {
 // The manifold preview kernel is mesh-CSG only; B-rep wires are out of its
 // scope (same divergence class as the other feature-node tests).
 const itBrep = it.skipIf(currentKernel === 'manifold');
+
+// Direction probes need faithful curvePointAt/locate on edges; brepkit's
+// adapter diverges there (parameter-space pointAt, no edge relocation), so
+// these orientation oracles run on the OCCT kernels only.
+const itOcct = it.skipIf(!currentKernel.startsWith('occt'));
 
 describe('Path node', () => {
   it('reports Wire output kind', () => {
@@ -86,6 +92,65 @@ describe('Path node', () => {
       arc += Math.hypot(a * (Math.cos(t1) - Math.cos(t0)), b * (Math.sin(t1) - Math.sin(t0)));
     }
     expect(len(unwrap(r))).toBeCloseTo(arc, 1);
+  });
+
+  itOcct('ellipse-arc direction: side selection and parametric order per flags', () => {
+    using ev = new Evaluator();
+    const cases = [
+      // [radii, clockwise, expected midpoint y sign]
+      { radii: [30, 20] as const, clockwise: false, midY: 20 },
+      { radii: [30, 20] as const, clockwise: true, midY: -20 },
+      // ry > rx exercises the major/minor axis swap
+      { radii: [20, 30] as const, clockwise: false, midY: 30 },
+      { radii: [20, 30] as const, clockwise: true, midY: -30 },
+    ];
+    for (const c of cases) {
+      const rx = c.radii[0];
+      const node = path([rx, 0], [ellipseArcTo([-rx, 0], c.radii, { clockwise: c.clockwise })]);
+      const r = ev.evaluate(node);
+      expect(isOk(r)).toBe(true);
+      const wire = unwrap(r) as Edge | Wire;
+      const mid = curvePointAt(wire, 0.5);
+      expect(mid[1]).toBeCloseTo(c.midY, 1);
+      // Parametric direction must follow path order: from -> to.
+      const start = curveStartPoint(wire);
+      const end = curveEndPoint(wire);
+      expect(start[0]).toBeCloseTo(rx, 1);
+      expect(end[0]).toBeCloseTo(-rx, 1);
+    }
+  });
+
+  itOcct('clockwise circular arc keeps path-order parametric direction', () => {
+    using ev = new Evaluator();
+    // Clockwise from 9 o'clock (-10,0) to 3 o'clock (10,0) passes 12 o'clock.
+    const node = path([-10, 0], [arcTo([10, 0], 10, { clockwise: true })]);
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    const wire = unwrap(r) as Edge | Wire;
+    expect(curvePointAt(wire, 0.5)[1]).toBeCloseTo(10, 1);
+    expect(curveStartPoint(wire)[0]).toBeCloseTo(-10, 1);
+    expect(curveEndPoint(wire)[0]).toBeCloseTo(10, 1);
+  });
+
+  itOcct('rotated ellipse-arc lands endpoints on the rotated frame', () => {
+    using ev = new Evaluator();
+    // Half-ellipse (a=30, b=20) rotated 30 deg: endpoints on the rotated
+    // major axis, on-arc midpoint at the rotated minor apex.
+    const phi = Math.PI / 6;
+    const a = 30;
+    const b = 20;
+    const p: [number, number] = [a * Math.cos(phi), a * Math.sin(phi)];
+    const q: [number, number] = [-p[0], -p[1]];
+    const node = path(p, [ellipseArcTo(q, [a, b], { rotation: 30 })]);
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    const wire = unwrap(r) as Edge | Wire;
+    const start = curveStartPoint(wire);
+    expect(start[0]).toBeCloseTo(p[0], 1);
+    expect(start[1]).toBeCloseTo(p[1], 1);
+    const mid = curvePointAt(wire, 0.5);
+    expect(mid[0]).toBeCloseTo(-b * Math.sin(phi), 1);
+    expect(mid[1]).toBeCloseTo(b * Math.cos(phi), 1);
   });
 
   itBrep('bezier segment evaluates and composes with transforms', () => {

--- a/tests/csg/csgPath.test.ts
+++ b/tests/csg/csgPath.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Path node — golden wire lengths for every segment kind, transform
+ * composition, parametric cache reuse, serialization round-trip, optimizer
+ * folding, builder immutability, and error paths.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from '../setup.js';
+import {
+  path,
+  lineTo,
+  arcTo,
+  bezierTo,
+  ellipseArcTo,
+  translate,
+  param,
+  optimize,
+  outputKindOf,
+  toJSON,
+  fromJSON,
+  Evaluator,
+  add,
+  numLit,
+  type Segment2D,
+} from '@/csg/index.js';
+import { isOk, unwrap, measureLength } from '@/index.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+function len(s: AnyShape<Dimension>): number {
+  return unwrap(measureLength(s));
+}
+
+// The manifold preview kernel is mesh-CSG only; B-rep wires are out of its
+// scope (same divergence class as the other feature-node tests).
+const itBrep = it.skipIf(currentKernel === 'manifold');
+
+describe('Path node', () => {
+  it('reports Wire output kind', () => {
+    expect(outputKindOf(path([0, 0], [lineTo([10, 0])]))).toBe('Wire');
+  });
+
+  itBrep('polyline path has exact length', () => {
+    using ev = new Evaluator();
+    const node = path([0, 0], [lineTo([40, 0]), lineTo([40, 30]), lineTo([0, 30])]);
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    expect(len(unwrap(r))).toBeCloseTo(40 + 30 + 40, 1);
+  });
+
+  itBrep('circular arc segment has exact length (half circle)', () => {
+    using ev = new Evaluator();
+    const node = path([-10, 0], [arcTo([10, 0], 10)]);
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    expect(len(unwrap(r))).toBeCloseTo(Math.PI * 10, 1);
+  });
+
+  itBrep('stadium path: lines + half-circle caps, exact perimeter', () => {
+    using ev = new Evaluator();
+    const node = path(
+      [0, 0],
+      [lineTo([40, 0]), arcTo([40, 20], 10), lineTo([0, 20]), arcTo([0, 0], 10)]
+    );
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    expect(len(unwrap(r))).toBeCloseTo(2 * 40 + 2 * Math.PI * 10, 1);
+  });
+
+  itBrep('ellipse-arc segment has the exact half-ellipse arc length', () => {
+    using ev = new Evaluator();
+    const a = 30;
+    const b = 20;
+    const node = path([a, 0], [ellipseArcTo([-a, 0], [a, b])]);
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    // Half-ellipse perimeter via numeric integration oracle.
+    const steps = 100000;
+    let arc = 0;
+    for (let i = 0; i < steps; i++) {
+      const t0 = (Math.PI * i) / steps;
+      const t1 = (Math.PI * (i + 1)) / steps;
+      arc += Math.hypot(a * (Math.cos(t1) - Math.cos(t0)), b * (Math.sin(t1) - Math.sin(t0)));
+    }
+    expect(len(unwrap(r))).toBeCloseTo(arc, 1);
+  });
+
+  itBrep('bezier segment evaluates and composes with transforms', () => {
+    using ev = new Evaluator();
+    const node = translate(path([0, 0], [bezierTo([[20, 30]], [40, 0])]), [0, 0, 50]);
+    const r = ev.evaluate(node);
+    expect(isOk(r)).toBe(true);
+    expect(len(unwrap(r))).toBeGreaterThan(40);
+  });
+
+  itBrep('parametric endpoint: cache re-evaluates only the path', () => {
+    using ev = new Evaluator();
+    const inner = path([0, 0], [lineTo([param('w'), 0])]);
+    const node = translate(inner, [5, 5, 5]);
+    expect(len(unwrap(ev.evaluate(node, { w: 10 })))).toBeCloseTo(10, 1);
+    const s1 = ev.cacheStats();
+    expect(len(unwrap(ev.evaluate(node, { w: 25 })))).toBeCloseTo(25, 1);
+    const s2 = ev.cacheStats();
+    // Both the Path and the dependent Translate re-evaluate; nothing hits.
+    expect(s2.misses - s1.misses).toBe(2);
+    expect(s2.hits - s1.hits).toBe(0);
+  });
+
+  it('serialize round-trip preserves the structural hash for every segment kind', () => {
+    const node = path(
+      [0, 0],
+      [
+        lineTo([param('w'), 0]),
+        arcTo([40, 20], add(param('r'), numLit(2)), { largeArc: true, clockwise: true }),
+        bezierTo(
+          [
+            [10, 10],
+            [20, 20],
+          ],
+          [0, 20]
+        ),
+        ellipseArcTo([0, 0], [30, 20], { rotation: 15, clockwise: true }),
+      ]
+    );
+    const back = fromJSON(toJSON(node));
+    expect(isOk(back)).toBe(true);
+    expect(unwrap(back).structuralHash).toBe(node.structuralHash);
+  });
+
+  it('optimize() folds expressions inside segments', () => {
+    const node = path([0, 0], [arcTo([40, 0], add(numLit(15), numLit(5)))]);
+    const opt = optimize(node);
+    expect(opt.kind).toBe('Path');
+    expect(opt.structuralHash).toBe(path([0, 0], [arcTo([40, 0], 20)]).structuralHash);
+  });
+
+  it('copies the segments array at construction', () => {
+    const segments: Segment2D[] = [lineTo([10, 0])];
+    const node = path([0, 0], segments);
+    segments.push(lineTo([20, 0]));
+    expect(node.segments).toHaveLength(1);
+    expect(node.structuralHash).toBe(path([0, 0], [lineTo([10, 0])]).structuralHash);
+  });
+
+  it('rejects an empty path with a Result error', () => {
+    using ev = new Evaluator();
+    expect(isOk(ev.evaluate(path([0, 0], [])))).toBe(false);
+  });
+
+  it('rejects an arc whose radius cannot span the chord', () => {
+    using ev = new Evaluator();
+    expect(isOk(ev.evaluate(path([0, 0], [arcTo([100, 0], 10)])))).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds the open-spine vocabulary to the CSG IR: `Path { start, segments }` producing a `Wire`, plus the serializable 2D segment model it is built on. Follows #2025 / #2029 / #2030.

## What

- **`csg/segments.ts` — the segment vocabulary.** Endpoint-parametrized (SVG-style) segments: `Line`, `Arc` (radius + large-arc/sweep flags), `Bezier` (control poles, Q/C semantics), `EllipseArc` (radii + rotation + flags). Every position/radius/rotation is an `Expr`, so `freeParams` propagates and segments hash with the same FNV machinery as node fields. Authoring helpers: `lineTo`, `arcTo`, `bezierTo`, `ellipseArcTo`. This vocabulary is shared with the future Profile node (closed contours), keeping one segment model across open and closed curves.
- **`path(start, segments)` builder**: static `'Wire'` output kind; the path lies in the XY plane at z = 0 and is positioned in 3D by transform nodes. Segments array copied at construction (per the #2031 contract). A path whose last point returns to `start` is incidentally closed; no flag needed.
- **Evaluator** (`evaluators/path.ts`): evaluates segment expressions, converts endpoint arcs via center recovery (circular) and SVG F.6.5 (elliptical, including the axis-swap when ry > rx since the kernel requires major >= minor), builds edges through `topology/curveBuilders`, and assembles the wire. Intermediate edges are scope-disposed. Rotation is degrees, matching `rotate`/`revolve`.
- Wired through every consumer surface, including both serialize directions with a full segment codec (flags default false, validated as booleans).

## Tests

`tests/csg/csgPath.test.ts`: exact wire lengths (polyline, half-circle arc, stadium perimeter, half-ellipse against a numeric-integration oracle), bezier + transform composition, parametric endpoint cache accounting, serialize round-trip covering all four segment kinds with params and flags, optimizer folding to the literal-equivalent hash, builder immutability, and error paths (empty path, arc radius shorter than the chord). Manifold preview kernel skips as before.

## Size

57.26 -> 59.79 kB main bundle (+2.53 kB — this PR carries a data model, not just a node) and raises the limit 59 -> 61 kB per the ratified bump-to-measured-need strategy, leaving headroom for the final Sweep node. Total gate: 362.71 / 380 kB.
