### PR TITLE
fix(families): carry identity props past zod schemas into BIM export

### DIFF
--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -9,7 +9,8 @@
  * fill-role void (Door/Window family) maps onto addDoor/addWindow, which cut
  * the wall and wire IfcRelVoidsElement + IfcRelFillsElement; the opening and
  * filler GlobalIds derive from the synthesized key paths. Anonymous (non-fill)
- * voids stay IR-only and never reach the spec path.
+ * voids are rejected: they cut only the IR/viewport geometry, and exporting
+ * the uncut spec body would silently diverge from what the user sees.
  */
 
 import { ok, err, type Result, type csg } from 'brepjs';
@@ -152,18 +153,58 @@ function specInput(el: ResolvedElement): Record<string, unknown> {
   };
 }
 
+/** `Pset_<Type>Common` fields the specs model first-class: mapped onto their
+ *  spec names so the writer emits them in the element's own common pset. */
+const COMMON_PSET_FIELDS: Readonly<Record<string, string>> = {
+  IsExternal: 'isExternal',
+  FireRating: 'fireRating',
+  AcousticRating: 'acousticRating',
+  ThermalTransmittance: 'thermalTransmittance',
+  LoadBearing: 'loadBearing',
+  Status: 'status',
+};
+
 function collectSpecProps(el: ResolvedElement): Record<string, unknown> {
-  const psets = el.attributes['psets'];
   const out: Record<string, unknown> = {};
+  const material = el.attributes['material'];
+  if (typeof material === 'string' && el.props['materialName'] === undefined) {
+    out['materialName'] = material;
+  }
+  const psets = el.attributes['psets'];
   if (psets && typeof psets === 'object') {
-    const common = (psets as Record<string, unknown>)['Pset_WallCommon'];
-    if (common && typeof common === 'object') {
-      const c = common as Record<string, unknown>;
-      if (typeof c['IsExternal'] === 'boolean') out['isExternal'] = c['IsExternal'];
-      if (typeof c['FireRating'] === 'string') out['fireRating'] = c['FireRating'];
+    const custom: Record<string, Record<string, string | number | boolean>> = {};
+    for (const [psetName, fields] of Object.entries(psets as Record<string, unknown>)) {
+      if (!fields || typeof fields !== 'object') continue;
+      const record = fields as Record<string, unknown>;
+      if (/^Pset_[A-Za-z]+Common$/.test(psetName)) {
+        for (const [field, specKey] of Object.entries(COMMON_PSET_FIELDS)) {
+          if (record[field] !== undefined) out[specKey] = record[field];
+        }
+      } else {
+        // Non-Common psets flow through as custom properties; the writer emits
+        // them verbatim. The element's own common pset stays spec-generated,
+        // so it is never duplicated here.
+        const values: Record<string, string | number | boolean> = {};
+        for (const [field, value] of Object.entries(record)) {
+          if (
+            typeof value === 'string' ||
+            typeof value === 'number' ||
+            typeof value === 'boolean'
+          ) {
+            values[field] = value;
+          }
+        }
+        if (Object.keys(values).length > 0) custom[psetName] = values;
+      }
+    }
+    if (Object.keys(custom).length > 0) {
+      const declared = el.props['customProperties'];
+      out['customProperties'] =
+        declared && typeof declared === 'object'
+          ? { ...custom, ...(declared as Record<string, unknown>) }
+          : custom;
     }
   }
-  delete out['psets'];
   return out;
 }
 
@@ -310,6 +351,21 @@ export function familiesToBim(
     } else if (route !== undefined) {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
+      // The spec path rebuilds the body parametrically: an anonymous
+      // (non-fill) void cuts only the IR/viewport geometry, so exporting it
+      // silently would diverge the IFC body from what the user sees.
+      const voids = el.props['voids'];
+      if (Array.isArray(voids)) {
+        const openings = el.children.filter((c) => c.type === 'Opening').length;
+        if (voids.length > openings) {
+          return err(
+            specError(
+              'FAMILIES_ANONYMOUS_VOID',
+              `familiesToBim: '${el.keyPath}' has ${voids.length - openings} anonymous void(s) the IFC body cannot carry — use a fill-role family (Door/Window) for each void`
+            )
+          );
+        }
+      }
       const parsed = route.parse(('input' in route ? route.input : specInput)(el));
       if (!parsed.ok) return parsed;
       const added = route.add(model, parsed.value, el.keyPath);

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -173,10 +173,14 @@ function collectSpecProps(el: ResolvedElement): Record<string, unknown> {
   const psets = el.attributes['psets'];
   if (psets && typeof psets === 'object') {
     const custom: Record<string, Record<string, string | number | boolean>> = {};
+    // Only the element's OWN common pset maps onto spec fields — a foreign
+    // Common pset (e.g. Pset_DoorCommon on a Wall) must not be relabeled onto
+    // this element's common pset, so it flows through as a custom pset.
+    const ownCommonPset = `Pset_${el.type}Common`;
     for (const [psetName, fields] of Object.entries(psets as Record<string, unknown>)) {
       if (!fields || typeof fields !== 'object') continue;
       const record = fields as Record<string, unknown>;
-      if (/^Pset_[A-Za-z]+Common$/.test(psetName)) {
+      if (psetName === ownCommonPset) {
         for (const [field, specKey] of Object.entries(COMMON_PSET_FIELDS)) {
           if (record[field] !== undefined) out[specKey] = record[field];
         }
@@ -267,6 +271,7 @@ function addOpenings(
     const input = {
       materialName: SPEC_DEFAULTS.materialName,
       ...stripGeometryProps(fill.props),
+      ...collectSpecProps(fill),
       wallLocalId: wallId,
       offsetAlongWall: delta[0] * axisX[0] + delta[1] * axisX[1] + delta[2] * axisX[2],
       offsetFromFloor: delta[2],

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Registry families -> familiesToBim integration: the shipped copy-in
+ * components carry identity data (storey name, psets, material) through their
+ * zod schemas into IFC output, and anonymous voids are rejected instead of
+ * silently diverging the exported body from the viewport.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOCCT } from '../../../tests/setup.js';
+import { isOk, unwrap } from 'brepjs';
+import { z } from 'zod';
+import { family, el, resolve } from 'brepjs-families';
+import { Wall } from '../../brepjs-families/registry/families/wall.js';
+import { Door } from '../../brepjs-families/registry/families/door.js';
+import { Storey } from '../../brepjs-families/registry/families/storey.js';
+import { familiesToBim } from '../src/familiesAdapter.js';
+import { toIfc } from '../src/serialize/toIfc.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30000);
+
+const PROJECT = { name: 'Registry', projectId: 'registry-project' };
+const META = { applicationName: 'registry-test', applicationVersion: '1' };
+
+describe('registry families through familiesToBim', () => {
+  it('projects storey name, custom psets, and a door opening into IFC', async () => {
+    const tree = resolve(
+      Storey({
+        key: 'ground',
+        name: 'Ground floor',
+        elevation: 0,
+        items: [
+          Wall({
+            key: 'south',
+            length: 4000,
+            height: 2700,
+            thickness: 200,
+            isExternal: true,
+            psets: { Pset_ProjectSpecific: { Zone: 'A', Occupancy: 12 } },
+            voids: [Door({ key: 'entry', width: 1000, height: 2100, at: [1500, 0] })],
+          }),
+        ],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    expect(projected.idByKeyPath.has('ground/south')).toBe(true);
+    expect(projected.idByKeyPath.has('ground/south/voids:entry/fill')).toBe(true);
+
+    const text = new TextDecoder().decode(unwrap(await toIfc(model, META)));
+    expect(text).toContain('Ground floor');
+    expect(text).toContain('IFCDOOR');
+    expect(text).toContain('IFCRELFILLSELEMENT');
+    expect(text).toContain('Pset_ProjectSpecific');
+    expect(text).toContain('Zone');
+  });
+
+  it('adopts the material attribute when a family declares no materialName', async () => {
+    const slabSchema = z.object({
+      length: z.number().positive(),
+      width: z.number().positive(),
+      thickness: z.number().positive(),
+      predefinedType: z.literal('FLOOR').default('FLOOR'),
+    });
+    const BareSlab = family(
+      'Slab',
+      (p: z.output<typeof slabSchema>) => el('Box', { size: [p.length, p.width, p.thickness] }),
+      { props: slabSchema }
+    );
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          BareSlab({ key: 's', length: 4000, width: 3000, thickness: 200, material: 'Cast concrete' }),
+        ],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    const text = new TextDecoder().decode(unwrap(await toIfc(model, META)));
+    expect(text).toContain('Cast concrete');
+  });
+
+  it('rejects an anonymous void instead of silently diverging the IFC body', () => {
+    const Hole = family<{ readonly size?: number }>('Hole', () =>
+      el('Box', { size: [500, 500, 500] })
+    );
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          Wall({ key: 'w', length: 4000, height: 2700, thickness: 200, voids: [Hole({ key: 'h' })] }),
+        ],
+      })
+    );
+    const projected = familiesToBim(tree, { project: PROJECT });
+    expect(isOk(projected)).toBe(false);
+    if (!projected.ok) expect(projected.error.code).toBe('FAMILIES_ANONYMOUS_VOID');
+  });
+});

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -37,8 +37,21 @@ describe('registry families through familiesToBim', () => {
             height: 2700,
             thickness: 200,
             isExternal: true,
-            psets: { Pset_ProjectSpecific: { Zone: 'A', Occupancy: 12 } },
-            voids: [Door({ key: 'entry', width: 1000, height: 2100, at: [1500, 0] })],
+            // Pset_SlabCommon is foreign to a Wall: it must flow through as a
+            // custom pset, not be relabeled onto the wall's own common pset.
+            psets: {
+              Pset_ProjectSpecific: { Zone: 'A', Occupancy: 12 },
+              Pset_SlabCommon: { IsExternal: false },
+            },
+            voids: [
+              Door({
+                key: 'entry',
+                width: 1000,
+                height: 2100,
+                at: [1500, 0],
+                psets: { Pset_DoorCommon: { FireRating: 'EI30' } },
+              }),
+            ],
           }),
         ],
       })
@@ -54,6 +67,10 @@ describe('registry families through familiesToBim', () => {
     expect(text).toContain('IFCRELFILLSELEMENT');
     expect(text).toContain('Pset_ProjectSpecific');
     expect(text).toContain('Zone');
+    // The door's own common pset reaches its spec fields through the fill path.
+    expect(text).toContain('EI30');
+    // The foreign common pset survives as a custom pset under its own name.
+    expect(text).toContain('Pset_SlabCommon');
   });
 
   it('adopts the material attribute when a family declares no materialName', async () => {

--- a/packages/brepjs-families/README.md
+++ b/packages/brepjs-families/README.md
@@ -54,6 +54,7 @@ model.byKeyPath.get('ground/south'); // mesh + identity for the wall
 What the pieces buy you:
 
 - **Families** are typed, validated constructors (`family(name, render, { props })` takes a zod schema). Invalid props fail at construction, not at export.
+- **Identity props** (`name`, `psets`, `material`, `classification`) are accepted by every family and ride past schema validation into `ResolvedElement.attributes`, so a component carries IFC-facing data without declaring it in its schema; a BIM projection consumes them (storey names, common psets, custom psets, material fallback).
 - **Key paths** (`ground/south/voids:entry`) are order-independent identity. Reorder siblings and every element keeps its identity; a BIM projection derives stable IFC GlobalIds from them.
 - **The CSG IR** is content-addressed: two identical walls evaluate once and share one materialization, while each keeps its own identity.
 - **Fill roles** make openings real: a `role: 'fill'` family inside a wall's `voids` synthesizes an `Opening` element with a `Fills` relationship, which a BIM export turns into `IfcOpeningElement` + `IfcRelFillsElement` rather than an anonymous boolean hole.

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -18,6 +18,26 @@ interface WithKey {
 }
 
 /**
+ * Identity-side props accepted by every family invocation, beside the
+ * family's own schema. Zod object schemas strip undeclared keys, so these are
+ * re-attached after validation — a semantic component carries IFC-facing data
+ * without every schema declaring it. `resolve()` captures them into
+ * `ResolvedElement.attributes`.
+ */
+export const IDENTITY_PROPS = ['name', 'psets', 'material', 'classification'] as const;
+
+export interface IdentityProps {
+  /** Display name an exporter may adopt (e.g. IfcBuildingStorey.Name). */
+  readonly name?: string | undefined;
+  /** Property sets keyed by pset name (e.g. `Pset_WallCommon`). */
+  readonly psets?: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined;
+  /** Material name an exporter may adopt when the family declares none. */
+  readonly material?: string | undefined;
+  /** Classification reference (system/code/...); the exporter defines the shape. */
+  readonly classification?: Readonly<Record<string, unknown>> | undefined;
+}
+
+/**
  * A family component: a callable that constructs Elements, carrying its
  * declared name and render function. The component REFERENCE is the identity
  * (copy-in files make name lookup collide); the declared name serves key-path
@@ -28,7 +48,7 @@ interface WithKey {
  * output `P`. Schema-less families use one type for both.
  */
 export interface FamilyComponent<P, I = P> {
-  (props: I & WithKey): Element;
+  (props: I & WithKey & IdentityProps): Element;
   readonly familyName: string;
   /** `'fill'` marks a family whose instances fill an opening when placed in a
    *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
@@ -52,7 +72,7 @@ export function family<P extends object, I extends object = P>(
   options?: FamilyOptions<P, I>
 ): FamilyComponent<P, I> {
   const schema = options?.props;
-  const make = (props: I & WithKey): Element => {
+  const make = (props: I & WithKey & IdentityProps): Element => {
     const { key, ...rest } = props;
     let validated: Readonly<Record<string, unknown>> = rest;
     if (schema) {
@@ -62,7 +82,15 @@ export function family<P extends object, I extends object = P>(
           `brepjs-families: invalid props for family '${name}': ${parsed.error.message}`
         );
       }
-      validated = parsed.data as Readonly<Record<string, unknown>>;
+      const out = { ...(parsed.data as Record<string, unknown>) };
+      // Zod strips undeclared keys; identity props are contract, not schema
+      // surface, so they ride past validation (a schema that declares one
+      // keeps its own validated value).
+      const raw = rest as Record<string, unknown>;
+      for (const k of IDENTITY_PROPS) {
+        if (raw[k] !== undefined && out[k] === undefined) out[k] = raw[k];
+      }
+      validated = out;
     }
     return { type: component, key, props: validated, children: [] };
   };

--- a/packages/brepjs-families/src/index.ts
+++ b/packages/brepjs-families/src/index.ts
@@ -9,9 +9,11 @@
 export {
   family,
   el,
+  IDENTITY_PROPS,
   type Element,
   type FamilyComponent,
   type FamilyOptions,
+  type IdentityProps,
 } from './element.js';
 export { jsx, jsxs, Fragment } from './jsxRuntime.js';
 export {

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -10,7 +10,7 @@
  */
 
 import { csg } from 'brepjs';
-import { isFamily, typeNameOf, type Element } from './element.js';
+import { IDENTITY_PROPS, isFamily, typeNameOf, type Element } from './element.js';
 
 export interface TransformOp {
   readonly op: 'translate';
@@ -45,8 +45,6 @@ export interface ResolvedElement {
   readonly relationships: readonly Relationship[];
   readonly children: readonly ResolvedElement[];
 }
-
-const IDENTITY_PROPS = ['psets', 'material', 'classification'] as const;
 
 function identityAttributes(elem: Element): Readonly<Record<string, unknown>> {
   const out: Record<string, unknown> = {};

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -337,6 +337,31 @@ describe('props validation (Zod)', () => {
     );
     expect(() => Free({ key: 'f', anything: { odd: true } })).not.toThrow();
   });
+
+  it('identity props ride past the schema into attributes', () => {
+    const r = resolve(
+      Sized({
+        key: 's',
+        size: 2,
+        name: 'South wall',
+        material: 'Brick',
+        psets: { Pset_WallCommon: { IsExternal: true } },
+      })
+    );
+    expect(r.attributes['name']).toBe('South wall');
+    expect(r.attributes['material']).toBe('Brick');
+    expect(r.attributes['psets']).toEqual({ Pset_WallCommon: { IsExternal: true } });
+  });
+
+  it('a schema-declared identity prop keeps its validated value', () => {
+    const Named = family<{ readonly name: string }>(
+      'Named',
+      () => el('Box', { size: [1, 1, 1] }),
+      { props: z.object({ name: z.string().transform((s) => s.toUpperCase()) }) }
+    );
+    const r = resolve(Named({ key: 'n', name: 'ground' }));
+    expect(r.attributes['name']).toBe('GROUND');
+  });
 });
 
 describe('keyed tracking', () => {


### PR DESCRIPTION
## Problem

The semantic-component premise (a family owns its IFC-facing data) was broken in three places, found in an ecosystem audit:

1. **Zod strips identity data.** All ten shipped registry families use zod schemas, and zod object schemas strip undeclared keys, so `psets`, `material`, and `classification` never survived props validation. The pset path only worked for hand-rolled schema-less families, which is what every existing test used. `familiesToBim` had never been run against the registry components.
2. **Dead storey-name read.** `familiesAdapter.ts` read the storey name from `attributes['name']`, but `resolve()` never captured `name`, so every exported storey was named by its key path.
3. **Anonymous voids diverged silently.** A non-fill void cuts the IR/viewport geometry, but the parametric IFC body stayed solid, with no warning: the export looked different from the screen.

## Fix

- `family()` re-attaches identity props (`name`, `psets`, `material`, `classification`) after schema validation; a schema that declares one keeps its own validated value. `IdentityProps` joins every family call signature; `IDENTITY_PROPS` is exported.
- `resolve()` captures `name` into attributes, making the storey-name path live.
- `collectSpecProps` now maps the six `Pset_*Common` fields the specs model first-class (IsExternal, FireRating, AcousticRating, ThermalTransmittance, LoadBearing, Status), passes non-Common psets through as `customProperties` (the writer emits them verbatim; the element's own common pset stays spec-generated so nothing is duplicated), and adopts the `material` attribute when the family declares no `materialName`.
- `familiesToBim` rejects anonymous voids with `FAMILIES_ANONYMOUS_VOID` naming the key path, instead of exporting a body that silently diverges from the viewport.

## Validation

- New `packages/brepjs-bim/tests/familiesRegistry.test.ts`: the first test anywhere that runs the shipped registry components (`Wall`, `Door`, `Storey`) through `familiesToBim` into IFC text. Asserts storey name, custom pset, door opening + fills relationship, the material fallback, and the anonymous-void rejection.
- New families unit tests: identity props ride past a schema into attributes; a schema-declared identity prop keeps its validated (transformed) value.
- Full brepjs-bim suite 654/654 (byte-stability tests unchanged), brepjs-families 41/41, typecheck + lint + build clean in both packages.
