### PR TITLE
docs: add openings, validation, and ifc export pages

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -311,6 +311,9 @@ export default withMermaid(
             { text: 'Why a Family Layer', link: '/families/overview' },
             { text: 'Your First Building', link: '/families/first-building' },
             { text: 'Elements, Key Paths & Identity', link: '/families/identity' },
+            { text: 'Openings & Voids', link: '/families/openings' },
+            { text: 'Props & Validation', link: '/families/props-and-validation' },
+            { text: 'IFC Export', link: '/families/ifc-export' },
           ],
         },
         {

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -306,6 +306,14 @@ export default withMermaid(
           ],
         },
         {
+          text: 'Declarative Models',
+          items: [
+            { text: 'Why a Family Layer', link: '/families/overview' },
+            { text: 'Your First Building', link: '/families/first-building' },
+            { text: 'Elements, Key Paths & Identity', link: '/families/identity' },
+          ],
+        },
+        {
           text: 'Advanced',
           items: [
             { text: 'Memory Management', link: '/advanced/memory' },

--- a/apps/docs/families/first-building.md
+++ b/apps/docs/families/first-building.md
@@ -1,0 +1,140 @@
+---
+title: 'Your First Building'
+description: 'Build a storey with walls and a door as a families element tree, evaluate it to meshes, then edit a prop and watch unchanged siblings come back as the same mesh objects.'
+---
+
+# Your First Building
+
+This walkthrough builds a one-storey model: two walls, one of them with a door opening, evaluated to meshes. By the end you'll have made a prop edit and verified, by object identity, that the evaluator only re-meshed the wall you touched.
+
+If you haven't read **[Why a Family Layer](/families/overview)** yet, start there. This page assumes you know that families render to elements and elements project onto the [CSG IR](/concepts/csg-ir).
+
+## The model
+
+A `Storey` containing two `Wall`s along X, 4 m and 3 m long, 200 mm thick, 2.7 m high. The south wall carries a door void: 1 m wide, 2.1 m tall, 1.5 m along the wall. Dimensions are millimeters, matching the bim conventions.
+
+## Step 1: The door is a family with a role
+
+```typescript
+import { family, el, tTranslate, type Element } from 'brepjs-families';
+
+interface DoorProps {
+  readonly width: number;
+  readonly height: number;
+  /** [along-wall, sill] in the host wall's local frame. */
+  readonly at: readonly [number, number];
+}
+
+const Door = family<DoorProps>(
+  'Door',
+  (p) =>
+    el('Box', {
+      size: [p.width, 300, p.height],
+      transform: [tTranslate([p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill' }
+);
+```
+
+`role: 'fill'` is the load-bearing line. A plain element placed in a wall's `voids` is just a boolean cut: geometry only, no identity. A **fill-role family** in `voids` additionally synthesizes an `Opening` element during resolution, with its own key path and a `Fills` relationship to the door. That distinction is what lets a BIM export later emit a real `IfcOpeningElement` instead of an anonymous hole.
+
+The door's box is 300 mm deep against a 200 mm wall: cut tools may overshoot their host freely, only the intersection is removed.
+
+## Step 2: Walls accept voids
+
+```typescript
+interface WallProps {
+  readonly length: number;
+  readonly height: number;
+  readonly at: readonly [number, number, number];
+  readonly voids?: readonly Element[];
+}
+
+const Wall = family<WallProps>('Wall', (p) =>
+  el('Box', {
+    size: [p.length, 200, p.height],
+    voids: p.voids ?? [],
+    transform: [tTranslate(p.at)],
+  })
+);
+
+const Storey = family<{ readonly items: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.items)
+);
+```
+
+Desugaring order is normative and worth internalizing: **voids are cut in the host's local frame, then `fuse` entries merge, then the host `transform` applies**. The door above is positioned relative to the wall, and the wall's own placement carries the door with it. Move a wall; its openings move too.
+
+`Storey` renders to a `Group`: a pure container with no geometry of its own. Containers exist for structure and identity, and evaluation skips them.
+
+## Step 3: Resolve and evaluate
+
+```typescript
+import { csg } from 'brepjs';
+import { resolve, evaluateModel } from 'brepjs-families';
+
+function building(southLength: number) {
+  return resolve(
+    Storey({
+      key: 'ground',
+      items: [
+        Wall({
+          key: 'south',
+          length: southLength,
+          height: 2700,
+          at: [0, 0, 0],
+          voids: [Door({ key: 'entry', width: 1000, height: 2100, at: [1500, 0] })],
+        }),
+        Wall({ key: 'north', length: 3000, height: 2700, at: [0, 3800, 0] }),
+      ],
+    })
+  );
+}
+
+using evaluator = new csg.Evaluator();
+const first = evaluateModel(building(4000), evaluator);
+
+for (const [keyPath, node] of first.byKeyPath) {
+  if (node.mesh.ok) {
+    console.log(keyPath, node.mesh.value.triangles.length / 3, 'triangles');
+  }
+}
+// ground/south                    ~28 triangles (a box with a doorway)
+// ground/south/voids:entry        the opening's own geometry
+// ground/south/voids:entry/fill   the door that fills it
+// ground/north                    12 triangles (a plain box)
+```
+
+Three things to notice:
+
+- **Key paths are the ancestor chain.** `ground/south` is the south wall; the synthesized opening lives at `ground/south/voids:entry`, adopting the void slot's key. The `:` is reserved for these synthesized segments, so they can never collide with a child key you wrote.
+- **The storey has no entry.** `byKeyPath` maps geometry-bearing elements only; containers are identity, not geometry.
+- **Meshes, not shapes.** Each record's `mesh` is plain data you can hand to a renderer. There is nothing to dispose in this loop; only the `Evaluator` itself is `using`-scoped.
+
+## Step 4: Edit a prop, count what re-meshed
+
+Stretch the south wall from 4 m to 4.2 m and evaluate again with the same evaluator:
+
+```typescript
+const second = evaluateModel(building(4200), evaluator);
+
+const southBefore = first.byKeyPath.get('ground/south');
+const southAfter = second.byKeyPath.get('ground/south');
+const northBefore = first.byKeyPath.get('ground/north');
+const northAfter = second.byKeyPath.get('ground/north');
+
+if (southBefore?.mesh.ok && southAfter.mesh.ok) {
+  console.log(southAfter.mesh.value === southBefore.mesh.value); // false: re-meshed
+}
+if (northBefore?.mesh.ok && northAfter.mesh.ok) {
+  console.log(northAfter.mesh.value === northBefore.mesh.value); // true: SAME object
+}
+```
+
+The north wall's mesh comes back as the **same object**, not an equal one: its recipe hashed identically, so the evaluator served it from the mesh cache without touching the kernel. The south wall's subtree (its box, the cut, the carried door) re-evaluated; nothing else did. This is the [subtree-caching behavior](/concepts/csg-ir#content-addressed-hashing) of the IR, surfacing per element.
+
+The mesh cache is independent of the shape cache, so this holds even under memory pressure: a bounded evaluator can evict B-Rep shapes and still serve meshes as pure data hits.
+
+## Where the identity went
+
+Nothing in this walkthrough attached properties yet, but the seams are all in place: every element has a key path, the opening synthesized its own identity, and `resolve` captured relationships (`Contains`, `Voids`, `Fills`) on the way down. **[Elements, Key Paths & Identity](/families/identity)** explains the model those seams implement, and why every element that will carry identity needs an explicit key.

--- a/apps/docs/families/identity.md
+++ b/apps/docs/families/identity.md
@@ -49,7 +49,7 @@ graph TD
 
 ## Key paths are the identity axis
 
-Every resolved element's `keyPath` is its ancestor chain of keys joined with `/`: `ground/w1`. The path is what downstream consumers derive durable identifiers from; in the IFC projection it becomes the seed of a deterministic GlobalId, which is why the same wall keeps the same GlobalId across rebuilds and across reordering its siblings.
+Every resolved element's `keyPath` is its ancestor chain of keys joined with `/`: `ground/w1`. The path is what downstream consumers derive durable identifiers from; in the [IFC projection](/families/ifc-export) it becomes the seed of a deterministic GlobalId, which is why the same wall keeps the same GlobalId across rebuilds and across reordering its siblings.
 
 Three rules keep paths sound:
 
@@ -80,7 +80,7 @@ interface ResolvedElement {
 
 Two fields deserve emphasis:
 
-- **`props` are the invocation props, pre-desugaring.** An adapter that needs parameters (IFC's extruded-solid path cannot recover `length` from baked geometry) reads them here, exactly as the author wrote them, after any schema validation applied defaults.
+- **`props` are the invocation props, pre-desugaring.** An adapter that needs parameters (IFC's extruded-solid path cannot recover `length` from baked geometry) reads them here, exactly as the author wrote them, after any [schema validation](/families/props-and-validation) applied defaults.
 - **`attributes` are captured, not rendered.** `psets`, `material`, and `classification` props are lifted off the element before render, so identity-side data structurally cannot reach the geometry hash.
 
 ## Synthesized openings

--- a/apps/docs/families/identity.md
+++ b/apps/docs/families/identity.md
@@ -1,0 +1,113 @@
+---
+title: 'Elements, Key Paths & Identity'
+description: 'How brepjs-families keeps stable, order-independent identity beside a content-addressed geometry cache: key paths, resolved elements, synthesized openings, and the keyed rule.'
+---
+
+# Elements, Key Paths & Identity
+
+The [CSG IR](/concepts/csg-ir) answers "have I built this shape before?" by hashing structure. Identity asks the opposite question: "is this _that_ wall?", and the answer must survive reordering siblings, editing dimensions, and rebuilding from scratch. This page is the model families uses to answer both questions at once without letting either contaminate the other.
+
+## Two identical walls, one materialization
+
+```typescript
+import { family, el, resolve, evaluateModel, type Element } from 'brepjs-families';
+import { csg } from 'brepjs';
+
+const Wall = family<{ readonly length: number }>('Wall', (p) =>
+  el('Box', { size: [p.length, 200, 2700] })
+);
+const Storey = family<{ readonly walls: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.walls)
+);
+
+const storey = resolve(
+  Storey({
+    key: 'ground',
+    walls: [Wall({ key: 'w1', length: 3000 }), Wall({ key: 'w2', length: 3000 })],
+  })
+);
+
+using ev = new csg.Evaluator();
+evaluateModel(storey, ev);
+console.log(ev.cacheStats().entries); // 1
+```
+
+One cache entry for two walls. Both elements exist, both have key paths, and if you opt into shapes (`{ shapes: true }`) both records hold the **same kernel handle**. The cache key contains zero identity fragments; the element tree contains zero geometry. That separation is the entire design:
+
+```mermaid
+graph TD
+  subgraph "Element tree (identity)"
+    S["Storey · ground"] --> W1["Wall · ground/w1"]
+    S --> W2["Wall · ground/w2"]
+  end
+  subgraph "IR (content-addressed)"
+    B["Box(3000, 200, 2700) · one cache entry"]
+  end
+  W1 -->|geometry| B
+  W2 -->|geometry| B
+```
+
+## Key paths are the identity axis
+
+Every resolved element's `keyPath` is its ancestor chain of keys joined with `/`: `ground/w1`. The path is what downstream consumers derive durable identifiers from; in the IFC projection it becomes the seed of a deterministic GlobalId, which is why the same wall keeps the same GlobalId across rebuilds and across reordering its siblings.
+
+Three rules keep paths sound:
+
+- **Duplicate sibling keys throw** at resolution. Two children named `w1` under one parent would be one identity claimed twice.
+- **`:` is reserved.** Synthesized segments (below) use it, so a user key can never collide with a generated path.
+- **Unkeyed elements get an index fallback** (`Wall[0]`) for addressing, and the resolved element records `keyed: false`. Fallback paths are order-dependent by construction, which leads to the most important rule in the system:
+
+> An element without an explicit key can render, resolve, and evaluate, but it can never mint durable identity. `familiesToBim` rejects unkeyed storeys, walls, slabs, and opening slots with a `Result` error rather than derive a GlobalId that silently changes when you reorder an array.
+
+This is deliberately stricter than "only error when properties are present". A GlobalId derived from `Wall[0]` _works_ until the day someone inserts a wall in front of it, and then every downstream system sees a deleted wall and a new one. Refusing early is the honest contract.
+
+## What resolution produces
+
+`resolve()` runs render functions top-down and returns a `ResolvedElement` tree:
+
+```typescript
+interface ResolvedElement {
+  readonly type: string; // 'Wall', 'Storey', 'Opening', ...
+  readonly keyPath: string; // 'ground/w1'
+  readonly keyed: boolean; // explicit key on this element?
+  readonly geometry: csg.IRNode; // the content-addressed recipe
+  readonly props: Readonly<Record<string, unknown>>; // pre-desugared invocation props
+  readonly attributes: Readonly<Record<string, unknown>>; // psets, material, classification
+  readonly relationships: readonly Relationship[]; // Contains / Voids / Fills
+  readonly children: readonly ResolvedElement[];
+}
+```
+
+Two fields deserve emphasis:
+
+- **`props` are the invocation props, pre-desugaring.** An adapter that needs parameters (IFC's extruded-solid path cannot recover `length` from baked geometry) reads them here, exactly as the author wrote them, after any schema validation applied defaults.
+- **`attributes` are captured, not rendered.** `psets`, `material`, and `classification` props are lifted off the element before render, so identity-side data structurally cannot reach the geometry hash.
+
+## Synthesized openings
+
+When a **fill-role** family (a door, a window) appears in a host's `voids`, resolution synthesizes an `Opening` element between host and filler:
+
+```
+ground/w1                    the wall        Voids -> ground/w1/voids:entry
+ground/w1/voids:entry        the opening     Fills -> ground/w1/voids:entry/fill
+ground/w1/voids:entry/fill   the door
+```
+
+The opening adopts the void slot's identity: it belongs to the _host's_ slot, so it survives the host being relocated and inherits the slot key's `keyed` state. Plain (non-fill) voids stay anonymous: a cut with no identity and no relationships, which is exactly right for a construction hole nobody needs to track.
+
+## Where each concern lives
+
+| Question                        | Answered by                                |
+| ------------------------------- | ------------------------------------------ |
+| Have I built this shape before? | `structuralHash` on the IR node            |
+| Is this that wall?              | `keyPath` on the resolved element          |
+| What are its properties?        | `props` / `attributes` beside the geometry |
+| What does it contain or cut?    | `relationships` derived at resolution      |
+| May it carry durable identity?  | `keyed` (explicit key required)            |
+
+If you find yourself wanting geometry to depend on identity, or identity to depend on evaluation order, the model is telling you the design has the dependency backwards.
+
+## Next steps
+
+- **[Your First Building](/families/first-building)**: the walkthrough that exercises everything above.
+- **[Why a Family Layer](/families/overview)**: the shorter framing, plus the copy-in distribution boundary.

--- a/apps/docs/families/ifc-export.md
+++ b/apps/docs/families/ifc-export.md
@@ -1,0 +1,79 @@
+---
+title: 'IFC Export'
+description: 'Project a families element tree onto an IFC4 model with brepjs-bim: key-path-derived GlobalIds that survive reordering, property sets, wall openings with IfcRelVoids, and independent IfcOpenShell validation.'
+---
+
+# IFC Export
+
+Everything before this page kept identity abstract: key paths, `keyed` flags, relationships. IFC is where it cashes out. `familiesToBim` (from [brepjs-bim](https://www.npmjs.com/package/brepjs-bim)) projects a resolved element tree onto an IFC4 model in which every element's **GlobalId derives from its key path**, so the same wall keeps the same GlobalId across rebuilds, reorders, and re-exports. For anyone consuming the file downstream (clash detection, facility management, a model server tracking deltas), that stability is the difference between "the wall moved" and "a wall was deleted and another appeared".
+
+```typescript
+import { resolve } from 'brepjs-families';
+import { familiesToBim, toIfcValidated } from 'brepjs-bim';
+
+const projected = familiesToBim(resolve(building()), {
+  project: { name: 'Office Block A', projectId: 'office-a' },
+  siteName: 'Riverside Plot',
+});
+if (!projected.ok) throw new Error(projected.error.message);
+using model = projected.value.model;
+
+const ifc = await toIfcValidated(model, {
+  applicationName: 'my-app',
+  applicationVersion: '1',
+});
+// ifc.value.bytes is the IFC4 file; ifc.value.report carries validation issues.
+```
+
+The adapter returns a `Result`; the model it produces owns kernel geometry, so hold it in a `using` scope. `idByKeyPath` on the result maps each families key path to its element in the model.
+
+## What maps to what
+
+| Families element                   | IFC                                                                                                   |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Storey`                           | `IfcBuildingStorey`, aggregated under site and building                                               |
+| `Wall`                             | `IfcWall` with an extruded-solid body                                                                 |
+| `Slab`                             | `IfcSlab` (`FLOOR`, `ROOF`, `LANDING`, `BASESLAB`)                                                    |
+| Fill-role `Door` in `voids`        | `IfcDoor` + synthesized `IfcOpeningElement`, wired with `IfcRelVoidsElement` and `IfcRelFillsElement` |
+| Fill-role `Window` in `voids`      | `IfcWindow`, same opening wiring                                                                      |
+| `Group` and other empty containers | Structure only, no IFC element                                                                        |
+
+Walls and slabs must sit under a `Storey` ancestor: IFC requires spatial containment, and the adapter returns a `Result` error rather than emit an uncontained element. Fillers are contained in their wall's storey, openings are related to their wall through `IfcRelVoidsElement` alone, exactly as the schema intends.
+
+## Two sources, one element
+
+The adapter reads each element twice, on purpose:
+
+- **Props feed the parametric spec.** IFC's extruded-solid representation wants `length`, `height`, `thickness`, `axisX` as parameters, which cannot be recovered from baked geometry. The resolved element's pre-desugared props feed the spec 1:1 under their spec names.
+- **Geometry supplies placement.** The resolved geometry's outer translate chain folds into the IFC local placement, so the placement matches the IR world frame no matter whether the transform came from a prop or from inside a family's render. Millimeters in; the writer emits meters.
+
+For openings the same split holds: the door's `width` and `height` come from its props, while `offsetAlongWall` and the sill height derive from the void geometry's frame, projected onto the wall's axis so doors land correctly on rotated walls too.
+
+## Property sets
+
+Identity-side attributes flow into IFC property sets. A wall carrying `psets: { Pset_WallCommon: { FireRating: 'REI 120', IsExternal: true } }` emits those into `Pset_WallCommon`; spec-level fields (`materialName`, `loadBearing`, `thermalTransmittance` on windows) travel as props. Two walls sharing one cached solid still emit distinct psets, because attributes never touched the geometry path.
+
+## The rules the adapter enforces
+
+- **Explicit keys everywhere identity is minted.** Unkeyed storeys, walls, slabs, or void slots produce a `FAMILIES_UNKEYED_ELEMENT` error (see [the identity page](/families/identity) for why this is not negotiable).
+- **Stable keys are single-use.** Two elements resolving to the same key path would be one GlobalId claimed twice; the adapter refuses before building any geometry.
+- **Unmapped types fail loudly.** An element type without a spec mapping is a `Result` error, not a silent omission from the file.
+
+## Proof, not promises
+
+The repository carries this pipeline end to end: `packages/brepjs-bim/examples/sampleBuildingFamilies.ts` authors a two-storey building (four walls including Y-running ones, a door, a window, two slabs) as declarative source and writes `sample-building-families.ifc`. The committed fixture is validated by **IfcOpenShell**, an independent IFC implementation sharing no code with the writer:
+
+```
+[1] Parsed OK — schema IFC4
+[2] Schema validation: PASS (no EXPRESS / where-rule violations)
+[3] Spatial structure: 1 project, 1 site, 1 building, 2 storey(s)
+[4] GlobalIds: 62 unique, 0 malformed
+[5] Geometry: 10/10 products generated a shape
+```
+
+A CI gate additionally asserts the export is byte-identical across independent rebuilds and that every key-path-derived GlobalId lands in the file. If you change the projection, the fixture test tells you; if you break the schema, IfcOpenShell does.
+
+## Next steps
+
+- **[Openings & Voids](/families/openings)**: the synthesis model behind the door and window rows above.
+- **[Props & Validation](/families/props-and-validation)**: schemas, defaults, and how validated props reach the spec path.

--- a/apps/docs/families/openings.md
+++ b/apps/docs/families/openings.md
@@ -1,0 +1,105 @@
+---
+title: 'Openings & Voids'
+description: 'How voids desugar into boolean cuts, when a cut becomes a first-class Opening with identity and relationships, and how host transforms carry openings along.'
+---
+
+# Openings & Voids
+
+A hole in a wall is two different things depending on who is asking. To the geometry kernel it is a boolean cut, done and forgotten. To a building model it is an **opening**: an element with identity, related to the wall it voids and the door that fills it. Families keeps both meanings, and the `role` of the voiding element decides which one you get.
+
+## Plain voids: geometry only
+
+Any element placed in a host's `voids` becomes a cut tool:
+
+```typescript
+import { family, el, tTranslate, type Element } from 'brepjs-families';
+
+const Wall = family<{ readonly length: number }>('Wall', (p) =>
+  el('Box', {
+    size: [p.length, 200, 2700],
+    voids: [
+      // An anonymous service penetration: cut it, track nothing.
+      el('Box', { size: [200, 300, 200], transform: [tTranslate([500, -50, 2200])] }),
+    ],
+  })
+);
+```
+
+The tool is projected to IR, cut from the host, and that is the end of it: no key path, no relationships, nothing for an export to see. This is the right shape for holes nobody manages: penetrations, chamfers, sculpting cuts. Tools may overshoot their host freely (the 300 mm depth against a 200 mm wall above); only the intersection is removed.
+
+## Fill-role voids: an Opening is synthesized
+
+Declare a family with `role: 'fill'` and place an _instance of it_ in `voids`, and resolution builds more than a cut:
+
+```typescript
+const Door = family<{
+  readonly width: number;
+  readonly height: number;
+  readonly at: readonly [number, number];
+}>(
+  'Door',
+  (p) =>
+    el('Box', {
+      size: [p.width, 300, p.height],
+      transform: [tTranslate([p.at[0], 0, p.at[1]])],
+    }),
+  { role: 'fill' }
+);
+
+const VoidedWall = family<{ readonly voids: readonly Element[] }>('Wall', (p) =>
+  el('Box', { size: [4000, 200, 2700], voids: p.voids })
+);
+
+const wall = VoidedWall({
+  key: 'south',
+  voids: [Door({ key: 'entry', width: 1000, height: 2100, at: [1500, 0] })],
+});
+```
+
+Resolution synthesizes an `Opening` element between host and filler, with the full relationship triangle:
+
+```mermaid
+graph LR
+  W["Wall · south"] -->|Voids| O["Opening · south/voids:entry"]
+  O -->|Fills| D["Door · south/voids:entry/fill"]
+  W -->|Contains| D2["(children as usual)"]
+```
+
+- The **opening adopts the void slot's identity**: its path is `south/voids:entry`, built from the _host's_ slot, so it survives the host being moved or renamed elsewhere in the tree. The `:` in the segment is reserved, which makes synthesized paths structurally collision-free against any child key you could write.
+- The **filler sits at `/fill`** under the opening and keeps its own props: `width`, `height`, materials, ratings.
+- Slot keys follow the same rules as child keys: explicit key if given, index fallback if not, duplicates throw, and an unkeyed slot marks the opening `keyed: false`, which an [IFC export](/families/ifc-export) will refuse.
+
+## Transforms carry openings
+
+Desugaring order is voids first, then `fuse`, then the host `transform`. Openings and fills are cut in the host's **local frame** and then carried by the host's transform, so this wall and its doorway move as one:
+
+```typescript
+const MovedWall = family<{ readonly voids: readonly Element[] }>('Wall', (p) =>
+  el('Box', {
+    size: [4000, 200, 2700],
+    voids: p.voids,
+    transform: [tTranslate([12000, 0, 0])],
+  })
+);
+
+const moved = MovedWall({
+  key: 'south',
+  voids: [Door({ key: 'entry', width: 1000, height: 2100, at: [1500, 0] })],
+});
+// The door's world position is 12000 + 1500 along X. Its identity is unchanged.
+```
+
+Position is geometry; the key path is identity. Relocating a host changes where the opening _is_, never _which opening it is_.
+
+## Orientation on rotated hosts
+
+Walls that run along Y instead of X orient their box accordingly, and their fills do the same (the registry's starter `door` and `window` take an `alongY` flag for exactly this). At export time, the along-wall offset is recovered by projecting the void's frame onto the wall's axis, so a door 1.5 m along a Y-running wall lands 1.5 m along it in IFC too, and a door that would overhang the wall's end fails wall-bounds validation instead of silently clipping.
+
+## What this buys downstream
+
+The synthesized triangle is precisely what IFC wants: `IfcOpeningElement` related to the wall via `IfcRelVoidsElement`, filled via `IfcRelFillsElement`. Because the identity existed from resolution onward, the [export](/families/ifc-export) derives all three GlobalIds from key paths, and a reordered `voids` array with explicit slot keys changes nothing in the file.
+
+## Next steps
+
+- **[IFC Export](/families/ifc-export)**: the full projection, including containment rules and the validated sample building.
+- **[Props & Validation](/families/props-and-validation)**: schema-checking fill props like widths and sills before they reach geometry.

--- a/apps/docs/families/overview.md
+++ b/apps/docs/families/overview.md
@@ -38,13 +38,13 @@ A `family()` is a plain function from props to an element tree. There is no Reac
 
 ## What a family carries
 
-| Concern                  | Where it lives                                      |
-| ------------------------ | --------------------------------------------------- |
-| Geometry recipe          | The rendered IR subtree (content-addressed, cached) |
-| Identity                 | The element's key path (`ground/north`)             |
-| Properties               | `props`, validated by an optional Zod schema        |
-| Property sets, materials | `attributes`, captured beside the geometry          |
-| Containment and openings | `relationships` derived during resolution           |
+| Concern                  | Where it lives                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| Geometry recipe          | The rendered IR subtree (content-addressed, cached)                            |
+| Identity                 | The element's key path (`ground/north`)                                        |
+| Properties               | `props`, validated by an optional [Zod schema](/families/props-and-validation) |
+| Property sets, materials | `attributes`, captured beside the geometry                                     |
+| Containment and openings | `relationships` derived during resolution                                      |
 
 The split is strict by construction: the IR node under an element carries none of the identity, so nothing you attach to an element can perturb geometry hashing or fragment the cache.
 
@@ -73,7 +73,7 @@ Families are distributed on the copy-in model: `npx brepjs add wall door` writes
 | Material assignment                  | GlobalId derivation                        |
 | Which geometry recipe to use         | Spatial aggregation, relationship emission |
 
-A family that needs to reimplement IFC writing means the boundary was drawn wrong; that capability belongs in `brepjs-bim`.
+A family that needs to reimplement IFC writing means the boundary was drawn wrong; that capability belongs in [brepjs-bim](/families/ifc-export).
 
 ## Installing
 

--- a/apps/docs/families/overview.md
+++ b/apps/docs/families/overview.md
@@ -1,0 +1,89 @@
+---
+title: Why a Family Layer
+description: 'brepjs-families adds an identity-preserving element tree on top of the CSG IR: reusable, validated components for buildings and assemblies, with deduplication for free underneath.'
+---
+
+# Why a Family Layer
+
+The [CSG IR](/concepts/csg-ir) is deliberately anonymous. Two identical wall recipes hash identically, share one cache entry, and materialize once. That is exactly what you want from a geometry cache, and exactly what you cannot ship to a BIM consumer: a building needs every wall to keep its own name, its own properties, and its own stable identity across exports.
+
+`brepjs-families` resolves that tension by adding a second tree **beside** the IR, not inside it. You describe a model as a tree of **elements**, each optionally carrying a key, properties, and property sets. Resolution projects every element onto the content-addressed IR for geometry, while identity rides on the element tree and never enters a cache key. Identical recipes still share one materialization; identities stay distinct.
+
+```typescript
+import { family, el, resolve, evaluateModel, type Element } from 'brepjs-families';
+import { csg } from 'brepjs';
+
+const Wall = family<{ readonly length: number; readonly height: number }>('Wall', (p) =>
+  el('Box', { size: [p.length, 200, p.height] })
+);
+
+const Storey = family<{ readonly walls: readonly Element[] }>('Storey', (p) =>
+  el('Group', {}, p.walls)
+);
+
+const model = resolve(
+  Storey({
+    key: 'ground',
+    walls: [
+      Wall({ key: 'north', length: 4000, height: 2700 }),
+      Wall({ key: 'south', length: 4000, height: 2700 }),
+    ],
+  })
+);
+// Two elements, two key paths: 'ground/north' and 'ground/south'.
+// One IR recipe underneath: both walls share a single cache entry.
+```
+
+A `family()` is a plain function from props to an element tree. There is no React, no reconciler, no lifecycle: calling a family builds a description, and `resolve()` runs the render functions to produce a `ResolvedElement` tree. If you prefer JSX, the package ships a `jsx-runtime` export and the plain-function API stays primary.
+
+## What a family carries
+
+| Concern                  | Where it lives                                      |
+| ------------------------ | --------------------------------------------------- |
+| Geometry recipe          | The rendered IR subtree (content-addressed, cached) |
+| Identity                 | The element's key path (`ground/north`)             |
+| Properties               | `props`, validated by an optional Zod schema        |
+| Property sets, materials | `attributes`, captured beside the geometry          |
+| Containment and openings | `relationships` derived during resolution           |
+
+The split is strict by construction: the IR node under an element carries none of the identity, so nothing you attach to an element can perturb geometry hashing or fragment the cache.
+
+## Evaluation is mesh-first
+
+`evaluateModel` walks the resolved tree and returns one record per geometry-bearing element. The primary output is a **mesh**: plain data with no kernel lifetimes to manage, cached by content so a re-evaluation after an edit only re-meshes what changed.
+
+```typescript
+using evaluator = new csg.Evaluator();
+const evaluated = evaluateModel(model, evaluator);
+for (const [keyPath, node] of evaluated.byKeyPath) {
+  if (node.mesh.ok) console.log(keyPath, node.mesh.value.triangles.length / 3, 'triangles');
+}
+```
+
+B-Rep shape handles are opt-in (`{ shapes: true }`) for export paths. Viewport consumers never touch a handle, which means there are no disposal rules to get wrong in rendering code.
+
+## Copy-in, not framework
+
+Families are distributed on the copy-in model: `npx brepjs add wall door` writes family **source files into your project**, where you own and edit them. The package supplies the vocabulary (`family`, `el`, `resolve`, `evaluateModel`); the components are yours. The boundary is deliberate:
+
+| Ships as owned source                | Stays in the package                       |
+| ------------------------------------ | ------------------------------------------ |
+| Render functions (props to elements) | IR node construction and evaluation        |
+| Default property sets, naming        | IFC entity writing                         |
+| Material assignment                  | GlobalId derivation                        |
+| Which geometry recipe to use         | Spatial aggregation, relationship emission |
+
+A family that needs to reimplement IFC writing means the boundary was drawn wrong; that capability belongs in `brepjs-bim`.
+
+## Installing
+
+```sh
+npm install brepjs-families
+```
+
+The package currently ships TypeScript source, so use it with a bundler (Vite, esbuild, webpack) or a TS-aware runner like `tsx`. `npm create brepjs` scaffolds a ready-to-run project with both wired up.
+
+## Next steps
+
+- **[Your First Building](/families/first-building)**: a storey with walls and a door, evaluated to meshes, with a prop edit that shows the cache sparing unchanged siblings.
+- **[Elements, Key Paths & Identity](/families/identity)**: the mental model in depth, including why unkeyed elements cannot mint identity.

--- a/apps/docs/families/props-and-validation.md
+++ b/apps/docs/families/props-and-validation.md
@@ -1,0 +1,106 @@
+---
+title: 'Props & Validation'
+description: 'Validate family props with Zod at element construction: defaults and transforms applied before render, invocation vs render types, cross-field rules, and where errors surface.'
+---
+
+# Props & Validation
+
+A family's props are its entire public surface, and they travel further than most function arguments: into the geometry recipe, into identity capture, and (in a BIM projection) into a parametric spec that other software will read. Families therefore validates at the **earliest possible moment**: element construction, where the stack trace still points at the call that wrote the bad value.
+
+## A schema on the family
+
+Pass a [Zod](https://zod.dev) schema as `props` and every invocation is checked before an element exists:
+
+```typescript
+import { family, el } from 'brepjs-families';
+import { z } from 'zod';
+
+const slabSchema = z.object({
+  length: z.number().positive(),
+  width: z.number().positive(),
+  thickness: z.number().positive(),
+  predefinedType: z.enum(['FLOOR', 'ROOF', 'LANDING', 'BASESLAB']).default('FLOOR'),
+  materialName: z.string().min(1).default('Concrete'),
+});
+
+const Slab = family(
+  'Slab',
+  (p: z.output<typeof slabSchema>) => el('Box', { size: [p.length, p.width, p.thickness] }),
+  { props: slabSchema }
+);
+
+Slab({ key: 'floor', length: 6000, width: 4000, thickness: -250 });
+// throws: brepjs-families: invalid props for family 'Slab': ...
+```
+
+Failures throw with the family's name in the message. This is deliberately a throw, not a `Result`: bad props at construction are an authoring bug in code you are editing right now, the same category as a duplicate key, and the loudest possible failure is the kindest one.
+
+## Schema output replaces the props
+
+Validation is not a gate, it is a transformation: the schema's **output** becomes the element's props. Defaults and transforms apply before the render function runs and before identity capture, so everything downstream sees one consistent, completed value:
+
+```typescript
+const slab = Slab({ key: 'floor', length: 6000, width: 4000, thickness: 250 });
+// slab.props.predefinedType === 'FLOOR'
+// slab.props.materialName === 'Concrete'
+// Both defaults are real values now, visible to render, resolve, and any exporter.
+```
+
+This matters most at the [IFC boundary](/families/ifc-export): the spec path reads resolved props, and a default applied at construction reaches the file identically whether the caller wrote it or the schema supplied it.
+
+## Invocation type vs render type
+
+Defaults create a type asymmetry: callers may omit `materialName`, but render always receives it. `family` models this with two type parameters, `family<P, I>`, where `P` is the render (output) type and `I` the invocation (input) type. With a schema, both are inferred from it:
+
+```typescript
+const Slab = family(
+  'Slab',
+  (p: z.output<typeof slabSchema>) => /* p.materialName is string, not string | undefined */,
+  { props: slabSchema }
+);
+// Callers get z.input<typeof slabSchema>: materialName is optional.
+```
+
+The schema's output type must be assignable to the render props, and the compiler enforces it: a schema that strips or transforms a field render depends on is a type error at the `family()` call, not a runtime surprise. Schema-less families use one type for both sides, unchanged.
+
+## Cross-field rules
+
+Real components have constraints between fields. The starter `room` family refuses a door that cannot fit its own south wall:
+
+```typescript
+const roomSchema = z
+  .object({
+    width: z.number().positive(),
+    height: z.number().positive(),
+    doorWidth: z.number().positive().default(1000),
+    doorHeight: z.number().positive().default(2100),
+    doorAlong: z.number().nonnegative().default(0),
+  })
+  .superRefine((p, ctx) => {
+    const along = p.doorAlong > 0 ? p.doorAlong : (p.width - p.doorWidth) / 2;
+    if (along + p.doorWidth > p.width) {
+      ctx.addIssue({ code: 'custom', message: 'door does not fit the south wall' });
+    }
+    if (p.doorHeight > p.height) {
+      ctx.addIssue({ code: 'custom', message: 'door is taller than the room' });
+    }
+  });
+```
+
+Catching this at construction beats catching it as a mangled boolean cut three layers down, and beats by miles catching it as a wall-bounds error during export.
+
+## Where each failure surfaces
+
+| Mistake                          | Surfaces as                                     |
+| -------------------------------- | ----------------------------------------------- |
+| Invalid or out-of-range prop     | Throw at element construction, named family     |
+| Duplicate sibling or slot key    | Throw during `resolve()`                        |
+| Geometry that cannot build       | `Result` error per element from `evaluateModel` |
+| Unkeyed element minting identity | `Result` error from `familiesToBim`             |
+
+The pattern: authoring mistakes throw where you typed them; data and geometry problems flow as `Result`s where a program can handle them, consistent with [Result<T,E> everywhere else in brepjs](/concepts/result).
+
+## Next steps
+
+- **[IFC Export](/families/ifc-export)**: validated props feeding the parametric spec path.
+- **[Elements, Key Paths & Identity](/families/identity)**: the identity rules the last table row enforces.


### PR DESCRIPTION
Second docs PR for the Declarative Models section (stacked on #2098): the three feature pages, plus restoring the cross-links that PR 1 deliberately shipped as plain text while these pages did not exist.

- **Openings & Voids** (`/families/openings`): the two meanings of a hole (a cut to the kernel, an element to a building model) and how `role: 'fill'` selects between them; the synthesized relationship triangle with its key-path anatomy; desugaring order and why host transforms carry openings; orientation on Y-running hosts.
- **Props & Validation** (`/families/props-and-validation`): Zod schemas at element construction; schema output replacing props so defaults reach render, identity capture, and the IFC spec path identically; the `family<P, I>` invocation-vs-render type split and its compile-time enforcement; cross-field rules via the starter room's door-bounds refinement; a table of where each failure class surfaces (throws for authoring mistakes, Results for data and geometry), consistent with the site's Result page.
- **IFC Export** (`/families/ifc-export`): calibrated for a BIM-literate reader on the semantics while staying developer-first in code. Key-path-derived GlobalIds framed by their downstream consequence (the difference between "the wall moved" and "a wall was deleted and another appeared"), the mapping table, the two-sources-one-element design (props feed the parametric spec, geometry supplies placement), pset flow, the adapter's refusal rules, and the independently validated sample building with its IfcOpenShell report quoted as proof.

`npm run docs:build` is green (dead links included) and all 321 extracted snippets pass syntax extraction; families blocks remain default-skipped in the doc-test harness as in PR 1.
