### PR TITLE
fix(sheetmetal): drop the unused brepjs-opencascade devdep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15278,7 +15278,6 @@
       "devDependencies": {
         "@eslint/js": "*",
         "@types/node": "26.2.0",
-        "brepjs-opencascade": ">=0.15.0",
         "eslint": "*",
         "tsx": "4.23.11",
         "typescript": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15278,7 +15278,7 @@
       "devDependencies": {
         "@eslint/js": "*",
         "@types/node": "26.2.0",
-        "brepjs-opencascade": ">=0.16.0",
+        "brepjs-opencascade": ">=0.15.0",
         "eslint": "*",
         "tsx": "4.23.11",
         "typescript": "*",

--- a/packages/brepjs-sheetmetal/package.json
+++ b/packages/brepjs-sheetmetal/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@eslint/js": "*",
     "@types/node": "26.2.0",
-    "brepjs-opencascade": ">=0.16.0",
+    "brepjs-opencascade": ">=0.15.0",
     "eslint": "*",
     "tsx": "4.23.11",
     "typescript": "*",

--- a/packages/brepjs-sheetmetal/package.json
+++ b/packages/brepjs-sheetmetal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brepjs-sheetmetal",
   "version": "0.3.0",
-  "description": "Sheet-metal CAD domain for brepjs — flange authoring, auto-miter, fold/unfold flat patterns",
+  "description": "Sheet-metal CAD domain for brepjs \u2014 flange authoring, auto-miter, fold/unfold flat patterns",
   "keywords": [
     "sheet-metal",
     "cad",
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@eslint/js": "*",
     "@types/node": "26.2.0",
-    "brepjs-opencascade": ">=0.15.0",
     "eslint": "*",
     "tsx": "4.23.11",
     "typescript": "*",


### PR DESCRIPTION
Unblocks the stalled release automerges (#2094 brepjs-families 0.2.0, #2095 brepjs-bim 0.8.0) and the failing release-branch Vercel previews.

Root cause: `brepjs-sheetmetal` carried a devDependency on `brepjs-opencascade@">=0.16.0"` since the package's creation. The published brepjs-opencascade is 0.15.6 — its 0.16.0 release is permanently held by design (expensive WASM build, manual publish), so main's version runs ahead of npm. On main, `npm ci` satisfies the range from the workspace and everything is green; on release-please branches, `release-install-check` resolves against the registry and fails with `ETARGET`, blocking every release PR and failing their Vercel previews the same way.

The fix removes the devDependency outright rather than relaxing it: the dependency is dead code. occt-wasm has been the default kernel since before this package existed — sheetmetal's tests initialize through the shared root setup (occt-wasm 4.2.0), and nothing in its source or tests imports brepjs-opencascade. All 233 sheetmetal tests pass unchanged after removal.

Once this merges, the next release-please run regenerates both release PRs on top of it and their armed automerges complete. The durable rule this leaves behind: nothing outside `packages/brepjs-opencascade` should depend on brepjs-opencascade at a version only main has — its published version lags by design, and occt-wasm is the default kernel everywhere else.
