### PR TITLE
fix(bim): normalize bare scientific reals to valid step tokens

### DIFF
--- a/packages/brepjs-bim/VALIDATION.md
+++ b/packages/brepjs-bim/VALIDATION.md
@@ -42,6 +42,12 @@ Its first run caught a real cross-implementation bug: `IfcTriangulatedFaceSet.Cl
 as `.U.` (a raw JS boolean, serialized by web-ifc as UNKNOWN) on every tessellated body — web-ifc
 accepts it, IfcOpenShell's where-rules reject it. The writer now emits a typed `.T.`.
 
+The first buildingSMART Validation Service run caught a second one, a level deeper: web-ifc prints
+integral-mantissa scientific reals without the decimal point ISO 10303-21 requires (`1E-05` in the
+representation context's precision), and both web-ifc and IfcOpenShell tolerate the invalid token
+while the official validator's strict STEP grammar rejects the whole file. The writer now
+normalizes bare reals post-save (`1.E-05`), with a regression test on the full export path.
+
 ## External tool checklist
 
 Manual gates for the 1.0 flip, run per tool against **both** fixtures

--- a/packages/brepjs-bim/examples/interop-fixture.ifc
+++ b/packages/brepjs-bim/examples/interop-fixture.ifc
@@ -8,7 +8,7 @@ HEADER;
 * Issues: https://github.com/ThatOpen/engine_web-ifc/issues
 ******************************************************/
 FILE_DESCRIPTION(('ViewDefinition [ReferenceView_v1.2]'),'2;1');
-FILE_NAME('web-ifc-model-0.ifc','2026-08-18T04:45:08',(''),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
+FILE_NAME('web-ifc-model-0.ifc','2026-08-18T05:19:09',(''),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
@@ -845,7 +845,7 @@ DATA;
 #18=IFCCARTESIANPOINT((0.,0.,0.));
 #17=IFCPROJECT('39InrBayPTqhyMRldG0qim',#6,'brepjs-bim Interop Fixture',$,$,$,$,(#11),#10);
 #16=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#11,$,.MODEL_VIEW.,$);
-#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1E-05,#15,$);
+#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#15,$);
 #15=IFCAXIS2PLACEMENT3D(#12,#13,#14);
 #14=IFCDIRECTION((1.,0.,0.));
 #13=IFCDIRECTION((0.,0.,1.));

--- a/packages/brepjs-bim/examples/sample-building-families.ifc
+++ b/packages/brepjs-bim/examples/sample-building-families.ifc
@@ -8,7 +8,7 @@ HEADER;
 * Issues: https://github.com/ThatOpen/engine_web-ifc/issues
 ******************************************************/
 FILE_DESCRIPTION(('ViewDefinition [ReferenceView_v1.2]'),'2;1');
-FILE_NAME('web-ifc-model-0.ifc','2026-08-17T23:06:45',(''),(''),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
+FILE_NAME('web-ifc-model-0.ifc','2026-08-18T05:19:22',(''),(''),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
@@ -349,7 +349,7 @@ DATA;
 #18=IFCCARTESIANPOINT((0.,0.,0.));
 #17=IFCPROJECT('25KuZScZ5JUPrTXIOWrrgR',#6,'brepjs-families Sample Office',$,$,$,$,(#11),#10);
 #16=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#11,$,.MODEL_VIEW.,$);
-#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1E-05,#15,$);
+#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#15,$);
 #15=IFCAXIS2PLACEMENT3D(#12,#13,#14);
 #14=IFCDIRECTION((1.,0.,0.));
 #13=IFCDIRECTION((0.,0.,1.));

--- a/packages/brepjs-bim/examples/sample-building.ifc
+++ b/packages/brepjs-bim/examples/sample-building.ifc
@@ -8,7 +8,7 @@ HEADER;
 * Issues: https://github.com/ThatOpen/engine_web-ifc/issues
 ******************************************************/
 FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
-FILE_NAME('web-ifc-model-0.ifc','2026-08-18T04:45:06',('Andy Aragon'),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
+FILE_NAME('web-ifc-model-0.ifc','2026-08-18T05:19:08',('Andy Aragon'),('brepjs'),'thatopen/web-ifc-api','thatopen/web-ifc-api','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
@@ -410,7 +410,7 @@ DATA;
 #18=IFCCARTESIANPOINT((0.,0.,0.));
 #17=IFCPROJECT('3EKiQj_OjU09Aj44FLCHYM',#6,'brepjs-bim Sample Office',$,$,$,$,(#11),#10);
 #16=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#11,$,.MODEL_VIEW.,$);
-#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1E-05,#15,$);
+#11=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#15,$);
 #15=IFCAXIS2PLACEMENT3D(#12,#13,#14);
 #14=IFCDIRECTION((1.,0.,0.));
 #13=IFCDIRECTION((0.,0.,1.));

--- a/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
@@ -36,6 +36,23 @@ export interface IfcHeaderMeta {
   readonly organization?: string | undefined;
 }
 
+// ISO 10303-21 REAL tokens must carry a decimal point in the mantissa;
+// web-ifc prints integral-mantissa scientific reals as `1E-05`, which the
+// buildingSMART validator's strict STEP grammar rejects while web-ifc and
+// IfcOpenShell both tolerate it. Insert the missing point, leaving quoted
+// strings (which may legitimately contain E-notation text) untouched.
+const STRING_OR_BARE_REAL_RE = /'(?:[^']|'')*'|(?<![\d.])(-?\d+)E([+-]?\d+)/g;
+
+function normalizeStepReals(bytes: Uint8Array): Uint8Array {
+  const text = new TextDecoder().decode(bytes);
+  const fixed = text.replace(
+    STRING_OR_BARE_REAL_RE,
+    (match, mantissa?: string, exponent?: string) =>
+      mantissa === undefined || exponent === undefined ? match : `${mantissa}.E${exponent}`
+  );
+  return fixed === text ? bytes : new TextEncoder().encode(fixed);
+}
+
 export class IfcWriter {
   readonly #api: IfcAPI;
   readonly #modelId: number;
@@ -118,7 +135,7 @@ export class IfcWriter {
     }
     try {
       const bytes = this.#api.SaveModel(this.#modelId);
-      return ok(this.#patchHeader(bytes));
+      return ok(normalizeStepReals(this.#patchHeader(bytes)));
     } catch (e) {
       return err(ifcError('IFC_SAVE_FAILED', 'Failed to serialize IFC model', e));
     } finally {

--- a/packages/brepjs-bim/tests/ifcWriterHeader.test.ts
+++ b/packages/brepjs-bim/tests/ifcWriterHeader.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
+import { unwrap } from 'brepjs';
+import { BimModel } from '../src/model/bimModel.js';
+import { toIfc } from '../src/serialize/toIfc.js';
 
 beforeAll(async () => {
   await initOCCT();
@@ -39,5 +42,21 @@ describe('IfcWriter STEP header', () => {
     // Still a LIST with one (empty) STRING element — satisfies the [1:?] cardinality.
     expect(line).toContain("(''),(''),");
     expect(line).not.toContain('($)');
+  });
+});
+
+describe('STEP real token conformance', () => {
+  it('emits no integral-mantissa scientific reals (strict Part 21 grammar)', async () => {
+    using model = new BimModel();
+    unwrap(model.init({ name: 'Reals' }));
+    const bytes = unwrap(
+      await toIfc(model, { applicationName: 'reals-test', applicationVersion: '1' })
+    );
+    const text = new TextDecoder().decode(bytes);
+    // The representation context precision is the known emitter of a bare
+    // `1E-05`; after normalization it must carry the mantissa point, and no
+    // bare scientific real may survive anywhere outside quoted strings.
+    expect(text).toContain('1.E-05');
+    expect(text).not.toMatch(/[,(=]-?\d+E[+-]?\d+/);
   });
 });


### PR DESCRIPTION
Andy's first buildingSMART Validation Service run failed both fixtures at the same token: the representation context precision serialized by web-ifc as 1E-05. ISO 10303-21 requires a REAL's mantissa to carry a decimal point, so the official validator's strict STEP grammar rejects the file — while web-ifc and IfcOpenShell both tolerate the invalid token, which is exactly why neither internal validation nor the independent IfcOpenShell gate caught it. It took the third implementation.

The writer's save() now normalizes integral-mantissa scientific reals (1.E-05) with a quote-aware pass so strings containing E-notation text are untouched, covering any future emitter of tiny reals, not just the context precision. A regression test asserts the full toIfc path emits no bare token. All three committed fixtures (sample building, interop fixture, families sample) are regenerated and re-pass the IfcOpenShell gate; full bim suite 645 tests, typecheck + lint + prettier clean.

The fixtures are ready for a buildingSMART re-run once this merges.