### PR TITLE
feat(families): scaffold the brepjs-families package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,23 @@ jobs:
       - run: npm run test --workspace=brepjs-sheetmetal
       - run: npm run build --workspace=brepjs-sheetmetal
 
+  packages-families:
+    # Declarative family layer satellite (element trees over the CSG IR).
+    # Build root brepjs first so the package typecheck resolves `brepjs` via
+    # package exports -> dist/; tests resolve `brepjs` to source through the
+    # vitest alias and need the OCCT WASM the setup composite restores.
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+      - run: npm run build
+      - run: npm run typecheck --workspace=brepjs-families
+      - run: npm run lint --workspace=brepjs-families
+      - run: npm run test --workspace=brepjs-families
+
   packages-bim:
     # Experimental BIM (IFC4) domain satellite. Build root brepjs first so the
     # package typecheck/build resolve `brepjs` via package exports → dist/; tests
@@ -486,6 +503,7 @@ jobs:
         packages-verify,
         packages-sheetmetal,
         packages-bim,
+        packages-families,
         voxel-wasm-rust,
         test,
         size,

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -50,6 +50,11 @@ const config: KnipConfig = {
     'packages/brepjs-voxel-wasm': {
       ignore: ['**'],
     },
+    // API-surface satellite consumed by out-of-repo users; exports are the
+    // product, so unused-export analysis has nothing to check yet.
+    'packages/brepjs-families': {
+      ignore: ['**'],
+    },
     'packages/brepjs-viewer': {
       ignore: ['**'],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "packages/brepjs-bim",
         "packages/brepjs-sheetmetal",
         "packages/brepjs-manifold",
+        "packages/brepjs-families",
         "packages/brepjs-voxel-wasm",
         "packages/brepjs-voxel",
         "packages/brepjs-cad",
@@ -7181,6 +7182,10 @@
     },
     "node_modules/brepjs-docs": {
       "resolved": "apps/docs",
+      "link": true
+    },
+    "node_modules/brepjs-families": {
+      "resolved": "packages/brepjs-families",
       "link": true
     },
     "node_modules/brepjs-manifold": {
@@ -15228,6 +15233,13 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/brepjs-families": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "brepjs": ">=18.0.0"
+      }
     },
     "packages/brepjs-manifold": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "packages/brepjs-bim",
     "packages/brepjs-sheetmetal",
     "packages/brepjs-manifold",
+    "packages/brepjs-families",
     "packages/brepjs-voxel-wasm",
     "packages/brepjs-voxel",
     "packages/brepjs-cad",

--- a/packages/brepjs-families/eslint.config.js
+++ b/packages/brepjs-families/eslint.config.js
@@ -1,0 +1,45 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/prefer-readonly': 'error',
+      'prefer-const': 'error',
+      eqeqeq: 'error',
+      'no-var': 'error',
+      'no-console': ['error', { allow: ['error', 'warn'] }],
+    },
+  },
+  {
+    files: ['tests/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.test.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/prefer-readonly': 'error',
+      'prefer-const': 'error',
+      eqeqeq: 'error',
+      'no-var': 'error',
+      'no-console': ['error', { allow: ['error', 'warn'] }],
+    },
+  }
+);

