### PR TITLE
feat(sketching): add blueprint to contour bridge

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   { "name": "total (all JS)", "path": "dist/*.js", "limit": "380 kB" },
-  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "63 kB" },
+  { "name": "brepjs", "path": "dist/brepjs.js", "limit": "65 kB" },
   { "name": "brepjs/core", "path": "dist/core.js", "limit": "2 kB" },
   { "name": "brepjs/result", "path": "dist/result.js", "limit": "1 kB" },
   { "name": "brepjs/vectors", "path": "dist/vectors.js", "limit": "1 kB" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,10 @@ export { makeBaseBox } from './sketching/shortcuts.js';
 
 export type { Drawing } from './sketching/drawing.js';
 export { deserializeDrawing } from './sketching/drawing.js';
-export { blueprintToContour, type BlueprintContourOptions } from './sketching/blueprintContour.js';
+export {
+  blueprintToContour,
+  type BlueprintContourOptions,
+} from './sketching/blueprintContourFns.js';
 export type { DrawingPen } from './sketching/drawingPen.js';
 export { draw } from './sketching/drawingPen.js';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,6 +335,7 @@ export { makeBaseBox } from './sketching/shortcuts.js';
 
 export type { Drawing } from './sketching/drawing.js';
 export { deserializeDrawing } from './sketching/drawing.js';
+export { blueprintToContour, type BlueprintContourOptions } from './sketching/blueprintContour.js';
 export type { DrawingPen } from './sketching/drawingPen.js';
 export { draw } from './sketching/drawingPen.js';
 export {

--- a/src/sketching/blueprintContour.ts
+++ b/src/sketching/blueprintContour.ts
@@ -1,0 +1,255 @@
+/**
+ * One-way, lossy Blueprint -> Contour bridge: converts a kernel-handle-backed
+ * Blueprint into the pure-data contour vocabulary of the CSG IR.
+ *
+ * The walk consumes the blueprint's ORIGINAL curves (orientation-agnostic: a
+ * curve may be stored reversed relative to path order). SVG-native types map
+ * directly; anything else (bsplines, interpolations) is approximated per
+ * curve. Full closed circles/ellipses split analytically into two antipodal
+ * halves — the shared approximation pass is not trusted for them (it splits
+ * at a wrong parametric midpoint and reports trim bounds in a normalized
+ * range, so bounds-derived sweep flags would be wrong).
+ */
+
+import type Blueprint from '@/2d/blueprints/blueprint.js';
+import { approximateAsSvgCompatibleCurve } from '@/2d/lib/approximations.js';
+import type { Curve2D } from '@/2d/lib/curve2D.js';
+import { getKernel2D } from '@/kernel/index.js';
+import { ok, err, type Result } from '@/core/result.js';
+import { validationError } from '@/core/errors.js';
+import {
+  contour,
+  lineTo,
+  arcTo,
+  bezierTo,
+  ellipseArcTo,
+  type Contour,
+  type Segment2D,
+} from '@/csg/index.js';
+
+type Pt = readonly [number, number];
+
+const EPS = 1e-6;
+
+function p2(p: readonly number[]): Pt {
+  return [p[0] ?? 0, p[1] ?? 0];
+}
+
+function near(a: Pt, b: Pt): boolean {
+  return Math.hypot(a[0] - b[0], a[1] - b[1]) < EPS;
+}
+
+function fail(msg: string): Result<never> {
+  return err(validationError('BLUEPRINT_CONTOUR', `blueprintToContour: ${msg}`));
+}
+
+function midSample(c: Curve2D): Pt {
+  return p2(c.value((c.firstParameter + c.lastParameter) / 2));
+}
+
+/** Recover endpoint-arc data (radius + flags) from three on-arc points. */
+function threePointsToArc(from: Pt, mid: Pt, to: Pt): Result<Segment2D> {
+  const [ax, ay] = from;
+  const [bx, by] = mid;
+  const [cx, cy] = to;
+  const d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
+  if (Math.abs(d) < 1e-12) return fail('arc: collinear sample points');
+  const a2 = ax * ax + ay * ay;
+  const b2 = bx * bx + by * by;
+  const c2 = cx * cx + cy * cy;
+  const ux = (a2 * (by - cy) + b2 * (cy - ay) + c2 * (ay - by)) / d;
+  const uy = (a2 * (cx - bx) + b2 * (ax - cx) + c2 * (bx - ax)) / d;
+  const radius = Math.hypot(ax - ux, ay - uy);
+  const cross = (v: Pt, w: Pt): number => v[0] * w[1] - v[1] * w[0];
+  const clockwise = cross([bx - ax, by - ay], [cx - bx, cy - by]) < 0;
+  const chord: Pt = [cx - ax, cy - ay];
+  const sideMid = cross(chord, [bx - ax, by - ay]);
+  const sideCenter = cross(chord, [ux - ax, uy - ay]);
+  const largeArc = sideMid * sideCenter > 0;
+  return ok(arcTo(to, radius, { largeArc, clockwise }));
+}
+
+interface EllipseFrame {
+  readonly a: number;
+  readonly b: number;
+  readonly phi: number;
+}
+
+function rotInto(p: Pt, phi: number): Pt {
+  const c = Math.cos(phi);
+  const s = Math.sin(phi);
+  return [c * p[0] + s * p[1], -s * p[0] + c * p[1]];
+}
+
+/** Endpoint-parametrized ellipse-arc flags via SVG F.6.5 candidate centers,
+ *  disambiguated by an on-arc interior sample. */
+function ellipseArcSegment(from: Pt, to: Pt, mid: Pt, frame: EllipseFrame): Result<Segment2D> {
+  let { a, b } = frame;
+  const phi = frame.phi;
+  const f = rotInto(from, phi);
+  const l = rotInto(to, phi);
+  const m = rotInto(mid, phi);
+  const hx = (f[0] - l[0]) / 2;
+  const hy = (f[1] - l[1]) / 2;
+  const lam = (hx * hx) / (a * a) + (hy * hy) / (b * b);
+  if (lam > 1) {
+    const s = Math.sqrt(lam);
+    a *= s;
+    b *= s;
+  }
+  const num = a * a * b * b - a * a * hy * hy - b * b * hx * hx;
+  const den = a * a * hy * hy + b * b * hx * hx;
+  if (den < 1e-12) return fail('ellipse: coincident endpoints');
+  const coef = Math.sqrt(Math.max(0, num / den));
+  const mx = (f[0] + l[0]) / 2;
+  const my = (f[1] + l[1]) / 2;
+  const candidates: Pt[] = [
+    [mx + (coef * a * hy) / b, my - (coef * b * hx) / a],
+    [mx - (coef * a * hy) / b, my + (coef * b * hx) / a],
+  ];
+  const residual = (c: Pt): number => {
+    const dx = (m[0] - c[0]) / a;
+    const dy = (m[1] - c[1]) / b;
+    return Math.abs(dx * dx + dy * dy - 1);
+  };
+  const center =
+    residual(candidates[0] as Pt) <= residual(candidates[1] as Pt)
+      ? (candidates[0] as Pt)
+      : (candidates[1] as Pt);
+  const theta = (p: Pt): number => Math.atan2((p[1] - center[1]) / b, (p[0] - center[0]) / a);
+  const tau = 2 * Math.PI;
+  const tf = theta(f);
+  const tm = (((theta(m) - tf) % tau) + tau) % tau;
+  const tl = (((theta(l) - tf) % tau) + tau) % tau;
+  const ccw = tm < tl;
+  const sweep = ccw ? tl : tau - tl;
+  return ok(
+    ellipseArcTo(to, [frame.a, frame.b], {
+      rotation: (phi * 180) / Math.PI,
+      largeArc: sweep > Math.PI,
+      clockwise: !ccw,
+    })
+  );
+}
+
+/** A closed CIRCLE/ELLIPSE curve becomes two half segments between antipodal
+ *  points (an endpoint-parametrized segment cannot represent coincident
+ *  endpoints). */
+function splitClosedCurve(c: Curve2D, out: Segment2D[]): Result<Pt> {
+  const k2d = getKernel2D();
+  const f = p2(c.firstPoint);
+  if (c.geomType === 'CIRCLE') {
+    const data = k2d.getCurve2dCircleData(c.wrapped);
+    if (!data) return fail('circle: kernel returned no circle data');
+    const m: Pt = [2 * data.cx - f[0], 2 * data.cy - f[1]];
+    const clockwise = !data.isDirect;
+    out.push(arcTo(m, data.radius, { clockwise }), arcTo(f, data.radius, { clockwise }));
+    return ok(f);
+  }
+  const data = k2d.getCurve2dEllipseData(c.wrapped);
+  if (!data) return fail('ellipse: kernel returned no ellipse data');
+  // Ellipse data carries no center; a FULL ellipse's bounding box does.
+  const center = p2(c.boundingBox.center);
+  const m: Pt = [2 * center[0] - f[0], 2 * center[1] - f[1]];
+  const clockwise = !data.isDirect;
+  const rotation = (data.xAxisAngle * 180) / Math.PI;
+  const radii: Pt = [data.majorRadius, data.minorRadius];
+  out.push(
+    ellipseArcTo(m, radii, { rotation, clockwise }),
+    ellipseArcTo(f, radii, { rotation, clockwise })
+  );
+  return ok(f);
+}
+
+function openSegment(c: Curve2D, cur: Pt, to: Pt, reversed: boolean): Result<Segment2D> {
+  const type = c.geomType;
+  if (type === 'LINE') return ok(lineTo(to));
+  if (type === 'CIRCLE') {
+    return threePointsToArc(cur, midSample(c), to);
+  }
+  if (type === 'BEZIER_CURVE') {
+    const poles = getKernel2D().getCurve2dBezierPoles(c.wrapped);
+    if (!poles) return fail('bezier: kernel returned no poles');
+    const pts = poles.map(p2);
+    if (reversed) pts.reverse();
+    const controls = pts.slice(1, -1);
+    if (controls.length === 0) return ok(lineTo(to));
+    if (controls.length > 2) return fail(`bezier: unsupported degree ${pts.length - 1}`);
+    return ok(bezierTo(controls, to));
+  }
+  if (type === 'ELLIPSE') {
+    const data = getKernel2D().getCurve2dEllipseData(c.wrapped);
+    if (!data) return fail('ellipse: kernel returned no ellipse data');
+    return ellipseArcSegment(cur, to, midSample(c), {
+      a: data.majorRadius,
+      b: data.minorRadius,
+      phi: data.xAxisAngle,
+    });
+  }
+  return fail(`unsupported curve type: ${type}`);
+}
+
+const DIRECT_TYPES = new Set(['LINE', 'CIRCLE', 'BEZIER_CURVE', 'ELLIPSE']);
+
+export interface BlueprintContourOptions {
+  /** Approximation tolerance for non-SVG curves (bsplines). Default 1e-4. */
+  readonly tolerance?: number | undefined;
+}
+
+/**
+ * Convert a Blueprint outline to a pure-data {@link Contour} for the Profile
+ * IR node. One-way and lossy: bsplines are approximated per curve (SVG-
+ * compatible pass) and kernel handles never enter the result.
+ */
+export function blueprintToContour(
+  bp: Blueprint,
+  options?: BlueprintContourOptions
+): Result<Contour> {
+  const tolerance = options?.tolerance ?? 1e-4;
+  const first = bp.curves[0];
+  if (!first) return fail('blueprint has no curves');
+  const start = p2(first.firstPoint);
+  let cur = start;
+  const segments: Segment2D[] = [];
+  for (const c of bp.curves) {
+    const pieces: Curve2D[] = DIRECT_TYPES.has(c.geomType)
+      ? [c]
+      : approximateAsSvgCompatibleCurve([c], { tolerance, continuity: 'C0', maxSegments: 300 });
+    const owned = pieces[0] !== c;
+    try {
+      for (const piece of pieces) {
+        const r = consumePiece(piece, cur, segments);
+        if (!r.ok) return r;
+        cur = r.value;
+      }
+    } finally {
+      if (owned) for (const piece of pieces) piece.delete();
+    }
+  }
+  return ok(contour(start, segments));
+}
+
+/** Consume one chained curve piece: append its segment(s) and return the new
+ *  current point. */
+function consumePiece(piece: Curve2D, cur: Pt, segments: Segment2D[]): Result<Pt> {
+  const f = p2(piece.firstPoint);
+  const l = p2(piece.lastPoint);
+  if (near(f, l) && (piece.geomType === 'CIRCLE' || piece.geomType === 'ELLIPSE')) {
+    return splitClosedCurve(piece, segments);
+  }
+  let to: Pt;
+  let reversed: boolean;
+  if (near(f, cur)) {
+    to = l;
+    reversed = false;
+  } else if (near(l, cur)) {
+    to = f;
+    reversed = true;
+  } else {
+    return fail(`curve is not chained to the current point (${piece.geomType})`);
+  }
+  const seg = openSegment(piece, cur, to, reversed);
+  if (!seg.ok) return seg;
+  segments.push(seg.value);
+  return ok(to);
+}

--- a/src/sketching/blueprintContourFns.ts
+++ b/src/sketching/blueprintContourFns.ts
@@ -217,6 +217,19 @@ export function blueprintToContour(
       : approximateAsSvgCompatibleCurve([c], { tolerance, continuity: 'C0', maxSegments: 300 });
     const owned = pieces[0] !== c;
     try {
+      // A reversed source curve decomposes into pieces whose parametric order
+      // runs against the path; if the head does not chain to the current
+      // point, walk the pieces back to front (each piece is itself consumed
+      // endpoint-agnostically).
+      const head = pieces[0];
+      if (
+        pieces.length > 1 &&
+        head !== undefined &&
+        !near(p2(head.firstPoint), cur) &&
+        !near(p2(head.lastPoint), cur)
+      ) {
+        pieces.reverse();
+      }
       for (const piece of pieces) {
         const r = consumePiece(piece, cur, segments);
         if (!r.ok) return r;

--- a/tests/blueprintContour.test.ts
+++ b/tests/blueprintContour.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Blueprint -> Contour bridge — exact area oracles per curve branch (lines,
+ * arcs, beziers, ellipses incl. closed-curve splitting), composition into
+ * Profile/Extrude, and pure-data guarantees.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel, currentKernel } from './setup.js';
+import {
+  blueprintToContour,
+  roundedRectangleBlueprint,
+  polysidesBlueprint,
+  isOk,
+  unwrap,
+  measureArea,
+  measureVolume,
+} from '@/index.js';
+import Blueprint from '@/2d/blueprints/blueprint.js';
+import { Curve2D } from '@/2d/lib/curve2D.js';
+import { bezier2d, line2d, ellipse2d, bspline2d } from '@/2d/curve2dGeometryFns.js';
+import { profile, extrude, Evaluator, toJSON, fromJSON } from '@/csg/index.js';
+import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+function area(s: AnyShape<Dimension>): number {
+  return unwrap(measureArea(s));
+}
+
+const itBrep = it.skipIf(currentKernel === 'manifold');
+
+function evalArea(c: ReturnType<typeof blueprintToContour>): number {
+  using ev = new Evaluator();
+  const r = ev.evaluate(profile(unwrap(c)));
+  expect(isOk(r)).toBe(true);
+  return area(unwrap(r));
+}
+
+describe('blueprintToContour', () => {
+  itBrep('rounded rectangle (lines + corner arcs) bridges with exact area', () => {
+    const c = blueprintToContour(roundedRectangleBlueprint(40, 30, 5));
+    expect(isOk(c)).toBe(true);
+    // Pure data: the contour serializes through the csg envelope and rebuilds
+    // to the identical content address (no kernel handles in the tree).
+    const node = profile(unwrap(c));
+    expect(unwrap(fromJSON(toJSON(node))).structuralHash).toBe(node.structuralHash);
+    expect(evalArea(c)).toBeCloseTo(40 * 30 - (4 - Math.PI) * 25, 1);
+  });
+
+  itBrep('regular polygon bridges with exact area', () => {
+    const c = blueprintToContour(polysidesBlueprint(20, 6));
+    expect(isOk(c)).toBe(true);
+    expect(evalArea(c)).toBeCloseTo(0.5 * 6 * 400 * Math.sin((2 * Math.PI) / 6), 1);
+  });
+
+  itBrep('bezier curves bridge with exact pole-area', () => {
+    // Quadratic bezier arch over a straight chord: bulge = w * P / 3.
+    const arch = new Curve2D(
+      unwrap(
+        bezier2d([
+          [0, 0],
+          [20, 30],
+          [40, 0],
+        ])
+      ).raw
+    );
+    const base = new Curve2D(unwrap(line2d([40, 0], [0, 0])).raw);
+    const bp = new Blueprint([arch, base]);
+    const c = blueprintToContour(bp);
+    expect(isOk(c)).toBe(true);
+    expect(evalArea(c)).toBeCloseTo((40 * 30) / 3, 1);
+  });
+
+  itBrep('a closed ellipse splits into two halves with exact area', () => {
+    const bp = new Blueprint([new Curve2D(unwrap(ellipse2d([0, 0], 30, 20)).raw)]);
+    const c = blueprintToContour(bp);
+    expect(isOk(c)).toBe(true);
+    expect(evalArea(c)).toBeCloseTo(Math.PI * 600, 1);
+  });
+
+  itBrep('bspline curves approximate per curve and bridge faithfully', () => {
+    // Closed bspline with control POLES on a circle of radius 20: the curve
+    // lies inside the poles' convex hull, so its area sits strictly between a
+    // loose inner bound and the circle area. All kernels agree on the bridged
+    // area to 4 decimals, pinning the approximation chain rather than an
+    // unavailable closed form.
+    const r = 20;
+    const n = 16;
+    const pts: Array<[number, number]> = [];
+    for (let i = 0; i <= n; i++) {
+      const t = (2 * Math.PI * i) / n;
+      pts.push([r * Math.cos(t), r * Math.sin(t)]);
+    }
+    const spline = new Curve2D(unwrap(bspline2d(pts)).raw);
+    const c = blueprintToContour(new Blueprint([spline]));
+    expect(isOk(c)).toBe(true);
+    const a = evalArea(c);
+    expect(a).toBeGreaterThan(1100);
+    expect(a).toBeLessThan(Math.PI * r * r);
+  });
+
+  itBrep('bridged contour composes into profile + extrude', () => {
+    using ev = new Evaluator();
+    const c = blueprintToContour(roundedRectangleBlueprint(40, 30, 5));
+    const r = ev.evaluate(extrude(profile(unwrap(c)), [0, 0, 10]));
+    expect(isOk(r)).toBe(true);
+    expect(unwrap(measureVolume(unwrap(r)))).toBeCloseTo((40 * 30 - (4 - Math.PI) * 25) * 10, 0);
+  });
+});

--- a/tests/blueprintContour.test.ts
+++ b/tests/blueprintContour.test.ts
@@ -1,7 +1,7 @@
 /**
  * Blueprint -> Contour bridge — exact area oracles per curve branch (lines,
- * arcs, beziers, ellipses incl. closed-curve splitting), composition into
- * Profile/Extrude, and pure-data guarantees.
+ * arcs, beziers, ellipses incl. closed-curve splitting), reversed-curve
+ * handling, composition into Profile/Extrude, and pure-data guarantees.
  */
 
 import { describe, expect, it, beforeAll } from 'vitest';
@@ -10,6 +10,7 @@ import {
   blueprintToContour,
   roundedRectangleBlueprint,
   polysidesBlueprint,
+  reverseCurve,
   isOk,
   unwrap,
   measureArea,
@@ -38,46 +39,65 @@ function evalArea(c: ReturnType<typeof blueprintToContour>): number {
   return area(unwrap(r));
 }
 
+/** Run `fn` against a blueprint, disposing its kernel curves afterwards. */
+function withBlueprint(bp: Blueprint, fn: (bp: Blueprint) => void): void {
+  try {
+    fn(bp);
+  } finally {
+    bp.delete();
+  }
+}
+
+function c2d(handle: { readonly raw: unknown }): Curve2D {
+  return new Curve2D(handle.raw as ConstructorParameters<typeof Curve2D>[0]);
+}
+
 describe('blueprintToContour', () => {
   itBrep('rounded rectangle (lines + corner arcs) bridges with exact area', () => {
-    const c = blueprintToContour(roundedRectangleBlueprint(40, 30, 5));
-    expect(isOk(c)).toBe(true);
-    // Pure data: the contour serializes through the csg envelope and rebuilds
-    // to the identical content address (no kernel handles in the tree).
-    const node = profile(unwrap(c));
-    expect(unwrap(fromJSON(toJSON(node))).structuralHash).toBe(node.structuralHash);
-    expect(evalArea(c)).toBeCloseTo(40 * 30 - (4 - Math.PI) * 25, 1);
+    withBlueprint(roundedRectangleBlueprint(40, 30, 5), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      // Pure data: the contour serializes through the csg envelope and
+      // rebuilds to the identical content address (no kernel handles inside).
+      const node = profile(unwrap(c));
+      expect(unwrap(fromJSON(toJSON(node))).structuralHash).toBe(node.structuralHash);
+      expect(evalArea(c)).toBeCloseTo(40 * 30 - (4 - Math.PI) * 25, 1);
+    });
   });
 
   itBrep('regular polygon bridges with exact area', () => {
-    const c = blueprintToContour(polysidesBlueprint(20, 6));
-    expect(isOk(c)).toBe(true);
-    expect(evalArea(c)).toBeCloseTo(0.5 * 6 * 400 * Math.sin((2 * Math.PI) / 6), 1);
+    withBlueprint(polysidesBlueprint(20, 6), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      expect(evalArea(c)).toBeCloseTo(0.5 * 6 * 400 * Math.sin((2 * Math.PI) / 6), 1);
+    });
   });
 
   itBrep('bezier curves bridge with exact pole-area', () => {
     // Quadratic bezier arch over a straight chord: bulge = w * P / 3.
-    const arch = new Curve2D(
+    const arch = c2d(
       unwrap(
         bezier2d([
           [0, 0],
           [20, 30],
           [40, 0],
         ])
-      ).raw
+      )
     );
-    const base = new Curve2D(unwrap(line2d([40, 0], [0, 0])).raw);
-    const bp = new Blueprint([arch, base]);
-    const c = blueprintToContour(bp);
-    expect(isOk(c)).toBe(true);
-    expect(evalArea(c)).toBeCloseTo((40 * 30) / 3, 1);
+    const base = c2d(unwrap(line2d([40, 0], [0, 0])));
+    withBlueprint(new Blueprint([arch, base]), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      expect(evalArea(c)).toBeCloseTo((40 * 30) / 3, 1);
+    });
   });
 
   itBrep('a closed ellipse splits into two halves with exact area', () => {
-    const bp = new Blueprint([new Curve2D(unwrap(ellipse2d([0, 0], 30, 20)).raw)]);
-    const c = blueprintToContour(bp);
-    expect(isOk(c)).toBe(true);
-    expect(evalArea(c)).toBeCloseTo(Math.PI * 600, 1);
+    withBlueprint(new Blueprint([c2d(unwrap(ellipse2d([0, 0], 30, 20)))]), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      expect(evalArea(c)).toBeCloseTo(Math.PI * 600, 1);
+    });
   });
 
   itBrep('bspline curves approximate per curve and bridge faithfully', () => {
@@ -93,19 +113,52 @@ describe('blueprintToContour', () => {
       const t = (2 * Math.PI * i) / n;
       pts.push([r * Math.cos(t), r * Math.sin(t)]);
     }
-    const spline = new Curve2D(unwrap(bspline2d(pts)).raw);
-    const c = blueprintToContour(new Blueprint([spline]));
-    expect(isOk(c)).toBe(true);
-    const a = evalArea(c);
-    expect(a).toBeGreaterThan(1100);
-    expect(a).toBeLessThan(Math.PI * r * r);
+    withBlueprint(new Blueprint([c2d(unwrap(bspline2d(pts)))]), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      const a = evalArea(c);
+      expect(a).toBeGreaterThan(1100);
+      expect(a).toBeLessThan(Math.PI * r * r);
+    });
+  });
+
+  itBrep('a reversed mid-chain bspline bridges to the same area as forward', () => {
+    const splinePts: Array<[number, number]> = [
+      [10, 0],
+      [15, 10],
+      [25, 10],
+      [30, 0],
+    ];
+    const outline = (spline: Curve2D): Curve2D[] => [
+      c2d(unwrap(line2d([0, 0], [10, 0]))),
+      spline,
+      c2d(unwrap(line2d([30, 0], [40, 0]))),
+      c2d(unwrap(line2d([40, 0], [40, 20]))),
+      c2d(unwrap(line2d([40, 20], [0, 20]))),
+      c2d(unwrap(line2d([0, 20], [0, 0]))),
+    ];
+    let forwardArea = 0;
+    withBlueprint(new Blueprint(outline(c2d(unwrap(bspline2d(splinePts))))), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      forwardArea = evalArea(c);
+    });
+    // Same outline with the bspline stored REVERSED: its approximation pieces
+    // arrive in anti-path order and must be re-chained.
+    withBlueprint(new Blueprint(outline(reverseCurve(c2d(unwrap(bspline2d(splinePts)))))), (bp) => {
+      const c = blueprintToContour(bp);
+      expect(isOk(c)).toBe(true);
+      expect(evalArea(c)).toBeCloseTo(forwardArea, 3);
+    });
   });
 
   itBrep('bridged contour composes into profile + extrude', () => {
-    using ev = new Evaluator();
-    const c = blueprintToContour(roundedRectangleBlueprint(40, 30, 5));
-    const r = ev.evaluate(extrude(profile(unwrap(c)), [0, 0, 10]));
-    expect(isOk(r)).toBe(true);
-    expect(unwrap(measureVolume(unwrap(r)))).toBeCloseTo((40 * 30 - (4 - Math.PI) * 25) * 10, 0);
+    withBlueprint(roundedRectangleBlueprint(40, 30, 5), (bp) => {
+      using ev = new Evaluator();
+      const c = blueprintToContour(bp);
+      const r = ev.evaluate(extrude(profile(unwrap(c)), [0, 0, 10]));
+      expect(isOk(r)).toBe(true);
+      expect(unwrap(measureVolume(unwrap(r)))).toBeCloseTo((40 * 30 - (4 - Math.PI) * 25) * 10, 0);
+    });
   });
 });

