### PR TITLE
feat(families): add the starter registry with manifest and version markers

### DIFF
--- a/packages/brepjs-families/eslint.config.js
+++ b/packages/brepjs-families/eslint.config.js
@@ -24,7 +24,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['tests/**/*.ts'],
+    files: ['tests/**/*.ts', 'registry/**/*.ts'],
     languageOptions: {
       parserOptions: {
         project: './tsconfig.test.json',

--- a/packages/brepjs-families/package.json
+++ b/packages/brepjs-families/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "typecheck": "tsgo --noEmit",
-    "lint": "eslint src tests",
+    "lint": "eslint src tests registry",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/brepjs-families/registry/families/door.ts
+++ b/packages/brepjs-families/registry/families/door.ts
@@ -1,0 +1,33 @@
+// brepjs-family: door@1
+/**
+ * Door — a fill-role family: placed in a wall's `voids`, resolution
+ * synthesizes an Opening (IfcRelVoidsElement + IfcRelFillsElement in a BIM
+ * projection). `at` is [along-wall, sill] in the host wall's local frame;
+ * `alongY` orients the cut box for Y-running hosts.
+ */
+
+import { family, el, tTranslate } from 'brepjs-families';
+import { z } from 'zod';
+
+export const doorSchema = z.object({
+  width: z.number().positive(),
+  height: z.number().positive(),
+  at: z.tuple([z.number(), z.number()]).default([0, 0]),
+  depth: z.number().positive().default(300),
+  alongY: z.boolean().default(false),
+  materialName: z.string().min(1).default('Timber'),
+  isExternal: z.boolean().optional(),
+  fireRating: z.string().optional(),
+});
+
+export type DoorProps = z.input<typeof doorSchema>;
+
+export const Door = family(
+  'Door',
+  (p: z.output<typeof doorSchema>) =>
+    el('Box', {
+      size: p.alongY ? [p.depth, p.width, p.height] : [p.width, p.depth, p.height],
+      transform: [tTranslate(p.alongY ? [0, p.at[0], p.at[1]] : [p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill', props: doorSchema }
+);

--- a/packages/brepjs-families/registry/families/room.ts
+++ b/packages/brepjs-families/registry/families/room.ts
@@ -1,0 +1,55 @@
+// brepjs-family: room@1
+/**
+ * Room — a composed family: four keyed perimeter walls with a door in the
+ * south wall. Copy-in composes (it only calls other families and the
+ * brepjs-families surface); it never reaches around them into IFC writing.
+ * Depends on: wall, door.
+ */
+
+import { family, el } from 'brepjs-families';
+import { z } from 'zod';
+import { Wall } from './wall.js';
+import { Door } from './door.js';
+
+export const roomSchema = z.object({
+  width: z.number().positive(),
+  depth: z.number().positive(),
+  height: z.number().positive(),
+  thickness: z.number().positive().default(200),
+  doorWidth: z.number().positive().default(1000),
+  doorHeight: z.number().positive().default(2100),
+  doorAlong: z.number().nonnegative().default(0),
+  materialName: z.string().min(1).default('Concrete'),
+});
+
+export type RoomProps = z.input<typeof roomSchema>;
+
+export const Room = family(
+  'Room',
+  (p: z.output<typeof roomSchema>) => {
+    const { width: w, depth: d, height, thickness: t, materialName } = p;
+    const doorAlong = p.doorAlong > 0 ? p.doorAlong : (w - p.doorWidth) / 2;
+    const shared = { height, thickness: t, materialName };
+    return el('Group', {}, [
+      Wall({
+        key: 'south',
+        ...shared,
+        length: w,
+        at: [0, 0, 0],
+        voids: [
+          Door({
+            key: 'door',
+            width: p.doorWidth,
+            height: p.doorHeight,
+            at: [doorAlong, 0],
+            depth: t,
+          }),
+        ],
+      }),
+      Wall({ key: 'north', ...shared, length: w, at: [0, d - t, 0] }),
+      Wall({ key: 'west', ...shared, length: d, at: [t, 0, 0], axisX: [0, 1, 0] }),
+      Wall({ key: 'east', ...shared, length: d, at: [w, 0, 0], axisX: [0, 1, 0] }),
+    ]);
+  },
+  { props: roomSchema }
+);

--- a/packages/brepjs-families/registry/families/room.ts
+++ b/packages/brepjs-families/registry/families/room.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { Wall } from './wall.js';
 import { Door } from './door.js';
 
-export const roomSchema = z.object({
+const roomShape = z.object({
   width: z.number().positive(),
   depth: z.number().positive(),
   height: z.number().positive(),
@@ -22,13 +22,33 @@ export const roomSchema = z.object({
   materialName: z.string().min(1).default('Concrete'),
 });
 
+/** Explicit `doorAlong`, or centered in the south wall when 0. */
+function doorAlongOf(p: z.output<typeof roomShape>): number {
+  return p.doorAlong > 0 ? p.doorAlong : (p.width - p.doorWidth) / 2;
+}
+
+export const roomSchema = roomShape.superRefine((p, ctx) => {
+  if (doorAlongOf(p) < 0 || doorAlongOf(p) + p.doorWidth > p.width) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `door (along ${doorAlongOf(p)} + width ${p.doorWidth}) does not fit the ${p.width} south wall`,
+    });
+  }
+  if (p.doorHeight > p.height) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `door height ${p.doorHeight} exceeds the room height ${p.height}`,
+    });
+  }
+});
+
 export type RoomProps = z.input<typeof roomSchema>;
 
 export const Room = family(
   'Room',
   (p: z.output<typeof roomSchema>) => {
     const { width: w, depth: d, height, thickness: t, materialName } = p;
-    const doorAlong = p.doorAlong > 0 ? p.doorAlong : (w - p.doorWidth) / 2;
+    const doorAlong = doorAlongOf(p);
     const shared = { height, thickness: t, materialName };
     return el('Group', {}, [
       Wall({

--- a/packages/brepjs-families/registry/families/slab.ts
+++ b/packages/brepjs-families/registry/families/slab.ts
@@ -1,0 +1,31 @@
+// brepjs-family: slab@1
+/**
+ * Slab — a horizontal plate (floor, roof, landing, base slab). Props feed
+ * the IFC slab spec 1:1 in a BIM projection.
+ */
+
+import { family, el, tTranslate } from 'brepjs-families';
+import { z } from 'zod';
+
+export const slabSchema = z.object({
+  length: z.number().positive(),
+  width: z.number().positive(),
+  thickness: z.number().positive(),
+  at: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
+  predefinedType: z.enum(['FLOOR', 'ROOF', 'LANDING', 'BASESLAB']).default('FLOOR'),
+  materialName: z.string().min(1).default('Concrete'),
+  isExternal: z.boolean().optional(),
+  loadBearing: z.boolean().optional(),
+});
+
+export type SlabProps = z.input<typeof slabSchema>;
+
+export const Slab = family(
+  'Slab',
+  (p: z.output<typeof slabSchema>) =>
+    el('Box', {
+      size: [p.length, p.width, p.thickness],
+      transform: [tTranslate(p.at)],
+    }),
+  { props: slabSchema }
+);

--- a/packages/brepjs-families/registry/families/storey.ts
+++ b/packages/brepjs-families/registry/families/storey.ts
@@ -1,0 +1,21 @@
+// brepjs-family: storey@1
+/**
+ * Storey — a pure spatial container: no geometry of its own, maps onto
+ * IfcBuildingStorey in a BIM projection. Children are the storey's elements.
+ */
+
+import { family, el, type Element } from 'brepjs-families';
+import { z } from 'zod';
+
+export const storeySchema = z.object({
+  elevation: z.number().default(0),
+  items: z.array(z.custom<Element>()).default([]),
+});
+
+export type StoreyProps = z.input<typeof storeySchema>;
+
+export const Storey = family(
+  'Storey',
+  (p: z.output<typeof storeySchema>) => el('Group', {}, p.items),
+  { props: storeySchema }
+);

--- a/packages/brepjs-families/registry/families/wall.ts
+++ b/packages/brepjs-families/registry/families/wall.ts
@@ -1,0 +1,44 @@
+// brepjs-family: wall@1
+/**
+ * Wall — a solid wall running along `axisX` with optional fill-role voids
+ * (doors, windows). Props feed the IFC wall spec 1:1 when projected through
+ * a BIM adapter; the render orients the IR box to coincide with the spec
+ * solid (thickness spans axisZ x axisX, so a +Y wall shifts -X).
+ */
+
+import { family, el, tTranslate, type Element } from 'brepjs-families';
+import { z } from 'zod';
+
+const vec3 = z.tuple([z.number(), z.number(), z.number()]);
+
+export const wallSchema = z.object({
+  length: z.number().positive(),
+  height: z.number().positive(),
+  thickness: z.number().positive(),
+  at: vec3.default([0, 0, 0]),
+  axisX: vec3.default([1, 0, 0]),
+  materialName: z.string().min(1).default('Concrete'),
+  isExternal: z.boolean().optional(),
+  loadBearing: z.boolean().optional(),
+  fireRating: z.string().optional(),
+  voids: z.array(z.custom<Element>()).default([]),
+});
+
+export type WallProps = z.input<typeof wallSchema>;
+
+export const Wall = family(
+  'Wall',
+  (p: z.output<typeof wallSchema>) => {
+    const alongY = p.axisX[1] !== 0;
+    return el('Box', {
+      size: alongY
+        ? [p.thickness, p.length, p.height]
+        : [p.length, p.thickness, p.height],
+      voids: p.voids,
+      transform: [
+        tTranslate(alongY ? [p.at[0] - p.thickness, p.at[1], p.at[2]] : p.at),
+      ],
+    });
+  },
+  { props: wallSchema }
+);

--- a/packages/brepjs-families/registry/families/window.ts
+++ b/packages/brepjs-families/registry/families/window.ts
@@ -1,0 +1,32 @@
+// brepjs-family: window@1
+/**
+ * Window — a fill-role family: placed in a wall's `voids`, resolution
+ * synthesizes an Opening. `at` is [along-wall, sill] in the host wall's
+ * local frame; `alongY` orients the cut box for Y-running hosts.
+ */
+
+import { family, el, tTranslate } from 'brepjs-families';
+import { z } from 'zod';
+
+export const windowSchema = z.object({
+  width: z.number().positive(),
+  height: z.number().positive(),
+  at: z.tuple([z.number(), z.number()]).default([0, 900]),
+  depth: z.number().positive().default(300),
+  alongY: z.boolean().default(false),
+  materialName: z.string().min(1).default('Aluminium + Glazing'),
+  isExternal: z.boolean().optional(),
+  thermalTransmittance: z.number().positive().optional(),
+});
+
+export type WindowProps = z.input<typeof windowSchema>;
+
+export const Window = family(
+  'Window',
+  (p: z.output<typeof windowSchema>) =>
+    el('Box', {
+      size: p.alongY ? [p.depth, p.width, p.height] : [p.width, p.depth, p.height],
+      transform: [tTranslate(p.alongY ? [0, p.at[0], p.at[1]] : [p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill', props: windowSchema }
+);

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "name": "brepjs-families starter registry",
+  "families": [
+    {
+      "name": "storey",
+      "version": 1,
+      "description": "Spatial container mapping onto IfcBuildingStorey",
+      "files": ["families/storey.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
+      "name": "wall",
+      "version": 1,
+      "description": "Solid wall along a configurable axis with fill-role voids",
+      "files": ["families/wall.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
+      "name": "slab",
+      "version": 1,
+      "description": "Horizontal plate: floor, roof, landing, or base slab",
+      "files": ["families/slab.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
+      "name": "door",
+      "version": 1,
+      "description": "Fill-role void: synthesizes an Opening with IfcRelVoids/Fills",
+      "files": ["families/door.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
+      "name": "window",
+      "version": 1,
+      "description": "Fill-role void: synthesizes an Opening with IfcRelVoids/Fills",
+      "files": ["families/window.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
+      "name": "room",
+      "version": 1,
+      "description": "Composed family: four keyed perimeter walls with a door",
+      "files": ["families/room.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": ["wall", "door"]
+    }
+  ]
+}

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -22,9 +22,13 @@ interface WithKey {
  * declared name and render function. The component REFERENCE is the identity
  * (copy-in files make name lookup collide); the declared name serves key-path
  * fallbacks and display only.
+ *
+ * `I` is the INVOCATION props type: with a schema carrying defaults or
+ * transforms, callers pass the schema's input while render receives its
+ * output `P`. Schema-less families use one type for both.
  */
-export interface FamilyComponent<P> {
-  (props: P & WithKey): Element;
+export interface FamilyComponent<P, I = P> {
+  (props: I & WithKey): Element;
   readonly familyName: string;
   /** `'fill'` marks a family whose instances fill an opening when placed in a
    *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
@@ -32,23 +36,23 @@ export interface FamilyComponent<P> {
   readonly renderErased: (props: object) => Element;
 }
 
-export interface FamilyOptions<P = unknown> {
+export interface FamilyOptions<P = unknown, I = P> {
   readonly role?: 'fill' | undefined;
   /** Optional Zod schema validated at element construction (the earliest
    *  point with a useful stack). Schema output replaces the props, so
    *  defaults and transforms apply before render — the output type must be
    *  assignable to the render props `P`, enforced by this parameter.
    *  `key` is not validated. */
-  readonly props?: ZodType<P> | undefined;
+  readonly props?: ZodType<P, I> | undefined;
 }
 
-export function family<P extends object>(
+export function family<P extends object, I extends object = P>(
   name: string,
   render: (props: P) => Element,
-  options?: FamilyOptions<P>
-): FamilyComponent<P> {
+  options?: FamilyOptions<P, I>
+): FamilyComponent<P, I> {
   const schema = options?.props;
-  const make = (props: P & WithKey): Element => {
+  const make = (props: I & WithKey): Element => {
     const { key, ...rest } = props;
     let validated: Readonly<Record<string, unknown>> = rest;
     if (schema) {
@@ -62,7 +66,7 @@ export function family<P extends object>(
     }
     return { type: component, key, props: validated, children: [] };
   };
-  const component: FamilyComponent<P> = Object.assign(make, {
+  const component: FamilyComponent<P, I> = Object.assign(make, {
     familyName: name,
     role: options?.role,
     renderErased: (props: object) => render(props as P),

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -132,4 +132,19 @@ describe('starter families', () => {
       /invalid props for family 'Wall'/
     );
   });
+
+  it('a door that cannot fit its room is rejected at construction', () => {
+    // Wider than the south wall (centered placement goes negative).
+    expect(() => Room({ key: 'r', width: 900, depth: 900, height: 2400 })).toThrow(
+      /does not fit/
+    );
+    // Explicit placement overflowing the wall.
+    expect(() =>
+      Room({ key: 'r', width: 3000, depth: 3000, height: 2400, doorAlong: 2500 })
+    ).toThrow(/does not fit/);
+    // Taller than the room.
+    expect(() =>
+      Room({ key: 'r', width: 3000, depth: 3000, height: 2000, doorHeight: 2100 })
+    ).toThrow(/exceeds the room height/);
+  });
 });

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Starter registry — the copy-in distribution's ground truth. The manifest
+ * is data (self-hostable); every family file carries a machine-managed
+ * version-marker first line that `brepjs diff` anchors on. These tests keep
+ * manifest, markers, and files from drifting apart, and prove the starter
+ * families actually resolve and materialize.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, expect, it, beforeAll } from 'vitest';
+import { z } from 'zod';
+import { initOCCT } from '../../../tests/setup.js';
+import { csg, isOk } from 'brepjs';
+import { resolve, evaluateModel } from '../src/index.js';
+import { Room } from '../registry/families/room.js';
+import { Storey } from '../registry/families/storey.js';
+import { Slab } from '../registry/families/slab.js';
+import { Window } from '../registry/families/window.js';
+import { Wall } from '../registry/families/wall.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const REGISTRY_DIR = join(dirname(fileURLToPath(import.meta.url)), '../registry');
+
+const manifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  name: z.string().min(1),
+  families: z.array(
+    z.object({
+      name: z.string().regex(/^[a-z][a-z0-9-]*$/),
+      version: z.number().int().positive(),
+      description: z.string().min(1),
+      files: z.array(z.string().min(1)).min(1),
+      npmDeps: z.array(z.string().min(1)),
+      familyDeps: z.array(z.string().min(1)),
+    })
+  ),
+});
+
+async function loadManifest(): Promise<z.output<typeof manifestSchema>> {
+  const raw = await readFile(join(REGISTRY_DIR, 'manifest.json'), 'utf8');
+  return manifestSchema.parse(JSON.parse(raw));
+}
+
+describe('registry manifest', () => {
+  it('parses, lists every family file, and every listed file exists', async () => {
+    const manifest = await loadManifest();
+    const listed = new Set(manifest.families.flatMap((f) => f.files));
+    for (const file of listed) {
+      await expect(readFile(join(REGISTRY_DIR, file), 'utf8')).resolves.toBeTruthy();
+    }
+    const onDisk = (await readdir(join(REGISTRY_DIR, 'families'))).map((f) => `families/${f}`);
+    for (const file of onDisk) {
+      expect(listed.has(file), `${file} missing from manifest`).toBe(true);
+    }
+  });
+
+  it('every file starts with a version marker matching its manifest entry', async () => {
+    const manifest = await loadManifest();
+    for (const fam of manifest.families) {
+      for (const file of fam.files) {
+        const firstLine = (await readFile(join(REGISTRY_DIR, file), 'utf8')).split('\n', 1)[0];
+        expect(firstLine, file).toBe(`// brepjs-family: ${fam.name}@${fam.version}`);
+      }
+    }
+  });
+
+  it('family names are unique and familyDeps close over the manifest', async () => {
+    const manifest = await loadManifest();
+    const names = manifest.families.map((f) => f.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const fam of manifest.families) {
+      for (const dep of fam.familyDeps) {
+        expect(names, `${fam.name} -> ${dep}`).toContain(dep);
+      }
+    }
+  });
+});
+
+describe('starter families', () => {
+  it('a room on a storey resolves with keyed paths and a synthesized opening', () => {
+    const storey = resolve(
+      Storey({
+        key: 'ground',
+        items: [
+          Room({ key: 'office', width: 6000, depth: 4000, height: 3000 }),
+          Slab({ key: 'floor', length: 6000, width: 4000, thickness: 250, at: [0, 0, -250] }),
+        ],
+      })
+    );
+    const room = storey.children[0];
+    const south = room?.children.find((c) => c.keyPath.endsWith('/south'));
+    expect(south?.keyed).toBe(true);
+    const opening = south?.children.find((c) => c.type === 'Opening');
+    expect(opening?.keyPath).toBe('ground/office/south/voids:door');
+    expect(opening?.keyed).toBe(true);
+  });
+
+  it('starter walls and windows materialize with meshes', () => {
+    using ev = new csg.Evaluator();
+    const storey = resolve(
+      Storey({
+        key: 's',
+        items: [
+          Wall({
+            key: 'w',
+            length: 3000,
+            height: 2700,
+            thickness: 200,
+            voids: [Window({ key: 'n', width: 1200, height: 1000, at: [900, 900], depth: 200 })],
+          }),
+        ],
+      })
+    );
+    const model = evaluateModel(storey, ev);
+    const wall = model.byKeyPath.get('s/w');
+    expect(wall && isOk(wall.mesh)).toBe(true);
+  });
+
+  it('schema defaults apply at construction', () => {
+    const slab = resolve(Slab({ key: 'f', length: 100, width: 100, thickness: 10 }));
+    expect(slab.props['predefinedType']).toBe('FLOOR');
+    expect(slab.props['materialName']).toBe('Concrete');
+  });
+
+  it('invalid starter props throw with the family name', () => {
+    expect(() => Wall({ key: 'w', length: -1, height: 100, thickness: 10 })).toThrow(
+      /invalid props for family 'Wall'/
+    );
+  });
+});

--- a/packages/brepjs-families/tsconfig.test.json
+++ b/packages/brepjs-families/tsconfig.test.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
-  "include": ["tests/**/*.ts", "src/**/*.ts"],
+  "include": ["tests/**/*.ts", "src/**/*.ts", "registry/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
First slice of the copy-in distribution story (the shadcn model): a starter registry of six families shipped as owned source, plus the manifest format that `brepjs add` / `brepjs diff` will consume.

## Registry

`packages/brepjs-families/registry/` holds `manifest.json` (schemaVersion, per-family name/version/description/files/npmDeps/familyDeps — pure data, so the registry is self-hostable by copying the directory) and six starter families: `storey`, `wall`, `slab`, `door`, `window`, and `room`. Every family file's first line is a machine-managed version marker (`// brepjs-family: wall@1`), the anchor `diff` will use in copied-out files.

The starter families hold the copy-in boundary: they call only the `brepjs-families` surface (`family`/`el`/`tTranslate`) and Zod. Geometry recipes, pset-shaped defaults, and material names live in the copied source; IFC entity writing, GlobalId derivation, and relationship emission stay behind the adapter. `room` composes `wall` and `door` (the `familyDeps` case for dependency resolution).

## Invocation vs render props

Starter families lean on schema defaults, which exposed an API gap: `family<P>` used one type for both invocation and render, but a schema with defaults has different input and output types. `family` now takes `<P, I = P>` — callers pass the schema's input type (defaults optional), render receives its output — carried through `FamilyComponent<P, I>` and `FamilyOptions<P, I>` (`ZodType<P, I>`). Schema-less families are unchanged (`I` defaults to `P`).

## Tests

The registry test file keeps manifest, markers, and files from drifting: every listed file exists and every file is listed, version markers match manifest entries exactly, names are unique, and `familyDeps` close over the manifest. Functionally: a `room` on a `storey` resolves with keyed paths and a synthesized opening at the expected key path, starter walls with windows materialize meshes, schema defaults land in resolved props, and invalid props throw naming the family.
