### PR TITLE
feat(viewer): bridge evaluated family models to renderable mesh data

### DIFF
--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -7,10 +7,7 @@ export { ViewerCanvas, type ViewerCanvasProps } from './ViewerCanvas.js';
 export { ViewerControls, type ViewerControlsProps } from './ViewerControls.js';
 export { ViewerInfoPanel, type ViewerInfoPanelProps } from './ViewerInfoPanel.js';
 export { ViewerSelectionPanel, type ViewerSelectionPanelProps } from './ViewerSelectionPanel.js';
-export {
-  ViewerSectionControls,
-  type ViewerSectionControlsProps,
-} from './ViewerSectionControls.js';
+export { ViewerSectionControls, type ViewerSectionControlsProps } from './ViewerSectionControls.js';
 export * from './types.js';
 export {
   buildGeometry,
@@ -25,3 +22,12 @@ export {
   type InstancePlacement,
   type InstancedMeshOptions,
 } from './geometry.js';
+export {
+  modelToMeshData,
+  findElementAt,
+  type ElementMesh,
+  type ElementRange,
+  type EvaluatedModelLike,
+  type EvaluatedNodeLike,
+  type ModelMeshResult,
+} from './model.js';

--- a/packages/brepjs-viewer/src/model.ts
+++ b/packages/brepjs-viewer/src/model.ts
@@ -1,0 +1,118 @@
+/**
+ * Bridge from an evaluated declarative model (brepjs-families
+ * `evaluateModel()` output) to renderable MeshData. Typed structurally so the
+ * viewer stays decoupled from brepjs-families: anything with a `byKeyPath`
+ * map of key path -> { mesh: Result-like } works.
+ *
+ * The per-element identity that `byKeyPath` carries is preserved as
+ * `ElementRange`s over the merged index buffer, so picking can map a
+ * triangle back to its element key path (`findElementAt`).
+ */
+
+import type { FaceGroup, MeshData } from './types.js';
+
+export interface ElementMesh {
+  readonly triangles: Uint32Array;
+  readonly vertices: Float32Array;
+  readonly normals: Float32Array;
+  readonly faceGroups?: readonly { start: number; count: number; faceId: number }[] | undefined;
+}
+
+export interface EvaluatedNodeLike {
+  readonly mesh:
+    | { readonly ok: true; readonly value: ElementMesh }
+    | { readonly ok: false; readonly value?: undefined };
+}
+
+export interface EvaluatedModelLike {
+  readonly byKeyPath: ReadonlyMap<string, EvaluatedNodeLike>;
+}
+
+/** One element's triangle range in the merged index buffer (index-array units,
+ *  i.e. 3 per triangle — the same units as FaceGroup). */
+export interface ElementRange {
+  readonly keyPath: string;
+  readonly start: number;
+  readonly count: number;
+}
+
+export interface ModelMeshResult {
+  readonly data: MeshData;
+  /** Insertion-ordered, contiguous, ascending by `start`. */
+  readonly elements: readonly ElementRange[];
+  /** Key paths whose mesh evaluation failed; absent from the merge. */
+  readonly failed: readonly string[];
+}
+
+/**
+ * Merge every element mesh into one MeshData, preserving element identity as
+ * index ranges. Merged faceGroups keep their per-element faceIds, which can
+ * collide across elements that share a materialization — `elements` is the
+ * authoritative element identity; faceGroups only subdivide within one.
+ */
+export function modelToMeshData(model: EvaluatedModelLike): ModelMeshResult {
+  const parts: { keyPath: string; mesh: ElementMesh }[] = [];
+  const failed: string[] = [];
+  let floats = 0;
+  let indices = 0;
+  for (const [keyPath, node] of model.byKeyPath) {
+    if (node.mesh.ok) {
+      parts.push({ keyPath, mesh: node.mesh.value });
+      floats += node.mesh.value.vertices.length;
+      indices += node.mesh.value.triangles.length;
+    } else {
+      failed.push(keyPath);
+    }
+  }
+
+  const position = new Float32Array(floats);
+  const normal = new Float32Array(floats);
+  const index = new Uint32Array(indices);
+  const faceGroups: FaceGroup[] = [];
+  const elements: ElementRange[] = [];
+  let floatOffset = 0;
+  let indexOffset = 0;
+  for (const { keyPath, mesh } of parts) {
+    position.set(mesh.vertices, floatOffset);
+    normal.set(mesh.normals, floatOffset);
+    const vertexBase = floatOffset / 3;
+    for (let i = 0; i < mesh.triangles.length; i++) {
+      index[indexOffset + i] = (mesh.triangles[i] ?? 0) + vertexBase;
+    }
+    elements.push({ keyPath, start: indexOffset, count: mesh.triangles.length });
+    for (const g of mesh.faceGroups ?? []) {
+      faceGroups.push({ start: g.start + indexOffset, count: g.count, faceId: g.faceId });
+    }
+    floatOffset += mesh.vertices.length;
+    indexOffset += mesh.triangles.length;
+  }
+
+  const data: MeshData = {
+    position,
+    normal,
+    index,
+    edges: new Float32Array(0),
+    ...(faceGroups.length > 0 ? { faceGroups } : {}),
+  };
+  return { data, elements, failed };
+}
+
+/** Map a picked triangle index back to its element (binary search; ranges are
+ *  contiguous and ascending by construction). */
+export function findElementAt(
+  elements: readonly ElementRange[],
+  triangleIndex: number
+): ElementRange | null {
+  const off = triangleIndex * 3;
+  let lo = 0;
+  let hi = elements.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const e = elements[mid];
+    if (!e) break;
+    if (off < e.start) hi = mid - 1;
+    else if (off >= e.start + e.count) lo = mid + 1;
+    else return e;
+  }
+  return null;
+}

