### PR TITLE
docs: add the declarative models section core

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -306,6 +306,14 @@ export default withMermaid(
           ],
         },
         {
+          text: 'Declarative Models',
+          items: [
+            { text: 'Why a Family Layer', link: '/families/overview' },
+            { text: 'Your First Building', link: '/families/first-building' },
+            { text: 'Elements, Key Paths & Identity', link: '/families/identity' },
+          ],
+        },
+        {
           text: 'Advanced',
           items: [
             { text: 'Memory Management', link: '/advanced/memory' },

--- a/apps/docs/families/first-building.md
+++ b/apps/docs/families/first-building.md
@@ -1,0 +1,140 @@
+---
+title: 'Your First Building'
+description: 'Build a storey with walls and a door as a families element tree, evaluate it to meshes, then edit a prop and watch unchanged siblings come back as the same mesh objects.'
+---
+
+# Your First Building
+
+This walkthrough builds a one-storey model: two walls, one of them with a door opening, evaluated to meshes. By the end you'll have made a prop edit and verified, by object identity, that the evaluator only re-meshed the wall you touched.
+
+If you haven't read **[Why a Family Layer](/families/overview)** yet, start there. This page assumes you know that families render to elements and elements project onto the [CSG IR](/concepts/csg-ir).
+
+## The model
+
+A `Storey` containing two `Wall`s along X, 4 m and 3 m long, 200 mm thick, 2.7 m high. The south wall carries a door void: 1 m wide, 2.1 m tall, 1.5 m along the wall. Dimensions are millimeters, matching the bim conventions.
+
+## Step 1: The door is a family with a role
+
+```typescript
+import { family, el, tTranslate, type Element } from 'brepjs-families';
+
+interface DoorProps {
+  readonly width: number;
+  readonly height: number;
+  /** [along-wall, sill] in the host wall's local frame. */
+  readonly at: readonly [number, number];
+}
+
+const Door = family<DoorProps>(
+  'Door',
+  (p) =>
+    el('Box', {
+      size: [p.width, 300, p.height],
+      transform: [tTranslate([p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill' }
+);
+```
+
+`role: 'fill'` is the load-bearing line. A plain element placed in a wall's `voids` is just a boolean cut: geometry only, no identity. A **fill-role family** in `voids` additionally synthesizes an `Opening` element during resolution, with its own key path and a `Fills` relationship to the door. That distinction is what lets a BIM export later emit a real `IfcOpeningElement` instead of an anonymous hole.
+
+The door's box is 300 mm deep against a 200 mm wall: cut tools may overshoot their host freely, only the intersection is removed.
+
+## Step 2: Walls accept voids
+
+```typescript
+interface WallProps {
+  readonly length: number;
+  readonly height: number;
+  readonly at: readonly [number, number, number];
+  readonly voids?: readonly Element[];
+}
+
+const Wall = family<WallProps>('Wall', (p) =>
+  el('Box', {
+    size: [p.length, 200, p.height],
+    voids: p.voids ?? [],
+    transform: [tTranslate(p.at)],
+  })
+);
+
+const Storey = family<{ readonly items: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.items)
+);
+```
+
+Desugaring order is normative and worth internalizing: **voids are cut in the host's local frame, then `fuse` entries merge, then the host `transform` applies**. The door above is positioned relative to the wall, and the wall's own placement carries the door with it. Move a wall; its openings move too.
+
+`Storey` renders to a `Group`: a pure container with no geometry of its own. Containers exist for structure and identity, and evaluation skips them.
+
+## Step 3: Resolve and evaluate
+
+```typescript
+import { csg } from 'brepjs';
+import { resolve, evaluateModel } from 'brepjs-families';
+
+function building(southLength: number) {
+  return resolve(
+    Storey({
+      key: 'ground',
+      items: [
+        Wall({
+          key: 'south',
+          length: southLength,
+          height: 2700,
+          at: [0, 0, 0],
+          voids: [Door({ key: 'entry', width: 1000, height: 2100, at: [1500, 0] })],
+        }),
+        Wall({ key: 'north', length: 3000, height: 2700, at: [0, 3800, 0] }),
+      ],
+    })
+  );
+}
+
+using evaluator = new csg.Evaluator();
+const first = evaluateModel(building(4000), evaluator);
+
+for (const [keyPath, node] of first.byKeyPath) {
+  if (node.mesh.ok) {
+    console.log(keyPath, node.mesh.value.triangles.length / 3, 'triangles');
+  }
+}
+// ground/south                    ~28 triangles (a box with a doorway)
+// ground/south/voids:entry        the opening's own geometry
+// ground/south/voids:entry/fill   the door that fills it
+// ground/north                    12 triangles (a plain box)
+```
+
+Three things to notice:
+
+- **Key paths are the ancestor chain.** `ground/south` is the south wall; the synthesized opening lives at `ground/south/voids:entry`, adopting the void slot's key. The `:` is reserved for these synthesized segments, so they can never collide with a child key you wrote.
+- **The storey has no entry.** `byKeyPath` maps geometry-bearing elements only; containers are identity, not geometry.
+- **Meshes, not shapes.** Each record's `mesh` is plain data you can hand to a renderer. There is nothing to dispose in this loop; only the `Evaluator` itself is `using`-scoped.
+
+## Step 4: Edit a prop, count what re-meshed
+
+Stretch the south wall from 4 m to 4.2 m and evaluate again with the same evaluator:
+
+```typescript
+const second = evaluateModel(building(4200), evaluator);
+
+const southBefore = first.byKeyPath.get('ground/south');
+const southAfter = second.byKeyPath.get('ground/south');
+const northBefore = first.byKeyPath.get('ground/north');
+const northAfter = second.byKeyPath.get('ground/north');
+
+if (southBefore?.mesh.ok && southAfter.mesh.ok) {
+  console.log(southAfter.mesh.value === southBefore.mesh.value); // false: re-meshed
+}
+if (northBefore?.mesh.ok && northAfter.mesh.ok) {
+  console.log(northAfter.mesh.value === northBefore.mesh.value); // true: SAME object
+}
+```
+
+The north wall's mesh comes back as the **same object**, not an equal one: its recipe hashed identically, so the evaluator served it from the mesh cache without touching the kernel. The south wall's subtree (its box, the cut, the carried door) re-evaluated; nothing else did. This is the [subtree-caching behavior](/concepts/csg-ir#content-addressed-hashing) of the IR, surfacing per element.
+
+The mesh cache is independent of the shape cache, so this holds even under memory pressure: a bounded evaluator can evict B-Rep shapes and still serve meshes as pure data hits.
+
+## Where the identity went
+
+Nothing in this walkthrough attached properties yet, but the seams are all in place: every element has a key path, the opening synthesized its own identity, and `resolve` captured relationships (`Contains`, `Voids`, `Fills`) on the way down. **[Elements, Key Paths & Identity](/families/identity)** explains the model those seams implement, and why every element that will carry identity needs an explicit key.

--- a/apps/docs/families/identity.md
+++ b/apps/docs/families/identity.md
@@ -1,0 +1,113 @@
+---
+title: 'Elements, Key Paths & Identity'
+description: 'How brepjs-families keeps stable, order-independent identity beside a content-addressed geometry cache: key paths, resolved elements, synthesized openings, and the keyed rule.'
+---
+
+# Elements, Key Paths & Identity
+
+The [CSG IR](/concepts/csg-ir) answers "have I built this shape before?" by hashing structure. Identity asks the opposite question: "is this _that_ wall?", and the answer must survive reordering siblings, editing dimensions, and rebuilding from scratch. This page is the model families uses to answer both questions at once without letting either contaminate the other.
+
+## Two identical walls, one materialization
+
+```typescript
+import { family, el, resolve, evaluateModel, type Element } from 'brepjs-families';
+import { csg } from 'brepjs';
+
+const Wall = family<{ readonly length: number }>('Wall', (p) =>
+  el('Box', { size: [p.length, 200, 2700] })
+);
+const Storey = family<{ readonly walls: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.walls)
+);
+
+const storey = resolve(
+  Storey({
+    key: 'ground',
+    walls: [Wall({ key: 'w1', length: 3000 }), Wall({ key: 'w2', length: 3000 })],
+  })
+);
+
+using ev = new csg.Evaluator();
+evaluateModel(storey, ev);
+console.log(ev.cacheStats().entries); // 1
+```
+
+One cache entry for two walls. Both elements exist, both have key paths, and if you opt into shapes (`{ shapes: true }`) both records hold the **same kernel handle**. The cache key contains zero identity fragments; the element tree contains zero geometry. That separation is the entire design:
+
+```mermaid
+graph TD
+  subgraph "Element tree (identity)"
+    S["Storey · ground"] --> W1["Wall · ground/w1"]
+    S --> W2["Wall · ground/w2"]
+  end
+  subgraph "IR (content-addressed)"
+    B["Box(3000, 200, 2700) · one cache entry"]
+  end
+  W1 -->|geometry| B
+  W2 -->|geometry| B
+```
+
+## Key paths are the identity axis
+
+Every resolved element's `keyPath` is its ancestor chain of keys joined with `/`: `ground/w1`. The path is what downstream consumers derive durable identifiers from; in the IFC projection it becomes the seed of a deterministic GlobalId, which is why the same wall keeps the same GlobalId across rebuilds and across reordering its siblings.
+
+Three rules keep paths sound:
+
+- **Duplicate sibling keys throw** at resolution. Two children named `w1` under one parent would be one identity claimed twice.
+- **`:` is reserved.** Synthesized segments (below) use it, so a user key can never collide with a generated path.
+- **Unkeyed elements get an index fallback** (`Wall[0]`) for addressing, and the resolved element records `keyed: false`. Fallback paths are order-dependent by construction, which leads to the most important rule in the system:
+
+> An element without an explicit key can render, resolve, and evaluate, but it can never mint durable identity. `familiesToBim` rejects unkeyed storeys, walls, slabs, and opening slots with a `Result` error rather than derive a GlobalId that silently changes when you reorder an array.
+
+This is deliberately stricter than "only error when properties are present". A GlobalId derived from `Wall[0]` _works_ until the day someone inserts a wall in front of it, and then every downstream system sees a deleted wall and a new one. Refusing early is the honest contract.
+
+## What resolution produces
+
+`resolve()` runs render functions top-down and returns a `ResolvedElement` tree:
+
+```typescript
+interface ResolvedElement {
+  readonly type: string; // 'Wall', 'Storey', 'Opening', ...
+  readonly keyPath: string; // 'ground/w1'
+  readonly keyed: boolean; // explicit key on this element?
+  readonly geometry: csg.IRNode; // the content-addressed recipe
+  readonly props: Readonly<Record<string, unknown>>; // pre-desugared invocation props
+  readonly attributes: Readonly<Record<string, unknown>>; // psets, material, classification
+  readonly relationships: readonly Relationship[]; // Contains / Voids / Fills
+  readonly children: readonly ResolvedElement[];
+}
+```
+
+Two fields deserve emphasis:
+
+- **`props` are the invocation props, pre-desugaring.** An adapter that needs parameters (IFC's extruded-solid path cannot recover `length` from baked geometry) reads them here, exactly as the author wrote them, after any schema validation applied defaults.
+- **`attributes` are captured, not rendered.** `psets`, `material`, and `classification` props are lifted off the element before render, so identity-side data structurally cannot reach the geometry hash.
+
+## Synthesized openings
+
+When a **fill-role** family (a door, a window) appears in a host's `voids`, resolution synthesizes an `Opening` element between host and filler:
+
+```
+ground/w1                    the wall        Voids -> ground/w1/voids:entry
+ground/w1/voids:entry        the opening     Fills -> ground/w1/voids:entry/fill
+ground/w1/voids:entry/fill   the door
+```
+
+The opening adopts the void slot's identity: it belongs to the _host's_ slot, so it survives the host being relocated and inherits the slot key's `keyed` state. Plain (non-fill) voids stay anonymous: a cut with no identity and no relationships, which is exactly right for a construction hole nobody needs to track.
+
+## Where each concern lives
+
+| Question                        | Answered by                                |
+| ------------------------------- | ------------------------------------------ |
+| Have I built this shape before? | `structuralHash` on the IR node            |
+| Is this that wall?              | `keyPath` on the resolved element          |
+| What are its properties?        | `props` / `attributes` beside the geometry |
+| What does it contain or cut?    | `relationships` derived at resolution      |
+| May it carry durable identity?  | `keyed` (explicit key required)            |
+
+If you find yourself wanting geometry to depend on identity, or identity to depend on evaluation order, the model is telling you the design has the dependency backwards.
+
+## Next steps
+
+- **[Your First Building](/families/first-building)**: the walkthrough that exercises everything above.
+- **[Why a Family Layer](/families/overview)**: the shorter framing, plus the copy-in distribution boundary.

--- a/apps/docs/families/overview.md
+++ b/apps/docs/families/overview.md
@@ -1,0 +1,89 @@
+---
+title: Why a Family Layer
+description: 'brepjs-families adds an identity-preserving element tree on top of the CSG IR: reusable, validated components for buildings and assemblies, with deduplication for free underneath.'
+---
+
+# Why a Family Layer
+
+The [CSG IR](/concepts/csg-ir) is deliberately anonymous. Two identical wall recipes hash identically, share one cache entry, and materialize once. That is exactly what you want from a geometry cache, and exactly what you cannot ship to a BIM consumer: a building needs every wall to keep its own name, its own properties, and its own stable identity across exports.
+
+`brepjs-families` resolves that tension by adding a second tree **beside** the IR, not inside it. You describe a model as a tree of **elements**, each optionally carrying a key, properties, and property sets. Resolution projects every element onto the content-addressed IR for geometry, while identity rides on the element tree and never enters a cache key. Identical recipes still share one materialization; identities stay distinct.
+
+```typescript
+import { family, el, resolve, evaluateModel, type Element } from 'brepjs-families';
+import { csg } from 'brepjs';
+
+const Wall = family<{ readonly length: number; readonly height: number }>('Wall', (p) =>
+  el('Box', { size: [p.length, 200, p.height] })
+);
+
+const Storey = family<{ readonly walls: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.walls)
+);
+
+const model = resolve(
+  Storey({
+    key: 'ground',
+    walls: [
+      Wall({ key: 'north', length: 4000, height: 2700 }),
+      Wall({ key: 'south', length: 4000, height: 2700 }),
+    ],
+  })
+);
+// Two elements, two key paths: 'ground/north' and 'ground/south'.
+// One IR recipe underneath: both walls share a single cache entry.
+```
+
+A `family()` is a plain function from props to an element tree. There is no React, no reconciler, no lifecycle: calling a family builds a description, and `resolve()` runs the render functions to produce a `ResolvedElement` tree. If you prefer JSX, the package ships a `jsx-runtime` export and the plain-function API stays primary.
+
+## What a family carries
+
+| Concern                  | Where it lives                                      |
+| ------------------------ | --------------------------------------------------- |
+| Geometry recipe          | The rendered IR subtree (content-addressed, cached) |
+| Identity                 | The element's key path (`ground/north`)             |
+| Properties               | `props`, validated by an optional Zod schema        |
+| Property sets, materials | `attributes`, captured beside the geometry          |
+| Containment and openings | `relationships` derived during resolution           |
+
+The split is strict by construction: the IR node under an element carries none of the identity, so nothing you attach to an element can perturb geometry hashing or fragment the cache.
+
+## Evaluation is mesh-first
+
+`evaluateModel` walks the resolved tree and returns one record per geometry-bearing element. The primary output is a **mesh**: plain data with no kernel lifetimes to manage, cached by content so a re-evaluation after an edit only re-meshes what changed.
+
+```typescript
+using evaluator = new csg.Evaluator();
+const evaluated = evaluateModel(model, evaluator);
+for (const [keyPath, node] of evaluated.byKeyPath) {
+  if (node.mesh.ok) console.log(keyPath, node.mesh.value.triangles.length / 3, 'triangles');
+}
+```
+
+B-Rep shape handles are opt-in (`{ shapes: true }`) for export paths. Viewport consumers never touch a handle, which means there are no disposal rules to get wrong in rendering code.
+
+## Copy-in, not framework
+
+Families are distributed on the copy-in model: `npx brepjs add wall door` writes family **source files into your project**, where you own and edit them. The package supplies the vocabulary (`family`, `el`, `resolve`, `evaluateModel`); the components are yours. The boundary is deliberate:
+
+| Ships as owned source                | Stays in the package                       |
+| ------------------------------------ | ------------------------------------------ |
+| Render functions (props to elements) | IR node construction and evaluation        |
+| Default property sets, naming        | IFC entity writing                         |
+| Material assignment                  | GlobalId derivation                        |
+| Which geometry recipe to use         | Spatial aggregation, relationship emission |
+
+A family that needs to reimplement IFC writing means the boundary was drawn wrong; that capability belongs in `brepjs-bim`.
+
+## Installing
+
+```sh
+npm install brepjs-families
+```
+
+The package currently ships TypeScript source, so use it with a bundler (Vite, esbuild, webpack) or a TS-aware runner like `tsx`. `npm create brepjs` scaffolds a ready-to-run project with both wired up.
+
+## Next steps
+
+- **[Your First Building](/families/first-building)**: a storey with walls and a door, evaluated to meshes, with a prop edit that shows the cache sparing unchanged siblings.
+- **[Elements, Key Paths & Identity](/families/identity)**: the mental model in depth, including why unkeyed elements cannot mint identity.


### PR DESCRIPTION
First of three planned docs PRs for the families layer: a new `Declarative Models` sidebar section with the load-bearing arc, written in the site's established voice (motivate by contrast, teach the model before the mechanics, concrete millimeter examples, mermaid where a diagram earns its place).

- **Why a Family Layer** (`/families/overview`): the tension the layer resolves (a content-addressed cache is deliberately anonymous; a building needs every wall to keep its identity), what a family carries and where each concern lives, mesh-first evaluation, the copy-in distribution boundary table, and honest install guidance (the package ships TypeScript source; bundler or tsx).
- **Your First Building** (`/families/first-building`): the walkthrough in the parametric-CSG page's style: a storey, two walls, a fill-role door, evaluated to meshes, ending with a prop edit verified by object identity — the unchanged wall's mesh comes back as the same object, not an equal one.
- **Elements, Key Paths & Identity** (`/families/identity`): the mental model in depth: key paths as the identity axis, the three path rules, why unkeyed elements cannot mint durable identity (stricter than "error when properties are present", with the reorder failure spelled out), the `ResolvedElement` contract, and synthesized openings.

Cross-links to the two follow-up pages (props/validation, IFC export) are deliberately plain text until those pages land in PR 2, so the dead-link check stays meaningful. Code blocks are default-skipped in the doc-test harness (it injects only root-brepjs exports; extending injection to satellite packages is noted for later) but every block passes sucrase syntax extraction, and `npm run docs:build` is green including dead links and sitemap.
