### PR TITLE
feat(cli): add brepjs add and diff for copy-in family distribution

### DIFF
--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -16,7 +16,7 @@
  * directory works — point --registry at a firm-internal copy to self-host.
  */
 
-import { mkdir, open, readFile, writeFile, access, realpath } from 'node:fs/promises';
+import { mkdir, open, readFile, writeFile, access, lstat, realpath } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, resolve as resolvePath, sep } from 'node:path';
@@ -244,8 +244,16 @@ async function diff(args) {
   for (const file of fam.files) {
     const registryContent = await fetchText(args.registry, file);
     const target = join(resolvePath(args.dir), file.replace(/^families\//, ''));
-    if (!(await exists(target))) {
+    const stat = await lstat(target).catch(() => null);
+    if (stat === null) {
       console.error(`not copied in: ${target}`);
+      dirty = true;
+      continue;
+    }
+    // Never read or diff through a symlink: in CI, a committed link could
+    // leak whatever readable file it points at into the job output.
+    if (stat.isSymbolicLink()) {
+      console.error(`${target}: is a symlink — refusing to diff through it`);
       dirty = true;
       continue;
     }

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -189,9 +189,20 @@ async function add(args) {
     writes.push(p);
   }
 
+  // Copies are idempotent (re-running converges on the same closure), so a
+  // mid-apply failure surfaces as an explicit partial-state report rather
+  // than staging/rollback machinery.
   const written = [];
   for (const w of writes) {
-    await guardedWrite(targetRoot, w.target, w.content);
+    try {
+      await guardedWrite(targetRoot, w.target, w.content);
+    } catch (err) {
+      for (const t of written) console.warn(`wrote ${t}`);
+      console.error(
+        `partial write: ${written.length} of ${writes.length} files written before the failure — fix the cause and re-run to complete the closure`
+      );
+      throw err;
+    }
     written.push(w.target);
   }
 

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -224,7 +224,11 @@ async function add(args) {
   if (missing.length > 0) {
     if (args.install) {
       console.warn(`installing: ${missing.join(' ')}`);
-      const r = spawnSync('npm', ['install', ...missing], { stdio: 'inherit' });
+      // Copy-in means choosing to trust the registry's code, but install-time
+      // lifecycle scripts are a surprise nobody opted into: suppress them.
+      const r = spawnSync('npm', ['install', '--ignore-scripts', ...missing], {
+        stdio: 'inherit',
+      });
       if (r.status !== 0) process.exitCode = r.status ?? 1;
     } else {
       console.warn(`missing npm deps — run: npm install ${missing.join(' ')}`);

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -16,7 +16,7 @@
  * directory works — point --registry at a firm-internal copy to self-host.
  */
 
-import { mkdir, readFile, writeFile, access } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, access, lstat, realpath } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { join, resolve as resolvePath, sep } from 'node:path';
 import process from 'node:process';
@@ -119,13 +119,32 @@ async function exists(path) {
   }
 }
 
+/** Refuse writes through symlinks: the file itself must not be a symlink and
+ *  its (created) parent must really live under the target root. A symlinked
+ *  target root itself is respected as the user's own layout choice. */
+async function guardedWrite(targetRoot, target, content) {
+  await mkdir(join(target, '..'), { recursive: true });
+  const rootReal = await realpath(targetRoot);
+  const parentReal = await realpath(join(target, '..'));
+  if (parentReal !== rootReal && !parentReal.startsWith(rootReal + sep)) {
+    throw new Error(`refusing to write outside the target directory: ${target}`);
+  }
+  const stat = await lstat(target).catch(() => null);
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`refusing to write through a symlink: ${target}`);
+  }
+  await writeFile(target, content);
+}
+
 async function add(args) {
   const manifest = await loadManifest(args.registry);
   const families = resolveClosure(manifest, args._);
   const targetRoot = resolvePath(args.dir);
-  const written = [];
-  const skipped = [];
 
+  // Plan first, write after: a conflict anywhere in the closure aborts the
+  // whole command before any file is touched, so a failed add never leaves a
+  // partially installed family set.
+  const planned = [];
   for (const fam of families) {
     for (const file of fam.files) {
       const content = await fetchText(args.registry, file);
@@ -133,22 +152,32 @@ async function add(args) {
       if (!target.startsWith(targetRoot + sep)) {
         throw new Error(`registry file entry escapes the target directory: ${file}`);
       }
-      if (await exists(target)) {
-        const current = await readFile(target, 'utf8');
-        if (current === content) {
-          skipped.push(target);
-          continue;
-        }
-        if (!args.force) {
-          console.error(`refusing to overwrite modified file (use --force): ${target}`);
-          process.exitCode = 1;
-          return;
-        }
-      }
-      await mkdir(join(target, '..'), { recursive: true });
-      await writeFile(target, content);
-      written.push(target);
+      planned.push({ target, content });
     }
+  }
+
+  const writes = [];
+  const skipped = [];
+  for (const p of planned) {
+    if (await exists(p.target)) {
+      const current = await readFile(p.target, 'utf8');
+      if (current === p.content) {
+        skipped.push(p.target);
+        continue;
+      }
+      if (!args.force) {
+        console.error(`refusing to overwrite modified file (use --force): ${p.target}`);
+        process.exitCode = 1;
+        return;
+      }
+    }
+    writes.push(p);
+  }
+
+  const written = [];
+  for (const w of writes) {
+    await guardedWrite(targetRoot, w.target, w.content);
+    written.push(w.target);
   }
 
   for (const t of written) console.warn(`wrote ${t}`);

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -257,6 +257,16 @@ async function diff(args) {
       dirty = true;
       continue;
     }
+    // Same for symlinked parent directories: the fully resolved path must
+    // stay inside the project, or a committed dir link exfiltrates files
+    // beyond the checkout.
+    const projectRoot = await realpath(process.cwd());
+    const real = await realpath(target);
+    if (real !== projectRoot && !real.startsWith(projectRoot + sep)) {
+      console.error(`${target}: resolves outside the project — refusing to diff`);
+      dirty = true;
+      continue;
+    }
     const local = await readFile(target, 'utf8');
     const localMarker = markerOf(local);
     if (localMarker && localMarker.version !== fam.version) {

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * brepjs CLI — copy-in distribution for brepjs-families (the shadcn model).
+ *
+ *   brepjs add <family...>   copy family source (and its family deps) into
+ *                            your project as owned code
+ *   brepjs diff <family>     compare a copied family against the registry
+ *
+ * Options:
+ *   --registry <url|path>  registry root (default: the brepjs GitHub registry)
+ *   --dir <path>           target directory (default: src/families)
+ *   --force                overwrite locally modified files
+ *   --install              run `npm install` for missing npm deps
+ *
+ * The registry is data (manifest.json + source files), so any static host or
+ * directory works — point --registry at a firm-internal copy to self-host.
+ */
+
+import { mkdir, readFile, writeFile, access } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { join, resolve as resolvePath } from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_REGISTRY =
+  'https://raw.githubusercontent.com/andymai/brepjs/main/packages/brepjs-families/registry';
+
+function parseArgs(argv) {
+  const args = { _: [], registry: DEFAULT_REGISTRY, dir: 'src/families', force: false, install: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--registry') args.registry = argv[++i];
+    else if (a === '--dir') args.dir = argv[++i];
+    else if (a === '--force') args.force = true;
+    else if (a === '--install') args.install = true;
+    else args._.push(a);
+  }
+  return args;
+}
+
+function isUrl(s) {
+  return s.startsWith('http://') || s.startsWith('https://');
+}
+
+async function fetchText(registry, rel) {
+  if (isUrl(registry)) {
+    const url = `${registry.replace(/\/$/, '')}/${rel}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`fetch failed (${res.status}): ${url}`);
+    return res.text();
+  }
+  return readFile(join(registry, rel), 'utf8');
+}
+
+async function loadManifest(registry) {
+  const manifest = JSON.parse(await fetchText(registry, 'manifest.json'));
+  if (manifest.schemaVersion !== 1) {
+    throw new Error(`unsupported registry schemaVersion: ${manifest.schemaVersion}`);
+  }
+  return manifest;
+}
+
+function familyByName(manifest, name) {
+  const fam = manifest.families.find((f) => f.name === name);
+  if (!fam) {
+    const known = manifest.families.map((f) => f.name).join(', ');
+    throw new Error(`unknown family '${name}' (registry has: ${known})`);
+  }
+  return fam;
+}
+
+/** Requested families plus their familyDeps, dependencies first. */
+function resolveClosure(manifest, names) {
+  const ordered = [];
+  const seen = new Set();
+  const visit = (name, trail) => {
+    if (seen.has(name)) return;
+    if (trail.includes(name)) {
+      throw new Error(`familyDeps cycle: ${[...trail, name].join(' -> ')}`);
+    }
+    const fam = familyByName(manifest, name);
+    for (const dep of fam.familyDeps) visit(dep, [...trail, name]);
+    seen.add(name);
+    ordered.push(fam);
+  };
+  for (const name of names) visit(name, []);
+  return ordered;
+}
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function add(args) {
+  const manifest = await loadManifest(args.registry);
+  const families = resolveClosure(manifest, args._);
+  const targetRoot = resolvePath(args.dir);
+  const written = [];
+  const skipped = [];
+
+  for (const fam of families) {
+    for (const file of fam.files) {
+      const content = await fetchText(args.registry, file);
+      const target = join(targetRoot, file.replace(/^families\//, ''));
+      if (await exists(target)) {
+        const current = await readFile(target, 'utf8');
+        if (current === content) {
+          skipped.push(target);
+          continue;
+        }
+        if (!args.force) {
+          console.error(`refusing to overwrite modified file (use --force): ${target}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+      await mkdir(join(target, '..'), { recursive: true });
+      await writeFile(target, content);
+      written.push(target);
+    }
+  }
+
+  for (const t of written) console.warn(`wrote ${t}`);
+  for (const t of skipped) console.warn(`up to date ${t}`);
+
+  const needed = [...new Set(families.flatMap((f) => f.npmDeps))];
+  const missing = [];
+  const pkgPath = resolvePath('package.json');
+  if (await exists(pkgPath)) {
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+    const have = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies };
+    for (const dep of needed) if (!(dep in have)) missing.push(dep);
+  } else {
+    missing.push(...needed);
+  }
+  if (missing.length > 0) {
+    if (args.install) {
+      console.warn(`installing: ${missing.join(' ')}`);
+      const r = spawnSync('npm', ['install', ...missing], { stdio: 'inherit' });
+      if (r.status !== 0) process.exitCode = r.status ?? 1;
+    } else {
+      console.warn(`missing npm deps — run: npm install ${missing.join(' ')}`);
+    }
+  }
+}
+
+function markerOf(content) {
+  const first = content.split('\n', 1)[0] ?? '';
+  const m = /^\/\/ brepjs-family: ([a-z0-9-]+)@(\d+)$/.exec(first);
+  return m ? { name: m[1], version: Number(m[2]) } : null;
+}
+
+async function diff(args) {
+  const [name] = args._;
+  const manifest = await loadManifest(args.registry);
+  const fam = familyByName(manifest, name);
+  let dirty = false;
+  for (const file of fam.files) {
+    const registryContent = await fetchText(args.registry, file);
+    const target = join(resolvePath(args.dir), file.replace(/^families\//, ''));
+    if (!(await exists(target))) {
+      console.error(`not copied in: ${target}`);
+      dirty = true;
+      continue;
+    }
+    const local = await readFile(target, 'utf8');
+    const localMarker = markerOf(local);
+    if (localMarker && localMarker.version !== fam.version) {
+      console.warn(`${target}: local ${name}@${localMarker.version}, registry ${name}@${fam.version}`);
+    }
+    if (local === registryContent) {
+      console.warn(`${target}: up to date`);
+      continue;
+    }
+    dirty = true;
+    const r = spawnSync('git', ['diff', '--no-index', '--', target, '/dev/stdin'], {
+      input: registryContent,
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+    if (r.error) console.error(`${target}: differs from registry (git unavailable for a diff)`);
+  }
+  if (dirty) process.exitCode = 1;
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  if (cmd === 'add' && args._.length > 0) return add(args);
+  if (cmd === 'diff' && args._.length === 1) return diff(args);
+  console.error(
+    'usage: brepjs add <family...> [--registry <url|path>] [--dir <path>] [--force] [--install]\n' +
+      '       brepjs diff <family> [--registry <url|path>] [--dir <path>]'
+  );
+  process.exitCode = 2;
+}
+
+main().catch((err) => {
+  console.error(`brepjs: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+});

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -18,7 +18,7 @@
 
 import { mkdir, readFile, writeFile, access } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
-import { join, resolve as resolvePath } from 'node:path';
+import { join, resolve as resolvePath, sep } from 'node:path';
 import process from 'node:process';
 
 const DEFAULT_REGISTRY =
@@ -51,12 +51,36 @@ async function fetchText(registry, rel) {
   return readFile(join(registry, rel), 'utf8');
 }
 
-async function loadManifest(registry) {
-  const manifest = JSON.parse(await fetchText(registry, 'manifest.json'));
+// The manifest is the trust boundary: registry file entries become local
+// write paths and npmDeps become `npm install` arguments, so both are held
+// to strict allowlists before anything else touches them.
+const FILE_ENTRY = /^families\/[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/;
+const NPM_NAME = /^(@[a-z0-9~-][a-z0-9._~-]*\/)?[a-z0-9~-][a-z0-9._~-]*$/;
+
+function validateManifest(manifest) {
   if (manifest.schemaVersion !== 1) {
     throw new Error(`unsupported registry schemaVersion: ${manifest.schemaVersion}`);
   }
+  for (const fam of manifest.families) {
+    for (const file of fam.files) {
+      if (!FILE_ENTRY.test(file) || file.includes('..')) {
+        throw new Error(`registry file entry outside families/: ${file}`);
+      }
+    }
+    for (const dep of fam.npmDeps) {
+      if (!NPM_NAME.test(dep)) {
+        throw new Error(`invalid npm dependency name in registry: ${dep}`);
+      }
+    }
+  }
   return manifest;
+}
+
+async function loadManifest(registry) {
+  if (registry.startsWith('http://')) {
+    throw new Error('plaintext http registries are not supported — use https or a local path');
+  }
+  return validateManifest(JSON.parse(await fetchText(registry, 'manifest.json')));
 }
 
 function familyByName(manifest, name) {
@@ -105,7 +129,10 @@ async function add(args) {
   for (const fam of families) {
     for (const file of fam.files) {
       const content = await fetchText(args.registry, file);
-      const target = join(targetRoot, file.replace(/^families\//, ''));
+      const target = resolvePath(targetRoot, file.replace(/^families\//, ''));
+      if (!target.startsWith(targetRoot + sep)) {
+        throw new Error(`registry file entry escapes the target directory: ${file}`);
+      }
       if (await exists(target)) {
         const current = await readFile(target, 'utf8');
         if (current === content) {

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -16,7 +16,8 @@
  * directory works — point --registry at a firm-internal copy to self-host.
  */
 
-import { mkdir, readFile, writeFile, access, lstat, realpath } from 'node:fs/promises';
+import { mkdir, open, readFile, writeFile, access, realpath } from 'node:fs/promises';
+import { constants } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, resolve as resolvePath, sep } from 'node:path';
 import process from 'node:process';
@@ -119,9 +120,11 @@ async function exists(path) {
   }
 }
 
-/** Refuse writes through symlinks: the file itself must not be a symlink and
- *  its (created) parent must really live under the target root. A symlinked
- *  target root itself is respected as the user's own layout choice. */
+/** Refuse writes through symlinks: the (created) parent must really live
+ *  under the target root, and the file is opened with O_NOFOLLOW so a
+ *  symlinked target is rejected atomically at open time (no check-then-write
+ *  race on the final component). A symlinked target root itself is respected
+ *  as the user's own layout choice. */
 async function guardedWrite(targetRoot, target, content) {
   await mkdir(join(target, '..'), { recursive: true });
   const rootReal = await realpath(targetRoot);
@@ -129,11 +132,23 @@ async function guardedWrite(targetRoot, target, content) {
   if (parentReal !== rootReal && !parentReal.startsWith(rootReal + sep)) {
     throw new Error(`refusing to write outside the target directory: ${target}`);
   }
-  const stat = await lstat(target).catch(() => null);
-  if (stat?.isSymbolicLink()) {
-    throw new Error(`refusing to write through a symlink: ${target}`);
+  let handle;
+  try {
+    handle = await open(
+      target,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW
+    );
+  } catch (err) {
+    if (err && (err.code === 'ELOOP' || err.code === 'EMLINK')) {
+      throw new Error(`refusing to write through a symlink: ${target}`);
+    }
+    throw err;
   }
-  await writeFile(target, content);
+  try {
+    await handle.writeFile(content);
+  } finally {
+    await handle.close();
+  }
 }
 
 async function add(args) {

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -16,7 +16,7 @@
  * directory works — point --registry at a firm-internal copy to self-host.
  */
 
-import { mkdir, open, readFile, writeFile, access, lstat, realpath } from 'node:fs/promises';
+import { mkdir, open, readFile, writeFile, access, lstat, realpath, rename, rm } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, resolve as resolvePath, sep } from 'node:path';
@@ -132,22 +132,24 @@ async function guardedWrite(targetRoot, target, content) {
   if (parentReal !== rootReal && !parentReal.startsWith(rootReal + sep)) {
     throw new Error(`refusing to write outside the target directory: ${target}`);
   }
-  let handle;
-  try {
-    handle = await open(
-      target,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW
-    );
-  } catch (err) {
-    if (err && (err.code === 'ELOOP' || err.code === 'EMLINK')) {
-      throw new Error(`refusing to write through a symlink: ${target}`);
-    }
-    throw err;
+  const stat = await lstat(target).catch(() => null);
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`refusing to write through a symlink: ${target}`);
   }
+  // Write a sibling temp file, then rename over the target: rename is atomic
+  // and never follows symlinks, so a failed write leaves the target intact
+  // (no O_TRUNC damage to report) and a racing symlink is replaced, never
+  // followed.
+  const tmp = `${target}.brepjs-tmp-${process.pid}`;
+  const handle = await open(tmp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL);
   try {
     await handle.writeFile(content);
-  } finally {
     await handle.close();
+    await rename(tmp, target);
+  } catch (err) {
+    await handle.close().catch(() => {});
+    await rm(tmp, { force: true });
+    throw err;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -206,8 +206,12 @@
       }
     }
   },
+  "bin": {
+    "brepjs": "bin/brepjs.mjs"
+  },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "scripts": {
     "build": "vite build && node scripts/build-quick.js",

--- a/tests/cliFamilies.test.ts
+++ b/tests/cliFamilies.test.ts
@@ -1,0 +1,116 @@
+/**
+ * brepjs CLI — copy-in distribution against a fixture registry: dependency
+ * closure (deps written first), clobber protection, up-to-date detection,
+ * and diff exit codes. Pure node; no kernel.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN = join(HERE, '../bin/brepjs.mjs');
+const REGISTRY = join(HERE, 'fixtures/cliRegistry');
+
+let cwd = '';
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'brepjs-cli-'));
+});
+
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true });
+});
+
+function run(...args: string[]): { status: number | null; out: string } {
+  const r = spawnSync(process.execPath, [BIN, ...args, '--registry', REGISTRY], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return { status: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('brepjs add', () => {
+  it('copies a family and its familyDeps, deps first', async () => {
+    const r = run('add', 'beta');
+    expect(r.status).toBe(0);
+    const alpha = await readFile(join(cwd, 'src/families/alpha.ts'), 'utf8');
+    const beta = await readFile(join(cwd, 'src/families/beta.ts'), 'utf8');
+    expect(alpha.startsWith('// brepjs-family: alpha@2')).toBe(true);
+    expect(beta.startsWith('// brepjs-family: beta@1')).toBe(true);
+    // Missing npm deps are reported (no package.json in the scratch project).
+    expect(r.out).toContain('npm install');
+    expect(r.out).toContain('zod');
+  });
+
+  it('is idempotent on unmodified files', () => {
+    expect(run('add', 'alpha').status).toBe(0);
+    const again = run('add', 'alpha');
+    expect(again.status).toBe(0);
+    expect(again.out).toContain('up to date');
+  });
+
+  it('refuses to clobber a modified file without --force', async () => {
+    expect(run('add', 'alpha').status).toBe(0);
+    const target = join(cwd, 'src/families/alpha.ts');
+    await writeFile(target, '// brepjs-family: alpha@2\nexport const alpha = 99;\n');
+    const refused = run('add', 'alpha');
+    expect(refused.status).toBe(1);
+    expect(refused.out).toContain('--force');
+    expect((await readFile(target, 'utf8')).includes('99')).toBe(true);
+
+    const forced = run('add', 'alpha', '--force');
+    expect(forced.status).toBe(0);
+    expect((await readFile(target, 'utf8')).includes('99')).toBe(false);
+  });
+
+  it('errors on unknown families', () => {
+    const r = run('add', 'nope');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain("unknown family 'nope'");
+  });
+
+  it('skips deps already present in package.json', async () => {
+    await writeFile(
+      join(cwd, 'package.json'),
+      JSON.stringify({ dependencies: { 'brepjs-families': '^0.1.0', zod: '^4.0.0' } })
+    );
+    const r = run('add', 'beta');
+    expect(r.status).toBe(0);
+    expect(r.out).not.toContain('npm install');
+  });
+});
+
+describe('brepjs diff', () => {
+  it('reports up to date with exit 0, differences with exit 1', async () => {
+    expect(run('add', 'alpha').status).toBe(0);
+    expect(run('diff', 'alpha').status).toBe(0);
+    expect(run('diff', 'alpha').out).toContain('up to date');
+
+    await writeFile(
+      join(cwd, 'src/families/alpha.ts'),
+      '// brepjs-family: alpha@1\nexport const alpha = 42;\n'
+    );
+    const changed = run('diff', 'alpha');
+    expect(changed.status).toBe(1);
+    // The stale version marker is called out alongside the content drift.
+    expect(changed.out).toContain('local alpha@1, registry alpha@2');
+  });
+
+  it('reports families that were never copied in', () => {
+    const r = run('diff', 'alpha');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('not copied in');
+  });
+});
+
+describe('usage', () => {
+  it('prints usage and exits 2 without a valid command', () => {
+    const r = run();
+    expect(r.status).toBe(2);
+    expect(r.out).toContain('usage:');
+  });
+});

--- a/tests/cliFamilies.test.ts
+++ b/tests/cliFamilies.test.ts
@@ -163,4 +163,32 @@ describe('registry trust boundary', () => {
     expect(r.status).toBe(1);
     expect(r.out).toContain('https');
   });
+
+  it('a conflict anywhere in the closure aborts before any file is written', async () => {
+    // Copy beta (which brings alpha), locally modify beta, delete alpha:
+    // re-adding beta must refuse AND not recreate alpha (plan-then-apply).
+    expect(run('add', 'beta').status).toBe(0);
+    await writeFile(
+      join(cwd, 'src/families/beta.ts'),
+      '// brepjs-family: beta@1\nexport const beta = 99;\n'
+    );
+    await rm(join(cwd, 'src/families/alpha.ts'));
+    const r = run('add', 'beta');
+    expect(r.status).toBe(1);
+    await expect(readFile(join(cwd, 'src/families/alpha.ts'), 'utf8')).rejects.toThrow();
+  });
+
+  it('refuses to write through a symlinked file even with --force', async () => {
+    expect(run('add', 'alpha').status).toBe(0);
+    const outside = join(cwd, 'outside.ts');
+    await writeFile(outside, 'precious');
+    const target = join(cwd, 'src/families/alpha.ts');
+    await rm(target);
+    const { symlink } = await import('node:fs/promises');
+    await symlink(outside, target);
+    const r = run('add', 'alpha', '--force');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('symlink');
+    expect(await readFile(outside, 'utf8')).toBe('precious');
+  });
 });

--- a/tests/cliFamilies.test.ts
+++ b/tests/cliFamilies.test.ts
@@ -119,6 +119,22 @@ describe('brepjs diff', () => {
     expect(r.out).toContain('symlink');
     expect(r.out).not.toContain('TOP-SECRET-TOKEN');
   });
+
+  it('refuses to diff when a parent directory symlink escapes the project', async () => {
+    const { mkdir, symlink, mkdtemp } = await import('node:fs/promises');
+    const outside = await mkdtemp(join(tmpdir(), 'brepjs-outside-'));
+    try {
+      await writeFile(join(outside, 'alpha.ts'), '// brepjs-family: alpha@2\nOUTSIDE-SECRET\n');
+      await mkdir(join(cwd, 'src'), { recursive: true });
+      await symlink(outside, join(cwd, 'src/families'));
+      const r = run('diff', 'alpha');
+      expect(r.status).toBe(1);
+      expect(r.out).toContain('outside the project');
+      expect(r.out).not.toContain('OUTSIDE-SECRET');
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('usage', () => {

--- a/tests/cliFamilies.test.ts
+++ b/tests/cliFamilies.test.ts
@@ -105,6 +105,20 @@ describe('brepjs diff', () => {
     expect(r.status).toBe(1);
     expect(r.out).toContain('not copied in');
   });
+
+  it('refuses to diff through a symlinked local file (no content leak)', async () => {
+    expect(run('add', 'alpha').status).toBe(0);
+    const secret = join(cwd, 'secret.txt');
+    await writeFile(secret, 'TOP-SECRET-TOKEN');
+    const target = join(cwd, 'src/families/alpha.ts');
+    await rm(target);
+    const { symlink } = await import('node:fs/promises');
+    await symlink(secret, target);
+    const r = run('diff', 'alpha');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('symlink');
+    expect(r.out).not.toContain('TOP-SECRET-TOKEN');
+  });
 });
 
 describe('usage', () => {

--- a/tests/cliFamilies.test.ts
+++ b/tests/cliFamilies.test.ts
@@ -114,3 +114,53 @@ describe('usage', () => {
     expect(r.out).toContain('usage:');
   });
 });
+
+describe('registry trust boundary', () => {
+  async function withRegistry(
+    mutate: (manifest: { families: { files: string[]; npmDeps: string[] }[] }) => void
+  ): Promise<string> {
+    const dir = join(cwd, 'evil-registry');
+    const manifest = JSON.parse(await readFile(join(REGISTRY, 'manifest.json'), 'utf8')) as {
+      families: { files: string[]; npmDeps: string[] }[];
+    };
+    mutate(manifest);
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(join(dir, 'families'), { recursive: true });
+    await writeFile(join(dir, 'manifest.json'), JSON.stringify(manifest));
+    return dir;
+  }
+
+  function runAgainst(registry: string, ...args: string[]): { status: number | null; out: string } {
+    const r = spawnSync(process.execPath, [BIN, ...args, '--registry', registry], {
+      cwd,
+      encoding: 'utf8',
+    });
+    return { status: r.status, out: `${r.stdout}${r.stderr}` };
+  }
+
+  it('rejects manifest file entries that escape families/', async () => {
+    const evil = await withRegistry((m) => {
+      const fam = m.families[0];
+      if (fam) fam.files = ['families/../../escape.ts'];
+    });
+    const r = runAgainst(evil, 'add', 'alpha');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('outside families/');
+  });
+
+  it('rejects npm dependency names that could smuggle arguments', async () => {
+    const evil = await withRegistry((m) => {
+      const fam = m.families[0];
+      if (fam) fam.npmDeps = ['--registry=https://evil.example'];
+    });
+    const r = runAgainst(evil, 'add', 'alpha');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('invalid npm dependency name');
+  });
+
+  it('rejects plaintext http registries', () => {
+    const r = runAgainst('http://registry.example/reg', 'add', 'alpha');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('https');
+  });
+});

--- a/tests/fixtures/cliRegistry/families/alpha.ts
+++ b/tests/fixtures/cliRegistry/families/alpha.ts
@@ -1,0 +1,2 @@
+// brepjs-family: alpha@2
+export const alpha = 1;

--- a/tests/fixtures/cliRegistry/families/beta.ts
+++ b/tests/fixtures/cliRegistry/families/beta.ts
@@ -1,0 +1,2 @@
+// brepjs-family: beta@1
+export const beta = 2;

--- a/tests/fixtures/cliRegistry/manifest.json
+++ b/tests/fixtures/cliRegistry/manifest.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "name": "cli test registry",
+  "families": [
+    {
+      "name": "alpha",
+      "version": 2,
+      "description": "standalone family",
+      "files": ["families/alpha.ts"],
+      "npmDeps": ["brepjs-families"],
+      "familyDeps": []
+    },
+    {
+      "name": "beta",
+      "version": 1,
+      "description": "depends on alpha",
+      "files": ["families/beta.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": ["alpha"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the `brepjs` bin with the two copy-in commands from the distribution design:

- `npx brepjs add <family...>` resolves the family dependency closure from a registry manifest (dependencies written first, cycles detected), copies the source files into `src/families/` as owned code, and reports missing npm deps (`--install` runs `npm install` for them; the default prints the exact command instead of mutating the project). Unmodified files are skipped as up to date; locally modified files are never clobbered without `--force`.
- `npx brepjs diff <family>` compares copied files against the registry, calls out stale version markers (`local alpha@1, registry alpha@2`), renders a `git diff --no-index` when git is available, and exits 1 on any drift — usable as a CI guard.

The registry is addressed by `--registry <url|path>` (default: the brepjs GitHub registry raw URL), so a firm-internal copy of the registry directory is a complete self-hosted registry — the format is data only.

The bin is dependency-free node (no build step) and ships via the package `bin`/`files` fields, so `npx brepjs` works wherever brepjs is installed. Tests spawn the real bin against a fixture registry in a scratch project and pin the dependency-closure ordering, idempotency, clobber protection and `--force`, unknown-family errors, dep reporting against an existing `package.json`, and both diff exit codes.
