### PR TITLE
feat(csg): add canned bim profile builders

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   { "name": "total (all JS)", "path": "dist/*.js", "limit": "380 kB" },
-  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "62 kB" },
+  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "63 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },
   { "name": "brepjs/vectors", "path": "dist/vectors.js", "limit": "1 kB" },

--- a/src/csg/index.ts
+++ b/src/csg/index.ts
@@ -107,6 +107,35 @@ export {
   type EllipseArcOptions,
 } from './segments.js';
 
+// Canned profiles (bim parametric profile set)
+export {
+  rectangularProfile,
+  circularProfile,
+  iBeamProfile,
+  asymmetricIProfile,
+  lShapeProfile,
+  tShapeProfile,
+  uShapeProfile,
+  zShapeProfile,
+  cShapeProfile,
+  ellipseProfile,
+  trapeziumProfile,
+  rectangleHollowProfile,
+  circleHollowProfile,
+  arbitraryClosedProfile,
+  arbitraryProfileWithVoids,
+  type IBeamParams,
+  type AsymmetricIParams,
+  type LShapeParams,
+  type TShapeParams,
+  type UShapeParams,
+  type ZShapeParams,
+  type CShapeParams,
+  type TrapeziumParams,
+  type RectangleHollowParams,
+  type CircleHollowParams,
+} from './profiles.js';
+
 // Evaluator
 export {
   Evaluator,

--- a/src/csg/profiles.ts
+++ b/src/csg/profiles.ts
@@ -1,0 +1,344 @@
+/**
+ * Canned profile builders matching the brepjs-bim parametric profile set
+ * (IfcProfileDef vocabulary). Parameter names mirror the bim specs 1:1 so a
+ * downstream adapter can desugar spec -> node without translation. Every
+ * profile is bounding-box centered at the origin in the XY plane; fillet
+ * radii from the specs are not yet modeled (sharp sections).
+ */
+
+import { profile } from './builders.js';
+import { contour, lineTo, arcTo, ellipseArcTo, type Contour } from './segments.js';
+import type { ProfileNode } from './types.js';
+
+type Pt2 = readonly [number, number];
+
+/** Closed polyline contour from points, shifted so the bounding box centers
+ *  on the origin. */
+function centeredPoly(points: ReadonlyArray<Pt2>): Contour {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const [x, y] of points) {
+    minX = Math.min(minX, x);
+    maxX = Math.max(maxX, x);
+    minY = Math.min(minY, y);
+    maxY = Math.max(maxY, y);
+  }
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const shifted = points.map(([x, y]) => [x - cx, y - cy] as const);
+  const first = shifted[0] ?? [0, 0];
+  return contour(
+    first,
+    shifted.slice(1).map((p) => lineTo(p))
+  );
+}
+
+function circleContour(radius: number, cx = 0, cy = 0): Contour {
+  return contour(
+    [cx - radius, cy],
+    [arcTo([cx + radius, cy], radius), arcTo([cx - radius, cy], radius)]
+  );
+}
+
+export function rectangularProfile(width: number, height: number): ProfileNode {
+  const hw = width / 2;
+  const hh = height / 2;
+  return profile(
+    centeredPoly([
+      [-hw, -hh],
+      [hw, -hh],
+      [hw, hh],
+      [-hw, hh],
+    ])
+  );
+}
+
+export function circularProfile(radius: number): ProfileNode {
+  return profile(circleContour(radius));
+}
+
+export interface IBeamParams {
+  readonly overallWidth: number;
+  readonly overallDepth: number;
+  readonly flangeThickness: number;
+  readonly webThickness: number;
+}
+
+export function iBeamProfile(p: IBeamParams): ProfileNode {
+  const w = p.overallWidth;
+  const d = p.overallDepth;
+  const tf = p.flangeThickness;
+  const tw = p.webThickness;
+  const wx0 = (w - tw) / 2;
+  const wx1 = (w + tw) / 2;
+  return profile(
+    centeredPoly([
+      [0, 0],
+      [w, 0],
+      [w, tf],
+      [wx1, tf],
+      [wx1, d - tf],
+      [w, d - tf],
+      [w, d],
+      [0, d],
+      [0, d - tf],
+      [wx0, d - tf],
+      [wx0, tf],
+      [0, tf],
+    ])
+  );
+}
+
+export interface AsymmetricIParams {
+  readonly overallDepth: number;
+  readonly webThickness: number;
+  readonly topFlangeWidth: number;
+  readonly topFlangeThickness: number;
+  readonly bottomFlangeWidth: number;
+  readonly bottomFlangeThickness: number;
+}
+
+export function asymmetricIProfile(p: AsymmetricIParams): ProfileNode {
+  const d = p.overallDepth;
+  const tw = p.webThickness;
+  const bw = p.bottomFlangeWidth;
+  const bt = p.bottomFlangeThickness;
+  const uw = p.topFlangeWidth;
+  const ut = p.topFlangeThickness;
+  const half = Math.max(bw, uw) / 2;
+  return profile(
+    centeredPoly([
+      [half - bw / 2, 0],
+      [half + bw / 2, 0],
+      [half + bw / 2, bt],
+      [half + tw / 2, bt],
+      [half + tw / 2, d - ut],
+      [half + uw / 2, d - ut],
+      [half + uw / 2, d],
+      [half - uw / 2, d],
+      [half - uw / 2, d - ut],
+      [half - tw / 2, d - ut],
+      [half - tw / 2, bt],
+      [half - bw / 2, bt],
+    ])
+  );
+}
+
+export interface LShapeParams {
+  readonly depth: number;
+  readonly width: number;
+  readonly legThickness: number;
+}
+
+export function lShapeProfile(p: LShapeParams): ProfileNode {
+  const t = p.legThickness;
+  return profile(
+    centeredPoly([
+      [0, 0],
+      [p.width, 0],
+      [p.width, t],
+      [t, t],
+      [t, p.depth],
+      [0, p.depth],
+    ])
+  );
+}
+
+export interface TShapeParams {
+  readonly depth: number;
+  readonly flangeWidth: number;
+  readonly webThickness: number;
+  readonly flangeThickness: number;
+}
+
+export function tShapeProfile(p: TShapeParams): ProfileNode {
+  const b = p.flangeWidth;
+  const d = p.depth;
+  const tf = p.flangeThickness;
+  const tw = p.webThickness;
+  return profile(
+    centeredPoly([
+      [(b - tw) / 2, 0],
+      [(b + tw) / 2, 0],
+      [(b + tw) / 2, d - tf],
+      [b, d - tf],
+      [b, d],
+      [0, d],
+      [0, d - tf],
+      [(b - tw) / 2, d - tf],
+    ])
+  );
+}
+
+export interface UShapeParams {
+  readonly depth: number;
+  readonly flangeWidth: number;
+  readonly webThickness: number;
+  readonly flangeThickness: number;
+}
+
+export function uShapeProfile(p: UShapeParams): ProfileNode {
+  const b = p.flangeWidth;
+  const d = p.depth;
+  const tf = p.flangeThickness;
+  const tw = p.webThickness;
+  return profile(
+    centeredPoly([
+      [0, 0],
+      [b, 0],
+      [b, tf],
+      [tw, tf],
+      [tw, d - tf],
+      [b, d - tf],
+      [b, d],
+      [0, d],
+    ])
+  );
+}
+
+export interface ZShapeParams {
+  readonly depth: number;
+  readonly flangeWidth: number;
+  readonly webThickness: number;
+  readonly flangeThickness: number;
+}
+
+export function zShapeProfile(p: ZShapeParams): ProfileNode {
+  const b = p.flangeWidth;
+  const d = p.depth;
+  const tf = p.flangeThickness;
+  const tw = p.webThickness;
+  return profile(
+    centeredPoly([
+      [tw / 2 - b, -d / 2],
+      [tw / 2, -d / 2],
+      [tw / 2, d / 2 - tf],
+      [b - tw / 2, d / 2 - tf],
+      [b - tw / 2, d / 2],
+      [-tw / 2, d / 2],
+      [-tw / 2, -d / 2 + tf],
+      [tw / 2 - b, -d / 2 + tf],
+    ])
+  );
+}
+
+export interface CShapeParams {
+  readonly depth: number;
+  readonly width: number;
+  readonly wallThickness: number;
+  readonly girth: number;
+}
+
+export function cShapeProfile(p: CShapeParams): ProfileNode {
+  const b = p.width;
+  const d = p.depth;
+  const t = p.wallThickness;
+  const g = p.girth;
+  return profile(
+    centeredPoly([
+      [0, 0],
+      [b, 0],
+      [b, g],
+      [b - t, g],
+      [b - t, t],
+      [t, t],
+      [t, d - t],
+      [b - t, d - t],
+      [b - t, d - g],
+      [b, d - g],
+      [b, d],
+      [0, d],
+    ])
+  );
+}
+
+export function ellipseProfile(semiAxis1: number, semiAxis2: number): ProfileNode {
+  const a = semiAxis1;
+  return profile(
+    contour([-a, 0], [ellipseArcTo([a, 0], [a, semiAxis2]), ellipseArcTo([-a, 0], [a, semiAxis2])])
+  );
+}
+
+export interface TrapeziumParams {
+  readonly bottomXDim: number;
+  readonly topXDim: number;
+  readonly yDim: number;
+  readonly topXOffset: number;
+}
+
+export function trapeziumProfile(p: TrapeziumParams): ProfileNode {
+  return profile(
+    centeredPoly([
+      [0, 0],
+      [p.bottomXDim, 0],
+      [p.topXOffset + p.topXDim, p.yDim],
+      [p.topXOffset, p.yDim],
+    ])
+  );
+}
+
+export interface RectangleHollowParams {
+  readonly xDim: number;
+  readonly yDim: number;
+  readonly wallThickness: number;
+}
+
+export function rectangleHollowProfile(p: RectangleHollowParams): ProfileNode {
+  const hx = p.xDim / 2;
+  const hy = p.yDim / 2;
+  const t = p.wallThickness;
+  const outer = centeredPoly([
+    [-hx, -hy],
+    [hx, -hy],
+    [hx, hy],
+    [-hx, hy],
+  ]);
+  const inner = centeredPoly([
+    [-(hx - t), -(hy - t)],
+    [hx - t, -(hy - t)],
+    [hx - t, hy - t],
+    [-(hx - t), hy - t],
+  ]);
+  return profile(outer, [inner]);
+}
+
+export interface CircleHollowParams {
+  readonly radius: number;
+  readonly wallThickness: number;
+}
+
+export function circleHollowProfile(p: CircleHollowParams): ProfileNode {
+  return profile(circleContour(p.radius), [circleContour(p.radius - p.wallThickness)]);
+}
+
+export function arbitraryClosedProfile(points: ReadonlyArray<Pt2>): ProfileNode {
+  const first = points[0] ?? [0, 0];
+  return profile(
+    contour(
+      first,
+      points.slice(1).map((pt) => lineTo(pt))
+    )
+  );
+}
+
+export function arbitraryProfileWithVoids(
+  outerPoints: ReadonlyArray<Pt2>,
+  voids: ReadonlyArray<ReadonlyArray<Pt2>>
+): ProfileNode {
+  const first = outerPoints[0] ?? [0, 0];
+  return profile(
+    contour(
+      first,
+      outerPoints.slice(1).map((pt) => lineTo(pt))
+    ),
+    voids.map((v) => {
+      const f = v[0] ?? [0, 0];
+      return contour(
+        f,
+        v.slice(1).map((pt) => lineTo(pt))
+      );
+    })
+  );
+}

