### PR TITLE
feat(ci): autopublish brepjs-families and create-brepjs via release-please

### DIFF
--- a/.github/workflows/publish-brepjs-families.yml
+++ b/.github/workflows/publish-brepjs-families.yml
@@ -1,0 +1,41 @@
+name: Publish brepjs-families
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (pack only, skip publish)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+
+      # brepjs-families ships TypeScript source (files: ["src"]) — no build step.
+      - name: Pack preview
+        run: npm pack --dry-run -w brepjs-families
+
+      # Authenticates via OIDC trusted publisher (configured for this exact
+      # workflow filename on npmjs.com -> brepjs-families -> Trusted Publisher Mgmt).
+      - name: Publish brepjs-families
+        if: ${{ inputs.dry_run != true }}
+        run: npm publish -w brepjs-families --provenance

--- a/.github/workflows/publish-create-brepjs.yml
+++ b/.github/workflows/publish-create-brepjs.yml
@@ -1,0 +1,41 @@
+name: Publish create-brepjs
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (pack only, skip publish)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+
+      # create-brepjs is a plain bin + templates — no build step.
+      - name: Pack preview
+        run: npm pack --dry-run -w create-brepjs
+
+      # Authenticates via OIDC trusted publisher (configured for this exact
+      # workflow filename on npmjs.com -> create-brepjs -> Trusted Publisher Mgmt).
+      - name: Publish create-brepjs
+        if: ${{ inputs.dry_run != true }}
+        run: npm publish -w create-brepjs --provenance

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,10 @@ jobs:
       brepjs_bim_tag_name: ${{ steps.release.outputs['packages/brepjs-bim--tag_name'] }}
       brepjs_sheetmetal_release_created: ${{ steps.release.outputs['packages/brepjs-sheetmetal--release_created'] }}
       brepjs_sheetmetal_tag_name: ${{ steps.release.outputs['packages/brepjs-sheetmetal--tag_name'] }}
+      brepjs_families_release_created: ${{ steps.release.outputs['packages/brepjs-families--release_created'] }}
+      brepjs_families_tag_name: ${{ steps.release.outputs['packages/brepjs-families--tag_name'] }}
+      create_brepjs_release_created: ${{ steps.release.outputs['packages/create-brepjs--release_created'] }}
+      create_brepjs_tag_name: ${{ steps.release.outputs['packages/create-brepjs--tag_name'] }}
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
       prs: ${{ steps.release.outputs.prs }}
@@ -70,6 +74,10 @@ jobs:
   # up-to-date main, and this job — which runs on every push — arms their
   # auto-merge then. brepjs-opencascade stays permanently held (expensive WASM
   # build, manual review). Auto-PUBLISH fires when each release PR merges.
+  #
+  # A second ordering edge exists INSIDE the leaves: brepjs-bim depends on
+  # brepjs-families, so bim additionally holds while a families release PR is
+  # open (same ETARGET failure mode, one level down).
   auto-merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -104,6 +112,13 @@ jobs:
           root_open=$(echo "$prs" | jq --arg b "$ROOT_BRANCH" \
             '[.[] | select(.headRefName == $b)] | length')
 
+          # brepjs-bim depends on brepjs-families the same way every leaf
+          # depends on root brepjs: node-workspace re-pins bim's
+          # `brepjs-families` dependency to the pending families release, so
+          # bim must not merge while a families release PR is open.
+          families_open=$(echo "$prs" | jq \
+            '[.[] | select(.headRefName | endswith("--components--brepjs-families"))] | length')
+
           echo "$prs" | jq -c '.[]' | while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             title=$(echo "$pr" | jq -r '.title')
@@ -121,11 +136,18 @@ jobs:
                 ;;
             esac
 
+            is_bim=false
+            case "$branch" in
+              *--components--brepjs-bim) is_bim=true ;;
+            esac
+
             # Any other component is a leaf. Hold it while the root brepjs
             # release PR is open; it is regenerated with a valid pin and
             # auto-merged on the next run, after root merges + publishes.
             if [ "$root_open" -gt 0 ]; then
               echo "HOLD #$number ($title) — waiting for root brepjs release to merge first"
