### PR TITLE
docs: sync families and create-brepjs package docs, validation deps

### DIFF
--- a/.claude/skills/companion-packages/SKILL.md
+++ b/.claude/skills/companion-packages/SKILL.md
@@ -14,8 +14,10 @@ The root `package.json` `workspaces` field is the source of truth for the monore
 | `brepjs` (root)               | Core CAD library                                                 | Published; auto-released via release-please                                                          |
 | `packages/brepjs-opencascade` | Custom OpenCascade WASM build (fallback kernel)                  | Published; **manual publish only** (`publish-opencascade.yml` — expensive WASM build)                |
 | `packages/brepjs-bim`         | IFC4 parametric building elements + IFC import/export            | Published, experimental; auto-released                                                               |
+| `packages/brepjs-families`    | Declarative family layer: element trees, key paths → CSG IR      | Published, experimental; auto-released (dist build; bim type-imports it, bundles nothing)            |
 | `packages/brepjs-sheetmetal`  | Flange authoring, fold/unfold flat patterns, DXF/STEP            | Published, experimental; auto-released                                                               |
 | `packages/brepjs-cad`         | Agent skill pipeline + `brep`/`brep-mcp` CLI bins + WASM viewer  | Published; auto-released                                                                             |
+| `packages/create-brepjs`      | `npm create brepjs` scaffolder (dependency-free bin + templates) | Published; auto-released                                                                             |
 | `packages/brepjs-viewer`      | Shared React/R3F renderer (playground + brepjs-cad)              | Published; **manual publish, deliberately unmanaged by release-please**                              |
 | `packages/brepjs-manifold`    | Manifold mesh/CSG preview kernel adapter                         | Unpublished, source-shipped (`exports` → `./src/index.ts`, no build)                                 |
 | `packages/brepjs-voxel-wasm`  | Rust→WASM voxel/SDF engine (`wasm-pack` build, committed `pkg/`) | Versioned/tagged by release-please but **no publish workflow — not on npm**                          |
@@ -26,15 +28,16 @@ The root `package.json` `workspaces` field is the source of truth for the monore
 
 Three tiers, and the rules differ per tier:
 
-1. **Published satellites** (opencascade, bim, sheetmetal, cad, viewer): consumers may resolve them from the npm registry, so their manifests must always describe an installable package.
+1. **Published satellites** (opencascade, bim, families, sheetmetal, cad, viewer, create-brepjs): consumers may resolve them from the npm registry, so their manifests must always describe an installable package.
 2. **Source-shipped internals** (manifold, voxel, voxel-wasm): resolved only through workspace symlinks; manifold and voxel have no build step at all — editing their `src/` is immediately live for consumers.
 3. **Private** (vscode, playground, docs): never published; playground and docs deploy via Vercel/Pages instead.
 
-READMEs exist only for bim, sheetmetal, cad, and viewer — point users there for per-package API detail rather than restating it.
+READMEs exist only for bim, families, sheetmetal, cad, and viewer — point users there for per-package API detail rather than restating it.
 
 ## Workspace dependency rules
 
