### PR TITLE
feat(families): validate props with zod and require keys for identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15240,6 +15240,9 @@
     "packages/brepjs-families": {
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "peerDependencies": {
         "brepjs": ">=18.0.0"
       }

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -157,6 +157,8 @@ function addOpenings(
         )
       );
     }
+    const keyed = requireKeyed(opening);
+    if (!keyed.ok) return keyed;
     const fillT = peelTranslates(opening.geometry).total;
     const input = {
       materialName: SPEC_DEFAULTS.materialName,
@@ -184,6 +186,19 @@ function addOpenings(
   return ok(undefined);
 }
 
+/** Every element that mints an IFC identity needs an explicit key: an
+ *  index-fallback path is order-dependent, which would silently break the
+ *  reorder-stable GlobalId contract. */
+function requireKeyed(el: ResolvedElement): Result<void, BimError> {
+  if (el.keyed) return ok(undefined);
+  return err(
+    specError(
+      'FAMILIES_UNKEYED_ELEMENT',
+      `familiesToBim: '${el.keyPath}' has no explicit key — IFC identity needs order-independent key paths (add a key to the element)`
+    )
+  );
+}
+
 /**
  * Project a resolved families tree into an eager BimModel. The caller owns
  * the returned model (`using`); families stays domain-neutral — this adapter
@@ -204,6 +219,8 @@ export function familiesToBim(
   const walk = (el: ResolvedElement, storeyId: LocalId | null): Result<void, BimError> => {
     let containerId = storeyId;
     if (el.type === 'Storey') {
+      const keyed = requireKeyed(el);
+      if (!keyed.ok) return keyed;
       const id = model.addStorey(
         {
           name: (el.attributes['name'] as string | undefined) ?? el.keyPath,
@@ -215,6 +232,8 @@ export function familiesToBim(
       idByKeyPath.set(el.keyPath, id);
       containerId = id;
     } else if (el.type === 'Wall' || el.type === 'Slab') {
+      const keyed = requireKeyed(el);
+      if (!keyed.ok) return keyed;
       const parsed =
         el.type === 'Wall' ? parseWallSpec(specInput(el)) : parseSlabSpec(specInput(el));
       if (!parsed.ok) return parsed;

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -291,6 +291,23 @@ describe('familiesToBim openings', () => {
     expect(isOk(familiesToBim(bad, { project: PROJECT }))).toBe(false);
   });
 
+  it('rejects unkeyed identity-mapped elements', () => {
+    // An index-fallback key path is order-dependent; minting a GlobalId from
+    // it would silently break reorder stability.
+    const unkeyedWall = resolve(
+      Storey({ key: 's', walls: [VoidedWall({ ...WALL_DIMS, voids: [] })] })
+    );
+    expect(isOk(familiesToBim(unkeyedWall, { project: PROJECT }))).toBe(false);
+
+    const unkeyedStorey = resolve(
+      Storey({ walls: [VoidedWall({ key: 'w', ...WALL_DIMS, voids: [] })] })
+    );
+    expect(isOk(familiesToBim(unkeyedStorey, { project: PROJECT }))).toBe(false);
+
+    const unkeyedVoid = voidedStorey([Door({ width: 900, height: 2100, at: [600, 0] })]);
+    expect(isOk(familiesToBim(unkeyedVoid, { project: PROJECT }))).toBe(false);
+  });
+
   it('duplicate filler and opening stable keys error via Result', () => {
     const storey = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [600, 0] })]);
     const projected = familiesToBim(storey, { project: PROJECT });

--- a/packages/brepjs-families/package.json
+++ b/packages/brepjs-families/package.json
@@ -28,6 +28,9 @@
     "lint": "eslint src tests",
     "test": "vitest run"
   },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
   "peerDependencies": {
     "brepjs": ">=18.0.0"
   },

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -4,6 +4,8 @@
  * and must stay pure: they return Elements, never touch kernel handles.
  */
 
+import type { ZodType } from 'zod';
+
 export interface Element {
   readonly type: string | FamilyComponent<never>;
   readonly key: string | undefined;
@@ -32,6 +34,10 @@ export interface FamilyComponent<P> {
 
 export interface FamilyOptions {
   readonly role?: 'fill' | undefined;
+  /** Optional Zod schema validated at element construction (the earliest
+   *  point with a useful stack). Schema output replaces the props, so
+   *  defaults and transforms apply before render. `key` is not validated. */
+  readonly props?: ZodType | undefined;
 }
 
 export function family<P extends object>(
@@ -39,9 +45,20 @@ export function family<P extends object>(
   render: (props: P) => Element,
   options?: FamilyOptions
 ): FamilyComponent<P> {
+  const schema = options?.props;
   const make = (props: P & WithKey): Element => {
     const { key, ...rest } = props;
-    return { type: component, key, props: rest, children: [] };
+    let validated: Readonly<Record<string, unknown>> = rest;
+    if (schema) {
+      const parsed = schema.safeParse(rest);
+      if (!parsed.success) {
+        throw new Error(
+          `brepjs-families: invalid props for family '${name}': ${parsed.error.message}`
+        );
+      }
+      validated = parsed.data as Readonly<Record<string, unknown>>;
+    }
+    return { type: component, key, props: validated, children: [] };
   };
   const component: FamilyComponent<P> = Object.assign(make, {
     familyName: name,

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -32,18 +32,20 @@ export interface FamilyComponent<P> {
   readonly renderErased: (props: object) => Element;
 }
 
-export interface FamilyOptions {
+export interface FamilyOptions<P = unknown> {
   readonly role?: 'fill' | undefined;
   /** Optional Zod schema validated at element construction (the earliest
    *  point with a useful stack). Schema output replaces the props, so
-   *  defaults and transforms apply before render. `key` is not validated. */
-  readonly props?: ZodType | undefined;
+   *  defaults and transforms apply before render — the output type must be
+   *  assignable to the render props `P`, enforced by this parameter.
+   *  `key` is not validated. */
+  readonly props?: ZodType<P> | undefined;
 }
 
 export function family<P extends object>(
   name: string,
   render: (props: P) => Element,
-  options?: FamilyOptions
+  options?: FamilyOptions<P>
 ): FamilyComponent<P> {
   const schema = options?.props;
   const make = (props: P & WithKey): Element => {

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -31,6 +31,10 @@ export interface ResolvedElement {
   /** Ancestor chain joined with '/'; prop-embedded elements use
    *  `${hostPath}/${propName}:${slotKey}`. */
   readonly keyPath: string;
+  /** True when the element (or, for synthesized openings/fills, its void
+   *  slot) carried an explicit key. Index-fallback paths are order-dependent,
+   *  so identity consumers reject unkeyed elements. */
+  readonly keyed: boolean;
   readonly geometry: csg.IRNode;
   /** The element's own pre-desugared props (dimensions, placement, ...) — an
    *  adapter feeds these into parametric spec paths (e.g. IFC) that cannot
@@ -127,10 +131,11 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
       }
       slotKeys.add(slotKey);
       const openingPath = `${hostPath}/voids:${slotKey}`;
-      const fill = resolveAt(v, `${openingPath}/fill`);
+      const fill = resolveAt(v, `${openingPath}/fill`, v.key !== undefined);
       openings.push({
         type: 'Opening',
         keyPath: openingPath,
+        keyed: v.key !== undefined,
         geometry: fill.geometry,
         props: {},
         attributes: {},
@@ -169,7 +174,7 @@ function assertKeyAllowed(key: string, path: string): void {
   }
 }
 
-function resolveAt(elem: Element, path: string): ResolvedElement {
+function resolveAt(elem: Element, path: string, keyed: boolean): ResolvedElement {
   const { intrinsic, typeName } = renderToIntrinsic(elem);
   const d = desugar(intrinsic, path);
   const relationships: Relationship[] = [...d.hostRelationships];
@@ -182,7 +187,7 @@ function resolveAt(elem: Element, path: string): ResolvedElement {
       throw new Error(`brepjs-families: duplicate sibling key '${seg}' under '${path}'`);
     }
     seen.add(seg);
-    const rc = resolveAt(c, `${path}/${seg}`);
+    const rc = resolveAt(c, `${path}/${seg}`, c.key !== undefined);
     children.push(rc);
     relationships.push({ kind: 'Contains', target: rc.keyPath });
   });
@@ -190,6 +195,7 @@ function resolveAt(elem: Element, path: string): ResolvedElement {
   return {
     type: typeName,
     keyPath: path,
+    keyed,
     geometry: d.geometry,
     props: elem.props,
     attributes: identityAttributes(elem),
@@ -199,5 +205,5 @@ function resolveAt(elem: Element, path: string): ResolvedElement {
 }
 
 export function resolve(root: Element): ResolvedElement {
-  return resolveAt(root, root.key ?? `${typeNameOf(root)}[0]`);
+  return resolveAt(root, root.key ?? `${typeNameOf(root)}[0]`, root.key !== undefined);
 }

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it, beforeAll } from 'vitest';
+import { z } from 'zod';
 import { initOCCT } from '../../../tests/setup.js';
 import { csg, isOk, unwrap, measureVolume } from 'brepjs';
 import type { AnyShape, Dimension } from 'brepjs';
@@ -311,5 +312,48 @@ describe('mesh-primary evaluation (Phase 5 gate)', () => {
     expect(n1b.mesh.value).toBe(n1a.mesh.value);
     // No shape was re-materialized to serve the cached meshes.
     expect(ev.cacheStats().misses).toBe(missesBefore);
+  });
+});
+
+describe('props validation (Zod)', () => {
+  const Sized = family<{ readonly size: number; readonly label?: string }>(
+    'Sized',
+    (p) => el('Box', { size: [p.size, p.size, p.size] }),
+    { props: z.object({ size: z.number().positive(), label: z.string().default('unit') }) }
+  );
+
+  it('rejects invalid props at element construction', () => {
+    expect(() => Sized({ key: 's', size: -1 })).toThrow(/invalid props for family 'Sized'/);
+  });
+
+  it('applies schema defaults before render and identity capture', () => {
+    const r = resolve(Sized({ key: 's', size: 2 }));
+    expect(r.props['label']).toBe('unit');
+  });
+
+  it('families without a schema accept props untouched', () => {
+    const Free = family<{ readonly anything: unknown }>('Free', () =>
+      el('Box', { size: [1, 1, 1] })
+    );
+    expect(() => Free({ key: 'f', anything: { odd: true } })).not.toThrow();
+  });
+});
+
+describe('keyed tracking', () => {
+  it('marks explicit keys, index fallbacks, and void slots', () => {
+    const keyedWall = Wall({ key: 'w1', length: 100, height: 100, thickness: 10 });
+    const unkeyedWall = Wall({ length: 100, height: 100, thickness: 10 });
+    const storey = resolve(Storey({ key: 's', walls: [keyedWall, unkeyedWall] }));
+    expect(storey.keyed).toBe(true);
+    expect(storey.children[0]?.keyed).toBe(true);
+    expect(storey.children[1]?.keyed).toBe(false);
+
+    const unkeyedDoor = Door({ width: 90, height: 210, thickness: 20, at: [100, 0, 0] });
+    const voided = resolve(
+      Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [unkeyedDoor] })
+    );
+    const opening = voided.children[0];
+    expect(opening?.keyed).toBe(false);
+    expect(opening?.children[0]?.keyed).toBe(false);
   });
 });


### PR DESCRIPTION
Closes out the family-layer authoring contract with two guards:

**Props validation.** `family(name, render, { props: zodSchema })` accepts an optional Zod schema (same `zod@^4.4.3` the bim specs use), validated at element construction, the earliest point with a useful stack. Schema output replaces the props, so `z.default()` and transforms apply before render and before identity capture; `key` is stripped first and never validated. Families without a schema are untouched.

**Unkeyed elements cannot mint IFC identity.** `ResolvedElement` gains a `keyed` flag (explicit key present; synthesized openings and fills inherit their void slot's key state). `familiesToBim` now rejects unkeyed Storeys, Walls, Slabs, and opening slots with a `FAMILIES_UNKEYED_ELEMENT` Result error: an index-fallback key path is order-dependent, and deriving a GlobalId from it would silently break the reorder-stable identity contract that the adapter's gate tests pin. Pure containers still need no keys.

Tests cover construction-time rejection with the family name in the message, schema defaults surviving into resolved props, schema-less passthrough, keyed/fallback/void-slot tracking, and adapter rejection of all three unkeyed cases (wall, storey, void slot).