--- a/src/csg/profiles.ts
+++ b/src/csg/profiles.ts
@@ -206,20 +206,23 @@ export interface ZShapeParams {
 }
 
 export function zShapeProfile(p: ZShapeParams): ProfileNode {
-  const b = p.flangeWidth;
-  const d = p.depth;
-  const tf = p.flangeThickness;
-  const tw = p.webThickness;
+  // Matches the brepjs-bim Z_SHAPE contract: flangeWidth reaches from the web
+  // CENTER to the flange tip (each flange extends (flangeWidth - web)/2 past
+  // the web), bottom flange to -X, top flange to +X.
+  const halfFw = p.flangeWidth / 2;
+  const halfD = p.depth / 2;
+  const halfWeb = p.webThickness / 2;
+  const ft = p.flangeThickness;
   return profile(
     centeredPoly([
-      [tw / 2 - b, -d / 2],
-      [tw / 2, -d / 2],
-      [tw / 2, d / 2 - tf],
-      [b - tw / 2, d / 2 - tf],
-      [b - tw / 2, d / 2],
-      [-tw / 2, d / 2],
-      [-tw / 2, -d / 2 + tf],
-      [tw / 2 - b, -d / 2 + tf],
+      [-halfFw, -halfD],
+      [halfWeb, -halfD],
+      [halfWeb, halfD - ft],
+      [halfFw, halfD - ft],
+      [halfFw, halfD],
+      [-halfWeb, halfD],
+      [-halfWeb, -halfD + ft],
+      [-halfFw, -halfD + ft],
     ])
   );
 }
