### PR TITLE
feat(families): roof mapping with shaped geometry, profile-bridge hardening

### DIFF
--- a/apps/docs/families/for-bim-professionals.md
+++ b/apps/docs/families/for-bim-professionals.md
@@ -44,7 +44,7 @@ A door in a wall is not a boolean subtraction that happens to look right. The mo
 
 ## Current scope, stated plainly
 
-The IFC projection today maps **storeys, walls, slabs, doors, windows, columns, and beams** (columns and beams in rectangular, circular, and I-shape profiles, with openings, property sets, and materials throughout). Roofs, stairs, and the rest of the `brepjs-bim` catalog exist in the underlying library but are not yet driven from the families layer. If your models are mostly walls-slabs-openings (residential, fit-out, early massing for data), the pipeline is complete; if you need the full structural catalog through this declarative surface, that mapping work is visible on the project roadmap.
+The IFC projection today maps **storeys, walls, slabs, doors, windows, columns, beams, and roofs** (columns and beams in rectangular, circular, and I-shape profiles; roofs flat or pitched as shed / gable / hip / dome; openings, property sets, and materials throughout). Stairs and the rest of the `brepjs-bim` catalog exist in the underlying library but are not yet driven from the families layer. If your models are mostly walls-slabs-openings (residential, fit-out, early massing for data), the pipeline is complete; if you need the full structural catalog through this declarative surface, that mapping work is visible on the project roadmap.
 
 This is also not a Revit or ArchiCAD replacement. There is no drawing sheet, no annotation, no GUI authoring. It is a **programmatic model pipeline**: configurators, generative studies, firm-standard component libraries, and automated IFC production feeding the tools you already use.
 

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -5,7 +5,7 @@
  * while the IR path serves the viewport and dedup. GlobalIds derive from
  * families key paths (stable under reordering), not insertion order.
  *
- * Scope: Storey containers, Wall/Slab/Column/Beam elements, and wall openings — a
+ * Scope: Storey containers, Wall/Slab/Column/Beam/Roof elements, and wall openings — a
  * fill-role void (Door/Window family) maps onto addDoor/addWindow, which cut
  * the wall and wire IfcRelVoidsElement + IfcRelFillsElement; the opening and
  * filler GlobalIds derive from the synthesized key paths. Anonymous (non-fill)
@@ -20,6 +20,7 @@ import { parseWallSpec } from './specs/wallSpec.js';
 import { parseSlabSpec } from './specs/slabSpec.js';
 import { parseColumnSpec } from './specs/columnSpec.js';
 import { parseBeamSpec } from './specs/beamSpec.js';
+import { parseRoofSpec } from './specs/roofSpec.js';
 import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
 import { specError, type BimError } from './errors/bimError.js';
@@ -63,6 +64,10 @@ const SPEC_ROUTES = {
   Beam: {
     parse: parseBeamSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addBeam(spec as never, { stableKey: key }),
+  },
+  Roof: {
+    parse: parseRoofSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addRoof(spec as never, { stableKey: key }),
   },
 } as const;
 

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -215,10 +215,12 @@ export class BimModel {
     return ok(id);
   }
 
