### PR TITLE
fix(2d): transform trimmed arcs exactly in mirrors and rotations

### DIFF
--- a/src/2d/lib/approximations.ts
+++ b/src/2d/lib/approximations.ts
@@ -87,7 +87,10 @@ export function approximateAsSvgCompatibleCurve(
       curveType === 'ELLIPSE' ||
       (curveType === 'CIRCLE' && samePoint(curve.firstPoint, curve.lastPoint))
     ) {
-      return curve.splitAt([0.5]);
+      // splitAt takes RAW parameters: a full conic spans [0, 2*PI], so the
+      // literal 0.5 split a closed circle into a 0.5 rad sliver and a 5.78
+      // rad remainder instead of two halves.
+      return curve.splitAt([(curve.firstParameter + curve.lastParameter) / 2]);
     }
 
     if (['LINE', 'ELLIPSE', 'CIRCLE'].includes(curveType)) {

--- a/src/2d/lib/svgPath.ts
+++ b/src/2d/lib/svgPath.ts
@@ -3,6 +3,8 @@ import { bug } from '@/core/errors.js';
 import { getKernel2D } from '@/kernel/index.js';
 import { round2, round5 } from '@/utils/precisionRound.js';
 import { wasmIndex } from '@/utils/vec3.js';
+import { samePoint } from './vectorOperations.js';
+import { PRECISION_POINT } from './precision.js';
 import type { Point2D } from './definitions.js';
 import type { Curve2D } from './curve2D.js';
 
@@ -37,7 +39,7 @@ function circleArcPathElem(curve: Curve2D, endX: number, endY: number, endpoint:
 
   const [startX, startY] = curve.firstPoint;
   // A closed loop cannot be a single A command; nudge the endpoint.
-  if (Math.abs(endX - startX) < 1e-9 && Math.abs(endY - startY) < 1e-9) {
+  if (samePoint([startX, startY], [endX, endY])) {
     return `A ${radius} ${radius} 0 1 ${isDirect ? '1' : '0'} ${round5(endX)} ${round5(
       endY + 0.0001
     )}`;
@@ -45,8 +47,10 @@ function circleArcPathElem(curve: Curve2D, endX: number, endY: number, endpoint:
 
   const bounds = k2d.getCurve2dBounds(curve.wrapped);
   const [midX, midY] = curve.value((bounds.first + bounds.last) / 2);
+  // |d| is 2x the triangle area: below chord * PRECISION_POINT, the midpoint
+  // deviates from the chord by less than the point tolerance — degenerate.
   const d = 2 * (startX * (midY - endY) + midX * (endY - startY) + endX * (startY - midY));
-  if (Math.abs(d) < 1e-12) {
+  if (Math.abs(d) < Math.hypot(endX - startX, endY - startY) * PRECISION_POINT) {
     return `L ${endpoint}`;
   }
   const s2 = startX * startX + startY * startY;

--- a/src/2d/lib/svgPath.ts
+++ b/src/2d/lib/svgPath.ts
@@ -17,6 +17,54 @@ import type { Curve2D } from './curve2D.js';
  * @param lastPoint - The endpoint of the curve, used as the SVG command target.
  * @returns An SVG path command such as `L`, `Q`, `C`, or `A`.
  */
+/** Positive CCW angular distance from `from` to `to`. */
+const ccwFrom = (from: number, to: number): number => {
+  let a = (to - from) % (2 * Math.PI);
+  if (a < 0) a += 2 * Math.PI;
+  return a;
+};
+
+/** Emit an `A` command for a circular arc, deriving the large-arc and sweep
+ *  flags from geometry: trimmed-curve bounds may be normalized rather than
+ *  angular, so the on-arc midpoint (the parameter midpoint IS the angular
+ *  midpoint on a circle) decides the traversal direction and which of the
+ *  two candidate arcs this is. */
+function circleArcPathElem(curve: Curve2D, endX: number, endY: number, endpoint: string): string {
+  const k2d = getKernel2D();
+  const circleData = k2d.getCurve2dCircleData(curve.wrapped);
+  if (!circleData) bug('adaptedCurveToPathElem', 'Expected circle data');
+  const { radius, isDirect } = circleData;
+
+  const [startX, startY] = curve.firstPoint;
+  // A closed loop cannot be a single A command; nudge the endpoint.
+  if (Math.abs(endX - startX) < 1e-9 && Math.abs(endY - startY) < 1e-9) {
+    return `A ${radius} ${radius} 0 1 ${isDirect ? '1' : '0'} ${round5(endX)} ${round5(
+      endY + 0.0001
+    )}`;
+  }
+
+  const bounds = k2d.getCurve2dBounds(curve.wrapped);
+  const [midX, midY] = curve.value((bounds.first + bounds.last) / 2);
+  const d = 2 * (startX * (midY - endY) + midX * (endY - startY) + endX * (startY - midY));
+  if (Math.abs(d) < 1e-12) {
+    return `L ${endpoint}`;
+  }
+  const s2 = startX * startX + startY * startY;
+  const m2 = midX * midX + midY * midY;
+  const e2 = endX * endX + endY * endY;
+  const cx = (s2 * (midY - endY) + m2 * (endY - startY) + e2 * (startY - midY)) / d;
+  const cy = (s2 * (endX - midX) + m2 * (startX - endX) + e2 * (midX - startX)) / d;
+  const thetaS = Math.atan2(startY - cy, startX - cx);
+  const thetaM = Math.atan2(midY - cy, midX - cx);
+  const thetaE = Math.atan2(endY - cy, endX - cx);
+  const goesCcw = ccwFrom(thetaS, thetaM) <= ccwFrom(thetaS, thetaE);
+  const sweepAngle = goesCcw ? ccwFrom(thetaS, thetaE) : ccwFrom(thetaE, thetaS);
+
+  return `A ${radius} ${radius} 0 ${sweepAngle > Math.PI ? '1' : '0'} ${
+    goesCcw ? '1' : '0'
+  } ${endpoint}`;
+}
+
 export const adaptedCurveToPathElem = (curve: Curve2D, lastPoint: Point2D): string => {
   const k2d = getKernel2D();
   const curveType = curve.geomType;
@@ -47,18 +95,7 @@ export const adaptedCurveToPathElem = (curve: Curve2D, lastPoint: Point2D): stri
     }
   }
   if (curveType === 'CIRCLE') {
-    const circleData = k2d.getCurve2dCircleData(curve.wrapped);
-    if (!circleData) bug('adaptedCurveToPathElem', 'Expected circle data');
-    const { radius, isDirect } = circleData;
-
-    const bounds = k2d.getCurve2dBounds(curve.wrapped);
-    const paramAngle = (bounds.last - bounds.first) * RAD2DEG;
-
-    const end = paramAngle !== 360 ? endpoint : `${round5(endX)} ${round5(endY + 0.0001)}`;
-
-    return `A ${radius} ${radius} 0 ${Math.abs(paramAngle) > 180 ? '1' : '0'} ${
-      isDirect ? '1' : '0'
-    } ${end}`;
+    return circleArcPathElem(curve, endX, endY, endpoint);
   }
 
   if (curveType === 'ELLIPSE') {

--- a/src/kernel/geometry2d.ts
+++ b/src/kernel/geometry2d.ts
@@ -389,8 +389,18 @@ export function rotateCurve2d(c: Curve2dObj, angle: number, cx: number, cy: numb
       return { ...c, poles: c.poles.map(([x, y]) => rotatePoint(x, y)) };
     case 'bspline':
       return { ...c, poles: c.poles.map(([x, y]) => rotatePoint(x, y)) };
-    case 'trimmed':
-      return { ...c, basis: rotateCurve2d(c.basis, angle, cx, cy) };
+    case 'trimmed': {
+      const basis = rotateCurve2d(c.basis, angle, cx, cy);
+      // A circle carries no frame angle, so its rotation must land in the
+      // trim range: parameter IS the geometric angle (negated when
+      // sense=false). Without this shift, rotating an arc about its own
+      // circle center was a silent no-op.
+      if (basis.__bk2d === 'circle') {
+        const shift = basis.sense ? angle : -angle;
+        return { ...c, basis, tStart: c.tStart + shift, tEnd: c.tEnd + shift };
+      }
+      return { ...c, basis };
+    }
   }
 }
 
@@ -446,7 +456,11 @@ export function scaleCurve2d(c: Curve2dObj, factor: number, cx: number, cy: numb
 }
 
 export function mirrorAtPoint(c: Curve2dObj, cx: number, cy: number): Curve2dObj {
-  return scaleCurve2d(c, -1, cx, cy);
+  // A point mirror IS a half-turn. Routing through rotate keeps every curve
+  // type's parameterization exact: scale(-1) reflected conic centers but left
+  // their angular parameterization behind, so trimmed-arc endpoints came back
+  // point-reflected through the center.
+  return rotateCurve2d(c, Math.PI, cx, cy);
 }
 
 export function mirrorAcrossAxis(
@@ -457,6 +471,7 @@ export function mirrorAcrossAxis(
   dy: number
 ): Curve2dObj {
   const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 1e-15) return c;
   const nx = dx / len;
   const ny = dy / len;
 
@@ -493,8 +508,19 @@ export function mirrorAcrossAxis(
       return { ...c, poles: c.poles.map(([x, y]) => reflectPoint(x, y)) };
     case 'bspline':
       return { ...c, poles: c.poles.map(([x, y]) => reflectPoint(x, y)) };
-    case 'trimmed':
-      return { ...c, basis: mirrorAcrossAxis(c.basis, ox, oy, dx, dy) };
+    case 'trimmed': {
+      const basis = mirrorAcrossAxis(c.basis, ox, oy, dx, dy);
+      // Reflection maps a circle's geometric angle theta to 2*phi - theta
+      // (phi = axis angle). The sense flip on the basis absorbs the negation;
+      // the 2*phi rotation has nowhere to live on a frameless circle, so it
+      // lands in the trim range (sign follows the ORIGINAL sense).
+      if (c.basis.__bk2d === 'circle' && basis.__bk2d === 'circle') {
+        const phi = Math.atan2(ny, nx);
+        const shift = c.basis.sense ? -2 * phi : 2 * phi;
+        return { ...c, basis, tStart: c.tStart + shift, tEnd: c.tEnd + shift };
+      }
+      return { ...c, basis };
+    }
   }
 }
 

--- a/src/kernel/occtWasm/kernel2dOps.ts
+++ b/src/kernel/occtWasm/kernel2dOps.ts
@@ -485,7 +485,16 @@ export function transformCurve2dGeneral(curve: Curve2dHandle, gtrsf: KernelType)
     return scaleCurve2d(curve, Number(t['sx']) || 1, Number(t['cx']) || 0, Number(t['cy']) || 0);
   }
   if (t['type'] === 'mirror2d') {
-    return mirrorCurve2dAtPoint(curve, Number(t['ox']) || 0, Number(t['oy']) || 0);
+    if (t['mode'] === 'axis') {
+      return mirrorCurve2dAcrossAxis(
+        curve,
+        Number(t['originX']) || 0,
+        Number(t['originY']) || 0,
+        Number(t['dirX']) || 0,
+        Number(t['dirY']) || 0
+      );
+    }
+    return mirrorCurve2dAtPoint(curve, Number(t['cx']) || 0, Number(t['cy']) || 0);
   }
   if (t['type'] === 'affinity2d') {
     return affinityCurve2d(

--- a/tests/geometry2dTransforms.test.ts
+++ b/tests/geometry2dTransforms.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure-TS geometry2d transform contract: transforming a curve must commute
+ * with evaluation — evaluate(T(c), t) === T(evaluate(c, t)) for every t in
+ * the parameter range. Trimmed circles are the hard case: the circle model
+ * carries no frame angle, so rotations and mirrors must land in the trim
+ * range instead of being silently dropped (the toSVGPathD reversed-arc bug).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateCurve2d,
+  makeCircle2d,
+  makeEllipse2d,
+  makeLine2d,
+  mirrorAtPoint,
+  mirrorAcrossAxis,
+  rotateCurve2d,
+  type Curve2dObj,
+} from '@/kernel/geometry2d.js';
+
+type Pt = [number, number];
+
+function trimmed(basis: Curve2dObj, tStart: number, tEnd: number): Curve2dObj {
+  return { __bk2d: 'trimmed', basis, tStart, tEnd };
+}
+
+const SAMPLES = [0, 0.2, 0.5, 0.8, 1];
+
+function expectCommutes(
+  c: Curve2dObj,
+  transform: (c: Curve2dObj) => Curve2dObj,
+  mapPoint: (p: Pt) => Pt
+): void {
+  const tc = transform(c);
+  for (const t of SAMPLES) {
+    const [ex, ey] = mapPoint(evaluateCurve2d(c, t));
+    const [ax, ay] = evaluateCurve2d(tc, t);
+    expect(ax, `x at t=${t}`).toBeCloseTo(ex, 9);
+    expect(ay, `y at t=${t}`).toBeCloseTo(ey, 9);
+  }
+}
+
+const rotatePt =
+  (angle: number, cx: number, cy: number) =>
+  ([x, y]: Pt): Pt => {
+    const c = Math.cos(angle);
+    const s = Math.sin(angle);
+    return [cx + (x - cx) * c - (y - cy) * s, cy + (x - cx) * s + (y - cy) * c];
+  };
+
+const reflectPt =
+  (ox: number, oy: number, dx: number, dy: number) =>
+  ([x, y]: Pt): Pt => {
+    const len = Math.hypot(dx, dy);
+    const nx = dx / len;
+    const ny = dy / len;
+    const rx = x - ox;
+    const ry = y - oy;
+    const dot = rx * nx + ry * ny;
+    return [ox + 2 * dot * nx - rx, oy + 2 * dot * ny - ry];
+  };
+
+const pointReflect =
+  (cx: number, cy: number) =>
+  ([x, y]: Pt): Pt => [2 * cx - x, 2 * cy - y];
+
+describe('rotateCurve2d', () => {
+  it('rotates a trimmed circle arc about the circle center (not a no-op)', () => {
+    const arc = trimmed(makeCircle2d(10, 5, 3), 0.3, 1.4);
+    expectCommutes(arc, (c) => rotateCurve2d(c, Math.PI / 2, 10, 5), rotatePt(Math.PI / 2, 10, 5));
+  });
+
+  it('rotates a trimmed circle arc about an external point', () => {
+    const arc = trimmed(makeCircle2d(-4, 2, 5), -0.5, 2.0);
+    expectCommutes(arc, (c) => rotateCurve2d(c, 1.1, 7, -3), rotatePt(1.1, 7, -3));
+  });
+
+  it('rotates a clockwise (sense=false) trimmed circle arc', () => {
+    const arc = trimmed(makeCircle2d(0, 0, 2, false), 0.2, 1.0);
+    expectCommutes(arc, (c) => rotateCurve2d(c, 0.7, 1, 1), rotatePt(0.7, 1, 1));
+  });
+});
+
+describe('mirrorAtPoint', () => {
+  it('point-mirrors a trimmed circle arc exactly', () => {
+    const arc = trimmed(makeCircle2d(-15, -10, 5), 0, 1);
+    expectCommutes(arc, (c) => mirrorAtPoint(c, 0, 0), pointReflect(0, 0));
+  });
+
+  it('point-mirrors a trimmed ellipse arc exactly', () => {
+    const arc = trimmed(makeEllipse2d(3, 2, 6, 2, 0.4), 0.1, 1.3);
+    expectCommutes(arc, (c) => mirrorAtPoint(c, 1, -2), pointReflect(1, -2));
+  });
+
+  it('point-mirrors a line exactly', () => {
+    const line = makeLine2d(1, 1, 5, 3);
+    expectCommutes(line, (c) => mirrorAtPoint(c, 2, 2), pointReflect(2, 2));
+  });
+});
+
+describe('mirrorAcrossAxis', () => {
+  it('mirrors a trimmed circle arc across the x-axis (the SVG y-flip)', () => {
+    const arc = trimmed(makeCircle2d(-15, 10, 5), 0.4, 1.9);
+    expectCommutes(arc, (c) => mirrorAcrossAxis(c, 0, 0, 1, 0), reflectPt(0, 0, 1, 0));
+  });
+
+  it('mirrors a trimmed circle arc across a diagonal axis', () => {
+    const arc = trimmed(makeCircle2d(4, 1, 2.5), -0.3, 1.1);
+    expectCommutes(arc, (c) => mirrorAcrossAxis(c, 1, 2, 1, 1), reflectPt(1, 2, 1, 1));
+  });
+
+  it('mirrors a clockwise trimmed circle arc across a diagonal axis', () => {
+    const arc = trimmed(makeCircle2d(0, 3, 4, false), 0.5, 2.2);
+    expectCommutes(arc, (c) => mirrorAcrossAxis(c, -1, 0, 2, 1), reflectPt(-1, 0, 2, 1));
+  });
+
+  it('mirrors a trimmed ellipse arc across a diagonal axis', () => {
+    const arc = trimmed(makeEllipse2d(2, -1, 5, 2, 0.9), 0.2, 1.5);
+    expectCommutes(arc, (c) => mirrorAcrossAxis(c, 0, 1, 3, 2), reflectPt(0, 1, 3, 2));
+  });
+});

--- a/tests/svgPathRegression.test.ts
+++ b/tests/svgPathRegression.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SVG path emission regression — toSVGPathD mirrors the blueprint (SVG
+ * y-flip) before emitting, which historically point-reflected every trimmed
+ * arc's endpoints through its center (the path never closed), and arc flags
+ * were derived from trim bounds that occt-wasm reports normalized.
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { initKernel } from './setup.js';
+import { roundedRectangleBlueprint } from '@/2d/blueprints/cannedBlueprints.js';
+import { adaptedCurveToPathElem } from '@/2d/lib/svgPath.js';
+import { approximateAsSvgCompatibleCurve } from '@/2d/lib/approximations.js';
+import { make2dCircle } from '@/2d/lib/makeCurves.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30000);
+
+function dist(a: readonly number[], b: readonly number[]): number {
+  return Math.hypot((a[0] ?? NaN) - (b[0] ?? NaN), (a[1] ?? NaN) - (b[1] ?? NaN));
+}
+
+describe('toSVGPathD', () => {
+  it('mirrored blueprint curves chain and close', () => {
+    const mirrored = roundedRectangleBlueprint(40, 30, 5).clone().mirror([1, 0], [0, 0], 'plane');
+    const curves = mirrored.curves;
+    for (let i = 1; i < curves.length; i++) {
+      const prev = curves[i - 1];
+      const cur = curves[i];
+      if (!prev || !cur) throw new Error('missing curve');
+      expect(dist(cur.firstPoint, prev.lastPoint), `joint ${i}`).toBeLessThan(1e-6);
+    }
+    const first = curves[0];
+    const last = curves[curves.length - 1];
+    if (!first || !last) throw new Error('missing curve');
+    expect(dist(first.firstPoint, last.lastPoint)).toBeLessThan(1e-6);
+  });
+
+  it('emits a path that returns to its start point', () => {
+    const d = roundedRectangleBlueprint(40, 30, 5).toSVGPathD();
+    const tokens = d.replace(/Z\s*$/, '').trim().split(/\s+/);
+    const mx = Number(tokens[1]);
+    const my = Number(tokens[2]);
+    const lastX = Number(tokens[tokens.length - 2]);
+    const lastY = Number(tokens[tokens.length - 1]);
+    expect(Number.isFinite(mx) && Number.isFinite(lastX)).toBe(true);
+    expect(dist([lastX, lastY], [mx, my])).toBeLessThan(1e-4);
+  });
+
+  it('a 270-degree arc gets the large-arc flag from geometry, not trim bounds', () => {
+    const circle = make2dCircle(5);
+    // The [PI/2, 2*PI] piece spans 270 degrees.
+    const arc = circle.splitAt([Math.PI / 2])[1];
+    if (!arc) throw new Error('no split piece');
+    const elem = adaptedCurveToPathElem(arc, arc.lastPoint);
+    const flags = elem.trim().split(/\s+/);
+    // A rx ry rot largeArc sweep x y
+    expect(flags[0]).toBe('A');
+    expect(flags[4]).toBe('1');
+  });
+
+  it('splits a closed circle at the true parametric midpoint (antipodal halves)', () => {
+    const pieces = approximateAsSvgCompatibleCurve([make2dCircle(5)]);
+    expect(pieces.length).toBe(2);
+    for (const p of pieces) {
+      expect(dist(p.firstPoint, p.lastPoint)).toBeCloseTo(10, 5);
+    }
+  });
+});


### PR DESCRIPTION
Fixes the long-standing `toSVGPathD` reversed-arc bug (`roundedRectangleBlueprint(40, 30, 5)` emitted a path that never closed) plus three adjacent defects the investigation surfaced. Root cause chain:

1. **Mirror dispatch dropped the axis.** `transformCurve2dGeneral` (occt-wasm path) routed every `mirror2d` descriptor to the point-mirror with field names that do not exist on the descriptor, so the SVG y-flip (an axis mirror) became a point mirror about the origin. Masked on symmetric shapes because a point mirror of a symmetric outline coincides set-wise with the axis mirror. Now dispatched by `mode` with the real fields.

2. **Point mirror kept conic parameterization behind.** `mirrorAtPoint` was `scaleCurve2d(-1)`, which reflected a circle's center but not its angular parameterization: a trimmed arc evaluated at the old angles on the moved circle, returning endpoints point-reflected through the center (the exact observed symptom). A point mirror is a half-turn, so it now routes through `rotateCurve2d(PI)`, exact for every curve type.

3. **Rotating a trimmed circle was a silent no-op around its own center.** The pure-TS circle model carries no frame angle, so rotation has nowhere to live except the trim range. `rotateCurve2d` and `mirrorAcrossAxis` now shift `tStart`/`tEnd` for circle bases (sense-aware; the axis-mirror shift is `-2*phi` for the axis angle `phi`, which degenerates to the previously-correct zero for the horizontal axis). Ellipses were already exact: their `xDirAngle` frame absorbs the transform.

4. **Arc flags came from trim bounds; closed conics split at 0.5 radians.** occt-wasm reports normalized trim bounds, so `(bounds.last - bounds.first)` is not a sweep angle: any arc over 180 degrees got the wrong large-arc flag. The circle branch of `adaptedCurveToPathElem` now derives both flags from geometry (circumcenter of start / on-arc midpoint / end). And `approximateAsSvgCompatibleCurve` split closed conics at parameter `0.5` on a `[0, 2*PI]` range, producing a 0.5 rad sliver plus a 5.78 rad remainder; it now splits at the true parametric midpoint.

## Tests

- `tests/geometry2dTransforms.test.ts` — the pure transform contract, `evaluate(T(c), t) === T(evaluate(c, t))` sampled across the parameter range, for trimmed circles (both senses) and ellipses under rotation, point mirror, and axis mirrors including diagonal axes. 7 of 10 fail on the previous implementation.
- `tests/svgPathRegression.test.ts` — end to end: the mirrored blueprint chain closes joint by joint, the emitted `d` returns to its start point, a 270-degree arc gets `large-arc = 1`, and a closed circle splits into antipodal halves.

Verified no regressions across the 2d, sketcher, offset, boolean, blueprint-bridge, and text-blueprint suites on all four kernel projects (the pre-existing manifold 2d failures reproduce identically on clean main). The shared pure-TS geometry module also backs the brepkit kernel, so both benefit.