@@ -269,13 +272,18 @@ export interface TrapeziumParams {
 }
 
 export function trapeziumProfile(p: TrapeziumParams): ProfileNode {
+  // Matches the brepjs-bim TRAPEZIUM contract: bottom edge centered on the
+  // origin, top edge centered at topXOffset (an offset of centers, not of
+  // left corners) — deliberately NOT bbox-recentered.
+  const halfB = p.bottomXDim / 2;
+  const halfY = p.yDim / 2;
+  const topLeft = -p.topXDim / 2 + p.topXOffset;
+  const topRight = p.topXDim / 2 + p.topXOffset;
   return profile(
-    centeredPoly([
-      [0, 0],
-      [p.bottomXDim, 0],
-      [p.topXOffset + p.topXDim, p.yDim],
-      [p.topXOffset, p.yDim],
-    ])
+    contour(
+      [-halfB, -halfY],
+      [lineTo([halfB, -halfY]), lineTo([topRight, halfY]), lineTo([topLeft, halfY])]
+    )
   );
 }
 

--- a/tests/csg/csgProfilesCanned.test.ts
+++ b/tests/csg/csgProfilesCanned.test.ts
@@ -28,7 +28,8 @@ import {
   type IRNode,
 } from '@/csg/index.js';
 import { isOk, unwrap, measureArea, measureVolume } from '@/index.js';