--- a/packages/brepjs-viewer/tests/model.test.ts
+++ b/packages/brepjs-viewer/tests/model.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { modelToMeshData, findElementAt, type EvaluatedNodeLike } from '@/model.js';
+
+function tri(offset: number): EvaluatedNodeLike {
+  return {
+    mesh: {
+      ok: true,
+      value: {
+        triangles: new Uint32Array([0, 1, 2]),
+        vertices: new Float32Array([offset, 0, 0, offset + 1, 0, 0, offset, 1, 0]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        faceGroups: [{ start: 0, count: 3, faceId: 42 }],
+      },
+    },
+  };
+}
+
+describe('modelToMeshData', () => {
+  it('merges element meshes with rebased indices and per-element ranges', () => {
+    const model = {
+      byKeyPath: new Map([
+        ['ground/south', tri(0)],
+        ['ground/north', tri(10)],
+      ]),
+    };
+    const { data, elements, failed } = modelToMeshData(model);
+    expect(failed).toEqual([]);
+    expect(data.position.length).toBe(18);
+    expect(data.normal.length).toBe(18);
+    expect(Array.from(data.index)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(elements).toEqual([
+      { keyPath: 'ground/south', start: 0, count: 3 },
+      { keyPath: 'ground/north', start: 3, count: 3 },
+    ]);
+    expect(data.faceGroups).toEqual([
+      { start: 0, count: 3, faceId: 42 },
+      { start: 3, count: 3, faceId: 42 },
+    ]);
+    expect(data.edges.length).toBe(0);
+  });
+
+  it('collects failed elements instead of dropping them silently', () => {
+    const model = {
+      byKeyPath: new Map<string, EvaluatedNodeLike>([
+        ['good', tri(0)],
+        ['bad', { mesh: { ok: false } }],
+      ]),
+    };
+    const { data, elements, failed } = modelToMeshData(model);
+    expect(failed).toEqual(['bad']);
+    expect(elements.map((e) => e.keyPath)).toEqual(['good']);
+    expect(data.index.length).toBe(3);
+  });
+
+  it('findElementAt maps a picked triangle back to its key path', () => {
+    const model = {
+      byKeyPath: new Map([
+        ['a', tri(0)],
+        ['b', tri(5)],
+      ]),
+    };
+    const { elements } = modelToMeshData(model);
+    expect(findElementAt(elements, 0)?.keyPath).toBe('a');
+    expect(findElementAt(elements, 1)?.keyPath).toBe('b');
+    expect(findElementAt(elements, 2)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

From the ecosystem audit: `brepjs-viewer` has no entry point for a families `evaluateModel()` result. `RendererProps` takes one flat `MeshData`, so per-element identity (`byKeyPath`) is destroyed at the render boundary, and the playground's families examples hand-enumerate every element by string key path (one line per element) to get anything on screen.

## Fix

New `packages/brepjs-viewer/src/model.ts`:

- `modelToMeshData(model)` merges every element mesh into one `MeshData` (positions/normals/index rebased, faceGroup starts offset) and returns `elements: ElementRange[]` (keyPath + contiguous index range) plus `failed: string[]` for elements whose mesh evaluation errored, so failures are visible instead of silently missing from the scene.
- `findElementAt(elements, triangleIndex)` maps a picked triangle back to its element by binary search, mirroring `findFaceGroupAt`.
- Typed structurally (`EvaluatedModelLike` / `EvaluatedNodeLike`), so the viewer keeps zero dependency on brepjs-families; the families `EvaluatedModel` satisfies it as-is.

Merged faceGroups keep their per-element faceIds (elements sharing a materialization share faceIds); `elements` is the authoritative element identity, documented on the function.

## Validation

Viewer suite 14/14 (3 new tests: merge + rebase + ranges, failed-element reporting, picking), typecheck, lint, and build clean.

Follow-up candidate: adopt this in the playground families examples to replace the per-element hand-wiring.