+            elif [ "$families_open" -gt 0 ] && [ "$is_bim" = true ]; then
+              echo "HOLD #$number ($title) — waiting for brepjs-families release to merge first"
             else
               echo "MERGE #$number ($title) — no root brepjs release pending"
               gh pr merge "$number" --auto --squash --repo "$GH_REPO"
@@ -214,6 +236,44 @@ jobs:
           # Dispatch against the immutable release tag, not main (see verify above).
           GH_REF: ${{ needs.release-please.outputs.brepjs_bim_tag_name }}
         run: gh workflow run publish-brepjs-bim.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
+
+  # Auto-publish brepjs-families — same pattern as brepjs-bim above.
+  publish-brepjs-families:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.brepjs_families_release_created == 'true' }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
+          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
+      - name: Dispatch publish-brepjs-families (real publish)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_REF: ${{ needs.release-please.outputs.brepjs_families_tag_name }}
+        run: gh workflow run publish-brepjs-families.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
+
+  # Auto-publish create-brepjs — same pattern as brepjs-bim above.
+  publish-create-brepjs:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.create_brepjs_release_created == 'true' }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BREPJS_BOT_APP_ID }}
+          private-key: ${{ secrets.BREPJS_BOT_PRIVATE_KEY }}
+      - name: Dispatch publish-create-brepjs (real publish)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          GH_REF: ${{ needs.release-please.outputs.create_brepjs_tag_name }}
+        run: gh workflow run publish-create-brepjs.yml -f dry_run=false --ref "$GH_REF" --repo "$GH_REPO"
 
   # Auto-publish brepjs-sheetmetal — same pattern as brepjs-bim above.
   publish-brepjs-sheetmetal:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,7 @@
   "packages/brepjs-voxel-wasm": "0.7.0",
   "packages/brepjs-cad": "0.166.0",
   "packages/brepjs-bim": "0.7.0",
-  "packages/brepjs-sheetmetal": "0.3.0"
+  "packages/brepjs-sheetmetal": "0.3.0",
+  "packages/brepjs-families": "0.1.0",
+  "packages/create-brepjs": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,8 +48,22 @@
       "changelog-path": "CHANGELOG.md",
       "component": "brepjs-sheetmetal",
       "bump-minor-pre-major": true
+    },
+    "packages/brepjs-families": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "component": "brepjs-families",
+      "bump-minor-pre-major": true
+    },
+    "packages/create-brepjs": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "component": "create-brepjs",
+      "bump-minor-pre-major": true
     }
   },
-  "plugins": ["node-workspace"],
+  "plugins": [
+    "node-workspace"
+  ],
   "separate-pull-requests": true
 }


### PR DESCRIPTION
Registers `brepjs-families` and `create-brepjs` (both now on npm at 0.1.0, published manually) with release-please and wires their autopublish path, mirroring the brepjs-bim pattern:

- `release-please-config.json` + `.release-please-manifest.json`: both packages registered at 0.1.0 with their own components and changelogs.
- `publish-brepjs-families.yml` / `publish-create-brepjs.yml`: per-package `workflow_dispatch` publish workflows (dry-run by default) — separate files because each npm OIDC trusted publisher is bound to its exact workflow filename. Neither package has a build step: families ships TypeScript source, create-brepjs is a bin plus templates, so the workflows `npm pack --dry-run` as the preview and publish with provenance.
- `release-please.yml`: new outputs and two dispatch jobs that fire on the post-merge run cutting each release, dispatched against the immutable release tag like the existing leaves.

One new ordering rule in the auto-merge script: `brepjs-bim` depends on `brepjs-families`, so the node-workspace plugin re-pins bim's dependency to the pending families version. Bim's release PR now holds while a families release PR is open — the same ETARGET failure mode the root-before-leaves serialization already guards, one level down. The hold releases on the next push-triggered run after families merges, exactly like leaves waiting on root.

Activation requires one manual step per package on npmjs.com (Settings -> Trusted Publisher Management): bind `brepjs-families` to `publish-brepjs-families.yml` and `create-brepjs` to `publish-create-brepjs.yml` in this repository. Until then, the dispatch jobs run but the publish step fails at authentication; the manual `workflow_dispatch` path doubles as the recovery route either way.
