### PR TITLE
docs: correct stale bim and families facts

### DIFF
--- a/apps/docs/bim/validation.md
+++ b/apps/docs/bim/validation.md
@@ -1,20 +1,21 @@
 ---
 title: Validation
-description: 'Four internal checkers, one-call validated export, and an independent IfcOpenShell gate: how brepjs-bim proves its IFC is real.'
+description: 'Five internal checkers, one-call validated export, the official buildingSMART rule catalog run locally, and an independent IfcOpenShell gate: how brepjs-bim proves its IFC is real.'
 ---
 
 # Validation
 
-An IFC file that only its own writer can read is not an exchange format. brepjs-bim validates at three distances from the code that wrote the file.
+An IFC file that only its own writer can read is not an exchange format. brepjs-bim validates at four distances from the code that wrote the file.
 
 ## Internal checkers
 
-Four composable checks, each returning a severity-tagged report:
+Five composable checks, each returning a severity-tagged report:
 
 - `checkReferentialIntegrity(model)`: every relationship points at an element that exists; containment, voids, fills, aggregation, and group membership all resolve.
 - `checkSchema(bytes)`: the exported file re-parses and passes structural schema checks.
 - `checkGeometryValidity(solids)`: the given element solids pass brepjs validity (closed, manifold, positive volume).
 - `checkRoundTrip(bytes)`: re-read an exported file and compare entity counts; losses are reported per type.
+- `checkGherkinRules(bytes)`: local implementations of the buildingSMART Validation Service's normative rules that touch this writer's vocabulary, currently IFC102 (no deprecated IFC4 entities or attributes), QTY001 (every `Qto_*` set validated against the official quantity table), and GRF003 (a facility model warns unless it declares a coordinate reference system).
 
 `toIfcValidated(model, meta)` runs export plus the suite in one call:
 