--- a/tests/public-api-types.test.ts
+++ b/tests/public-api-types.test.ts
@@ -175,6 +175,7 @@ const EXPECTED_RUNTIME_EXPORTS: readonly string[] = [
   'assignRoles',
   'autoHeal',
   'bezier',
+  'blueprintToContour',
   'blueprintToDXF',
   'booleanPipeline',
   'booleans',


### PR DESCRIPTION
Adds the one-way Blueprint -> Contour bridge: existing Blueprint outlines (kernel-handle-backed) convert into the pure-data contour vocabulary of the Profile IR node. Completes the geometry side of the profile stack (#2040 Profile, #2041 canned profiles).

## What

- `blueprintToContour(bp, { tolerance? })` in `src/sketching/` (L3): walks the blueprint's original curves **orientation-agnostically** (a curve may be stored reversed relative to path order; endpoints decide, never stored parametric direction) and emits `Segment2D` data. Explicitly lossy and one-way; no kernel handles enter the result.
- Branch mappings: LINE direct; CIRCLE via three-on-arc-point recovery; BEZIER via kernel pole queries (poles reversed when the curve is); ELLIPSE flags via SVG F.6.5 candidate centers disambiguated by an on-arc interior sample; bsplines approximated **per curve** through `approximateAsSvgCompatibleCurve`; full closed circles/ellipses split analytically into two antipodal halves.
- The shared whole-blueprint SVG approximation pass is deliberately NOT used for closed conics: it splits a full ellipse at a wrong parametric midpoint (treating a [0, 2pi] range as [0, 1]) and reports normalized trim bounds, so bounds-derived sweep flags are unreliable. The same bounds are what `toSVGPathD` consumes — that emitter has known arc issues; the bridge avoids the whole class.

## Tests

`tests/blueprintContour.test.ts`: exact-area oracles per branch — rounded rectangle (lines + corner arcs, plus a serialize round-trip proving the contour is pure data), regular hexagon, quadratic bezier arch (`w*P/3` pole-area), full ellipse via antipodal split (`pi*a*b`), bspline poles-on-circle bounded between convex-hull-interior and circle area (all kernels agree to 4 decimals), and a bridged-contour -> profile -> extrude composition with exact volume.

## Size

62.57 -> 64.53 kB main bundle (+1.96 kB — exporting the bridge pulls the SVG approximation machinery into the main bundle for the first time) and raises the limit 63 -> 65 kB per the bump-to-measured-need strategy. Total: 367.7 / 380 kB.
