### PR TITLE
feat(families): ship built dist with type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,8 +243,10 @@ jobs:
   packages-families:
     # Declarative family layer satellite (element trees over the CSG IR).
     # Build root brepjs first so the package typecheck resolves `brepjs` via
-    # package exports -> dist/; tests resolve `brepjs` to source through the
-    # vitest alias and need the OCCT WASM the setup composite restores.
+    # package exports -> dist/, then the families dist itself: the package's
+    # tests and registry lint-resolve `brepjs-families` via its own exports ->
+    # dist/. Tests resolve `brepjs` to source through the vitest alias and need
+    # the OCCT WASM the setup composite restores.
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
@@ -253,10 +255,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - run: npm run build
+      - run: npm run build --workspace=brepjs-families
       - run: npm run typecheck --workspace=brepjs-families
       - run: npm run lint --workspace=brepjs-families
       - run: npm run test --workspace=brepjs-families
-      - run: npm run build --workspace=brepjs-families
 
   packages-bim:
     # Experimental BIM (IFC4) domain satellite. Build root brepjs and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,12 +256,14 @@ jobs:
       - run: npm run typecheck --workspace=brepjs-families
       - run: npm run lint --workspace=brepjs-families
       - run: npm run test --workspace=brepjs-families
+      - run: npm run build --workspace=brepjs-families
 
   packages-bim:
-    # Experimental BIM (IFC4) domain satellite. Build root brepjs first so the
-    # package typecheck/build resolve `brepjs` via package exports → dist/; tests
-    # resolve `brepjs` to source through the vitest alias and need the OCCT WASM
-    # the setup composite restores (web-ifc is a devDep, installed by npm ci).
+    # Experimental BIM (IFC4) domain satellite. Build root brepjs and
+    # brepjs-families first so the package typecheck/build resolve both via
+    # package exports → dist/; tests resolve them to source through the vitest
+    # aliases and need the OCCT WASM the setup composite restores (web-ifc is a
+    # devDep, installed by npm ci).
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
@@ -270,6 +272,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
       - run: npm run build
+      - run: npm run build --workspace=brepjs-families
       - run: npm run typecheck --workspace=brepjs-bim
       - run: npm run lint --workspace=brepjs-bim
       - run: npm run test --workspace=brepjs-bim

--- a/.github/workflows/publish-brepjs-bim.yml
+++ b/.github/workflows/publish-brepjs-bim.yml
@@ -30,12 +30,13 @@ jobs:
 
       - run: npm ci
 
-      # Build the root brepjs first: brepjs-bim externalizes `brepjs` at runtime,
-      # but vite-plugin-dts needs brepjs's emitted types to resolve `import type`s
-      # when generating brepjs-bim's declarations.
+      # Build the root brepjs and brepjs-families first: brepjs-bim externalizes
+      # `brepjs` at runtime, but vite-plugin-dts needs both packages' emitted
+      # types to resolve `import type`s when generating brepjs-bim's declarations.
       - name: Build brepjs-bim (root brepjs prerequisite)
         run: |
           npm run build
+          npm run build --workspace=brepjs-families
           npm run build --workspace=brepjs-bim
 
       # Authenticates via OIDC trusted publisher (configured for this exact

--- a/.github/workflows/publish-brepjs-families.yml
+++ b/.github/workflows/publish-brepjs-families.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (pack only, skip publish)'
+        description: 'Dry run (build + pack only, skip publish)'
         required: false
         type: boolean
         default: true
@@ -15,7 +15,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
@@ -30,7 +30,14 @@ jobs:
 
       - run: npm ci
 
-      # brepjs-families ships TypeScript source (files: ["src"]) — no build step.
+      # Build the root brepjs first: brepjs-families externalizes `brepjs` at
+      # runtime, but vite-plugin-dts needs brepjs's emitted types to resolve
+      # `import type`s when generating brepjs-families's declarations.
+      - name: Build brepjs-families (root brepjs prerequisite)
+        run: |
+          npm run build
+          npm run build --workspace=brepjs-families
+
       - name: Pack preview
         run: npm pack --dry-run -w brepjs-families
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,7 +1212,6 @@
       "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