-  addRoof(spec: RoofSpec): Result<LocalId, BimError> {
+  addRoof(spec: RoofSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
     const geomResult = roofToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('ROOF', spec, geomResult.value);
+    const id = this.#makeElement('ROOF', spec, geomResult.value, options?.stableKey);
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -231,6 +231,41 @@ describe('familiesToBim', () => {
     expect(ifc).toContain('IFCRECTANGLEPROFILEDEF');
   });
 
+  it('maps a pitched gable roof onto IfcRoof', async () => {
+    const Roof = family<{
+      readonly length: number;
+      readonly width: number;
+      readonly thickness: number;
+      readonly predefinedType: string;
+      readonly pitch: number;
+    }>('Roof', (p) => el('Box', { size: [p.length, p.width, p.thickness] }));
+    const storey = resolve(
+      Storey({
+        key: 's',
+        walls: [
+          Roof({
+            key: 'r1',
+            length: 8000,
+            width: 5000,
+            thickness: 200,
+            predefinedType: 'GABLE_ROOF',
+            pitch: 30,
+          }),
+        ],
+      })
+    );
+    const projected = familiesToBim(storey, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    expect(unwrap(projected).idByKeyPath.has('s/r1')).toBe(true);
+    expect(checkReferentialIntegrity(model).issues.filter((i) => i.severity === 'error')).toEqual(
+      []
+    );
+    const ifc = await ifcText(model);
+    expect(ifc).toContain('IFCROOF');
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/r1'));
+  });
+
   it('rejects a wall without a storey ancestor', () => {
     const orphan = resolve(Wall({ key: 'lonely', length: 3000, height: 2700, thickness: 200 }));
     expect(isOk(familiesToBim(orphan, { project: PROJECT }))).toBe(false);

--- a/packages/brepjs-families/registry/families/beam.ts
+++ b/packages/brepjs-families/registry/families/beam.ts
@@ -12,28 +12,57 @@ import { csg } from 'brepjs';
 import { family, el, tTranslate } from 'brepjs-families';
 import { z } from 'zod';
 
-const profileSchema = z.discriminatedUnion('kind', [
-  z.object({
-    kind: z.literal('RECTANGULAR'),
-    width: z.number().positive(),
-    height: z.number().positive(),
-  }),
-  z.object({ kind: z.literal('CIRCULAR'), radius: z.number().positive() }),
-  z.object({
-    kind: z.literal('I_BEAM'),
-    overallWidth: z.number().positive(),
-    overallDepth: z.number().positive(),
-    flangeThickness: z.number().positive(),
-    webThickness: z.number().positive(),
-    filletRadius: z.number().positive().optional(),
-  }),
-]);
+// Mirrors the BIM parseProfile constraints so invalid dimensions fail at
+// family construction instead of surviving to a rejected BIM projection.
+const profileSchema = z
+  .discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('RECTANGULAR'),
+      width: z.number().positive(),
+      height: z.number().positive(),
+    }),
+    z.object({ kind: z.literal('CIRCULAR'), radius: z.number().positive() }),
+    z.object({
+      kind: z.literal('I_BEAM'),
+      overallWidth: z.number().positive(),
+      overallDepth: z.number().positive(),
+      flangeThickness: z.number().positive(),
+      webThickness: z.number().positive(),
+      filletRadius: z.number().positive().optional(),
+    }),
+  ])
+  .superRefine((v, ctx) => {
+    if (v.kind !== 'I_BEAM') return;
+    if (2 * v.flangeThickness >= v.overallDepth) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'flangeThickness × 2 must be less than overallDepth',
+      });
+    }
+    if (v.webThickness >= v.overallWidth) {
+      ctx.addIssue({ code: 'custom', message: 'webThickness must be less than overallWidth' });
+    }
+    if (v.filletRadius !== undefined) {
+      const clearHeight = v.overallDepth / 2 - v.flangeThickness;
+      const clearSpan = (v.overallWidth - v.webThickness) / 2;
+      if (v.filletRadius >= clearHeight || v.filletRadius >= clearSpan) {
+        ctx.addIssue({ code: 'custom', message: 'filletRadius must fit the web-flange notch' });
+      }
+    }
+  });
 
 export const beamSchema = z.object({
   length: z.number().positive(),
   profile: profileSchema,
   at: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
-  axisX: z.tuple([z.number(), z.number(), z.number()]).default([1, 0, 0]),
+  // Only the two axes the render supports; anything else would diverge from
+  // the IFC placement the adapter derives from the same prop.
+  axisX: z
+    .union([
+      z.tuple([z.literal(1), z.literal(0), z.literal(0)]),
+      z.tuple([z.literal(0), z.literal(1), z.literal(0)]),
+    ])
+    .default([1, 0, 0]),
   predefinedType: z
     .enum([
       'BEAM',

--- a/packages/brepjs-families/registry/families/column.ts
+++ b/packages/brepjs-families/registry/families/column.ts
@@ -12,22 +12,44 @@ import { csg } from 'brepjs';
 import { family, el, tTranslate } from 'brepjs-families';
 import { z } from 'zod';
 
-const profileSchema = z.discriminatedUnion('kind', [
-  z.object({
-    kind: z.literal('RECTANGULAR'),
-    width: z.number().positive(),
-    height: z.number().positive(),
-  }),
-  z.object({ kind: z.literal('CIRCULAR'), radius: z.number().positive() }),
-  z.object({
-    kind: z.literal('I_BEAM'),
-    overallWidth: z.number().positive(),
-    overallDepth: z.number().positive(),
-    flangeThickness: z.number().positive(),
-    webThickness: z.number().positive(),
-    filletRadius: z.number().positive().optional(),
-  }),
-]);
+// Mirrors the BIM parseProfile constraints so invalid dimensions fail at
+// family construction instead of surviving to a rejected BIM projection.
+const profileSchema = z
+  .discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('RECTANGULAR'),
+      width: z.number().positive(),
+      height: z.number().positive(),
+    }),
+    z.object({ kind: z.literal('CIRCULAR'), radius: z.number().positive() }),
+    z.object({
+      kind: z.literal('I_BEAM'),
+      overallWidth: z.number().positive(),
+      overallDepth: z.number().positive(),
+      flangeThickness: z.number().positive(),
+      webThickness: z.number().positive(),
+      filletRadius: z.number().positive().optional(),
+    }),
+  ])
+  .superRefine((v, ctx) => {
+    if (v.kind !== 'I_BEAM') return;
+    if (2 * v.flangeThickness >= v.overallDepth) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'flangeThickness × 2 must be less than overallDepth',
+      });
+    }
+    if (v.webThickness >= v.overallWidth) {
+      ctx.addIssue({ code: 'custom', message: 'webThickness must be less than overallWidth' });
+    }
+    if (v.filletRadius !== undefined) {
+      const clearHeight = v.overallDepth / 2 - v.flangeThickness;
+      const clearSpan = (v.overallWidth - v.webThickness) / 2;
+      if (v.filletRadius >= clearHeight || v.filletRadius >= clearSpan) {
+        ctx.addIssue({ code: 'custom', message: 'filletRadius must fit the web-flange notch' });
+      }
+    }
+  });
 
 export const columnSchema = z.object({
   height: z.number().positive(),

--- a/packages/brepjs-families/registry/families/roof.ts
+++ b/packages/brepjs-families/registry/families/roof.ts
@@ -1,0 +1,141 @@
+// brepjs-family: roof@1
+/**
+ * Roof — a rectangular roof over a corner-origin length × width footprint.
+ * Props feed the IFC roof spec 1:1 in a BIM projection. Presence of `pitch`
+ * opts into shaped geometry for the predefinedType (shed / gable / hip /
+ * dome), matching the spec-solid rule; flat otherwise. Flat, shed, and gable
+ * renders reproduce the spec solid exactly; hip is the intersection of two
+ * gable prisms (the classic construction) and dome is a stepped stack of
+ * 24-gon prisms over the spec path's hull rings. Both use planar faces only:
+ * lofted, conical, and spherical surfaces all hang the occt-wasm mesher. The
+ * IFC body stays authoritative.
+ */
+
+import { csg } from 'brepjs';
+import { family, el, tTranslate } from 'brepjs-families';
+import { z } from 'zod';
+
+export const roofSchema = z.object({
+  length: z.number().positive(),
+  width: z.number().positive(),
+  thickness: z.number().positive(),
+  at: z.tuple([z.number(), z.number(), z.number()]).default([0, 0, 0]),
+  predefinedType: z
+    .enum([
+      'FLAT_ROOF',
+      'SHED_ROOF',
+      'GABLE_ROOF',
+      'HIP_ROOF',
+      'HIPPED_GABLE_ROOF',
+      'GAMBREL_ROOF',
+      'MANSARD_ROOF',
+      'BARREL_ROOF',
+      'RAINBOW_ROOF',
+      'BUTTERFLY_ROOF',
+      'PAVILION_ROOF',
+      'DOME_ROOF',
+      'FREEFORM',
+      'NOTDEFINED',
+    ])
+    .default('FLAT_ROOF'),
+  pitch: z.number().positive().max(89).optional(),
+  materialName: z.string().min(1).default('Concrete'),
+  isExternal: z.boolean().optional(),
+  fireRating: z.string().optional(),
+});
+
+export type RoofProps = z.input<typeof roofSchema>;
+
+const DEG2RAD = Math.PI / 180;
+
+function shedNode(l: number, w: number, t: number, pitch: number): csg.IRNode {
+  const rise = w * Math.tan(pitch * DEG2RAD);
+  return csg.extrude(
+    csg.polygon([
+      [0, 0, 0],
+      [0, w, 0],
+      [0, w, t + rise],
+      [0, 0, t],
+    ]),
+    [l, 0, 0]
+  );
+}
+
+function gableNode(l: number, w: number, t: number, pitch: number): csg.IRNode {
+  const ridge = (w / 2) * Math.tan(pitch * DEG2RAD);
+  return csg.extrude(
+    csg.polygon([
+      [0, 0, 0],
+      [0, w, 0],
+      [0, w, t],
+      [0, w / 2, t + ridge],
+      [0, 0, t],
+    ]),
+    [l, 0, 0]
+  );
+}
+
+function hipNode(l: number, w: number, pitch: number): csg.IRNode {
+  const tan = Math.tan(pitch * DEG2RAD);
+  const alongX = csg.extrude(
+    csg.polygon([
+      [0, 0, 0],
+      [0, w, 0],
+      [0, w / 2, (w / 2) * tan],
+    ]),
+    [l, 0, 0]
+  );
+  const alongY = csg.extrude(
+    csg.polygon([
+      [0, 0, 0],
+      [l, 0, 0],
+      [l / 2, 0, (l / 2) * tan],
+    ]),
+    [0, w, 0]
+  );
+  return csg.intersect(alongX, alongY);
+}
+
+function domeNode(l: number, w: number): csg.IRNode {
+  const r = Math.min(l, w) / 2;
+  const cx = l / 2;
+  const cy = w / 2;
+  const segments = 24;
+  const rings = [0, 0.4, 0.7, 0.9, 0.995];
+  const steps: csg.IRNode[] = [];
+  for (let i = 0; i < rings.length - 1; i++) {
+    const h0 = rings[i] ?? 0;
+    const h1 = rings[i + 1] ?? 0;
+    const ringR = r * Math.sqrt(1 - h0 * h0);
+    const pts: Array<[number, number, number]> = [];
+    for (let j = 0; j < segments; j++) {
+      const a = (2 * Math.PI * j) / segments;
+      pts.push([cx + ringR * Math.cos(a), cy + ringR * Math.sin(a), r * h0]);
+    }
+    steps.push(csg.extrude(csg.polygon(pts), [0, 0, r * (h1 - h0)]));
+  }
+  return csg.fuseAll(steps);
+}
+
+function roofNode(p: z.output<typeof roofSchema>): csg.IRNode {
+  if (p.pitch === undefined) return csg.box(p.length, p.width, p.thickness);
+  switch (p.predefinedType) {
+    case 'SHED_ROOF':
+      return shedNode(p.length, p.width, p.thickness, p.pitch);
+    case 'GABLE_ROOF':
+      return gableNode(p.length, p.width, p.thickness, p.pitch);
+    case 'HIP_ROOF':
+      return hipNode(p.length, p.width, p.pitch);
+    case 'DOME_ROOF':
+      return domeNode(p.length, p.width);
+    default:
+      return csg.box(p.length, p.width, p.thickness);
+  }
+}
+
+export const Roof = family(
+  'Roof',
+  (p: z.output<typeof roofSchema>) =>
+    el('Geometry', { node: roofNode(p), transform: [tTranslate(p.at)] }),
+  { props: roofSchema }
+);

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -43,6 +43,14 @@
       "familyDeps": []
     },
     {
+      "name": "roof",
+      "version": 1,
+      "description": "Rectangular roof (flat / shed / gable / hip / dome) mapping onto IfcRoof",
+      "files": ["families/roof.ts"],
+      "npmDeps": ["brepjs", "brepjs-families", "zod"],
+      "familyDeps": []
+    },
+    {
       "name": "door",
       "version": 1,
       "description": "Fill-role void: synthesizes an Opening with IfcRelVoids/Fills",

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -19,6 +19,7 @@ import { Storey } from '../registry/families/storey.js';
 import { Slab } from '../registry/families/slab.js';
 import { Column } from '../registry/families/column.js';
 import { Beam } from '../registry/families/beam.js';
+import { Roof } from '../registry/families/roof.js';
 import { Window } from '../registry/families/window.js';
 import { Wall } from '../registry/families/wall.js';
 
@@ -161,6 +162,23 @@ describe('starter families', () => {
     }
   });
 
+  const ROOF_DIMS = { length: 8000, width: 5000, thickness: 200 };
+  const ROOF_SHAPES: ReadonlyArray<Record<string, unknown>> = [
+    { key: 'flat' },
+    { key: 'shed', predefinedType: 'SHED_ROOF', pitch: 15 },
+    { key: 'gable', predefinedType: 'GABLE_ROOF', pitch: 30 },
+    { key: 'hip', predefinedType: 'HIP_ROOF', pitch: 25 },
+    { key: 'dome', predefinedType: 'DOME_ROOF', pitch: 1 },
+  ];
+
+  it.each(ROOF_SHAPES)('starter roof shape $key materializes', (shape) => {
+    using ev = new csg.Evaluator();
+    const storey = resolve(Storey({ key: 's', items: [Roof({ ...ROOF_DIMS, ...shape })] }));
+    const model = evaluateModel(storey, ev);
+    const roof = model.byKeyPath.get(`s/${shape['key'] as string}`);
+    expect(roof && isOk(roof.mesh)).toBe(true);
+  });
+
   it('a rectangular column materializes through the profile bridge', () => {
     using ev = new csg.Evaluator();
     const storey = resolve(
@@ -199,6 +217,43 @@ describe('starter families', () => {
     const slab = resolve(Slab({ key: 'f', length: 100, width: 100, thickness: 10 }));
     expect(slab.props['predefinedType']).toBe('FLOOR');
     expect(slab.props['materialName']).toBe('Concrete');
+  });
+
+  it('degenerate I-profiles and unsupported beam axes are rejected at construction', () => {
+    expect(() =>
+      Beam({
+        key: 'b',
+        length: 4000,
+        profile: {
+          kind: 'I_BEAM',
+          overallWidth: 100,
+          overallDepth: 200,
+          flangeThickness: 100,
+          webThickness: 5.6,
+        },
+      })
+    ).toThrow(/invalid props for family 'Beam'/);
+    expect(() =>
+      Column({
+        key: 'c',
+        height: 3000,
+        profile: {
+          kind: 'I_BEAM',
+          overallWidth: 100,
+          overallDepth: 200,
+          flangeThickness: 8.5,
+          webThickness: 100,
+        },
+      })
+    ).toThrow(/invalid props for family 'Column'/);
+    expect(() =>
+      Beam({
+        key: 'b',
+        length: 4000,
+        profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+        axisX: [0, -1, 0] as never,
+      })
+    ).toThrow(/invalid props for family 'Beam'/);
   });
 
   it('invalid starter props throw with the family name', () => {


### PR DESCRIPTION
## What

Third catalog step of the bim graduation arc (Column ✔ → Beam ✔ → **Roof**): roofs now flow from the families layer onto `IfcRoof`, completing the committed pre-1.0 element set (stairs pending their feasibility spike).

- **Registry**: new starter family `roof@1` — flat by default, shaped when `pitch` is present (the same opt-in rule as `roofToSolid`): shed, gable, hip, dome; spec-shaped props with the full IFC roof enum
- **Geometry**: flat/shed/gable renders reproduce the spec solid exactly (same polygon math). Hip is the intersection of two gable prisms (the classic construction, exact). Dome is a stepped stack of 24-gon prisms over the spec path's hull rings. **Planar faces only, by necessity**: probing showed lofted surfaces and even a single conical frustum hang the occt-wasm mesher, joining the spherical-surface hang already documented in `roofFns` — worth knowing for any future IR-side curved geometry
- **BimModel**: `addRoof` gains `ElementIdentityOptions` (same pattern as wall/slab/column/beam)
- **Review follow-up from #2125** (both Greptile P1s, merged before the fixes landed): beam/column family schemas now mirror `parseProfile`'s I-beam constraints (flange/web/fillet fits) so degenerate dimensions fail at family construction instead of surviving to a rejected BIM projection, and beam `axisX` is pinned to the two axes the render supports (`[1,0,0]` / `[0,1,0]`) instead of silently collapsing arbitrary vectors while IFC placement followed the original
- **Docs**: for-bim-professionals moves roofs into the mapped set; stairs stay honestly listed

## Tests

- families registry: per-shape roof materialization (flat/shed/gable/hip/dome), degenerate I-profile and unsupported-axis rejection for both beam and column (37 tests pass)
- bim adapter: pitched gable roof maps with key-path GlobalId, zero integrity errors, `IFCROOF` in output (18 tests pass)
- Full bim suite: 642 tests pass; typecheck + lint + prettier clean on both packages
