### PR TITLE
fix(csg): linear DAG walks + registry pinned to the installed release

### DIFF
--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -19,7 +19,7 @@
 import { mkdir, open, readFile, writeFile, access, lstat, realpath, rename, rm } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { join, resolve as resolvePath, sep } from 'node:path';
+import { dirname, join, resolve as resolvePath, sep } from 'node:path';
 import process from 'node:process';
 
 // The default registry pins to the release tag of the INSTALLED
@@ -28,19 +28,31 @@ import process from 'node:process';
 // install, fall back to main.
 const REGISTRY_PATH = 'packages/brepjs-families/registry';
 
-async function defaultRegistry() {
-  try {
-    const pkg = JSON.parse(
-      await readFile(
-        join(process.cwd(), 'node_modules', 'brepjs-families', 'package.json'),
-        'utf8'
-      )
-    );
-    if (typeof pkg.version === 'string' && /^\d+\.\d+\.\d+$/.test(pkg.version)) {
-      return `https://raw.githubusercontent.com/andymai/brepjs/brepjs-families-v${pkg.version}/${REGISTRY_PATH}`;
+async function installedFamiliesVersion() {
+  // Walk ancestor node_modules like Node's resolver, so a hoisted install
+  // (workspaces, monorepos) still pins the registry.
+  let dir = process.cwd();
+  for (;;) {
+    try {
+      const pkg = JSON.parse(
+        await readFile(join(dir, 'node_modules', 'brepjs-families', 'package.json'), 'utf8')
+      );
+      if (typeof pkg.version === 'string' && /^\d+\.\d+\.\d+$/.test(pkg.version)) {
+        return pkg.version;
+      }
+    } catch {
+      // keep walking
     }
-  } catch {
-    // No local brepjs-families: track main.
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+async function defaultRegistry() {
+  const version = await installedFamiliesVersion();
+  if (version !== null) {
+    return `https://raw.githubusercontent.com/andymai/brepjs/brepjs-families-v${version}/${REGISTRY_PATH}`;
   }
   return `https://raw.githubusercontent.com/andymai/brepjs/main/${REGISTRY_PATH}`;
 }

--- a/bin/brepjs.mjs
+++ b/bin/brepjs.mjs
@@ -22,11 +22,31 @@ import { spawnSync } from 'node:child_process';
 import { join, resolve as resolvePath, sep } from 'node:path';
 import process from 'node:process';
 
-const DEFAULT_REGISTRY =
-  'https://raw.githubusercontent.com/andymai/brepjs/main/packages/brepjs-families/registry';
+// The default registry pins to the release tag of the INSTALLED
+// brepjs-families, so copied sources match the package the project compiles
+// against instead of tracking main (which can drift ahead). Without a local
+// install, fall back to main.
+const REGISTRY_PATH = 'packages/brepjs-families/registry';
+
+async function defaultRegistry() {
+  try {
+    const pkg = JSON.parse(
+      await readFile(
+        join(process.cwd(), 'node_modules', 'brepjs-families', 'package.json'),
+        'utf8'
+      )
+    );
+    if (typeof pkg.version === 'string' && /^\d+\.\d+\.\d+$/.test(pkg.version)) {
+      return `https://raw.githubusercontent.com/andymai/brepjs/brepjs-families-v${pkg.version}/${REGISTRY_PATH}`;
+    }
+  } catch {
+    // No local brepjs-families: track main.
+  }
+  return `https://raw.githubusercontent.com/andymai/brepjs/main/${REGISTRY_PATH}`;
+}
 
 function parseArgs(argv) {
-  const args = { _: [], registry: DEFAULT_REGISTRY, dir: 'src/families', force: false, install: false };
+  const args = { _: [], registry: null, dir: 'src/families', force: false, install: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--registry') args.registry = argv[++i];
@@ -295,6 +315,7 @@ async function diff(args) {
 async function main() {
   const [cmd, ...rest] = process.argv.slice(2);
   const args = parseArgs(rest);
+  args.registry = args.registry ?? (await defaultRegistry());
   if (cmd === 'add' && args._.length > 0) return add(args);
   if (cmd === 'diff' && args._.length === 1) return diff(args);
   console.error(

--- a/src/csg/edit.ts
+++ b/src/csg/edit.ts
@@ -16,15 +16,26 @@ import type {
 export type NodePredicate = (node: IRNode) => boolean;
 
 export function replaceNode(root: IRNode, pred: NodePredicate, replacement: IRNode): IRNode {
-  return walk(root, pred, replacement);
+  return walk(root, pred, replacement, new Map());
 }
 
-function walk(node: IRNode, pred: NodePredicate, repl: IRNode): IRNode {
-  if (pred(node)) return repl;
-  return rebuildChildren(node, pred, repl);
+// Memoized by node identity: a shared subtree rebuilds once and STAYS shared
+// in the output, and a self-referencing DAG walks in linear time instead of
+// expanding to its exponential path count.
+function walk(node: IRNode, pred: NodePredicate, repl: IRNode, memo: Map<IRNode, IRNode>): IRNode {
+  const cached = memo.get(node);
+  if (cached !== undefined) return cached;
+  const out = pred(node) ? repl : rebuildChildren(node, pred, repl, memo);
+  memo.set(node, out);
+  return out;
 }
 
-function rebuildChildren(n: IRNode, pred: NodePredicate, repl: IRNode): IRNode {
+function rebuildChildren(
+  n: IRNode,
+  pred: NodePredicate,
+  repl: IRNode,
+  memo: Map<IRNode, IRNode>
+): IRNode {
   switch (n.kind) {
     case 'Box':
     case 'Sphere':
@@ -40,34 +51,34 @@ function rebuildChildren(n: IRNode, pred: NodePredicate, repl: IRNode): IRNode {
     case 'Profile':
       return n;
     case 'Fuse':
-      return B.fuse(walk(n.a, pred, repl), walk(n.b, pred, repl), n.tolerance);
+      return B.fuse(walk(n.a, pred, repl, memo), walk(n.b, pred, repl, memo), n.tolerance);
     case 'Cut':
-      return B.cut(walk(n.a, pred, repl), walk(n.b, pred, repl), n.tolerance);
+      return B.cut(walk(n.a, pred, repl, memo), walk(n.b, pred, repl, memo), n.tolerance);
     case 'Intersect':
-      return B.intersect(walk(n.a, pred, repl), walk(n.b, pred, repl), n.tolerance);
+      return B.intersect(walk(n.a, pred, repl, memo), walk(n.b, pred, repl, memo), n.tolerance);
     case 'FuseAll':
       return B.fuseAll(
-        n.shapes.map((c) => walk(c, pred, repl)),
+        n.shapes.map((c) => walk(c, pred, repl, memo)),
         n.tolerance
       );
     case 'CutAll':
       return B.cutAll(
-        walk(n.base, pred, repl),
-        n.tools.map((c) => walk(c, pred, repl)),
+        walk(n.base, pred, repl, memo),
+        n.tools.map((c) => walk(c, pred, repl, memo)),
         n.tolerance
       );
     case 'Translate':
-      return B.translate(walk(n.target, pred, repl), n.vector);
+      return B.translate(walk(n.target, pred, repl, memo), n.vector);
     case 'Rotate':
-      return B.rotate(walk(n.target, pred, repl), n.angle, { axis: n.axis, at: n.at });
+      return B.rotate(walk(n.target, pred, repl, memo), n.angle, { axis: n.axis, at: n.at });
     case 'Scale':
-      return B.scale(walk(n.target, pred, repl), n.factor, { center: n.center });
+      return B.scale(walk(n.target, pred, repl, memo), n.factor, { center: n.center });
     case 'Mirror':
-      return B.mirror(walk(n.target, pred, repl), { normal: n.normal, at: n.at });
+      return B.mirror(walk(n.target, pred, repl, memo), { normal: n.normal, at: n.at });
     case 'Compound':
-      return B.compound(n.children.map((c) => walk(c, pred, repl)));
+      return B.compound(n.children.map((c) => walk(c, pred, repl, memo)));
     case 'Instance':
-      return B.instance(walk(n.source, pred, repl), n.placements, n.fuse);
+      return B.instance(walk(n.source, pred, repl, memo), n.placements, n.fuse);
     case 'Extrude':
     case 'Revolve':
     case 'Loft':
@@ -76,7 +87,7 @@ function rebuildChildren(n: IRNode, pred: NodePredicate, repl: IRNode): IRNode {
     case 'Fillet':
     case 'Chamfer':
     case 'Shell':
-      return rebuildFeature(n, pred, repl);
+      return rebuildFeature(n, pred, repl, memo);
   }
 }
 
@@ -91,36 +102,45 @@ function rebuildFeature(
     | ChamferNode
     | ShellNode,
   pred: NodePredicate,
-  repl: IRNode
+  repl: IRNode,
+  memo: Map<IRNode, IRNode>
 ): IRNode {
   switch (n.kind) {
     case 'Extrude':
-      return B.extrude(walk(n.profile, pred, repl), n.vector);
+      return B.extrude(walk(n.profile, pred, repl, memo), n.vector);
     case 'Revolve':
-      return B.revolve(walk(n.profile, pred, repl), n.angle, { axis: n.axis, at: n.at });
+      return B.revolve(walk(n.profile, pred, repl, memo), n.angle, { axis: n.axis, at: n.at });
     case 'Loft':
       return B.loft(
-        n.sections.map((s) => walk(s, pred, repl)),
+        n.sections.map((s) => walk(s, pred, repl, memo)),
         { ruled: n.ruled }
       );
     case 'Sweep':
-      return B.sweep(walk(n.profile, pred, repl), walk(n.spine, pred, repl), {
+      return B.sweep(walk(n.profile, pred, repl, memo), walk(n.spine, pred, repl, memo), {
         frenet: n.frenet,
       });
     case 'Color':
-      return B.color(walk(n.target, pred, repl), [...n.color]);
+      return B.color(walk(n.target, pred, repl, memo), [...n.color]);
     case 'Fillet':
-      return B.fillet(walk(n.target, pred, repl), n.ref, n.radius);
+      return B.fillet(walk(n.target, pred, repl, memo), n.ref, n.radius);
     case 'Chamfer':
-      return B.chamfer(walk(n.target, pred, repl), n.ref, n.distance);
+      return B.chamfer(walk(n.target, pred, repl, memo), n.ref, n.distance);
     case 'Shell':
-      return B.shell(walk(n.target, pred, repl), n.refs, n.thickness);
+      return B.shell(walk(n.target, pred, repl, memo), n.refs, n.thickness);
   }
 }
 
+/** Visits each DISTINCT node once (identity-deduplicated), so a shared
+ *  subtree is reported once and a self-referencing DAG walks in linear time. */
 export function forEachNode(root: IRNode, fn: (node: IRNode) => void): void {
-  fn(root);
-  for (const child of childrenOf(root)) forEachNode(child, fn);
+  const seen = new Set<IRNode>();
+  const visit = (node: IRNode): void => {
+    if (seen.has(node)) return;
+    seen.add(node);
+    fn(node);
+    for (const child of childrenOf(node)) visit(child);
+  };
+  visit(root);
 }
 
 function childrenOf(n: IRNode): readonly IRNode[] {

--- a/src/csg/optimize.ts
+++ b/src/csg/optimize.ts
@@ -123,7 +123,20 @@ function foldBuildVec(dim: 2 | 3, comps: readonly Expr[]): Expr | undefined {
 // Node-level rewrites
 // ---------------------------------------------------------------------------
 
+// Pure node -> optimized-node rewrite, memoized by identity so a shared
+// subtree rewrites once and a self-referencing DAG optimizes in linear time
+// (results stay valid across calls because the rewrite is deterministic).
+const optimized = new WeakMap<IRNode, IRNode>();
+
 function optimizeNode(n: IRNode): IRNode {
+  const cached = optimized.get(n);
+  if (cached !== undefined) return cached;
+  const out = rewriteNode(n);
+  optimized.set(n, out);
+  return out;
+}
+
+function rewriteNode(n: IRNode): IRNode {
   switch (n.kind) {
     case 'Box':
       return B.box(foldExpr(n.x), foldExpr(n.y), foldExpr(n.z));

--- a/tests/csg/csgCoverage.test.ts
+++ b/tests/csg/csgCoverage.test.ts
@@ -767,10 +767,15 @@ describe('edit — coverage', () => {
     const tree = compound([fuseAll([box(1, 1, 1), sphere(1)]), cutAll(box(2, 2, 2), [sphere(1)])]);
     const edited = replaceNode(tree, (n) => n.kind === 'Sphere', cylinder(1, 1));
     let cyls = 0;
+    let spheres = 0;
     forEachNode(edited, (n) => {
       if (n.kind === 'Cylinder') cyls++;
+      if (n.kind === 'Sphere') spheres++;
     });
-    expect(cyls).toBe(2);
+    // Both sphere slots hold the ONE replacement node; walks are
+    // identity-deduplicated, so it is reported once and no Sphere survives.
+    expect(cyls).toBe(1);
+    expect(spheres).toBe(0);
   });
 
   it('replaceNode handles transforms', () => {

--- a/tests/csg/csgDagWalks.test.ts
+++ b/tests/csg/csgDagWalks.test.ts
@@ -1,0 +1,69 @@
+/**
+ * DAG-aware tree walks — forEachNode/nodeCount/replaceNode/optimize on
+ * self-sharing graphs. Before identity memoization these expanded a shared
+ * DAG to its exponential path count (a 30-level doubling graph has 2^31-1
+ * paths over 31 distinct nodes).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  box,
+  fuse,
+  nodeCount,
+  forEachNode,
+  optimize,
+  replaceNode,
+  type IRNode,
+} from '@/csg/index.js';
+
+function doublingDag(depth: number): IRNode {
+  let node: IRNode = box(1, 1, 1);
+  for (let i = 0; i < depth; i++) {
+    node = fuse(node, node);
+  }
+  return node;
+}
+
+describe('DAG-aware walks', () => {
+  it('nodeCount counts distinct nodes, not paths', () => {
+    const dag = doublingDag(30);
+    expect(nodeCount(dag)).toBe(31);
+  });
+
+  it('forEachNode visits each distinct node once', () => {
+    const dag = doublingDag(30);
+    let visits = 0;
+    forEachNode(dag, () => {
+      visits++;
+    });
+    expect(visits).toBe(31);
+  });
+
+  it('replaceNode evaluates its predicate once per distinct node and preserves sharing', () => {
+    const dag = doublingDag(30);
+    let calls = 0;
+    const edited = replaceNode(
+      dag,
+      (n) => {
+        calls++;
+        return n.kind === 'Box';
+      },
+      box(9, 9, 9)
+    );
+    expect(calls).toBe(31);
+    expect(nodeCount(edited)).toBe(31);
+    // Sharing survives the rebuild: each fuse's two child slots hold the
+    // same rebuilt object.
+    let shared = true;
+    forEachNode(edited, (n) => {
+      if (n.kind === 'Fuse' && n.a !== n.b) shared = false;
+    });
+    expect(shared).toBe(true);
+  });
+
+  it('optimize completes on a deep shared DAG', () => {
+    const dag = doublingDag(40);
+    const out = optimize(dag);
+    expect(nodeCount(out)).toBe(41);
+  });
+});

--- a/tests/csg/csgIR.test.ts
+++ b/tests/csg/csgIR.test.ts
@@ -267,7 +267,11 @@ describe('edit', () => {
   it('replaceNode swaps every matching node', () => {
     const tree = compound([box(1, 1, 1), box(2, 2, 2), sphere(5)]);
     const edited = replaceNode(tree, (n) => n.kind === 'Box', sphere(99));
-    expect(nodeCount(edited)).toBe(nodeCount(tree));
+    // Walks are identity-deduplicated: both Box slots now hold the ONE
+    // replacement node, so the edited tree has 3 distinct nodes to the
+    // original's 4 (Compound + two boxes + sphere).
+    expect(nodeCount(tree)).toBe(4);
+    expect(nodeCount(edited)).toBe(3);
     let boxes = 0;
     forEachNode(edited, (n) => {
       if (n.kind === 'Box') boxes++;


### PR DESCRIPTION
Two independent scale/correctness fixes from the ecosystem audit.

## Memoized IR tree walks

`forEachNode`, `nodeCount`, `replaceNode`, and `optimize` had no visited set, so a self-sharing DAG expanded to its path count: a measured 30-level doubling graph (31 distinct nodes) walked 2^31-1 paths, and `toJSON`-scale graphs made `replaceNode`/`optimize` effectively hang. The IR is content-addressed and deliberately encourages shared subtrees, so this hit exactly the graphs the design rewards.

- Walks are identity-memoized: each distinct node visits once.
- `replaceNode` evaluates its predicate once per distinct node and preserves sharing in the rebuilt output (shared subtrees rebuild once and stay shared).
- `optimize` memoizes its pure rewrite in a WeakMap (deterministic, so results stay valid across calls).
- `nodeCount`'s contract is now distinct nodes, not paths. Two tests asserting path semantics are updated with comments; a new `csgDagWalks.test.ts` pins the linear behavior (visit counts, predicate-call counts, sharing preservation, deep-DAG optimize).

Full csg suite: 353/353 on occt-wasm.

Not addressed here (wire-format design, separate follow-up): `toJSON` still expands DAGs to trees; a `$ref`-table format needs a serialize version bump.

## Registry pinned to the installed release

`brepjs add`/`brepjs diff` defaulted to the registry on `main`, so copied families could drift ahead of the `brepjs-families` package the project compiles against. The default now reads the installed package's version and pins to its release tag (`brepjs-families-v<version>`, which release-please already creates), falling back to `main` when nothing is installed. `--registry` still overrides for self-hosting. Verified live: a sandbox with families 0.7.1 fetches from the v0.7.1 tag ("up to date"), and a bare directory falls back to main.
