### PR TITLE
docs: correct stale readme facts ahead of the graduation flip

### DIFF
--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -43,7 +43,7 @@ export.
 | Spatial structure | project → site → building → storey aggregation; `placeIn` to assign elements to a storey                 |
 | Property sets     | IFC pset templates + measure types; quantity sets for takeoff                                            |
 | Data layers       | materials (layer/profile/simple sets), classification refs, surface styles, zones/systems                |
-| IFC export        | `toIfc` → IFC-SPF (`Uint8Array`); IFC2X3 / IFC4 schema selection; owner history                          |
+| IFC export        | `toIfc` → IFC-SPF (`Uint8Array`); IFC4 / IFC4X3 schema selection; owner history                          |
 | IFC import        | `fromIfc` / `SpfReader` → `ImportedModel` (elements, geometry, psets, materials, spatial tree)           |
 | Validation        | referential integrity, schema check, geometry validity, IFC round-trip report                            |
 | Interop           | COBie 2.4 export (CSV/JSON), IDS 1.0 checking, BCF 3.0 read/write                                        |
@@ -57,8 +57,9 @@ validator and generates geometry for every product. See [VALIDATION.md](./VALIDA
 to reproduce, and `examples/sampleBuilding.mjs` for the model it validates.
 
 > **Not yet:** the official buildingSMART Validation Service and desktop-tool
-> interop (Revit / ArchiCAD / Solibri) are unverified. This is an early-stage
-> (`0.1.x`) experimental package and the API will change.
+> interop (Revit / Solibri) are unverified — the fixtures and per-tool
+> checklists are ready in [VALIDATION.md](./VALIDATION.md). This is an
+> experimental pre-1.0 package and the API may change.
 
 ## Usage
 

--- a/packages/brepjs-families/README.md
+++ b/packages/brepjs-families/README.md
@@ -61,11 +61,11 @@ What the pieces buy you:
 
 ## Starter registry
 
-A copy-in starter registry (storey, wall, slab, column, beam, roof, door, window, and room families, spec-shaped props feeding the IFC specs in brepjs-bim 1:1) is distributed shadcn-style, not inside this package: the families become source files you own. `npm create brepjs` scaffolds a working project, then `npx brepjs add wall room` copies family sources into `src/families/`, resolving the registry from GitHub by default or from any static host via `--registry`. See [Copy-In Distribution](https://brepjs.dev/families/copy-in).
+A copy-in starter registry (storey, wall, slab, column, beam, roof, stair, door, window, and room families, spec-shaped props feeding the IFC specs in brepjs-bim 1:1) is distributed shadcn-style, not inside this package: the families become source files you own. `npm create brepjs` scaffolds a working project, then `npx brepjs add wall room` copies family sources into `src/families/`, resolving the registry from GitHub by default or from any static host via `--registry`. See [Copy-In Distribution](https://brepjs.dev/families/copy-in).
 
 ## BIM projection
 
-`brepjs-bim`'s `familiesToBim()` projects a resolved tree into a `BimModel`: storeys, walls, slabs, columns, beams, roofs, and wall openings, with property sets, materials, spatial containment, and reorder-stable GlobalIds, exportable to IFC with independent validation. See the [families docs](https://brepjs.dev/families/overview) and [for BIM professionals](https://brepjs.dev/families/for-bim-professionals).
+`brepjs-bim`'s `familiesToBim()` projects a resolved tree into a `BimModel`: storeys, walls, slabs, columns, beams, roofs, stairs, and wall openings, with property sets, materials, spatial containment, and reorder-stable GlobalIds, exportable to IFC with independent validation. See the [families docs](https://brepjs.dev/families/overview) and [for BIM professionals](https://brepjs.dev/families/for-bim-professionals).
 
 ## Docs
 


### PR DESCRIPTION
Truth fixes only; the experimental banners stay until the external-validation gate clears. brepjs-bim: the IFC export row claimed IFC2X3/IFC4 while the writer targets IFC4/IFC4X3 (caught during the docs-section review), and the not-yet block referenced 0.1.x while pointing at nothing actionable — it now points at the ready VALIDATION.md fixtures and per-tool checklists. brepjs-families: the registry list and bim-projection scope gain stairs (#2136).