-import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+import { faceCenter } from '@/topology/faceFns.js';
+import type { AnyShape, Dimension, Face } from '@/core/shapeTypes.js';
 
 beforeAll(async () => {
   await initKernel();
@@ -87,8 +88,10 @@ const GOLDENS: readonly Golden[] = [
   },
   {
     name: 'Z_SHAPE',
+    // bim contract: flangeWidth reaches from web center to tip, so total
+    // flange area is (flangeWidth - web) * flangeThickness.
     node: () => zShapeProfile({ depth: 100, flangeWidth: 50, webThickness: 6, flangeThickness: 8 }),
-    area: 6 * 100 + 2 * (50 - 6) * 8,
+    area: 6 * 100 + (50 - 6) * 8,
   },
   {
     name: 'C_SHAPE',
@@ -153,6 +156,35 @@ describe('canned bim profiles', () => {
       expect(area(unwrap(r))).toBeCloseTo(g.area, 1);
     });
   }
+
+  itBrep('TRAPEZIUM: topXOffset shifts the top-edge CENTER (bim contract)', () => {
+    using ev = new Evaluator();
+    const p = { bottomXDim: 60, topXDim: 40, yDim: 30, topXOffset: 20 };
+    const r = ev.evaluate(trapeziumProfile(p));
+    expect(isOk(r)).toBe(true);
+    // Independent oracle: polygon centroid of the bim-contract vertices.
+    const pts: ReadonlyArray<readonly [number, number]> = [
+      [-30, -15],
+      [30, -15],
+      [40, 15],
+      [0, 15],
+    ];
+    let a2 = 0;
+    let cx = 0;
+    let cy = 0;
+    for (let i = 0; i < pts.length; i++) {
+      const [x0, y0] = pts[i] as [number, number];
+      const [x1, y1] = pts[(i + 1) % pts.length] as [number, number];
+      const cross = x0 * y1 - x1 * y0;
+      a2 += cross;
+      cx += (x0 + x1) * cross;
+      cy += (y0 + y1) * cross;
+    }
+    const centroid = [cx / (3 * a2), cy / (3 * a2)];
+    const center = faceCenter(unwrap(r) as Face);
+    expect(center[0]).toBeCloseTo(centroid[0] ?? 0, 1);
+    expect(center[1]).toBeCloseTo(centroid[1] ?? 0, 1);
+  });
 
   itOcct('tall ELLIPSE (semiAxis2 > semiAxis1) via edge relocation', () => {
     using ev = new Evaluator();

--- a/tests/csg/csgProfilesCanned.test.ts
+++ b/tests/csg/csgProfilesCanned.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Canned bim-profile builders — independent closed-form area oracle per
+ * profile kind, hash determinism, serialization, and extrude composition.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from '../setup.js';
+import {
+  rectangularProfile,
+  circularProfile,
+  iBeamProfile,
+  asymmetricIProfile,
+  lShapeProfile,
+  tShapeProfile,
+  uShapeProfile,
+  zShapeProfile,
+  cShapeProfile,
+  ellipseProfile,
+  trapeziumProfile,
+  rectangleHollowProfile,
+  circleHollowProfile,
+  arbitraryClosedProfile,
+  arbitraryProfileWithVoids,
+  extrude,
+  toJSON,
+  fromJSON,
+  Evaluator,
+  type IRNode,
+} from '@/csg/index.js';
+import { isOk, unwrap, measureArea, measureVolume } from '@/index.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+function area(s: AnyShape<Dimension>): number {
+  return unwrap(measureArea(s));
+}
+
+const itBrep = it.skipIf(currentKernel === 'manifold');
+// Tall ellipses (semiAxis2 > semiAxis1) need edge relocation (occt-only).
+const itOcct = it.skipIf(!currentKernel.startsWith('occt'));
+
+interface Golden {
+  readonly name: string;
+  readonly node: () => IRNode;
+  readonly area: number;
+}
+
+const GOLDENS: readonly Golden[] = [
+  { name: 'RECTANGULAR', node: () => rectangularProfile(40, 30), area: 1200 },
+  { name: 'CIRCULAR', node: () => circularProfile(15), area: Math.PI * 225 },
+  {
+    name: 'I_BEAM',
+    node: () =>
+      iBeamProfile({ overallWidth: 100, overallDepth: 100, flangeThickness: 10, webThickness: 6 }),
+    area: 2 * 100 * 10 + 6 * (100 - 20),
+  },
+  {
+    name: 'ASYMMETRIC_I',
+    node: () =>
+      asymmetricIProfile({
+        overallDepth: 100,
+        webThickness: 6,
+        topFlangeWidth: 80,
+        topFlangeThickness: 8,
+        bottomFlangeWidth: 120,
+        bottomFlangeThickness: 12,
+      }),
+    area: 120 * 12 + 80 * 8 + 6 * (100 - 12 - 8),
+  },
+  {
+    name: 'L_SHAPE',
+    node: () => lShapeProfile({ depth: 80, width: 60, legThickness: 8 }),
+    area: 8 * (60 + 80 - 8),
+  },
+  {
+    name: 'T_SHAPE',
+    node: () => tShapeProfile({ depth: 90, flangeWidth: 70, webThickness: 8, flangeThickness: 10 }),
+    area: 70 * 10 + 8 * (90 - 10),
+  },
+  {
+    name: 'U_SHAPE',
+    node: () => uShapeProfile({ depth: 100, flangeWidth: 50, webThickness: 6, flangeThickness: 8 }),
+    area: 6 * (100 - 16) + 2 * 50 * 8,
+  },
+  {
+    name: 'Z_SHAPE',
+    node: () => zShapeProfile({ depth: 100, flangeWidth: 50, webThickness: 6, flangeThickness: 8 }),
+    area: 6 * 100 + 2 * (50 - 6) * 8,
+  },
+  {
+    name: 'C_SHAPE',
+    node: () => cShapeProfile({ depth: 100, width: 50, wallThickness: 5, girth: 20 }),
+    area: 2 * 50 * 5 + 5 * (100 - 10) + 2 * 5 * (20 - 5),
+  },
+  { name: 'ELLIPSE', node: () => ellipseProfile(30, 20), area: Math.PI * 600 },
+  {
+    name: 'TRAPEZIUM',
+    node: () => trapeziumProfile({ bottomXDim: 60, topXDim: 40, yDim: 30, topXOffset: 10 }),
+    area: ((60 + 40) / 2) * 30,
+  },
+  {
+    name: 'RECTANGLE_HOLLOW',
+    node: () => rectangleHollowProfile({ xDim: 60, yDim: 40, wallThickness: 5 }),
+    area: 60 * 40 - 50 * 30,
+  },
+  {
+    name: 'CIRCLE_HOLLOW',
+    node: () => circleHollowProfile({ radius: 20, wallThickness: 5 }),
+    area: Math.PI * (400 - 225),
+  },
+  {
+    name: 'ARBITRARY_CLOSED',
+    node: () =>
+      arbitraryClosedProfile([
+        [0, 0],
+        [40, 0],
+        [0, 30],
+      ]),
+    area: 600,
+  },
+  {
+    name: 'ARBITRARY_WITH_VOIDS',
+    node: () =>
+      arbitraryProfileWithVoids(
+        [
+          [0, 0],
+          [60, 0],
+          [60, 60],
+          [0, 60],
+        ],
+        [
+          [
+            [20, 20],
+            [40, 20],
+            [40, 40],
+            [20, 40],
+          ],
+        ]
+      ),
+    area: 3600 - 400,
+  },
+];
+
+describe('canned bim profiles', () => {
+  for (const g of GOLDENS) {
+    itBrep(`${g.name}: exact area`, () => {
+      using ev = new Evaluator();
+      const r = ev.evaluate(g.node());
+      expect(isOk(r)).toBe(true);
+      expect(area(unwrap(r))).toBeCloseTo(g.area, 1);
+    });
+  }
+
+  itOcct('tall ELLIPSE (semiAxis2 > semiAxis1) via edge relocation', () => {
+    using ev = new Evaluator();
+    const r = ev.evaluate(ellipseProfile(20, 30));
+    expect(isOk(r)).toBe(true);
+    expect(area(unwrap(r))).toBeCloseTo(Math.PI * 600, 1);
+  });
+
+  it('builders are deterministic: identical params share one content address', () => {
+    for (const g of GOLDENS) {
+      expect(g.node().structuralHash).toBe(g.node().structuralHash);
+    }
+  });
+
+  it('serialize round-trip preserves the structural hash for every kind', () => {
+    for (const g of GOLDENS) {
+      const node = g.node();
+      const back = fromJSON(toJSON(node));
+      expect(isOk(back)).toBe(true);
+      expect(unwrap(back).structuralHash).toBe(node.structuralHash);
+    }
+  });
+
+  itBrep('composes: extruded I-beam has exact volume', () => {
+    using ev = new Evaluator();
+    const beam = extrude(
+      iBeamProfile({ overallWidth: 100, overallDepth: 100, flangeThickness: 10, webThickness: 6 }),
+      [0, 0, 500]
+    );
+    const r = ev.evaluate(beam);
+    expect(isOk(r)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(r)))).toBeCloseTo(2480 * 500, 0);
+  });
+});


### PR DESCRIPTION
Adds fifteen canned profile builders covering the brepjs-bim parametric profile set (the IfcProfileDef vocabulary): RECTANGULAR, CIRCULAR, I_BEAM, ASYMMETRIC_I, L/T/U/Z/C_SHAPE, ELLIPSE, TRAPEZIUM, RECTANGLE_HOLLOW, CIRCLE_HOLLOW, ARBITRARY_CLOSED, ARBITRARY_WITH_VOIDS. Follows #2040 (Profile node).

## What

- `csg/profiles.ts`: each builder returns a `ProfileNode` built from the shared contour vocabulary. **Parameter names mirror the bim specs 1:1** (`overallWidth`, `flangeThickness`, `topXOffset`, ...) so a downstream spec -> node adapter needs no translation layer.
- All profiles are bounding-box centered at the origin in the XY plane. Fillet radii from the specs are not yet modeled (sharp sections) — hollow sections use sharp corners for now.
- Pure data constructors: no kernel calls, no new node kinds, no serialization changes (canned profiles serialize as ordinary Profile nodes).

## Tests

`tests/csg/csgProfilesCanned.test.ts`: an independent closed-form area oracle per profile kind (e.g. I-beam `2*W*tf + tw*(D - 2tf)`, C-section `2bt + t(d - 2t) + 2t(g - t)`, trapezium midline rule), all exact on the B-rep kernels; a tall-ellipse case exercising the axis-swap path (occt-only — needs edge relocation); hash determinism across identical calls; serialize round-trip for every kind; an extruded I-beam composition with exact volume.

## Size

61.53 -> 62.57 kB main bundle (+1.04 kB for 15 builders) and raises the limit 62 -> 63 kB per the bump-to-measured-need strategy. Total: 365.7 / 380 kB.
