### PR TITLE
fix(release): remove node-workspace re-pinning and widen the bim pin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15149,7 +15149,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "brepjs-families": "^0.1.0"
+        "brepjs-families": ">=0.1.0"
       },
       "devDependencies": {
         "@eslint/js": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15149,7 +15149,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "brepjs-families": ">=0.1.0"
+        "brepjs-families": ">=0.1.0 <1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "*",

--- a/packages/brepjs-bim/package.json
+++ b/packages/brepjs-bim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brepjs-bim",
   "version": "0.8.0",
-  "description": "BIM layer for brepjs — IFC4-aligned parametric building elements",
+  "description": "BIM layer for brepjs \u2014 IFC4-aligned parametric building elements",
   "keywords": [
     "bim",
     "ifc",
@@ -61,6 +61,6 @@
     "zod": "^4.4.3"
   },
   "dependencies": {
-    "brepjs-families": "^0.1.0"
+    "brepjs-families": ">=0.1.0"
   }
 }

--- a/packages/brepjs-bim/package.json
+++ b/packages/brepjs-bim/package.json
@@ -61,6 +61,6 @@
     "zod": "^4.4.3"
   },
   "dependencies": {
-    "brepjs-families": ">=0.1.0"
+    "brepjs-families": ">=0.1.0 <1.0.0"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -62,8 +62,6 @@
       "bump-minor-pre-major": true
     }
   },
-  "plugins": [
-    "node-workspace"
-  ],
+  "plugins": [],
   "separate-pull-requests": true
 }


### PR DESCRIPTION
Stops the release churn at its source. Today brepjs-cad released seven times (0.166.0 through 0.172.0) with changelogs repeating the same historical commits, version numbers skipping (no 0.167/0.169/0.171), and `brepjs-cad-v0.171.0` referenced in a changelog compare link while the tag does not exist. Two release PRs also stalled for hours on corrupted lockfiles.

The common engine is the `node-workspace` plugin:

- On every release it rewrites dependent packages' pins to the pending version, minting dependency-bump commits that the next run treats as releasable changes — release begets release. The changelog's own history shows prior attempts to fix the churn by adjusting ranges ("`*` did not fix the release churn"); the ranges were never the engine.
- Its lockfile rewriting is lossy: today it dropped `brepjs-families`' `zod` dependency from the lockfile and baked other pending PRs' versions into the families release branch, failing `release-install-check` with a package.json/lockfile desync until manually reconciled.
- It re-pins to versions that may never publish (the held brepjs-opencascade), the exact failure mode that removed brepjs-viewer from release-please management previously.

This PR removes the plugin. Re-pinning served no purpose here: every cross-package dependency is a wide floor range (`brepjs >=18.0.0`, `brepjs-voxel-wasm >=0.2.0`, and with this PR `brepjs-bim -> brepjs-families >=0.1.0`, widened from `^0.1.0` which would have gone unsatisfiable-on-regenerate the moment families 0.2.0 published). Wide floors mean released leaves always resolve against npm, and packages release only on their own conventional commits.

The auto-merge ordering in release-please.yml (root before leaves, bim after families) stays: it is harmless, and remains correct defense if a pin is ever narrowed again.

Not addressed here: the missing-tag baseline glitch that produced the duplicate changelogs. With the dependency-bump fuel removed, a baseline hiccup no longer cascades; if phantom releases recur, the next step is auditing GitHub releases vs git tags for brepjs-cad.
