### PR TITLE
feat(families): map circular columns onto IfcColumn through the adapter

### DIFF
--- a/apps/docs/families/for-bim-professionals.md
+++ b/apps/docs/families/for-bim-professionals.md
@@ -44,7 +44,7 @@ A door in a wall is not a boolean subtraction that happens to look right. The mo
 
 ## Current scope, stated plainly
 
-The IFC projection today maps **storeys, walls, slabs, doors, and windows** (with their openings, property sets, and materials). Columns, beams, roofs, stairs, and the rest of the `brepjs-bim` catalog exist in the underlying library but are not yet driven from the families layer. If your models are mostly walls-slabs-openings (residential, fit-out, early massing for data), the pipeline is complete; if you need the full structural catalog through this declarative surface, that mapping work is visible on the project roadmap.
+The IFC projection today maps **storeys, walls, slabs, doors, windows, and circular columns** (with their openings, property sets, and materials). Beams, roofs, stairs, and the rest of the `brepjs-bim` catalog exist in the underlying library but are not yet driven from the families layer. If your models are mostly walls-slabs-openings (residential, fit-out, early massing for data), the pipeline is complete; if you need the full structural catalog through this declarative surface, that mapping work is visible on the project roadmap.
 
 This is also not a Revit or ArchiCAD replacement. There is no drawing sheet, no annotation, no GUI authoring. It is a **programmatic model pipeline**: configurators, generative studies, firm-standard component libraries, and automated IFC production feeding the tools you already use.
 

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -5,7 +5,7 @@
  * while the IR path serves the viewport and dedup. GlobalIds derive from
  * families key paths (stable under reordering), not insertion order.
  *
- * Scope: Storey containers, Wall/Slab elements, and wall openings — a
+ * Scope: Storey containers, Wall/Slab/Column elements, and wall openings — a
  * fill-role void (Door/Window family) maps onto addDoor/addWindow, which cut
  * the wall and wire IfcRelVoidsElement + IfcRelFillsElement; the opening and
  * filler GlobalIds derive from the synthesized key paths. Anonymous (non-fill)
@@ -18,6 +18,7 @@ import { BimModel, type OpeningIdentityOptions } from './model/bimModel.js';
 import type { LocalId } from './identity/localId.js';
 import { parseWallSpec } from './specs/wallSpec.js';
 import { parseSlabSpec } from './specs/slabSpec.js';
+import { parseColumnSpec } from './specs/columnSpec.js';
 import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
 import { specError, type BimError } from './errors/bimError.js';