@@ -31,6 +32,12 @@ if (validated.ok) {
 }
 ```
 
+## The complete official rule catalog
+
+`checkGherkinRules` covers only the rules this writer's vocabulary can trip. The **entire** normative catalog is also runnable locally: `scripts/setupGherkinRunner.sh` in the package builds a pinned instance of the exact rule engine behind the buildingSMART Validation Service, and `run-gherkin.sh model.ifc` executes every ALB / GEM / GRF / IFC / OJT / PJS / PSE / QTY / SPS feature against a file in about a second. All three committed fixtures pass it completely: 950 scenarios, zero failures, zero undefined.
+
+The distinction is worth keeping straight. `toIfcValidated` gives you a fast in-process subset on every export; the runner gives you the full catalog, the same rules the service would apply, before anything is uploaded.
+
 ## The independent gate
 
 Internal checks share code with the writer, so they cannot catch bugs the writer and reader agree on. The committed sample building is therefore validated by **IfcOpenShell**, a separate C++/Python IFC implementation sharing no code with `web-ifc`: EXPRESS schema + where-rules, spatial-structure presence, GlobalId validity and uniqueness, and geometry generation for every product. See `VALIDATION.md` in the package for the reproduction steps (two commands).
@@ -41,4 +48,6 @@ The test suite additionally gates on semantic fidelity through a full source →
 
 ## External tools
 
-buildingSMART's official Validation Service and desktop imports (Solibri, Revit) are the remaining frontier; results are recorded in the package's `VALIDATION.md` as they land.
+The buildingSMART Validation Service has been run against the fixtures, and its findings drove real writer fixes: an invalid scientific-real STEP token, then a semantic pass that surfaced six more defects (owner-history change action, person identification, unnamed type objects, an undefined curtain-wall enum literal, duplicated occurrence predefined types, and missing `MethodOfMeasurement` on quantity sets). All are fixed and regression-tested, and its rule catalog now runs locally as described above, so the service is confirmation rather than discovery.
+
+Desktop imports (Solibri, Revit) remain unverified. Per-tool checklists and both fixtures are ready in the package's `VALIDATION.md`; results are recorded there as they land.

--- a/apps/docs/families/first-building.md
+++ b/apps/docs/families/first-building.md
@@ -9,7 +9,7 @@ This walkthrough builds a one-storey model: two walls, one of them with a door o
 
 If you haven't read **[Why a Family Layer](/families/overview)** yet, start there. This page assumes you know that families render to elements and elements project onto the [CSG IR](/concepts/csg-ir).
 
-> **Try it live:** the <a href="/playground/examples/families-building" target="_blank" rel="noopener">Declarative Building</a> playground example is this walkthrough's model, ready to run and edit in the browser.
+> **Try it live:** the <a href="/playground/examples/families-building" target="_blank" rel="noopener">Declarative Building</a> playground example builds on this walkthrough, adding the remaining perimeter walls, a floor slab, and a window, ready to run and edit in the browser.
 
 ## The model
 

--- a/apps/docs/families/for-bim-professionals.md
+++ b/apps/docs/families/for-bim-professionals.md
@@ -31,12 +31,13 @@ Every element carries an explicit name (a key), and its IFC GlobalId derives fro
 
 ## Validation posture
 
-Exported files are checked twice, by implementations that share no code:
+Exported files are checked three ways, by implementations that share no code:
 
 1. The writer's own validation: referential integrity (everything contained, nothing dangling) and a schema check on the produced bytes.
-2. **IfcOpenShell** (the engine behind BlenderBIM/Bonsai): EXPRESS schema and where-rule validation, spatial structure, GlobalId uniqueness and syntax, and geometry generation for every product.
+2. **The buildingSMART Validation Service's own rule engine**, run locally. The complete normative catalog (the same ALB / GEM / GRF / IFC / OJT / PJS / PSE / QTY / SPS rules the online service applies) executes against a file in about a second. The committed fixtures pass all 950 scenarios.
+3. **IfcOpenShell** (the engine behind BlenderBIM/Bonsai): EXPRESS schema and where-rule validation, spatial structure, GlobalId uniqueness and syntax, and geometry generation for every product.
 
-The repository's sample building runs this gauntlet in automation; a model that stops passing cannot ship unnoticed.
+The repository's sample building runs this gauntlet in automation; a model that stops passing cannot ship unnoticed. Round-tripping through desktop authoring tools (Revit, ArchiCAD, Solibri) is the part still done by hand.
 
 ## Openings are first-class
 

--- a/apps/docs/families/for-bim-professionals.md
+++ b/apps/docs/families/for-bim-professionals.md
@@ -37,7 +37,7 @@ Exported files are checked three ways, by implementations that share no code:
 2. **The buildingSMART Validation Service's own rule engine**, run locally. The complete normative catalog (the same ALB / GEM / GRF / IFC / OJT / PJS / PSE / QTY / SPS rules the online service applies) executes against a file in about a second. The committed fixtures pass all 950 scenarios.
 3. **IfcOpenShell** (the engine behind BlenderBIM/Bonsai): EXPRESS schema and where-rule validation, spatial structure, GlobalId uniqueness and syntax, and geometry generation for every product.
 
-The repository's sample building runs this gauntlet in automation; a model that stops passing cannot ship unnoticed. Round-tripping through desktop authoring tools (Revit, ArchiCAD, Solibri) is the part still done by hand.
+Which of these run automatically is worth stating plainly. Continuous integration runs the writer's own validation on every change, plus the complete official IDS conformance suite. The buildingSMART rule catalog and IfcOpenShell are run on demand rather than per-commit, because both need a toolchain outside the JavaScript build. Round-tripping through desktop authoring tools (Revit, ArchiCAD, Solibri) is done by hand against the committed fixtures.
 
 ## Openings are first-class
 

--- a/apps/docs/families/ifc-export.md
+++ b/apps/docs/families/ifc-export.md
@@ -34,11 +34,15 @@ The adapter returns a `Result`; the model it produces owns kernel geometry, so h
 | `Storey`                           | `IfcBuildingStorey`, aggregated under site and building                                               |
 | `Wall`                             | `IfcWall` with an extruded-solid body                                                                 |
 | `Slab`                             | `IfcSlab` (`FLOOR`, `ROOF`, `LANDING`, `BASESLAB`)                                                    |
+| `Column`                           | `IfcColumn`, rectangular / circular / I-shape profile extruded along `axisZ`                          |
+| `Beam`                             | `IfcBeam`, the same profile vocabulary extruded along `axisX`                                         |
+| `Roof`                             | `IfcRoof`, flat by default, shaped (shed / gable / hip / dome) when `pitch` is present                |
+| `Stair`                            | `IfcStair` assembly, one `IfcStairFlight` per flight with its own placement                           |
 | Fill-role `Door` in `voids`        | `IfcDoor` + synthesized `IfcOpeningElement`, wired with `IfcRelVoidsElement` and `IfcRelFillsElement` |
 | Fill-role `Window` in `voids`      | `IfcWindow`, same opening wiring                                                                      |
 | `Group` and other empty containers | Structure only, no IFC element                                                                        |
 
-Walls and slabs must sit under a `Storey` ancestor: IFC requires spatial containment, and the adapter returns a `Result` error rather than emit an uncontained element. Fillers are contained in their wall's storey, openings are related to their wall through `IfcRelVoidsElement` alone, exactly as the schema intends.
+Every mapped element must sit under a `Storey` ancestor: IFC requires spatial containment, and the adapter returns `FAMILIES_NO_STOREY` rather than emit an uncontained element. Fillers are contained in their wall's storey, openings are related to their wall through `IfcRelVoidsElement` alone, exactly as the schema intends. Openings are a wall-only mapping; a fill-role element hosted by anything else returns `FAMILIES_OPENING_OUTSIDE_WALL`.
 
 ## Two sources, one element
 

--- a/apps/docs/families/overview.md
+++ b/apps/docs/families/overview.md
@@ -97,7 +97,7 @@ A family that needs to reimplement IFC writing means the boundary was drawn wron
 npm install brepjs-families
 ```
 
