### PR TITLE
feat(families): make meshes the primary evaluateModel output

### DIFF
--- a/packages/brepjs-families/src/evaluateModel.ts
+++ b/packages/brepjs-families/src/evaluateModel.ts
@@ -1,10 +1,14 @@
 /**
- * Model evaluation: one `evaluate()` per element, keyed by path. Identity
- * (keyPath, attributes, relationships) rides on the record beside the
- * geometry Result; identical recipes share one materialization underneath.
+ * Model evaluation: one record per element, keyed by path. Identity (keyPath,
+ * attributes, relationships) rides on the record beside the geometry;
+ * identical recipes share one materialization underneath.
+ *
+ * Meshes are the primary output: plain data with no kernel lifetimes, cached
+ * by content so re-evaluation after shape-cache eviction is a pure data hit.
+ * B-rep shape handles are opt-in (`shapes: true`) for export paths.
  */
 
-import type { csg, Result, AnyShape, Dimension } from 'brepjs';
+import type { csg, Result, AnyShape, Dimension, ShapeMesh, MeshOptions } from 'brepjs';
 import type { Relationship, ResolvedElement } from './resolve.js';
 
 export interface EvaluatedNode {
@@ -12,8 +16,18 @@ export interface EvaluatedNode {
   readonly type: string;
   readonly attributes: Readonly<Record<string, unknown>>;
   readonly relationships: readonly Relationship[];
-  /** Borrowed from the Evaluator — do not dispose; valid per its contract. */
-  readonly result: Result<AnyShape<Dimension>>;
+  /** Borrowed from the Evaluator's mesh cache — do not mutate. */
+  readonly mesh: Result<ShapeMesh>;
+  /** Present only with `shapes: true`. Borrowed from the Evaluator — do not
+   *  dispose; valid per its cache contract. */
+  readonly shape?: Result<AnyShape<Dimension>> | undefined;
+}
+
+export interface EvaluateModelOptions {
+  /** Also materialize a B-rep handle per element (export paths). Off by
+   *  default so viewport consumers never pin kernel lifetimes. */
+  readonly shapes?: boolean | undefined;
+  readonly mesh?: MeshOptions | undefined;
 }
 
 export interface EvaluatedModel {
@@ -26,7 +40,8 @@ export interface EvaluatedModel {
 export function evaluateModel(
   root: ResolvedElement,
   evaluator: csg.Evaluator,
-  env: csg.Env = {}
+  env: csg.Env = {},
+  options: EvaluateModelOptions = {}
 ): EvaluatedModel {
   const byKeyPath = new Map<string, EvaluatedNode>();
   const walk = (n: ResolvedElement): void => {
@@ -37,7 +52,8 @@ export function evaluateModel(
         type: n.type,
         attributes: n.attributes,
         relationships: n.relationships,
-        result: evaluator.evaluate(n.geometry, env),
+        mesh: evaluator.evaluateMesh(n.geometry, env, { ...options.mesh }),
+        ...(options.shapes ? { shape: evaluator.evaluate(n.geometry, env) } : {}),
       });
     }
     for (const c of n.children) walk(c);

--- a/packages/brepjs-families/src/index.ts
+++ b/packages/brepjs-families/src/index.ts
@@ -21,4 +21,9 @@ export {
   type Relationship,
   type ResolvedElement,
 } from './resolve.js';
-export { evaluateModel, type EvaluatedModel, type EvaluatedNode } from './evaluateModel.js';
+export {
+  evaluateModel,
+  type EvaluatedModel,
+  type EvaluatedNode,
+  type EvaluateModelOptions,
+} from './evaluateModel.js';

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -228,15 +228,15 @@ describe('identity beside content addressing (Phase 3 gate)', () => {
         ],
       })
     );
-    const model = evaluateModel(storey, ev);
+    const model = evaluateModel(storey, ev, {}, { shapes: true });
     const n1 = model.byKeyPath.get('storey-1/w1');
     const n2 = model.byKeyPath.get('storey-1/w2');
     expect(n1 && n2).toBeTruthy();
     if (!n1 || !n2) return;
-    // One materialized solid under two identities.
-    expect(isOk(n1.result) && isOk(n2.result)).toBe(true);
-    if (isOk(n1.result) && isOk(n2.result)) {
-      expect(n1.result.value).toBe(n2.result.value);
+    // One materialized solid under two identities (shapes opted in).
+    expect(n1.shape && isOk(n1.shape) && n2.shape && isOk(n2.shape)).toBe(true);
+    if (n1.shape && isOk(n1.shape) && n2.shape && isOk(n2.shape)) {
+      expect(n1.shape.value).toBe(n2.shape.value);
     }
     expect(ev.cacheStats().entries).toBe(1);
     // Distinct identity records beside the shared geometry.
@@ -245,5 +245,71 @@ describe('identity beside content addressing (Phase 3 gate)', () => {
     expect(n2.attributes['psets']).toEqual({ Pset_WallCommon: { FireRating: '90' } });
     // Containers are identity-only: no geometry entry for the storey.
     expect(model.byKeyPath.has('storey-1')).toBe(false);
+  });
+});
+
+describe('mesh-primary evaluation (Phase 5 gate)', () => {
+  const dims = { length: 400, height: 270, thickness: 20 };
+
+  function threeWalls(w1Length: number): ResolvedElement {
+    return resolve(
+      Storey({
+        key: 's',
+        walls: [
+          Wall({ key: 'w1', ...dims, length: w1Length }),
+          Wall({ key: 'w2', ...dims }),
+          Wall({ key: 'w3', ...dims }),
+        ],
+      })
+    );
+  }
+
+  it('meshes are the primary output; identical recipes share one tessellation', () => {
+    using ev = new csg.Evaluator();
+    const model = evaluateModel(threeWalls(500), ev);
+    const n2 = model.byKeyPath.get('s/w2');
+    const n3 = model.byKeyPath.get('s/w3');
+    expect(n2 && n3).toBeTruthy();
+    if (!n2 || !n3) return;
+    expect(isOk(n2.mesh)).toBe(true);
+    if (isOk(n2.mesh)) {
+      expect(n2.mesh.value.vertices.length).toBeGreaterThan(0);
+      expect(n2.mesh.value.triangles.length).toBeGreaterThan(0);
+    }
+    // One tessellation under two identities, straight from the mesh cache.
+    if (isOk(n2.mesh) && isOk(n3.mesh)) expect(n2.mesh.value).toBe(n3.mesh.value);
+    // Shapes are strictly opt-in.
+    expect(n2.shape).toBeUndefined();
+  });
+
+  it('a prop edit re-meshes only the edited element', () => {
+    using ev = new csg.Evaluator();
+    const before = evaluateModel(threeWalls(500), ev);
+    const after = evaluateModel(threeWalls(600), ev);
+    const pick = (m: typeof before, k: string) => {
+      const n = m.byKeyPath.get(k);
+      if (!n || !isOk(n.mesh)) throw new Error(`no mesh for ${k}`);
+      return n.mesh.value;
+    };
+    // Unchanged siblings are pure mesh-cache hits (same object).
+    expect(pick(after, 's/w2')).toBe(pick(before, 's/w2'));
+    expect(pick(after, 's/w3')).toBe(pick(before, 's/w3'));
+    expect(pick(after, 's/w1')).not.toBe(pick(before, 's/w1'));
+  });
+
+  it('meshes survive shape-cache eviction as pure data hits', () => {
+    using ev = new csg.Evaluator({ maxCacheEntries: 1 });
+    const storey = threeWalls(500);
+    const first = evaluateModel(storey, ev);
+    // Evict every wall shape by materializing an unrelated node.
+    ev.evaluate(csg.box(5, 6, 7));
+    const missesBefore = ev.cacheStats().misses;
+    const again = evaluateModel(storey, ev);
+    const n1a = first.byKeyPath.get('s/w1');
+    const n1b = again.byKeyPath.get('s/w1');
+    if (!n1a || !isOk(n1a.mesh) || !n1b || !isOk(n1b.mesh)) throw new Error('mesh missing');
+    expect(n1b.mesh.value).toBe(n1a.mesh.value);
+    // No shape was re-materialized to serve the cached meshes.
+    expect(ev.cacheStats().misses).toBe(missesBefore);
   });
 });


### PR DESCRIPTION
Makes meshes the primary output of `evaluateModel`. Each `EvaluatedNode` now carries `mesh: Result<ShapeMesh>` (plain data, no kernel lifetimes, borrowed from the Evaluator's content-addressed mesh cache) instead of a bare shape Result. B-rep handles become opt-in via `EvaluateModelOptions.shapes` for export paths, so viewport consumers never pin kernel lifetimes.

Because the mesh cache is keyed by content and independent of the shape cache, a re-evaluation after shape-cache eviction is a pure data hit: no shape re-materialization, no re-tessellation. That is the property the new gate tests pin down:

- identical wall recipes share one tessellation object under two identities
- a prop edit re-meshes only the edited element; unchanged siblings return the same mesh object
- with `maxCacheEntries: 1` and a forced eviction, re-evaluating the model returns the original mesh objects with zero new shape-cache misses

The existing identity gate keeps its shared-handle assertion through the `shapes: true` opt-in. `EvaluateModelOptions` (with a `mesh: MeshOptions` passthrough for tessellation tolerances) is exported from the package root.
