### PR TITLE
docs: replace load-bearing metaphors with plain wording

### DIFF
--- a/apps/docs/families/first-building.md
+++ b/apps/docs/families/first-building.md
@@ -36,7 +36,7 @@ const Door = family<DoorProps>(
 );
 ```
 
-`role: 'fill'` is the load-bearing line. A plain element placed in a wall's `voids` is just a boolean cut: geometry only, no identity. A **fill-role family** in `voids` additionally synthesizes an `Opening` element during resolution, with its own key path and a `Fills` relationship to the door. That distinction is what lets a BIM export later emit a real `IfcOpeningElement` instead of an anonymous hole.
+`role: 'fill'` is the detail that matters. A plain element placed in a wall's `voids` is just a boolean cut: geometry only, no identity. A **fill-role family** in `voids` additionally synthesizes an `Opening` element during resolution, with its own key path and a `Fills` relationship to the door. That distinction is what lets a BIM export later emit a real `IfcOpeningElement` instead of an anonymous hole.
 
 The door's box is 300 mm deep against a 200 mm wall: cut tools may overshoot their host freely, only the intersection is removed.
 

--- a/packages/brepjs-bim/tests/bcfXml.test.ts
+++ b/packages/brepjs-bim/tests/bcfXml.test.ts
@@ -3,7 +3,7 @@ import { parseXml, findChild, childText } from '../src/bcf/bcfXml.js';
 
 /**
  * Low-level BCF XML tokenizer tests. The tokenizer reads untrusted `.bcfzip`
- * payloads, so the ReDoS-resistance cases below are load-bearing, not cosmetic:
+ * payloads, so the ReDoS-resistance cases below are essential, not cosmetic:
  * the sticky-flag tokenizer must stay linear on hostile input.
  */
 

--- a/packages/brepjs-cad/skills/implement/references/gridfinity.md
+++ b/packages/brepjs-cad/skills/implement/references/gridfinity.md
@@ -17,7 +17,7 @@ the skill ships worked examples (`gridfinity-baseplate`, `gridfinity-bin`, `grid
 ## Notes
 
 - The spec is a community "work in progress" — treat exact lip geometry as the example encodes it,
-  and keep the 42 mm grid / 7 mm U / Ø6×2 magnets as the load-bearing invariants.
+  and treat the 42 mm grid / 7 mm U / Ø6×2 magnets as invariants.
 - Generate feet by tiling one foot block per cell on the 42 mm grid (`fuseAll`/`compound`), hollow
   the body from the top, add the stacking lip, then drill magnet pockets up from below — see
   `gridfinity-bin.brep.ts`.

--- a/packages/brepjs-sheetmetal/tests/nfpNest.test.ts
+++ b/packages/brepjs-sheetmetal/tests/nfpNest.test.ts
@@ -205,7 +205,7 @@ describe('nest — true-shape (nfp)', () => {
         }
       }
       // Exhaustive: NO two placed outline polygons overlap (with spacing clearance).
-      // This is the load-bearing correctness check — concave parts whose bounding
+      // This is the central correctness check — concave parts whose bounding
       // boxes overlap must still not overlap at the true-outline level.
       for (let i = 0; i < polys.length; i += 1) {
         for (let j = i + 1; j < polys.length; j += 1) {


### PR DESCRIPTION
Rewrites the four metaphorical uses of load-bearing (docs page, gridfinity skill reference, two test comments) with plain wording. Literal IFC loadBearing property usage is untouched.