### PR TITLE
docs(bim): add the bim docs-site section

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -319,6 +319,16 @@ export default withMermaid(
           ],
         },
         {
+          text: 'BIM (IFC4)',
+          items: [
+            { text: 'The BIM Layer', link: '/bim/overview' },
+            { text: 'Element Catalog', link: '/bim/elements' },
+            { text: 'IFC Export & Import', link: '/bim/ifc' },
+            { text: 'Validation', link: '/bim/validation' },
+            { text: 'Interop: COBie, IDS, BCF', link: '/bim/interop' },
+          ],
+        },
+        {
           text: 'Advanced',
           items: [
             { text: 'Memory Management', link: '/advanced/memory' },

--- a/apps/docs/bim/elements.md
+++ b/apps/docs/bim/elements.md
@@ -32,7 +32,7 @@ Beams and columns extrude a **profile**, one vocabulary shared by both:
 - Core: `RECTANGULAR`, `CIRCULAR`, `I_BEAM` (with optional root `filletRadius`)
 - Extended: L / T / U / Z / C shapes, asymmetric I, ellipse, trapezium, hollow rectangular and circular sections, and arbitrary polygons with voids
 
-Core profiles emit parametric IFC profile defs (`IfcRectangleProfileDef`, `IfcCircleProfileDef`, `IfcIShapeProfileDef`); extended profiles build faces via `extendedProfileToFace` and serialize as `IfcArbitraryClosedProfileDef` (with voids where applicable). `profileCrossSectionArea` gives closed-form areas for takeoff.
+Core profiles emit parametric IFC profile defs (`IfcRectangleProfileDef`, `IfcCircleProfileDef`, `IfcIShapeProfileDef`); extended profiles build faces via `extendedProfileToFace` and serialize as `IfcArbitraryClosedProfileDef` (with voids where applicable), with `extendedProfileArea` giving closed-form areas for takeoff.
 
 ## Shaped roofs
 

--- a/apps/docs/bim/elements.md
+++ b/apps/docs/bim/elements.md
@@ -1,0 +1,47 @@
+---
+title: Element Catalog
+description: 'Every parametric element brepjs-bim authors: structural, spatial, openings, and the profile vocabulary they extrude.'
+---
+
+# Element Catalog
+
+Every element follows the same contract: a typed spec in millimeters, an analytically built brepjs solid in local coordinates, and placement applied downstream via `IfcLocalPlacement`. The `parse*Spec` functions validate specs standalone; the `add*` methods validate, build, and store.
+
+| Element        | Method                   | Notes                                                                                |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| Wall           | `addWall`                | Length along `axisX`, openings cut via `addDoor` / `addWindow`                       |
+| Slab           | `addSlab`                | `FLOOR` / `ROOF` / `LANDING` / `BASESLAB`; slab openings via `parseSlabOpeningInput` |
+| Beam           | `addBeam`                | Profile extruded along `axisX` by length                                             |
+| Column         | `addColumn`              | Profile extruded along `axisZ` by height                                             |
+| Roof           | `addRoof`                | Flat slab, or shaped (shed / gable / hip / dome) when `pitch` is present             |
+| Curtain wall   | `addCurtainWall`         | Panel and mullion grid                                                               |
+| Space          | `addSpace`               | Room volumes for zoning and COBie                                                    |
+| Footing / pile | `addFooting` / `addPile` | Foundations                                                                          |
+| Stair          | `addStair`               | One or more flights, each a stepped sawtooth solid with its own placement            |
+| Ramp           | `addRamp`                | Flights like stairs, inclined slabs                                                  |
+| Railing        | `addRailing`             | Posts + rails with `infill: 'POSTED'`, or a single swept panel                       |
+| Covering       | `addCovering`            | Finishes: flooring, cladding, ceilings                                               |
+| Proxy          | `addProxy`               | Anything else, carrying arbitrary brepjs geometry                                    |
+
+Doors and windows are not free-standing: `addDoor` / `addWindow` take a host wall, cut the opening as a boolean void, and wire `IfcRelVoidsElement` + `IfcRelFillsElement`.
+
+## Profiles
+
+Beams and columns extrude a **profile**, one vocabulary shared by both:
+
+- Core: `RECTANGULAR`, `CIRCULAR`, `I_BEAM` (with optional root `filletRadius`)
+- Extended: L / T / U / Z / C shapes, asymmetric I, ellipse, trapezium, hollow rectangular and circular sections, and arbitrary polygons with voids
+
+Core profiles emit parametric IFC profile defs (`IfcRectangleProfileDef`, `IfcCircleProfileDef`, `IfcIShapeProfileDef`); extended profiles build faces via `extendedProfileToFace` and serialize as `IfcArbitraryClosedProfileDef` (with voids where applicable). `profileCrossSectionArea` gives closed-form areas for takeoff.
+
+## Shaped roofs
+
+`pitch` opts a roof into shaped geometry for its `predefinedType`: a right-trapezoid prism (shed), a house-pentagon prism (gable), a convex-hull hip with the ridge along the longer side, or a faceted dome. Without `pitch` the roof is a flat slab whatever the type says. Shaped roofs and posted railings serialize as tessellated bodies; everything else stays parametric `IfcExtrudedAreaSolid`.
+
+## Placement and display
+
+Element geometry is **unplaced template geometry**. A wall's solid starts at the local origin and runs along local +X regardless of where the wall stands; `origin` / `axisX` / `axisZ` live in the spec and become `IfcLocalPlacement`. When you need world-placed solids (display, clash checks), `placedSolids(element)` returns fresh, caller-owned solids already transformed (stairs return one per flight), so the scene you render matches the IFC you export.
+
+## Data layers
+
+Beyond geometry, elements carry: property sets from IFC pset templates with typed measures, quantity sets for takeoff, materials (simple, layer sets, profile sets), classification references (Uniclass, OmniClass, and friends), surface styles, and zone / system membership. Stable identity comes from deterministic GUIDs: `deriveIfcGuid` for content-derived ids, `newIfcGuid` for random ones.

--- a/apps/docs/bim/ifc.md
+++ b/apps/docs/bim/ifc.md
@@ -1,6 +1,6 @@
 ---
 title: IFC Export & Import
-description: 'toIfc serializes a BimModel to IFC-SPF bytes (IFC4 or IFC2X3); fromIfc and SpfReader read IFC back into elements, psets, and a spatial tree.'
+description: 'toIfc serializes a BimModel to IFC-SPF bytes (IFC4 or IFC4X3); fromIfc and SpfReader read IFC back into elements, psets, and a spatial tree.'
 ---
 
 # IFC Export & Import

--- a/apps/docs/bim/ifc.md
+++ b/apps/docs/bim/ifc.md
@@ -13,17 +13,18 @@ description: 'toIfc serializes a BimModel to IFC-SPF bytes (IFC4 or IFC2X3); fro
 import { toIfc } from 'brepjs-bim';
 
 const result = await toIfc(model, {
-  name: 'Office Block A',
-  author: 'jane@example.com',
-  organization: 'Example Ltd',
+  applicationName: 'office-tool',
+  applicationVersion: '1.0',
+  author: { givenName: 'Jane', familyName: 'Doe', email: 'jane@example.com' },
+  organizationName: 'Example Ltd',
 });
 if (result.ok) await writeFile('model.ifc', result.value);
 ```
 
-- **Schema**: IFC4 by default; pass `schema: 'IFC2X3'` for consumers stuck on the older schema.
+- **Schema**: IFC4 by default; pass `ifcSchema: 'IFC4X3'` to target the newer schema.
 - **Units**: specs are millimeters; the writer emits SI metres (`toIfcLengthM` / `toLengthMm` convert explicitly).
 - **Owner history**: author and organization metadata become a proper `IfcOwnerHistory`.
-- **Determinism**: element GUIDs and local id counters are stable, so re-exporting an unchanged model yields byte-identical content (modulo the timestamped `FILE_NAME` header line).
+- **Determinism**: element GUIDs and local id counters are stable, and `creationTimestamp` defaults to the epoch, so re-exporting an unchanged model yields byte-identical content (modulo the timestamped `FILE_NAME` header line).
 
 `toIfcValidated` runs export plus the [validation suite](/bim/validation) in one call and returns the bytes together with the reports.
 
@@ -46,4 +47,4 @@ Imported geometry pins kernel memory; call `disposeImportedModel` when done. For
 
 ## Round-tripping
 
-Export → import → compare is a first-class operation, not a demo: `checkRoundTrip` re-reads an exported model and reports entity counts and losses, and the test suite gates on semantic round-trip fidelity (identity, relationships, psets, containment, and volumes within 0.5%). If you build on the families layer, GlobalIds additionally survive **source-level** edits: they derive from key paths, not insertion order.
+Export → import → compare is a first-class operation, not a demo: `checkRoundTrip(bytes)` re-reads an exported file and reports entity counts and losses, and the test suite gates on semantic round-trip fidelity (identity, relationships, psets, containment, and volumes within 0.5%). If you build on the families layer, GlobalIds additionally survive **source-level** edits: they derive from key paths, not insertion order.

--- a/apps/docs/bim/ifc.md
+++ b/apps/docs/bim/ifc.md
@@ -1,0 +1,49 @@
+---
+title: IFC Export & Import
+description: 'toIfc serializes a BimModel to IFC-SPF bytes (IFC4 or IFC2X3); fromIfc and SpfReader read IFC back into elements, psets, and a spatial tree.'
+---
+
+# IFC Export & Import
+
+## Export
+
+`toIfc(model, meta)` walks the model and returns IFC-SPF bytes.
+
+```typescript
+import { toIfc } from 'brepjs-bim';
+
+const result = await toIfc(model, {
+  name: 'Office Block A',
+  author: 'jane@example.com',
+  organization: 'Example Ltd',
+});
+if (result.ok) await writeFile('model.ifc', result.value);
+```
+
+- **Schema**: IFC4 by default; pass `schema: 'IFC2X3'` for consumers stuck on the older schema.
+- **Units**: specs are millimeters; the writer emits SI metres (`toIfcLengthM` / `toLengthMm` convert explicitly).
+- **Owner history**: author and organization metadata become a proper `IfcOwnerHistory`.
+- **Determinism**: element GUIDs and local id counters are stable, so re-exporting an unchanged model yields byte-identical content (modulo the timestamped `FILE_NAME` header line).
+
+`toIfcValidated` runs export plus the [validation suite](/bim/validation) in one call and returns the bytes together with the reports.
+
+## Import
+
+`fromIfc(bytes)` parses an IFC file (via `web-ifc`) into an `ImportedModel`: elements with geometry, property sets, materials, and the spatial tree.
+
+```typescript
+import { fromIfc, disposeImportedModel } from 'brepjs-bim';
+
+const imported = await fromIfc(bytes);
+if (imported.ok) {
+  const model = imported.value;
+  // model.elements, model.spatialTree, model.psets, ...
+  disposeImportedModel(model);
+}
+```
+
+Imported geometry pins kernel memory; call `disposeImportedModel` when done. For header-level inspection without geometry, `SpfReader` parses the STEP structure directly.
+
+## Round-tripping
+
+Export → import → compare is a first-class operation, not a demo: `checkRoundTrip` re-reads an exported model and reports entity counts and losses, and the test suite gates on semantic round-trip fidelity (identity, relationships, psets, containment, and volumes within 0.5%). If you build on the families layer, GlobalIds additionally survive **source-level** edits: they derive from key paths, not insertion order.

--- a/apps/docs/bim/interop.md
+++ b/apps/docs/bim/interop.md
@@ -1,0 +1,51 @@
+---
+title: 'Interop: COBie, IDS, BCF'
+description: 'Handover data (COBie 2.4), requirement checking (IDS 1.0), and issue exchange (BCF 3.0) on top of the BIM model.'
+---
+
+# Interop: COBie, IDS, BCF
+
+IFC carries the model; three sibling formats carry the workflows around it.
+
+## COBie 2.4 (handover data)
+
+`deriveCobieModel(model, meta)` (alias `exportCobie`) extracts the facility-management view: contacts, facility, floors, spaces, zones, types, components, systems, and attributes, straight from the model's spatial structure and psets.
+
+```typescript
+import { deriveCobieModel, serializeCobieToCsv, serializeCobieToJson } from 'brepjs-bim';
+
+const cobie = deriveCobieModel(model, { createdBy: 'jane@example.com' });
+if (cobie.ok) {
+  const csv = serializeCobieToCsv(cobie.value); // one CSV per sheet
+  const json = serializeCobieToJson(cobie.value);
+}
+```
+
+## IDS 1.0 (requirement checking)
+
+The Information Delivery Specification is buildingSMART's machine-readable requirements format ("every external wall must carry a FireRating"). `parseIdsXml` reads an IDS document; `checkModelAgainstIds` (alias `checkIds`) evaluates every specification against the model and reports pass / fail per element with the failing facet.
+
+```typescript
+import { parseIdsXml, checkIds } from 'brepjs-bim';
+
+const ids = parseIdsXml(idsXml);
+if (ids.ok) {
+  const report = checkIds(model, ids.value);
+  // report.value.results: per-spec, per-element outcomes
+}
+```
+
+## BCF 3.0 (issue exchange)
+
+The BIM Collaboration Format moves issues (topics, comments, viewpoints, component selections) between tools without moving the model. `parseBcfFiles` reads an unzipped BCF container into typed data; `serializeBcfFiles` writes one. Zip packaging is deliberately left to the caller, so the library stays dependency-free.
+
+```typescript
+import { parseBcfFiles, serializeBcfFiles } from 'brepjs-bim';
+
+const container = parseBcfFiles(files); // Record<path, bytes>
+if (container.ok) {
+  const roundTripped = serializeBcfFiles(container.value);
+}
+```
+
+Topics reference model elements by GlobalId, which is where [stable identity](/families/identity) pays off again: a families-projected model keeps GlobalIds stable across rebuilds, so BCF issues filed against one export still point at the right elements in the next.

--- a/apps/docs/bim/interop.md
+++ b/apps/docs/bim/interop.md
@@ -14,24 +14,25 @@ IFC carries the model; three sibling formats carry the workflows around it.
 ```typescript
 import { deriveCobieModel, serializeCobieToCsv, serializeCobieToJson } from 'brepjs-bim';
 
-const cobie = deriveCobieModel(model, { createdBy: 'jane@example.com' });
-if (cobie.ok) {
-  const csv = serializeCobieToCsv(cobie.value); // one CSV per sheet
-  const json = serializeCobieToJson(cobie.value);
-}
+const cobie = deriveCobieModel(model, {
+  contact: { email: 'jane@example.com', givenName: 'Jane', familyName: 'Doe' },
+});
+const csv = serializeCobieToCsv(cobie); // one CSV per sheet
+const json = serializeCobieToJson(cobie);
 ```
 
 ## IDS 1.0 (requirement checking)
 
-The Information Delivery Specification is buildingSMART's machine-readable requirements format ("every external wall must carry a FireRating"). `parseIdsXml` reads an IDS document; `checkModelAgainstIds` (alias `checkIds`) evaluates every specification against the model and reports pass / fail per element with the failing facet.
+The Information Delivery Specification is buildingSMART's machine-readable requirements format ("every external wall must carry a FireRating"). `parseIdsXml` reads an IDS document; `checkModelAgainstIds` (alias `checkIds`) evaluates every specification against an **imported** model (the exported file read back with `fromIfc`, so requirements are checked against what consumers will actually receive) and reports pass / fail per element with the failing facet.
 
 ```typescript
-import { parseIdsXml, checkIds } from 'brepjs-bim';
+import { fromIfc, parseIdsXml, checkIds } from 'brepjs-bim';
 
+const imported = await fromIfc(bytes);
 const ids = parseIdsXml(idsXml);
-if (ids.ok) {
-  const report = checkIds(model, ids.value);
-  // report.value.results: per-spec, per-element outcomes
+if (imported.ok && ids.ok) {
+  const report = checkIds(imported.value, ids.value);
+  // report.results: per-spec, per-element outcomes
 }
 ```
 

--- a/apps/docs/bim/overview.md
+++ b/apps/docs/bim/overview.md
@@ -1,0 +1,56 @@
+---
+title: The BIM Layer
+description: 'brepjs-bim authors IFC4-aligned parametric building elements on brepjs geometry: typed specs in, a validated BimModel out, IFC-SPF at the end.'
+---
+
+# The BIM Layer
+
+`brepjs-bim` turns brepjs geometry into building information. You describe elements as typed parametric specs (a wall is a length, height, thickness, placement, and material, not a mesh); the model assembles them into a spatial structure (project → site → building → storey), layers on property sets, materials, quantities, and classifications, and serializes the result to a valid **IFC-SPF** file. A matching importer reads IFC back in.
+
+```bash
+npm install brepjs-bim brepjs web-ifc
+```
+
+Two ways in:
+
+- **Through families** (recommended for new models): author a declarative element tree with [brepjs-families](/families/overview) and project it with `familiesToBim`. Identity, openings, and containment come from the tree; GlobalIds derive from key paths and survive reorders. Start at [IFC Export](/families/ifc-export).
+- **Direct `BimModel`**: imperative `add*` calls when you already know exactly what to build, or when you need elements the families projection does not cover yet.
+
+```typescript
+import { BimModel, toIfc } from 'brepjs-bim';
+
+const model = new BimModel();
+model.init({ name: 'Example' });
+
+const siteId = model.addSite({ name: 'Site' });
+const buildingId = model.addBuilding({ name: 'Building' });
+const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+const project = model.getProject();
+if (project) model.aggregate(project.localId, siteId);
+model.aggregate(siteId, buildingId);
+model.aggregate(buildingId, storeyId);
+
+const wall = model.addWall({
+  length: 4000,
+  height: 3000,
+  thickness: 200,
+  origin: [0, 0, 0],
+  axisX: [1, 0, 0],
+  axisZ: [0, 0, 1],
+  materialName: 'Concrete',
+});
+if (wall.ok) model.placeIn(wall.value, storeyId);
+
+const ifc = await toIfc(model, { name: 'Example', author: 'me' });
+// ifc.ok && ifc.value instanceof Uint8Array
+```
+
+Three design decisions carry the package:
+
+1. **Specs are the source of truth.** Every `add*` call validates its spec (zod schemas; the `parse*Spec` functions are exported for standalone use), builds the brepjs solid analytically, and stores a typed element. The IFC writer emits parametric entities (`IfcExtrudedAreaSolid`, profile defs) from the same spec, so the exported file stays editable data, not frozen triangles.
+2. **Geometry is unplaced template geometry.** Element solids live in local coordinates; `origin` / `axisX` / `axisZ` are applied by the IFC layer via `IfcLocalPlacement`. Use `placedSolids(element)` when you need world-placed solids for display.
+3. **Results, not exceptions.** Every operation returns `Result<T, BimError>` from brepjs. Validation issues travel inside reports; nothing throws across the API boundary.
+
+Dimensions are millimeters everywhere; IFC export emits SI metres. Reading element geometry needs only the brepjs kernel; `toIfc` / `fromIfc` additionally load the `web-ifc` peer dependency.
+
+Continue with the [element catalog](/bim/elements), [IFC export & import](/bim/ifc), [validation](/bim/validation), and [interop](/bim/interop).

--- a/apps/docs/bim/overview.md
+++ b/apps/docs/bim/overview.md
@@ -41,7 +41,7 @@ const wall = model.addWall({
 });
 if (wall.ok) model.placeIn(wall.value, storeyId);
 
-const ifc = await toIfc(model, { name: 'Example', author: 'me' });
+const ifc = await toIfc(model, { applicationName: 'example-app', applicationVersion: '1' });
 // ifc.ok && ifc.value instanceof Uint8Array
 ```
 

--- a/apps/docs/bim/validation.md
+++ b/apps/docs/bim/validation.md
@@ -1,0 +1,41 @@
+---
+title: Validation
+description: 'Four internal checkers, one-call validated export, and an independent IfcOpenShell gate: how brepjs-bim proves its IFC is real.'
+---
+
+# Validation
+
+An IFC file that only its own writer can read is not an exchange format. brepjs-bim validates at three distances from the code that wrote the file.
+
+## Internal checkers
+
+Four composable checks, each returning a severity-tagged report:
+
+- `checkReferentialIntegrity(model)`: every relationship points at an element that exists; containment, voids, fills, aggregation, and group membership all resolve.
+- `checkSchema(bytes)`: the exported file re-parses and passes structural schema checks.
+- `checkGeometryValidity(model)`: every element's solid passes brepjs validity (closed, manifold, positive volume).
+- `checkRoundTrip(model)`: export → import → compare entity counts; losses are reported per type.
+
+`toIfcValidated(model, meta)` runs export plus the suite in one call:
+
+```typescript
+import { toIfcValidated } from 'brepjs-bim';
+
+const validated = await toIfcValidated(model, { name: 'Office' });
+if (validated.ok) {
+  const { bytes, reports } = validated.value;
+  // reports.integrity, reports.schema, reports.geometry, reports.roundTrip
+}
+```
+
+## The independent gate
+
+Internal checks share code with the writer, so they cannot catch bugs the writer and reader agree on. The committed sample building is therefore validated by **IfcOpenShell**, a separate C++/Python IFC implementation sharing no code with `web-ifc`: EXPRESS schema + where-rules, spatial-structure presence, GlobalId validity and uniqueness, and geometry generation for every product. See `VALIDATION.md` in the package for the reproduction steps (two commands).
+
+## The semantic round-trip gate
+
+The test suite additionally gates on semantic fidelity through a full source → IFC → import cycle: identity (GlobalIds), relationships (voids / fills / containment), property sets, spatial structure, and solid volumes within 0.5% all survive. This is what "round-trip" means here: not that a file parses, but that the model that comes back is the model that went out.
+
+## External tools
+
+buildingSMART's official Validation Service and desktop imports (Solibri, Revit) are the remaining frontier; results are recorded in the package's `VALIDATION.md` as they land.

--- a/apps/docs/bim/validation.md
+++ b/apps/docs/bim/validation.md
@@ -14,17 +14,20 @@ Four composable checks, each returning a severity-tagged report:
 - `checkReferentialIntegrity(model)`: every relationship points at an element that exists; containment, voids, fills, aggregation, and group membership all resolve.
 - `checkSchema(bytes)`: the exported file re-parses and passes structural schema checks.
 - `checkGeometryValidity(model)`: every element's solid passes brepjs validity (closed, manifold, positive volume).
-- `checkRoundTrip(model)`: export → import → compare entity counts; losses are reported per type.
+- `checkRoundTrip(bytes)`: re-read an exported file and compare entity counts; losses are reported per type.
 
 `toIfcValidated(model, meta)` runs export plus the suite in one call:
 
 ```typescript
 import { toIfcValidated } from 'brepjs-bim';
 
-const validated = await toIfcValidated(model, { name: 'Office' });
+const validated = await toIfcValidated(model, {
+  applicationName: 'office-tool',
+  applicationVersion: '1.0',
+});
 if (validated.ok) {
-  const { bytes, reports } = validated.value;
-  // reports.integrity, reports.schema, reports.geometry, reports.roundTrip
+  const { bytes, report } = validated.value;
+  // report.issues: severity-tagged findings from every gate
 }
 ```
 

--- a/apps/docs/bim/validation.md
+++ b/apps/docs/bim/validation.md
@@ -13,7 +13,7 @@ Four composable checks, each returning a severity-tagged report:
 
 - `checkReferentialIntegrity(model)`: every relationship points at an element that exists; containment, voids, fills, aggregation, and group membership all resolve.
 - `checkSchema(bytes)`: the exported file re-parses and passes structural schema checks.
-- `checkGeometryValidity(model)`: every element's solid passes brepjs validity (closed, manifold, positive volume).
+- `checkGeometryValidity(solids)`: the given element solids pass brepjs validity (closed, manifold, positive volume).
 - `checkRoundTrip(bytes)`: re-read an exported file and compare entity counts; losses are reported per type.
 
 `toIfcValidated(model, meta)` runs export plus the suite in one call:


### PR DESCRIPTION
Graduation Phase 3 item: brepjs-bim docs lived only in the package README while families has a full docs-site section. Adds five pages under a new BIM (IFC4) sidebar group mirroring the families section: overview (two ways in, the three design decisions), element catalog (with the profile vocabulary and the unplaced-template placement model), IFC export/import (schemas, units, determinism, round-tripping), validation (internal checkers, the IfcOpenShell independent gate, the semantic round-trip gate, external-tool status), and COBie/IDS/BCF interop. All snippets use real exported API names; vitepress build passes locally with the dead-link check.