### PR TITLE
feat(families): add cylinder and geometry intrinsics

### DIFF
--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -67,13 +67,37 @@ function renderToIntrinsic(elem: Element): { intrinsic: Element; typeName: strin
   return { intrinsic: cur, typeName };
 }
 
+function isIRNode(v: unknown): v is csg.IRNode {
+  return typeof v === 'object' && v !== null && 'structuralHash' in v && 'kind' in v;
+}
+
 function baseGeometry(intrinsic: Element): csg.IRNode {
   if (intrinsic.type === 'Box') {
     const size = intrinsic.props['size'] as readonly [number, number, number];
     return csg.box(size[0], size[1], size[2]);
   }
+  if (intrinsic.type === 'Cylinder') {
+    return csg.cylinder(
+      intrinsic.props['radius'] as number,
+      intrinsic.props['height'] as number
+    );
+  }
+  // The bridge to the full csg vocabulary (Profile, Extrude, Revolve, Sweep,
+  // Loft, booleans, ...): render functions build any IR node and hand it over;
+  // voids/fuse/transform desugaring composes on top as usual.
+  if (intrinsic.type === 'Geometry') {
+    const node = intrinsic.props['node'];
+    if (!isIRNode(node)) {
+      throw new Error(
+        "brepjs-families: 'Geometry' requires a csg IR node in props.node"
+      );
+    }
+    return node;
+  }
   if (intrinsic.type === 'Group' || intrinsic.type === 'Fragment') return csg.emptySolid();
-  throw new Error(`brepjs-families: unknown intrinsic element '${String(intrinsic.type)}'`);
+  throw new Error(
+    `brepjs-families: unknown intrinsic element '${String(intrinsic.type)}' (intrinsics: Box, Cylinder, Geometry, Group, Fragment)`
+  );
 }
 
 /** Identity-free projection: element -> IR only. Used for plain geometry

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -357,3 +357,68 @@ describe('keyed tracking', () => {
     expect(opening?.children[0]?.keyed).toBe(false);
   });
 });
+
+describe('intrinsic vocabulary', () => {
+  it('Cylinder resolves and materializes with exact volume', () => {
+    const Column = family<{ readonly radius: number; readonly height: number }>('Column', (p) =>
+      el('Cylinder', { radius: p.radius, height: p.height })
+    );
+    using ev = new csg.Evaluator();
+    const model = evaluateModel(
+      resolve(Column({ key: 'c1', radius: 150, height: 3000 })),
+      ev,
+      {},
+      { shapes: true }
+    );
+    const node = model.byKeyPath.get('c1');
+    expect(node?.shape && isOk(node.shape)).toBe(true);
+    if (node?.shape && isOk(node.shape)) {
+      expect(vol(node.shape.value)).toBeCloseTo(Math.PI * 150 * 150 * 3000, -2);
+    }
+  });
+
+  it('Geometry bridges the full csg vocabulary (profile + extrude wall)', () => {
+    const ProfiledWall = family<{ readonly length: number; readonly height: number }>(
+      'Wall',
+      (p) =>
+        el('Geometry', {
+          node: csg.extrude(
+            csg.profile(
+              csg.contour([0, 0], [
+                csg.lineTo([p.length, 0]),
+                csg.lineTo([p.length, 200]),
+                csg.lineTo([0, 200]),
+              ])
+            ),
+            [0, 0, p.height]
+          ),
+          voids: [
+            el('Box', { size: [1000, 300, 2100], transform: [tTranslate([1500, -50, 0])] }),
+          ],
+        })
+    );
+    using ev = new csg.Evaluator();
+    const model = evaluateModel(
+      resolve(ProfiledWall({ key: 'w', length: 4000, height: 2700 })),
+      ev,
+      {},
+      { shapes: true }
+    );
+    const node = model.byKeyPath.get('w');
+    expect(node?.shape && isOk(node.shape)).toBe(true);
+    if (node?.shape && isOk(node.shape)) {
+      // 4000 x 200 x 2700 wall minus a 1000 x 200 x 2100 doorway.
+      expect(vol(node.shape.value)).toBeCloseTo(4000 * 200 * 2700 - 1000 * 200 * 2100, -2);
+    }
+  });
+
+  it('Geometry without an IR node throws with a clear message', () => {
+    const Bad = family<Record<string, never>>('Bad', () => el('Geometry', { node: { not: 'a node' } }));
+    expect(() => resolve(Bad({ key: 'b' }))).toThrow(/requires a csg IR node/);
+  });
+
+  it('unknown intrinsics name the vocabulary in the error', () => {
+    const Bad = family<Record<string, never>>('Bad', () => el('Torus', {}));
+    expect(() => resolve(Bad({ key: 'b' }))).toThrow(/intrinsics: Box, Cylinder, Geometry/);
+  });
+});


### PR DESCRIPTION
A docs comprehensiveness audit against the roadmap's goals surfaced a real gap: the CSG feature nodes built for the family layer (Profile, Extrude, Revolve, Sweep, Loft) were unreachable from it — `el()`'s intrinsic vocabulary stopped at `Box`, `Group`, and `Fragment`, so a families wall could not be a profile+extrude even though those nodes were added precisely for that purpose.

Two additions close it:

- **`Cylinder`** (`radius`, `height`): the missing primitive for columns and round elements.
- **`Geometry`** (`node`): the general bridge — a render function builds any csg IR node and hands it over, and the voids/fuse/transform desugaring composes on top exactly as for `Box`. This makes the entire csg vocabulary (including the Phase 1-2 feature nodes and booleans) available to family authors through one intrinsic instead of an ever-growing prop-shaped mirror of the builder API.

Tests pin a cylinder column at exact volume, a profile+extrude wall with a doorway void at exact volume (the vocabulary the roadmap promised, now expressible), a clear error for a non-IR `node`, and an unknown-intrinsic error that names the full vocabulary.
