### PR TITLE
fix(voxel): adopt as_chunks over chunks_exact for constant chunk sizes

### DIFF
--- a/packages/brepjs-voxel-wasm/src/contour.rs
+++ b/packages/brepjs-voxel-wasm/src/contour.rs
@@ -472,7 +472,7 @@ mod tests {
         }
 
         // Extracted vertices should sit near the cube surface (world coords).
-        for p in mesh.positions.chunks_exact(3) {
+        for p in mesh.positions.as_chunks::<3>().0 {
             assert!(
                 p[0] > -0.5 && p[0] < 1.5 && p[1] > -0.5 && p[1] < 1.5 && p[2] > -0.5 && p[2] < 1.5,
                 "vertex {p:?} is far from the unit cube"
@@ -661,7 +661,7 @@ mod tests {
         }
 
         let mut tris: Vec<[u32; 3]> = Vec::new();
-        for t in m.indices.chunks_exact(3) {
+        for t in m.indices.as_chunks::<3>().0 {
             let mut tri = [remap[t[0] as usize], remap[t[1] as usize], remap[t[2] as usize]];
             // Rotate so the smallest index is first (preserves winding).
             let mn = tri.iter().copied().enumerate().min_by_key(|&(_, v)| v).map(|(i, _)| i).unwrap();
@@ -676,7 +676,7 @@ mod tests {
     fn is_watertight(m: &ContourMesh) -> bool {
         use std::collections::HashMap as Map;
         let mut edges: Map<(u32, u32), i32> = Map::new();
-        for t in m.indices.chunks_exact(3) {
+        for t in m.indices.as_chunks::<3>().0 {
             for &(a, b) in &[(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
                 let k = if a < b { (a, b) } else { (b, a) };
                 *edges.entry(k).or_insert(0) += 1;

--- a/packages/brepjs-voxel-wasm/src/fwn.rs
+++ b/packages/brepjs-voxel-wasm/src/fwn.rs
@@ -50,11 +50,11 @@ impl Mesh {
     /// Build from the flat f32 buffers crossing the wasm boundary.
     pub fn from_flat(verts: &[f32], tris: &[u32]) -> Self {
         let verts = verts
-            .chunks_exact(3)
+            .as_chunks::<3>().0.iter()
             .map(|c| [c[0] as f64, c[1] as f64, c[2] as f64])
             .collect();
         let tris = tris
-            .chunks_exact(3)
+            .as_chunks::<3>().0.iter()
             .map(|c| [c[0] as usize, c[1] as usize, c[2] as usize])
             .collect();
         Mesh { verts, tris }

--- a/packages/brepjs-voxel-wasm/src/lib.rs
+++ b/packages/brepjs-voxel-wasm/src/lib.rs
@@ -121,7 +121,7 @@ fn check_lattice_params(period: f32, thickness: f32) -> Result<(), JsError> {
 fn bbox(verts: &[f32]) -> ([f32; 3], [f32; 3]) {
     let mut min = [f32::INFINITY; 3];
     let mut max = [f32::NEG_INFINITY; 3];
-    for p in verts.chunks_exact(3) {
+    for p in verts.as_chunks::<3>().0 {
         for axis in 0..3 {
             if p[axis] < min[axis] {
                 min[axis] = p[axis];
@@ -717,7 +717,7 @@ impl Sdf {
                 "sweep spine must be flat xyz with at least 2 stations (length 3·N, N >= 2)",
             ));
         }
-        let pts: Vec<[f64; 3]> = spine.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect();
+        let pts: Vec<[f64; 3]> = spine.as_chunks::<3>().0.iter().map(|c| [c[0], c[1], c[2]]).collect();
         if !pts.iter().all(|p| p.iter().all(|c| c.is_finite())) {
             return Err(JsError::new("sweep spine coordinates must be finite"));
         }
@@ -1049,7 +1049,7 @@ fn check_axis(axis: u32) -> Result<usize, JsError> {
 pub fn winding_numbers(verts: &[f32], tris: &[u32], queries: &[f32]) -> Vec<f32> {
     let mesh = fwn::Mesh::from_flat(verts, tris);
     queries
-        .chunks_exact(3)
+        .as_chunks::<3>().0.iter()
         .map(|q| mesh.winding_number([q[0] as f64, q[1] as f64, q[2] as f64]) as f32)
         .collect()
 }
@@ -1062,7 +1062,7 @@ pub fn winding_numbers(verts: &[f32], tris: &[u32], queries: &[f32]) -> Vec<f32>
 pub fn points_inside(verts: &[f32], tris: &[u32], queries: &[f32]) -> Vec<u8> {
     let mesh = fwn::Mesh::from_flat(verts, tris);
     queries
-        .chunks_exact(3)
+        .as_chunks::<3>().0.iter()
         .map(|q| u8::from(mesh.is_inside([q[0] as f64, q[1] as f64, q[2] as f64])))
         .collect()
 }
@@ -1138,7 +1138,7 @@ mod tests {
         let (verts_a, tris_a) = unit_cube();
         // Second cube shifted +0.5 on x so the two overlap.
         let (mut verts_b, tris_b) = unit_cube();
-        for p in verts_b.chunks_exact_mut(3) {
+        for p in verts_b.as_chunks_mut::<3>().0 {
             p[0] += 0.5;
         }
         let r = voxel_boolean(&verts_a, &tris_a, &verts_b, &tris_b, 0, 24, 2)
@@ -1161,7 +1161,7 @@ mod tests {
     fn boolean_of_co_registers_and_is_chainable() {
         let (verts_a, tris_a) = unit_cube();
         let (mut verts_b, tris_b) = unit_cube();
-        for p in verts_b.chunks_exact_mut(3) {
+        for p in verts_b.as_chunks_mut::<3>().0 {
             p[0] += 0.5;
         }
         let field = VoxelField::boolean_of(&verts_a, &tris_a, &verts_b, &tris_b, 0, 24, 2)
@@ -1184,7 +1184,7 @@ mod tests {
     fn offset_after_union_reinit_changes_surface() {
         let (verts_a, tris_a) = unit_cube();
         let (mut verts_b, tris_b) = unit_cube();
-        for p in verts_b.chunks_exact_mut(3) {
+        for p in verts_b.as_chunks_mut::<3>().0 {
             p[0] += 0.5;
         }
         let d = 0.2_f32;
@@ -1205,7 +1205,7 @@ mod tests {
         // The reinit shifts the min/max-blended join saddle, so the two contoured
         // surfaces are NOT identical: their max-extent differs near the join.
         let extent = |pos: &[f32]| {
-            pos.chunks_exact(3)
+            pos.as_chunks::<3>().0.iter()
                 .fold(f32::NEG_INFINITY, |m, p| m.max(p[1]).max(p[0]).max(p[2]))
         };
         let e_with = extent(&with_mesh.positions);

--- a/packages/brepjs-voxel-wasm/src/ops.rs
+++ b/packages/brepjs-voxel-wasm/src/ops.rs
@@ -1304,7 +1304,7 @@ mod tests {
         let bbox = |pos: &[f32]| {
             let mut lo = [f32::INFINITY; 3];
             let mut hi = [f32::NEG_INFINITY; 3];
-            for p in pos.chunks_exact(3) {
+            for p in pos.as_chunks::<3>().0 {
                 for d in 0..3 {
                     lo[d] = lo[d].min(p[d]);
                     hi[d] = hi[d].max(p[d]);
@@ -1600,12 +1600,12 @@ mod tests {
             let h = g.spacing();
             let before_pts: Vec<[f32; 3]> = before
                 .positions
-                .chunks_exact(3)
+                .as_chunks::<3>().0.iter()
                 .map(|p| [p[0], p[1], p[2]])
                 .collect();
             let after_pts: Vec<[f32; 3]> = after
                 .positions
-                .chunks_exact(3)
+                .as_chunks::<3>().0.iter()
                 .map(|p| [p[0], p[1], p[2]])
                 .collect();
             let mut max_drift = 0.0f32;
@@ -1694,7 +1694,7 @@ mod tests {
         let join_y_extent = |g: &Grid| -> f32 {
             let m = surface_nets_mesh(g);
             let mut max_y = f32::NEG_INFINITY;
-            for p in m.positions.chunks_exact(3) {
+            for p in m.positions.as_chunks::<3>().0 {
                 // Slab around the join plane x ≈ 0.3, near z = 0.
                 if (p[0] - 0.3).abs() < 0.15 && p[2].abs() < 0.15 {
                     max_y = max_y.max(p[1]);

--- a/packages/brepjs-voxel-wasm/src/sdf/expr.rs
+++ b/packages/brepjs-voxel-wasm/src/sdf/expr.rs
@@ -1187,7 +1187,7 @@ mod tests {
         assert!(!mesh.indices.is_empty(), "modulated shell must contour to triangles");
 
         let mut edges: HashMap<(u32, u32), i32> = HashMap::new();
-        for tri in mesh.indices.chunks_exact(3) {
+        for tri in mesh.indices.as_chunks::<3>().0 {
             for &(a, b) in &[(tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])] {
                 let key = if a < b { (a, b) } else { (b, a) };
                 *edges.entry(key).or_insert(0) += 1;
@@ -1204,7 +1204,7 @@ mod tests {
     fn watertight(indices: &[u32]) -> bool {
         use std::collections::HashMap;
         let mut edges: HashMap<(u32, u32), i32> = HashMap::new();
-        for tri in indices.chunks_exact(3) {
+        for tri in indices.as_chunks::<3>().0 {
             for &(a, b) in &[(tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])] {
                 let key = if a < b { (a, b) } else { (b, a) };
                 *edges.entry(key).or_insert(0) += 1;

--- a/packages/brepjs-voxel-wasm/src/sdf/mod.rs
+++ b/packages/brepjs-voxel-wasm/src/sdf/mod.rs
@@ -314,7 +314,7 @@ mod tests {
     /// Every undirected edge is shared by exactly two triangles.
     fn is_watertight(indices: &[u32]) -> bool {
         let mut edges: HashMap<(u32, u32), i32> = HashMap::new();
-        for t in indices.chunks_exact(3) {
+        for t in indices.as_chunks::<3>().0 {
             for &(a, b) in &[(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
                 let k = if a < b { (a, b) } else { (b, a) };
                 *edges.entry(k).or_insert(0) += 1;
@@ -326,7 +326,7 @@ mod tests {
     fn flat_bbox(verts: &[f32]) -> ([f32; 3], [f32; 3]) {
         let mut mn = [f32::INFINITY; 3];
         let mut mx = [f32::NEG_INFINITY; 3];
-        for p in verts.chunks_exact(3) {
+        for p in verts.as_chunks::<3>().0 {
             for a in 0..3 {
                 mn[a] = mn[a].min(p[a]);
                 mx[a] = mx[a].max(p[a]);


### PR DESCRIPTION
The CI runner's clippy 1.98 added `chunks_exact_to_as_chunks`, and the voxel-wasm-rust job runs `cargo clippy --all-targets -- -D warnings`, so every PR whose paths trigger the job (anything touching ci.yml or the crate) went red on lint alone; cargo tests were green. Currently blocking #2186.

All fixed-size-3 chunking moves to `as_chunks`/`as_chunks_mut` (stable since Rust 1.88): `for` loops iterate `.0` directly, chained iterator uses go through `.0.iter()`. Behavior identical.

Validation: 122/122 cargo tests pass and `cargo clippy --all-targets -- -D warnings` is clean on local 1.97; CI's 1.98 confirms the new lint.