### PR TITLE
feat(bim): spatial and group adds return Result like the rest of the api

### DIFF
--- a/apps/docs/bim/overview.md
+++ b/apps/docs/bim/overview.md
@@ -18,13 +18,14 @@ Two ways in:
 
 ```typescript
 import { BimModel, toIfc } from 'brepjs-bim';
+import { unwrap } from 'brepjs';
 
 const model = new BimModel();
 model.init({ name: 'Example' });
 
-const siteId = model.addSite({ name: 'Site' });
-const buildingId = model.addBuilding({ name: 'Building' });
-const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+const siteId = unwrap(model.addSite({ name: 'Site' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
 const project = model.getProject();
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);

--- a/apps/playground/src/lib/examples/bim.ts
+++ b/apps/playground/src/lib/examples/bim.ts
@@ -14,6 +14,7 @@ export const BIM_EXAMPLES: readonly Example[] = [
       'A parametric structural-steel wide-flange (I-beam) authored through a BimModel, complete with the rolled root fillets where the web meets the flanges. The element carries a brepjs solid for display and the model serializes to IFC.',
     code: `import { BimModel } from 'brepjs-bim';
 import { present } from 'brepjs/playground';
+import { unwrap } from 'brepjs/quick';
 
 // A parametric structural-steel I-beam authored through the BIM model (it also
 // serializes to IFC via toIfc(model)). filletRadius adds the rolled root fillets
@@ -24,9 +25,9 @@ model.init({ name: 'Beam example' });
 
 // Spatial structure — what makes this a BIM model, not just geometry.
 const project = model.getProject();
