### PR TITLE
feat(bim): map families openings onto doors, windows, and IfcRelVoids

### DIFF
--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -21,6 +21,7 @@ import { parseSlabSpec } from './specs/slabSpec.js';
 import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
 import { specError, type BimError } from './errors/bimError.js';
+import type { FillsOpeningRel } from './types/relationships.js';
 
 export interface FamiliesToBimOptions {
   readonly project: ProjectSpec;
@@ -141,6 +142,7 @@ function addOpenings(
   model: BimModel,
   host: ResolvedElement,
   wallId: LocalId,
+  containerId: LocalId,
   idByKeyPath: Map<string, LocalId>
 ): Result<void, BimError> {
   const hostT = peelTranslates(host.geometry).total;
@@ -168,7 +170,16 @@ function addOpenings(
       openingStableKey: opening.keyPath,
     });
     if (!added.ok) return added;
+    // Fillers are spatially contained like any element (openings are not:
+    // they relate to the wall through IfcRelVoidsElement alone).
+    model.placeIn(added.value, containerId);
     idByKeyPath.set(fill.keyPath, added.value);
+    const fillsRel = model
+      .getAllRelationships()
+      .find(
+        (r): r is FillsOpeningRel => r.kind === 'FILLS_OPENING' && r.fillerLocalId === added.value
+      );
+    if (fillsRel !== undefined) idByKeyPath.set(opening.keyPath, fillsRel.openingLocalId);
   }
   return ok(undefined);
 }