-The package currently ships TypeScript source, so use it with a bundler (Vite, esbuild, webpack) or a TS-aware runner like `tsx`. `npm create brepjs` scaffolds a ready-to-run project with both wired up.
+The package ships a built ESM and CJS bundle with TypeScript declarations, so it works in any bundler or Node setup without extra configuration. `npm create brepjs` scaffolds a ready-to-run project around it.
 
 ## Next steps
 

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -35,18 +35,18 @@ export.
 
 ## Status
 
-| Area              | State                                                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------- |
-| Elements          | wall, slab, beam, column, roof, curtain wall, space, footing/pile, stair, ramp, railing, covering, proxy |
-| Profiles          | rectangular / circular / I-shape cores + extended L/T/U/Z/C, hollow, ellipse, arbitrary-with-voids       |
-| Openings          | door / window / slab openings cut as boolean voids; `FillsOpening` / `Voids*` relationships              |
-| Spatial structure | project → site → building → storey aggregation; `placeIn` to assign elements to a storey                 |
-| Property sets     | IFC pset templates + measure types; quantity sets for takeoff                                            |
-| Data layers       | materials (layer/profile/simple sets), classification refs, surface styles, zones/systems                |
-| IFC export        | `toIfc` → IFC-SPF (`Uint8Array`); IFC4 / IFC4X3 schema selection; owner history                          |
-| IFC import        | `fromIfc` / `SpfReader` → `ImportedModel` (elements, geometry, psets, materials, spatial tree)           |
-| Validation        | referential integrity, schema check, geometry validity, IFC round-trip report                            |
-| Interop           | COBie 2.4 export (CSV/JSON), IDS 1.0 checking, BCF 3.0 read/write                                        |
+| Area              | State                                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| Elements          | wall, slab, beam, column, roof, curtain wall, space, footing/pile, stair, ramp, railing, covering, proxy   |
+| Profiles          | rectangular / circular / I-shape cores + extended L/T/U/Z/C, hollow, ellipse, arbitrary-with-voids         |
+| Openings          | door / window / slab openings cut as boolean voids; `FillsOpening` / `Voids*` relationships                |
+| Spatial structure | project → site → building → storey aggregation; `placeIn` to assign elements to a storey                   |
+| Property sets     | IFC pset templates + measure types; quantity sets for takeoff                                              |
+| Data layers       | materials (layer/profile/simple sets), classification refs, surface styles, zones/systems                  |
+| IFC export        | `toIfc` → IFC-SPF (`Uint8Array`); IFC4 / IFC4X3 schema selection; owner history                            |
+| IFC import        | `fromIfc` / `SpfReader` → `ImportedModel` (elements, geometry, psets, materials, spatial tree)             |
+| Validation        | referential integrity, schema check, geometry validity, IFC round-trip report, buildingSMART gherkin rules |
+| Interop           | COBie 2.4 export (CSV/JSON), IDS 1.0 checking, BCF 3.0 read/write                                          |
 
 ### Independent validation
 
