### PR TITLE
docs: surface the declarative families layer on every discovery path

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ The command exits non-zero unless the report is `ok` (valid **and** every declar
 const Wall = family('Wall', (p: WallProps) =>
   el('Box', { size: [p.length, p.thickness, p.height], voids: p.voids ?? [] })
 );
-const tree = resolve(Storey({ key: 'ground', items: [Wall({ key: 'south', ... })] }));
+const wall = Wall({ key: 'south', length: 4000, thickness: 200, height: 2700 });
+const tree = resolve(Storey({ key: 'ground', items: [wall] }));
 evaluateModel(tree, evaluator); // viewport meshes, one per key path
 familiesToBim(tree, { project }); // IFC via brepjs-bim
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ To set expectations, this project deliberately does not:
 npm install brepjs occt-wasm
 ```
 
+Starting fresh? `npm create brepjs my-project` scaffolds a TypeScript app with the kernel and the declarative family layer preconfigured.
+
 `brepjs/quick` handles WASM init automatically via top-level await (ESM only). Other options:
 
 ```typescript
@@ -84,6 +86,7 @@ The chapter-based guide is the recommended starting point:
 - **[Cheat Sheet](https://brepjs.dev/getting-started/cheat-sheet)**: single-page reference
 - **[Core Concepts](https://brepjs.dev/concepts/brep-vs-mesh)**: B-Rep, topology, types, kernels, tolerance
 - **[Common Tasks](https://brepjs.dev/tasks/booleans)**: booleans, fillets, sketching, lofts, sweeps, finders, measurement, IO
+- **[Declarative Models](https://brepjs.dev/families/overview)**: React-like parametric components (brepjs-families), key-path identity, IFC export
 - **[Three.js Integration](https://brepjs.dev/integration/threejs)**: meshing and rendering
 - **[Migration](https://brepjs.dev/migration/replicad)**: coming from Replicad, OpenSCAD, or Three.js
 - **[Extending brepjs](https://brepjs.dev/extending/architecture)**: custom kernels, custom operations, architecture
@@ -138,6 +141,26 @@ npx -y -p brepjs-cad brep bracket.brep.ts --check --step bracket.step --json rep
 ```
 
 The command exits non-zero unless the report is `ok` (valid **and** every declared dimension within tolerance), so it drops straight into CI or an agent loop. For MCP-capable agents the package also ships a stdio MCP server (`brep-mcp`) exposing the same build-and-verify step as a `run_program` tool. See the [**Authoring with AI**](https://brepjs.dev/agent/overview) guide for the full loop, CLI reference, the MCP server, examples, and the measurement eval.
+
+## Declarative models and BIM (brepjs-families + brepjs-bim)
+
+[`brepjs-families`](https://www.npmjs.com/package/brepjs-families) is a React-like component layer over the CSG IR: parametric parts are prop-driven, composable, zod-validated components, and identical subtrees materialize once because the IR is content-addressed. [`brepjs-bim`](https://www.npmjs.com/package/brepjs-bim) projects the same tree to IFC4 with stable GlobalIds derived from component key paths — walls, slabs, columns, beams, roofs, stairs, and real openings (`IfcOpeningElement` + `IfcRelFillsElement`).
+
+```typescript
+const Wall = family('Wall', (p: WallProps) =>
+  el('Box', { size: [p.length, p.thickness, p.height], voids: p.voids ?? [] })
+);
+const tree = resolve(Storey({ key: 'ground', items: [Wall({ key: 'south', ... })] }));
+evaluateModel(tree, evaluator); // viewport meshes, one per key path
+familiesToBim(tree, { project }); // IFC via brepjs-bim
+```
+
+```bash
+npm create brepjs my-building   # scaffold a project
+npx brepjs add room storey slab # copy in starter families (code you own)
+```
+
+See the [**Declarative Models**](https://brepjs.dev/families/overview) guide.
 
 ## Projects Using brepjs
 

--- a/apps/docs/.vitepress/theme/components/Landing.vue
+++ b/apps/docs/.vitepress/theme/components/Landing.vue
@@ -406,6 +406,24 @@ onBeforeUnmount(() => observer?.disconnect());
         </div>
       </section>
 
+      <!-- ──────────────────── DECLARATIVE MODELS ──────────────────── -->
+      <section class="band alt" data-reveal>
+        <div class="wrap narrow">
+          <p class="eyebrow">Declarative models</p>
+          <h2>Parametric components, down to IFC.</h2>
+          <p class="lead">
+            brepjs-families gives you React-like components for parametric models: prop-driven,
+            composable, zod-validated, deduplicated for free by the content-addressed CSG IR.
+            Scaffold a project with <code>npm create brepjs</code>, copy in starter families with
+            <code>npx brepjs add</code>, and project one tree to viewport meshes — or to IFC through
+            brepjs-bim, with stable GlobalIds derived from your component keys.
+          </p>
+          <p class="lead">
+            <a href="/families/overview">Read the Declarative Models guide →</a>
+          </p>
+        </div>
+      </section>
+
       <!-- ──────────────────── SCOPE ──────────────────── -->
       <section class="band" data-reveal>
         <div class="wrap narrow">

--- a/apps/docs/concepts/csg-ir.md
+++ b/apps/docs/concepts/csg-ir.md
@@ -162,5 +162,6 @@ The examples above touch `box`, `sphere`, `cylinder`, `cut`, `fuse`, and `transl
 ## Next steps
 
 - **[Parametric CSG walkthrough](/tasks/parametric-csg)**: build a gridfinity-style bin with named parameters, change a slider, watch the cache absorb the unchanged subtrees.
+- **[Declarative Models](/families/overview)**: the component layer built on this IR — `brepjs-families` projects prop-driven element trees onto it, so identical components share one materialization while each keeps its own identity.
 - **[CSG caching internals](/advanced/csg-caching)**: `cacheStats`, `optimize`, serialization, what the cache key actually contains, and what _doesn't_ cache.
 - **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)**: if you've built your own `Map<key, Solid>` cache around eager geometry, here's the IR equivalent and what you'd inherit by switching.

--- a/apps/docs/getting-started/install.md
+++ b/apps/docs/getting-started/install.md
@@ -160,8 +160,13 @@ import { ok, isOk, unwrap, type Result } from 'brepjs/core';
 
 All sub-paths re-export a subset of the main `brepjs` entry. You can mix and match.
 
+## Scaffold a project
+
+Rather not wire this up by hand? `npm create brepjs my-project` scaffolds a TypeScript app with the kernel, `brepjs-families` (the declarative component layer), and a working example model preconfigured. `npx brepjs add room storey slab` then copies starter families into `src/families/` as code you own. See [Copy-in components](../families/copy-in) for the full flow.
+
 ## Next steps
 
 - [Your First Solid](./first-solid): the canonical drill-fillet-export workflow
 - [Cheat Sheet](./cheat-sheet): single-page quick reference
+- [Declarative Models](../families/overview): parametric components, key-path identity, IFC export
 - [B-Rep vs Mesh](../concepts/brep-vs-mesh): why brepjs is different from Three.js

--- a/apps/docs/tasks/parametric-csg.md
+++ b/apps/docs/tasks/parametric-csg.md
@@ -165,6 +165,7 @@ isErr(r3); // true
 
 ## Where to go next
 
+- **[Declarative Models](/families/overview)**: wrap trees like this one in prop-driven `brepjs-families` components — the bin becomes `<Bin length={42} wall={1.2} />` with key-path identity and free dedup on this same evaluator.
 - **[CSG caching internals](/advanced/csg-caching)**: `cacheStats`, what's in the cache key, when to call `optimize()`, JSON round-trip, and tree-editing primitives like `replaceNode`.
 - **[Migrating from a hand-rolled cache](/migration/manual-csg-cache)**: if you've already built `Map<key, Solid>` plumbing around the eager API, here's the side-by-side translation.
 - **[The eager topology API](/tasks/booleans)**: when you build a single part and don't need re-evaluation, plain `fuse`/`cut`/`intersect` is leaner.

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -14,6 +14,13 @@ and serializes the result to a valid **IFC-SPF** file — with a matching import
 Pipeline: **author spec → `BimModel` (typed element + brepjs geometry) → spatial structure +
 property sets + classification → export IFC / COBie, validate, round-trip.**
 
+The declarative entry point is
+[`brepjs-families`](https://www.npmjs.com/package/brepjs-families): author the building as a tree of
+prop-driven components, then `familiesToBim(tree, { project })` projects it onto a `BimModel` with
+stable GlobalIds derived from component key paths. Hand-authoring specs against `BimModel` remains
+the low-level path (and covers elements the declarative route doesn't yet). See the
+[Declarative Models guide](https://brepjs.dev/families/overview).
+
 ## Scope
 
 Parametric authoring of the common IFC4 building elements plus the data layers that make a model


### PR DESCRIPTION
## Problem

An ecosystem audit found every discovery surface silent about the declarative layer. The root README has zero mentions of families, create-brepjs, BIM, IFC, or the viewer; the brepjs.dev landing page presents an imperative-only story; getting-started never mentions families; the CSG IR concept/task pages never link forward to the component layer built on them; and the brepjs-bim README's pipeline starts at hand-authored specs, never naming `familiesToBim` as the declarative entry point.

## Fix

- **Root README**: `npm create brepjs` pointer in Install, a Declarative Models line in the guide list, and a `brepjs-families` + `brepjs-bim` section with the component example, the scaffold/copy-in commands, and a link to the guide.
- **Docs landing (Landing.vue)**: a "Declarative models" band (existing band/lead styles, no new CSS) linking the Declarative Models guide.
- **getting-started/install.md**: a "Scaffold a project" section and a next-steps link to the families overview.
- **concepts/csg-ir.md + tasks/parametric-csg.md**: forward links positioning families as the component layer over the IR.
- **brepjs-bim README**: names `familiesToBim` as the declarative entry point, with the imperative `BimModel` path framed as the low-level route.

## Validation

`npm run docs:build` (vitepress with dead-link validation) passes.
