### PR TITLE
feat(families): structural composition — children, hierarchical transforms, rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15147,7 +15147,7 @@
       }
     },
     "packages/brepjs-bim": {
-      "version": "0.16.1",
+      "version": "0.17.2",
       "license": "Apache-2.0",
       "dependencies": {
         "brepjs-families": ">=0.1.0 <1.0.0"
@@ -15169,18 +15169,6 @@
       "peerDependencies": {
         "brepjs": ">=18.0.0",
         "web-ifc": ">=0.0.50"
-      }
-    },
-    "packages/brepjs-bim/node_modules/brepjs-families": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/brepjs-families/-/brepjs-families-0.1.0.tgz",
-      "integrity": "sha512-Doo3i9aWp6yO3Jw75ervSEVzLNpuuxiOIJH+vE4t9EQ3AEPdCekF93JTm4AfqtBA6r+y0hf1Luxu0n+VrREOuA==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "brepjs": ">=18.0.0"
       }
     },
     "packages/brepjs-cad": {
@@ -15322,7 +15310,7 @@
       "license": "MIT"
     },
     "packages/brepjs-families": {
-      "version": "0.7.0",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -123,6 +123,19 @@ function peelTranslates(node: csg.IRNode): {
   return { total, moved };
 }
 
+/** True when the outer placement chain carries a rotation. The spec path can
+ *  fold only translations into IfcLocalPlacement (walls orient via `axisX`),
+ *  so a rotated routed element would export un-rotated while the viewport
+ *  shows it rotated — reject instead of diverging. */
+function hasOuterRotation(node: csg.IRNode): boolean {
+  let cur = node;
+  while (cur.kind === 'Translate') {
+    if (cur.vector.kind !== 'Vec3Lit') break;
+    cur = cur.target;
+  }
+  return cur.kind === 'Rotate';
+}
+
 /** Fold the resolved geometry's outer translate chain into the spec placement
  *  origin, so IfcLocalPlacement matches the IR world frame no matter where the
  *  transform came from (family-internal or prop-level). */
@@ -356,6 +369,14 @@ export function familiesToBim(
     } else if (route !== undefined) {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
+      if (hasOuterRotation(el.geometry)) {
+        return err(
+          specError(
+            'FAMILIES_UNSUPPORTED_TRANSFORM',
+            `familiesToBim: '${el.keyPath}' carries a rotated placement — the spec path folds only translations into IfcLocalPlacement; orient walls via axisX instead of tRotate`
+          )
+        );
+      }
       // The spec path rebuilds the body parametrically: an anonymous
       // (non-fill) void cuts only the IR/viewport geometry, so exporting it
       // silently would diverge the IFC body from what the user sees.

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -123,17 +123,20 @@ function peelTranslates(node: csg.IRNode): {
   return { total, moved };
 }
 
-/** True when the outer placement chain carries a rotation. The spec path can
- *  fold only translations into IfcLocalPlacement (walls orient via `axisX`),
- *  so a rotated routed element would export un-rotated while the viewport
- *  shows it rotated — reject instead of diverging. */
-function hasOuterRotation(node: csg.IRNode): boolean {
-  let cur = node;
-  while (cur.kind === 'Translate') {
-    if (cur.vector.kind !== 'Vec3Lit') break;
-    cur = cur.target;
-  }
-  return cur.kind === 'Rotate';
+/** True when the element's transform PROP carries a rotation. The spec path
+ *  folds only translations into IfcLocalPlacement (walls orient via `axisX`),
+ *  so a tRotate placement would export un-rotated while the viewport shows it
+ *  rotated — reject instead of diverging. Rotations a family render bakes
+ *  into its own body geometry (e.g. a circular beam oriented along axisX) are
+ *  fine: the spec rebuilds that body parametrically from props. */
+function hasRotateOp(el: ResolvedElement): boolean {
+  const ops = el.props['transform'];
+  return (
+    Array.isArray(ops) &&
+    ops.some(
+      (op) => typeof op === 'object' && op !== null && (op as { op?: unknown }).op === 'rotate'
+    )
+  );
 }
 
 /** Fold the resolved geometry's outer translate chain into the spec placement
@@ -349,7 +352,14 @@ export function familiesToBim(
   model.aggregate(siteResult.value, buildingId);
 
   const idByKeyPath = new Map<string, LocalId>();
-  const walk = (el: ResolvedElement, storeyId: LocalId | null): Result<void, BimError> => {
+  const walk = (
+    el: ResolvedElement,
+    storeyId: LocalId | null,
+    rotated: boolean
+  ): Result<void, BimError> => {
+    // A rotate op anywhere on the ancestor chain taints every routed
+    // descendant: inherited transforms carry it into their geometry.
+    const rotatedHere = rotated || hasRotateOp(el);
     let containerId = storeyId;
     const route = specRoute(el.type);
     if (el.type === 'Storey') {
@@ -369,7 +379,7 @@ export function familiesToBim(
     } else if (route !== undefined) {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
-      if (hasOuterRotation(el.geometry)) {
+      if (rotatedHere) {
         return err(
           specError(
             'FAMILIES_UNSUPPORTED_TRANSFORM',
@@ -427,13 +437,13 @@ export function familiesToBim(
     }
     for (const child of el.children) {
       if (el.type === 'Wall' && child.type === 'Opening') continue;
-      const r = walk(child, containerId);
+      const r = walk(child, containerId, rotatedHere);
       if (!r.ok) return r;
     }
     return ok(undefined);
   };
 
-  const walked = walk(root, null);
+  const walked = walk(root, null, false);
   if (!walked.ok) {
     model[Symbol.dispose]();
     return walked;

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -9,9 +9,10 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
 import { isOk, unwrap } from 'brepjs';
 import { z } from 'zod';
-import { family, el, resolve } from 'brepjs-families';
+import { family, el, resolve, tRotate } from 'brepjs-families';
 import { Wall } from '../../brepjs-families/registry/families/wall.js';
 import { Door } from '../../brepjs-families/registry/families/door.js';
+import { Room } from '../../brepjs-families/registry/families/room.js';
 import { Storey } from '../../brepjs-families/registry/families/storey.js';
 import { familiesToBim } from '../src/familiesAdapter.js';
 import { toIfc } from '../src/serialize/toIfc.js';
@@ -89,7 +90,13 @@ describe('registry families through familiesToBim', () => {
       Storey({
         key: 'g',
         items: [
-          BareSlab({ key: 's', length: 4000, width: 3000, thickness: 200, material: 'Cast concrete' }),
+          BareSlab({
+            key: 's',
+            length: 4000,
+            width: 3000,
+            thickness: 200,
+            material: 'Cast concrete',
+          }),
         ],
       })
     );
@@ -97,6 +104,39 @@ describe('registry families through familiesToBim', () => {
     using model = projected.model;
     const text = new TextDecoder().decode(unwrap(await toIfc(model, META)));
     expect(text).toContain('Cast concrete');
+  });
+
+  it('folds a composed room placement into wall origins', () => {
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [Room({ key: 'r', width: 4000, depth: 3000, height: 2700, at: [1000, 2000] })],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    const wallAt = (keyPath: string): [number, number, number] | undefined => {
+      const localId = projected.idByKeyPath.get(keyPath);
+      return model.getWalls().find((w) => w.localId === localId)?.spec.origin;
+    };
+    expect(wallAt('g/r/south')).toEqual([1000, 2000, 0]);
+    expect(wallAt('g/r/north')).toEqual([1000, 2000 + 3000 - 200, 0]);
+  });
+
+  it('rejects a rotated routed element instead of exporting a diverged body', () => {
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          el('Group', { key: 'wing', transform: [tRotate(30)] }, [
+            Wall({ key: 'w', length: 4000, height: 2700, thickness: 200 }),
+          ]),
+        ],
+      })
+    );
+    const projected = familiesToBim(tree, { project: PROJECT });
+    expect(isOk(projected)).toBe(false);
+    if (!projected.ok) expect(projected.error.code).toBe('FAMILIES_UNSUPPORTED_TRANSFORM');
   });
 
   it('rejects an anonymous void instead of silently diverging the IFC body', () => {
@@ -107,7 +147,13 @@ describe('registry families through familiesToBim', () => {
       Storey({
         key: 'g',
         items: [
-          Wall({ key: 'w', length: 4000, height: 2700, thickness: 200, voids: [Hole({ key: 'h' })] }),
+          Wall({
+            key: 'w',
+            length: 4000,
+            height: 2700,
+            thickness: 200,
+            voids: [Hole({ key: 'h' })],
+          }),
         ],
       })
     );

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -10,6 +10,7 @@ import { initOCCT } from '../../../tests/setup.js';
 import { isOk, unwrap } from 'brepjs';
 import { z } from 'zod';
 import { family, el, resolve, tRotate } from 'brepjs-families';
+import { Beam } from '../../brepjs-families/registry/families/beam.js';
 import { Wall } from '../../brepjs-families/registry/families/wall.js';
 import { Door } from '../../brepjs-families/registry/families/door.js';
 import { Room } from '../../brepjs-families/registry/families/room.js';
@@ -121,6 +122,28 @@ describe('registry families through familiesToBim', () => {
     };
     expect(wallAt('g/r/south')).toEqual([1000, 2000, 0]);
     expect(wallAt('g/r/north')).toEqual([1000, 2000 + 3000 - 200, 0]);
+  });
+
+  it('routes a circular beam whose render orients its body internally', () => {
+    // The beam family bakes a csg.rotate into its body to run along axisX;
+    // that is body orientation the spec rebuilds from props, not a placement
+    // rotation, and must not trip the tRotate rejection.
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          Beam({
+            key: 'b',
+            length: 3000,
+            profile: { kind: 'CIRCULAR', radius: 100 },
+            axisX: [0, 1, 0],
+          }),
+        ],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using _model = projected.model;
+    expect(projected.idByKeyPath.has('g/b')).toBe(true);
   });
 
   it('rejects a rotated routed element instead of exporting a diverged body', () => {

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -142,8 +142,9 @@ describe('registry families through familiesToBim', () => {
       })
     );
     const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
-    using _model = projected.model;
+    using model = projected.model;
     expect(projected.idByKeyPath.has('g/b')).toBe(true);
+    expect(model.getBeams()).toHaveLength(1);
   });
 
   it('rejects a rotated routed element instead of exporting a diverged body', () => {

--- a/packages/brepjs-families/README.md
+++ b/packages/brepjs-families/README.md
@@ -54,6 +54,7 @@ model.byKeyPath.get('ground/south'); // mesh + identity for the wall
 What the pieces buy you:
 
 - **Families** are typed, validated constructors (`family(name, render, { props })` takes a zod schema). Invalid props fail at construction, not at export.
+- **Composition is structural**: a family receives its JSX (or `children:` prop) children in `props.children`, a parent's `transform` carries every descendant with it (translate + `tRotate`), and fragments inline without touching key paths. A composed family places as a unit while identical children keep sharing one materialization.
 - **Identity props** (`name`, `psets`, `material`, `classification`) are accepted by every family and ride past schema validation into `ResolvedElement.attributes`, so a component carries IFC-facing data without declaring it in its schema; a BIM projection consumes them (storey names, common psets, custom psets, material fallback).
 - **Key paths** (`ground/south/voids:entry`) are order-independent identity. Reorder siblings and every element keeps its identity; a BIM projection derives stable IFC GlobalIds from them.
 - **The CSG IR** is content-addressed: two identical walls evaluate once and share one materialization, while each keeps its own identity.

--- a/packages/brepjs-families/package.json
+++ b/packages/brepjs-families/package.json
@@ -63,6 +63,16 @@
         "types": "./dist/jsxRuntime.d.ts",
         "default": "./dist/jsxRuntime.cjs"
       }
+    },
+    "./jsx-dev-runtime": {
+      "import": {
+        "types": "./dist/jsxRuntime.d.ts",
+        "default": "./dist/jsxRuntime.js"
+      },
+      "require": {
+        "types": "./dist/jsxRuntime.d.ts",
+        "default": "./dist/jsxRuntime.cjs"
+      }
     }
   }
 }

--- a/packages/brepjs-families/registry/families/room.ts
+++ b/packages/brepjs-families/registry/families/room.ts
@@ -1,17 +1,17 @@
-// brepjs-family: room@2
+// brepjs-family: room@3
 /**
  * Room — a composed family: four keyed perimeter walls with a door in the
  * south wall. Copy-in composes (it only calls other families and the
  * brepjs-families surface); it never reaches around them into IFC writing.
  * Depends on: wall, door.
  *
- * `at` is the room's south-west corner. A composed family has to thread its
- * own placement down to the children it builds: element trees carry no
- * hierarchical transform, so wrapping the group in one would move the
- * group's geometry and leave every wall behind at the origin.
+ * `at` is the room's south-west corner, applied as the group's transform:
+ * children ride with their parent, so the walls stay in room-local
+ * coordinates. Two rooms with the same dimensions share every wall
+ * materialization — only the placement differs.
  */
 
-import { family, el } from 'brepjs-families';
+import { family, el, tTranslate } from 'brepjs-families';
 import { z } from 'zod';
 import { Wall } from './wall.js';
 import { Door } from './door.js';
@@ -56,13 +56,11 @@ export const Room = family(
     const { width: w, depth: d, height, thickness: t, materialName } = p;
     const doorAlong = doorAlongOf(p);
     const shared = { height, thickness: t, materialName };
-    const [x, y] = p.at;
-    return el('Group', {}, [
+    return el('Group', { transform: [tTranslate([p.at[0], p.at[1], 0])] }, [
       Wall({
         key: 'south',
         ...shared,
         length: w,
-        at: [x, y, 0],
         voids: [
           Door({
             key: 'door',
@@ -73,9 +71,9 @@ export const Room = family(
           }),
         ],
       }),
-      Wall({ key: 'north', ...shared, length: w, at: [x, y + d - t, 0] }),
-      Wall({ key: 'west', ...shared, length: d, at: [x + t, y, 0], axisX: [0, 1, 0] }),
-      Wall({ key: 'east', ...shared, length: d, at: [x + w, y, 0], axisX: [0, 1, 0] }),
+      Wall({ key: 'north', ...shared, length: w, at: [0, d - t, 0] }),
+      Wall({ key: 'west', ...shared, length: d, at: [t, 0, 0], axisX: [0, 1, 0] }),
+      Wall({ key: 'east', ...shared, length: d, at: [w, 0, 0], axisX: [0, 1, 0] }),
     ]);
   },
   { props: roomSchema }

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "room",
-      "version": 2,
+      "version": 3,
       "description": "Composed family: four keyed perimeter walls with a door, placed by its south-west corner",
       "files": ["families/room.ts"],
       "npmDeps": ["brepjs-families", "zod"],

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -17,6 +17,26 @@ interface WithKey {
   readonly key?: string | undefined;
 }
 
+interface WithChildren {
+  readonly children?: Element | readonly Element[] | undefined;
+}
+
+/** Flatten nested child arrays and drop null/undefined/boolean, so JSX idioms
+ *  like `{cond && <X/>}` and `.map(...)` compose. */
+export function normalizeChildren(value: unknown): Element[] {
+  const out: Element[] = [];
+  const visit = (v: unknown): void => {
+    if (v === null || v === undefined || typeof v === 'boolean') return;
+    if (Array.isArray(v)) {
+      for (const item of v) visit(item);
+      return;
+    }
+    out.push(v as Element);
+  };
+  visit(value);
+  return out;
+}
+
 /**
  * Identity-side props accepted by every family invocation, beside the
  * family's own schema. Zod object schemas strip undeclared keys, so these are
@@ -48,7 +68,7 @@ export interface IdentityProps {
  * output `P`. Schema-less families use one type for both.
  */
 export interface FamilyComponent<P, I = P> {
-  (props: I & WithKey & IdentityProps): Element;
+  (props: I & WithKey & IdentityProps & WithChildren): Element;
   readonly familyName: string;
   /** `'fill'` marks a family whose instances fill an opening when placed in a
    *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
@@ -72,8 +92,8 @@ export function family<P extends object, I extends object = P>(
   options?: FamilyOptions<P, I>
 ): FamilyComponent<P, I> {
   const schema = options?.props;
-  const make = (props: I & WithKey & IdentityProps): Element => {
-    const { key, ...rest } = props;
+  const make = (props: I & WithKey & IdentityProps & WithChildren): Element => {
+    const { key, children, ...rest } = props;
     let validated: Readonly<Record<string, unknown>> = rest;
     if (schema) {
       const parsed = schema.safeParse(rest);
@@ -92,7 +112,9 @@ export function family<P extends object, I extends object = P>(
       }
       validated = out;
     }
-    return { type: component, key, props: validated, children: [] };
+    // Children are structure, not schema surface: they bypass validation and
+    // reach the render function as `props.children` during resolution.
+    return { type: component, key, props: validated, children: normalizeChildren(children) };
   };
   const component: FamilyComponent<P, I> = Object.assign(make, {
     familyName: name,

--- a/packages/brepjs-families/src/index.ts
+++ b/packages/brepjs-families/src/index.ts
@@ -15,10 +15,11 @@ export {
   type FamilyOptions,
   type IdentityProps,
 } from './element.js';
-export { jsx, jsxs, Fragment } from './jsxRuntime.js';
+export { jsx, jsxs, jsxDEV, Fragment } from './jsxRuntime.js';
 export {
   resolve,
   tTranslate,
+  tRotate,
   type TransformOp,
   type Relationship,
   type ResolvedElement,

--- a/packages/brepjs-families/src/jsxRuntime.ts
+++ b/packages/brepjs-families/src/jsxRuntime.ts
@@ -2,10 +2,12 @@
  * React-automatic JSX runtime (`jsxImportSource: "brepjs-families"`). No
  * React: `jsx(type, props, key)` constructs a plain Element; children arrive
  * inside props per the automatic-runtime convention. The plain-function API
- * is primary; JSX is sugar over it.
+ * is primary; JSX is sugar over it — a family component is invoked, so schema
+ * validation, defaults, and identity-prop capture behave identically on both
+ * paths.
  */
 
-import type { Element, FamilyComponent } from './element.js';
+import { isFamily, normalizeChildren, type Element, type FamilyComponent } from './element.js';
 
 export function jsx(
   type: string | FamilyComponent<never>,
@@ -15,15 +17,25 @@ export function jsx(
   const rest = { ...props };
   const rawChildren = rest['children'];
   delete rest['children'];
-  const children = Array.isArray(rawChildren)
-    ? (rawChildren as Element[])
-    : rawChildren !== undefined
-      ? [rawChildren as Element]
-      : [];
+  const children = normalizeChildren(rawChildren);
+  if (isFamily(type)) {
+    return (type as FamilyComponent<object>)({ ...rest, key, children });
+  }
   return { type, key, props: rest, children };
 }
 
 export const jsxs = jsx;
 
-/** Fragment renders nothing itself; its children inline into the parent. */
+/** Development-runtime entry (`jsx: "react-jsxdev"`): same construction, the
+ *  extra dev metadata (source/self) is not used. */
+export function jsxDEV(
+  type: string | FamilyComponent<never>,
+  props: Readonly<Record<string, unknown>>,
+  key?: string
+): Element {
+  return jsx(type, props, key);
+}
+
+/** Fragment renders nothing itself; resolution inlines its children into the
+ *  parent, so it never contributes a key-path segment. */
 export const Fragment = 'Fragment';

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -12,13 +12,31 @@
 import { csg } from 'brepjs';
 import { IDENTITY_PROPS, isFamily, typeNameOf, type Element } from './element.js';
 
-export interface TransformOp {
-  readonly op: 'translate';
-  readonly v: readonly [number, number, number];
-}
+export type TransformOp =
+  | { readonly op: 'translate'; readonly v: readonly [number, number, number] }
+  | {
+      readonly op: 'rotate';
+      readonly angleDeg: number;
+      readonly axis?: readonly [number, number, number] | undefined;
+      readonly at?: readonly [number, number, number] | undefined;
+    };
 
 export function tTranslate(v: readonly [number, number, number]): TransformOp {
   return { op: 'translate', v };
+}
+
+/** Rotation in degrees about `axis` (default Z) through `at` (default origin).
+ *  Viewport-first: a parametric BIM projection folds only translations into
+ *  IfcLocalPlacement and rejects rotated routed elements (walls orient via
+ *  `axisX` instead). */
+export function tRotate(
+  angleDeg: number,
+  options?: {
+    readonly axis?: readonly [number, number, number] | undefined;
+    readonly at?: readonly [number, number, number] | undefined;
+  }
+): TransformOp {
+  return { op: 'rotate', angleDeg, axis: options?.axis, at: options?.at };
 }
 
 export interface Relationship {
@@ -55,14 +73,29 @@ function identityAttributes(elem: Element): Readonly<Record<string, unknown>> {
 }
 
 /** Run family render functions until an intrinsic element remains. The
- *  outermost family supplies the resolved type name. */
+ *  outermost family supplies the resolved type name. An element's children
+ *  reach the render function as `props.children` (the React contract), so a
+ *  container family decides where they land in its intrinsic tree. */
 function renderToIntrinsic(elem: Element): { intrinsic: Element; typeName: string } {
   const typeName = typeNameOf(elem);
   let cur = elem;
   while (isFamily(cur.type)) {
-    cur = cur.type.renderErased(cur.props);
+    cur = cur.type.renderErased(
+      cur.children.length > 0 ? { ...cur.props, children: cur.children } : cur.props
+    );
   }
   return { intrinsic: cur, typeName };
+}
+
+/** Fragments inline: their children join the parent's child list and the
+ *  fragment itself never contributes a key-path segment. */
+function expandFragments(children: readonly Element[]): Element[] {
+  const out: Element[] = [];
+  for (const c of children) {
+    if (c.type === 'Fragment') out.push(...expandFragments(c.children));
+    else out.push(c);
+  }
+  return out;
 }
 
 function isIRNode(v: unknown): v is csg.IRNode {
@@ -75,10 +108,7 @@ function baseGeometry(intrinsic: Element): csg.IRNode {
     return csg.box(size[0], size[1], size[2]);
   }
   if (intrinsic.type === 'Cylinder') {
-    return csg.cylinder(
-      intrinsic.props['radius'] as number,
-      intrinsic.props['height'] as number
-    );
+    return csg.cylinder(intrinsic.props['radius'] as number, intrinsic.props['height'] as number);
   }
   // The bridge to the full csg vocabulary (Profile, Extrude, Revolve, Sweep,
   // Loft, booleans, ...): render functions build any IR node and hand it over;
@@ -86,9 +116,7 @@ function baseGeometry(intrinsic: Element): csg.IRNode {
   if (intrinsic.type === 'Geometry') {
     const node = intrinsic.props['node'];
     if (!isIRNode(node)) {
-      throw new Error(
-        "brepjs-families: 'Geometry' requires a csg IR node in props.node"
-      );
+      throw new Error("brepjs-families: 'Geometry' requires a csg IR node in props.node");
     }
     return node;
   }
@@ -117,7 +145,17 @@ interface DesugarOut {
 function applyOps(geometry: csg.IRNode, ops: readonly TransformOp[]): csg.IRNode {
   let out = geometry;
   for (const op of ops) {
-    out = csg.translate(out, op.v);
+    switch (op.op) {
+      case 'translate':
+        out = csg.translate(out, op.v);
+        break;
+      case 'rotate':
+        out = csg.rotate(out, op.angleDeg, {
+          ...(op.axis ? { axis: op.axis } : {}),
+          ...(op.at ? { at: op.at } : {}),
+        });
+        break;
+    }
   }
   return out;
 }
@@ -153,7 +191,9 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
       }
       slotKeys.add(slotKey);
       const openingPath = `${hostPath}/voids:${slotKey}`;
-      const fill = resolveAt(v, `${openingPath}/fill`, v.key !== undefined);
+      // Fills resolve in the host's LOCAL frame; the host's own and inherited
+      // transforms are applied afterwards via transformResolved.
+      const fill = resolveAt(v, `${openingPath}/fill`, v.key !== undefined, []);
       openings.push({
         type: 'Opening',
         keyPath: openingPath,
@@ -177,7 +217,10 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
 
   const ops = (intrinsic.props['transform'] as readonly TransformOp[] | undefined) ?? [];
   if (ops.length > 0) {
-    geometry = applyOps(geometry, ops);
+    // Empty container geometry stays Empty: wrapping it in a transform would
+    // make it look materializable (and fail) downstream. The transform still
+    // reaches descendants through resolveAt's inherited chain.
+    if (geometry.kind !== 'Empty') geometry = applyOps(geometry, ops);
     // Openings/fills were cut in the local frame; the host transform carries
     // them into the same frame as the host's own geometry.
     openings = openings.map((o) => transformResolved(o, ops));
@@ -196,29 +239,45 @@ function assertKeyAllowed(key: string, path: string): void {
   }
 }
 
-function resolveAt(elem: Element, path: string, keyed: boolean): ResolvedElement {
+function resolveAt(
+  elem: Element,
+  path: string,
+  keyed: boolean,
+  inherited: readonly TransformOp[]
+): ResolvedElement {
   const { intrinsic, typeName } = renderToIntrinsic(elem);
   const d = desugar(intrinsic, path);
+  // The element's own transform is applied inside desugar (local frame, after
+  // voids/fuse); ancestor transforms compose outside it, and thread down so
+  // children ride with their parent — a composed family places as a unit.
+  const geometry =
+    inherited.length > 0 && d.geometry.kind !== 'Empty'
+      ? applyOps(d.geometry, inherited)
+      : d.geometry;
+  const openings =
+    inherited.length > 0 ? d.openings.map((o) => transformResolved(o, inherited)) : d.openings;
+  const ownOps = (intrinsic.props['transform'] as readonly TransformOp[] | undefined) ?? [];
+  const childInherited = ownOps.length > 0 ? [...ownOps, ...inherited] : inherited;
   const relationships: Relationship[] = [...d.hostRelationships];
   const children: ResolvedElement[] = [];
   const seen = new Set<string>();
-  intrinsic.children.forEach((c, i) => {
+  expandFragments(intrinsic.children).forEach((c, i) => {
     if (c.key !== undefined) assertKeyAllowed(c.key, path);
     const seg = c.key ?? `${typeNameOf(c)}[${i}]`;
     if (seen.has(seg)) {
       throw new Error(`brepjs-families: duplicate sibling key '${seg}' under '${path}'`);
     }
     seen.add(seg);
-    const rc = resolveAt(c, `${path}/${seg}`, c.key !== undefined);
+    const rc = resolveAt(c, `${path}/${seg}`, c.key !== undefined, childInherited);
     children.push(rc);
     relationships.push({ kind: 'Contains', target: rc.keyPath });
   });
-  children.push(...d.openings);
+  children.push(...openings);
   return {
     type: typeName,
     keyPath: path,
     keyed,
-    geometry: d.geometry,
+    geometry,
     props: elem.props,
     attributes: identityAttributes(elem),
     relationships,
@@ -227,5 +286,5 @@ function resolveAt(elem: Element, path: string, keyed: boolean): ResolvedElement
 }
 
 export function resolve(root: Element): ResolvedElement {
-  return resolveAt(root, root.key ?? `${typeNameOf(root)}[0]`, root.key !== undefined);
+  return resolveAt(root, root.key ?? `${typeNameOf(root)}[0]`, root.key !== undefined, []);
 }

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -8,15 +8,17 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { z } from 'zod';
 import { initOCCT } from '../../../tests/setup.js';
-import { csg, isOk, unwrap, measureVolume } from 'brepjs';
+import { csg, getBounds, isOk, unwrap, measureVolume } from 'brepjs';
 import type { AnyShape, Dimension } from 'brepjs';
 import {
   family,
   el,
   jsx,
+  Fragment,
   resolve,
   evaluateModel,
   tTranslate,
+  tRotate,
   type Element,
   type ResolvedElement,
 } from '../src/index.js';
@@ -166,11 +168,15 @@ describe('key paths and opening synthesis', () => {
         ? Door({ key, width: 90, height: 210, thickness: 20, at: [100, 0, 0] })
         : Door({ width: 90, height: 210, thickness: 20, at: [200, 0, 0] });
     expect(() =>
-      resolve(Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [door('d1'), door('d1')] }))
+      resolve(
+        Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [door('d1'), door('d1')] })
+      )
     ).toThrow(/duplicate void slot/i);
     // Explicit key '1' collides with the second void's index fallback.
     expect(() =>
-      resolve(Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [door('1'), door()] }))
+      resolve(
+        Wall({ key: 'w', length: 400, height: 270, thickness: 20, voids: [door('1'), door()] })
+      )
     ).toThrow(/duplicate void slot/i);
   });
 
@@ -354,11 +360,9 @@ describe('props validation (Zod)', () => {
   });
 
   it('a schema-declared identity prop keeps its validated value', () => {
-    const Named = family<{ readonly name: string }>(
-      'Named',
-      () => el('Box', { size: [1, 1, 1] }),
-      { props: z.object({ name: z.string().transform((s) => s.toUpperCase()) }) }
-    );
+    const Named = family<{ readonly name: string }>('Named', () => el('Box', { size: [1, 1, 1] }), {
+      props: z.object({ name: z.string().transform((s) => s.toUpperCase()) }),
+    });
     const r = resolve(Named({ key: 'n', name: 'ground' }));
     expect(r.attributes['name']).toBe('GROUND');
   });
@@ -403,24 +407,19 @@ describe('intrinsic vocabulary', () => {
   });
 
   it('Geometry bridges the full csg vocabulary (profile + extrude wall)', () => {
-    const ProfiledWall = family<{ readonly length: number; readonly height: number }>(
-      'Wall',
-      (p) =>
-        el('Geometry', {
-          node: csg.extrude(
-            csg.profile(
-              csg.contour([0, 0], [
-                csg.lineTo([p.length, 0]),
-                csg.lineTo([p.length, 200]),
-                csg.lineTo([0, 200]),
-              ])
-            ),
-            [0, 0, p.height]
+    const ProfiledWall = family<{ readonly length: number; readonly height: number }>('Wall', (p) =>
+      el('Geometry', {
+        node: csg.extrude(
+          csg.profile(
+            csg.contour(
+              [0, 0],
+              [csg.lineTo([p.length, 0]), csg.lineTo([p.length, 200]), csg.lineTo([0, 200])]
+            )
           ),
-          voids: [
-            el('Box', { size: [1000, 300, 2100], transform: [tTranslate([1500, -50, 0])] }),
-          ],
-        })
+          [0, 0, p.height]
+        ),
+        voids: [el('Box', { size: [1000, 300, 2100], transform: [tTranslate([1500, -50, 0])] })],
+      })
     );
     using ev = new csg.Evaluator();
     const model = evaluateModel(
@@ -438,12 +437,110 @@ describe('intrinsic vocabulary', () => {
   });
 
   it('Geometry without an IR node throws with a clear message', () => {
-    const Bad = family<Record<string, never>>('Bad', () => el('Geometry', { node: { not: 'a node' } }));
+    const Bad = family<Record<string, never>>('Bad', () =>
+      el('Geometry', { node: { not: 'a node' } })
+    );
     expect(() => resolve(Bad({ key: 'b' }))).toThrow(/requires a csg IR node/);
   });
 
   it('unknown intrinsics name the vocabulary in the error', () => {
     const Bad = family<Record<string, never>>('Bad', () => el('Torus', {}));
     expect(() => resolve(Bad({ key: 'b' }))).toThrow(/intrinsics: Box, Cylinder, Geometry/);
+  });
+});
+
+describe('composition (children, hierarchical transforms, rotation)', () => {
+  const Level = family<{ readonly children?: readonly Element[] | undefined }>('Level', (p) =>
+    el('Group', {}, p.children ?? [])
+  );
+
+  it('children passed to a family reach its render function', () => {
+    const tree = resolve(
+      Level({ key: 'l', children: [Wall({ key: 'w', length: 100, height: 50, thickness: 10 })] })
+    );
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children[0]?.keyPath).toBe('l/w');
+  });
+
+  it('jsx invokes the component: schema validation and defaults apply', () => {
+    const Sized = family<{ readonly size: number; readonly label?: string }>(
+      'Sized',
+      (p) => el('Box', { size: [p.size, p.size, p.size] }),
+      { props: z.object({ size: z.number().positive(), label: z.string().default('unit') }) }
+    );
+    expect(() => jsx(Sized, { size: -1 }, 's')).toThrow(/invalid props for family 'Sized'/);
+    const e = jsx(Sized, { size: 2 }, 's');
+    expect(e.props['label']).toBe('unit');
+  });
+
+  it('jsx normalizes children: conditionals and nested arrays compose', () => {
+    const walls = [
+      Wall({ key: 'a', length: 100, height: 50, thickness: 10 }),
+      Wall({ key: 'b', length: 100, height: 50, thickness: 10 }),
+    ];
+    const e = jsx(Level, { children: [false, null, walls, undefined] }, 'l');
+    expect(e.children).toHaveLength(2);
+  });
+
+  it('a parent transform carries resolved children with it', () => {
+    const tree = resolve(
+      Level({
+        key: 'l',
+        children: [
+          el('Group', { key: 'g', transform: [tTranslate([1000, 0, 0])] }, [
+            Wall({ key: 'w', length: 100, height: 50, thickness: 10 }),
+          ]),
+        ],
+      })
+    );
+    const wall = tree.children[0]?.children[0];
+    expect(wall?.keyPath).toBe('l/g/w');
+    using ev = new csg.Evaluator();
+    const shape = unwrap(ev.evaluate(wall?.geometry as csg.IRNode));
+    const b = getBounds(shape);
+    expect(b.xMin).toBeCloseTo(1000, 5);
+    expect(b.xMax).toBeCloseTo(1100, 5);
+  });
+
+  it('nested transforms compose parent-out', () => {
+    const inner = el('Group', { key: 'inner', transform: [tTranslate([0, 200, 0])] }, [
+      Wall({ key: 'w', length: 100, height: 50, thickness: 10 }),
+    ]);
+    const tree = resolve(
+      el('Group', { key: 'outer', transform: [tTranslate([1000, 0, 0])] }, [inner])
+    );
+    const wall = tree.children[0]?.children[0];
+    using ev = new csg.Evaluator();
+    const b = getBounds(unwrap(ev.evaluate(wall?.geometry as csg.IRNode)));
+    expect(b.xMin).toBeCloseTo(1000, 5);
+    expect(b.yMin).toBeCloseTo(200, 5);
+  });
+
+  it('tRotate rotates in degrees about the given axis', () => {
+    const Beam = family<Record<string, never>>('Beam', () =>
+      el('Box', { size: [400, 10, 10], transform: [tRotate(90, { axis: [0, 0, 1] })] })
+    );
+    const tree = resolve(Beam({ key: 'b' }));
+    using ev = new csg.Evaluator();
+    const b = getBounds(unwrap(ev.evaluate(tree.geometry)));
+    expect(b.yMax - b.yMin).toBeCloseTo(400, 5);
+    expect(b.xMax - b.xMin).toBeCloseTo(10, 5);
+  });
+
+  it('fragments inline: no key-path segment, children join the parent', () => {
+    const tree = resolve(
+      Level({
+        key: 'l',
+        children: [
+          jsx(Fragment, {
+            children: [
+              Wall({ key: 'w1', length: 100, height: 50, thickness: 10 }),
+              Wall({ key: 'w2', length: 100, height: 50, thickness: 10 }),
+            ],
+          }),
+        ],
+      })
+    );
+    expect(tree.children.map((c) => c.keyPath)).toEqual(['l/w1', 'l/w2']);
   });
 });

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -104,9 +104,8 @@ describe('starter families', () => {
     expect(opening?.keyed).toBe(true);
   });
 
-  // A composed family must thread its own placement into the children it
-  // builds: element trees carry no hierarchical transform, so two rooms that
-  // ignored `at` would render one on top of the other.
+  // The room's `at` becomes a group transform that carries the walls with it,
+  // so two rooms that ignored `at` would render one on top of the other.
   it('places each room by its own corner instead of stacking them', () => {
     const suite = resolve(
       Storey({
@@ -124,6 +123,29 @@ describe('starter families', () => {
           ?.children.find((w) => w.keyPath.endsWith('/south'))?.geometry.structuralHash
       );
     expect(southOf('a')).not.toBe(southOf('b'));
+  });
+
+  // Hierarchical placement keeps wall props room-local, so identically-sized
+  // rooms share every wall's inner materialization: only the outer placement
+  // node differs between room a and room b.
+  it('identically-sized rooms share wall materializations across placements', () => {
+    const suite = resolve(
+      Storey({
+        key: 'ground',
+        items: [
+          Room({ key: 'a', width: 4000, depth: 3000, height: 2700 }),
+          Room({ key: 'b', width: 4000, depth: 3000, height: 2700, at: [4200, 0] }),
+        ],
+      })
+    );
+    const southInner = (key: string): string => {
+      const geometry = suite.children
+        .find((c) => c.keyPath === `ground/${key}`)
+        ?.children.find((w) => w.keyPath.endsWith('/south'))?.geometry;
+      expect(geometry?.kind).toBe('Translate');
+      return String((geometry as { target: csg.IRNode }).target.structuralHash);
+    };
+    expect(southInner('a')).toBe(southInner('b'));
   });
 
   it('starter walls and windows materialize with meshes', () => {


### PR DESCRIPTION
## Problem

The ecosystem audit's core finding about the component model: it could not compose the way its README promises.

- Family components silently dropped their children (`family()` hardcoded `children: []`; `resolve()` never passed children to render), so `<Storey><Wall/></Storey>` lost the wall with no error. Composition worked only through array props.
- A parent's `transform` did not carry its resolved children. The registry room hand-threaded world coordinates into every wall it built (its own header comment documented the limitation), which also forked every wall's subtree hash and defeated dedup across rooms.
- The transform vocabulary was translate-only.
- `jsx()` constructed elements directly instead of invoking the component, so JSX-built families skipped zod validation, defaults, and identity capture. There was no `jsx-dev-runtime` export, and no child normalization: `{cond && <X/>}` pushed `false` into children.
- `Fragment` claimed to inline but inserted a key-path segment, silently changing identity.

## Fix

- **Children**: an element's children reach the render function as `props.children` on both the call path (`children:` prop) and the JSX path; `normalizeChildren` flattens nested arrays and drops null/undefined/boolean.
- **Hierarchical transforms**: `resolveAt` threads ancestor transforms down, so a composed family places as a unit. Fills still resolve in the host-local frame and are carried by `transformResolved`; `Empty` container geometry is never wrapped in a transform (it would fail materialization downstream).
- **`tRotate(angleDeg, { axis, at })`** joins the vocabulary (degrees, matching `csg.rotate`).
- **JSX**: `jsx()` invokes family components so validation, defaults, and identity capture behave identically to direct calls; `jsxDEV` + a `./jsx-dev-runtime` package export make `react-jsxdev` tsconfigs resolve; `Fragment` now inlines with no key-path segment.
- **Registry room@3** places via a group transform: walls stay room-local, so identically-sized rooms share every wall's materialization (asserted by a new registry test), and the placement still folds into IFC wall origins (asserted in brepjs-bim).
- **BIM safety**: `familiesToBim` rejects rotated routed elements with `FAMILIES_UNSUPPORTED_TRANSFORM` instead of exporting a body that diverges from the viewport (the spec path folds only translations into IfcLocalPlacement; walls orient via `axisX`).
- **Lockfile**: removes a stale `brepjs-families@0.1.0` registry copy pinned under `packages/brepjs-bim/node_modules`, which shadowed the workspace package for type-aware lint (it resolved the families API at 0.1.0).

## Validation

- brepjs-families: 49/49 (7 new composition tests: children on both paths, JSX validation + defaults, child normalization, single and nested hierarchical transforms with bounds assertions, rotation, fragment inlining) plus the new room-sharing test; typecheck, lint, build clean.
- brepjs-bim: 67 files / 656 tests green, including the new room-placement fold and rotation-rejection tests; typecheck and lint clean after the lockfile fix.
- Existing key paths, opening synthesis, and byte-stability tests unchanged.