@@ -15146,7 +15145,7 @@
       }
     },
     "packages/brepjs-bim": {
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "brepjs-families": ">=0.1.0 <1.0.0"
@@ -15325,6 +15324,11 @@
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "typescript": "*",
+        "vite": "^8.0.0",
+        "vite-plugin-dts": "^5.0.0"
       },
       "peerDependencies": {
         "brepjs": ">=18.0.0"

--- a/packages/brepjs-bim/vitest.config.ts
+++ b/packages/brepjs-bim/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, '../../src'),
       brepjs: resolve(__dirname, '../../src/index.ts'),
+      'brepjs-families': resolve(__dirname, '../brepjs-families/src/index.ts'),
     },
   },
   test: {

--- a/packages/brepjs-families/package.json
+++ b/packages/brepjs-families/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
-    "src"
+    "dist"
   ],
   "license": "MIT",
   "repository": {
@@ -23,7 +23,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "./dist/brepjs-families.cjs",
+  "module": "./dist/brepjs-families.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
+    "build": "vite build",
     "typecheck": "tsgo --noEmit",
     "lint": "eslint src tests registry",
     "test": "vitest run"
@@ -34,14 +38,31 @@
   "peerDependencies": {
     "brepjs": ">=18.0.0"
   },
+  "devDependencies": {
+    "typescript": "*",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^5.0.0"
+  },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/brepjs-families.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/brepjs-families.cjs"
+      }
     },
     "./jsx-runtime": {
-      "types": "./src/jsxRuntime.ts",
-      "default": "./src/jsxRuntime.ts"
+      "import": {
+        "types": "./dist/jsxRuntime.d.ts",
+        "default": "./dist/jsxRuntime.js"
+      },
+      "require": {
+        "types": "./dist/jsxRuntime.d.ts",
+        "default": "./dist/jsxRuntime.cjs"
+      }
     }
   }
 }

--- a/packages/brepjs-families/vite.config.ts
+++ b/packages/brepjs-families/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  plugins: [dts({ rollupTypes: false, compilerOptions: { declarationMap: false } })],
+  build: {
+    target: 'es2022',
+    minify: false,
+    lib: {
+      entry: {
+        'brepjs-families': 'src/index.ts',
+        jsxRuntime: 'src/jsxRuntime.ts',
+      },
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: ['brepjs', 'zod'],
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
       // the last-published dist) and don't need a dist build in CI.
       'brepjs-sheetmetal': resolve(__dirname, 'packages/brepjs-sheetmetal/src/index.ts'),
       'brepjs-bim': resolve(__dirname, 'packages/brepjs-bim/src/index.ts'),
+      'brepjs-families': resolve(__dirname, 'packages/brepjs-families/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## What

`brepjs-families` published raw TypeScript source (`files: ["src"]`, exports pointing at `src/index.ts`), so only TS-transpiling loaders (vitest, tsx, bundlers) could consume it; plain node threw `ERR_UNKNOWN_FILE_EXTENSION`. This adds a vite build and flips the package to ship `dist/`.

- New `vite.config.ts` mirroring brepjs-bim: ES + CJS + per-module `.d.ts` via vite-plugin-dts, entries for `index` and `jsxRuntime`, `brepjs` and `zod` external
- `exports` map and `files` flipped to `dist/`, `jsx-runtime` subpath kept with its own types condition; top-level `main`/`module`/`types` added
- Tarball: 10 files, 5.9 kB packed

## Build ordering

- `packages-families` CI job builds the dist after typecheck/lint/test (same shape as `packages-bim`)
- `packages-bim` CI job and both publish workflows build families right after the root build: bim's typecheck and declaration emit now resolve `brepjs-families` via exports → `dist/index.d.ts`
- bim's vitest config gains a `brepjs-families` → source alias so its tests keep resolving source, the same pattern as its existing `brepjs` alias
- `publish-brepjs-families.yml` gains the build step (root prerequisite first) and its timeout matches bim's 15 min

## Verified

- Plain node: `import('brepjs-families')`, `require('brepjs-families')`, and `import('brepjs-families/jsx-runtime')` all load from the built dist
- families: typecheck, lint, 28 tests, build all pass
- bim: typecheck, build (dts against families dist), and the 3 families-dependent test files (23 tests) all pass
- `npm pack --dry-run` ships only `dist/` + `package.json`

Roadmap item 1 from the families handoff (unblocks plain-node consumers; playground examples for families are gated on this).
