### PR TITLE
fix(families): give the dome roof a true hemispherical cap

### DIFF
--- a/packages/brepjs-families/registry/families/roof.ts
+++ b/packages/brepjs-families/registry/families/roof.ts
@@ -1,14 +1,13 @@
-// brepjs-family: roof@1
+// brepjs-family: roof@2
 /**
  * Roof — a rectangular roof over a corner-origin length × width footprint.
  * Props feed the IFC roof spec 1:1 in a BIM projection. Presence of `pitch`
  * opts into shaped geometry for the predefinedType (shed / gable / hip /
  * dome), matching the spec-solid rule; flat otherwise. Flat, shed, and gable
  * renders reproduce the spec solid exactly; hip is the intersection of two
- * gable prisms (the classic construction) and dome is a stepped stack of
- * 24-gon prisms over the spec path's hull rings. Both use planar faces only:
- * lofted, conical, and spherical surfaces all hang the occt-wasm mesher. The
- * IFC body stays authoritative.
+ * gable prisms (the classic construction); dome is a true hemispherical cap
+ * clipped to the footprint. The IFC body (tessellated hull rings for the
+ * dome) stays authoritative.
  */
 
 import { csg } from 'brepjs';
@@ -98,23 +97,10 @@ function hipNode(l: number, w: number, pitch: number): csg.IRNode {
 
 function domeNode(l: number, w: number): csg.IRNode {
   const r = Math.min(l, w) / 2;
-  const cx = l / 2;
-  const cy = w / 2;
-  const segments = 24;
-  const rings = [0, 0.4, 0.7, 0.9, 0.995];
-  const steps: csg.IRNode[] = [];
-  for (let i = 0; i < rings.length - 1; i++) {
-    const h0 = rings[i] ?? 0;
-    const h1 = rings[i + 1] ?? 0;
-    const ringR = r * Math.sqrt(1 - h0 * h0);
-    const pts: Array<[number, number, number]> = [];
-    for (let j = 0; j < segments; j++) {
-      const a = (2 * Math.PI * j) / segments;
-      pts.push([cx + ringR * Math.cos(a), cy + ringR * Math.sin(a), r * h0]);
-    }
-    steps.push(csg.extrude(csg.polygon(pts), [0, 0, r * (h1 - h0)]));
-  }
-  return csg.fuseAll(steps);
+  // A real hemispherical cap: the sphere at footprint center, clipped to the
+  // upper half by the footprint box. Default meshing is scale-relative, so
+  // the curved surface tessellates sanely even at mm building scale.
+  return csg.intersect(csg.translate(csg.sphere(r), [l / 2, w / 2, 0]), csg.box(l, w, r));
 }
 
 function roofNode(p: z.output<typeof roofSchema>): csg.IRNode {

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "roof",
-      "version": 1,
+      "version": 2,
       "description": "Rectangular roof (flat / shed / gable / hip / dome) mapping onto IfcRoof",
       "files": ["families/roof.ts"],
       "npmDeps": ["brepjs", "brepjs-families", "zod"],

--- a/packages/brepjs-families/tests/registry.test.ts
+++ b/packages/brepjs-families/tests/registry.test.ts
@@ -12,7 +12,7 @@ import { dirname, join } from 'node:path';
 import { describe, expect, it, beforeAll } from 'vitest';
 import { z } from 'zod';
 import { initOCCT } from '../../../tests/setup.js';
-import { csg, isOk } from 'brepjs';
+import { csg, isOk, measureVolume, unwrap } from 'brepjs';
 import { resolve, evaluateModel } from '../src/index.js';
 import { Room } from '../registry/families/room.js';
 import { Storey } from '../registry/families/storey.js';
@@ -200,6 +200,23 @@ describe('starter families', () => {
     const model = evaluateModel(storey, ev);
     const roof = model.byKeyPath.get(`s/${shape['key'] as string}`);
     expect(roof && isOk(roof.mesh)).toBe(true);
+  });
+
+  it('the dome roof is a true hemispherical cap', () => {
+    using ev = new csg.Evaluator();
+    const storey = resolve(
+      Storey({
+        key: 's',
+        items: [Roof({ ...ROOF_DIMS, key: 'dome', predefinedType: 'DOME_ROOF', pitch: 1 })],
+      })
+    );
+    const model = evaluateModel(storey, ev, {}, { shapes: true });
+    const shape = model.byKeyPath.get('s/dome')?.shape;
+    expect(shape !== undefined && isOk(shape)).toBe(true);
+    if (shape && isOk(shape)) {
+      const r = Math.min(ROOF_DIMS.length, ROOF_DIMS.width) / 2;
+      expect(unwrap(measureVolume(unwrap(shape)))).toBeCloseTo((2 / 3) * Math.PI * r ** 3, -7);
+    }
   });
 
   it('a two-flight return stair materializes', () => {


### PR DESCRIPTION
The registry roof family's dome was a stepped stack of 24-gon prisms, built when the recorded diagnosis was 'occt-wasm mesher hangs on lofted/conical/spherical surfaces via the IR'. That diagnosis traced to the absolute default mesh deflection exploding at mm scale, fixed in #2187 by the scale-relative default.

roof@2 renders the dome as a true hemispherical cap (sphere clipped to the footprint box). A new registry test evaluates it at BIM scale (8000x5000 footprint) and pins the hemisphere volume; the existing materialization matrix still passes. The IFC body (tessellated hull rings from the spec path) stays authoritative, as before.

Validation: brepjs-families registry suite 20/20, typecheck + lint clean.