--- a/packages/brepjs-families/package.json
+++ b/packages/brepjs-families/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "brepjs-families",
+  "version": "0.1.0",
+  "description": "Declarative family layer for brepjs: element trees, key paths, and projection onto the content-addressed CSG IR",
+  "keywords": [
+    "cad",
+    "bim",
+    "parametric",
+    "families",
+    "jsx"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "src"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andymai/brepjs.git",
+    "directory": "packages/brepjs-families"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "lint": "eslint src tests",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "brepjs": ">=18.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./jsx-runtime": {
+      "types": "./src/jsxRuntime.ts",
+      "default": "./src/jsxRuntime.ts"
+    }
+  }
+}

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -1,0 +1,72 @@
+/**
+ * Element model — a pure description tree. Calling a family component builds
+ * an Element (no render, no kernel); `render` functions run inside `resolve()`
+ * and must stay pure: they return Elements, never touch kernel handles.
+ */
+
+export interface Element {
+  readonly type: string | FamilyComponent<never>;
+  readonly key: string | undefined;
+  readonly props: Readonly<Record<string, unknown>>;
+  readonly children: readonly Element[];
+}
+
+interface WithKey {
+  readonly key?: string | undefined;
+}
+
+/**
+ * A family component: a callable that constructs Elements, carrying its
+ * declared name and render function. The component REFERENCE is the identity
+ * (copy-in files make name lookup collide); the declared name serves key-path
+ * fallbacks and display only.
+ */
+export interface FamilyComponent<P> {
+  (props: P & WithKey): Element;
+  readonly familyName: string;
+  /** `'fill'` marks a family whose instances fill an opening when placed in a
+   *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
+  readonly role: 'fill' | undefined;
+  readonly renderErased: (props: object) => Element;
+}
+
+export interface FamilyOptions {
+  readonly role?: 'fill' | undefined;
+}
+
+export function family<P extends object>(
+  name: string,
+  render: (props: P) => Element,
+  options?: FamilyOptions
+): FamilyComponent<P> {
+  const make = (props: P & WithKey): Element => {
+    const { key, ...rest } = props;
+    return { type: component, key, props: rest, children: [] };
+  };
+  const component: FamilyComponent<P> = Object.assign(make, {
+    familyName: name,
+    role: options?.role,
+    renderErased: (props: object) => render(props as P),
+  });
+  return component;
+}
+
+/** Construct an intrinsic element (`'Box'`, `'Group'`, ...). */
+export function el(
+  type: string,
+  props: Readonly<Record<string, unknown>>,
+  children: readonly Element[] = []
+): Element {
+  const key = props['key'];
+  const rest = { ...props };
+  delete rest['key'];
+  return { type, key: typeof key === 'string' ? key : undefined, props: rest, children };
+}
+
+export function isFamily(t: Element['type']): t is FamilyComponent<never> {
+  return typeof t === 'function';
+}
+
+export function typeNameOf(e: Element): string {
+  return isFamily(e.type) ? e.type.familyName : e.type;
+}

--- a/packages/brepjs-families/src/evaluateModel.ts
+++ b/packages/brepjs-families/src/evaluateModel.ts
@@ -1,0 +1,47 @@
+/**
+ * Model evaluation: one `evaluate()` per element, keyed by path. Identity
+ * (keyPath, attributes, relationships) rides on the record beside the
+ * geometry Result; identical recipes share one materialization underneath.
+ */
+
+import type { csg, Result, AnyShape, Dimension } from 'brepjs';
+import type { Relationship, ResolvedElement } from './resolve.js';
+
+export interface EvaluatedNode {
+  readonly keyPath: string;
+  readonly type: string;
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly relationships: readonly Relationship[];
+  /** Borrowed from the Evaluator — do not dispose; valid per its contract. */
+  readonly result: Result<AnyShape<Dimension>>;
+}
+
+export interface EvaluatedModel {
+  readonly root: ResolvedElement;
+  /** Geometry-bearing elements only: pure containers (Empty geometry) exist
+   *  for identity/containment and have no entry. */
+  readonly byKeyPath: ReadonlyMap<string, EvaluatedNode>;
+}
+
+export function evaluateModel(
+  root: ResolvedElement,
+  evaluator: csg.Evaluator,
+  env: csg.Env = {}
+): EvaluatedModel {
+  const byKeyPath = new Map<string, EvaluatedNode>();
+  const walk = (n: ResolvedElement): void => {
+    // The Empty identity node is not directly materializable by design.
+    if (n.geometry.kind !== 'Empty') {
+      byKeyPath.set(n.keyPath, {
+        keyPath: n.keyPath,
+        type: n.type,
+        attributes: n.attributes,
+        relationships: n.relationships,
+        result: evaluator.evaluate(n.geometry, env),
+      });
+    }
+    for (const c of n.children) walk(c);
+  };
+  walk(root);
+  return { root, byKeyPath };
+}

--- a/packages/brepjs-families/src/index.ts
+++ b/packages/brepjs-families/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * brepjs-families — declarative family layer over the brepjs CSG IR.
+ *
+ * Element trees are identity-preserving (key paths, attributes,
+ * relationships); projection onto the content-addressed IR is where
+ * deduplication happens for free. Domain-neutral: no BIM imports here.
+ */
+
+export {
+  family,
+  el,
+  type Element,
+  type FamilyComponent,
+  type FamilyOptions,
+} from './element.js';
+export { jsx, jsxs, Fragment } from './jsxRuntime.js';
+export {
+  resolve,
+  tTranslate,
+  type TransformOp,
+  type Relationship,
+  type ResolvedElement,
+} from './resolve.js';
+export { evaluateModel, type EvaluatedModel, type EvaluatedNode } from './evaluateModel.js';

--- a/packages/brepjs-families/src/jsxRuntime.ts
+++ b/packages/brepjs-families/src/jsxRuntime.ts
@@ -1,0 +1,29 @@
+/**
+ * React-automatic JSX runtime (`jsxImportSource: "brepjs-families"`). No
+ * React: `jsx(type, props, key)` constructs a plain Element; children arrive
+ * inside props per the automatic-runtime convention. The plain-function API
+ * is primary; JSX is sugar over it.
+ */
+
+import type { Element, FamilyComponent } from './element.js';
+
+export function jsx(
+  type: string | FamilyComponent<never>,
+  props: Readonly<Record<string, unknown>>,
+  key?: string
+): Element {
+  const rest = { ...props };
+  const rawChildren = rest['children'];
+  delete rest['children'];
+  const children = Array.isArray(rawChildren)
+    ? (rawChildren as Element[])
+    : rawChildren !== undefined
+      ? [rawChildren as Element]
+      : [];
+  return { type, key, props: rest, children };
+}
+
+export const jsxs = jsx;
+
+/** Fragment renders nothing itself; its children inline into the parent. */
+export const Fragment = 'Fragment';

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -114,6 +114,7 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
   voids.forEach((v, i) => {
     const fillRole = isFamily(v.type) && v.type.role === 'fill';
     if (fillRole && hostPath !== null) {
+      if (v.key !== undefined) assertKeyAllowed(v.key, hostPath);
       const slotKey = v.key ?? String(i);
       if (slotKeys.has(slotKey)) {
         throw new Error(
@@ -153,6 +154,16 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
   return { geometry, openings, hostRelationships };
 }
 
+/** ':' is reserved for prop-embedded slot segments (`voids:d1`), which makes
+ *  synthesized paths structurally collision-free against child keys. */
+function assertKeyAllowed(key: string, path: string): void {
+  if (key.includes(':')) {
+    throw new Error(
+      `brepjs-families: key '${key}' under '${path}' contains ':', which is reserved for prop-embedded slots`
+    );
+  }
+}
+
 function resolveAt(elem: Element, path: string): ResolvedElement {
   const { intrinsic, typeName } = renderToIntrinsic(elem);
   const d = desugar(intrinsic, path);
@@ -160,6 +171,7 @@ function resolveAt(elem: Element, path: string): ResolvedElement {
   const children: ResolvedElement[] = [];
   const seen = new Set<string>();
   intrinsic.children.forEach((c, i) => {
+    if (c.key !== undefined) assertKeyAllowed(c.key, path);
     const seg = c.key ?? `${typeNameOf(c)}[${i}]`;
     if (seen.has(seg)) {
       throw new Error(`brepjs-families: duplicate sibling key '${seg}' under '${path}'`);

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -84,17 +84,43 @@ interface DesugarOut {
 /** Normative desugaring order: voids (local frame) -> fuse -> transform.
  *  With a hostPath, fill-role voids synthesize Opening elements; pathless
  *  desugaring (projection) treats every void as plain geometry. */
+function applyOps(geometry: csg.IRNode, ops: readonly TransformOp[]): csg.IRNode {
+  let out = geometry;
+  for (const op of ops) {
+    out = csg.translate(out, op.v);
+  }
+  return out;
+}
+
+/** Rebuild a resolved subtree with the host's transform applied to every
+ *  geometry (identity fields untouched): synthesized openings and fills are
+ *  cut in the host's LOCAL frame, so a transformed host must carry them. */
+function transformResolved(node: ResolvedElement, ops: readonly TransformOp[]): ResolvedElement {
+  return {
+    ...node,
+    geometry: applyOps(node.geometry, ops),
+    children: node.children.map((c) => transformResolved(c, ops)),
+  };
+}
+
 function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
   let geometry = baseGeometry(intrinsic);
-  const openings: ResolvedElement[] = [];
+  let openings: ResolvedElement[] = [];
   const hostRelationships: Relationship[] = [];
 
   const voids = (intrinsic.props['voids'] as readonly Element[] | undefined) ?? [];
   const tools: csg.IRNode[] = [];
+  const slotKeys = new Set<string>();
   voids.forEach((v, i) => {
     const fillRole = isFamily(v.type) && v.type.role === 'fill';
     if (fillRole && hostPath !== null) {
       const slotKey = v.key ?? String(i);
+      if (slotKeys.has(slotKey)) {
+        throw new Error(
+          `brepjs-families: duplicate void slot key '${slotKey}' under '${hostPath}'`
+        );
+      }
+      slotKeys.add(slotKey);
       const openingPath = `${hostPath}/voids:${slotKey}`;
       const fill = resolveAt(v, `${openingPath}/fill`);
       openings.push({
@@ -117,8 +143,11 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
   if (fuses.length > 0) geometry = csg.fuseAll([geometry, ...fuses.map(project)]);
 
   const ops = (intrinsic.props['transform'] as readonly TransformOp[] | undefined) ?? [];
-  for (const op of ops) {
-    geometry = csg.translate(geometry, op.v);
+  if (ops.length > 0) {
+    geometry = applyOps(geometry, ops);
+    // Openings/fills were cut in the local frame; the host transform carries
+    // them into the same frame as the host's own geometry.
+    openings = openings.map((o) => transformResolved(o, ops));
   }
 
   return { geometry, openings, hostRelationships };

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -1,0 +1,156 @@
+/**
+ * Resolution: Element tree -> ResolvedElement tree. Assigns key paths, runs
+ * render functions, desugars geometry props onto the content-addressed CSG IR
+ * (voids in the local frame, then fuse, then transform), synthesizes Opening
+ * elements for fill-role voids, and captures identity-side attributes.
+ *
+ * Identity rides on ResolvedElement (keyPath, attributes, relationships); the
+ * IR DAG beneath carries none of it, so identical recipes share one cache
+ * entry while identities stay distinct.
+ */
+
+import { csg } from 'brepjs';
+import { isFamily, typeNameOf, type Element } from './element.js';
+
+export interface TransformOp {
+  readonly op: 'translate';
+  readonly v: readonly [number, number, number];
+}
+
+export function tTranslate(v: readonly [number, number, number]): TransformOp {
+  return { op: 'translate', v };
+}
+
+export interface Relationship {
+  readonly kind: 'Voids' | 'Fills' | 'Contains';
+  readonly target: string;
+}
+
+export interface ResolvedElement {
+  readonly type: string;
+  /** Ancestor chain joined with '/'; prop-embedded elements use
+   *  `${hostPath}/${propName}:${slotKey}`. */
+  readonly keyPath: string;
+  readonly geometry: csg.IRNode;
+  /** Identity-side data (psets, ...) — beside the geometry, never inside it. */
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly relationships: readonly Relationship[];
+  readonly children: readonly ResolvedElement[];
+}
+
+const IDENTITY_PROPS = ['psets', 'material', 'classification'] as const;
+
+function identityAttributes(elem: Element): Readonly<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  for (const key of IDENTITY_PROPS) {
+    if (elem.props[key] !== undefined) out[key] = elem.props[key];
+  }
+  return out;
+}
+
+/** Run family render functions until an intrinsic element remains. The
+ *  outermost family supplies the resolved type name. */
+function renderToIntrinsic(elem: Element): { intrinsic: Element; typeName: string } {
+  const typeName = typeNameOf(elem);
+  let cur = elem;
+  while (isFamily(cur.type)) {
+    cur = cur.type.renderErased(cur.props);
+  }
+  return { intrinsic: cur, typeName };
+}
+
+function baseGeometry(intrinsic: Element): csg.IRNode {
+  if (intrinsic.type === 'Box') {
+    const size = intrinsic.props['size'] as readonly [number, number, number];
+    return csg.box(size[0], size[1], size[2]);
+  }
+  if (intrinsic.type === 'Group' || intrinsic.type === 'Fragment') return csg.emptySolid();
+  throw new Error(`brepjs-families: unknown intrinsic element '${String(intrinsic.type)}'`);
+}
+
+/** Identity-free projection: element -> IR only. Used for plain geometry
+ *  voids/fuse entries, which contribute a boolean tool but no resolved node. */
+function project(elem: Element): csg.IRNode {
+  const { intrinsic } = renderToIntrinsic(elem);
+  return desugar(intrinsic, null).geometry;
+}
+
+interface DesugarOut {
+  readonly geometry: csg.IRNode;
+  readonly openings: readonly ResolvedElement[];
+  readonly hostRelationships: readonly Relationship[];
+}
+
+/** Normative desugaring order: voids (local frame) -> fuse -> transform.
+ *  With a hostPath, fill-role voids synthesize Opening elements; pathless
+ *  desugaring (projection) treats every void as plain geometry. */
+function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
+  let geometry = baseGeometry(intrinsic);
+  const openings: ResolvedElement[] = [];
+  const hostRelationships: Relationship[] = [];
+
+  const voids = (intrinsic.props['voids'] as readonly Element[] | undefined) ?? [];
+  const tools: csg.IRNode[] = [];
+  voids.forEach((v, i) => {
+    const fillRole = isFamily(v.type) && v.type.role === 'fill';
+    if (fillRole && hostPath !== null) {
+      const slotKey = v.key ?? String(i);
+      const openingPath = `${hostPath}/voids:${slotKey}`;
+      const fill = resolveAt(v, `${openingPath}/fill`);
+      openings.push({
+        type: 'Opening',
+        keyPath: openingPath,
+        geometry: fill.geometry,
+        attributes: {},
+        relationships: [{ kind: 'Fills', target: fill.keyPath }],
+        children: [fill],
+      });
+      hostRelationships.push({ kind: 'Voids', target: openingPath });
+      tools.push(fill.geometry);
+    } else {
+      tools.push(project(v));
+    }
+  });
+  if (tools.length > 0) geometry = csg.cutAll(geometry, tools);
+
+  const fuses = (intrinsic.props['fuse'] as readonly Element[] | undefined) ?? [];
+  if (fuses.length > 0) geometry = csg.fuseAll([geometry, ...fuses.map(project)]);
+
+  const ops = (intrinsic.props['transform'] as readonly TransformOp[] | undefined) ?? [];
+  for (const op of ops) {
+    geometry = csg.translate(geometry, op.v);
+  }
+
+  return { geometry, openings, hostRelationships };
+}
+
+function resolveAt(elem: Element, path: string): ResolvedElement {
+  const { intrinsic, typeName } = renderToIntrinsic(elem);
+  const d = desugar(intrinsic, path);
+  const relationships: Relationship[] = [...d.hostRelationships];
+  const children: ResolvedElement[] = [];
+  const seen = new Set<string>();
+  intrinsic.children.forEach((c, i) => {
+    const seg = c.key ?? `${typeNameOf(c)}[${i}]`;
+    if (seen.has(seg)) {
+      throw new Error(`brepjs-families: duplicate sibling key '${seg}' under '${path}'`);
+    }
+    seen.add(seg);
+    const rc = resolveAt(c, `${path}/${seg}`);
+    children.push(rc);
+    relationships.push({ kind: 'Contains', target: rc.keyPath });
+  });
+  children.push(...d.openings);
+  return {
+    type: typeName,
+    keyPath: path,
+    geometry: d.geometry,
+    attributes: identityAttributes(elem),
+    relationships,
+    children,
+  };
+}
+
+export function resolve(root: Element): ResolvedElement {
+  return resolveAt(root, root.key ?? `${typeNameOf(root)}[0]`);
+}

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -158,6 +158,50 @@ describe('key paths and opening synthesis', () => {
     const w = (): Element => Wall({ key: 'w1', length: 100, height: 100, thickness: 10 });
     expect(() => resolve(Storey({ key: 's', walls: [w(), w()] }))).toThrow(/duplicate/i);
   });
+
+  it('duplicate void slot keys throw (explicit and index-fallback collisions)', () => {
+    const door = (key?: string): Element =>
+      key !== undefined
+        ? Door({ key, width: 90, height: 210, thickness: 20, at: [100, 0, 0] })
+        : Door({ width: 90, height: 210, thickness: 20, at: [200, 0, 0] });
+    expect(() =>
+      resolve(Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [door('d1'), door('d1')] }))
+    ).toThrow(/duplicate void slot/i);
+    // Explicit key '1' collides with the second void's index fallback.
+    expect(() =>
+      resolve(Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [door('1'), door()] }))
+    ).toThrow(/duplicate void slot/i);
+  });
+
+  it('a transformed host carries its openings and fills into the same frame', () => {
+    const TransformedWall = family<WallProps & { readonly at: readonly [number, number, number] }>(
+      'TWall',
+      (p) =>
+        el('Box', {
+          size: [p.length, p.thickness, p.height],
+          voids: p.voids ?? [],
+          transform: [tTranslate(p.at)],
+        })
+    );
+    const door = Door({ key: 'd1', width: 90, height: 210, thickness: 20, at: [100, 0, 0] });
+    const wall = resolve(
+      TransformedWall({
+        key: 'w',
+        length: 400,
+        height: 270,
+        thickness: 20,
+        at: [1000, 2000, 0],
+        voids: [door],
+      })
+    );
+    const opening = wall.children[0];
+    const fill = opening?.children[0];
+    // Expected: the door's local recipe wrapped in the host transform.
+    const localDoor = csg.translate(csg.box(90, 20, 210), [100, 0, 0]);
+    const worldDoor = csg.translate(localDoor, [1000, 2000, 0]);
+    expect(opening?.geometry.structuralHash).toBe(worldDoor.structuralHash);
+    expect(fill?.geometry.structuralHash).toBe(worldDoor.structuralHash);
+  });
 });
 
 describe('identity beside content addressing (Phase 3 gate)', () => {

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Family layer — element trees, key paths (children and prop-embedded),
+ * opening synthesis as relationship data, cache economics on prop edits,
+ * jsx runtime parity, and the Phase 3 identity gate: identical recipes share
+ * one materialization while identities and attribute records stay distinct.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { csg, isOk, unwrap, measureVolume } from 'brepjs';
+import type { AnyShape, Dimension } from 'brepjs';
+import {
+  family,
+  el,
+  jsx,
+  resolve,
+  evaluateModel,
+  tTranslate,
+  type Element,
+  type ResolvedElement,
+} from '../src/index.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+function vol(s: AnyShape<Dimension>): number {
+  return unwrap(measureVolume(s));
+}
+
+interface BinProps {
+  readonly size: readonly [number, number, number];
+  readonly pockets: ReadonlyArray<{
+    readonly at: readonly [number, number, number];
+    readonly size: readonly [number, number, number];
+  }>;
+  readonly at: readonly [number, number, number];
+}
+
+const Bin = family<BinProps>('Bin', (p) =>
+  el('Box', {
+    size: p.size,
+    voids: p.pockets.map((pk) => el('Box', { size: pk.size, transform: [tTranslate(pk.at)] })),
+    transform: [tTranslate(p.at)],
+  })
+);
+
+interface DoorProps {
+  readonly width: number;
+  readonly height: number;
+  readonly thickness: number;
+  readonly at: readonly [number, number, number];
+}
+
+const Door = family<DoorProps>(
+  'Door',
+  (p) =>
+    el('Box', {
+      size: [p.width, p.thickness, p.height],
+      transform: [tTranslate(p.at)],
+    }),
+  { role: 'fill' }
+);
+
+interface WallProps {
+  readonly length: number;
+  readonly height: number;
+  readonly thickness: number;
+  readonly voids?: readonly Element[] | undefined;
+  readonly psets?: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined;
+}
+
+const Wall = family<WallProps>('Wall', (p) =>
+  el('Box', {
+    size: [p.length, p.thickness, p.height],
+    voids: p.voids ?? [],
+  })
+);
+
+const Storey = family<{ readonly walls: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.walls)
+);
+
+describe('end to end', () => {
+  it('materializes the bin with correct volume', () => {
+    using ev = new csg.Evaluator();
+    const bin = Bin({
+      key: 'bin-1',
+      size: [100, 60, 20],
+      pockets: [
+        { at: [10, 10, 10], size: [20, 20, 10] },
+        { at: [50, 10, 10], size: [20, 20, 10] },
+      ],
+      at: [5, 0, 0],
+    });
+    const resolved = resolve(bin);
+    expect(resolved.keyPath).toBe('bin-1');
+    const r = ev.evaluate(resolved.geometry);
+    expect(isOk(r)).toBe(true);
+    expect(vol(unwrap(r))).toBeCloseTo(120000 - 8000, 0);
+  });
+
+  it('prop edit re-evaluates only the changed subtree', () => {
+    using ev = new csg.Evaluator();
+    const pockets = [
+      { at: [10, 10, 10] as const, size: [20, 20, 10] as const },
+      { at: [50, 10, 10] as const, size: [20, 20, 10] as const },
+    ];
+    const v1 = resolve(Bin({ key: 'b', size: [100, 60, 20], pockets, at: [5, 0, 0] }));
+    expect(isOk(ev.evaluate(v1.geometry))).toBe(true);
+    const s1 = ev.cacheStats();
+    const v2 = resolve(Bin({ key: 'b', size: [100, 60, 20], pockets, at: [7, 0, 0] }));
+    expect(isOk(ev.evaluate(v2.geometry))).toBe(true);
+    const s2 = ev.cacheStats();
+    expect(s2.misses - s1.misses).toBe(1);
+    expect(s2.hits - s1.hits).toBe(1);
+  });
+});
+
+describe('jsx runtime', () => {
+  it('jsx(Bin, props) produces hash-identical IR to Bin(props)', () => {
+    const props: BinProps = {
+      size: [100, 60, 20],
+      pockets: [{ at: [10, 10, 10], size: [20, 20, 10] }],
+      at: [0, 0, 0],
+    };
+    const viaFn = resolve(Bin({ key: 'b', ...props }));
+    const viaJsx = resolve(jsx(Bin, { ...props }, 'b'));
+    expect(viaJsx.geometry.structuralHash).toBe(viaFn.geometry.structuralHash);
+    expect(viaJsx.keyPath).toBe(viaFn.keyPath);
+  });
+});
+
+describe('key paths and opening synthesis', () => {
+  function buildStorey(): ResolvedElement {
+    const door = Door({ key: 'd1', width: 90, height: 210, thickness: 20, at: [100, 0, 0] });
+    const wall = Wall({ key: 'w1', length: 400, height: 270, thickness: 20, voids: [door] });
+    return resolve(Storey({ key: 'storey-1', walls: [wall] }));
+  }
+
+  it('assigns hierarchical key paths and synthesizes Opening relationships', () => {
+    const storey = buildStorey();
+    const wall = storey.children[0];
+    expect(wall?.keyPath).toBe('storey-1/w1');
+    const opening = wall?.children[0];
+    expect(opening?.type).toBe('Opening');
+    expect(opening?.keyPath).toBe('storey-1/w1/voids:d1');
+    expect(opening?.children[0]?.keyPath).toBe('storey-1/w1/voids:d1/fill');
+    expect(wall?.relationships).toContainEqual({ kind: 'Voids', target: 'storey-1/w1/voids:d1' });
+    expect(opening?.relationships).toContainEqual({
+      kind: 'Fills',
+      target: 'storey-1/w1/voids:d1/fill',
+    });
+    expect(storey.relationships).toContainEqual({ kind: 'Contains', target: 'storey-1/w1' });
+  });
+
+  it('duplicate sibling keys throw', () => {
+    const w = (): Element => Wall({ key: 'w1', length: 100, height: 100, thickness: 10 });
+    expect(() => resolve(Storey({ key: 's', walls: [w(), w()] }))).toThrow(/duplicate/i);
+  });
+});
+
+describe('identity beside content addressing (Phase 3 gate)', () => {
+  it('two identical walls: one materialization, distinct identity records', () => {
+    using ev = new csg.Evaluator();
+    const dims = { length: 400, height: 270, thickness: 20 };
+    const storey = resolve(
+      Storey({
+        key: 'storey-1',
+        walls: [
+          Wall({ key: 'w1', ...dims, psets: { Pset_WallCommon: { FireRating: '60' } } }),
+          Wall({ key: 'w2', ...dims, psets: { Pset_WallCommon: { FireRating: '90' } } }),
+        ],
+      })
+    );
+    const model = evaluateModel(storey, ev);
+    const n1 = model.byKeyPath.get('storey-1/w1');
+    const n2 = model.byKeyPath.get('storey-1/w2');
+    expect(n1 && n2).toBeTruthy();
+    if (!n1 || !n2) return;
+    // One materialized solid under two identities.
+    expect(isOk(n1.result) && isOk(n2.result)).toBe(true);
+    if (isOk(n1.result) && isOk(n2.result)) {
+      expect(n1.result.value).toBe(n2.result.value);
+    }
+    expect(ev.cacheStats().entries).toBe(1);
+    // Distinct identity records beside the shared geometry.
+    expect(n1.keyPath).not.toBe(n2.keyPath);
+    expect(n1.attributes['psets']).toEqual({ Pset_WallCommon: { FireRating: '60' } });
+    expect(n2.attributes['psets']).toEqual({ Pset_WallCommon: { FireRating: '90' } });
+    // Containers are identity-only: no geometry entry for the storey.
+    expect(model.byKeyPath.has('storey-1')).toBe(false);
+  });
+});

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -173,6 +173,17 @@ describe('key paths and opening synthesis', () => {
     ).toThrow(/duplicate void slot/i);
   });
 
+  it("rejects ':' in user keys (reserved for prop-embedded slot segments)", () => {
+    expect(() =>
+      resolve(
+        Storey({
+          key: 's',
+          walls: [Wall({ key: 'voids:d1', length: 100, height: 100, thickness: 10 })],
+        })
+      )
+    ).toThrow(/reserved/i);
+  });
+
   it('a transformed host carries its openings and fills into the same frame', () => {
     const TransformedWall = family<WallProps & { readonly at: readonly [number, number, number] }>(
       'TWall',

--- a/packages/brepjs-families/tsconfig.json
+++ b/packages/brepjs-families/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "paths": {}
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/brepjs-families/tsconfig.test.json
+++ b/packages/brepjs-families/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["tests/**/*.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/brepjs-families/vitest.config.ts
+++ b/packages/brepjs-families/vitest.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '../../src'),
+      brepjs: resolve(__dirname, '../../src/index.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    testTimeout: 90000,
+    pool: 'forks',
+    execArgv: ['--max-old-space-size=6144'],
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Scaffolds `packages/brepjs-families` — the declarative family layer over the CSG IR, promoted from throwaway prototypes into a workspace package. Domain-neutral by rule (no BIM imports; serves mechanical parts too); a single `brepjs >= 18` peer dependency and zero runtime deps.

## The model

Two trees with different identity semantics:
- **Element tree** (this package): identity-preserving. `family(name, render)` returns a callable component; calling it builds an `Element` description (render functions run only inside `resolve()` and stay pure — no kernel, nothing to dispose). Two identical walls are two elements.
- **IR DAG** (brepjs `csg`): content-addressed. Projection during `resolve()` is where deduplication happens for free.

## What's in

- `element.ts` — `family()` / `el()`; the component REFERENCE is the identity (copy-in files make name lookup collide), the declared name serves key-path fallback only.
- `jsxRuntime.ts` — react-automatic `jsx`/`jsxs`/`Fragment` exported as `./jsx-runtime` for `jsxImportSource`; the plain-function API stays primary.
- `resolve.ts` — hierarchical key paths (children `parent/key`, prop-embedded `hostPath/prop:slot`), the normative voids -> fuse -> transform desugaring (voids cut in the element's local frame so components stay relocatable), `Opening` synthesis for fill-role families in `voids` expressed as `Voids`/`Fills`/`Contains` relationship data, duplicate-sibling-key errors, and identity-attribute capture (`psets`, ...) from the element's own props so identity can never perturb geometry hashing.
- `evaluateModel.ts` — one `evaluate()` per geometry-bearing element; returns identity records (`keyPath`, `attributes`, `relationships`) beside borrowed geometry `Result`s. Pure containers (Empty geometry) are identity-only and get no entry.

## Tests

The identity gate: two identical walls evaluate to ONE cache entry holding ONE kernel handle while key paths and pset records stay distinct. Plus: bin end-to-end volume, prop-edit cache accounting (+1 miss/+1 hit on a transform edit), jsx/function-call hash parity, opening-synthesis relationship data, duplicate-key rejection.

## Wiring

Workspace + surgical lockfile entries (local npm install is blocked by an unrelated engines constraint), a `packages-families` CI job mirroring `packages-bim` (typecheck, lint, test after root build), knip workspace entry. Source-exports package, no build step.