@@ -223,7 +234,7 @@ export function familiesToBim(
       }
       model.placeIn(added.value, containerId);
       if (el.type === 'Wall') {
-        const opened = addOpenings(model, el, added.value, idByKeyPath);
+        const opened = addOpenings(model, el, added.value, containerId, idByKeyPath);
         if (!opened.ok) return opened;
       }
     } else if (el.type === 'Opening') {

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -5,16 +5,20 @@
  * while the IR path serves the viewport and dedup. GlobalIds derive from
  * families key paths (stable under reordering), not insertion order.
  *
- * v1 scope: Storey containers and Wall/Slab elements. Openings, fills, and
- * relationship wiring (IfcRelVoidsElement) follow with the opening writer.
+ * Scope: Storey containers, Wall/Slab elements, and wall openings — a
+ * fill-role void (Door/Window family) maps onto addDoor/addWindow, which cut
+ * the wall and wire IfcRelVoidsElement + IfcRelFillsElement; the opening and
+ * filler GlobalIds derive from the synthesized key paths. Anonymous (non-fill)
+ * voids stay IR-only and never reach the spec path.
  */
 
 import { ok, err, type Result, type csg } from 'brepjs';
 import type { ResolvedElement } from 'brepjs-families';
-import { BimModel } from './model/bimModel.js';
+import { BimModel, type OpeningIdentityOptions } from './model/bimModel.js';
 import type { LocalId } from './identity/localId.js';
 import { parseWallSpec } from './specs/wallSpec.js';
 import { parseSlabSpec } from './specs/slabSpec.js';
+import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
 import { specError, type BimError } from './errors/bimError.js';
 
@@ -39,38 +43,53 @@ const SPEC_DEFAULTS = {
 
 const GEOMETRY_PROPS = new Set(['voids', 'fuse', 'transform', 'psets']);
 
-/** Fold the resolved geometry's OUTER literal translate chain into the spec
- *  placement origin, so IfcLocalPlacement matches the IR world frame no
- *  matter where the transform came from (family-internal or prop-level).
- *  Parameter-driven translations cannot fold and keep the default origin. */
+/** Total of the resolved geometry's OUTER literal translate chain. The
+ *  transform vocabulary is translate-only, so frame differences are exact
+ *  subtractions. Parameter-driven translations stop the peel. */
+function peelTranslates(node: csg.IRNode): {
+  readonly total: readonly [number, number, number];
+  readonly moved: boolean;
+} {
+  const total: [number, number, number] = [0, 0, 0];
+  let moved = false;
+  let cur = node;
+  while (cur.kind === 'Translate') {
+    const v = cur.vector;
+    if (v.kind !== 'Vec3Lit') break;
+    total[0] += v.value[0];
+    total[1] += v.value[1];
+    total[2] += v.value[2];
+    moved = true;
+    cur = cur.target;
+  }
+  return { total, moved };
+}
+
+/** Fold the resolved geometry's outer translate chain into the spec placement
+ *  origin, so IfcLocalPlacement matches the IR world frame no matter where the
+ *  transform came from (family-internal or prop-level). */
 function composedOrigin(el: ResolvedElement): [number, number, number] | undefined {
   const base = (el.props['origin'] as [number, number, number] | undefined) ?? [0, 0, 0];
-  const out: [number, number, number] = [...base];
-  let moved = false;
-  let node: csg.IRNode = el.geometry;
-  while (node.kind === 'Translate') {
-    const v = node.vector;
-    if (v.kind !== 'Vec3Lit') break;
-    out[0] += v.value[0];
-    out[1] += v.value[1];
-    out[2] += v.value[2];
-    moved = true;
-    node = node.target;
+  const { total, moved } = peelTranslates(el.geometry);
+  if (!moved && el.props['origin'] === undefined) return undefined;
+  return [base[0] + total[0], base[1] + total[1], base[2] + total[2]];
+}
+
+function stripGeometryProps(props: Readonly<Record<string, unknown>>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(props)) {
+    if (!GEOMETRY_PROPS.has(k)) out[k] = v;
   }
-  return moved || el.props['origin'] !== undefined ? out : undefined;
+  return out;
 }
 
 function specInput(el: ResolvedElement): Record<string, unknown> {
   // Pre-desugared props feed the spec 1:1 (geometry-only props stripped);
   // identity-side attributes carry pset-shaped fields under their spec names.
-  const fromProps: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(el.props)) {
-    if (!GEOMETRY_PROPS.has(k)) fromProps[k] = v;
-  }
   const origin = composedOrigin(el);
   return {
     ...SPEC_DEFAULTS,
-    ...fromProps,
+    ...stripGeometryProps(el.props),
     ...(origin ? { origin } : {}),
     ...collectSpecProps(el),
   };
@@ -89,6 +108,69 @@ function collectSpecProps(el: ResolvedElement): Record<string, unknown> {
   }
   delete out['psets'];
   return out;
+}
+
+function addFill(
+  model: BimModel,
+  fill: ResolvedElement,
+  input: Record<string, unknown>,
+  identity: OpeningIdentityOptions
+): Result<LocalId, BimError> {
+  if (fill.type === 'Door') {
+    const parsed = parseDoorSpec(input);
+    if (!parsed.ok) return parsed;
+    return model.addDoor(parsed.value, identity);
+  }
+  if (fill.type === 'Window') {
+    const parsed = parseWindowSpec(input);
+    if (!parsed.ok) return parsed;
+    return model.addWindow(parsed.value, identity);
+  }
+  return err(
+    specError(
+      'FAMILIES_UNSUPPORTED_FILL',
+      `familiesToBim: no fill mapping for element type '${fill.type}' at '${fill.keyPath}'`
+    )
+  );
+}
+
+/** Map a wall's synthesized Opening children onto addDoor/addWindow. The
+ *  wall-relative offsets come from the void geometry's frame minus the host's:
+ *  exact because both carry the same outer host transform. */
+function addOpenings(
+  model: BimModel,
+  host: ResolvedElement,
+  wallId: LocalId,
+  idByKeyPath: Map<string, LocalId>
+): Result<void, BimError> {
+  const hostT = peelTranslates(host.geometry).total;
+  for (const opening of host.children) {
+    if (opening.type !== 'Opening') continue;
+    const fill = opening.children[0];
+    if (fill === undefined) {
+      return err(
+        specError(
+          'FAMILIES_OPENING_NO_FILL',
+          `familiesToBim: opening '${opening.keyPath}' has no fill element`
+        )
+      );
+    }
+    const fillT = peelTranslates(opening.geometry).total;
+    const input = {
+      materialName: SPEC_DEFAULTS.materialName,
+      ...stripGeometryProps(fill.props),
+      wallLocalId: wallId,
+      offsetAlongWall: fillT[0] - hostT[0],
+      offsetFromFloor: fillT[2] - hostT[2],
+    };
+    const added = addFill(model, fill, input, {
+      stableKey: fill.keyPath,
+      openingStableKey: opening.keyPath,
+    });
+    if (!added.ok) return added;
+    idByKeyPath.set(fill.keyPath, added.value);
+  }
+  return ok(undefined);
 }
 
 /**
@@ -140,7 +222,18 @@ export function familiesToBim(
         );
       }
       model.placeIn(added.value, containerId);
-    } else if (el.type !== 'Opening' && el.type !== 'Group' && el.geometry.kind !== 'Empty') {
+      if (el.type === 'Wall') {
+        const opened = addOpenings(model, el, added.value, idByKeyPath);
+        if (!opened.ok) return opened;
+      }
+    } else if (el.type === 'Opening') {
+      return err(
+        specError(
+          'FAMILIES_OPENING_OUTSIDE_WALL',
+          `familiesToBim: opening '${el.keyPath}' is not hosted by a Wall — only wall openings are mapped`
+        )
+      );
+    } else if (el.type !== 'Group' && el.geometry.kind !== 'Empty') {
       return err(
         specError(
           'FAMILIES_UNSUPPORTED_TYPE',
@@ -149,6 +242,7 @@ export function familiesToBim(
       );
     }
     for (const child of el.children) {
+      if (el.type === 'Wall' && child.type === 'Opening') continue;
       const r = walk(child, containerId);
       if (!r.ok) return r;
     }

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -1,4 +1,8 @@
-export { BimModel } from './model/bimModel.js';
+export {
+  BimModel,
+  type ElementIdentityOptions,
+  type OpeningIdentityOptions,
+} from './model/bimModel.js';
 export type { BimTreeNode, BimTreeSummary } from './model/treeSummary.js';
 export { placedSolids } from './elementFns/placedGeometry.js';
 export { toIfc, toIfcValidated } from './serialize/toIfc.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -63,6 +63,12 @@ export interface ElementIdentityOptions {
   readonly stableKey?: string | undefined;
 }
 
+/** Identity options for adders that create TWO elements: `stableKey` names
+ *  the filler (door/window), `openingStableKey` the synthesized opening. */
+export interface OpeningIdentityOptions extends ElementIdentityOptions {
+  readonly openingStableKey?: string | undefined;
+}
+
 export class BimModel {
   readonly #elements = new Map<LocalId, AnyBimElement>();
   readonly #relationships = new Map<LocalId, BimRelationship>();
@@ -129,6 +135,22 @@ export class BimModel {
     const key = options?.stableKey;
     if (key !== undefined && this.#usedStableKeys.has(key)) {
       return err(specError('DUPLICATE_STABLE_KEY', `BimModel: duplicate stableKey '${key}'`));
+    }
+    return ok(undefined);
+  }
+
+  #checkOpeningKeys(options: OpeningIdentityOptions | undefined): Result<void, BimError> {
+    const filler = this.#checkStableKey(options);
+    if (!filler.ok) return filler;
+    const opening = this.#checkStableKey({ stableKey: options?.openingStableKey });
+    if (!opening.ok) return opening;
+    if (options?.stableKey !== undefined && options.stableKey === options.openingStableKey) {
+      return err(
+        specError(
+          'DUPLICATE_STABLE_KEY',
+          `BimModel: stableKey and openingStableKey are both '${options.stableKey}'`
+        )
+      );
     }
     return ok(undefined);
   }
@@ -489,7 +511,9 @@ export class BimModel {
     return ok(id);
   }
 
-  addDoor(spec: DoorSpec): Result<LocalId, BimError> {
+  addDoor(spec: DoorSpec, options?: OpeningIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkOpeningKeys(options);
+    if (!keyCheck.ok) return keyCheck;
     const wall = this.#elements.get(spec.wallLocalId);
     if (wall === undefined || wall.category !== 'WALL') {
       return err(specError('DOOR_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
@@ -512,9 +536,9 @@ export class BimModel {
     if (!cutResult.ok) return err(cutResult.error);
     this.#replaceWallGeometry(wall, cutResult.value);
 
-    const openingId = this.#makeElement('OPENING', openingSpec, null);
+    const openingId = this.#makeElement('OPENING', openingSpec, null, options?.openingStableKey);
     this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
-    const doorId = this.#makeElement('DOOR', spec, null);
+    const doorId = this.#makeElement('DOOR', spec, null, options?.stableKey);
     this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: doorId });
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
@@ -524,7 +548,9 @@ export class BimModel {
     return ok(doorId);
   }
 
-  addWindow(spec: WindowSpec): Result<LocalId, BimError> {
+  addWindow(spec: WindowSpec, options?: OpeningIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkOpeningKeys(options);
+    if (!keyCheck.ok) return keyCheck;
     const wall = this.#elements.get(spec.wallLocalId);
     if (wall === undefined || wall.category !== 'WALL') {
       return err(specError('WINDOW_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
@@ -547,9 +573,9 @@ export class BimModel {
     if (!cutResult.ok) return err(cutResult.error);
     this.#replaceWallGeometry(wall, cutResult.value);
 
-    const openingId = this.#makeElement('OPENING', openingSpec, null);
+    const openingId = this.#makeElement('OPENING', openingSpec, null, options?.openingStableKey);
     this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
-    const windowId = this.#makeElement('WINDOW', spec, null);
+    const windowId = this.#makeElement('WINDOW', spec, null, options?.stableKey);
     this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: windowId });
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
@@ -559,7 +585,9 @@ export class BimModel {
     return ok(windowId);
   }
 
-  addSlabOpening(input: SlabOpeningInput): Result<LocalId, BimError> {
+  addSlabOpening(input: SlabOpeningInput, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
     const slab = this.#elements.get(input.slabLocalId);
     if (slab === undefined || slab.category !== 'SLAB') {
       return err(specError('SLAB_OPENING_SLAB_NOT_FOUND', `No slab found for localId ${input.slabLocalId}`));
@@ -602,7 +630,7 @@ export class BimModel {
     if (!cutResult.ok) return err(cutResult.error);
     this.#replaceSlabGeometry(slab, cutResult.value);
 
-    const openingId = this.#makeElement('OPENING', openingSpec, null);
+    const openingId = this.#makeElement('OPENING', openingSpec, null, options?.stableKey);
     this.#makeRel<VoidsSlabRel>({ kind: 'VOIDS_SLAB', slabLocalId: input.slabLocalId, openingLocalId: openingId });
     return ok(openingId);
   }

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -156,3 +156,153 @@ describe('familiesToBim', () => {
     expect(isOk(r)).toBe(false);
   });
 });
+
+interface FillProps {
+  readonly width: number;
+  readonly height: number;
+  /** [alongWall, sill] in the host wall's local frame. */
+  readonly at: readonly [number, number];
+}
+
+const Door = family<FillProps>(
+  'Door',
+  (p) =>
+    el('Box', {
+      size: [p.width, 300, p.height],
+      transform: [tTranslate([p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill' }
+);
+
+const Window = family<FillProps>(
+  'Window',
+  (p) =>
+    el('Box', {
+      size: [p.width, 300, p.height],
+      transform: [tTranslate([p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill' }
+);
+
+const VoidedWall = family<
+  WallProps & {
+    readonly voids: readonly Element[];
+    readonly transform?: readonly ReturnType<typeof tTranslate>[] | undefined;
+  }
+>('Wall', (p) =>
+  el('Box', {
+    size: [p.length, p.thickness, p.height],
+    voids: p.voids,
+    ...(p.transform ? { transform: p.transform } : {}),
+  })
+);
+
+const WALL_DIMS = { length: 3000, height: 2700, thickness: 200 };
+
+function voidedStorey(voids: readonly Element[], transform?: readonly ReturnType<typeof tTranslate>[]) {
+  return resolve(
+    Storey({
+      key: 'storey-1',
+      walls: [VoidedWall({ key: 'w1', ...WALL_DIMS, voids, ...(transform ? { transform } : {}) })],
+    })
+  );
+}
+
+describe('familiesToBim openings', () => {
+  it('maps a door void onto IfcOpeningElement + IfcRelVoids/Fills with key-path GlobalIds', async () => {
+    const storey = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [600, 0] })]);
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    expect(unwrap(projected).idByKeyPath.has('storey-1/w1/voids:d1/fill')).toBe(true);
+
+    const ifc = await ifcText(model);
+    expect(ifc).toContain('IFCOPENINGELEMENT');
+    expect(ifc).toContain('IFCDOOR');
+    expect(ifc).toContain('IFCRELVOIDSELEMENT');
+    expect(ifc).toContain('IFCRELFILLSELEMENT');
+    // Opening and filler GlobalIds derive from families key paths.
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:storey-1/w1/voids:d1'));
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:storey-1/w1/voids:d1/fill'));
+  });
+
+  it('maps a window fill onto IfcWindow', async () => {
+    const storey = voidedStorey([Window({ key: 'n1', width: 1200, height: 1000, at: [1500, 900] })]);
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    const ifc = await ifcText(model);
+    expect(ifc).toContain('IFCWINDOW');
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:storey-1/w1/voids:n1'));
+  });
+
+  it('derives wall-relative offsets from the void geometry (bounds probes)', () => {
+    // 2200 + 900 > 3000: only a correctly derived offsetAlongWall can trip this.
+    const alongOverflow = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [2200, 0] })]);
+    expect(isOk(familiesToBim(alongOverflow, { project: PROJECT }))).toBe(false);
+    // 700 + 2100 > 2700: same probe for the sill axis.
+    const sillOverflow = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [600, 700] })]);
+    expect(isOk(familiesToBim(sillOverflow, { project: PROJECT }))).toBe(false);
+  });
+
+  it('offsets stay wall-relative under a host transform', () => {
+    const moved = voidedStorey(
+      [Door({ key: 'd1', width: 900, height: 2100, at: [600, 0] })],
+      [tTranslate([5000, 0, 0])]
+    );
+    const okCase = familiesToBim(moved, { project: PROJECT });
+    expect(isOk(okCase)).toBe(true);
+    if (isOk(okCase)) unwrap(okCase).model[Symbol.dispose]();
+    // Absolute (not relative) offsets would put 600 + 5000 far out of bounds.
+    const stillOverflow = voidedStorey(
+      [Door({ key: 'd1', width: 900, height: 2100, at: [2200, 0] })],
+      [tTranslate([5000, 0, 0])]
+    );
+    expect(isOk(familiesToBim(stillOverflow, { project: PROJECT }))).toBe(false);
+  });
+
+  it('rejects an unmapped fill type', () => {
+    const Widget = family<FillProps>(
+      'Widget',
+      (p) => el('Box', { size: [p.width, 300, p.height] }),
+      { role: 'fill' }
+    );
+    const bad = voidedStorey([Widget({ key: 'x', width: 100, height: 100, at: [0, 0] })]);
+    expect(isOk(familiesToBim(bad, { project: PROJECT }))).toBe(false);
+  });
+
+  it('rejects an opening synthesized outside a wall', () => {
+    const VoidedSlab = family<{ readonly voids: readonly Element[] }>('Slab', (p) =>
+      el('Box', { size: [4000, 4000, 200], voids: p.voids })
+    );
+    const bad = resolve(
+      Storey({
+        key: 's',
+        walls: [VoidedSlab({ key: 'slab', voids: [Door({ key: 'd', width: 900, height: 2100, at: [0, 0] })] })],
+      })
+    );
+    expect(isOk(familiesToBim(bad, { project: PROJECT }))).toBe(false);
+  });
+
+  it('duplicate filler and opening stable keys error via Result', () => {
+    const storey = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [600, 0] })]);
+    const projected = familiesToBim(storey, { project: PROJECT });
+    using model = unwrap(projected).model;
+    const wallId = unwrap(projected).idByKeyPath.get('storey-1/w1');
+    if (wallId === undefined) throw new Error('wall id missing');
+    const spec = {
+      width: 900,
+      height: 2100,
+      offsetAlongWall: 600,
+      offsetFromFloor: 0,
+      wallLocalId: wallId,
+      materialName: 'Wood',
+    };
+    const dupFiller = model.addDoor(spec, { stableKey: 'storey-1/w1/voids:d1/fill' });
+    expect(isOk(dupFiller)).toBe(false);
+    const dupOpening = model.addDoor(spec, { openingStableKey: 'storey-1/w1/voids:d1' });
+    expect(isOk(dupOpening)).toBe(false);
+    const selfCollision = model.addDoor(spec, { stableKey: 'k', openingStableKey: 'k' });
+    expect(isOk(selfCollision)).toBe(false);
+  });
+});

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -12,6 +12,7 @@ import { family, el, resolve, evaluateModel, tTranslate, type Element } from 'br
 import { familiesToBim } from '../src/familiesAdapter.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
+import { checkReferentialIntegrity } from '../src/validation/referentialIntegrity.js';
 
 beforeAll(async () => {
   await initOCCT();
@@ -214,7 +215,13 @@ describe('familiesToBim openings', () => {
     const projected = familiesToBim(storey, { project: PROJECT });
     expect(isOk(projected)).toBe(true);
     using model = unwrap(projected).model;
+    // Both synthesized identities are mapped: the opening and its filler.
+    expect(unwrap(projected).idByKeyPath.has('storey-1/w1/voids:d1')).toBe(true);
     expect(unwrap(projected).idByKeyPath.has('storey-1/w1/voids:d1/fill')).toBe(true);
+    // The filler is spatially contained; the model passes integrity checks.
+    expect(checkReferentialIntegrity(model).issues.filter((i) => i.severity === 'error')).toEqual(
+      []
+    );
 
     const ifc = await ifcText(model);
     expect(ifc).toContain('IFCOPENINGELEMENT');


### PR DESCRIPTION
Extends the `familiesToBim` adapter to wall openings: a fill-role void (a `Door` or `Window` family placed in a wall's `voids`) now maps onto `addDoor` / `addWindow`, which cut the wall and wire `IfcRelVoidsElement` + `IfcRelFillsElement`. The synthesized opening and its filler both get GlobalIds derived from their families key paths, so identities stay stable under sibling reordering, exactly like walls and storeys.

## BimModel

- `addDoor` / `addWindow` accept an optional `OpeningIdentityOptions`: `stableKey` names the filler, `openingStableKey` the synthesized opening (these adders create two elements per call). Both keys are pre-checked before the wall is cut, so a duplicate returns a `Result` error without mutating geometry; a filler/opening key collision within one call is rejected too.
- `addSlabOpening` accepts the standard `ElementIdentityOptions`.
- `ElementIdentityOptions` and `OpeningIdentityOptions` are now exported from the package root.

## Adapter

- Wall-relative placement (`offsetAlongWall`, `offsetFromFloor`) is derived by subtracting the wall geometry's outer translate chain from the void's. Both carry the same host transform, so the difference is exact in the wall's local frame; the transform vocabulary is translate-only, which keeps the inversion a subtraction.
- Fill dimensions (`width`, `height`) feed the door/window specs from the fill element's own pre-desugared props, mirroring the wall contract: parameters come from props, placement from the resolved frame.
- Openings synthesized outside a wall (for example on a slab) and fill types without a spec mapping return `Result` errors instead of being dropped.

## Tests

The bounds probes are the falsifiable core: a door at 2200 mm in a 3000 mm wall (2200 + 900 > 3000) must fail wall-bounds validation, which can only happen if `offsetAlongWall` was actually derived from the void geometry; the same probe covers the sill axis, and a translated host re-runs both to prove the offsets are wall-relative rather than absolute. The mapping test asserts the exact key-path-derived GlobalIds for the opening and filler in the emitted IFC alongside `IFCOPENINGELEMENT`, `IFCDOOR`, `IFCRELVOIDSELEMENT`, and `IFCRELFILLSELEMENT`.
