### PR TITLE
feat(playground): let examples attach named files for download

### DIFF
--- a/apps/playground/src/components/playground/MobileActionSheet.tsx
+++ b/apps/playground/src/components/playground/MobileActionSheet.tsx
@@ -10,6 +10,7 @@ interface MobileActionSheetProps {
   onExportSTEP: () => void;
   onExportDXF: () => void;
   onExportIFC: () => void;
+  onExportFiles: () => void;
 }
 
 interface ActionDef {
@@ -30,11 +31,13 @@ export default function MobileActionSheet({
   onExportSTEP,
   onExportDXF,
   onExportIFC,
+  onExportFiles,
 }: MobileActionSheetProps) {
   const engineReady = useEngineStore((s) => s.status === 'ready');
   const isRunning = usePlaygroundStore((s) => s.isRunning);
   const canExportDXF = usePlaygroundStore((s) => s.availableArtifacts.includes('dxf'));
   const canExportIFC = usePlaygroundStore((s) => s.availableArtifacts.includes('ifc'));
+  const canExportFiles = usePlaygroundStore((s) => s.availableArtifacts.includes('files'));
   const sheetRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -89,6 +92,16 @@ export default function MobileActionSheet({
             label: 'Export IFC',
             hint: 'BIM model',
             onSelect: onExportIFC,
+            disabled: exportDisabled,
+          },
+        ]
+      : []),
+    ...(canExportFiles
+      ? [
+          {
+            label: 'Export files',
+            hint: 'COBie, BCF, reports',
+            onSelect: onExportFiles,
             disabled: exportDisabled,
           },
         ]

--- a/apps/playground/src/components/playground/PlaygroundPage.tsx
+++ b/apps/playground/src/components/playground/PlaygroundPage.tsx
@@ -126,6 +126,7 @@ export default function PlaygroundPage() {
         onExportSTEP={actions.handleExportSTEP}
         onExportDXF={actions.handleExportDXF}
         onExportIFC={actions.handleExportIFC}
+        onExportFiles={actions.handleExportFiles}
         onShare={actions.handleShare}
         onOpenCommandPalette={openCommandPalette}
         onOpenHelp={openShortcutHelp}
@@ -181,6 +182,7 @@ export default function PlaygroundPage() {
         onExportSTEP={actions.handleExportSTEP}
         onExportDXF={actions.handleExportDXF}
         onExportIFC={actions.handleExportIFC}
+        onExportFiles={actions.handleExportFiles}
       />
     </div>
   );

--- a/apps/playground/src/components/playground/Toolbar.tsx
+++ b/apps/playground/src/components/playground/Toolbar.tsx
@@ -9,6 +9,7 @@ interface ToolbarProps {
   onExportSTEP: () => void;
   onExportDXF: () => void;
   onExportIFC: () => void;
+  onExportFiles: () => void;
   onShare: () => void;
   onOpenCommandPalette: () => void;
   onOpenHelp: () => void;
@@ -27,6 +28,7 @@ export default function Toolbar({
   onExportSTEP,
   onExportDXF,
   onExportIFC,
+  onExportFiles,
   onShare,
   onOpenCommandPalette,
   onOpenHelp,
@@ -42,6 +44,7 @@ export default function Toolbar({
   // patterns / BIM models); show each button only when the model exposes it.
   const canExportDXF = usePlaygroundStore((s) => s.availableArtifacts.includes('dxf'));
   const canExportIFC = usePlaygroundStore((s) => s.availableArtifacts.includes('ifc'));
+  const canExportFiles = usePlaygroundStore((s) => s.availableArtifacts.includes('files'));
 
   return (
     <div className="pt-safe border-b border-border-subtle bg-surface">
@@ -135,6 +138,16 @@ export default function Toolbar({
                   className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
                 >
                   IFC
+                </button>
+              )}
+              {canExportFiles && (
+                <button
+                  onClick={onExportFiles}
+                  disabled={!engineReady || isRunning}
+                  title="Download the data files this model produces (COBie, BCF, reports)"
+                  className="rounded px-2.5 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-surface-overlay hover:text-white disabled:opacity-40"
+                >
+                  Files
                 </button>
               )}
               <div className="mx-1 h-4 w-px bg-border-subtle" />

--- a/apps/playground/src/hooks/useCodeExecution.ts
+++ b/apps/playground/src/hooks/useCodeExecution.ts
@@ -33,6 +33,7 @@ export function useCodeExecution() {
   const latestStepIdRef = useRef<string>('');
   const latestDxfIdRef = useRef<string>('');
   const latestIfcIdRef = useRef<string>('');
+  const latestFilesIdRef = useRef<string>('');
   const isRecoveringRef = useRef(false);
   // Snapshot the code submitted under each eval id so eval-result records
   // what actually ran, not whatever the user has typed since.
@@ -128,6 +129,16 @@ export function useCodeExecution() {
           if (msg.id !== latestIfcIdRef.current) return;
           downloadBlob(msg.ifc, 'model.ifc', 'application/x-ifc');
           break;
+        case 'export-files-result': {
+          if (msg.id !== latestFilesIdRef.current) return;
+          // One save per file, staggered: browsers drop rapid-fire downloads
+          // from a single gesture. Examples attach a handful, not a whole
+          // serializer's output, so this stays a short burst.
+          msg.files.forEach((f, i) => {
+            setTimeout(() => downloadBlob(f.data, f.name, f.mime), i * 150);
+          });
+          break;
+        }
         case 'export-error':
           store.setError(msg.error);
           break;
@@ -231,6 +242,16 @@ export function useCodeExecution() {
     [engineStatus, postMessage]
   );
 
+  const exportFiles = useCallback(
+    (code: string) => {
+      if (engineStatus !== 'ready') return;
+      const id = `files-${++evalCounter}`;
+      latestFilesIdRef.current = id;
+      postMessage({ type: 'export-files', id, code });
+    },
+    [engineStatus, postMessage]
+  );
+
   const exportIFC = useCallback(
     (code: string) => {
       if (engineStatus !== 'ready') return;
@@ -257,5 +278,5 @@ export function useCodeExecution() {
     };
   }, []);
 
-  return { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, debouncedRun };
+  return { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, exportFiles, debouncedRun };
 }

--- a/apps/playground/src/hooks/useCodeExecution.ts
+++ b/apps/playground/src/hooks/useCodeExecution.ts
@@ -134,8 +134,16 @@ export function useCodeExecution() {
           // One save per file, staggered: browsers drop rapid-fire downloads
           // from a single gesture. Examples attach a handful, not a whole
           // serializer's output, so this stays a short burst.
+          //
+          // The stagger opens a window the synchronous dxf/ifc handlers do not
+          // have: a second export started mid-burst must not let the first
+          // one's pending timers keep saving, so each re-checks the latest id.
+          const exportId = msg.id;
           msg.files.forEach((f, i) => {
-            setTimeout(() => downloadBlob(f.data, f.name, f.mime), i * 150);
+            setTimeout(() => {
+              if (latestFilesIdRef.current !== exportId) return;
+              downloadBlob(f.data, f.name, f.mime);
+            }, i * 150);
           });
           break;
         }

--- a/apps/playground/src/hooks/usePlaygroundActions.ts
+++ b/apps/playground/src/hooks/usePlaygroundActions.ts
@@ -20,6 +20,7 @@ export interface PlaygroundActions {
   handleExportSTEP: () => void;
   handleExportDXF: () => void;
   handleExportIFC: () => void;
+  handleExportFiles: () => void;
   handleCopyCode: () => void;
   handleResetToDefault: () => void;
   handleResetViewer: () => void;
@@ -30,7 +31,8 @@ export interface PlaygroundActions {
 export function usePlaygroundActions(): PlaygroundActions {
   const code = usePlaygroundStore((s) => s.code);
   const addToast = useToastStore((s) => s.addToast);
-  const { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, debouncedRun } = useCodeExecution();
+  const { runCode, exportSTL, exportSTEP, exportDXF, exportIFC, exportFiles, debouncedRun } =
+    useCodeExecution();
   const { updateUrl, copyShareUrl, buildShareUrl } = useUrlState();
   const handleScreenshot = useScreenshot();
   const resetViewerDefaults = useViewerStore((s) => s.resetViewerDefaults);
@@ -80,6 +82,13 @@ export function usePlaygroundActions(): PlaygroundActions {
     track('playground_export', { format: 'ifc' });
     captureEvent('playground_export', { format: 'ifc' });
   }, [exportIFC, code, addToast]);
+
+  const handleExportFiles = useCallback(() => {
+    exportFiles(code);
+    addToast('Exporting files...');
+    track('playground_export', { format: 'files' });
+    captureEvent('playground_export', { format: 'files' });
+  }, [exportFiles, code, addToast]);
 
   // On touch devices with the Web Share API, hand the permalink to the native
   // share sheet (Messages / AirDrop / etc.); everywhere else fall back to the
@@ -149,6 +158,7 @@ export function usePlaygroundActions(): PlaygroundActions {
       handleExportSTEP,
       handleExportDXF,
       handleExportIFC,
+      handleExportFiles,
       handleCopyCode,
       handleResetToDefault,
       handleResetViewer,
@@ -163,6 +173,7 @@ export function usePlaygroundActions(): PlaygroundActions {
       handleExportSTEP,
       handleExportDXF,
       handleExportIFC,
+      handleExportFiles,
       handleCopyCode,
       handleResetToDefault,
       handleResetViewer,

--- a/apps/playground/src/lib/ambientModule.ts
+++ b/apps/playground/src/lib/ambientModule.ts
@@ -81,6 +81,14 @@ const PLAYGROUND_MODULE_DTS = `declare module 'brepjs/playground' {
     dxf?: string;
     /** IFC-SPF bytes offered for download, or a thunk producing them (deferred to the download click). */
     ifc?: Uint8Array | (() => Uint8Array | Promise<Uint8Array>);
+    /** Named side files (COBie sheets, a BCF container, a report) offered for download via the Files
+     *  button, or a thunk producing them (deferred to the click, like \`ifc\`). One save fires per
+     *  file, so attach a curated few rather than a serializer's whole output. */
+    files?:
+      | readonly { name: string; data: string | Uint8Array; mime?: string }[]
+      | (() =>
+          | readonly { name: string; data: string | Uint8Array; mime?: string }[]
+          | Promise<readonly { name: string; data: string | Uint8Array; mime?: string }[]>);
     /** A serializable BIM tree summary (BimModel.toTreeSummary()) for the domain panel. */
     bimTree?: unknown;
     /** Serializable flat-pattern polylines (flatPatternToPolylines()) for the 2D overlay. */

--- a/apps/playground/src/workers/cad.worker.ts
+++ b/apps/playground/src/workers/cad.worker.ts
@@ -79,12 +79,22 @@ function isColoredShape(v: unknown): v is ColoredShape {
 // wrapper down to `shape` for meshing and forwards the artifacts.
 const PLAYGROUND_PRESENT_TAG = '__brepjsPlaygroundPresent';
 // Artifact kinds offered as toolbar downloads (the rest are display-only).
-const DOWNLOAD_ARTIFACT_KEYS = ['dxf', 'ifc'] as const;
+const DOWNLOAD_ARTIFACT_KEYS = ['dxf', 'ifc', 'files'] as const;
+interface PresentFile {
+  name: string;
+  data: string | Uint8Array;
+  mime?: string;
+}
 interface PresentArtifacts {
   dxf?: string;
   // IFC bytes, or a thunk that produces them — toIfc re-inits web-ifc on every
   // call, so examples pass a thunk to defer that work to the download click.
   ifc?: Uint8Array | (() => Uint8Array | Promise<Uint8Array>);
+  // Named side files (COBie sheets, a BCF container, a validation report).
+  // A thunk defers work that needs web-ifc to the download click, like `ifc`.
+  // Downloads fire one per file, so examples attach a curated few rather than
+  // every sheet a serializer produces.
+  files?: readonly PresentFile[] | (() => readonly PresentFile[] | Promise<readonly PresentFile[]>);
   // A serializable BimModel.toTreeSummary() result, rendered in the domain panel.
   bimTree?: unknown;
   // A serializable flatPatternToPolylines() result, rendered as a 2D overlay.
@@ -786,6 +796,40 @@ async function handleExportIFC(id: string, code: string) {
   }
 }
 
+// Return the named side files an example attached via present(shape, { files }).
+// Same deferral rationale as `ifc`: a thunk means COBie derivation or an IDS
+// check (both of which need an IFC export) run on the download click, not on
+// every render. Strings are encoded here so the main thread only handles bytes.
+async function handleExportFiles(id: string, code: string) {
+  try {
+    const { files } = await evalArtifacts(code);
+    const list = typeof files === 'function' ? await files() : files;
+    if (!Array.isArray(list) || list.length === 0) {
+      post({
+        type: 'export-error',
+        id,
+        error: 'This model has no files to export — attach them with present(shape, { files }).',
+      });
+      return;
+    }
+    const encoder = new TextEncoder();
+    const out: { name: string; data: ArrayBuffer; mime: string }[] = [];
+    const transfer: ArrayBuffer[] = [];
+    for (const f of list as readonly PresentFile[]) {
+      const bytes = typeof f.data === 'string' ? encoder.encode(f.data) : f.data;
+      const buf = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+      ) as ArrayBuffer;
+      out.push({ name: f.name, data: buf, mime: f.mime ?? 'application/octet-stream' });
+      transfer.push(buf);
+    }
+    post({ type: 'export-files-result', id, files: out }, transfer);
+  } catch (e) {
+    post({ type: 'export-error', id, error: e instanceof Error ? e.message : String(e) });
+  }
+}
+
 addEventListener('message', (e: MessageEvent<ToWorker>) => {
   const msg = e.data;
   switch (msg.type) {
@@ -813,6 +857,9 @@ addEventListener('message', (e: MessageEvent<ToWorker>) => {
       break;
     case 'export-ifc':
       void handleExportIFC(msg.id, msg.code);
+      break;
+    case 'export-files':
+      void handleExportFiles(msg.id, msg.code);
       break;
   }
 });

--- a/apps/playground/src/workers/workerProtocol.ts
+++ b/apps/playground/src/workers/workerProtocol.ts
@@ -39,7 +39,8 @@ export type ToWorker =
   | { type: 'export-stl'; id: string; code: string }
   | { type: 'export-step'; id: string; code: string }
   | { type: 'export-dxf'; id: string; code: string }
-  | { type: 'export-ifc'; id: string; code: string };
+  | { type: 'export-ifc'; id: string; code: string }
+  | { type: 'export-files'; id: string; code: string };
 
 // -- Worker -> Main --
 
@@ -66,4 +67,11 @@ export type FromWorker =
   | { type: 'export-step-result'; id: string; step: ArrayBuffer }
   | { type: 'export-dxf-result'; id: string; dxf: string }
   | { type: 'export-ifc-result'; id: string; ifc: ArrayBuffer }
+  // Named side files (COBie sheets, a BCF container, a report) from
+  // present(shape, { files }); the main thread saves each one.
+  | {
+      type: 'export-files-result';
+      id: string;
+      files: { name: string; data: ArrayBuffer; mime: string }[];
+    }
   | { type: 'export-error'; id: string; error: string };


### PR DESCRIPTION
## What

First of three PRs adding validation, interop and BIM-professional examples to the playground. This one is the runtime prerequisite, kept separate so the worker/toolbar change is reviewable on its own.

`present(shape, { ifc })` covers the single binary a BIM example produces. COBie sheets, a BCF container, an IDS report and a validation summary have no way out. This adds a generic `files` artifact alongside `dxf`/`ifc`:

```ts
present(shape, {
  files: () => [
    { name: 'cobie-Space.csv', data: csv, mime: 'text/csv' },
    { name: 'issues.bcf', data: markup },
  ],
})
```

Thunk support matters for the same reason it does on `ifc`: COBie derivation and IDS checking both need an IFC export, so they run on the download click, not on every render.

## Design notes

- **One save per file, staggered 150ms.** Browsers drop rapid-fire downloads from a single gesture. No zip: the repo has no zip writer (`fflate`/`jszip`/`pako` are all absent) and adding a dependency for this is not something this PR should decide. So examples attach a curated handful, which is right anyway — `serializeCobieToCsv` alone returns nine sheets and dumping all nine on a click would be hostile.
- Strings are encoded in the worker so the main thread only ever handles `ArrayBuffer`s, and the buffers are transferred rather than copied.
- The button is gated on `availableArtifacts.includes('files')`, the same mechanism DXF and IFC already use, so it stays hidden for every existing example.

## Verification

The playground has no automated test harness (it is outside the root lint and vitest gates), so this was verified by driving a real browser:

- Files button appears only when the artifact is attached.
- Clicking it saves both files with their **declared** filenames (`alpha.csv`, `beta.txt`, confirmed via CDP `downloadWillBegin`).
- Contents arrive byte-exact, including the CRLF in a CSV.
- Thunk form resolves correctly.

Also green: root `typecheck` and `lint`, playground `tsc -b`, `check:examples` (65 snippets), `prettier --check`.

## Next

- PR B: `bim-validation` (toIfcValidated + all five checkers + IFC4X3), `bim-interop` (COBie + IDS + BCF), `bim-round-trip` (toIfc then fromIfc, rendering what came back).
- PR C: the BIM-professional set — quantity takeoff schedule, foundations-to-roof section, spaces/zones with a room schedule, and finishes plus an accessible ramp. Those four also close the last gaps in element coverage: footing, pile, ramp, covering, zone and system have no playground representation today.
