### PR TITLE
feat(families): beam mapping and the profile bridge for columns and beams

### DIFF
--- a/apps/docs/families/for-bim-professionals.md
+++ b/apps/docs/families/for-bim-professionals.md
@@ -44,7 +44,7 @@ A door in a wall is not a boolean subtraction that happens to look right. The mo
 
 ## Current scope, stated plainly
 
-The IFC projection today maps **storeys, walls, slabs, doors, windows, and circular columns** (with their openings, property sets, and materials). Beams, roofs, stairs, and the rest of the `brepjs-bim` catalog exist in the underlying library but are not yet driven from the families layer. If your models are mostly walls-slabs-openings (residential, fit-out, early massing for data), the pipeline is complete; if you need the full structural catalog through this declarative surface, that mapping work is visible on the project roadmap.
+The IFC projection today maps **storeys, walls, slabs, doors, windows, columns, and beams** (columns and beams in rectangular, circular, and I-shape profiles, with openings, property sets, and materials throughout). Roofs, stairs, and the rest of the `brepjs-bim` catalog exist in the underlying library but are not yet driven from the families layer. If your models are mostly walls-slabs-openings (residential, fit-out, early massing for data), the pipeline is complete; if you need the full structural catalog through this declarative surface, that mapping work is visible on the project roadmap.
 
 This is also not a Revit or ArchiCAD replacement. There is no drawing sheet, no annotation, no GUI authoring. It is a **programmatic model pipeline**: configurators, generative studies, firm-standard component libraries, and automated IFC production feeding the tools you already use.
 

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -5,7 +5,7 @@
  * while the IR path serves the viewport and dedup. GlobalIds derive from
  * families key paths (stable under reordering), not insertion order.
  *
- * Scope: Storey containers, Wall/Slab/Column elements, and wall openings — a
+ * Scope: Storey containers, Wall/Slab/Column/Beam elements, and wall openings — a
  * fill-role void (Door/Window family) maps onto addDoor/addWindow, which cut
  * the wall and wire IfcRelVoidsElement + IfcRelFillsElement; the opening and
  * filler GlobalIds derive from the synthesized key paths. Anonymous (non-fill)
@@ -19,6 +19,7 @@ import type { LocalId } from './identity/localId.js';
 import { parseWallSpec } from './specs/wallSpec.js';
 import { parseSlabSpec } from './specs/slabSpec.js';
 import { parseColumnSpec } from './specs/columnSpec.js';
+import { parseBeamSpec } from './specs/beamSpec.js';
 import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
 import { specError, type BimError } from './errors/bimError.js';
@@ -44,6 +45,32 @@ const SPEC_DEFAULTS = {
 };
 
 const GEOMETRY_PROPS = new Set(['voids', 'fuse', 'transform', 'psets']);