-const siteId = model.addSite({ name: 'Site' });
-const buildingId = model.addBuilding({ name: 'Building' });
-const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+const siteId = unwrap(model.addSite({ name: 'Site' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);
 model.aggregate(buildingId, storeyId);
@@ -62,6 +63,7 @@ export default present(model.getBeams()[0].geometry, {
       'A parametric wall hosting a door and a window, placed in a project → site → building → storey spatial structure. The BIM panel shows the live IFC model tree.',
     code: `import { BimModel, toIfc } from 'brepjs-bim';
 import { present } from 'brepjs/playground';
+import { unwrap } from 'brepjs/quick';
 
 // A parametric wall hosting a door and a window, organised into a real IFC
 // spatial structure (project → site → building → storey). Each opening is a void
@@ -72,9 +74,9 @@ model.init({ name: 'Wall example' });
 
 // Spatial structure — what makes this a BIM model, not just geometry.
 const project = model.getProject();
-const siteId = model.addSite({ name: 'Site' });
-const buildingId = model.addBuilding({ name: 'Building' });
-const storeyId = model.addStorey({ name: 'Ground Floor', elevation: 0 });
+const siteId = unwrap(model.addSite({ name: 'Site' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+const storeyId = unwrap(model.addStorey({ name: 'Ground Floor', elevation: 0 }));
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);
 model.aggregate(buildingId, storeyId);
@@ -136,7 +138,7 @@ export default present(model.getWalls()[0].geometry, {
       'A parametric curtain-wall facade — a grid of glazing panels framed by vertical and horizontal mullions, each placed from its IFC local origin.',
     code: `import { BimModel } from 'brepjs-bim';
 import { present } from 'brepjs/playground';
-import { translate } from 'brepjs/quick';
+import { translate, unwrap } from 'brepjs/quick';
 
 // A parametric curtain wall: a columns x rows grid of glazing panels framed by
 // mullions. The model returns each panel and mullion as a local-origin solid
@@ -147,9 +149,9 @@ model.init({ name: 'Curtain wall' });
 
 // Spatial structure — what makes this a BIM model, not just geometry.
 const project = model.getProject();
-const siteId = model.addSite({ name: 'Site' });
-const buildingId = model.addBuilding({ name: 'Building' });
-const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+const siteId = unwrap(model.addSite({ name: 'Site' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);
 model.aggregate(buildingId, storeyId);
@@ -191,9 +193,9 @@ import { color, present } from 'brepjs/playground';
 // A two-bay steel frame: 3x2 columns, a beam grid over their heads, a floor deck.
 const model = new BimModel();
 model.init({ name: 'Steel frame' });
-const site = model.addSite({ name: 'Site' });
-const building = model.addBuilding({ name: 'Building' });
-const storey = model.addStorey({ name: 'Level 1', elevation: 0 });
+const site = unwrap(model.addSite({ name: 'Site' }));
+const building = unwrap(model.addBuilding({ name: 'Building' }));
+const storey = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
 const project = model.getProject();
 if (project) model.aggregate(project.localId, site);
 model.aggregate(site, building);
@@ -227,7 +229,7 @@ const deck = model.addSlab({ length: SPAN_X, width: SPAN_Y, thickness: 150, orig
 if (!deck.ok) throw deck.error;
 model.placeIn(deck.value, storey);
 
-const assembly = model.addElementAssembly({ name: 'Frame' });
+const assembly = unwrap(model.addElementAssembly({ name: 'Frame' }));
 for (const e of [...model.getColumns(), ...model.getBeams(), ...model.getSlabs()]) model.aggregate(assembly, e.localId);
 
 // Playground runtime owns the displayed geometry for this eval; snippets don't dispose it.
@@ -257,9 +259,9 @@ import { color, present } from 'brepjs/playground';
 // corners, a door + two windows, a gable roof seated on the wall heads, + an IfcSpace.
 const model = new BimModel();
 model.init({ name: 'Building shell' });
-const site = model.addSite({ name: 'Site' });
-const building = model.addBuilding({ name: 'Building' });
-const storey = model.addStorey({ name: 'Ground Floor', elevation: 0 });
+const site = unwrap(model.addSite({ name: 'Site' }));
+const building = unwrap(model.addBuilding({ name: 'Building' }));
+const storey = unwrap(model.addStorey({ name: 'Ground Floor', elevation: 0 }));
 const project = model.getProject();
 if (project) model.aggregate(project.localId, site);
 model.aggregate(site, building);
@@ -338,9 +340,9 @@ import { color, present } from 'brepjs/playground';
 // landing. Each flight is a real stepped solid read back via placedSolids().
 const model = new BimModel();
 model.init({ name: 'Stair core' });
-const site = model.addSite({ name: 'Site' });
-const building = model.addBuilding({ name: 'Building' });
-const storey = model.addStorey({ name: 'Ground Floor', elevation: 0 });
+const site = unwrap(model.addSite({ name: 'Site' }));
+const building = unwrap(model.addBuilding({ name: 'Building' }));
+const storey = unwrap(model.addStorey({ name: 'Ground Floor', elevation: 0 }));
 const project = model.getProject();
 if (project) model.aggregate(project.localId, site);
 model.aggregate(site, building);
@@ -412,9 +414,9 @@ import { present } from 'brepjs/playground';
 
 const model = new BimModel();
 model.init({ name: 'Roof gallery' });
-const site = model.addSite({ name: 'Site' });
-const building = model.addBuilding({ name: 'Building' });
-const storey = model.addStorey({ name: 'Level', elevation: 0 });
+const site = unwrap(model.addSite({ name: 'Site' }));
+const building = unwrap(model.addBuilding({ name: 'Building' }));
+const storey = unwrap(model.addStorey({ name: 'Level', elevation: 0 }));
 const project = model.getProject();
 if (project) model.aggregate(project.localId, site);
 model.aggregate(site, building);
@@ -452,9 +454,9 @@ import { color, present } from 'brepjs/playground';
 
 const model = new BimModel();
 model.init({ name: 'Space' });
-const site = model.addSite({ name: 'Site' });
-const building = model.addBuilding({ name: 'Building' });
-const storey = model.addStorey({ name: 'Level', elevation: 0 });
+const site = unwrap(model.addSite({ name: 'Site' }));
+const building = unwrap(model.addBuilding({ name: 'Building' }));
+const storey = unwrap(model.addStorey({ name: 'Level', elevation: 0 }));
 const project = model.getProject();
 if (project) model.aggregate(project.localId, site);
 model.aggregate(site, building);

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -17,9 +17,9 @@ declare class BimModel {
     #private;
     init(spec: ProjectSpec): Result<LocalId, BimError>;
     [Symbol.dispose](): void;
-    addSite(spec: SiteSpec): LocalId;
-    addBuilding(spec: BuildingSpec, options?: ElementIdentityOptions): LocalId;
-    addStorey(spec: StoreySpec, options?: ElementIdentityOptions): LocalId;
+    addSite(spec: SiteSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
+    addBuilding(spec: BuildingSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
+    addStorey(spec: StoreySpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
     addWall(spec: WallSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
     addSlab(spec: SlabSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
     addBeam(spec: BeamSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
@@ -52,19 +52,19 @@ declare class BimModel {
      * attach parts with {@link aggregate} (IfcRelAggregates) or {@link nest}
      * (IfcRelNests, order-preserving). Returns the assembly's localId.
      */
-    addElementAssembly(spec: ElementAssemblySpec): LocalId;
+    addElementAssembly(spec: ElementAssemblySpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
     /**
      * Adds an IfcZone grouping object (a thermal/fire/occupancy zone). The zone
      * carries no geometry; attach members (spaces or other elements) with
-     * {@link assignToGroup}. Returns the zone's localId.
+     * {@link assignToGroup}. Returns the zone's localId as a Result.
      */
-    addZone(spec: ZoneSpec): LocalId;
+    addZone(spec: ZoneSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
     /**
      * Adds an IfcSystem grouping object (an HVAC/electrical/plumbing system). The
      * system carries no geometry; attach members with {@link assignToGroup}.
-     * Returns the system's localId.
+     * Returns the system's localId as a Result.
      */
-    addSystem(spec: SystemSpec): LocalId;
+    addSystem(spec: SystemSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
     /**
      * Assigns members to a zone or system via IfcRelAssignsToGroup. Repeated calls
      * for the same group extend the single relationship in call order. Returns the

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -67,15 +67,16 @@ Author a small model and export IFC:
 
 ```ts
 import { BimModel, toIfc } from 'brepjs-bim';
+import { unwrap } from 'brepjs';
 
 const model = new BimModel();
 model.init({ name: 'Example' });
 
 // Spatial structure: project → site → building → storey.
 const project = model.getProject();
-const siteId = model.addSite({ name: 'Site' });
-const buildingId = model.addBuilding({ name: 'Building' });
-const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+const siteId = unwrap(model.addSite({ name: 'Site' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);
 model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/examples/interop-fixture.ifc
+++ b/packages/brepjs-bim/examples/interop-fixture.ifc
@@ -8,7 +8,7 @@ HEADER;
 * Issues: https://github.com/ThatOpen/engine_web-ifc/issues
 ******************************************************/
 FILE_DESCRIPTION(('ViewDefinition [ReferenceView_v1.2]'),'2;1');
-FILE_NAME('web-ifc-model-0.ifc','2026-08-18T04:17:23',(''),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
+FILE_NAME('web-ifc-model-0.ifc','2026-08-18T04:45:08',(''),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
@@ -155,7 +155,7 @@ DATA;
 #708=IFCDIRECTION((1.,0.,0.));
 #707=IFCDIRECTION((0.,0.,1.));
 #706=IFCCARTESIANPOINT((0.5,0.5,0.));
-#705=IFCSTAIR('1X2g0G2ofJWOlV7SAqroPB',#6,'Main Stair',$,$,#704,$,$,.HALF_TURN_STAIR.);
+#705=IFCSTAIR('1CsMJNg$nLV9IVDK459TnE',#6,'Main Stair',$,$,#704,$,$,.HALF_TURN_STAIR.);
 #704=IFCLOCALPLACEMENT(#34,#703);
 #703=IFCAXIS2PLACEMENT3D(#700,#701,#702);
 #702=IFCDIRECTION((1.,0.,0.));

--- a/packages/brepjs-bim/examples/interopFixture.mjs
+++ b/packages/brepjs-bim/examples/interopFixture.mjs
@@ -7,6 +7,7 @@
 // `python scripts/validateIfc.py examples/interop-fixture.ifc` and the
 // checklist in VALIDATION.md. Run: `node examples/interopFixture.mjs`.
 import 'brepjs/quick';
+import { unwrap } from 'brepjs';
 import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -27,9 +28,9 @@ const model = new BimModel();
 model.init({ name: 'brepjs-bim Interop Fixture' });
 
 const project = model.getProject();
-const siteId = model.addSite({ name: 'Interop Site' });
-const buildingId = model.addBuilding({ name: 'Interop Pavilion' });
-const groundId = model.addStorey({ name: 'Ground', elevation: 0 });
+const siteId = unwrap(model.addSite({ name: 'Interop Site' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Interop Pavilion' }));
+const groundId = unwrap(model.addStorey({ name: 'Ground', elevation: 0 }));
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);
 model.aggregate(buildingId, groundId);

--- a/packages/brepjs-bim/examples/sample-building.ifc
+++ b/packages/brepjs-bim/examples/sample-building.ifc
@@ -8,7 +8,7 @@ HEADER;
 * Issues: https://github.com/ThatOpen/engine_web-ifc/issues
 ******************************************************/
 FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
-FILE_NAME('web-ifc-model-0.ifc','2026-06-17T20:07:48',('Andy Aragon'),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
+FILE_NAME('web-ifc-model-0.ifc','2026-08-18T04:45:06',('Andy Aragon'),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;

--- a/packages/brepjs-bim/examples/sampleBuilding.mjs
+++ b/packages/brepjs-bim/examples/sampleBuilding.mjs
@@ -6,6 +6,7 @@
 // Importing 'brepjs/quick' initialises the OCCT-WASM kernel (top-level await)
 // before any geometry is built; brepjs-bim shares that same kernel singleton.
 import 'brepjs/quick';
+import { unwrap } from 'brepjs';
 import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -15,7 +16,9 @@ const outFile = resolve(dirname(fileURLToPath(import.meta.url)), 'sample-buildin
 
 function expect(result, label) {
   if (result && result.ok === false) {
-    throw new Error(`${label} failed: ${result.error?.code ?? ''} ${result.error?.message ?? result.error}`);
+    throw new Error(
+      `${label} failed: ${result.error?.code ?? ''} ${result.error?.message ?? result.error}`
+    );
   }
   return result && 'value' in result ? result.value : result;
 }
@@ -25,10 +28,10 @@ model.init({ name: 'brepjs-bim Sample Office' });
 
 // Spatial structure: project → site → building → two storeys.
 const project = model.getProject();
-const siteId = model.addSite({ name: 'Riverside Plot' });
-const buildingId = model.addBuilding({ name: 'Office Block A' });
-const groundId = model.addStorey({ name: 'Ground Floor', elevation: 0 });
-const firstId = model.addStorey({ name: 'First Floor', elevation: 3200 });
+const siteId = unwrap(model.addSite({ name: 'Riverside Plot' }));
+const buildingId = unwrap(model.addBuilding({ name: 'Office Block A' }));
+const groundId = unwrap(model.addStorey({ name: 'Ground Floor', elevation: 0 }));
+const firstId = unwrap(model.addStorey({ name: 'First Floor', elevation: 3200 }));
 if (project) model.aggregate(project.localId, siteId);
 model.aggregate(siteId, buildingId);
 model.aggregate(buildingId, groundId);
@@ -59,8 +62,8 @@ const wallIds = wallDefs.map((d, i) =>
       loadBearing: true,
       fireRating: 'REI 120',
     }),
-    `addWall[${i}]`,
-  ),
+    `addWall[${i}]`
+  )
 );
 for (const id of wallIds) model.placeIn(id, groundId);
 
@@ -76,7 +79,7 @@ const windowId = expect(
     isExternal: true,
     thermalTransmittance: 1.4,
   }),
-  'addWindow',
+  'addWindow'
 );
 const doorId = expect(
   model.addDoor({
@@ -89,7 +92,7 @@ const doorId = expect(
     isExternal: true,
     fireRating: 'EI 60',
   }),
-  'addDoor',
+  'addDoor'
 );
 model.placeIn(windowId, groundId);
 model.placeIn(doorId, groundId);
@@ -108,7 +111,7 @@ const slabGround = expect(
     isExternal: false,
     loadBearing: true,
   }),
-  'addSlab[ground]',
+  'addSlab[ground]'
 );
 model.placeIn(slabGround, groundId);
 const slabFirst = expect(
@@ -123,7 +126,7 @@ const slabFirst = expect(
     materialName: 'Concrete',
     loadBearing: true,
   }),
-  'addSlab[first]',
+  'addSlab[first]'
 );
 model.placeIn(slabFirst, firstId);
 
@@ -142,7 +145,7 @@ for (const [cx, cy] of [
       materialName: 'Steel',
       loadBearing: true,
     }),
-    'addColumn',
+    'addColumn'
   );
   model.placeIn(col, groundId);
 }
@@ -154,7 +157,7 @@ model.addClassification(
     code: 'EF_25_10',
     name: 'Walls',
   },
-  wallIds,
+  wallIds
 );
 
 const result = await toIfcValidated(model, {

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -274,9 +274,18 @@ export function familiesToBim(
   const model = new BimModel();
   const initResult = model.init(options.project);
   if (!initResult.ok) return initResult;
-  const siteId = model.addSite({ name: options.siteName ?? 'Site' });
-  const buildingId = model.addBuilding({ name: options.buildingName ?? 'Building' });
-  model.aggregate(siteId, buildingId);
+  const siteResult = model.addSite({ name: options.siteName ?? 'Site' });
+  if (!siteResult.ok) {
+    model[Symbol.dispose]();
+    return siteResult;
+  }
+  const buildingResult = model.addBuilding({ name: options.buildingName ?? 'Building' });
+  if (!buildingResult.ok) {
+    model[Symbol.dispose]();
+    return buildingResult;
+  }
+  const buildingId = buildingResult.value;
+  model.aggregate(siteResult.value, buildingId);
 
   const idByKeyPath = new Map<string, LocalId>();
   const walk = (el: ResolvedElement, storeyId: LocalId | null): Result<void, BimError> => {
@@ -285,16 +294,17 @@ export function familiesToBim(
     if (el.type === 'Storey') {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
-      const id = model.addStorey(
+      const storeyResult = model.addStorey(
         {
           name: (el.attributes['name'] as string | undefined) ?? el.keyPath,
           elevation: (el.props['elevation'] as number | undefined) ?? 0,
         },
         { stableKey: el.keyPath }
       );
-      model.aggregate(buildingId, id);
-      idByKeyPath.set(el.keyPath, id);
-      containerId = id;
+      if (!storeyResult.ok) return storeyResult;
+      model.aggregate(buildingId, storeyResult.value);
+      idByKeyPath.set(el.keyPath, storeyResult.value);
+      containerId = storeyResult.value;
     } else if (route !== undefined) {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -124,16 +124,22 @@ export class BimModel {
     }
   }
 
-  addSite(spec: SiteSpec): LocalId {
-    return this.#makeElement('SITE', spec, null);
+  addSite(spec: SiteSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
+    return ok(this.#makeElement('SITE', spec, null, options?.stableKey));
   }
 
-  addBuilding(spec: BuildingSpec, options?: ElementIdentityOptions): LocalId {
-    return this.#makeElement('BUILDING', spec, null, options?.stableKey);
+  addBuilding(spec: BuildingSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
+    return ok(this.#makeElement('BUILDING', spec, null, options?.stableKey));
   }
 
-  addStorey(spec: StoreySpec, options?: ElementIdentityOptions): LocalId {
-    return this.#makeElement('STOREY', spec, null, options?.stableKey);
+  addStorey(spec: StoreySpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
+    return ok(this.#makeElement('STOREY', spec, null, options?.stableKey));
   }
 
   /** Reject a duplicate stableKey BEFORE any geometry is built, so the
@@ -334,26 +340,35 @@ export class BimModel {
    * attach parts with {@link aggregate} (IfcRelAggregates) or {@link nest}
    * (IfcRelNests, order-preserving). Returns the assembly's localId.
    */
-  addElementAssembly(spec: ElementAssemblySpec): LocalId {
-    return this.#makeElement('ELEMENT_ASSEMBLY', spec, null);
+  addElementAssembly(
+    spec: ElementAssemblySpec,
+    options?: ElementIdentityOptions
+  ): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
+    return ok(this.#makeElement('ELEMENT_ASSEMBLY', spec, null, options?.stableKey));
   }
 
   /**
    * Adds an IfcZone grouping object (a thermal/fire/occupancy zone). The zone
    * carries no geometry; attach members (spaces or other elements) with
-   * {@link assignToGroup}. Returns the zone's localId.
+   * {@link assignToGroup}. Returns the zone's localId as a Result.
    */
-  addZone(spec: ZoneSpec): LocalId {
-    return this.#makeElement('ZONE', spec, null);
+  addZone(spec: ZoneSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
+    return ok(this.#makeElement('ZONE', spec, null, options?.stableKey));
   }
 
   /**
    * Adds an IfcSystem grouping object (an HVAC/electrical/plumbing system). The
    * system carries no geometry; attach members with {@link assignToGroup}.
-   * Returns the system's localId.
+   * Returns the system's localId as a Result.
    */
-  addSystem(spec: SystemSpec): LocalId {
-    return this.#makeElement('SYSTEM', spec, null);
+  addSystem(spec: SystemSpec, options?: ElementIdentityOptions): Result<LocalId, BimError> {
+    const keyCheck = this.#checkStableKey(options);
+    if (!keyCheck.ok) return keyCheck;
+    return ok(this.#makeElement('SYSTEM', spec, null, options?.stableKey));
   }
 
   /**

--- a/packages/brepjs-bim/tests/assemblyWriter.test.ts
+++ b/packages/brepjs-bim/tests/assemblyWriter.test.ts
@@ -115,7 +115,15 @@ describe('assemblyWriter', () => {
     const w = await makeWriter();
     const oh = writeOwnerHistory(w);
     const assemblyGuid = deriveIfcGuidSync(makeElementKey('ELEMENT_ASSEMBLY', 2));
-    const assembly = writeElementAssemblyEntity(w, assemblyGuid, 'Frame', 'RIGID_FRAME', oh, null, null);
+    const assembly = writeElementAssemblyEntity(
+      w,
+      assemblyGuid,
+      'Frame',
+      'RIGID_FRAME',
+      oh,
+      null,
+      null
+    );
     const memberA = writeBeam(w, oh);
     const memberB = writeBeam(w, oh);
 

--- a/packages/brepjs-bim/tests/bcf.test.ts
+++ b/packages/brepjs-bim/tests/bcf.test.ts
@@ -133,7 +133,10 @@ describe('BCF 3.0 read/write', () => {
   it('fails with BCF_VERSION_UNSUPPORTED for a non-3.0 container', () => {
     const data = buildContainer();
     const files = serializeBcfFiles(data);
-    files.set('bcf.version', '<?xml version="1.0" encoding="UTF-8"?>\n<Version VersionId="2.1"></Version>');
+    files.set(
+      'bcf.version',
+      '<?xml version="1.0" encoding="UTF-8"?>\n<Version VersionId="2.1"></Version>'
+    );
     const parsed = parseBcfFiles(files);
     expect(parsed.ok).toBe(false);
     if (!parsed.ok) {

--- a/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
+++ b/packages/brepjs-bim/tests/bimGeometryIfc.test.ts
@@ -14,9 +14,9 @@ function decode(bytes: Uint8Array): string {
 async function ifcText(build: (m: BimModel) => void): Promise<string> {
   const m = new BimModel();
   m.init({ name: 'T' });
-  const site = m.addSite({ name: 'S' });
-  const bld = m.addBuilding({ name: 'B' });
-  const st = m.addStorey({ name: 'L', elevation: 0 });
+  const site = unwrap(m.addSite({ name: 'S' }));
+  const bld = unwrap(m.addBuilding({ name: 'B' }));
+  const st = unwrap(m.addStorey({ name: 'L', elevation: 0 }));
   const p = m.getProject();
   if (p) m.aggregate(p.localId, site);
   m.aggregate(site, bld);
@@ -96,33 +96,55 @@ describe('shaped model round-trips cleanly', () => {
   it('shaped roof + posted railing + stair → no error-severity IFC issues', async () => {
     const m = new BimModel();
     m.init({ name: 'Validity' });
-    const site = m.addSite({ name: 'S' });
-    const bld = m.addBuilding({ name: 'B' });
-    const st = m.addStorey({ name: 'L', elevation: 0 });
+    const site = unwrap(m.addSite({ name: 'S' }));
+    const bld = unwrap(m.addBuilding({ name: 'B' }));
+    const st = unwrap(m.addStorey({ name: 'L', elevation: 0 }));
     const p = m.getProject();
     if (p) m.aggregate(p.localId, site);
     m.aggregate(site, bld);
     m.aggregate(bld, st);
     const roof = unwrap(
       m.addRoof({
-        length: 4000, width: 3000, thickness: 200, origin: [0, 0, 0],
-        axisX: [1, 0, 0], axisZ: [0, 0, 1], predefinedType: 'HIP_ROOF', pitch: 35, materialName: 'Tile',
+        length: 4000,
+        width: 3000,
+        thickness: 200,
+        origin: [0, 0, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        predefinedType: 'HIP_ROOF',
+        pitch: 35,
+        materialName: 'Tile',
       })
     );
     m.placeIn(roof, st);
     const rail = unwrap(
       m.addRailing({
-        length: 2000, height: 1000, thickness: 50, origin: [0, 0, 0],
-        axisX: [1, 0, 0], axisZ: [0, 0, 1], predefinedType: 'GUARDRAIL', infill: 'POSTED', materialName: 'Steel',
+        length: 2000,
+        height: 1000,
+        thickness: 50,
+        origin: [0, 0, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        predefinedType: 'GUARDRAIL',
+        infill: 'POSTED',
+        materialName: 'Steel',
       })
     );
     m.placeIn(rail, st);
     const stair = unwrap(
       m.addStair({
-        flights: [{
-          width: 1000, riserHeight: 175, treadLength: 250, numberOfRisers: 10,
-          origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1], materialName: 'Concrete',
-        }],
+        flights: [
+          {
+            width: 1000,
+            riserHeight: 175,
+            treadLength: 250,
+            numberOfRisers: 10,
+            origin: [0, 0, 0],
+            axisX: [1, 0, 0],
+            axisZ: [0, 0, 1],
+            materialName: 'Concrete',
+          },
+        ],
         materialName: 'Concrete',
       })
     );

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -120,9 +120,9 @@ describe('BimModel', () => {
   it('addWall returns a LocalId on success', () => {
     const model = new BimModel();
     unwrap(model.init({ name: 'P' }));
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     const project = model.getProject();
     if (project === null) throw new Error('Expected project to exist');
     model.aggregate(project.localId, siteId);
@@ -169,9 +169,9 @@ describe('BimModel', () => {
   it('getWalls returns only wall elements', () => {
     const model = new BimModel();
     unwrap(model.init({ name: 'P' }));
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     const project = model.getProject();
     if (project === null) throw new Error('Expected project to exist');
     model.aggregate(project.localId, siteId);
@@ -773,9 +773,9 @@ describe('BimModel.toTreeSummary', () => {
     unwrap(model.init({ name: 'Project' }));
     const project = model.getProject();
     if (!project) throw new Error('no project');
-    const siteId = model.addSite({ name: 'Site' });
-    const buildingId = model.addBuilding({ name: 'Building' });
-    const storeyId = model.addStorey({ name: 'Level 1', elevation: 3000 });
+    const siteId = unwrap(model.addSite({ name: 'Site' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+    const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 3000 }));
     model.aggregate(project.localId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/tests/classificationWriter.test.ts
+++ b/packages/brepjs-bim/tests/classificationWriter.test.ts
@@ -129,9 +129,8 @@ describe('classificationWriter', () => {
     const rel = api.GetLine(mid, relIds.get(0)) as Record<string, unknown>;
     const related = (rel['RelatedObjects'] ?? []) as Array<{ value: number }>;
     expect(related.map((r) => r.value)).toContain(wall);
-    const relatingClassification = (
-      rel['RelatingClassification'] as { value?: number } | undefined
-    )?.value;
+    const relatingClassification = (rel['RelatingClassification'] as { value?: number } | undefined)
+      ?.value;
     expect(relatingClassification).toBe(refIds.get(0));
 
     // The rel carries a valid 22-char deterministic GlobalId.

--- a/packages/brepjs-bim/tests/cobieExport.test.ts
+++ b/packages/brepjs-bim/tests/cobieExport.test.ts
@@ -16,9 +16,9 @@ function unwrap<T>(r: { ok: true; value: T } | { ok: false; error: { message: st
 function buildModel(): BimModel {
   const model = new BimModel();
   unwrap(model.init({ name: 'Test Project', description: 'COBie export project' }));
-  const siteId = model.addSite({ name: 'Test Site' });
-  const buildingId = model.addBuilding({ name: 'Test Building' });
-  const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Test Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Test Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
 

--- a/packages/brepjs-bim/tests/coveringFns.test.ts
+++ b/packages/brepjs-bim/tests/coveringFns.test.ts
@@ -13,7 +13,9 @@ import { deriveIfcGuidSync, makeElementKey, makeRelKey } from '../src/identity/g
 import { writeHeader } from '../src/ifc-writer/headerWriter.js';
 import { measureVolume } from 'brepjs';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const spec = {
   length: 3000,

--- a/packages/brepjs-bim/tests/curtainWallFns.test.ts
+++ b/packages/brepjs-bim/tests/curtainWallFns.test.ts
@@ -9,7 +9,9 @@ import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
 import { writeHeader } from '../src/ifc-writer/headerWriter.js';
 import { writeCurtainWall } from '../src/ifc-writer/curtainWallWriter.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 // A 2 × 2 grid: 4 panels, 3 vertical mullions + 3 horizontal mullions = 6.
 const SPEC: CurtainWallSpec = {

--- a/packages/brepjs-bim/tests/familiesSampleBuilding.test.ts
+++ b/packages/brepjs-bim/tests/familiesSampleBuilding.test.ts
@@ -58,9 +58,7 @@ describe('families sample building (Phase 6 gate)', () => {
     const scope = SAMPLE_PROJECT.projectId;
     expect(ifc).toContain(deriveIfcGuidSync(`elem:${scope}:office/ground/south`));
     expect(ifc).toContain(deriveIfcGuidSync(`elem:${scope}:office/ground/east/voids:door-1`));
-    expect(ifc).toContain(
-      deriveIfcGuidSync(`elem:${scope}:office/ground/south/voids:win-1/fill`)
-    );
+    expect(ifc).toContain(deriveIfcGuidSync(`elem:${scope}:office/ground/south/voids:win-1/fill`));
     expect(ifc).toContain(deriveIfcGuidSync(`elem:${scope}:office/first/floor`));
   });
 
@@ -108,9 +106,7 @@ describe('families sample building (Phase 6 gate)', () => {
             thickness: 200,
             axisX: [0, 1, 0],
             materialName: 'Concrete',
-            voids: [
-              YDoor({ key: 'd', along, width: 1000, height: 2100, materialName: 'Timber' }),
-            ],
+            voids: [YDoor({ key: 'd', along, width: 1000, height: 2100, materialName: 'Timber' })],
           }),
         ],
       });
@@ -126,10 +122,7 @@ describe('families sample building (Phase 6 gate)', () => {
 
   it('matches the committed fixture (regenerate via the example script on change)', async () => {
     const fixture = await readFile(
-      join(
-        dirname(fileURLToPath(import.meta.url)),
-        '../examples/sample-building-families.ifc'
-      ),
+      join(dirname(fileURLToPath(import.meta.url)), '../examples/sample-building-families.ifc'),
       'utf8'
     );
     const stripHeader = (s: string): string =>

--- a/packages/brepjs-bim/tests/foundationFns.test.ts
+++ b/packages/brepjs-bim/tests/foundationFns.test.ts
@@ -6,11 +6,18 @@ import { footingToSolid, pileToSolid } from '../src/elementFns/foundationFns.js'
 import { parseFootingSpec, parsePileSpec } from '../src/specs/foundationSpec.js';
 import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
 import { writeHeader } from '../src/ifc-writer/headerWriter.js';
-import { writeFootingEntity, writeFootingGeometry, writePileEntity, writePileGeometry } from '../src/ifc-writer/foundationWriter.js';
+import {
+  writeFootingEntity,
+  writeFootingGeometry,
+  writePileEntity,
+  writePileGeometry,
+} from '../src/ifc-writer/foundationWriter.js';
 import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
 import type { FootingSpec, PileSpec } from '../src/specs/foundationSpec.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const footingSpec: FootingSpec = {
   length: 2000,
@@ -171,7 +178,12 @@ describe('parsePileSpec', () => {
   });
 
   it('accepts each construction type', () => {
-    for (const constructionType of ['CAST_IN_PLACE', 'COMPOSITE', 'PRECAST_CONCRETE', 'PREFAB_STEEL'] as const) {
+    for (const constructionType of [
+      'CAST_IN_PLACE',
+      'COMPOSITE',
+      'PRECAST_CONCRETE',
+      'PREFAB_STEEL',
+    ] as const) {
       expect(parsePileSpec({ ...pileSpec, constructionType }).ok).toBe(true);
     }
   });

--- a/packages/brepjs-bim/tests/groupWriter.test.ts
+++ b/packages/brepjs-bim/tests/groupWriter.test.ts
@@ -11,7 +11,9 @@ import {
 import { parseZoneSpec, parseSystemSpec } from '../src/specs/groupSpec.js';
 import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -71,7 +73,14 @@ describe('groupWriter', () => {
     const spaceBId = writeMinimalSpace(w, ownerHistoryId, 'Space B');
 
     const zoneGuid = deriveIfcGuidSync('test:zone:1');
-    const zoneId = writeZoneEntity(w, zoneGuid, 'Thermal Zone A', 'Top Floor Thermal Zone', null, ownerHistoryId);
+    const zoneId = writeZoneEntity(
+      w,
+      zoneGuid,
+      'Thermal Zone A',
+      'Top Floor Thermal Zone',
+      null,
+      ownerHistoryId
+    );
 
     const relGuid = deriveIfcGuidSync('test:rel:zone:1');
     writeRelAssignsToGroup(w, relGuid, ownerHistoryId, zoneId, [spaceAId, spaceBId]);
@@ -116,7 +125,14 @@ describe('groupWriter', () => {
     const elemBId = writeMinimalProxy(w, ownerHistoryId, 'Duct 2');
 
     const sysGuid = deriveIfcGuidSync('test:system:1');
-    const systemId = writeSystemEntity(w, sysGuid, 'HVAC Supply', 'Supply Air System', null, ownerHistoryId);
+    const systemId = writeSystemEntity(
+      w,
+      sysGuid,
+      'HVAC Supply',
+      'Supply Air System',
+      null,
+      ownerHistoryId
+    );
 
     const relGuid = deriveIfcGuidSync('test:rel:system:1');
     writeRelAssignsToGroup(w, relGuid, ownerHistoryId, systemId, [elemAId, elemBId]);

--- a/packages/brepjs-bim/tests/idsCheck.test.ts
+++ b/packages/brepjs-bim/tests/idsCheck.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
@@ -77,9 +78,9 @@ function buildWallModel(withIsExternal: boolean): BimModel {
   const initResult = model.init({ name: 'IDS Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/tests/importData.test.ts
+++ b/packages/brepjs-bim/tests/importData.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as WebIFC from 'web-ifc';
 import { initOCCT } from '../../../tests/setup.js';
@@ -33,9 +34,9 @@ function buildModel(): Built {
   const initResult = model.init({ name: 'Import Data Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/tests/importGeometry.test.ts
+++ b/packages/brepjs-bim/tests/importGeometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as WebIFC from 'web-ifc';
-import { measureVolume } from 'brepjs';
+import { measureVolume, unwrap } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
@@ -26,9 +26,9 @@ function buildWallModel(): BimModel {
   const initResult = model.init({ name: 'Geometry RoundTrip' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
@@ -61,9 +61,9 @@ function buildCircularColumnModel(): BimModel {
   const ir = model.init({ name: 'Column RoundTrip' });
   if (!ir.ok) throw new Error(ir.error.message);
   const pid = ir.value;
-  const sid = model.addSite({ name: 'Site' });
-  const bid = model.addBuilding({ name: 'Building' });
-  const stid = model.addStorey({ name: 'L1', elevation: 0 });
+  const sid = unwrap(model.addSite({ name: 'Site' }));
+  const bid = unwrap(model.addBuilding({ name: 'Building' }));
+  const stid = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(pid, sid);
   model.aggregate(sid, bid);
   model.aggregate(bid, stid);
@@ -85,9 +85,9 @@ function buildIBeamModel(): BimModel {
   const ir = model.init({ name: 'IBeam RoundTrip' });
   if (!ir.ok) throw new Error(ir.error.message);
   const pid = ir.value;
-  const sid = model.addSite({ name: 'Site' });
-  const bid = model.addBuilding({ name: 'Building' });
-  const stid = model.addStorey({ name: 'L1', elevation: 0 });
+  const sid = unwrap(model.addSite({ name: 'Site' }));
+  const bid = unwrap(model.addBuilding({ name: 'Building' }));
+  const stid = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(pid, sid);
   model.aggregate(sid, bid);
   model.aggregate(bid, stid);

--- a/packages/brepjs-bim/tests/importPlacement.test.ts
+++ b/packages/brepjs-bim/tests/importPlacement.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as WebIFC from 'web-ifc';
 import { initOCCT } from '../../../tests/setup.js';
@@ -35,10 +36,10 @@ function buildPlacedModel(): PlacedModel {
   const initResult = model.init({ name: 'Placement Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
   const storeyElevation = 3500;
-  const storeyId = model.addStorey({ name: 'L1', elevation: storeyElevation });
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: storeyElevation }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
@@ -178,9 +179,9 @@ describe('placement round-trip', () => {
     const initResult = model.init({ name: 'Origin Project' });
     if (!initResult.ok) throw new Error(initResult.error.message);
     const projectId = initResult.value;
-    const siteId = model.addSite({ name: 'Site' });
-    const buildingId = model.addBuilding({ name: 'Building' });
-    const storeyId = model.addStorey({ name: 'L0', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'Site' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L0', elevation: 0 }));
     model.aggregate(projectId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/tests/importSpatialTree.test.ts
+++ b/packages/brepjs-bim/tests/importSpatialTree.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
@@ -33,10 +34,10 @@ function buildMultiStoreyModel(): { model: BimModel; meta: RoundTrip } {
   const initResult = model.init({ name: 'Tree Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site A' });
-  const buildingId = model.addBuilding({ name: 'Building A' });
-  const level1Id = model.addStorey({ name: 'Level 1', elevation: 0 });
-  const level2Id = model.addStorey({ name: 'Level 2', elevation: 3000 });
+  const siteId = unwrap(model.addSite({ name: 'Site A' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building A' }));
+  const level1Id = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
+  const level2Id = unwrap(model.addStorey({ name: 'Level 2', elevation: 3000 }));
 
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);

--- a/packages/brepjs-bim/tests/irDrift.test.ts
+++ b/packages/brepjs-bim/tests/irDrift.test.ts
@@ -47,10 +47,7 @@ const PLACEMENT = {
 
 /** Corner-origin rectangle contour in the XY plane. */
 function cornerRect(w: number, h: number) {
-  return csg.contour(
-    [0, 0],
-    [csg.lineTo([w, 0]), csg.lineTo([w, h]), csg.lineTo([0, h])]
-  );
+  return csg.contour([0, 0], [csg.lineTo([w, 0]), csg.lineTo([w, h]), csg.lineTo([0, h])]);
 }
 
 describe('IR drift gate: profile+extrude vs *ToSolid', () => {
@@ -123,7 +120,16 @@ describe('IR drift gate: profile+extrude vs *ToSolid', () => {
       bottomFlangeWidth: 260,
       bottomFlangeThickness: 18,
     };
-    using beam = unwrap(beamToSolid({ length: 5000, profile, materialName: 'Steel', origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1] }));
+    using beam = unwrap(
+      beamToSolid({
+        length: 5000,
+        profile,
+        materialName: 'Steel',
+        origin: [0, 0, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+      })
+    );
     // Mirror the spec convention in IR: extrude along +Z, then rotate +90
     // about Y so the beam length runs along +X.
     const ir = unwrap(

--- a/packages/brepjs-bim/tests/openingFns.test.ts
+++ b/packages/brepjs-bim/tests/openingFns.test.ts
@@ -6,8 +6,12 @@ import { openingToSolid } from '../src/elementFns/openingFns.js';
 
 describe('parseDoorSpec', () => {
   const BASE = {
-    width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
-    wallLocalId: 1, materialName: 'Wood',
+    width: 900,
+    height: 2100,
+    offsetAlongWall: 500,
+    offsetFromFloor: 0,
+    wallLocalId: 1,
+    materialName: 'Wood',
   };
 
   it('accepts minimal valid door spec', () => {
@@ -16,7 +20,12 @@ describe('parseDoorSpec', () => {
   });
 
   it('accepts optional Pset fields', () => {
-    const result = parseDoorSpec({ ...BASE, isExternal: true, fireRating: 'EI60', acousticRating: 'Rw 35' });
+    const result = parseDoorSpec({
+      ...BASE,
+      isExternal: true,
+      fireRating: 'EI60',
+      acousticRating: 'Rw 35',
+    });
     expect(result.ok).toBe(true);
   });
 
@@ -38,8 +47,12 @@ describe('parseDoorSpec', () => {
 
 describe('parseWindowSpec', () => {
   const BASE = {
-    width: 1200, height: 1400, offsetAlongWall: 1000, offsetFromFloor: 900,
-    wallLocalId: 1, materialName: 'Aluminum',
+    width: 1200,
+    height: 1400,
+    offsetAlongWall: 1000,
+    offsetFromFloor: 900,
+    wallLocalId: 1,
+    materialName: 'Aluminum',
   };
 
   it('accepts minimal valid window spec', () => {

--- a/packages/brepjs-bim/tests/ownerHistoryWriter.test.ts
+++ b/packages/brepjs-bim/tests/ownerHistoryWriter.test.ts
@@ -90,7 +90,9 @@ describe('ownerHistoryWriter', () => {
     const appIds = api.GetLineIDsWithType(mid, WebIFC.IFCAPPLICATION);
     expect(appIds.size()).toBe(1);
     const app = api.GetLine(mid, appIds.get(0)) as Record<string, unknown>;
-    expect((app['ApplicationFullName'] as { value?: string } | undefined)?.value).toBe('My CAD App');
+    expect((app['ApplicationFullName'] as { value?: string } | undefined)?.value).toBe(
+      'My CAD App'
+    );
     expect((app['Version'] as { value?: string } | undefined)?.value).toBe('3.1.4');
 
     api.CloseModel(mid);

--- a/packages/brepjs-bim/tests/phase1Integration.test.ts
+++ b/packages/brepjs-bim/tests/phase1Integration.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import * as WebIFC from 'web-ifc';
@@ -6,7 +7,9 @@ import { toIfc, toIfcValidated } from '../src/serialize/toIfc.js';
 import { hasErrors } from '../src/validation/severity.js';
 import { DEFAULT_MVD_VIEW_DEFINITION } from '../src/ifc-writer/ifcWriter.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -15,25 +18,34 @@ function buildModel(): BimModel {
   const initResult = model.init({ name: 'Phase1 Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
 
   const wall = model.addWall({
-    length: 5000, height: 3000, thickness: 250,
-    origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+    length: 5000,
+    height: 3000,
+    thickness: 250,
+    origin: [0, 0, 0],
+    axisX: [1, 0, 0],
+    axisZ: [0, 0, 1],
     materialName: 'Concrete',
   });
   if (!wall.ok) throw new Error(wall.error.message);
   model.placeIn(wall.value, storeyId);
 
   const slab = model.addSlab({
-    length: 6000, width: 4000, thickness: 250,
-    origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
-    predefinedType: 'FLOOR', materialName: 'Concrete',
+    length: 6000,
+    width: 4000,
+    thickness: 250,
+    origin: [0, 0, 0],
+    axisX: [1, 0, 0],
+    axisZ: [0, 0, 1],
+    predefinedType: 'FLOOR',
+    materialName: 'Concrete',
   });
   if (!slab.ok) throw new Error(slab.error.message);
   model.placeIn(slab.value, storeyId);
@@ -77,7 +89,10 @@ describe('Phase 1 integration', () => {
   });
 
   it('honors a custom mvdViewDefinition from meta', async () => {
-    const result = await toIfc(buildModel(), { ...META, mvdViewDefinition: 'DesignTransferView_V1.0' });
+    const result = await toIfc(buildModel(), {
+      ...META,
+      mvdViewDefinition: 'DesignTransferView_V1.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
     const text = new TextDecoder().decode(result.value.subarray(0, 1024));
     expect(text).toContain('ViewDefinition [DesignTransferView_V1.0]');
@@ -122,8 +137,12 @@ describe('Phase 1 integration', () => {
     if (!initResult.ok) throw new Error(initResult.error.message);
     // Wall added but never placed in a spatial structure → ELEMENT_NOT_CONTAINED.
     const wall = model.addWall({
-      length: 3000, height: 2700, thickness: 200,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 3000,
+      height: 2700,
+      thickness: 200,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
     });
     if (!wall.ok) throw new Error(wall.error.message);

--- a/packages/brepjs-bim/tests/phase2Data.test.ts
+++ b/packages/brepjs-bim/tests/phase2Data.test.ts
@@ -1,10 +1,13 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import * as WebIFC from 'web-ifc';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -13,9 +16,9 @@ function spatialModel(): { model: BimModel; storeyId: number } {
   const initResult = model.init({ name: 'Phase2 Data' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
@@ -41,8 +44,12 @@ describe('Phase 2 data integration', () => {
   it('emits Pset_WallCommon properties with correct (non-IFCREAL) measure types', async () => {
     const { model, storeyId } = spatialModel();
     const wall = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
       isExternal: true,
       fireRating: 'REI120',
@@ -75,8 +82,12 @@ describe('Phase 2 data integration', () => {
   it('emits the Status property as an IfcPropertyEnumeratedValue', async () => {
     const { model, storeyId } = spatialModel();
     const wall = model.addWall({
-      length: 4000, height: 2700, thickness: 200,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 4000,
+      height: 2700,
+      thickness: 200,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
       status: 'EXISTING',
     });
@@ -98,8 +109,12 @@ describe('Phase 2 data integration', () => {
   it('associates a layered material via IfcRelAssociatesMaterial + IfcMaterialLayerSet', async () => {
     const { model, storeyId } = spatialModel();
     const wall = model.addWall({
-      length: 5000, height: 3000, thickness: 300,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 300,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Wall Buildup',
       layerSetName: 'Cavity Wall',
       materialLayers: [
@@ -131,8 +146,12 @@ describe('Phase 2 data integration', () => {
   it('associates a classification reference via IfcRelAssociatesClassification', async () => {
     const { model, storeyId } = spatialModel();
     const wall = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
       classification: {
         system: 'Uniclass2015',
@@ -152,7 +171,9 @@ describe('Phase 2 data integration', () => {
     const refIds = api.GetLineIDsWithType(mid, WebIFC.IFCCLASSIFICATIONREFERENCE);
     expect(refIds.size()).toBe(1);
     const refLine = api.GetLine(mid, refIds.get(0)) as Record<string, unknown>;
-    expect((refLine['Identification'] as { value?: string } | undefined)?.value).toBe('Ss_25_10_30');
+    expect((refLine['Identification'] as { value?: string } | undefined)?.value).toBe(
+      'Ss_25_10_30'
+    );
 
     const rels = api.GetLineIDsWithType(mid, WebIFC.IFCRELASSOCIATESCLASSIFICATION);
     expect(rels.size()).toBe(1);
@@ -166,8 +187,12 @@ describe('Phase 2 data integration', () => {
   it('addClassification associates an existing element after the fact', async () => {
     const { model, storeyId } = spatialModel();
     const wall = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
     });
     if (!wall.ok) throw new Error(wall.error.message);
@@ -184,8 +209,12 @@ describe('Phase 2 data integration', () => {
   it('keeps the bare-material path for walls without layers (backward compat)', async () => {
     const { model, storeyId } = spatialModel();
     const wall = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
     });
     if (!wall.ok) throw new Error(wall.error.message);

--- a/packages/brepjs-bim/tests/phase2Geometry.test.ts
+++ b/packages/brepjs-bim/tests/phase2Geometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as WebIFC from 'web-ifc';
-import { box, scale } from 'brepjs';
+import { box, scale, unwrap } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc, toIfcValidated } from '../src/serialize/toIfc.js';
@@ -19,9 +19,9 @@ function buildModelWithOpenings(): { model: BimModel; storeyId: number } {
   const initResult = model.init({ name: 'Phase2 Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/tests/phase3GroupA.test.ts
+++ b/packages/brepjs-bim/tests/phase3GroupA.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import * as WebIFC from 'web-ifc';
@@ -6,7 +7,9 @@ import { toIfc } from '../src/serialize/toIfc.js';
 import { parseProfile } from '../src/specs/profile.js';
 import type { ExtendedProfile } from '../src/specs/profilesExtended.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -20,60 +23,96 @@ function buildGroupAModel(): BimModel {
   const initResult = model.init({ name: 'Phase3 GroupA Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
 
   const wall = model.addWall({
-    length: 5000, height: 3000, thickness: 250,
-    origin: [0, 0, 0], axisX: XAXIS, axisZ: UP,
+    length: 5000,
+    height: 3000,
+    thickness: 250,
+    origin: [0, 0, 0],
+    axisX: XAXIS,
+    axisZ: UP,
     materialName: 'Concrete',
   });
   if (!wall.ok) throw new Error(wall.error.message);
   model.placeIn(wall.value, storeyId);
 
   const space = model.addSpace({
-    name: 'Office 101', length: 4000, width: 3000, height: 3000,
-    origin: [0, 0, 0], axisX: XAXIS, axisZ: UP,
-    materialName: 'Air', predefinedType: 'INTERNAL', isExternal: false,
+    name: 'Office 101',
+    length: 4000,
+    width: 3000,
+    height: 3000,
+    origin: [0, 0, 0],
+    axisX: XAXIS,
+    axisZ: UP,
+    materialName: 'Air',
+    predefinedType: 'INTERNAL',
+    isExternal: false,
   });
   if (!space.ok) throw new Error(space.error.message);
   model.placeIn(space.value, storeyId);
   model.addSpaceBoundary(space.value, wall.value, 'PHYSICAL');
 
   const roof = model.addRoof({
-    length: 6000, width: 4000, thickness: 200,
-    origin: [0, 0, 3000], axisX: XAXIS, axisZ: UP,
-    predefinedType: 'FLAT_ROOF', materialName: 'Concrete', isExternal: true,
+    length: 6000,
+    width: 4000,
+    thickness: 200,
+    origin: [0, 0, 3000],
+    axisX: XAXIS,
+    axisZ: UP,
+    predefinedType: 'FLAT_ROOF',
+    materialName: 'Concrete',
+    isExternal: true,
   });
   if (!roof.ok) throw new Error(roof.error.message);
   model.placeIn(roof.value, storeyId);
 
   const curtainWall = model.addCurtainWall({
-    width: 3000, height: 2400, columns: 2, rows: 2,
-    panelThickness: 30, mullionWidth: 60, mullionDepth: 80,
-    origin: [0, 5000, 0], axisX: XAXIS, axisZ: UP,
-    materialName: 'Aluminium', predefinedType: 'CURTAIN_WALL',
+    width: 3000,
+    height: 2400,
+    columns: 2,
+    rows: 2,
+    panelThickness: 30,
+    mullionWidth: 60,
+    mullionDepth: 80,
+    origin: [0, 5000, 0],
+    axisX: XAXIS,
+    axisZ: UP,
+    materialName: 'Aluminium',
+    predefinedType: 'CURTAIN_WALL',
   });
   if (!curtainWall.ok) throw new Error(curtainWall.error.message);
   model.placeIn(curtainWall.value, storeyId);
 
   const footing = model.addFooting({
-    length: 1200, width: 1200, thickness: 400,
-    origin: [0, 0, -400], axisX: XAXIS, axisZ: UP,
-    predefinedType: 'PAD_FOOTING', materialName: 'Concrete', loadBearing: true,
+    length: 1200,
+    width: 1200,
+    thickness: 400,
+    origin: [0, 0, -400],
+    axisX: XAXIS,
+    axisZ: UP,
+    predefinedType: 'PAD_FOOTING',
+    materialName: 'Concrete',
+    loadBearing: true,
   });
   if (!footing.ok) throw new Error(footing.error.message);
   model.placeIn(footing.value, storeyId);
 
   const pile = model.addPile({
-    length: 8000, profile: { kind: 'CIRCULAR', radius: 300 },
-    origin: [0, 0, -8400], axisX: XAXIS, axisZ: UP,
-    predefinedType: 'BORED', constructionType: 'CAST_IN_PLACE',
-    materialName: 'Concrete', loadBearing: true,
+    length: 8000,
+    profile: { kind: 'CIRCULAR', radius: 300 },
+    origin: [0, 0, -8400],
+    axisX: XAXIS,
+    axisZ: UP,
+    predefinedType: 'BORED',
+    constructionType: 'CAST_IN_PLACE',
+    materialName: 'Concrete',
+    loadBearing: true,
   });
   if (!pile.ok) throw new Error(pile.error.message);
   model.placeIn(pile.value, storeyId);
@@ -163,7 +202,8 @@ describe('Phase 3 Group A integration', () => {
     expect(boundaryIds.size()).toBe(1);
     const boundary = api.GetLine(mid, boundaryIds.get(0)) as Record<string, unknown>;
     const spaceRef = (boundary['RelatingSpace'] as { value?: number } | undefined)?.value;
-    const elementRef = (boundary['RelatedBuildingElement'] as { value?: number } | undefined)?.value;
+    const elementRef = (boundary['RelatedBuildingElement'] as { value?: number } | undefined)
+      ?.value;
     expect(spaceRef).toBeDefined();
     expect(elementRef).toBeDefined();
 
@@ -203,7 +243,10 @@ describe('Phase 3 Group A integration', () => {
 
   it('parseProfile accepts an extended profile and routes it to its IfcProfileDef', async () => {
     const lShape: ExtendedProfile = {
-      kind: 'L_SHAPE', depth: 100, width: 80, legThickness: 10,
+      kind: 'L_SHAPE',
+      depth: 100,
+      width: 80,
+      legThickness: 10,
     };
     const parsed = parseProfile(lShape);
     expect(parsed.ok).toBe(true);
@@ -211,11 +254,14 @@ describe('Phase 3 Group A integration', () => {
     const model = new BimModel();
     const initResult = model.init({ name: 'Extended Profile Project' });
     if (!initResult.ok) throw new Error(initResult.error.message);
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
 
     const pile = model.addPile({
-      length: 5000, profile: { kind: 'RECTANGULAR', width: 400, height: 400 },
-      origin: [0, 0, 0], axisX: XAXIS, axisZ: UP,
+      length: 5000,
+      profile: { kind: 'RECTANGULAR', width: 400, height: 400 },
+      origin: [0, 0, 0],
+      axisX: XAXIS,
+      axisZ: UP,
       materialName: 'Steel',
     });
     if (!pile.ok) throw new Error(pile.error.message);

--- a/packages/brepjs-bim/tests/phase3GroupB.test.ts
+++ b/packages/brepjs-bim/tests/phase3GroupB.test.ts
@@ -1,10 +1,13 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import * as WebIFC from 'web-ifc';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -25,9 +28,9 @@ function buildGroupBModel(): GroupBModel {
   const initResult = model.init({ name: 'Phase3 GroupB Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
@@ -38,12 +41,24 @@ function buildGroupBModel(): GroupBModel {
     materialName: 'Concrete',
     flights: [
       {
-        width: 1200, riserHeight: 175, treadLength: 280, numberOfRisers: 9,
-        origin: [0, 0, 0], axisX: XAXIS, axisZ: UP, materialName: 'Concrete',
+        width: 1200,
+        riserHeight: 175,
+        treadLength: 280,
+        numberOfRisers: 9,
+        origin: [0, 0, 0],
+        axisX: XAXIS,
+        axisZ: UP,
+        materialName: 'Concrete',
       },
       {
-        width: 1200, riserHeight: 175, treadLength: 280, numberOfRisers: 9,
-        origin: [3000, 0, 1575], axisX: XAXIS, axisZ: UP, materialName: 'Concrete',
+        width: 1200,
+        riserHeight: 175,
+        treadLength: 280,
+        numberOfRisers: 9,
+        origin: [3000, 0, 1575],
+        axisX: XAXIS,
+        axisZ: UP,
+        materialName: 'Concrete',
       },
     ],
   });
@@ -56,8 +71,14 @@ function buildGroupBModel(): GroupBModel {
     materialName: 'Concrete',
     flights: [
       {
-        width: 1500, length: 4000, slope: 0.08, thickness: 200,
-        origin: [0, 6000, 0], axisX: XAXIS, axisZ: UP, materialName: 'Concrete',
+        width: 1500,
+        length: 4000,
+        slope: 0.08,
+        thickness: 200,
+        origin: [0, 6000, 0],
+        axisX: XAXIS,
+        axisZ: UP,
+        materialName: 'Concrete',
       },
     ],
   });
@@ -65,17 +86,26 @@ function buildGroupBModel(): GroupBModel {
   model.placeIn(ramp.value, storeyId);
 
   const slab = model.addSlab({
-    length: 5000, width: 4000, thickness: 200,
-    origin: [0, 0, 0], axisX: XAXIS, axisZ: UP,
+    length: 5000,
+    width: 4000,
+    thickness: 200,
+    origin: [0, 0, 0],
+    axisX: XAXIS,
+    axisZ: UP,
     materialName: 'Concrete',
   });
   if (!slab.ok) throw new Error(slab.error.message);
   model.placeIn(slab.value, storeyId);
 
   const railing = model.addRailing({
-    length: 3000, height: 1100, thickness: 50,
-    origin: [0, 0, 0], axisX: XAXIS, axisZ: UP,
-    predefinedType: 'GUARDRAIL', materialName: 'Steel',
+    length: 3000,
+    height: 1100,
+    thickness: 50,
+    origin: [0, 0, 0],
+    axisX: XAXIS,
+    axisZ: UP,
+    predefinedType: 'GUARDRAIL',
+    materialName: 'Steel',
   });
   if (!railing.ok) throw new Error(railing.error.message);
   model.placeIn(railing.value, storeyId);
@@ -83,9 +113,14 @@ function buildGroupBModel(): GroupBModel {
 
   const covering = model.addCovering(
     {
-      length: 5000, width: 4000, thickness: 20,
-      origin: [0, 0, 200], axisX: XAXIS, axisZ: UP,
-      predefinedType: 'FLOORING', materialName: 'Tile',
+      length: 5000,
+      width: 4000,
+      thickness: 20,
+      origin: [0, 0, 200],
+      axisX: XAXIS,
+      axisZ: UP,
+      predefinedType: 'FLOORING',
+      materialName: 'Tile',
     },
     slab.value
   );
@@ -93,7 +128,9 @@ function buildGroupBModel(): GroupBModel {
   model.placeIn(covering.value, storeyId);
 
   // Element assembly nesting the railing (ordered nesting via IfcRelNests).
-  const assemblyId = model.addElementAssembly({ name: 'Guard Assembly', predefinedType: 'ACCESSORY_ASSEMBLY' });
+  const assemblyId = unwrap(
+    model.addElementAssembly({ name: 'Guard Assembly', predefinedType: 'ACCESSORY_ASSEMBLY' })
+  );
   model.placeIn(assemblyId, storeyId);
   model.nest(assemblyId, railing.value);
 
@@ -176,7 +213,10 @@ describe('Phase 3 Group B integration', () => {
       const line = api.GetLine(mid, flightIds.get(i)) as Record<string, unknown>;
       expect(line['Representation']).not.toBeNull();
     }
-    const stair = api.GetLine(mid, api.GetLineIDsWithType(mid, WebIFC.IFCSTAIR).get(0)) as Record<string, unknown>;
+    const stair = api.GetLine(mid, api.GetLineIDsWithType(mid, WebIFC.IFCSTAIR).get(0)) as Record<
+      string,
+      unknown
+    >;
     expect(stair['Representation']).toBeNull();
 
     api.CloseModel(mid);
@@ -192,7 +232,8 @@ describe('Phase 3 Group B integration', () => {
     expect(countOf(api, mid, WebIFC.IFCSTYLEDITEM)).toBe(1);
 
     const styledItem = api.GetLine(
-      mid, api.GetLineIDsWithType(mid, WebIFC.IFCSTYLEDITEM).get(0)
+      mid,
+      api.GetLineIDsWithType(mid, WebIFC.IFCSTYLEDITEM).get(0)
     ) as Record<string, unknown>;
     const itemRef = (styledItem['Item'] as { value?: number } | undefined)?.value;
     expect(itemRef).toBeDefined();

--- a/packages/brepjs-bim/tests/phase4RoundTrip.test.ts
+++ b/packages/brepjs-bim/tests/phase4RoundTrip.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { measureVolume } from 'brepjs';
+import { measureVolume, unwrap } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
@@ -24,9 +24,9 @@ function buildRoundTripModel(): BuiltModel {
   const initResult = model.init({ name: 'RoundTrip Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site A' });
-  const buildingId = model.addBuilding({ name: 'Building A' });
-  const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site A' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building A' }));
+  const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);

--- a/packages/brepjs-bim/tests/phase5Api.test.ts
+++ b/packages/brepjs-bim/tests/phase5Api.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import {
@@ -49,41 +50,55 @@ function buildModel(): { model: BimModel; spaceAId: number } {
   const initResult = model.init({ name: 'Phase5 API Project', description: 'End-to-end fixture' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Main Site' });
-  const buildingId = model.addBuilding({ name: 'HQ' });
-  const storeyId = model.addStorey({ name: 'Level 1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Main Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'HQ' }));
+  const storeyId = unwrap(model.addStorey({ name: 'Level 1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
 
   const wall = model.addWall({
-    length: 5000, height: 3000, thickness: 200,
-    origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+    length: 5000,
+    height: 3000,
+    thickness: 200,
+    origin: [0, 0, 0],
+    axisX: [1, 0, 0],
+    axisZ: [0, 0, 1],
     materialName: 'Concrete',
   });
   if (!wall.ok) throw new Error(wall.error.message);
   model.placeIn(wall.value, storeyId);
 
   const spaceA = model.addSpace({
-    name: 'Office 101', longName: 'Open-plan office',
-    length: 4000, width: 3000, height: 3000, origin: [0, 0, 0],
+    name: 'Office 101',
+    longName: 'Open-plan office',
+    length: 4000,
+    width: 3000,
+    height: 3000,
+    origin: [0, 0, 0],
     isExternal: false,
   });
   if (!spaceA.ok) throw new Error(spaceA.error.message);
   model.placeIn(spaceA.value, storeyId);
 
   const spaceB = model.addSpace({
-    name: 'Office 102', longName: 'Private office',
-    length: 4000, width: 3000, height: 3000, origin: [4000, 0, 0],
+    name: 'Office 102',
+    longName: 'Private office',
+    length: 4000,
+    width: 3000,
+    height: 3000,
+    origin: [4000, 0, 0],
     isExternal: false,
   });
   if (!spaceB.ok) throw new Error(spaceB.error.message);
   model.placeIn(spaceB.value, storeyId);
 
-  const zoneId = model.addZone({ name: 'Thermal Zone 1', longName: 'Ground-floor thermal zone' });
+  const zoneId = unwrap(
+    model.addZone({ name: 'Thermal Zone 1', longName: 'Ground-floor thermal zone' })
+  );
   model.assignToGroup(zoneId, [spaceA.value, spaceB.value]);
 
-  const systemId = model.addSystem({ name: 'HVAC Supply', longName: 'Air supply network' });
+  const systemId = unwrap(model.addSystem({ name: 'HVAC Supply', longName: 'Air supply network' }));
   model.assignToGroup(systemId, [wall.value]);
 
   return { model, spaceAId: spaceA.value };

--- a/packages/brepjs-bim/tests/phase5Writer.test.ts
+++ b/packages/brepjs-bim/tests/phase5Writer.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import * as WebIFC from 'web-ifc';
@@ -5,7 +6,9 @@ import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 import type { BimModelMeta } from '../src/ifc-writer/headerWriter.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META: BimModelMeta = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -14,16 +17,20 @@ function buildModel(): BimModel {
   const initResult = model.init({ name: 'Phase5 Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
 
   const wall = model.addWall({
-    length: 5000, height: 3000, thickness: 250,
-    origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+    length: 5000,
+    height: 3000,
+    thickness: 250,
+    origin: [0, 0, 0],
+    axisX: [1, 0, 0],
+    axisZ: [0, 0, 1],
     materialName: 'Concrete',
   });
   if (!wall.ok) throw new Error(wall.error.message);
@@ -108,15 +115,19 @@ describe('Phase 5 writer integration', () => {
     const initResult = model.init({ name: 'No-density Project' });
     if (!initResult.ok) throw new Error(initResult.error.message);
     const projectId = initResult.value;
-    const siteId = model.addSite({ name: 'Site' });
-    const buildingId = model.addBuilding({ name: 'Building' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'Site' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(projectId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
     const wall = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Unobtainium',
     });
     if (!wall.ok) throw new Error(wall.error.message);

--- a/packages/brepjs-bim/tests/profilesExtended.test.ts
+++ b/packages/brepjs-bim/tests/profilesExtended.test.ts
@@ -2,10 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import * as WebIFC from 'web-ifc';
 import { measureArea } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
-import {
-  extendedProfileToFace,
-  extendedProfileArea,
-} from '../src/specs/profilesExtended.js';
+import { extendedProfileToFace, extendedProfileArea } from '../src/specs/profilesExtended.js';
 import type { ExtendedProfile } from '../src/specs/profilesExtended.js';
 import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
 import { writeExtendedProfileDef } from '../src/ifc-writer/profileDefWriter.js';

--- a/packages/brepjs-bim/tests/psetTemplates.test.ts
+++ b/packages/brepjs-bim/tests/psetTemplates.test.ts
@@ -28,9 +28,7 @@ describe('psetTemplates — measure type table', () => {
   });
 
   it('maps ThermalTransmittance to its specific measure type, not IFCREAL', () => {
-    expect(PSET_PROPERTY_TYPE_TABLE['ThermalTransmittance']).toBe(
-      'IFCTHERMALTRANSMITTANCEMEASURE'
-    );
+    expect(PSET_PROPERTY_TYPE_TABLE['ThermalTransmittance']).toBe('IFCTHERMALTRANSMITTANCEMEASURE');
     expect(PSET_PROPERTY_TYPE_TABLE['ThermalTransmittance']).not.toBe('IFCREAL');
   });
 
@@ -44,18 +42,14 @@ describe('psetTemplates — measure type table', () => {
   });
 
   it('maps ratio/fraction properties to IFCPOSITIVERATIOMEASURE', () => {
-    expect(PSET_PROPERTY_TYPE_TABLE['GlazingAreaFraction']).toBe(
-      'IFCPOSITIVERATIOMEASURE'
-    );
+    expect(PSET_PROPERTY_TYPE_TABLE['GlazingAreaFraction']).toBe('IFCPOSITIVERATIOMEASURE');
   });
 });
 
 describe('psetTemplates — measureTypeFor helper', () => {
   it('returns the measure type for a known property', () => {
     expect(measureTypeFor('IsExternal')).toBe('IFCBOOLEAN');
-    expect(measureTypeFor('ThermalTransmittance')).toBe(
-      'IFCTHERMALTRANSMITTANCEMEASURE'
-    );
+    expect(measureTypeFor('ThermalTransmittance')).toBe('IFCTHERMALTRANSMITTANCEMEASURE');
   });
 
   it('returns undefined for an unknown property', () => {
@@ -122,9 +116,7 @@ describe('psetTemplates — per-category templates', () => {
 
   it('marks Status as an enumerated value with the standard status set', () => {
     for (const category of ALL_CATEGORIES) {
-      const status = PSET_TEMPLATES[category].properties.find(
-        (p) => p.name === 'Status'
-      );
+      const status = PSET_TEMPLATES[category].properties.find((p) => p.name === 'Status');
       expect(status, `${category} missing Status`).toBeDefined();
       if (status === undefined) continue;
       expect(status.kind).toBe('enumerated');
@@ -141,9 +133,7 @@ describe('psetTemplates — per-category templates', () => {
   });
 
   it('marks non-enumerated properties as single values', () => {
-    const isExternal = PSET_TEMPLATES.WALL.properties.find(
-      (p) => p.name === 'IsExternal'
-    );
+    const isExternal = PSET_TEMPLATES.WALL.properties.find((p) => p.name === 'IsExternal');
     expect(isExternal?.kind).toBe('single');
     expect(isExternal?.enumValues).toBeUndefined();
   });

--- a/packages/brepjs-bim/tests/qtoWeights.test.ts
+++ b/packages/brepjs-bim/tests/qtoWeights.test.ts
@@ -72,8 +72,7 @@ describe('qtoWeights — quantity builder', () => {
     const w = {
       nextId: () => 1,
       mkType: (type: number, value: unknown) => ({ type, value }),
-      writeLine: (entity: { expressID: number } & Record<string, unknown>) =>
-        entity.expressID,
+      writeLine: (entity: { expressID: number } & Record<string, unknown>) => entity.expressID,
     };
     writeWeightQuantity(w, 'GrossWeight', 1, 2400);
     expect(warn).not.toHaveBeenCalled();

--- a/packages/brepjs-bim/tests/railingFns.test.ts
+++ b/packages/brepjs-bim/tests/railingFns.test.ts
@@ -9,7 +9,9 @@ import { deriveIfcGuidSync, makeElementKey } from '../src/identity/guidDerivatio
 import { writeHeader } from '../src/ifc-writer/headerWriter.js';
 import { measureVolume } from 'brepjs';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const spec = {
   length: 4000,

--- a/packages/brepjs-bim/tests/referentialIntegrity.test.ts
+++ b/packages/brepjs-bim/tests/referentialIntegrity.test.ts
@@ -120,7 +120,7 @@ describe('checkReferentialIntegrity', () => {
       const { elements, relationships } = cleanModel();
       // Drop the wall (5) from the only containment rel.
       const broken = relationships.map((r) =>
-        r.kind === 'CONTAINED_IN' ? containedIn(103, 4, [6, 8]) : r,
+        r.kind === 'CONTAINED_IN' ? containedIn(103, 4, [6, 8]) : r
       );
       const report = checkReferentialIntegrity({ elements, relationships: broken });
       expect(hasErrors(report)).toBe(true);
@@ -167,7 +167,7 @@ describe('checkReferentialIntegrity', () => {
       const { elements, relationships } = cleanModel();
       // Opening 7 voids a nonexistent wall (99).
       const broken = relationships.map((r) =>
-        r.kind === 'VOIDS_WALL' ? voidsWall(104, 99, 7) : r,
+        r.kind === 'VOIDS_WALL' ? voidsWall(104, 99, 7) : r
       );
       const report = checkReferentialIntegrity({ elements, relationships: broken });
       const issue = report.issues.find((i) => i.code === 'VOID_HOST_MISSING');

--- a/packages/brepjs-bim/tests/roundTrip.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip.test.ts
@@ -5,7 +5,9 @@ import * as WebIFC from 'web-ifc';
 import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 describe('IFC round-trip (M1)', () => {
   function buildModel(): BimModel {
@@ -13,9 +15,9 @@ describe('IFC round-trip (M1)', () => {
     const initResult = model.init({ name: 'Test Project' });
     if (!initResult.ok) throw new Error(initResult.error.message);
     const projectLocalId = initResult.value;
-    const siteLocalId = model.addSite({ name: 'Test Site' });
-    const buildingLocalId = model.addBuilding({ name: 'Test Building' });
-    const storeyLocalId = model.addStorey({ name: 'Ground Floor', elevation: 0 });
+    const siteLocalId = unwrap(model.addSite({ name: 'Test Site' }));
+    const buildingLocalId = unwrap(model.addBuilding({ name: 'Test Building' }));
+    const storeyLocalId = unwrap(model.addStorey({ name: 'Ground Floor', elevation: 0 }));
     model.aggregate(projectLocalId, siteLocalId);
     model.aggregate(siteLocalId, buildingLocalId);
     model.aggregate(buildingLocalId, storeyLocalId);
@@ -35,7 +37,10 @@ describe('IFC round-trip (M1)', () => {
 
   it('toIfc produces non-empty bytes', async () => {
     const model = buildModel();
-    const result = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim',
+      applicationVersion: '0.1.0',
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.byteLength).toBeGreaterThan(0);
@@ -43,7 +48,10 @@ describe('IFC round-trip (M1)', () => {
 
   it('exported bytes parse back with web-ifc', async () => {
     const model = buildModel();
-    const result = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim',
+      applicationVersion: '0.1.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
 
     const api = new WebIFC.IfcAPI();
@@ -74,7 +82,10 @@ describe('IFC round-trip (M1)', () => {
 
   it('exported IFC contains IfcRelContainedInSpatialStructure', async () => {
     const model = buildModel();
-    const result = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim',
+      applicationVersion: '0.1.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
 
     const api = new WebIFC.IfcAPI();
@@ -103,7 +114,7 @@ describe('IFC Pset/Qto round-trip (M2)', () => {
     loadBearing: true,
     manufacturerName: 'Wienerberger',
     customProperties: {
-      'Pset_Acoustic': { SoundReductionIndex: 45 },
+      Pset_Acoustic: { SoundReductionIndex: 45 },
     },
   };
 
@@ -112,9 +123,9 @@ describe('IFC Pset/Qto round-trip (M2)', () => {
     const initResult = model.init({ name: 'Pset Test' });
     if (!initResult.ok) throw new Error(initResult.error.message);
     const projectLocalId = initResult.value;
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(projectLocalId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
@@ -122,7 +133,10 @@ describe('IFC Pset/Qto round-trip (M2)', () => {
     if (!wallResult.ok) throw new Error(wallResult.error.message);
     model.placeIn(wallResult.value, storeyId);
 
-    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim-test',
+      applicationVersion: '0.0.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
 
     const api = new WebIFC.IfcAPI();
@@ -218,15 +232,19 @@ describe('IFC Pset/Qto round-trip (M2)', () => {
     const initResult = model.init({ name: 'No-Pset Test' });
     if (!initResult.ok) throw new Error(initResult.error.message);
     const projectLocalId = initResult.value;
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(projectLocalId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
     const wallResult = model.addWall({
-      length: 3000, height: 2700, thickness: 200,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 3000,
+      height: 2700,
+      thickness: 200,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
     });
     if (!wallResult.ok) throw new Error(wallResult.error.message);
@@ -255,35 +273,52 @@ describe('IFC Opening round-trip (M3)', () => {
     const initResult = model.init({ name: 'Opening Test' });
     if (!initResult.ok) throw new Error(initResult.error.message);
     const projectLocalId = initResult.value;
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(projectLocalId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
     const wallResult = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
       materialName: 'Concrete',
     });
     if (!wallResult.ok) throw new Error(wallResult.error.message);
     model.placeIn(wallResult.value, storeyId);
 
     const doorResult = model.addDoor({
-      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
-      wallLocalId: wallResult.value, materialName: 'Wood',
-      isExternal: false, fireRating: 'EI30',
+      width: 900,
+      height: 2100,
+      offsetAlongWall: 500,
+      offsetFromFloor: 0,
+      wallLocalId: wallResult.value,
+      materialName: 'Wood',
+      isExternal: false,
+      fireRating: 'EI30',
     });
     if (!doorResult.ok) throw new Error(doorResult.error.message);
 
     const windowResult = model.addWindow({
-      width: 1200, height: 1400, offsetAlongWall: 2000, offsetFromFloor: 900,
-      wallLocalId: wallResult.value, materialName: 'Aluminum',
-      isExternal: true, thermalTransmittance: 1.2,
+      width: 1200,
+      height: 1400,
+      offsetAlongWall: 2000,
+      offsetFromFloor: 900,
+      wallLocalId: wallResult.value,
+      materialName: 'Aluminum',
+      isExternal: true,
+      thermalTransmittance: 1.2,
     });
     if (!windowResult.ok) throw new Error(windowResult.error.message);
 
-    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim-test',
+      applicationVersion: '0.0.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
 
     const api = new WebIFC.IfcAPI();
@@ -335,7 +370,10 @@ describe('IFC Opening round-trip (M3)', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
       const pset = api.GetLine(mid, ids.get(i));
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
-      if ((pset.Name?.value as string | undefined) === 'Pset_DoorCommon') { found = true; break; }
+      if ((pset.Name?.value as string | undefined) === 'Pset_DoorCommon') {
+        found = true;
+        break;
+      }
     }
     expect(found).toBe(true);
     api.CloseModel(mid);
@@ -349,7 +387,10 @@ describe('IFC Opening round-trip (M3)', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- web-ifc GetLine returns any
       const pset = api.GetLine(mid, ids.get(i));
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- web-ifc GetLine returns any
-      if ((pset.Name?.value as string | undefined) === 'Pset_WindowCommon') { found = true; break; }
+      if ((pset.Name?.value as string | undefined) === 'Pset_WindowCommon') {
+        found = true;
+        break;
+      }
     }
     expect(found).toBe(true);
     api.CloseModel(mid);
@@ -360,7 +401,6 @@ describe('IFC Opening round-trip (M3)', () => {
     const elemQuantities = api.GetLineIDsWithType(mid, WebIFC.IFCELEMENTQUANTITY);
     let qto: Record<string, unknown> | undefined;
     for (let i = 0; i < elemQuantities.size(); i++) {
-       
       const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
       const name = (candidate['Name'] as { value?: string } | undefined)?.value;
       if (name === 'Qto_WallBaseQuantities') {
@@ -374,7 +414,6 @@ describe('IFC Opening round-trip (M3)', () => {
     const numericByName = new Map<string, number>();
     const refs = qto['Quantities'] as Array<{ value: number }>;
     for (const ref of refs) {
-       
       const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
       const name = (q['Name'] as { value?: string } | undefined)?.value;
       if (name === undefined) continue;
@@ -412,15 +451,20 @@ describe('IFC Opening round-trip (M3)', () => {
     const model = new BimModel();
     const initResult = model.init({ name: 'No-Op Wall' });
     if (!initResult.ok) throw new Error(initResult.error.message);
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(initResult.value, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
     const wallResult = model.addWall({
-      length: 4000, height: 2800, thickness: 200,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1], materialName: 'Concrete',
+      length: 4000,
+      height: 2800,
+      thickness: 200,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      materialName: 'Concrete',
     });
     if (!wallResult.ok) throw new Error(wallResult.error.message);
     model.placeIn(wallResult.value, storeyId);
@@ -446,7 +490,6 @@ describe('IFC Opening round-trip (M3)', () => {
     let net = 0;
     const refs = qto['Quantities'] as Array<{ value: number }>;
     for (const ref of refs) {
-       
       const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
       const name = (q['Name'] as { value?: string } | undefined)?.value;
       const vol = (q['VolumeValue'] as { value?: number } | undefined)?.value;
@@ -462,20 +505,29 @@ describe('IFC Opening round-trip (M3)', () => {
     const model = new BimModel();
     const initResult = model.init({ name: 'GUID Test' });
     if (!initResult.ok) throw new Error(initResult.error.message);
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(initResult.value, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
     const wallResult = model.addWall({
-      length: 5000, height: 3000, thickness: 250,
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1], materialName: 'Concrete',
+      length: 5000,
+      height: 3000,
+      thickness: 250,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      materialName: 'Concrete',
     });
     if (!wallResult.ok) throw new Error(wallResult.error.message);
     const doorResult = model.addDoor({
-      width: 900, height: 2100, offsetAlongWall: 500, offsetFromFloor: 0,
-      wallLocalId: wallResult.value, materialName: 'Wood',
+      width: 900,
+      height: 2100,
+      offsetAlongWall: 500,
+      offsetFromFloor: 0,
+      wallLocalId: wallResult.value,
+      materialName: 'Wood',
     });
     if (!doorResult.ok) throw new Error(doorResult.error.message);
 
@@ -512,13 +564,15 @@ describe('IFC Slab round-trip (M5)', () => {
     compartmentation: true,
   };
 
-  async function buildSlabModel(extra?: { roof?: boolean }): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+  async function buildSlabModel(extra?: {
+    roof?: boolean;
+  }): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
     const model = new BimModel();
     const initResult = model.init({ name: 'Slab Test' });
     if (!initResult.ok) throw new Error(initResult.error.message);
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(initResult.value, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
@@ -535,7 +589,10 @@ describe('IFC Slab round-trip (M5)', () => {
       if (!roofResult.ok) throw new Error(roofResult.error.message);
       model.placeIn(roofResult.value, storeyId);
     }
-    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim-test',
+      applicationVersion: '0.0.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
     const api = new WebIFC.IfcAPI();
     await api.Init();
@@ -581,7 +638,10 @@ describe('IFC Slab round-trip (M5)', () => {
     for (let i = 0; i < ids.size(); i++) {
       const pset = api.GetLine(mid, ids.get(i)) as Record<string, unknown>;
       const name = (pset['Name'] as { value?: string } | undefined)?.value;
-      if (name === 'Pset_SlabCommon') { found = true; break; }
+      if (name === 'Pset_SlabCommon') {
+        found = true;
+        break;
+      }
     }
     expect(found).toBe(true);
     api.CloseModel(mid);
@@ -594,7 +654,10 @@ describe('IFC Slab round-trip (M5)', () => {
     for (let i = 0; i < elemQuantities.size(); i++) {
       const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
       const name = (candidate['Name'] as { value?: string } | undefined)?.value;
-      if (name === 'Qto_SlabBaseQuantities') { qto = candidate; break; }
+      if (name === 'Qto_SlabBaseQuantities') {
+        qto = candidate;
+        break;
+      }
     }
     if (qto === undefined) throw new Error('Expected Qto_SlabBaseQuantities');
 
@@ -658,9 +721,9 @@ describe('IFC Slab Opening round-trip (M6)', () => {
     const model = new BimModel();
     const initResult = model.init({ name: 'Slab Opening Test' });
     if (!initResult.ok) throw new Error(initResult.error.message);
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(initResult.value, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
@@ -669,16 +732,25 @@ describe('IFC Slab Opening round-trip (M6)', () => {
     model.placeIn(slabResult.value, storeyId);
     // Stairwell + MEP penetration
     const o1 = model.addSlabOpening({
-      sizeX: 1200, sizeY: 1500, offsetX: 500, offsetY: 500,
+      sizeX: 1200,
+      sizeY: 1500,
+      offsetX: 500,
+      offsetY: 500,
       slabLocalId: slabResult.value,
     });
     if (!o1.ok) throw new Error(o1.error.message);
     const o2 = model.addSlabOpening({
-      sizeX: 400, sizeY: 400, offsetX: 4500, offsetY: 3000,
+      sizeX: 400,
+      sizeY: 400,
+      offsetX: 4500,
+      offsetY: 3000,
       slabLocalId: slabResult.value,
     });
     if (!o2.ok) throw new Error(o2.error.message);
-    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim-test',
+      applicationVersion: '0.0.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
     const api = new WebIFC.IfcAPI();
     await api.Init();
@@ -714,7 +786,10 @@ describe('IFC Slab Opening round-trip (M6)', () => {
     for (let i = 0; i < elemQuantities.size(); i++) {
       const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
       const name = (candidate['Name'] as { value?: string } | undefined)?.value;
-      if (name === 'Qto_SlabBaseQuantities') { qto = candidate; break; }
+      if (name === 'Qto_SlabBaseQuantities') {
+        qto = candidate;
+        break;
+      }
     }
     if (qto === undefined) throw new Error('Expected Qto_SlabBaseQuantities');
 
@@ -743,9 +818,9 @@ describe('IFC Slab Opening round-trip (M6)', () => {
     const model = new BimModel();
     const initResult = model.init({ name: 'No-op Slab' });
     if (!initResult.ok) throw new Error(initResult.error.message);
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     model.aggregate(initResult.value, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
@@ -764,10 +839,16 @@ describe('IFC Slab Opening round-trip (M6)', () => {
     for (let i = 0; i < elemQuantities.size(); i++) {
       const candidate = api.GetLine(mid, elemQuantities.get(i)) as Record<string, unknown>;
       const name = (candidate['Name'] as { value?: string } | undefined)?.value;
-      if (name === 'Qto_SlabBaseQuantities') { qto = candidate; break; }
+      if (name === 'Qto_SlabBaseQuantities') {
+        qto = candidate;
+        break;
+      }
     }
     if (qto === undefined) throw new Error('Expected Qto_SlabBaseQuantities');
-    let grossArea = 0, netArea = 0, grossVol = 0, netVol = 0;
+    let grossArea = 0,
+      netArea = 0,
+      grossVol = 0,
+      netVol = 0;
     const refs = qto['Quantities'] as Array<{ value: number }>;
     for (const ref of refs) {
       const q = api.GetLine(mid, ref.value) as Record<string, unknown>;
@@ -790,36 +871,53 @@ describe('IFC Beam round-trip (M7)', () => {
   async function buildBeamModel(): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
     const model = new BimModel();
     unwrap(model.init({ name: 'Beam Test' }));
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     const project = model.getProject();
     if (!project) throw new Error('expected project');
     model.aggregate(project.localId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
 
-    const rect = unwrap(model.addBeam({
-      length: 5000,
-      profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
-      origin: [0, 0, 3000], axisX: [1, 0, 0], axisZ: [0, 0, 1],
-      predefinedType: 'BEAM',
-      materialName: 'Steel',
-      isExternal: false,
-      loadBearing: true,
-      fireRating: 'R60',
-    }));
-    const ibeam = unwrap(model.addBeam({
-      length: 5000,
-      profile: { kind: 'I_BEAM', overallWidth: 200, overallDepth: 400, flangeThickness: 15, webThickness: 10 },
-      origin: [0, 2000, 3000], axisX: [1, 0, 0], axisZ: [0, 0, 1],
-      predefinedType: 'JOIST',
-      materialName: 'Steel',
-    }));
+    const rect = unwrap(
+      model.addBeam({
+        length: 5000,
+        profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+        origin: [0, 0, 3000],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        predefinedType: 'BEAM',
+        materialName: 'Steel',
+        isExternal: false,
+        loadBearing: true,
+        fireRating: 'R60',
+      })
+    );
+    const ibeam = unwrap(
+      model.addBeam({
+        length: 5000,
+        profile: {
+          kind: 'I_BEAM',
+          overallWidth: 200,
+          overallDepth: 400,
+          flangeThickness: 15,
+          webThickness: 10,
+        },
+        origin: [0, 2000, 3000],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        predefinedType: 'JOIST',
+        materialName: 'Steel',
+      })
+    );
     model.placeIn(rect, storeyId);
     model.placeIn(ibeam, storeyId);
 
-    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim-test',
+      applicationVersion: '0.0.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
     const api = new WebIFC.IfcAPI();
     await api.Init();
@@ -861,7 +959,10 @@ describe('IFC Beam round-trip (M7)', () => {
     for (let i = 0; i < ids.size(); i++) {
       const pset = api.GetLine(mid, ids.get(i)) as Record<string, unknown>;
       const name = (pset['Name'] as { value?: string } | undefined)?.value;
-      if (name === 'Pset_BeamCommon') { found = true; break; }
+      if (name === 'Pset_BeamCommon') {
+        found = true;
+        break;
+      }
     }
     expect(found).toBe(true);
     api.CloseModel(mid);
@@ -872,12 +973,22 @@ describe('IFC Beam round-trip (M7)', () => {
     // and height along +Z in world space.
     const model = new BimModel();
     unwrap(model.init({ name: 'Orient Test' }));
-    unwrap(model.addBeam({
-      length: 5000,
-      profile: { kind: 'I_BEAM', overallWidth: 200, overallDepth: 400, flangeThickness: 15, webThickness: 10 },
-      origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
-      materialName: 'Steel',
-    }));
+    unwrap(
+      model.addBeam({
+        length: 5000,
+        profile: {
+          kind: 'I_BEAM',
+          overallWidth: 200,
+          overallDepth: 400,
+          flangeThickness: 15,
+          webThickness: 10,
+        },
+        origin: [0, 0, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        materialName: 'Steel',
+      })
+    );
     const result = await toIfc(model, { applicationName: 't', applicationVersion: '0' });
     if (!result.ok) throw new Error(result.error.message);
     const api = new WebIFC.IfcAPI();
@@ -963,34 +1074,45 @@ describe('IFC Column round-trip (M7)', () => {
   async function buildColumnModel(): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
     const model = new BimModel();
     unwrap(model.init({ name: 'Column Test' }));
-    const siteId = model.addSite({ name: 'S' });
-    const buildingId = model.addBuilding({ name: 'B' });
-    const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+    const siteId = unwrap(model.addSite({ name: 'S' }));
+    const buildingId = unwrap(model.addBuilding({ name: 'B' }));
+    const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
     const project = model.getProject();
     if (!project) throw new Error('expected project');
     model.aggregate(project.localId, siteId);
     model.aggregate(siteId, buildingId);
     model.aggregate(buildingId, storeyId);
 
-    const round = unwrap(model.addColumn({
-      height: 3000,
-      profile: { kind: 'CIRCULAR', radius: 200 },
-      origin: [1000, 1000, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
-      predefinedType: 'COLUMN',
-      materialName: 'Concrete',
-      loadBearing: true,
-    }));
-    const pilaster = unwrap(model.addColumn({
-      height: 3000,
-      profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
-      origin: [2000, 2000, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
-      predefinedType: 'PILASTER',
-      materialName: 'Concrete',
-    }));
+    const round = unwrap(
+      model.addColumn({
+        height: 3000,
+        profile: { kind: 'CIRCULAR', radius: 200 },
+        origin: [1000, 1000, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        predefinedType: 'COLUMN',
+        materialName: 'Concrete',
+        loadBearing: true,
+      })
+    );
+    const pilaster = unwrap(
+      model.addColumn({
+        height: 3000,
+        profile: { kind: 'RECTANGULAR', width: 200, height: 400 },
+        origin: [2000, 2000, 0],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        predefinedType: 'PILASTER',
+        materialName: 'Concrete',
+      })
+    );
     model.placeIn(round, storeyId);
     model.placeIn(pilaster, storeyId);
 
-    const result = await toIfc(model, { applicationName: 'brepjs-bim-test', applicationVersion: '0.0.0' });
+    const result = await toIfc(model, {
+      applicationName: 'brepjs-bim-test',
+      applicationVersion: '0.0.0',
+    });
     if (!result.ok) throw new Error(result.error.message);
     const api = new WebIFC.IfcAPI();
     await api.Init();
@@ -1039,7 +1161,11 @@ describe('IFC Column round-trip (M7)', () => {
         const qName = (q['Name'] as { value?: string } | undefined)?.value;
         const area = (q['AreaValue'] as { value?: number } | undefined)?.value;
         // Round column area in m² = π × 0.2² ≈ 0.12566
-        if (qName === 'CrossSectionArea' && area !== undefined && Math.abs(area - Math.PI * 0.04) < 1e-4) {
+        if (
+          qName === 'CrossSectionArea' &&
+          area !== undefined &&
+          Math.abs(area - Math.PI * 0.04) < 1e-4
+        ) {
           roundQto = candidate;
         }
       }

--- a/packages/brepjs-bim/tests/roundTrip2.test.ts
+++ b/packages/brepjs-bim/tests/roundTrip2.test.ts
@@ -15,9 +15,9 @@ function buildModel(): BimModel {
   unwrap(model.init({ name: 'Round-trip Project' }));
   const project = model.getProject();
   if (!project) throw new Error('expected project');
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(project.localId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
@@ -32,7 +32,7 @@ function buildModel(): BimModel {
       axisZ: [0, 0, 1],
       materialName: 'Concrete',
       isExternal: true,
-    }),
+    })
   );
   model.placeIn(wall, storeyId);
 
@@ -46,7 +46,7 @@ function buildModel(): BimModel {
       axisZ: [0, 0, 1],
       predefinedType: 'FLOOR',
       materialName: 'Concrete',
-    }),
+    })
   );
   model.placeIn(slab, storeyId);
 
@@ -59,7 +59,7 @@ function buildModel(): BimModel {
       axisZ: [0, 0, 1],
       predefinedType: 'BEAM',
       materialName: 'Steel',
-    }),
+    })
   );
   model.placeIn(beam, storeyId);
 
@@ -72,7 +72,7 @@ function buildModel(): BimModel {
       axisZ: [0, 0, 1],
       predefinedType: 'COLUMN',
       materialName: 'Concrete',
-    }),
+    })
   );
   model.placeIn(column, storeyId);
 

--- a/packages/brepjs-bim/tests/schemaCheck.test.ts
+++ b/packages/brepjs-bim/tests/schemaCheck.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
@@ -14,9 +15,9 @@ function buildModel(): BimModel {
   const initResult = model.init({ name: 'Schema Test Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectLocalId = initResult.value;
-  const siteLocalId = model.addSite({ name: 'Test Site' });
-  const buildingLocalId = model.addBuilding({ name: 'Test Building' });
-  const storeyLocalId = model.addStorey({ name: 'Ground Floor', elevation: 0 });
+  const siteLocalId = unwrap(model.addSite({ name: 'Test Site' }));
+  const buildingLocalId = unwrap(model.addBuilding({ name: 'Test Building' }));
+  const storeyLocalId = unwrap(model.addStorey({ name: 'Ground Floor', elevation: 0 }));
   model.aggregate(projectLocalId, siteLocalId);
   model.aggregate(siteLocalId, buildingLocalId);
   model.aggregate(buildingLocalId, storeyLocalId);

--- a/packages/brepjs-bim/tests/severity.test.ts
+++ b/packages/brepjs-bim/tests/severity.test.ts
@@ -45,10 +45,7 @@ describe('severity model', () => {
     });
 
     it('appendIssues appends many without mutating the original', () => {
-      const base: ValidationReport = appendIssue(
-        emptyReport(),
-        issue('info', 'NOTE', 'first'),
-      );
+      const base: ValidationReport = appendIssue(emptyReport(), issue('info', 'NOTE', 'first'));
       const more: readonly ValidationIssue[] = [
         issue('error', 'A', 'a'),
         issue('warning', 'B', 'b'),

--- a/packages/brepjs-bim/tests/spfReader.test.ts
+++ b/packages/brepjs-bim/tests/spfReader.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from 'brepjs';
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as WebIFC from 'web-ifc';
 import { initOCCT } from '../../../tests/setup.js';
@@ -5,7 +6,9 @@ import { BimModel } from '../src/model/bimModel.js';
 import { toIfc } from '../src/serialize/toIfc.js';
 import { SpfReader } from '../src/import/spfReader.js';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 const META = { applicationName: 'brepjs-bim', applicationVersion: '0.1.0' };
 
@@ -14,16 +17,20 @@ function buildModel(): BimModel {
   const initResult = model.init({ name: 'SpfReader Project' });
   if (!initResult.ok) throw new Error(initResult.error.message);
   const projectId = initResult.value;
-  const siteId = model.addSite({ name: 'Site' });
-  const buildingId = model.addBuilding({ name: 'Building' });
-  const storeyId = model.addStorey({ name: 'L1', elevation: 0 });
+  const siteId = unwrap(model.addSite({ name: 'Site' }));
+  const buildingId = unwrap(model.addBuilding({ name: 'Building' }));
+  const storeyId = unwrap(model.addStorey({ name: 'L1', elevation: 0 }));
   model.aggregate(projectId, siteId);
   model.aggregate(siteId, buildingId);
   model.aggregate(buildingId, storeyId);
 
   const wall = model.addWall({
-    length: 5000, height: 3000, thickness: 200,
-    origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1],
+    length: 5000,
+    height: 3000,
+    thickness: 200,
+    origin: [0, 0, 0],
+    axisX: [1, 0, 0],
+    axisZ: [0, 0, 1],
     materialName: 'Concrete',
   });
   if (!wall.ok) throw new Error(wall.error.message);

--- a/packages/brepjs-bim/tests/styleWriter.test.ts
+++ b/packages/brepjs-bim/tests/styleWriter.test.ts
@@ -82,7 +82,13 @@ describe('styleWriter', () => {
 
   it('writes an IfcStyledItem linking a geometry item to a surface style', async () => {
     const w = await makeWriter();
-    const styleId = writeSurfaceStyle(w, { name: 'Glass', r: 0.6, g: 0.8, b: 0.9, transparency: 0.6 });
+    const styleId = writeSurfaceStyle(w, {
+      name: 'Glass',
+      r: 0.6,
+      g: 0.8,
+      b: 0.9,
+      transparency: 0.6,
+    });
     const geomItem = writePoint(w);
 
     writeStyledItem(w, geomItem, styleId);

--- a/packages/brepjs-bim/tests/typeWriter.test.ts
+++ b/packages/brepjs-bim/tests/typeWriter.test.ts
@@ -80,9 +80,7 @@ function writeWall(w: IfcWriter, ownerHistoryId: number): number {
   });
 }
 
-async function openSaved(
-  w: IfcWriter
-): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
+async function openSaved(w: IfcWriter): Promise<{ api: WebIFC.IfcAPI; mid: number }> {
   const saved = w.save();
   if (!saved.ok) throw new Error(saved.error.message);
   const api = new WebIFC.IfcAPI();
@@ -100,10 +98,7 @@ describe('typeWriter', () => {
     const typeGuid = await deriveIfcGuid('type:WALL:NOTDEFINED');
     const relGuid = await deriveIfcGuid('rel-type:WALL:NOTDEFINED');
 
-    const res = writeIfcType(w, oh, 'IFCWALLTYPE', typeGuid, relGuid, 'NOTDEFINED', [
-      wall1,
-      wall2,
-    ]);
+    const res = writeIfcType(w, oh, 'IFCWALLTYPE', typeGuid, relGuid, 'NOTDEFINED', [wall1, wall2]);
     expect(res.typeExpressId).toBeGreaterThan(0);
     expect(res.relExpressId).toBeGreaterThan(0);
 

--- a/packages/brepjs-bim/tests/wallFns.test.ts
+++ b/packages/brepjs-bim/tests/wallFns.test.ts
@@ -4,7 +4,9 @@ import { wallToSolid } from '../src/elementFns/wallFns.js';
 import { parseWallSpec } from '../src/specs/wallSpec.js';
 import { measureVolume } from 'brepjs';
 
-beforeAll(async () => { await initOCCT(); }, 30000);
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
 
 describe('wallToSolid', () => {
   const spec = {
@@ -128,7 +130,7 @@ describe('parseWallSpec', () => {
     const result = parseWallSpec({
       ...valid,
       customProperties: {
-        'Pset_AcousticPerformance': { SoundReductionIndex: 45 },
+        Pset_AcousticPerformance: { SoundReductionIndex: 45 },
       },
     });
     expect(result.ok).toBe(true);


### PR DESCRIPTION
## What

Graduation audit finding 2, approved by Andy: the six LocalId-returning methods (`addSite`, `addBuilding`, `addStorey`, `addZone`, `addSystem`, `addElementAssembly`) threw on duplicate stableKeys, contradicting the documented contract that nothing throws across the API boundary. All six now return `Result<LocalId, BimError>` through the same `#checkStableKey` path as every element adder, and all six accept `ElementIdentityOptions` — closing the last identity gap: every minting method on `BimModel` now supports reorder-stable GlobalIds with Result-based duplicate rejection.

**Pre-1.0 behavior change** for direct `BimModel` users: wrap the six calls in `unwrap()` or branch on `.ok`. Deliberately no conventional-commits breaking marker per repo policy; this rides as a pre-1.0 minor.

## Ripples, all updated

- `familiesToBim` handles the new Results (with model disposal on the early error paths)
- 123 call sites across 20 test files and both example generators (scripted codemod + verification)
- README and docs-overview snippets, all 8 playground bim examples (each embedded import block gains `unwrap`), ambient types regenerated
- The regenerated interop fixture also picks up the corrected stair assembly GlobalId from #2136's identity fix (the fixture was committed before that merge); header timestamps refresh as always

## Verified

- Full bim suite: 644 tests pass
- Playground gates: all 59 snippets type-check; the 123-example geometry regression suite passes
- Both fixtures re-validated through the independent IfcOpenShell gate: PASS
- typecheck + lint + prettier clean
