### PR TITLE
chore(bim): enforce coverage thresholds floored at measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       - run: npm run build --workspace=brepjs-families
       - run: npm run typecheck --workspace=brepjs-bim
       - run: npm run lint --workspace=brepjs-bim
-      - run: npm run test --workspace=brepjs-bim
+      - run: npm run test:coverage --workspace=brepjs-bim
       - run: npm run build --workspace=brepjs-bim
 
   voxel-wasm-rust:

--- a/packages/brepjs-bim/package.json
+++ b/packages/brepjs-bim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brepjs-bim",
   "version": "0.11.0",
-  "description": "BIM layer for brepjs — IFC4-aligned parametric building elements",
+  "description": "BIM layer for brepjs \u2014 IFC4-aligned parametric building elements",
   "keywords": [
     "bim",
     "ifc",
@@ -43,6 +43,7 @@
     "build": "vite build",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint src tests"
   },
   "peerDependencies": {

--- a/packages/brepjs-bim/vitest.config.ts
+++ b/packages/brepjs-bim/vitest.config.ts
@@ -16,5 +16,19 @@ export default defineConfig({
     pool: 'forks',
     execArgv: ['--max-old-space-size=6144'],
     include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text-summary', 'lcov'],
+      // Floored at the measured coverage (2026-08-18), rounded down to whole
+      // percents — the root-repo policy: measured numbers, not aspirations.
+      // Re-measure and re-floor (npm run test:coverage) when the suite grows.
+      thresholds: {
+        statements: 81,
+        branches: 63,
+        functions: 91,
+        lines: 85,
+      },
+    },
   },
 });


### PR DESCRIPTION
Graduation Phase 2 item: brepjs-bim had no coverage gate while the root repo enforces one. Adds v8 coverage config with thresholds floored at the measured suite (statements 81, branches 63, functions 91, lines 85, rounded down to whole percents, same policy as the root config), a test:coverage script, and switches the packages-bim CI job to run it. Verified locally: the gate passes at 81.71/63.87/91.87/85.83.