### PR TITLE
feat(cli): add the create-brepjs project scaffold

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,6 +55,10 @@ const config: KnipConfig = {
     'packages/brepjs-families': {
       ignore: ['**'],
     },
+    // Scaffolding CLI: a bin plus copied-out template files, no exports.
+    'packages/create-brepjs': {
+      ignore: ['**'],
+    },
     'packages/brepjs-viewer': {
       ignore: ['**'],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7188,6 +7188,10 @@
       "resolved": "packages/brepjs-families",
       "link": true
     },
+    "node_modules/create-brepjs": {
+      "resolved": "packages/create-brepjs",
+      "link": true
+    },
     "node_modules/brepjs-manifold": {
       "resolved": "packages/brepjs-manifold",
       "link": true
@@ -15242,6 +15246,16 @@
       "license": "MIT",
       "peerDependencies": {
         "brepjs": ">=18.0.0"
+      }
+    },
+    "packages/create-brepjs": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "bin": {
+        "create-brepjs": "bin/create-brepjs.mjs"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/brepjs-manifold": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "packages/brepjs-sheetmetal",
     "packages/brepjs-manifold",
     "packages/brepjs-families",
+    "packages/create-brepjs",
     "packages/brepjs-voxel-wasm",
     "packages/brepjs-voxel",
     "packages/brepjs-cad",

--- a/packages/create-brepjs/bin/create-brepjs.mjs
+++ b/packages/create-brepjs/bin/create-brepjs.mjs
@@ -17,8 +17,18 @@ const TEMPLATES = join(dirname(fileURLToPath(import.meta.url)), '../templates');
 
 async function main() {
   const name = process.argv[2] ?? 'brepjs-app';
-  if (!/^[a-z0-9@][a-z0-9-_./]*$/i.test(name)) {
-    console.error(`create-brepjs: invalid project name '${name}'`);
+  // A relative path is allowed; its basename becomes the package name. No
+  // traversal, no absolute paths, no scopes (a scope is not a directory).
+  const segments = name.split('/');
+  const base = segments[segments.length - 1] ?? '';
+  const valid =
+    !name.startsWith('/') &&
+    !name.endsWith('/') &&
+    segments.every((s) => /^[a-z0-9][a-z0-9-_.]*$/.test(s) && s !== '.' && s !== '..');
+  if (!valid) {
+    console.error(
+      `create-brepjs: invalid project name '${name}' (relative path ending in a lowercase package name; no '..', no scopes)`
+    );
     process.exitCode = 1;
     return;
   }
@@ -39,7 +49,7 @@ async function main() {
   await rename(join(target, 'gitignore'), join(target, '.gitignore'));
   const pkgPath = join(target, 'package.json');
   const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
-  pkg.name = name.split('/').pop();
+  pkg.name = base;
   await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 
   console.warn(`Scaffolded ${target}`);

--- a/packages/create-brepjs/bin/create-brepjs.mjs
+++ b/packages/create-brepjs/bin/create-brepjs.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * create-brepjs — scaffold a brepjs + brepjs-families project.
+ *
+ *   npm create brepjs@latest my-project
+ *
+ * Copies the template (package.json, tsconfig, a working src/main.ts) into
+ * the target directory and prints the copy-in next steps (`npx brepjs add`).
+ */
+
+import { cp, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const TEMPLATES = join(dirname(fileURLToPath(import.meta.url)), '../templates');
+
+async function main() {
+  const name = process.argv[2] ?? 'brepjs-app';
+  if (!/^[a-z0-9@][a-z0-9-_./]*$/i.test(name)) {
+    console.error(`create-brepjs: invalid project name '${name}'`);
+    process.exitCode = 1;
+    return;
+  }
+  const target = resolve(name);
+  const existing = await readdir(target).catch(() => null);
+  if (existing !== null && existing.length > 0) {
+    console.error(`create-brepjs: target directory is not empty: ${target}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  await mkdir(target, { recursive: true });
+  await cp(TEMPLATES, target, { recursive: true });
+  // npm mangles nested package.json files in published packages; the template
+  // ships under a neutral name and is renamed on scaffold.
+  await rename(join(target, 'package.json.tpl'), join(target, 'package.json'));
+  // npm drops .gitignore from published tarballs; ship under a neutral name.
+  await rename(join(target, 'gitignore'), join(target, '.gitignore'));
+  const pkgPath = join(target, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+  pkg.name = name.split('/').pop();
+  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  console.warn(`Scaffolded ${target}`);
+  console.warn('');
+  console.warn('Next steps:');
+  console.warn(`  cd ${name}`);
+  console.warn('  npm install');
+  console.warn('  npx brepjs add room storey slab   # copy in starter families');
+  console.warn('  npx tsx src/main.ts');
+}
+
+main().catch((err) => {
+  console.error(`create-brepjs: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+});

--- a/packages/create-brepjs/package.json
+++ b/packages/create-brepjs/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "create-brepjs",
+  "version": "0.1.0",
+  "description": "Scaffold a brepjs + brepjs-families project (npm create brepjs)",
+  "keywords": [
+    "cad",
+    "bim",
+    "create",
+    "scaffold"
+  ],
+  "type": "module",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andymai/brepjs.git",
+    "directory": "packages/create-brepjs"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "create-brepjs": "bin/create-brepjs.mjs"
+  },
+  "files": [
+    "bin",
+    "templates"
+  ],
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/create-brepjs/templates/README.md
+++ b/packages/create-brepjs/templates/README.md
@@ -1,0 +1,13 @@
+# brepjs-app
+
+A [brepjs](https://github.com/andymai/brepjs) + brepjs-families project.
+
+```sh
+npm install
+npm start                          # evaluate src/main.ts and print mesh stats
+npx brepjs add room storey slab    # copy starter families into src/families/
+npx brepjs diff room               # compare a copied family against the registry
+```
+
+Families copied in by `brepjs add` are yours: edit them freely. `brepjs diff`
+compares your copies against the registry when you want to see upstream drift.

--- a/packages/create-brepjs/templates/gitignore
+++ b/packages/create-brepjs/templates/gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.log

--- a/packages/create-brepjs/templates/package.json.tpl
+++ b/packages/create-brepjs/templates/package.json.tpl
@@ -1,0 +1,18 @@
+{
+  "name": "brepjs-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "brepjs": "^18.0.0",
+    "brepjs-families": "^0.1.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/create-brepjs/templates/src/main.ts
+++ b/packages/create-brepjs/templates/src/main.ts
@@ -1,0 +1,40 @@
+/**
+ * A minimal brepjs-families model: a wall with a doorway, resolved to an
+ * element tree and materialized as a mesh. Run with `npm start`.
+ *
+ * Copy in richer starter families with `npx brepjs add room storey slab` —
+ * they land in src/families/ as code you own.
+ */
+
+import 'brepjs/quick';
+import { csg } from 'brepjs';
+import { family, el, resolve, evaluateModel, tTranslate } from 'brepjs-families';
+
+const Doorway = family<{ readonly width: number; readonly height: number; readonly at: number }>(
+  'Doorway',
+  (p) =>
+    el('Box', {
+      size: [p.width, 300, p.height],
+      transform: [tTranslate([p.at, 0, 0])],
+    }),
+  { role: 'fill' }
+);
+
+const Wall = family<{ readonly length: number; readonly height: number }>('Wall', (p) =>
+  el('Box', {
+    size: [p.length, 200, p.height],
+    voids: [Doorway({ key: 'door', width: 1000, height: 2100, at: 1500 })],
+  })
+);
+
+using evaluator = new csg.Evaluator();
+const model = evaluateModel(resolve(Wall({ key: 'wall-1', length: 4000, height: 2700 })), evaluator);
+
+for (const [keyPath, node] of model.byKeyPath) {
+  if (node.mesh.ok) {
+    const triangles = node.mesh.value.triangles.length / 3;
+    console.log(`${keyPath}: ${triangles} triangles`);
+  } else {
+    console.error(`${keyPath}: ${node.mesh.error.message}`);
+  }
+}

--- a/packages/create-brepjs/templates/tsconfig.json
+++ b/packages/create-brepjs/templates/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src"]
+}

--- a/tests/createBrepjs.test.ts
+++ b/tests/createBrepjs.test.ts
@@ -59,8 +59,27 @@ describe('create-brepjs', () => {
   });
 
   it('rejects hostile project names', () => {
-    const r = run('--oops');
-    expect(r.status).toBe(1);
-    expect(r.out).toContain('invalid project name');
+    for (const name of [
+      '--oops',
+      '../escape',
+      'a/../../b',
+      '/абс',
+      '/abs',
+      'name/',
+      '@scope/pkg',
+    ]) {
+      const r = run(name);
+      expect(r.status, name).toBe(1);
+      expect(r.out, name).toContain('invalid project name');
+    }
+  });
+
+  it('accepts a nested relative path and names the package by its basename', async () => {
+    const r = run('models/tiny-house');
+    expect(r.status).toBe(0);
+    const pkg = JSON.parse(await readFile(join(cwd, 'models/tiny-house/package.json'), 'utf8')) as {
+      name: string;
+    };
+    expect(pkg.name).toBe('tiny-house');
   });
 });

--- a/tests/createBrepjs.test.ts
+++ b/tests/createBrepjs.test.ts
@@ -1,0 +1,66 @@
+/**
+ * create-brepjs — scaffolds a working project skeleton: template files land
+ * with the right names (npm-mangled ones renamed), the package takes the
+ * project name, and non-empty targets are refused. Pure node; no kernel.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const BIN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../packages/create-brepjs/bin/create-brepjs.mjs'
+);
+
+let cwd = '';
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'create-brepjs-'));
+});
+
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true });
+});
+
+function run(...args: string[]): { status: number | null; out: string } {
+  const r = spawnSync(process.execPath, [BIN, ...args], { cwd, encoding: 'utf8' });
+  return { status: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+describe('create-brepjs', () => {
+  it('scaffolds a project with renamed template files and the project name', async () => {
+    const r = run('my-model');
+    expect(r.status).toBe(0);
+    const root = join(cwd, 'my-model');
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      name: string;
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.name).toBe('my-model');
+    expect(Object.keys(pkg.dependencies)).toContain('brepjs-families');
+    await expect(readFile(join(root, '.gitignore'), 'utf8')).resolves.toContain('node_modules');
+    await expect(readFile(join(root, 'src/main.ts'), 'utf8')).resolves.toContain('evaluateModel');
+    await expect(readFile(join(root, 'tsconfig.json'), 'utf8')).resolves.toBeTruthy();
+    // The template placeholder never leaks through.
+    await expect(readFile(join(root, 'package.json.tpl'), 'utf8')).rejects.toThrow();
+    expect(r.out).toContain('npx brepjs add');
+  });
+
+  it('refuses a non-empty target directory', async () => {
+    await mkdir(join(cwd, 'taken'));
+    await writeFile(join(cwd, 'taken/existing.txt'), 'x');
+    const r = run('taken');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('not empty');
+  });
+
+  it('rejects hostile project names', () => {
+    const r = run('--oops');
+    expect(r.status).toBe(1);
+    expect(r.out).toContain('invalid project name');
+  });
+});


### PR DESCRIPTION
Adds the `create-brepjs` package, completing the scaffold half of the copy-in distribution story:

```sh
npm create brepjs@latest my-project
cd my-project && npm install
npx brepjs add room storey slab   # copy starter families in as owned code
npx tsx src/main.ts
```

The scaffold is a dependency-free bin plus a template directory: a `package.json` (brepjs + brepjs-families + zod, tsx/typescript dev deps) that takes the project name, a strict `tsconfig`, a README pointing at the `brepjs add` / `brepjs diff` loop, and a working `src/main.ts` that builds a wall-with-doorway family, resolves it, and prints per-element mesh stats through `evaluateModel`.

npm mangles nested `package.json` and drops `.gitignore` from published tarballs, so both ship under neutral names (`package.json.tpl`, `gitignore`) and are renamed on scaffold. Non-empty target directories are refused; project names are validated.

The package is a workspace member (manual publish, like brepjs-viewer — not release-please managed) with a knip ignore entry. Tests spawn the real bin into a scratch directory and pin the renames, name substitution, dependency list, next-steps output, non-empty refusal, and hostile-name rejection.