+
+const SPEC_ROUTES = {
+  Wall: {
+    parse: parseWallSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addWall(spec as never, { stableKey: key }),
+  },
+  Slab: {
+    parse: parseSlabSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addSlab(spec as never, { stableKey: key }),
+  },
+  Column: {
+    parse: parseColumnSpec,
+    add: (m: BimModel, spec: unknown, key: string) =>
+      m.addColumn(spec as never, { stableKey: key }),
+  },
+  Beam: {
+    parse: parseBeamSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addBeam(spec as never, { stableKey: key }),
+  },
+} as const;
+
+function specRoute(type: string): (typeof SPEC_ROUTES)[keyof typeof SPEC_ROUTES] | undefined {
+  return Object.hasOwn(SPEC_ROUTES, type)
+    ? SPEC_ROUTES[type as keyof typeof SPEC_ROUTES]
+    : undefined;
+}
 
 /** Total of the resolved geometry's OUTER literal translate chain. The
  *  transform vocabulary is translate-only, so frame differences are exact
@@ -226,6 +253,7 @@ export function familiesToBim(
   const idByKeyPath = new Map<string, LocalId>();
   const walk = (el: ResolvedElement, storeyId: LocalId | null): Result<void, BimError> => {
     let containerId = storeyId;
+    const route = specRoute(el.type);
     if (el.type === 'Storey') {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
@@ -239,22 +267,12 @@ export function familiesToBim(
       model.aggregate(buildingId, id);
       idByKeyPath.set(el.keyPath, id);
       containerId = id;
-    } else if (el.type === 'Wall' || el.type === 'Slab' || el.type === 'Column') {
+    } else if (route !== undefined) {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
-      const parsed =
-        el.type === 'Wall'
-          ? parseWallSpec(specInput(el))
-          : el.type === 'Slab'
-            ? parseSlabSpec(specInput(el))
-            : parseColumnSpec(specInput(el));
+      const parsed = route.parse(specInput(el));
       if (!parsed.ok) return parsed;
-      const added =
-        el.type === 'Wall'
-          ? model.addWall(parsed.value as never, { stableKey: el.keyPath })
-          : el.type === 'Slab'
-            ? model.addSlab(parsed.value as never, { stableKey: el.keyPath })
-            : model.addColumn(parsed.value as never, { stableKey: el.keyPath });
+      const added = route.add(model, parsed.value, el.keyPath);
       if (!added.ok) return added;
       idByKeyPath.set(el.keyPath, added.value);
       if (containerId === null) {

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -184,10 +184,12 @@ export class BimModel {
     return ok(id);
   }
 
-  addBeam(spec: BeamSpec): Result<LocalId, BimError> {
+  addBeam(spec: BeamSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
     const geomResult = beamToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('BEAM', spec, geomResult.value);
+    const id = this.#makeElement('BEAM', spec, geomResult.value, options?.stableKey);
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -162,6 +162,75 @@ describe('familiesToBim', () => {
     expect(ifc).toContain('(0.5,0.25,0.)');
   });
 
+  it('maps a beam onto IfcBeam with an I-shape profile and key-path identity', async () => {
+    const Beam = family<{
+      readonly length: number;
+      readonly profile: Readonly<Record<string, unknown>>;
+      readonly at: readonly [number, number, number];
+    }>('Beam', (p) =>
+      el('Box', {
+        size: [p.length, 100, 200],
+        transform: [tTranslate(p.at)],
+      })
+    );
+    const storey = resolve(
+      Storey({
+        key: 's',
+        walls: [
+          Beam({
+            key: 'b1',
+            length: 4000,
+            profile: {
+              kind: 'I_BEAM',
+              overallWidth: 100,
+              overallDepth: 200,
+              flangeThickness: 8.5,
+              webThickness: 5.6,
+            },
+            at: [0, 0, 2700],
+          }),
+        ],
+      })
+    );
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    expect(unwrap(projected).idByKeyPath.has('s/b1')).toBe(true);
+    expect(checkReferentialIntegrity(model).issues.filter((i) => i.severity === 'error')).toEqual(
+      []
+    );
+    const ifc = await ifcText(model);
+    expect(ifc).toContain('IFCBEAM');
+    expect(ifc).toContain('IFCISHAPEPROFILEDEF');
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/b1'));
+    expect(ifc).toContain('(0.,0.,2.7)');
+  });
+
+  it('maps a rectangular column onto IfcRectangleProfileDef', async () => {
+    const Column = family<{
+      readonly height: number;
+      readonly profile: Readonly<Record<string, unknown>>;
+    }>('Column', (p) => el('Box', { size: [300, 300, p.height] }));
+    const storey = resolve(
+      Storey({
+        key: 's',
+        walls: [
+          Column({
+            key: 'c1',
+            height: 3000,
+            profile: { kind: 'RECTANGULAR', width: 300, height: 300 },
+          }),
+        ],
+      })
+    );
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    const ifc = await ifcText(model);
+    expect(ifc).toContain('IFCCOLUMN');
+    expect(ifc).toContain('IFCRECTANGLEPROFILEDEF');
+  });
+
   it('rejects a wall without a storey ancestor', () => {
     const orphan = resolve(Wall({ key: 'lonely', length: 3000, height: 2700, thickness: 200 }));
     expect(isOk(familiesToBim(orphan, { project: PROJECT }))).toBe(false);

--- a/packages/brepjs-families/registry/families/beam.ts
+++ b/packages/brepjs-families/registry/families/beam.ts
@@ -1,0 +1,113 @@
+// brepjs-family: beam@1
+/**
+ * Beam — a linear member (cross-section centred on the beam axis, extruded
+ * along `axisX` by `length`). Props feed the IFC beam spec 1:1 in a BIM
+ * projection. The render reproduces the placed spec solid: profile in the
+ * plane perpendicular to the axis, profile-y up. I-beam outlines skip root
+ * fillets — IfcIShapeProfileDef carries `filletRadius` parametrically, the
+ * viewport outline stays sharp.
+ */
+
+import { csg } from 'brepjs';
+import { family, el, tTranslate } from 'brepjs-families';
+import { z } from 'zod';
+
+const profileSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('RECTANGULAR'),
+    width: z.number().positive(),
+    height: z.number().positive(),
+  }),
+  z.object({ kind: z.literal('CIRCULAR'), radius: z.number().positive() }),
+  z.object({
+    kind: z.literal('I_BEAM'),
+    overallWidth: z.number().positive(),
+    overallDepth: z.number().positive(),
+    flangeThickness: z.number().positive(),
+    webThickness: z.number().positive(),
+    filletRadius: z.number().positive().optional(),
+  }),
+]);
+
+export const beamSchema = z.object({
+  length: z.number().positive(),
+  profile: profileSchema,
+  at: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
+  axisX: z.tuple([z.number(), z.number(), z.number()]).default([1, 0, 0]),
+  predefinedType: z
+    .enum([
+      'BEAM',
+      'JOIST',
+      'LINTEL',
+      'HOLLOWCORE',
+      'PURLIN',
+      'RAFTER',
+      'SPANDREL',
+      'T_BEAM',
+      'NOTDEFINED',
+    ])
+    .default('BEAM'),
+  materialName: z.string().min(1).default('Steel'),
+  isExternal: z.boolean().optional(),
+  loadBearing: z.boolean().optional(),
+  fireRating: z.string().optional(),
+});
+
+export type BeamProps = z.input<typeof beamSchema>;
+
+type PolygonProfile = Extract<z.output<typeof profileSchema>, { kind: 'RECTANGULAR' | 'I_BEAM' }>;
+
+function profilePoints(profile: PolygonProfile): ReadonlyArray<readonly [number, number]> {
+  if (profile.kind === 'RECTANGULAR') {
+    const hw = profile.width / 2;
+    const hh = profile.height / 2;
+    return [
+      [-hw, -hh],
+      [hw, -hh],
+      [hw, hh],
+      [-hw, hh],
+    ];
+  }
+  const hw = profile.overallWidth / 2;
+  const hd = profile.overallDepth / 2;
+  const hweb = profile.webThickness / 2;
+  const fi = hd - profile.flangeThickness;
+  return [
+    [-hw, -hd],
+    [hw, -hd],
+    [hw, -fi],
+    [hweb, -fi],
+    [hweb, fi],
+    [hw, fi],
+    [hw, hd],
+    [-hw, hd],
+    [-hw, fi],
+    [-hweb, fi],
+    [-hweb, -fi],
+    [-hw, -fi],
+  ];
+}
+
+export const Beam = family(
+  'Beam',
+  (p: z.output<typeof beamSchema>) => {
+    const alongY = p.axisX[1] !== 0;
+    let node: csg.IRNode;
+    if (p.profile.kind === 'CIRCULAR') {
+      const prism = csg.cylinder(p.profile.radius, p.length);
+      node = alongY
+        ? csg.rotate(prism, -90, { axis: [1, 0, 0] })
+        : csg.rotate(prism, 90, { axis: [0, 1, 0] });
+    } else {
+      // Placement frame per axis: along +X keeps profile-x on +Y; along +Y the
+      // placement's local Y is world -X (Z cross axisX), so profile-x flips.
+      const toWorld = alongY
+        ? ([px, py]: readonly [number, number]): [number, number, number] => [-px, 0, py]
+        : ([px, py]: readonly [number, number]): [number, number, number] => [0, px, py];
+      const dir: [number, number, number] = alongY ? [0, p.length, 0] : [p.length, 0, 0];
+      node = csg.extrude(csg.polygon(profilePoints(p.profile).map(toWorld)), dir);
+    }
+    return el('Geometry', { node, transform: [tTranslate(p.at)] });
+  },
+  { props: beamSchema }
+);