@@ -56,9 +56,13 @@ web-ifc parser used internally), not just self-checked. The committed sample
 validator and generates geometry for every product. See [VALIDATION.md](./VALIDATION.md)
 to reproduce, and `examples/sampleBuilding.mjs` for the model it validates.
 
-> **Not yet:** the official buildingSMART Validation Service and desktop-tool
-> interop (Revit / Solibri) are unverified — the fixtures and per-tool
-> checklists are ready in [VALIDATION.md](./VALIDATION.md). This is an
+The buildingSMART Validation Service's complete normative rule catalog also runs
+locally (`scripts/setupGherkinRunner.sh` builds the service's own engine; all three
+committed fixtures pass 950 scenarios with zero failures), so service findings are
+reproducible before upload.
+
+> **Not yet:** desktop-tool interop (Revit / Solibri) is unverified. The fixtures
+> and per-tool checklists are ready in [VALIDATION.md](./VALIDATION.md). This is an
 > experimental pre-1.0 package and the API may change.
 
 ## Usage
@@ -98,7 +102,7 @@ if (wall.ok) model.placeIn(wall.value, storeyId);
 const solid = model.getWalls()[0]?.geometry;
 
 // Serialize to an IFC-SPF byte buffer.
-const ifc = await toIfc(model, { name: 'Example', author: 'brepjs-bim' });
+const ifc = await toIfc(model, { applicationName: 'brepjs-bim', applicationVersion: '1.0' });
 // ifc.ok && ifc.value instanceof Uint8Array
 ```
 

--- a/packages/brepjs-bim/VALIDATION.md
+++ b/packages/brepjs-bim/VALIDATION.md
@@ -162,9 +162,7 @@ IfcOpenShell — both now fixed and regression-tested:
 
 ## Not yet covered
 
-- The official [buildingSMART Validation Service](https://validate.buildingsmart.org/)
-  (reporting-rule / MVD conformance) has not been run here — run a sample through it
-  before claiming certification.
-- Round-tripping through desktop authoring tools (Revit, ArchiCAD, Solibri) is unverified.
+- Round-tripping through desktop authoring tools (Revit, ArchiCAD, Solibri) is unverified;
+  the per-tool checklists above are the remaining manual gate.
 - Validation covers the elements exercised by the sample; element types not present in
   `examples/sampleBuilding.mjs` are covered only by the internal suite.

--- a/packages/brepjs-families/README.md
+++ b/packages/brepjs-families/README.md
@@ -56,7 +56,7 @@ What the pieces buy you:
 - **Families** are typed, validated constructors (`family(name, render, { props })` takes a zod schema). Invalid props fail at construction, not at export.
 - **Key paths** (`ground/south/voids:entry`) are order-independent identity. Reorder siblings and every element keeps its identity; a BIM projection derives stable IFC GlobalIds from them.
 - **The CSG IR** is content-addressed: two identical walls evaluate once and share one materialization, while each keeps its own identity.
-- **Fill roles** make openings real: a `role: 'fill'` family inside a wall's `voids` synthesizes an `Opening` element with a `Fills` relationship, which a BIM export turns into `IfcOpeningElement` + `IfcRelFilledElement` rather than an anonymous boolean hole.
+- **Fill roles** make openings real: a `role: 'fill'` family inside a wall's `voids` synthesizes an `Opening` element with a `Fills` relationship, which a BIM export turns into `IfcOpeningElement` + `IfcRelFillsElement` rather than an anonymous boolean hole.
 - **JSX optional**: `jsxImportSource: "brepjs-families"` lets you write the same trees as JSX. The plain-function API is primary.
 
 ## Starter registry


### PR DESCRIPTION
## What

First of three PRs from an audit of the BIM/families playground examples and the docs behind them. This one corrects doc facts that fell behind the packages. Every item was verified against source, not inferred.

### `apps/docs/bim/validation.md`

- **"Four internal checkers" was five.** `checkGherkinRules` is exported from the index and runs inside `toIfcValidated` (`toIfc.ts:1107`), and was documented nowhere. Added, with its actual rule scope (IFC102, QTY001, GRF003).
- **The Validation Service is no longer "the remaining frontier."** Since #2160, `scripts/setupGherkinRunner.sh` builds the service's own rule engine and all three fixtures pass its complete catalog at 950/950. Added a section that keeps the two gherkin layers distinct: the in-process subset on every export, versus the full catalog on demand. The External tools section now says what the service actually found (the scientific-real STEP token, then six semantic defects) and correctly leaves desktop imports as the open gate.
- "three distances" to four.

### `apps/docs/families/ifc-export.md`

The "What maps to what" table listed only Storey, Wall, Slab, Door and Window, omitting the entire Column to Beam to Roof to Stair graduation arc (#2121, #2125, #2129, #2136). `SPEC_ROUTES` in `familiesAdapter.ts:51` routes all nine, and `for-bim-professionals.md` already said so, so the docs contradicted each other. Also corrected the containment rule: it applies to every mapped element, not just walls and slabs, and the error codes are now named (`FAMILIES_NO_STOREY`, `FAMILIES_OPENING_OUTSIDE_WALL`).

### Other corrections

| File | Was | Is |
| --- | --- | --- |
| `families/overview.md` | "ships TypeScript source, so use it with a bundler" | ships built ESM/CJS with declarations (#2116) |
| `families/first-building.md` | the playground example "is this walkthrough's model" | it is a superset: 4 walls, a slab and a window versus the walkthrough's 2 walls |
| `families/for-bim-professionals.md` | "checked twice" | three ways, including the service's own rule engine |
| `brepjs-bim/README.md` | `toIfc(model, { name, author })` | would not compile; `BimModelMeta` requires `applicationName` + `applicationVersion` |
| `brepjs-bim/README.md` | Validation row omitted the gherkin layer | added |
| `brepjs-families/README.md` | `IfcRelFilledElement` | `IfcRelFillsElement`, the entity the writer actually emits |
| `brepjs-bim/VALIDATION.md` | "the Validation Service has not been run here" | contradicted the same file's account of two runs and the defects they caught; bullet removed |

## Audited and left alone

- All 10 registry families under `packages/brepjs-families/registry/families/`. No bugs found. I specifically checked that the circular branches of `column`/`beam` agree with their polygon branches on where the solid starts: `evalCylinder` calls `cylinderFn(r, h)` without `centered`, so the IR cylinder is base-at-origin, and the beam's rotations map +Z to +X and +Z to +Y consistently with its own `dir` vectors. A mismatch there would have shifted circular members by half their length while still passing a mesh-only test.
- All 10 version markers match `manifest.json` (`column@2`, the rest at 1). No `brepjs diff` drift.
- Root `docs/` has no BIM or families references, so nothing to correct there.
- `props-and-validation.md`'s `room` schema is an abridged illustration of the registry's, not a claim to be verbatim. Left as is.

## Verification

- `npm run test:docs` passes (33 snippets run, 310 kernel-skipped).
- Pre-commit: boundaries, typecheck, prettier, readme-reminders, commitlint all green.
- No code changed, so no geometry to re-verify.

## Next

- PR 2: playground example fixes, including a curtain-wall placement defect that drops the wall frame, plus a new `families-structure` example covering the four newly-mapped types.
- PR 3: `bim-profile-gallery`.
