### PR TITLE
feat(bim): add the families-to-bim adapter with key-path identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15096,6 +15096,9 @@
       "peerDependencies": {
         "brepjs": ">=18.0.0",
         "web-ifc": ">=0.0.50"
+      },
+      "dependencies": {
+        "brepjs-families": "^0.1.0"
       }
     },
     "packages/brepjs-cad": {

--- a/packages/brepjs-bim/package.json
+++ b/packages/brepjs-bim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brepjs-bim",
   "version": "0.3.1",
-  "description": "BIM layer for brepjs — IFC4-aligned parametric building elements",
+  "description": "BIM layer for brepjs \u2014 IFC4-aligned parametric building elements",
   "keywords": [
     "bim",
     "ifc",
@@ -59,5 +59,8 @@
     "vitest": "^4.0.0",
     "web-ifc": "^0.0.77",
     "zod": "^4.4.3"
+  },
+  "dependencies": {
+    "brepjs-families": "^0.1.0"
   }
 }

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -9,7 +9,7 @@
  * relationship wiring (IfcRelVoidsElement) follow with the opening writer.
  */
 
-import { ok, err, type Result } from 'brepjs';
+import { ok, err, type Result, type csg } from 'brepjs';
 import type { ResolvedElement } from 'brepjs-families';
 import { BimModel } from './model/bimModel.js';
 import type { LocalId } from './identity/localId.js';
