### PR TITLE
feat(csg): add profile node with contours and holes

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   { "name": "total (all JS)", "path": "dist/*.js", "limit": "380 kB" },
-  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "61 kB" },
+  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "62 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },
   { "name": "brepjs/vectors", "path": "dist/vectors.js", "limit": "1 kB" },

--- a/src/csg/builders.ts
+++ b/src/csg/builders.ts
@@ -9,7 +9,14 @@ import {
   type Vec2Input,
   type Vec3Input,
 } from './expressions.js';
-import { hashSegments, segmentFreeParams, type Segment2D } from './segments.js';
+import {
+  hashSegments,
+  segmentFreeParams,
+  hashContour,
+  contourFreeParams,
+  type Contour,
+  type Segment2D,
+} from './segments.js';
 import {
   fnvInit,
   fnvMixString,
@@ -43,6 +50,7 @@ import type {
   RevolveNode,
   LoftNode,
   SweepNode,
+  ProfileNode,
   PathNode,
   CompoundNode,
   InstanceNode,
@@ -371,6 +379,26 @@ export function extrude(profile: FaceNode, vector: Vec3Input): ExtrudeNode {
     vector: ve,
     structuralHash: h,
     freeParams: depsOf(profile, ve),
+  };
+}
+
+/** Planar face from a closed outline contour with optional first-class holes.
+ *  Contours auto-close at evaluation when the final segment does not return
+ *  to the start point. */
+export function profile(outline: Contour, holes: ReadonlyArray<Contour> = []): ProfileNode {
+  const copiedHoles = [...holes];
+  let h = hashContour(startHash('Profile'), outline);
+  h = fnvMixInt32(h, copiedHoles.length);
+  for (const hole of copiedHoles) h = hashContour(h, hole);
+  return {
+    kind: 'Profile',
+    outline,
+    holes: copiedHoles,
+    structuralHash: h,
+    freeParams: depsOf(
+      ...contourFreeParams(outline),
+      ...copiedHoles.flatMap((hole) => contourFreeParams(hole))
+    ),
   };
 }
 

--- a/src/csg/edit.ts
+++ b/src/csg/edit.ts
@@ -27,6 +27,7 @@ function rebuildChildren(n: IRNode, pred: NodePredicate, repl: IRNode): IRNode {
     case 'Vertex':
     case 'Empty':
     case 'Path':
+    case 'Profile':
       return n;
     case 'Fuse':
       return B.fuse(walk(n.a, pred, repl), walk(n.b, pred, repl), n.tolerance);
@@ -91,6 +92,7 @@ function childrenOf(n: IRNode): readonly IRNode[] {
     case 'Vertex':
     case 'Empty':
     case 'Path':
+    case 'Profile':
       return [];
     case 'Fuse':
     case 'Cut':

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -47,6 +47,7 @@ import { evalRevolve } from './evaluators/revolve.js';
 import { evalLoft } from './evaluators/loft.js';
 import { evalPath } from './evaluators/path.js';
 import { evalSweep } from './evaluators/sweep.js';
+import { evalProfile } from './evaluators/profile.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -151,6 +152,8 @@ function dispatch(node: IRNode, ctx: EvalContext): Result<AnyShape<Dimension>> {
       return evalPath(node, ctx);
     case 'Sweep':
       return evalSweep(node, ctx);
+    case 'Profile':
+      return evalProfile(node, ctx);
   }
 }
 

--- a/src/csg/evaluators/path.ts
+++ b/src/csg/evaluators/path.ts
@@ -250,7 +250,10 @@ export function buildSegmentWire(
     if (!end.ok) return end;
     cur = end.value;
   }
-  if (autoClose && Math.hypot(cur[0] - start0.value[0], cur[1] - start0.value[1]) > 1e-6) {
+  // Close on any gap above coincidence (EPS): a larger threshold would leave
+  // a dead zone where the gap is too big for the kernel's closure check but
+  // too small to trigger the closing segment.
+  if (autoClose && Math.hypot(cur[0] - start0.value[0], cur[1] - start0.value[1]) > EPS) {
     const closing = makeLine(v3(cur), v3(start0.value));
     scope.register(closing);
     edges.push(closing);

--- a/src/csg/evaluators/path.ts
+++ b/src/csg/evaluators/path.ts
@@ -10,9 +10,15 @@ import { getKernel } from '@/kernel/index.js';
 import { DisposalScope } from '@/core/disposal.js';
 import { ok, err, type Result } from '@/core/result.js';
 import { validationError, kernelError } from '@/core/errors.js';
-import { castShape, type AnyShape, type Dimension, type Edge } from '@/core/shapeTypes.js';
+import {
+  castShape,
+  type AnyShape,
+  type Dimension,
+  type Edge,
+  type Wire,
+} from '@/core/shapeTypes.js';
 import type { Vec2, Vec3 } from '@/core/types.js';
-import { evalScalar, evalVec2 } from '../expressions.js';
+import { evalScalar, evalVec2, type Expr } from '../expressions.js';
 import type { Segment2D } from '../segments.js';
 import type { PathNode } from '../types.js';
 import type { EvalContext } from './context.js';
@@ -24,7 +30,7 @@ function v3(p: Vec2): Vec3 {
 }
 
 function fail(msg: string): Result<never> {
-  return err(validationError('CSG_PATH_SEGMENT', `Path: ${msg}`));
+  return err(validationError('CSG_PATH_SEGMENT', `contour segment: ${msg}`));
 }
 
 /** SVG-style endpoint circular arc: recover the on-arc midpoint so the edge
@@ -217,16 +223,25 @@ function segmentToEdge(from: Vec2, seg: Segment2D, ctx: EvalContext): Result<Edg
   }
 }
 
-export function evalPath(node: PathNode, ctx: EvalContext): Result<AnyShape<Dimension>> {
-  if (node.segments.length === 0) return fail('at least one segment required');
-  const start = evalVec2(node.start, ctx.env, 'Path.start');
-  if (!start.ok) return start;
-  // Edges are intermediates consumed by wire assembly; the wire is the fresh
-  // handle handed to the evaluator cache.
-  using scope = new DisposalScope();
+/** Build a wire from a segment list. Edges register into `scope`; the wire is
+ *  returned unregistered (the caller decides its ownership). With `autoClose`,
+ *  an endpoint away from start gains a closing line segment (SVG Z). */
+export function buildSegmentWire(
+  start: Expr,
+  segments: readonly Segment2D[],
+  ctx: EvalContext,
+  scope: DisposalScope,
+  autoClose: boolean,
+  where: string
+): Result<Wire> {
+  if (segments.length === 0) {
+    return err(validationError('CSG_PATH_SEGMENT', `${where}: at least one segment required`));
+  }
+  const start0 = evalVec2(start, ctx.env, `${where}.start`);
+  if (!start0.ok) return start0;
   const edges: Edge[] = [];
-  let cur = start.value;
-  for (const seg of node.segments) {
+  let cur = start0.value;
+  for (const seg of segments) {
     const e = segmentToEdge(cur, seg, ctx);
     if (!e.ok) return e;
     scope.register(e.value);
@@ -235,5 +250,17 @@ export function evalPath(node: PathNode, ctx: EvalContext): Result<AnyShape<Dime
     if (!end.ok) return end;
     cur = end.value;
   }
+  if (autoClose && Math.hypot(cur[0] - start0.value[0], cur[1] - start0.value[1]) > 1e-6) {
+    const closing = makeLine(v3(cur), v3(start0.value));
+    scope.register(closing);
+    edges.push(closing);
+  }
   return assembleWire(edges);
+}
+
+export function evalPath(node: PathNode, ctx: EvalContext): Result<AnyShape<Dimension>> {
+  // Edges are intermediates consumed by wire assembly; the wire is the fresh
+  // handle handed to the evaluator cache.
+  using scope = new DisposalScope();
+  return buildSegmentWire(node.start, node.segments, ctx, scope, false, 'Path');
 }

--- a/src/csg/evaluators/profile.ts
+++ b/src/csg/evaluators/profile.ts
@@ -1,0 +1,50 @@
+import { face as makeFace } from '@/topology/primitiveFns.js';
+import { DisposalScope } from '@/core/disposal.js';
+import { ok, err, type Result } from '@/core/result.js';
+import { validationError } from '@/core/errors.js';
+import {
+  closedWire,
+  isPlanarWire,
+  type ClosedWire,
+  type PlanarWire,
+} from '@/core/validityTypes.js';
+import type { AnyShape, Dimension, Wire } from '@/core/shapeTypes.js';
+import type { Contour } from '../segments.js';
+import type { ProfileNode } from '../types.js';
+import type { EvalContext } from './context.js';
+import { buildSegmentWire } from './path.js';
+
+type Proven = ClosedWire<Dimension> & PlanarWire<Dimension>;
+
+function proveClosedPlanar(w: Wire<Dimension>, where: string): Result<Proven> {
+  const cw = closedWire(w);
+  if (!cw.ok) return err(validationError('CSG_PROFILE_CONTOUR', `${where}: ${cw.error}`));
+  if (!isPlanarWire(cw.value)) {
+    return err(validationError('CSG_PROFILE_CONTOUR', `${where}: contour is not planar`));
+  }
+  return ok(cw.value);
+}
+
+export function evalProfile(node: ProfileNode, ctx: EvalContext): Result<AnyShape<Dimension>> {
+  // Contour wires (and their edges) are intermediates; the face copies their
+  // topology, so everything in the scope is disposed on every exit path.
+  using scope = new DisposalScope();
+  const contourWire = (c: Contour, where: string): Result<Proven> => {
+    const w = buildSegmentWire(c.start, c.segments, ctx, scope, true, where);
+    if (!w.ok) return w;
+    scope.register(w.value);
+    return proveClosedPlanar(w.value, where);
+  };
+  const outline = contourWire(node.outline, 'Profile.outline');
+  if (!outline.ok) return outline;
+  const holes: Proven[] = [];
+  for (const [i, hc] of node.holes.entries()) {
+    const hw = contourWire(hc, `Profile.holes[${i}]`);
+    if (!hw.ok) return hw;
+    holes.push(hw.value);
+  }
+  return makeFace(
+    outline.value as ClosedWire & PlanarWire,
+    holes.length > 0 ? (holes as Array<ClosedWire & PlanarWire>) : undefined
+  );
+}

--- a/src/csg/index.ts
+++ b/src/csg/index.ts
@@ -34,6 +34,7 @@ export {
   revolve,
   loft,
   sweep,
+  profile,
   path,
   compound,
   instance,
@@ -82,6 +83,7 @@ export type {
   RevolveNode,
   LoftNode,
   SweepNode,
+  ProfileNode,
   PathNode,
   InstanceNode,
   SolidNode,
@@ -92,12 +94,14 @@ export type {
 } from './types.js';
 export { outputKindOf } from './types.js';
 
-// Segments (shared by Path now, Profile later)
+// Segments and contours (shared by Path and Profile)
 export {
   lineTo,
   arcTo,
   bezierTo,
   ellipseArcTo,
+  contour,
+  type Contour,
   type Segment2D,
   type SegmentOptions,
   type EllipseArcOptions,

--- a/src/csg/optimize.ts
+++ b/src/csg/optimize.ts
@@ -12,8 +12,16 @@ import {
   buildVec,
   type Expr,
 } from './expressions.js';
-import { foldSegment } from './segments.js';
-import type { IRNode, ExtrudeNode, RevolveNode, LoftNode, SweepNode, PathNode } from './types.js';
+import { foldSegment, foldContour } from './segments.js';
+import type {
+  IRNode,
+  ExtrudeNode,
+  RevolveNode,
+  LoftNode,
+  SweepNode,
+  ProfileNode,
+  PathNode,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -164,12 +172,15 @@ function optimizeNode(n: IRNode): IRNode {
     case 'Revolve':
     case 'Loft':
     case 'Sweep':
+    case 'Profile':
     case 'Path':
       return optimizeFeature(n);
   }
 }
 
-function optimizeFeature(n: ExtrudeNode | RevolveNode | LoftNode | SweepNode | PathNode): IRNode {
+type FeatureNode = ExtrudeNode | RevolveNode | LoftNode | SweepNode | ProfileNode | PathNode;
+
+function optimizeFeature(n: FeatureNode): IRNode {
   switch (n.kind) {
     case 'Extrude':
       return B.extrude(optimizeNode(n.profile), foldExpr(n.vector));
@@ -182,6 +193,11 @@ function optimizeFeature(n: ExtrudeNode | RevolveNode | LoftNode | SweepNode | P
       return B.loft(n.sections.map(optimizeNode), { ruled: n.ruled });
     case 'Sweep':
       return B.sweep(optimizeNode(n.profile), optimizeNode(n.spine), { frenet: n.frenet });
+    case 'Profile':
+      return B.profile(
+        foldContour(n.outline, foldExpr),
+        n.holes.map((hole) => foldContour(hole, foldExpr))
+      );
     case 'Path':
       return B.path(
         foldExpr(n.start),

--- a/src/csg/segments.ts
+++ b/src/csg/segments.ts
@@ -99,6 +99,21 @@ export function ellipseArcTo(
 }
 
 // ---------------------------------------------------------------------------
+// Contour — a closed outline (auto-closed at evaluation when the final
+// segment does not return to start), shared by Profile outlines and holes
+// ---------------------------------------------------------------------------
+
+export interface Contour {
+  /** Vec2 start point. */
+  readonly start: Expr;
+  readonly segments: readonly Segment2D[];
+}
+
+export function contour(start: Vec2Input, segments: ReadonlyArray<Segment2D>): Contour {
+  return { start: asVec2Expr(start), segments: [...segments] };
+}
+
+// ---------------------------------------------------------------------------
 // Hashing and dependency collection
 // ---------------------------------------------------------------------------
 
@@ -134,9 +149,24 @@ export function segmentFreeParams(segments: readonly Segment2D[]): Expr[] {
   return out;
 }
 
+export function hashContour(h0: bigint, c: Contour): bigint {
+  return hashSegments(fnvMixHash(h0, c.start.structuralHash), c.segments);
+}
+
+export function contourFreeParams(c: Contour): Expr[] {
+  return [c.start, ...segmentFreeParams(c.segments)];
+}
+
 // ---------------------------------------------------------------------------
 // Folding (used by optimize)
 // ---------------------------------------------------------------------------
+
+export function foldContour(c: Contour, foldExpr: (e: Expr) => Expr): Contour {
+  return {
+    start: foldExpr(c.start),
+    segments: c.segments.map((s) => foldSegment(s, foldExpr)),
+  };
+}
 
 export function foldSegment(s: Segment2D, foldExpr: (e: Expr) => Expr): Segment2D {
   switch (s.kind) {

--- a/src/csg/serialize.ts
+++ b/src/csg/serialize.ts
@@ -17,13 +17,21 @@ import {
   type UnaryOp,
 } from './expressions.js';
 import * as B from './builders.js';
-import { lineTo, arcTo, bezierTo, ellipseArcTo, type Segment2D } from './segments.js';
+import {
+  lineTo,
+  arcTo,
+  bezierTo,
+  ellipseArcTo,
+  contour,
+  type Contour,
+  type Segment2D,
+} from './segments.js';
 import type { IRNode } from './types.js';
 
 // Version history: 1 = the original vocabulary; 2 adds the feature nodes
-// (Extrude, Revolve, Loft, Sweep, Path). Additive only, so fromJSON accepts
-// the full range [MIN_CSG_VERSION, CSG_VERSION].
-export const CSG_VERSION = 2;
+// (Extrude, Revolve, Loft, Sweep, Path); 3 adds Profile. Additive only, so
+// fromJSON accepts the full range [MIN_CSG_VERSION, CSG_VERSION].
+export const CSG_VERSION = 3;
 const MIN_CSG_VERSION = 1;
 
 export interface CsgEnvelope {
@@ -146,6 +154,10 @@ function segmentToJson(s: Segment2D): unknown {
   }
 }
 
+function contourToJson(c: Contour): unknown {
+  return { start: exprToJson(c.start), segments: c.segments.map(segmentToJson) };
+}
+
 function transformToJson(n: IRNode): unknown {
   switch (n.kind) {
     case 'Translate':
@@ -202,6 +214,13 @@ function nodeToJson(n: IRNode): unknown {
       profile: nodeToJson(n.profile),
       spine: nodeToJson(n.spine),
       frenet: n.frenet,
+    };
+  }
+  if (n.kind === 'Profile') {
+    return {
+      kind: 'Profile',
+      outline: contourToJson(n.outline),
+      holes: n.holes.map(contourToJson),
     };
   }
   if (n.kind === 'Compound') return { kind: 'Compound', children: n.children.map(nodeToJson) };
@@ -392,6 +411,8 @@ function readNode(j: unknown): Result<IRNode> {
       return readPath(j);
     case 'Sweep':
       return readSweep(j);
+    case 'Profile':
+      return readProfile(j);
     default:
       return bad(`unknown node kind: ${String(kind)}`);
   }
@@ -676,6 +697,35 @@ function readSegment(j: unknown): Result<Segment2D> {
     default:
       return bad(`unknown segment kind: ${String(kind)}`);
   }
+}
+
+function readContour(j: unknown, where: string): Result<Contour> {
+  if (!isObj(j)) return bad(`${where}: not an object`);
+  const start = readExpr(j['start']);
+  if (!start.ok) return start;
+  const raw = j['segments'];
+  if (!Array.isArray(raw)) return bad(`${where}.segments: not array`);
+  const segments: Segment2D[] = [];
+  for (const s of raw) {
+    const r = readSegment(s);
+    if (!r.ok) return r;
+    segments.push(r.value);
+  }
+  return ok(contour(start.value, segments));
+}
+
+function readProfile(j: Record<string, unknown>): Result<IRNode> {
+  const outline = readContour(j['outline'], 'Profile.outline');
+  if (!outline.ok) return outline;
+  const rawHoles = j['holes'];
+  if (rawHoles !== undefined && !Array.isArray(rawHoles)) return bad('Profile.holes: not array');
+  const holes: Contour[] = [];
+  for (const [i, h] of (Array.isArray(rawHoles) ? rawHoles : []).entries()) {
+    const r = readContour(h, `Profile.holes[${i}]`);
+    if (!r.ok) return r;
+    holes.push(r.value);
+  }
+  return ok(B.profile(outline.value, holes));
 }
 
 function readSweep(j: Record<string, unknown>): Result<IRNode> {

--- a/src/csg/types.ts
+++ b/src/csg/types.ts
@@ -3,7 +3,7 @@
 // invalidation is scoped to subtrees that actually depend on a changed param.
 
 import type { Expr } from './expressions.js';
-import type { Segment2D } from './segments.js';
+import type { Contour, Segment2D } from './segments.js';
 import type { Matrix4x4 } from '@/core/types.js';
 
 // ---------------------------------------------------------------------------
@@ -177,6 +177,14 @@ export interface RevolveNode extends IRNodeBase {
   readonly at?: Expr | undefined;
 }
 
+export interface ProfileNode extends IRNodeBase {
+  readonly kind: 'Profile';
+  /** Closed outline in the XY plane (auto-closed at evaluation). */
+  readonly outline: Contour;
+  /** First-class holes — closed contours inside the outline. */
+  readonly holes: readonly Contour[];
+}
+
 export interface SweepNode extends IRNodeBase {
   readonly kind: 'Sweep';
   /** Must produce OutputKind 'Face'. */
@@ -250,6 +258,7 @@ export type IRNode =
   | RevolveNode
   | LoftNode
   | SweepNode
+  | ProfileNode
   | PathNode
   | CompoundNode
   | InstanceNode;
@@ -316,6 +325,8 @@ export function outputKindOf(node: IRNode): OutputKind {
     case 'Loft':
     case 'Sweep':
       return 'Solid';
+    case 'Profile':
+      return 'Face';
     case 'Path':
       return 'Wire';
     case 'Compound':

--- a/tests/csg/csgProfile.test.ts
+++ b/tests/csg/csgProfile.test.ts
@@ -72,6 +72,19 @@ describe('Profile node', () => {
     expect(area(unwrap(r))).toBeCloseTo(1200, 1);
   });
 
+  itBrep('near-closed contour (sub-tolerance gap) still closes', () => {
+    using ev = new Evaluator();
+    // Ends 5e-7 short of the start: too far apart for wire closure, small
+    // enough that a fixed auto-close threshold above EPS would skip it.
+    const c = contour(
+      [0, 0],
+      [lineTo([40, 0]), lineTo([40, 30]), lineTo([0, 30]), lineTo([0, 5e-7])]
+    );
+    const r = ev.evaluate(profile(c));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(1200, 1);
+  });
+
   itBrep('explicit closing segment produces the same face', () => {
     using ev = new Evaluator();
     const explicit = contour(

--- a/tests/csg/csgProfile.test.ts
+++ b/tests/csg/csgProfile.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Profile node — exact face areas for every segment kind, first-class holes,
+ * auto-close semantics, profile+extrude/revolve composition, parametric cache
+ * reuse, serialization round-trip (CSG_VERSION 3), optimizer folding, and
+ * builder immutability.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from '../setup.js';
+import {
+  box,
+  profile,
+  contour,
+  lineTo,
+  arcTo,
+  bezierTo,
+  ellipseArcTo,
+  extrude,
+  revolve,
+  sweep,
+  rotate,
+  path,
+  param,
+  optimize,
+  outputKindOf,
+  toJSON,
+  fromJSON,
+  Evaluator,
+  CSG_VERSION,
+  add,
+  numLit,
+  type Contour,
+} from '@/csg/index.js';
+import { isOk, unwrap, measureArea, measureVolume } from '@/index.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+function area(s: AnyShape<Dimension>): number {
+  return unwrap(measureArea(s));
+}
+
+function vol(s: AnyShape<Dimension>): number {
+  return unwrap(measureVolume(s));
+}
+
+// The manifold preview kernel is mesh-CSG only; B-rep faces are out of its
+// scope (same divergence class as the other feature-node tests).
+const itBrep = it.skipIf(currentKernel === 'manifold');
+
+// Rotated ellipse arcs need edge relocation, which brepkit lacks (surfaces as
+// a Result error by design) — occt kernels only.
+const itOcct = it.skipIf(!currentKernel.startsWith('occt'));
+
+/** w x h rectangle contour with its lower-left corner at (x0, y0). Leaves the
+ *  final closing segment to auto-close. */
+function rect(w: number, h: number, x0 = 0, y0 = 0): Contour {
+  return contour([x0, y0], [lineTo([x0 + w, y0]), lineTo([x0 + w, y0 + h]), lineTo([x0, y0 + h])]);
+}
+
+describe('Profile node', () => {
+  it('reports Face output kind', () => {
+    expect(outputKindOf(profile(rect(40, 30)))).toBe('Face');
+  });
+
+  itBrep('RECTANGULAR: line contour with exact area (auto-closed)', () => {
+    using ev = new Evaluator();
+    const r = ev.evaluate(profile(rect(40, 30)));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(1200, 1);
+  });
+
+  itBrep('explicit closing segment produces the same face', () => {
+    using ev = new Evaluator();
+    const explicit = contour(
+      [0, 0],
+      [lineTo([40, 0]), lineTo([40, 30]), lineTo([0, 30]), lineTo([0, 0])]
+    );
+    const r = ev.evaluate(profile(explicit));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(1200, 1);
+  });
+
+  itBrep('CIRCULAR: two half-arcs with area pi*r^2', () => {
+    using ev = new Evaluator();
+    const c = contour([-15, 0], [arcTo([15, 0], 15), arcTo([-15, 0], 15)]);
+    const r = ev.evaluate(profile(c));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(Math.PI * 225, 1);
+  });
+
+  itBrep('stadium: lines + arcs with exact area', () => {
+    using ev = new Evaluator();
+    const c = contour(
+      [0, 0],
+      [lineTo([40, 0]), arcTo([40, 20], 10), lineTo([0, 20]), arcTo([0, 0], 10)]
+    );
+    const r = ev.evaluate(profile(c));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(40 * 20 + Math.PI * 100, 1);
+  });
+
+  itBrep('I_BEAM: 12-segment outline with exact area', () => {
+    using ev = new Evaluator();
+    const fw = 100;
+    const ft = 10;
+    const wt = 6;
+    const h = 100;
+    const wx0 = (fw - wt) / 2;
+    const wx1 = (fw + wt) / 2;
+    const c = contour(
+      [0, 0],
+      [
+        lineTo([fw, 0]),
+        lineTo([fw, ft]),
+        lineTo([wx1, ft]),
+        lineTo([wx1, h - ft]),
+        lineTo([fw, h - ft]),
+        lineTo([fw, h]),
+        lineTo([0, h]),
+        lineTo([0, h - ft]),
+        lineTo([wx0, h - ft]),
+        lineTo([wx0, ft]),
+        lineTo([0, ft]),
+      ]
+    );
+    const r = ev.evaluate(profile(c));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(2 * fw * ft + wt * (h - 2 * ft), 1);
+  });
+
+  itOcct('rotated ELLIPSE: two rotated ellipse-arc halves with area pi*a*b', () => {
+    using ev = new Evaluator();
+    const a = 30;
+    const b = 20;
+    const phi = 30;
+    const rad = (phi * Math.PI) / 180;
+    const p: [number, number] = [a * Math.cos(rad), a * Math.sin(rad)];
+    const q: [number, number] = [-p[0], -p[1]];
+    const c = contour(p, [
+      ellipseArcTo(q, [a, b], { rotation: phi }),
+      ellipseArcTo(p, [a, b], { rotation: phi }),
+    ]);
+    const r = ev.evaluate(profile(c));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(Math.PI * a * b, 1);
+  });
+
+  itBrep('Bezier: quadratic bulge with exact pole-area (w*P/3)', () => {
+    using ev = new Evaluator();
+    const c = contour([0, 0], [lineTo([40, 0]), lineTo([40, 10]), bezierTo([[20, 25]], [0, 10])]);
+    const r = ev.evaluate(profile(c));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(400 + (40 * 15) / 3, 1);
+  });
+
+  itBrep('RECTANGLE_HOLLOW: first-class holes subtract exactly', () => {
+    using ev = new Evaluator();
+    const r = ev.evaluate(profile(rect(60, 40), [rect(40, 20, 10, 10)]));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(60 * 40 - 40 * 20, 1);
+  });
+
+  itBrep('wall: profile + extrude composes with exact volume', () => {
+    using ev = new Evaluator();
+    const wall = extrude(profile(rect(4000, 200)), [0, 0, 2700]);
+    const r = ev.evaluate(wall);
+    expect(isOk(r)).toBe(true);
+    expect(vol(unwrap(r))).toBeCloseTo(4000 * 200 * 2700, 0);
+  });
+
+  itBrep('washer: profile + revolve composes with exact volume', () => {
+    using ev = new Evaluator();
+    // Rectangle x in [10, 20] revolved around Z: pi*(R^2 - r^2)*h.
+    // Profile is in XY; rotate it into XZ via the revolve default frame by
+    // building the contour in XY and sweeping around the Y axis instead:
+    // revolve about the Y axis at origin with the profile in the XY plane.
+    const washer = revolve(profile(rect(10, 30, 10, 0)), 360, { axis: [0, 1, 0] });
+    const r = ev.evaluate(washer);
+    expect(isOk(r)).toBe(true);
+    expect(vol(unwrap(r))).toBeCloseTo(Math.PI * (400 - 100) * 30, 0);
+  });
+
+  itBrep('pipe: profile + sweep along a path composes (profile rotated out of plane)', () => {
+    using ev = new Evaluator();
+    // Profiles and Path spines both live in the XY plane, so a sweep needs
+    // the profile rotated perpendicular to the spine tangent first.
+    const sq = profile(contour([-5, -5], [lineTo([5, -5]), lineTo([5, 5]), lineTo([-5, 5])]));
+    const positioned = rotate(sq, -90, { axis: [1, 0, 0] });
+    const r = ev.evaluate(sweep(positioned, path([0, 0], [lineTo([0, 60])])));
+    expect(isOk(r)).toBe(true);
+    expect(vol(unwrap(r))).toBeCloseTo(10 * 10 * 60, 0);
+  });
+
+  itBrep('parametric width: only the profile and its consumers re-evaluate', () => {
+    using ev = new Evaluator();
+    const node = extrude(
+      profile(
+        contour([0, 0], [lineTo([param('w'), 0]), lineTo([param('w'), 30]), lineTo([0, 30])])
+      ),
+      [0, 0, 10]
+    );
+    expect(vol(unwrap(ev.evaluate(node, { w: 40 })))).toBeCloseTo(12000, 0);
+    const s1 = ev.cacheStats();
+    expect(vol(unwrap(ev.evaluate(node, { w: 80 })))).toBeCloseTo(24000, 0);
+    const s2 = ev.cacheStats();
+    // Profile and Extrude both depend on w: two misses, no hits.
+    expect(s2.misses - s1.misses).toBe(2);
+    expect(s2.hits - s1.hits).toBe(0);
+  });
+
+  it('serialize round-trip preserves the structural hash (holes + params)', () => {
+    const node = profile(
+      contour(
+        [0, 0],
+        [
+          lineTo([param('w'), 0]),
+          arcTo([40, 20], add(param('r'), numLit(2)), { largeArc: true }),
+          ellipseArcTo([0, 0], [30, 20], { rotation: 15, clockwise: true }),
+        ]
+      ),
+      [rect(10, 5, 5, 5)]
+    );
+    const back = fromJSON(toJSON(node));
+    expect(isOk(back)).toBe(true);
+    expect(unwrap(back).structuralHash).toBe(node.structuralHash);
+  });
+
+  it('envelope version is 3; versions 1..3 load, 4 rejects', () => {
+    expect(CSG_VERSION).toBe(3);
+    const envelope = JSON.parse(JSON.stringify(toJSON(box(1, 2, 3)))) as {
+      csgVersion: number;
+    };
+    for (const v of [1, 2, 3]) {
+      envelope.csgVersion = v;
+      expect(isOk(fromJSON(envelope))).toBe(true);
+    }
+    envelope.csgVersion = 4;
+    expect(isOk(fromJSON(envelope))).toBe(false);
+  });
+
+  it('optimize() folds expressions inside the contour', () => {
+    const node = profile(contour([0, 0], [arcTo([40, 0], add(numLit(15), numLit(5)))]));
+    const opt = optimize(node);
+    expect(opt.kind).toBe('Profile');
+    expect(opt.structuralHash).toBe(profile(contour([0, 0], [arcTo([40, 0], 20)])).structuralHash);
+  });
+
+  it('copies the holes array at construction', () => {
+    const holes = [rect(5, 5, 1, 1)];
+    const node = profile(rect(40, 30), holes);
+    holes.push(rect(5, 5, 20, 20));
+    expect(node.holes).toHaveLength(1);
+    expect(node.structuralHash).toBe(profile(rect(40, 30), [rect(5, 5, 1, 1)]).structuralHash);
+  });
+
+  it('rejects an empty contour with a Result error', () => {
+    using ev = new Evaluator();
+    expect(isOk(ev.evaluate(profile(contour([0, 0], []))))).toBe(false);
+  });
+});

--- a/tests/csg/csgSweep.test.ts
+++ b/tests/csg/csgSweep.test.ts
@@ -128,8 +128,7 @@ describe('Sweep node', () => {
     expect(unwrap(back).structuralHash).toBe(node.structuralHash);
   });
 
-  it('fromJSON accepts the previous envelope version and rejects future ones', () => {
-    expect(CSG_VERSION).toBe(2);
+  it('fromJSON accepts older envelope versions and rejects future ones', () => {
     const envelope = JSON.parse(JSON.stringify(toJSON(box(1, 2, 3)))) as {
       csgVersion: number;
     };


### PR DESCRIPTION
Opens the profile vocabulary: `Profile { outline, holes }` evaluates a closed XY contour (plus optional first-class hole contours) to a planar face — the profile side of profile+extrude modeling. Builds directly on the `Segment2D` vocabulary from #2032.

## What

- **`Contour { start, segments }`** in `csg/segments.ts` with a `contour()` constructor (copies its segments array). Contours **auto-close** at evaluation when the final segment does not return to the start point (SVG `Z` semantics) — an explicit closing segment produces the identical face.
- **`profile(outline, holes?)` builder**: static `'Face'` output kind; holes are first-class contours (the standard AEC hollow-section case), not a 2D boolean. Holes array copied at construction.
- **Evaluator** (`evaluators/profile.ts`): contour wires build through the shared segment machinery — `evalPath`'s core is extracted as `buildSegmentWire(start, segments, ctx, scope, autoClose, where)` and reused by both nodes — then proven closed and planar (`closedWire` + `isPlanarWire`) before `face(outline, holes)`.
- **`CSG_VERSION` 2 -> 3** (additive; `fromJSON` range extends to 1..3). The sweep suite's exact-version pin becomes range-based so future bumps stop touching old suites.
- Wired through all consumer surfaces; `optimize` folds expressions inside contours to the literal-equivalent hash.

## Tests

`tests/csg/csgProfile.test.ts` (72 across the kernel projects): exact areas for every segment kind — rectangle, circle-from-arcs, stadium, 12-segment I-beam, rotated ellipse (occt-only: rotated ellipse arcs need edge relocation, which brepkit lacks and surfaces as a `Result` error by design), quadratic bezier pole-area, hollow rectangle. Composition goldens: **wall = profile+extrude** (exact volume), washer = profile+revolve about Y, pipe = rotated profile + Path sweep (profiles and Path spines both live in XY, so sweeps rotate the profile out of plane first — asserted as the modeling contract). Parametric cache accounting, serialize round-trip with holes and params, version-range acceptance, optimizer folding, builder immutability, empty-contour rejection.

## Size

60.62 -> 61.53 kB main bundle (+0.91 kB) and raises the limit 61 -> 62 kB per the ratified bump-to-measured-need strategy. Total: 364.6 / 380 kB.
