### PR TITLE
fix(bim): return proxy solids from placedSolids

### DIFF
--- a/packages/brepjs-bim/src/elementFns/placedGeometry.ts
+++ b/packages/brepjs-bim/src/elementFns/placedGeometry.ts
@@ -35,8 +35,10 @@ function disposeAll(solids: readonly ValidSolid[]): void {
  *
  * Stairs and ramps carry no element solid (`.geometry` is null), so flight
  * solids are built from `spec.flights` and placed per flight. Curtain walls
- * return placed panels + mullions. Elements with no solid geometry
- * (doors/windows/groups/spatial) return an empty array.
+ * return placed panels + mullions. Proxies are authored in world coordinates
+ * (no placement frame), so their solid is returned as a fresh identity-placed
+ * copy. Elements with no solid geometry (doors/windows/groups/spatial) return
+ * an empty array.
  */
 export function placedSolids(el: AnyBimElement): Result<readonly ValidSolid[], BimError> {
   switch (el.category) {
@@ -91,6 +93,13 @@ export function placedSolids(el: AnyBimElement): Result<readonly ValidSolid[], B
         out.push(placed.value);
       }
       return ok(out);
+    }
+    case 'PROXY': {
+      // No frame on ProxySpec: the identity transform still routes through the
+      // kernel, minting a caller-owned copy of the model-owned solid.
+      const placed = place(el.geometry, { origin: [0, 0, 0], axisX: [1, 0, 0], axisZ: [0, 0, 1] });
+      if (!placed.ok) return placed;
+      return ok([placed.value]);
     }
     case 'CURTAIN_WALL': {
       const out: ValidSolid[] = [];

--- a/packages/brepjs-bim/tests/placedGeometry.test.ts
+++ b/packages/brepjs-bim/tests/placedGeometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { measureVolumeProps, isValidSolid, unwrap } from 'brepjs';
+import { measureVolumeProps, isValidSolid, unwrap, box } from 'brepjs';
 import { initOCCT } from '../../../tests/setup.js';
 import { BimModel } from '../src/model/bimModel.js';
 import { placementToMatrix } from '../src/import/placement.js';
@@ -95,6 +95,29 @@ describe('placedSolids', () => {
     const b = unwrap(measureVolumeProps(placed[1])).centerOfMass;
     expect(b[0] - a[0]).toBeCloseTo(4000, 1);
     expect(b[2] - a[2]).toBeCloseTo(200, 1);
+  });
+
+  // Proxies used to fall through to the empty-array default, so any equipment
+  // modeled as IfcBuildingElementProxy rendered nothing and took off at 0 m3.
+  it('returns a fresh caller-owned copy of a proxy solid', () => {
+    const m = new BimModel();
+    m.init({ name: 'T' });
+    unwrap(m.addProxy({ name: 'Rack', solid: box(600, 1070, 2000) }));
+    const proxy = m.getProxies()[0];
+    const placed = unwrap(placedSolids(proxy));
+    expect(placed.length).toBe(1);
+    expect(isValidSolid(placed[0])).toBe(true);
+    // World coordinates pass through unchanged (proxies carry no frame).
+    expect(unwrap(measureVolumeProps(placed[0])).mass).toBeCloseTo(600 * 1070 * 2000, -3);
+    const com = unwrap(measureVolumeProps(placed[0])).centerOfMass;
+    expect(com[0]).toBeCloseTo(300, 1);
+    expect(com[1]).toBeCloseTo(535, 1);
+    expect(com[2]).toBeCloseTo(1000, 1);
+    // The copy is independent: disposing it must not touch the model's solid.
+    for (const s of placed) s[Symbol.dispose]();
+    const again = unwrap(placedSolids(proxy));
+    expect(unwrap(measureVolumeProps(again[0])).mass).toBeCloseTo(600 * 1070 * 2000, -3);
+    for (const s of again) s[Symbol.dispose]();
   });
 
   it('places a solid element at its world origin (centroid shifts by origin)', () => {


### PR DESCRIPTION
## Summary

placedSolids() had no PROXY case, so IfcBuildingElementProxy elements fell through to the empty-array default: proxy equipment rendered nothing in the playground viewer and contributed 0 m3 to takeoffs, even though the IFC writer exports them fine via the tessellation path.

ProxySpec carries no placement frame (the solid is authored in world coordinates and the model owns it), so the fix returns a fresh caller-owned copy via an identity-frame kernel transform, consistent with the other branches' ownership contract.

## Changes

- Add a PROXY case to placedSolids returning an identity-placed copy of the model-owned solid
- Update the placedSolids docstring to state proxy world-coordinate semantics
- Regression test: proxy solid renders with correct volume/position, and the returned copy is independently disposable

## Test plan

- npx vitest run --project occt-wasm packages/brepjs-bim/tests/placedGeometry.test.ts (7 passed)