-- **Satellites depend on `brepjs` as a floor-ranged peerDependency**: `"brepjs": ">=18.0.0"` in `packages/brepjs-bim/package.json` and `packages/brepjs-sheetmetal/package.json`. Exception: `brepjs-cad` takes brepjs as a real dependency (`">=18.117.1"`) because its CLI must run standalone.
+- **Satellites depend on `brepjs` as a floor-ranged peerDependency**: `"brepjs": ">=18.0.0"` in `packages/brepjs-bim/package.json`, `packages/brepjs-families/package.json`, and `packages/brepjs-sheetmetal/package.json`. Exception: `brepjs-cad` takes brepjs as a real dependency (`">=18.117.1"`) because its CLI must run standalone.
+- **bim depends on families as a bounded range**: `"brepjs-families": ">=0.1.0 <1.0.0"` in `packages/brepjs-bim/package.json` (runtime dep for `familiesToBim` consumers; the adapter itself only type-imports families, so bim's dist bundles none of it). Release ordering: the families release PR merges before bim's.
 - **Root brepjs's kernel packages are optional peers**: `brepjs-manifold`, `brepjs-opencascade`, `brepkit-wasm`, `occt-wasm` are all `optional: true` under `peerDependenciesMeta` in the root `package.json`. Never promote one to a hard dependency — consumers pick exactly one kernel.
 - **Internal cross-references use `"*"`** (e.g. `"brepjs-viewer": "*"` in `apps/playground` and in brepjs-cad's devDependencies). npm workspaces symlink these locally. Gotcha: Dependabot scans each sub-manifest without a co-located lockfile, so an unconstrained `"*"` on an _external_ dev tool reads as permitting every vulnerable version. Fix by constraining a floor on the flagged spec (`"vite": "^8.0.0"`, `"vitest": "^4.0.0"` — see `packages/brepjs-viewer/package.json`), not by lockfile churn.
 - **`brepjs-viewer` role differs per consumer**: runtime `dependency` of the playground; build-time `devDependency` of brepjs-cad (its viewer bundle inlines it — see the `packages-verify` comment in `.github/workflows/ci.yml`). Viewer declares its react/three/fiber/drei peers as floor ranges (`>=19`, `>=0.184`, etc.) compatible with the playground's versions, so npm dedups to one copy monorepo-wide; rationale in `packages/brepjs-viewer/README.md`.

--- a/.claude/skills/companion-packages/SKILL.md
+++ b/.claude/skills/companion-packages/SKILL.md
@@ -5,7 +5,7 @@ description: This skill should be used when orienting in the brepjs monorepo's p
 
 # Monorepo companion packages
 
-The root `package.json` `workspaces` field is the source of truth for the monorepo layout: 9 packages under `packages/` plus `apps/playground` and `apps/docs`. The `## Packages` list in `CLAUDE.md` is a curated subset — when it disagrees with the manifests, trust the manifests.
+The root `package.json` `workspaces` field is the source of truth for the monorepo layout: 11 packages under `packages/` plus `apps/playground` and `apps/docs`. The `## Packages` list in `CLAUDE.md` is a curated subset — when it disagrees with the manifests, trust the manifests.
 
 ## Package map
 
@@ -61,7 +61,7 @@ Three ordered chains, all encoded in scripts (prefer running the script over han
 
 The package topology that shapes the pipeline lives in [references/publish-pipeline.md](references/publish-pipeline.md); the operator mechanics live in the **release-publishing** skill. The shape:
 
-- `release-please-config.json` manages 6 components: root, opencascade, voxel-wasm, cad, bim, sheetmetal — with the `node-workspace` plugin and separate PRs per component. Viewer and voxel are deliberately excluded.
+- `release-please-config.json` manages 8 components: root, opencascade, voxel-wasm, cad, bim, families, sheetmetal, create-brepjs; separate PRs per component and no plugins (`plugins: []`). Viewer and voxel are deliberately excluded.
 - Leaf release PRs are **held until the root brepjs release merges** — merging a leaf first pins it to an unpublished brepjs version and breaks `npm ci` with ETARGET.
 - npm OIDC trusted publishers are bound to specific workflow **filenames**, so release-please _dispatches_ each `publish-brepjs-*.yml` rather than inlining `npm publish`.
 - Every `publish-*.yml` is `workflow_dispatch` with `dry_run` defaulting to **true** — a bare manual dispatch is a safe dry run; pass `dry_run=false` to actually publish.

--- a/.claude/skills/companion-packages/references/publish-pipeline.md
+++ b/.claude/skills/companion-packages/references/publish-pipeline.md
@@ -4,7 +4,7 @@ How the monorepo's package layout shapes what release-please manages and how the
 
 ## What release-please manages
 
-Six components, each with its own release PR (`separate-pull-requests: true`) and the `node-workspace` plugin:
+Eight components, each with its own release PR (`separate-pull-requests: true`) and no release plugins (`plugins: []`):
 
 | Component            | Path                          | Published by                                                                                                             |
 | -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
@@ -13,16 +13,18 @@ Six components, each with its own release PR (`separate-pull-requests: true`) an
 | `brepjs-voxel-wasm`  | `packages/brepjs-voxel-wasm`  | **Nobody** — versioned and tagged (with a `Cargo.toml` extra-file bump) but no publish workflow exists; it is not on npm |
 | `brepjs-cad`         | `packages/brepjs-cad`         | Dispatched `publish-brepjs-cad.yml`                                                                                      |
 | `brepjs-bim`         | `packages/brepjs-bim`         | Dispatched `publish-brepjs-bim.yml`                                                                                      |
+| `brepjs-families`    | `packages/brepjs-families`    | Dispatched `publish-brepjs-families.yml` (its release PR merges before bim's)                                            |
 | `brepjs-sheetmetal`  | `packages/brepjs-sheetmetal`  | Dispatched `publish-brepjs-sheetmetal.yml`                                                                               |
+| `create-brepjs`      | `packages/create-brepjs`      | Dispatched `publish-create-brepjs.yml`                                                                                   |
 
 ## What is deliberately unmanaged
 
-- `brepjs-viewer` — the `node-workspace` plugin kept re-pinning brepjs-cad's build-time `brepjs-viewer` devDependency to viewer's pending, unpublished version on every release, repeatedly breaking `npm ci`. Viewer is versioned by hand and published via manual `publish-brepjs-viewer.yml` dispatch. Rationale comment: bottom of `release-please.yml`.
+- `brepjs-viewer`: versioned by hand and published via manual `publish-brepjs-viewer.yml` dispatch, because automated version re-pinning of brepjs-cad's build-time `brepjs-viewer` devDependency repeatedly broke `npm ci`. Rationale comment: bottom of `release-please.yml`.
 - `brepjs-voxel` — an unpublished workspace consumer, so there is nothing to release.
 
 ## The `exclude-paths` nuance
 
-`brepjs-voxel`, `packages/brepjs-cad`, `packages/brepjs-viewer`, and `apps` are listed in the root component's `exclude-paths` so root commits touching them do not bump the root library version. Note `packages/brepjs-cad` appears in _both_ the managed list (its own component) and the root's `exclude-paths` (so cad-only commits do not bump root). Adding a new managed package that root does not import means adding it to `exclude-paths` too.
+`brepjs-voxel`, `packages/brepjs-cad`, `packages/brepjs-viewer`, and `apps` are listed in the root component's `exclude-paths` so root commits touching them do not bump the root library version. Note `packages/brepjs-cad` appears in _both_ the managed list (its own component) and the root's `exclude-paths` (so cad-only commits do not bump root). The other satellite paths (opencascade, voxel-wasm, bim, families, sheetmetal, create-brepjs) are not excluded, so commits there bump the root library as well: that is why a satellite release pairs with a root `brepjs` release each cycle. When adding a new managed package, decide explicitly whether its commits should ride the root version or be added to `exclude-paths`.
 
 ## Build prerequisites inside publish workflows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@ Monorepo packages:
 - `brepjs` (root): Core library (published)
 - `packages/brepjs-opencascade`: OpenCascade WASM build (published)
 - `packages/brepjs-bim`: IFC/BIM parametric building elements + IFC import/export (experimental, published)
+- `packages/brepjs-families`: Declarative family layer (element trees, key paths, projection onto the CSG IR); BIM export via brepjs-bim's `familiesToBim` (experimental, published)
 - `packages/brepjs-sheetmetal`: Sheet-metal authoring + unfold/flat-pattern + DXF (experimental, published)
 - `packages/brepjs-manifold`: Manifold mesh/CSG preview kernel (experimental, unpublished)
 - `packages/brepjs-viewer`: Shared React/R3F renderer (consumed by the playground and brepjs-cad; published, manual publish — unmanaged by release-please)
 - `packages/brepjs-cad`: Agent skill + verify/preview CLI + WASM viewer (published; skill also ships via the repo Claude-plugin marketplace)
+- `packages/create-brepjs`: `npm create brepjs` project scaffolder (published)
 
 ## Commands
 

--- a/packages/brepjs-bim/VALIDATION.md
+++ b/packages/brepjs-bim/VALIDATION.md
@@ -18,7 +18,7 @@ schema validator and geometry engine is a genuine cross-implementation check.
 node examples/sampleBuilding.mjs            # writes examples/sample-building.ifc
 
 # 2. Validate it with IfcOpenShell (independent of web-ifc):
-pip install ifcopenshell                     # Python 3.9–3.12
+pip install ifcopenshell pytest              # Python 3.9–3.12; express-rule checks import pytest
 python scripts/validateIfc.py                # exit 0 = all gates pass
 ```
 

--- a/packages/brepjs-bim/examples/sampleBuildingFamilies.ts
+++ b/packages/brepjs-bim/examples/sampleBuildingFamilies.ts
@@ -10,8 +10,9 @@
  *
  *   npx tsx packages/brepjs-bim/examples/sampleBuildingFamilies.ts
  *
- * Columns and classifications from the imperative sample are out of scope:
- * the adapter maps Storey, Wall, Slab, and wall openings in v1.
+ * The fixture sticks to storeys, walls, slabs, and wall openings; the wider
+ * adapter catalog (columns, beams, roofs, stairs) is covered by the adapter
+ * tests, and the imperative interop fixture carries the shaped geometry.
  */
 
 import { family, el, tTranslate, type Element } from 'brepjs-families';


### PR DESCRIPTION
## What

Doc-staleness fixes found while re-verifying the BIM/families domain state:

- Root CLAUDE.md package list gains the two published packages it was missing: brepjs-families and create-brepjs.
- companion-packages SKILL.md: package-map rows for both, published-satellite tier list updated, READMEs line updated, and a dependency-rules bullet for the bim -> families bounded range (type-only adapter import, nothing bundled; families release PR merges before bim's).
- VALIDATION.md: the express-rule checks import pytest, so the reproduce line now installs it (a fresh venv with only ifcopenshell fails with ModuleNotFoundError: _pytest).
- sampleBuildingFamilies.ts header no longer claims the adapter maps only Storey/Wall/Slab (the catalog now covers columns, beams, roofs, stairs).

## Verification

All three committed fixtures re-validated locally from a clean environment: IfcOpenShell express rules PASS x3, full gherkin catalog 950 scenarios / 0 failed / 0 undefined x3, IDS conformance 334/334 at the CI pin. Regenerated fixtures are byte-identical to committed except the FILE_NAME timestamp.