@@ -238,16 +239,22 @@ export function familiesToBim(
       model.aggregate(buildingId, id);
       idByKeyPath.set(el.keyPath, id);
       containerId = id;
-    } else if (el.type === 'Wall' || el.type === 'Slab') {
+    } else if (el.type === 'Wall' || el.type === 'Slab' || el.type === 'Column') {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
       const parsed =
-        el.type === 'Wall' ? parseWallSpec(specInput(el)) : parseSlabSpec(specInput(el));
+        el.type === 'Wall'
+          ? parseWallSpec(specInput(el))
+          : el.type === 'Slab'
+            ? parseSlabSpec(specInput(el))
+            : parseColumnSpec(specInput(el));
       if (!parsed.ok) return parsed;
       const added =
         el.type === 'Wall'
           ? model.addWall(parsed.value as never, { stableKey: el.keyPath })
-          : model.addSlab(parsed.value as never, { stableKey: el.keyPath });
+          : el.type === 'Slab'
+            ? model.addSlab(parsed.value as never, { stableKey: el.keyPath })
+            : model.addColumn(parsed.value as never, { stableKey: el.keyPath });
       if (!added.ok) return added;
       idByKeyPath.set(el.keyPath, added.value);
       if (containerId === null) {

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -6,7 +6,12 @@ import type { LocalId } from '../identity/localId.js';
 import { makeLocalIdCounter } from '../identity/localId.js';
 import type { BimError } from '../errors/bimError.js';
 import { specError, fromBrepError } from '../errors/bimError.js';
-import type { AnyBimElement, BimElement, WallOpeningSpec, SlabOpeningSpec } from '../types/bimTypes.js';
+import type {
+  AnyBimElement,
+  BimElement,
+  WallOpeningSpec,
+  SlabOpeningSpec,
+} from '../types/bimTypes.js';
 import type { BimTreeNode, BimTreeSummary } from './treeSummary.js';
 import type {
   BimRelationship,
@@ -83,7 +88,9 @@ export class BimModel {
 
   init(spec: ProjectSpec): Result<LocalId, BimError> {
     if (this.#projectId !== null) {
-      return err(specError('DUPLICATE_PROJECT', 'BimModel.init() called twice — only one project per model'));
+      return err(
+        specError('DUPLICATE_PROJECT', 'BimModel.init() called twice — only one project per model')
+      );
     }
     // Prefer an explicit, globally-unique projectId; otherwise fall back to the
     // project name+description (stable, but unique only per distinct name).
@@ -186,10 +193,12 @@ export class BimModel {
     return ok(id);
   }
 
-  addColumn(spec: ColumnSpec): Result<LocalId, BimError> {
+  addColumn(spec: ColumnSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
     const geomResult = columnToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('COLUMN', spec, geomResult.value);
+    const id = this.#makeElement('COLUMN', spec, geomResult.value, options?.stableKey);
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);
@@ -519,10 +528,14 @@ export class BimModel {
       return err(specError('DOOR_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
     }
     if (spec.offsetAlongWall + spec.width > wall.spec.length) {
-      return err(specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetAlongWall + width) exceeds wall length'));
+      return err(
+        specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetAlongWall + width) exceeds wall length')
+      );
     }
     if (spec.offsetFromFloor + spec.height > wall.spec.height) {
-      return err(specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetFromFloor + height) exceeds wall height'));
+      return err(
+        specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetFromFloor + height) exceeds wall height')
+      );
     }
     const openingSpec: WallOpeningSpec = {
       kind: 'WALL_OPENING',
@@ -537,9 +550,17 @@ export class BimModel {
     this.#replaceWallGeometry(wall, cutResult.value);
 
     const openingId = this.#makeElement('OPENING', openingSpec, null, options?.openingStableKey);
-    this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
+    this.#makeRel<VoidsWallRel>({
+      kind: 'VOIDS_WALL',
+      wallLocalId: spec.wallLocalId,
+      openingLocalId: openingId,
+    });
     const doorId = this.#makeElement('DOOR', spec, null, options?.stableKey);
-    this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: doorId });
+    this.#makeRel<FillsOpeningRel>({
+      kind: 'FILLS_OPENING',
+      openingLocalId: openingId,
+      fillerLocalId: doorId,
+    });
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
       materialName: spec.materialName,
@@ -553,13 +574,25 @@ export class BimModel {
     if (!keyCheck.ok) return keyCheck;
     const wall = this.#elements.get(spec.wallLocalId);
     if (wall === undefined || wall.category !== 'WALL') {
-      return err(specError('WINDOW_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
+      return err(
+        specError('WINDOW_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`)
+      );
     }
     if (spec.offsetAlongWall + spec.width > wall.spec.length) {
-      return err(specError('WINDOW_EXCEEDS_WALL_BOUNDS', 'Window (offsetAlongWall + width) exceeds wall length'));
+      return err(
+        specError(
+          'WINDOW_EXCEEDS_WALL_BOUNDS',
+          'Window (offsetAlongWall + width) exceeds wall length'
+        )
+      );
     }
     if (spec.offsetFromFloor + spec.height > wall.spec.height) {
-      return err(specError('WINDOW_EXCEEDS_WALL_BOUNDS', 'Window (offsetFromFloor + height) exceeds wall height'));
+      return err(
+        specError(
+          'WINDOW_EXCEEDS_WALL_BOUNDS',
+          'Window (offsetFromFloor + height) exceeds wall height'
+        )
+      );
     }
     const openingSpec: WallOpeningSpec = {
       kind: 'WALL_OPENING',
@@ -574,9 +607,17 @@ export class BimModel {
     this.#replaceWallGeometry(wall, cutResult.value);
 
     const openingId = this.#makeElement('OPENING', openingSpec, null, options?.openingStableKey);
-    this.#makeRel<VoidsWallRel>({ kind: 'VOIDS_WALL', wallLocalId: spec.wallLocalId, openingLocalId: openingId });
+    this.#makeRel<VoidsWallRel>({
+      kind: 'VOIDS_WALL',
+      wallLocalId: spec.wallLocalId,
+      openingLocalId: openingId,
+    });
     const windowId = this.#makeElement('WINDOW', spec, null, options?.stableKey);
-    this.#makeRel<FillsOpeningRel>({ kind: 'FILLS_OPENING', openingLocalId: openingId, fillerLocalId: windowId });
+    this.#makeRel<FillsOpeningRel>({
+      kind: 'FILLS_OPENING',
+      openingLocalId: openingId,
+      fillerLocalId: windowId,
+    });
     this.#makeRel<AssociatesMaterialRel>({
       kind: 'ASSOCIATES_MATERIAL',
       materialName: spec.materialName,
@@ -585,18 +626,33 @@ export class BimModel {
     return ok(windowId);
   }
 
-  addSlabOpening(input: SlabOpeningInput, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+  addSlabOpening(
+    input: SlabOpeningInput,
+    options?: ElementIdentityOptions
+  ): Result<LocalId, BimError> {
     const keyCheck = this.#checkStableKey(options);
     if (!keyCheck.ok) return keyCheck;
     const slab = this.#elements.get(input.slabLocalId);
     if (slab === undefined || slab.category !== 'SLAB') {
-      return err(specError('SLAB_OPENING_SLAB_NOT_FOUND', `No slab found for localId ${input.slabLocalId}`));
+      return err(
+        specError('SLAB_OPENING_SLAB_NOT_FOUND', `No slab found for localId ${input.slabLocalId}`)
+      );
     }
     if (input.offsetX + input.sizeX > slab.spec.length) {
-      return err(specError('SLAB_OPENING_EXCEEDS_SLAB_BOUNDS', 'Opening (offsetX + sizeX) exceeds slab length'));
+      return err(
+        specError(
+          'SLAB_OPENING_EXCEEDS_SLAB_BOUNDS',
+          'Opening (offsetX + sizeX) exceeds slab length'
+        )
+      );
     }
     if (input.offsetY + input.sizeY > slab.spec.width) {
-      return err(specError('SLAB_OPENING_EXCEEDS_SLAB_BOUNDS', 'Opening (offsetY + sizeY) exceeds slab width'));
+      return err(
+        specError(
+          'SLAB_OPENING_EXCEEDS_SLAB_BOUNDS',
+          'Opening (offsetY + sizeY) exceeds slab width'
+        )
+      );
     }
     // Reject overlap with existing slab openings — overlapping rectangles would
     // double-subtract from NetArea/NetVolume in Qto_SlabBaseQuantities.
@@ -614,7 +670,12 @@ export class BimModel {
       const by0 = other.spec.offsetY;
       const by1 = other.spec.offsetY + other.spec.sizeY;
       if (ax0 < bx1 && bx0 < ax1 && ay0 < by1 && by0 < ay1) {
-        return err(specError('SLAB_OPENING_OVERLAP', 'Slab opening overlaps an existing opening on the same slab'));
+        return err(
+          specError(
+            'SLAB_OPENING_OVERLAP',
+            'Slab opening overlaps an existing opening on the same slab'
+          )
+        );
       }
     }
 
@@ -631,7 +692,11 @@ export class BimModel {
     this.#replaceSlabGeometry(slab, cutResult.value);
 
     const openingId = this.#makeElement('OPENING', openingSpec, null, options?.stableKey);
-    this.#makeRel<VoidsSlabRel>({ kind: 'VOIDS_SLAB', slabLocalId: input.slabLocalId, openingLocalId: openingId });
+    this.#makeRel<VoidsSlabRel>({
+      kind: 'VOIDS_SLAB',
+      slabLocalId: input.slabLocalId,
+      openingLocalId: openingId,
+    });
     return ok(openingId);
   }
 
@@ -976,9 +1041,7 @@ export class BimModel {
     return localId;
   }
 
-  #makeRel<R extends BimRelationship>(
-    fields: Omit<R, 'guid' | 'localId'>
-  ): LocalId {
+  #makeRel<R extends BimRelationship>(fields: Omit<R, 'guid' | 'localId'>): LocalId {
     const localId = this.#counter.next();
     // Deterministic GUID keyed on (kind, localId). localIds are assigned in a
     // fixed sequence, so an identical model produces identical relationship GUIDs.

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -113,9 +113,7 @@ describe('familiesToBim', () => {
     const storey = resolve(
       Storey({
         key: 's',
-        walls: [
-          Moved({ key: 'w', length: 3000, height: 2700, thickness: 200, at: [1234, 0, 0] }),
-        ],
+        walls: [Moved({ key: 'w', length: 3000, height: 2700, thickness: 200, at: [1234, 0, 0] })],
       })
     );
     const projected = familiesToBim(storey, { project: PROJECT });
@@ -125,10 +123,47 @@ describe('familiesToBim', () => {
     expect(await ifcText(model)).toContain('(1.234,0.,0.)');
   });
 
-  it('rejects a wall without a storey ancestor', () => {
-    const orphan = resolve(
-      Wall({ key: 'lonely', length: 3000, height: 2700, thickness: 200 })
+  it('maps a column onto IfcColumn with key-path identity and folded placement', async () => {
+    const Column = family<{
+      readonly height: number;
+      readonly profile: { readonly kind: 'CIRCULAR'; readonly radius: number };
+      readonly at: readonly [number, number, number];
+    }>('Column', (p) =>
+      el('Cylinder', {
+        radius: p.profile.radius,
+        height: p.height,
+        transform: [tTranslate(p.at)],
+      })
     );
+    const storey = resolve(
+      Storey({
+        key: 's',
+        walls: [
+          Column({
+            key: 'c1',
+            height: 3000,
+            profile: { kind: 'CIRCULAR', radius: 150 },
+            at: [500, 250, 0],
+          }),
+        ],
+      })
+    );
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    expect(unwrap(projected).idByKeyPath.has('s/c1')).toBe(true);
+    expect(checkReferentialIntegrity(model).issues.filter((i) => i.severity === 'error')).toEqual(
+      []
+    );
+    const ifc = await ifcText(model);
+    expect(ifc).toContain('IFCCOLUMN');
+    expect(ifc).toContain('IFCCIRCLEPROFILEDEF');
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/c1'));
+    expect(ifc).toContain('(0.5,0.25,0.)');
+  });
+
+  it('rejects a wall without a storey ancestor', () => {
+    const orphan = resolve(Wall({ key: 'lonely', length: 3000, height: 2700, thickness: 200 }));
     expect(isOk(familiesToBim(orphan, { project: PROJECT }))).toBe(false);
   });
 
@@ -200,7 +235,10 @@ const VoidedWall = family<
 
 const WALL_DIMS = { length: 3000, height: 2700, thickness: 200 };
 
-function voidedStorey(voids: readonly Element[], transform?: readonly ReturnType<typeof tTranslate>[]) {
+function voidedStorey(
+  voids: readonly Element[],
+  transform?: readonly ReturnType<typeof tTranslate>[]
+) {
   return resolve(
     Storey({
       key: 'storey-1',
@@ -234,7 +272,9 @@ describe('familiesToBim openings', () => {
   });
 
   it('maps a window fill onto IfcWindow', async () => {
-    const storey = voidedStorey([Window({ key: 'n1', width: 1200, height: 1000, at: [1500, 900] })]);
+    const storey = voidedStorey([
+      Window({ key: 'n1', width: 1200, height: 1000, at: [1500, 900] }),
+    ]);
     const projected = familiesToBim(storey, { project: PROJECT });
     expect(isOk(projected)).toBe(true);
     using model = unwrap(projected).model;
@@ -245,10 +285,14 @@ describe('familiesToBim openings', () => {
 
   it('derives wall-relative offsets from the void geometry (bounds probes)', () => {
     // 2200 + 900 > 3000: only a correctly derived offsetAlongWall can trip this.
-    const alongOverflow = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [2200, 0] })]);
+    const alongOverflow = voidedStorey([
+      Door({ key: 'd1', width: 900, height: 2100, at: [2200, 0] }),
+    ]);
     expect(isOk(familiesToBim(alongOverflow, { project: PROJECT }))).toBe(false);
     // 700 + 2100 > 2700: same probe for the sill axis.
-    const sillOverflow = voidedStorey([Door({ key: 'd1', width: 900, height: 2100, at: [600, 700] })]);
+    const sillOverflow = voidedStorey([
+      Door({ key: 'd1', width: 900, height: 2100, at: [600, 700] }),
+    ]);
     expect(isOk(familiesToBim(sillOverflow, { project: PROJECT }))).toBe(false);
   });
 
@@ -285,7 +329,12 @@ describe('familiesToBim openings', () => {
     const bad = resolve(
       Storey({
         key: 's',
-        walls: [VoidedSlab({ key: 'slab', voids: [Door({ key: 'd', width: 900, height: 2100, at: [0, 0] })] })],
+        walls: [
+          VoidedSlab({
+            key: 'slab',
+            voids: [Door({ key: 'd', width: 900, height: 2100, at: [0, 0] })],
+          }),
+        ],
       })
     );
     expect(isOk(familiesToBim(bad, { project: PROJECT }))).toBe(false);

--- a/packages/brepjs-families/registry/families/column.ts
+++ b/packages/brepjs-families/registry/families/column.ts
@@ -1,0 +1,38 @@
+// brepjs-family: column@1
+/**
+ * Column — a vertical circular column (cross-section centred on `at`,
+ * extruded up by `height`). Props feed the IFC column spec 1:1 in a BIM
+ * projection. Circular only in v1: the Cylinder intrinsic is base-centred at
+ * the local origin exactly like the spec solid, so the IR and IFC frames
+ * coincide; rectangular profiles arrive with the profile bridge (Beam arc).
+ */
+
+import { family, el, tTranslate } from 'brepjs-families';
+import { z } from 'zod';
+
+export const columnSchema = z.object({
+  height: z.number().positive(),
+  profile: z.object({
+    kind: z.literal('CIRCULAR'),
+    radius: z.number().positive(),
+  }),
+  at: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
+  predefinedType: z.enum(['COLUMN', 'PILASTER', 'NOTDEFINED']).default('COLUMN'),
+  materialName: z.string().min(1).default('Concrete'),
+  isExternal: z.boolean().optional(),
+  loadBearing: z.boolean().optional(),
+  fireRating: z.string().optional(),
+});
+
+export type ColumnProps = z.input<typeof columnSchema>;
+
+export const Column = family(
+  'Column',
+  (p: z.output<typeof columnSchema>) =>
+    el('Cylinder', {
+      radius: p.profile.radius,
+      height: p.height,
+      transform: [tTranslate(p.at)],
+    }),
+  { props: columnSchema }
+);

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -27,6 +27,14 @@
       "familyDeps": []
     },
     {
+      "name": "column",
+      "version": 1,
+      "description": "Vertical circular column mapping onto IfcColumn",
+      "files": ["families/column.ts"],
+      "npmDeps": ["brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
       "name": "door",
       "version": 1,
       "description": "Fill-role void: synthesizes an Opening with IfcRelVoids/Fills",

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -17,6 +17,7 @@ import { resolve, evaluateModel } from '../src/index.js';
 import { Room } from '../registry/families/room.js';
 import { Storey } from '../registry/families/storey.js';
 import { Slab } from '../registry/families/slab.js';
+import { Column } from '../registry/families/column.js';
 import { Window } from '../registry/families/window.js';
 import { Wall } from '../registry/families/wall.js';
 
@@ -121,6 +122,21 @@ describe('starter families', () => {
     expect(wall && isOk(wall.mesh)).toBe(true);
   });
 
+  it('a starter column resolves and materializes with a mesh', () => {
+    using ev = new csg.Evaluator();
+    const storey = resolve(
+      Storey({
+        key: 's',
+        items: [Column({ key: 'c1', height: 3000, profile: { kind: 'CIRCULAR', radius: 150 } })],
+      })
+    );
+    const model = evaluateModel(storey, ev);
+    const col = model.byKeyPath.get('s/c1');
+    expect(col && isOk(col.mesh)).toBe(true);
+    expect(storey.children[0]?.props['predefinedType']).toBe('COLUMN');
+    expect(storey.children[0]?.props['materialName']).toBe('Concrete');
+  });
+
   it('schema defaults apply at construction', () => {
     const slab = resolve(Slab({ key: 'f', length: 100, width: 100, thickness: 10 }));
     expect(slab.props['predefinedType']).toBe('FLOOR');
@@ -135,9 +151,7 @@ describe('starter families', () => {
 
   it('a door that cannot fit its room is rejected at construction', () => {
     // Wider than the south wall (centered placement goes negative).
-    expect(() => Room({ key: 'r', width: 900, depth: 900, height: 2400 })).toThrow(
-      /does not fit/
-    );
+    expect(() => Room({ key: 'r', width: 900, depth: 900, height: 2400 })).toThrow(/does not fit/);
     // Explicit placement overflowing the wall.
     expect(() =>
       Room({ key: 'r', width: 3000, depth: 3000, height: 2400, doorAlong: 2500 })


### PR DESCRIPTION
## What

First catalog-expansion step of the bim graduation arc (Column → Beam → Roof): circular columns now flow from the families layer onto `IfcColumn`.

- **Registry**: new starter family `column@1` (circular profile via the Cylinder intrinsic, `at` translate, spec-shaped props: `predefinedType`, `materialName`, `isExternal`, `loadBearing`, `fireRating`), with manifest entry and version marker
- **Adapter**: `'Column'` elements route through `parseColumnSpec` → `BimModel.addColumn` with key-path stable identity, spatial containment, and the same transform-fold-into-placement behavior as walls/slabs
- **BimModel**: `addColumn` gains the optional `ElementIdentityOptions` parameter (mirrors `addWall`/`addSlab`; backward compatible)
- **Docs**: for-bim-professionals moves columns into the mapped set, beams/roofs/stairs stay honestly listed as not yet driven

Circular-only in v1, and that's deliberate: the Cylinder intrinsic and the column spec solid are both base-centred at the local origin, so the IR and IFC frames coincide exactly. A rectangular column via the corner-origin Box intrinsic would need a centering translate that `composedOrigin` would fold into the IFC placement, corrupting it. Rectangular profiles arrive with the Beam PR's profile bridge.

## Tests

- families registry: column resolves, materializes with a mesh, schema defaults apply (29 tests pass)
- bim adapter: column maps with key-path GlobalId, zero referential-integrity errors, `IFCCOLUMN` + `IFCCIRCLEPROFILEDEF` in the IFC output, translate folded to the metre-scaled placement point (15 tests pass)
- Full bim suite: 639 tests pass; families/bim typecheck + lint + prettier clean