@@ -39,6 +39,27 @@ const SPEC_DEFAULTS = {
 
 const GEOMETRY_PROPS = new Set(['voids', 'fuse', 'transform', 'psets']);
 
+/** Fold the resolved geometry's OUTER literal translate chain into the spec
+ *  placement origin, so IfcLocalPlacement matches the IR world frame no
+ *  matter where the transform came from (family-internal or prop-level).
+ *  Parameter-driven translations cannot fold and keep the default origin. */
+function composedOrigin(el: ResolvedElement): [number, number, number] | undefined {
+  const base = (el.props['origin'] as [number, number, number] | undefined) ?? [0, 0, 0];
+  const out: [number, number, number] = [...base];
+  let moved = false;
+  let node: csg.IRNode = el.geometry;
+  while (node.kind === 'Translate') {
+    const v = node.vector;
+    if (v.kind !== 'Vec3Lit') break;
+    out[0] += v.value[0];
+    out[1] += v.value[1];
+    out[2] += v.value[2];
+    moved = true;
+    node = node.target;
+  }
+  return moved || el.props['origin'] !== undefined ? out : undefined;
+}
+
 function specInput(el: ResolvedElement): Record<string, unknown> {
   // Pre-desugared props feed the spec 1:1 (geometry-only props stripped);
   // identity-side attributes carry pset-shaped fields under their spec names.
@@ -46,7 +67,13 @@ function specInput(el: ResolvedElement): Record<string, unknown> {
   for (const [k, v] of Object.entries(el.props)) {
     if (!GEOMETRY_PROPS.has(k)) fromProps[k] = v;
   }
-  return { ...SPEC_DEFAULTS, ...fromProps, ...collectSpecProps(el) };
+  const origin = composedOrigin(el);
+  return {
+    ...SPEC_DEFAULTS,
+    ...fromProps,
+    ...(origin ? { origin } : {}),
+    ...collectSpecProps(el),
+  };
 }
 
 function collectSpecProps(el: ResolvedElement): Record<string, unknown> {
@@ -104,7 +131,15 @@ export function familiesToBim(
           : model.addSlab(parsed.value as never, { stableKey: el.keyPath });
       if (!added.ok) return added;
       idByKeyPath.set(el.keyPath, added.value);
-      if (containerId !== null) model.placeIn(added.value, containerId);
+      if (containerId === null) {
+        return err(
+          specError(
+            'FAMILIES_NO_STOREY',
+            `familiesToBim: '${el.keyPath}' has no Storey ancestor — IFC elements need spatial containment`
+          )
+        );
+      }
+      model.placeIn(added.value, containerId);
     } else if (el.type !== 'Opening' && el.type !== 'Group' && el.geometry.kind !== 'Empty') {
       return err(
         specError(

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -1,0 +1,129 @@
+/**
+ * brepjs-families -> BimModel adapter. Consumes a resolved element tree and
+ * feeds each element's PRE-DESUGARED props into the parametric specs — the
+ * spec path stays authoritative for IFC (IfcExtrudedAreaSolid + placement),
+ * while the IR path serves the viewport and dedup. GlobalIds derive from
+ * families key paths (stable under reordering), not insertion order.
+ *
+ * v1 scope: Storey containers and Wall/Slab elements. Openings, fills, and
+ * relationship wiring (IfcRelVoidsElement) follow with the opening writer.
+ */
+
+import { ok, err, type Result } from 'brepjs';
+import type { ResolvedElement } from 'brepjs-families';
+import { BimModel } from './model/bimModel.js';
+import type { LocalId } from './identity/localId.js';
+import { parseWallSpec } from './specs/wallSpec.js';
+import { parseSlabSpec } from './specs/slabSpec.js';
+import type { ProjectSpec } from './specs/spatialSpec.js';
+import { specError, type BimError } from './errors/bimError.js';
+
+export interface FamiliesToBimOptions {
+  readonly project: ProjectSpec;
+  readonly siteName?: string | undefined;
+  readonly buildingName?: string | undefined;
+}
+
+export interface FamiliesBimResult {
+  readonly model: BimModel;
+  /** LocalId per geometry-bearing families key path. */
+  readonly idByKeyPath: ReadonlyMap<string, LocalId>;
+}
+
+const SPEC_DEFAULTS = {
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+  materialName: 'Default',
+};
+
+const GEOMETRY_PROPS = new Set(['voids', 'fuse', 'transform', 'psets']);
+
+function specInput(el: ResolvedElement): Record<string, unknown> {
+  // Pre-desugared props feed the spec 1:1 (geometry-only props stripped);
+  // identity-side attributes carry pset-shaped fields under their spec names.
+  const fromProps: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(el.props)) {
+    if (!GEOMETRY_PROPS.has(k)) fromProps[k] = v;
+  }
+  return { ...SPEC_DEFAULTS, ...fromProps, ...collectSpecProps(el) };
+}
+
+function collectSpecProps(el: ResolvedElement): Record<string, unknown> {
+  const psets = el.attributes['psets'];
+  const out: Record<string, unknown> = {};
+  if (psets && typeof psets === 'object') {
+    const common = (psets as Record<string, unknown>)['Pset_WallCommon'];
+    if (common && typeof common === 'object') {
+      const c = common as Record<string, unknown>;
+      if (typeof c['IsExternal'] === 'boolean') out['isExternal'] = c['IsExternal'];
+      if (typeof c['FireRating'] === 'string') out['fireRating'] = c['FireRating'];
+    }
+  }
+  delete out['psets'];
+  return out;
+}
+
+/**
+ * Project a resolved families tree into an eager BimModel. The caller owns
+ * the returned model (`using`); families stays domain-neutral — this adapter
+ * is where families types meet the IFC vocabulary.
+ */
+export function familiesToBim(
+  root: ResolvedElement,
+  options: FamiliesToBimOptions
+): Result<FamiliesBimResult, BimError> {
+  const model = new BimModel();
+  const initResult = model.init(options.project);
+  if (!initResult.ok) return initResult;
+  const siteId = model.addSite({ name: options.siteName ?? 'Site' });
+  const buildingId = model.addBuilding({ name: options.buildingName ?? 'Building' });
+  model.aggregate(siteId, buildingId);
+
+  const idByKeyPath = new Map<string, LocalId>();
+  const walk = (el: ResolvedElement, storeyId: LocalId | null): Result<void, BimError> => {
+    let containerId = storeyId;
+    if (el.type === 'Storey') {
+      const id = model.addStorey(
+        {
+          name: (el.attributes['name'] as string | undefined) ?? el.keyPath,
+          elevation: (el.props['elevation'] as number | undefined) ?? 0,
+        },
+        { stableKey: el.keyPath }
+      );
+      model.aggregate(buildingId, id);
+      idByKeyPath.set(el.keyPath, id);
+      containerId = id;
+    } else if (el.type === 'Wall' || el.type === 'Slab') {
+      const parsed =
+        el.type === 'Wall' ? parseWallSpec(specInput(el)) : parseSlabSpec(specInput(el));
+      if (!parsed.ok) return parsed;
+      const added =
+        el.type === 'Wall'
+          ? model.addWall(parsed.value as never, { stableKey: el.keyPath })
+          : model.addSlab(parsed.value as never, { stableKey: el.keyPath });
+      if (!added.ok) return added;
+      idByKeyPath.set(el.keyPath, added.value);
+      if (containerId !== null) model.placeIn(added.value, containerId);
+    } else if (el.type !== 'Opening' && el.type !== 'Group' && el.geometry.kind !== 'Empty') {
+      return err(
+        specError(
+          'FAMILIES_UNSUPPORTED_TYPE',
+          `familiesToBim: no spec mapping for element type '${el.type}' at '${el.keyPath}'`
+        )
+      );
+    }
+    for (const child of el.children) {
+      const r = walk(child, containerId);
+      if (!r.ok) return r;
+    }
+    return ok(undefined);
+  };
+
+  const walked = walk(root, null);
+  if (!walked.ok) {
+    model[Symbol.dispose]();
+    return walked;
+  }
+  return ok({ model, idByKeyPath });
+}

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -265,3 +265,8 @@ export type {
 } from './bcf/index.js';
 
 export { bcfError, idsError } from './errors/bimError.js';
+export {
+  familiesToBim,
+  type FamiliesToBimOptions,
+  type FamiliesBimResult,
+} from './familiesAdapter.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -123,7 +123,19 @@ export class BimModel {
     return this.#makeElement('STOREY', spec, null, options?.stableKey);
   }
 
+  /** Reject a duplicate stableKey BEFORE any geometry is built, so the
+   *  Result-returning adders never allocate a solid they cannot store. */
+  #checkStableKey(options: ElementIdentityOptions | undefined): Result<void, BimError> {
+    const key = options?.stableKey;
+    if (key !== undefined && this.#usedStableKeys.has(key)) {
+      return err(specError('DUPLICATE_STABLE_KEY', `BimModel: duplicate stableKey '${key}'`));
+    }
+    return ok(undefined);
+  }
+
   addWall(spec: WallSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
     const geomResult = wallToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('WALL', spec, geomResult.value, options?.stableKey);
@@ -133,6 +145,8 @@ export class BimModel {
   }
 
   addSlab(spec: SlabSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
     const geomResult = slabToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
     const id = this.#makeElement('SLAB', spec, geomResult.value, options?.stableKey);

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -73,6 +73,7 @@ export class BimModel {
   // not collide. Set from the project identity in init() before any element is
   // created; empty until init() runs.
   #modelScope = '';
+  readonly #usedStableKeys = new Set<string>();
 
   init(spec: ProjectSpec): Result<LocalId, BimError> {
     if (this.#projectId !== null) {
@@ -915,7 +916,14 @@ export class BimModel {
     // Deterministic GUID. Default key: (category, localId), so re-serializing
     // an identical model is byte-for-byte stable. A caller-supplied stableKey
     // (e.g. a families key path) replaces the positional key, making the
-    // GlobalId stable under element reordering as well.
+    // GlobalId stable under element reordering as well. Duplicates would mint
+    // two elements sharing a GlobalId — an IFC validity break — so they throw.
+    if (stableKey !== undefined) {
+      if (this.#usedStableKeys.has(stableKey)) {
+        throw new Error(`BimModel: duplicate stableKey '${stableKey}'`);
+      }
+      this.#usedStableKeys.add(stableKey);
+    }
     const guid: IfcGuid = deriveIfcGuidSync(
       stableKey !== undefined
         ? `elem:${this.#modelScope}:${stableKey}`

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -57,6 +57,12 @@ import { footingToSolid, pileToSolid } from '../elementFns/foundationFns.js';
 import { railingToSolid } from '../elementFns/railingFns.js';
 import { coveringToSolid } from '../elementFns/coveringFns.js';
 
+/** Optional identity override for created elements: a stable key (e.g. a
+ *  families key path) that replaces the positional GlobalId derivation. */
+export interface ElementIdentityOptions {
+  readonly stableKey?: string | undefined;
+}
+
 export class BimModel {
   readonly #elements = new Map<LocalId, AnyBimElement>();
   readonly #relationships = new Map<LocalId, BimRelationship>();
@@ -108,27 +114,27 @@ export class BimModel {
     return this.#makeElement('SITE', spec, null);
   }
 
-  addBuilding(spec: BuildingSpec): LocalId {
-    return this.#makeElement('BUILDING', spec, null);
+  addBuilding(spec: BuildingSpec, options?: ElementIdentityOptions): LocalId {
+    return this.#makeElement('BUILDING', spec, null, options?.stableKey);
   }
 
-  addStorey(spec: StoreySpec): LocalId {
-    return this.#makeElement('STOREY', spec, null);
+  addStorey(spec: StoreySpec, options?: ElementIdentityOptions): LocalId {
+    return this.#makeElement('STOREY', spec, null, options?.stableKey);
   }
 
-  addWall(spec: WallSpec): Result<LocalId, BimError> {
+  addWall(spec: WallSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
     const geomResult = wallToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('WALL', spec, geomResult.value);
+    const id = this.#makeElement('WALL', spec, geomResult.value, options?.stableKey);
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);
   }
 
-  addSlab(spec: SlabSpec): Result<LocalId, BimError> {
+  addSlab(spec: SlabSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
     const geomResult = slabToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('SLAB', spec, geomResult.value);
+    const id = this.#makeElement('SLAB', spec, geomResult.value, options?.stableKey);
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);
@@ -902,12 +908,19 @@ export class BimModel {
   #makeElement<C extends AnyBimElement['category']>(
     category: C,
     spec: Extract<AnyBimElement, { category: C }>['spec'],
-    geometry: Extract<AnyBimElement, { category: C }>['geometry']
+    geometry: Extract<AnyBimElement, { category: C }>['geometry'],
+    stableKey?: string
   ): LocalId {
     const localId = this.#counter.next();
-    // Deterministic GUID keyed on (category, localId) so re-serializing an
-    // identical model yields byte-for-byte identical GlobalIds.
-    const guid: IfcGuid = deriveIfcGuidSync(makeElementKey(this.#modelScope, category, localId));
+    // Deterministic GUID. Default key: (category, localId), so re-serializing
+    // an identical model is byte-for-byte stable. A caller-supplied stableKey
+    // (e.g. a families key path) replaces the positional key, making the
+    // GlobalId stable under element reordering as well.
+    const guid: IfcGuid = deriveIfcGuidSync(
+      stableKey !== undefined
+        ? `elem:${this.#modelScope}:${stableKey}`
+        : makeElementKey(this.#modelScope, category, localId)
+    );
     const el = { guid, localId, category, spec, geometry } as AnyBimElement;
     this.#elements.set(localId, el);
     return localId;

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -131,6 +131,22 @@ describe('familiesToBim', () => {
     expect(isOk(familiesToBim(orphan, { project: PROJECT }))).toBe(false);
   });
 
+  it('duplicate stable keys return a Result error before building geometry', () => {
+    const projected = familiesToBim(buildStorey(), { project: PROJECT });
+    using model = unwrap(projected).model;
+    const spec = {
+      length: 100,
+      height: 100,
+      thickness: 10,
+      origin: [0, 0, 0] as [number, number, number],
+      axisX: [1, 0, 0] as [number, number, number],
+      axisZ: [0, 0, 1] as [number, number, number],
+      materialName: 'Concrete',
+    };
+    const dup = model.addWall(spec, { stableKey: 'storey-1/w1' });
+    expect(isOk(dup)).toBe(false);
+  });
+
   it('rejects unmapped element types with a Result error', () => {
     const Widget = family<{ readonly size: number }>('Widget', (p) =>
       el('Box', { size: [p.size, p.size, p.size] })

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -1,0 +1,111 @@
+/**
+ * families -> BimModel adapter — the identity gate end to end: two identical
+ * walls share one IR materialization upstream while the BIM model carries two
+ * elements with distinct, key-path-derived, reorder-stable GlobalIds and
+ * distinct pset-backed spec fields; IFC output is byte-identical across runs.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { csg, isOk, unwrap } from 'brepjs';
+import { family, el, resolve, evaluateModel, type Element } from 'brepjs-families';
+import { familiesToBim } from '../src/familiesAdapter.js';
+import { toIfc } from '../src/serialize/toIfc.js';
+import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+interface WallProps {
+  readonly length: number;
+  readonly height: number;
+  readonly thickness: number;
+  readonly psets?: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined;
+}
+
+const Wall = family<WallProps>('Wall', (p) =>
+  el('Box', { size: [p.length, p.thickness, p.height] })
+);
+
+const Storey = family<{ readonly walls: readonly Element[]; readonly elevation?: number }>(
+  'Storey',
+  (p) => el('Group', {}, p.walls)
+);
+
+const PROJECT = { name: 'Gate', projectId: 'gate-project' };
+
+function buildStorey(reordered = false): ReturnType<typeof resolve> {
+  const dims = { length: 3000, height: 2700, thickness: 200 };
+  const w1 = Wall({ key: 'w1', ...dims, psets: { Pset_WallCommon: { FireRating: '60' } } });
+  const w2 = Wall({ key: 'w2', ...dims, psets: { Pset_WallCommon: { FireRating: '90' } } });
+  return resolve(Storey({ key: 'storey-1', walls: reordered ? [w2, w1] : [w1, w2] }));
+}
+
+const META = { applicationName: 'gate-test', applicationVersion: '1' };
+
+/** Decode IFC bytes and drop the timestamped FILE_NAME header line so
+ *  byte-stability can be asserted on the model content. */
+async function ifcText(model: Parameters<typeof toIfc>[0]): Promise<string> {
+  const bytes = unwrap(await toIfc(model, META));
+  return new TextDecoder()
+    .decode(bytes)
+    .split('\n')
+    .filter((line) => !line.startsWith('FILE_NAME'))
+    .join('\n');
+}
+
+describe('familiesToBim', () => {
+  it('two identical walls: one IR materialization, two stable GlobalIds, stable IFC', async () => {
+    // One materialization upstream (IR side).
+    using ev = new csg.Evaluator();
+    const storey = buildStorey();
+    evaluateModel(storey, ev);
+    expect(ev.cacheStats().entries).toBe(1);
+
+    // Two identities on the BIM side, derived from key paths.
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    const ids = unwrap(projected).idByKeyPath;
+    expect(ids.has('storey-1/w1') && ids.has('storey-1/w2')).toBe(true);
+
+    const g1 = deriveIfcGuidSync('elem:gate-project:storey-1/w1');
+    const g2 = deriveIfcGuidSync('elem:gate-project:storey-1/w2');
+    expect(g1).not.toBe(g2);
+
+    const ifc = await ifcText(model);
+    expect(ifc).toContain(g1);
+    expect(ifc).toContain(g2);
+    // Distinct pset-backed fields survive into IFC.
+    expect(ifc).toContain('60');
+    expect(ifc).toContain('90');
+
+    // Content-identical across an independent rebuild from the same source.
+    const again = familiesToBim(buildStorey(), { project: PROJECT });
+    using model2 = unwrap(again).model;
+    expect(await ifcText(model2)).toBe(ifc);
+  });
+
+  it('GlobalIds are stable under sibling reordering (key-path identity)', async () => {
+    const a = familiesToBim(buildStorey(false), { project: PROJECT });
+    const b = familiesToBim(buildStorey(true), { project: PROJECT });
+    using modelA = unwrap(a).model;
+    using modelB = unwrap(b).model;
+    const g1 = deriveIfcGuidSync('elem:gate-project:storey-1/w1');
+    const ifcA = await ifcText(modelA);
+    const ifcB = await ifcText(modelB);
+    // The same wall keeps the same GlobalId regardless of insertion order.
+    expect(ifcA).toContain(g1);
+    expect(ifcB).toContain(g1);
+  });
+
+  it('rejects unmapped element types with a Result error', () => {
+    const Widget = family<{ readonly size: number }>('Widget', (p) =>
+      el('Box', { size: [p.size, p.size, p.size] })
+    );
+    const bad = resolve(Storey({ key: 's', walls: [Widget({ key: 'x', size: 10 })] }));
+    const r = familiesToBim(bad, { project: PROJECT });
+    expect(isOk(r)).toBe(false);
+  });
+});

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import { csg, isOk, unwrap } from 'brepjs';
-import { family, el, resolve, evaluateModel, type Element } from 'brepjs-families';
+import { family, el, resolve, evaluateModel, tTranslate, type Element } from 'brepjs-families';
 import { familiesToBim } from '../src/familiesAdapter.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
@@ -98,6 +98,37 @@ describe('familiesToBim', () => {
     // The same wall keeps the same GlobalId regardless of insertion order.
     expect(ifcA).toContain(g1);
     expect(ifcB).toContain(g1);
+  });
+
+  it('folds the transform chain into the IFC placement origin', async () => {
+    const Moved = family<WallProps & { readonly at: readonly [number, number, number] }>(
+      'Wall',
+      (p) =>
+        el('Box', {
+          size: [p.length, p.thickness, p.height],
+          transform: [tTranslate(p.at)],
+        })
+    );
+    const storey = resolve(
+      Storey({
+        key: 's',
+        walls: [
+          Moved({ key: 'w', length: 3000, height: 2700, thickness: 200, at: [1234, 0, 0] }),
+        ],
+      })
+    );
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    // The writer emits meters: 1234 mm arrives as a 1.234 placement point.
+    expect(await ifcText(model)).toContain('(1.234,0.,0.)');
+  });
+
+  it('rejects a wall without a storey ancestor', () => {
+    const orphan = resolve(
+      Wall({ key: 'lonely', length: 3000, height: 2700, thickness: 200 })
+    );
+    expect(isOk(familiesToBim(orphan, { project: PROJECT }))).toBe(false);
   });
 
   it('rejects unmapped element types with a Result error', () => {

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -32,6 +32,10 @@ export interface ResolvedElement {
    *  `${hostPath}/${propName}:${slotKey}`. */
   readonly keyPath: string;
   readonly geometry: csg.IRNode;
+  /** The element's own pre-desugared props (dimensions, placement, ...) — an
+   *  adapter feeds these into parametric spec paths (e.g. IFC) that cannot
+   *  recover parameters from baked geometry. */
+  readonly props: Readonly<Record<string, unknown>>;
   /** Identity-side data (psets, ...) — beside the geometry, never inside it. */
   readonly attributes: Readonly<Record<string, unknown>>;
   readonly relationships: readonly Relationship[];
@@ -128,6 +132,7 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
         type: 'Opening',
         keyPath: openingPath,
         geometry: fill.geometry,
+        props: {},
         attributes: {},
         relationships: [{ kind: 'Fills', target: fill.keyPath }],
         children: [fill],
@@ -186,6 +191,7 @@ function resolveAt(elem: Element, path: string): ResolvedElement {
     type: typeName,
     keyPath: path,
     geometry: d.geometry,
+    props: elem.props,
     attributes: identityAttributes(elem),
     relationships,
     children,


### PR DESCRIPTION
The keystone adapter: `familiesToBim` projects a resolved `brepjs-families` element tree into an eager `BimModel`, closing the identity loop the whole architecture was designed around.

## The identity model, end to end

- **One materialization, many identities.** Upstream, two identical walls share a single Evaluator cache entry (content addressing). Downstream, the BIM model carries two elements whose GlobalIds derive from **families key paths** via a new optional `stableKey` on `BimModel`'s element creation — `deriveIfcGuidSync('elem:{scope}:{keyPath}')`. Unlike the positional default (category + insertion order), key-path identity is **stable under sibling reordering**, which the tests pin by rebuilding with reversed wall order and asserting the same GlobalIds.
- **Dual geometry path respected.** Each element's PRE-DESUGARED props feed the parametric specs (`parseWallSpec`/`parseSlabSpec`), so IFC gets true `IfcExtrudedAreaSolid` parametrics — never baked IR geometry. To make that possible, `ResolvedElement` now carries the element's own `props` (an adapter cannot recover parameters from evaluated geometry); pset-shaped attributes (`Pset_WallCommon.IsExternal`/`FireRating`) map onto their spec fields.

## Gate test

`packages/brepjs-bim/tests/familiesAdapter.test.ts`: two identical walls -> one IR cache entry, two distinct reorder-stable GlobalIds present in the IFC output, distinct pset-backed fields, and **content-identical IFC across independent rebuilds** (timestamped header line excluded). Unmapped element types surface as `Result` errors.

## Scope

v1 maps Storey containers and Wall/Slab elements with site/building scaffolding and containment (`aggregate`/`placeIn`). Openings, fills, and IfcRelVoidsElement wiring follow with the opening writer. `brepjs-bim` gains a `brepjs-families` workspace dependency (surgical lockfile entry; local npm install remains blocked by an unrelated engines constraint).