--- a/packages/brepjs-families/registry/families/column.ts
+++ b/packages/brepjs-families/registry/families/column.ts
@@ -1,21 +1,37 @@
-// brepjs-family: column@1
+// brepjs-family: column@2
 /**
- * Column — a vertical circular column (cross-section centred on `at`,
- * extruded up by `height`). Props feed the IFC column spec 1:1 in a BIM
- * projection. Circular only in v1: the Cylinder intrinsic is base-centred at
- * the local origin exactly like the spec solid, so the IR and IFC frames
- * coincide; rectangular profiles arrive with the profile bridge (Beam arc).
+ * Column — a vertical column (cross-section centred on `at`, extruded up by
+ * `height`). Props feed the IFC column spec 1:1 in a BIM projection. The
+ * render coincides with the spec solid: every profile is centred at the local
+ * origin and extruded along +Z. I-beam outlines skip root fillets —
+ * IfcIShapeProfileDef carries `filletRadius` parametrically, the viewport
+ * outline stays sharp.
  */
 
+import { csg } from 'brepjs';
 import { family, el, tTranslate } from 'brepjs-families';
 import { z } from 'zod';
 
+const profileSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('RECTANGULAR'),
+    width: z.number().positive(),
+    height: z.number().positive(),
+  }),
+  z.object({ kind: z.literal('CIRCULAR'), radius: z.number().positive() }),
+  z.object({
+    kind: z.literal('I_BEAM'),
+    overallWidth: z.number().positive(),
+    overallDepth: z.number().positive(),
+    flangeThickness: z.number().positive(),
+    webThickness: z.number().positive(),
+    filletRadius: z.number().positive().optional(),
+  }),
+]);
+
 export const columnSchema = z.object({
   height: z.number().positive(),
-  profile: z.object({
-    kind: z.literal('CIRCULAR'),
-    radius: z.number().positive(),
-  }),
+  profile: profileSchema,
   at: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
   predefinedType: z.enum(['COLUMN', 'PILASTER', 'NOTDEFINED']).default('COLUMN'),
   materialName: z.string().min(1).default('Concrete'),
@@ -26,13 +42,58 @@ export const columnSchema = z.object({
 
 export type ColumnProps = z.input<typeof columnSchema>;
 
+type PolygonProfile = Extract<z.output<typeof profileSchema>, { kind: 'RECTANGULAR' | 'I_BEAM' }>;
+
+function profilePoints(profile: PolygonProfile): ReadonlyArray<readonly [number, number]> {
+  if (profile.kind === 'RECTANGULAR') {
+    const hw = profile.width / 2;
+    const hh = profile.height / 2;
+    return [
+      [-hw, -hh],
+      [hw, -hh],
+      [hw, hh],
+      [-hw, hh],
+    ];
+  }
+  const hw = profile.overallWidth / 2;
+  const hd = profile.overallDepth / 2;
+  const hweb = profile.webThickness / 2;
+  const fi = hd - profile.flangeThickness;
+  return [
+    [-hw, -hd],
+    [hw, -hd],
+    [hw, -fi],
+    [hweb, -fi],
+    [hweb, fi],
+    [hw, fi],
+    [hw, hd],
+    [-hw, hd],
+    [-hw, fi],
+    [-hweb, fi],
+    [-hweb, -fi],
+    [-hw, -fi],
+  ];
+}
+
 export const Column = family(
   'Column',
-  (p: z.output<typeof columnSchema>) =>
-    el('Cylinder', {
-      radius: p.profile.radius,
-      height: p.height,
+  (p: z.output<typeof columnSchema>) => {
+    if (p.profile.kind === 'CIRCULAR') {
+      return el('Cylinder', {
+        radius: p.profile.radius,
+        height: p.height,
+        transform: [tTranslate(p.at)],
+      });
+    }
+    const points = profilePoints(p.profile).map(([px, py]): [number, number, number] => [
+      px,
+      py,
+      0,
+    ]);
+    return el('Geometry', {
+      node: csg.extrude(csg.polygon(points), [0, 0, p.height]),
       transform: [tTranslate(p.at)],
-    }),
+    });
+  },
   { props: columnSchema }
 );

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -28,10 +28,18 @@
     },
     {
       "name": "column",
-      "version": 1,
-      "description": "Vertical circular column mapping onto IfcColumn",
+      "version": 2,
+      "description": "Vertical column (rectangular / circular / I-shape) mapping onto IfcColumn",
       "files": ["families/column.ts"],
-      "npmDeps": ["brepjs-families", "zod"],
+      "npmDeps": ["brepjs", "brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
+      "name": "beam",
+      "version": 1,
+      "description": "Linear beam (rectangular / circular / I-shape) mapping onto IfcBeam",
+      "files": ["families/beam.ts"],
+      "npmDeps": ["brepjs", "brepjs-families", "zod"],
       "familyDeps": []
     },
     {

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -18,6 +18,7 @@ import { Room } from '../registry/families/room.js';
 import { Storey } from '../registry/families/storey.js';
 import { Slab } from '../registry/families/slab.js';
 import { Column } from '../registry/families/column.js';
+import { Beam } from '../registry/families/beam.js';
 import { Window } from '../registry/families/window.js';
 import { Wall } from '../registry/families/wall.js';
 
@@ -120,6 +121,63 @@ describe('starter families', () => {
     const model = evaluateModel(storey, ev);
     const wall = model.byKeyPath.get('s/w');
     expect(wall && isOk(wall.mesh)).toBe(true);
+  });
+
+  it('starter beams materialize for every profile kind and both axes', () => {
+    using ev = new csg.Evaluator();
+    const storey = resolve(
+      Storey({
+        key: 's',
+        items: [
+          Beam({
+            key: 'rect',
+            length: 4000,
+            profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+          }),
+          Beam({
+            key: 'round',
+            length: 4000,
+            profile: { kind: 'CIRCULAR', radius: 120 },
+            axisX: [0, 1, 0],
+          }),
+          Beam({
+            key: 'ipe',
+            length: 4000,
+            profile: {
+              kind: 'I_BEAM',
+              overallWidth: 100,
+              overallDepth: 200,
+              flangeThickness: 8.5,
+              webThickness: 5.6,
+            },
+          }),
+        ],
+      })
+    );
+    const model = evaluateModel(storey, ev);
+    for (const key of ['s/rect', 's/round', 's/ipe']) {
+      const beam = model.byKeyPath.get(key);
+      expect(beam && isOk(beam.mesh), key).toBe(true);
+    }
+  });
+
+  it('a rectangular column materializes through the profile bridge', () => {
+    using ev = new csg.Evaluator();
+    const storey = resolve(
+      Storey({
+        key: 's',
+        items: [
+          Column({
+            key: 'c1',
+            height: 3000,
+            profile: { kind: 'RECTANGULAR', width: 300, height: 300 },
+          }),
+        ],
+      })
+    );
+    const model = evaluateModel(storey, ev);
+    const col = model.byKeyPath.get('s/c1');
+    expect(col && isOk(col.mesh)).toBe(true);
   });
 
   it('a starter column resolves and materializes with a mesh', () => {


### PR DESCRIPTION
## What

Second catalog step of the bim graduation arc (Column ✔ → **Beam** → Roof): beams now flow from the families layer onto `IfcBeam`, and the profile bridge this required also unlocks rectangular and I-shape columns.

- **Registry**: new starter family `beam@1` — rectangular / circular / I-shape profiles, `axisX` support for +X and +Y runs (wall-style), spec-shaped props (`predefinedType` with the full IFC beam enum, `materialName`, `isExternal`, `loadBearing`, `fireRating`)
- **Profile bridge**: non-circular profiles render through the `Geometry` intrinsic as `csg.polygon` + `csg.extrude` with the cross-section centred in the plane perpendicular to the axis, profile-y up — exactly the placed frame `beamToSolid`/`columnToSolid` produce, so `composedOrigin` folds only the real `at` translate into `IfcLocalPlacement`. Circular beams are a rotated Cylinder primitive. I-beam viewport outlines skip root fillets; `IfcIShapeProfileDef` carries `filletRadius` parametrically
- **`column@2`**: same profile union, so rectangular/I columns work (the deferral noted in #2121 is resolved)
- **BimModel**: `addBeam` gains `ElementIdentityOptions` (mirrors `addWall`/`addSlab`/`addColumn`; backward compatible)
- **Adapter**: with four mapped types, the per-type ternaries become a `SPEC_ROUTES` table; behavior unchanged
- **Docs**: for-bim-professionals moves beams into the mapped set; roofs/stairs stay honestly listed as not yet driven

## Tests

- families registry: beams materialize for all three profile kinds and both axes; rectangular column materializes through the bridge (31 tests pass)
- bim adapter: I-shape beam maps with key-path GlobalId, zero integrity errors, `IFCBEAM` + `IFCISHAPEPROFILEDEF`, placement folded to metres; rectangular column emits `IFCRECTANGLEPROFILEDEF` (17 tests pass)
- Full bim suite: 641 tests pass; typecheck + lint + prettier clean on both packages
