### PR TITLE
feat(families): typed JSX intrinsics and a compiled-path gate

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -314,6 +314,7 @@ export default withMermaid(
             { text: 'Elements, Key Paths & Identity', link: '/families/identity' },
             { text: 'Openings & Voids', link: '/families/openings' },
             { text: 'Props & Validation', link: '/families/props-and-validation' },
+            { text: 'JSX Authoring', link: '/families/jsx' },
             { text: 'IFC Export', link: '/families/ifc-export' },
             { text: 'Copy-In Distribution', link: '/families/copy-in' },
           ],

--- a/apps/docs/families/jsx.md
+++ b/apps/docs/families/jsx.md
@@ -1,0 +1,78 @@
+---
+title: JSX Authoring
+description: 'Author family trees as JSX: tsconfig setup, imported intrinsic components, children idioms, and how validation behaves identically to the plain-function API.'
+---
+
+# JSX Authoring
+
+Every family tree in this section can also be written as JSX. Nothing about the model changes: a JSX tag calls the same component function, so zod validation, defaults, and identity props behave identically. The plain-function API stays primary; JSX is sugar for people (and reviews) that read component trees best.
+
+## Setup
+
+Point your `tsconfig.json` at the runtime that ships inside `brepjs-families`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "brepjs-families"
+  }
+}
+```
+
+Name the file `.tsx` and you're done. No React involved: the runtime builds the same plain `Element` objects `family()` and `el()` do.
+
+## Components and intrinsics
+
+Family components work as tags directly. The intrinsic vocabulary (`Box`, `Cylinder`, `Geometry`, `Group`) is exported as typed components, because JSX resolves capitalized tags to imports:
+
+```tsx
+import { Box, Group, family, resolve, type FamilyChildren } from 'brepjs-families';
+import { z } from 'zod';
+
+const wallSchema = z.object({
+  length: z.number().positive(),
+  height: z.number().positive(),
+  thickness: z.number().positive().default(200),
+});
+
+const Wall = family(
+  'Wall',
+  (p: z.output<typeof wallSchema>) => <Box size={[p.length, p.thickness, p.height]} />,
+  { props: wallSchema }
+);
+
+const Storey = family<{ children?: FamilyChildren }>('Storey', (p) => <Group>{p.children}</Group>);
+
+const tree = resolve(
+  <Storey key="ground">
+    <Wall key="south" length={4000} height={2700} />
+    <Wall key="north" length={4000} height={2700} />
+  </Storey>
+);
+```
+
+Invalid props throw at element construction, exactly as on the function path. `key` works on every tag and is what [key-path identity](/families/identity) derives from, so keep keys on anything a BIM export will touch.
+
+## Children idioms
+
+Children reach the render function as `props.children`, already flattened and cleaned, so the usual React idioms compose:
+
+```tsx
+<Storey key="g">
+  {showPorch && <Wall key="porch" length={2000} height={1100} />}
+  {rooms.map((r) => (
+    <Room key={r.id} width={r.w} depth={r.d} height={2700} />
+  ))}
+  <>
+    <Wall key="a" length={100} height={100} />
+    <Wall key="b" length={100} height={100} />
+  </>
+</Storey>
+```
+
+Conditionals that evaluate to `false`/`null` disappear, nested arrays flatten, and fragments inline without contributing a key-path segment. Declare a children prop as `FamilyChildren` to accept all of that; resolution hands your render a flat `Element[]`.
+
+## When to prefer the function form
+
+The two forms produce hash-identical trees, so this is style, not capability. Reach for plain calls when you're generating elements programmatically (loops over data, builders), and JSX when a human reviews the model shape: a storey of keyed walls reads like the building it describes.

--- a/packages/brepjs-families/eslint.config.js
+++ b/packages/brepjs-families/eslint.config.js
@@ -24,7 +24,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['tests/**/*.ts', 'registry/**/*.ts'],
+    files: ['tests/**/*.{ts,tsx}', 'registry/**/*.ts'],
     languageOptions: {
       parserOptions: {
         project: './tsconfig.test.json',

--- a/packages/brepjs-families/package.json
+++ b/packages/brepjs-families/package.json
@@ -28,7 +28,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.jsx.json --noEmit",
     "lint": "eslint src tests registry",
     "test": "vitest run"
   },

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -17,8 +17,12 @@ interface WithKey {
   readonly key?: string | undefined;
 }
 
+/** What a caller (JSX or direct) may pass as children: single, nested arrays,
+ *  and conditional results. Normalized to a flat Element[] before render. */
+export type FamilyChildren = Element | boolean | null | undefined | readonly FamilyChildren[];
+
 interface WithChildren {
-  readonly children?: Element | readonly Element[] | undefined;
+  readonly children?: FamilyChildren;
 }
 
 /** Flatten nested child arrays and drop null/undefined/boolean, so JSX idioms

--- a/packages/brepjs-families/src/index.ts
+++ b/packages/brepjs-families/src/index.ts
@@ -12,10 +12,12 @@ export {
   IDENTITY_PROPS,
   type Element,
   type FamilyComponent,
+  type FamilyChildren,
   type FamilyOptions,
   type IdentityProps,
 } from './element.js';
 export { jsx, jsxs, jsxDEV, Fragment } from './jsxRuntime.js';
+export { Box, Cylinder, Geometry, Group, type IntrinsicProps } from './intrinsics.js';
 export {
   resolve,
   tTranslate,

--- a/packages/brepjs-families/src/intrinsics.ts
+++ b/packages/brepjs-families/src/intrinsics.ts
@@ -1,0 +1,43 @@
+/**
+ * Typed intrinsic components. JSX resolves capitalized tags to in-scope
+ * identifiers, so `<Box size={...}/>` needs a real export — these wrap `el()`
+ * with the intrinsic vocabulary's prop types, and work identically as plain
+ * function calls. `el(type, props)` stays the untyped low-level form.
+ */
+
+import type { csg } from 'brepjs';
+import { el, normalizeChildren, type Element, type FamilyChildren } from './element.js';
+import type { TransformOp } from './resolve.js';
+
+export interface IntrinsicProps {
+  readonly key?: string | undefined;
+  readonly voids?: readonly Element[] | undefined;
+  readonly fuse?: readonly Element[] | undefined;
+  readonly transform?: readonly TransformOp[] | undefined;
+  readonly children?: FamilyChildren;
+}
+
+function intrinsic(type: string, props: IntrinsicProps): Element {
+  const { children, ...rest } = props;
+  return el(type, rest, normalizeChildren(children));
+}
+
+export function Box(
+  props: IntrinsicProps & { readonly size: readonly [number, number, number] }
+): Element {
+  return intrinsic('Box', props);
+}
+
+export function Cylinder(
+  props: IntrinsicProps & { readonly radius: number; readonly height: number }
+): Element {
+  return intrinsic('Cylinder', props);
+}
+
+export function Geometry(props: IntrinsicProps & { readonly node: csg.IRNode }): Element {
+  return intrinsic('Geometry', props);
+}
+
+export function Group(props: IntrinsicProps = {}): Element {
+  return intrinsic('Group', props);
+}

--- a/packages/brepjs-families/src/jsxRuntime.ts
+++ b/packages/brepjs-families/src/jsxRuntime.ts
@@ -7,7 +7,29 @@
  * paths.
  */
 
-import { isFamily, normalizeChildren, type Element, type FamilyComponent } from './element.js';
+import {
+  isFamily,
+  normalizeChildren,
+  type Element as ElementModel,
+  type FamilyComponent,
+} from './element.js';
+
+type Element = ElementModel;
+
+// The compiler reads this namespace off the module named by `jsxImportSource`;
+// it is what makes `.tsx` components, keys, and children type-check. There are
+// no lowercase intrinsic tags: Box/Cylinder/Geometry/Group are real exported
+// components (see intrinsics.ts), typed by their own signatures.
+// eslint-disable-next-line @typescript-eslint/no-namespace -- TS's contract for typed JSX
+export namespace JSX {
+  export type Element = ElementModel;
+  export interface ElementChildrenAttribute {
+    children: unknown;
+  }
+  export interface IntrinsicAttributes {
+    readonly key?: string | undefined;
+  }
+}
 
 export function jsx(
   type: string | FamilyComponent<never>,

--- a/packages/brepjs-families/tests/familiesJsx.test.tsx
+++ b/packages/brepjs-families/tests/familiesJsx.test.tsx
@@ -1,0 +1,80 @@
+/** @jsxRuntime automatic @jsxImportSource brepjs-families */
+/**
+ * Typed JSX authoring — the real compiler path (react-jsx transform through
+ * `jsxImportSource: "brepjs-families"`), not direct jsx() calls. Pure data:
+ * resolution builds IR nodes without a kernel, so no WASM setup here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { Box, Group, family, resolve, tTranslate, type FamilyChildren } from '../src/index.js';
+
+const wallSchema = z.object({
+  length: z.number().positive(),
+  height: z.number().positive(),
+  thickness: z.number().positive().default(200),
+});
+
+const Wall = family(
+  'Wall',
+  (p: z.output<typeof wallSchema>) => <Box size={[p.length, p.thickness, p.height]} />,
+  { props: wallSchema }
+);
+
+const Storey = family<{ readonly children?: FamilyChildren }>('Storey', (p) => (
+  <Group>{p.children}</Group>
+));
+
+describe('typed JSX authoring', () => {
+  it('compiles intrinsics and components, applying schema defaults', () => {
+    const tree = resolve(
+      <Storey key="ground">
+        <Wall key="south" length={4000} height={2700} />
+      </Storey>
+    );
+    const wall = tree.children[0];
+    expect(wall?.keyPath).toBe('ground/south');
+    expect(wall?.props['thickness']).toBe(200);
+  });
+
+  it('rejects invalid props on the JSX path', () => {
+    expect(() => <Wall key="bad" length={-1} height={2700} />).toThrow(/invalid props/);
+  });
+
+  it('conditional and mapped children compose', () => {
+    const show = false;
+    const tree = resolve(
+      <Storey key="g">
+        {show && <Wall key="hidden" length={100} height={100} />}
+        {[1, 2].map((i) => (
+          <Wall key={`w${i}`} length={1000 * i} height={2700} />
+        ))}
+      </Storey>
+    );
+    expect(tree.children.map((c) => c.keyPath)).toEqual(['g/w1', 'g/w2']);
+  });
+
+  it('fragments inline without a key-path segment', () => {
+    const tree = resolve(
+      <Storey key="g">
+        <>
+          <Wall key="a" length={100} height={100} />
+          <Wall key="b" length={100} height={100} />
+        </>
+      </Storey>
+    );
+    expect(tree.children.map((c) => c.keyPath)).toEqual(['g/a', 'g/b']);
+  });
+
+  it('intrinsic transform and voids props type-check and resolve', () => {
+    const Bin = family<{ readonly size: number }>('Bin', (p) => (
+      <Box
+        size={[p.size, p.size, p.size]}
+        voids={[<Box size={[p.size / 2, p.size / 2, p.size / 2]} />]}
+        transform={[tTranslate([1, 2, 3])]}
+      />
+    ));
+    const tree = resolve(<Bin key="b" size={10} />);
+    expect(tree.geometry.kind).toBe('Translate');
+  });
+});

--- a/packages/brepjs-families/tsconfig.jsx.json
+++ b/packages/brepjs-families/tsconfig.jsx.json
@@ -1,9 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../..",
+    "rootDir": ".",
     "noEmit": true,
-    "types": ["node"],
     "jsx": "react-jsx",
     "jsxImportSource": "brepjs-families",
     "paths": {
@@ -12,6 +11,6 @@
       "brepjs-families": ["./src/index.ts"]
     }
   },
-  "include": ["tests/**/*.ts", "tests/**/*.tsx", "registry/**/*.ts", "src/**/*.ts"],
+  "include": ["tests/**/*.tsx", "src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/brepjs-families/vitest.config.ts
+++ b/packages/brepjs-families/vitest.config.ts
@@ -3,16 +3,31 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
-    alias: {
-      '@': resolve(__dirname, '../../src'),
-      brepjs: resolve(__dirname, '../../src/index.ts'),
-    },
+    // Array form: the jsx-runtime entry must win before the bare package
+    // prefix, so the automatic-JSX import resolves to source.
+    alias: [
+      {
+        find: 'brepjs-families/jsx-dev-runtime',
+        replacement: resolve(__dirname, 'src/jsxRuntime.ts'),
+      },
+      {
+        find: 'brepjs-families/jsx-runtime',
+        replacement: resolve(__dirname, 'src/jsxRuntime.ts'),
+      },
+      { find: 'brepjs-families', replacement: resolve(__dirname, 'src/index.ts') },
+      { find: 'brepjs', replacement: resolve(__dirname, '../../src/index.ts') },
+      { find: '@', replacement: resolve(__dirname, '../../src') },
+    ],
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'brepjs-families',
   },
   test: {
     globals: true,
     testTimeout: 90000,
     pool: 'forks',
     execArgv: ['--max-old-space-size=6144'],
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.{ts,tsx}'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,6 +61,16 @@ export default defineConfig({
       // the last-published dist) and don't need a dist build in CI.
       'brepjs-sheetmetal': resolve(__dirname, 'packages/brepjs-sheetmetal/src/index.ts'),
       'brepjs-bim': resolve(__dirname, 'packages/brepjs-bim/src/index.ts'),
+      // Subpath entries first: object-form aliases are exact-match, so the
+      // automatic-JSX runtime imports need their own rows (no dist in CI).
+      'brepjs-families/jsx-runtime': resolve(
+        __dirname,
+        'packages/brepjs-families/src/jsxRuntime.ts'
+      ),
+      'brepjs-families/jsx-dev-runtime': resolve(
+        __dirname,
+        'packages/brepjs-families/src/jsxRuntime.ts'
+      ),
       'brepjs-families': resolve(__dirname, 'packages/brepjs-families/src/index.ts'),
     },
   },


### PR DESCRIPTION
## Problem

From the ecosystem audit: JSX had a runtime but no typed or executable venue anywhere in the repo. Beyond that, the design had a hole the first `.tsx` file exposed: JSX resolves capitalized tags to in-scope identifiers, so the `el`-style intrinsic vocabulary (`Box`, `Group`, ...) could not be written as JSX at all.

## Fix

- **Typed intrinsic components** (`src/intrinsics.ts`): `Box`, `Cylinder`, `Geometry`, `Group` ship as real exported components wrapping `el()`, typed by their own signatures (size/radius/node plus the shared voids/fuse/transform/children props). They work identically as plain function calls.
- **JSX namespace** on the runtime types components, `key`, and children. No lowercase intrinsic tags: everything is an import, so there is no global `IntrinsicElements` surface to maintain.
- **`FamilyChildren`** models what JSX may pass (single child, nested arrays, conditional results, fragments); `normalizeChildren` already flattens it to `Element[]` before render, and it is now the exported type for components that accept children.
- **A compiled-path gate**: `tests/familiesJsx.test.tsx` exercises the real react-jsx transform (esbuild `@jsxImportSource` pragma) end to end — schema defaults and validation on the JSX path, conditional and mapped children, fragment inlining, transform/voids props. `tsconfig.jsx.json` type-checks it as part of `npm run typecheck`.
- **Typed linting repaired**: the families eslint config always referenced a `tsconfig.test.json` that did not exist; it now does (backing tests + registry typed linting, with `@types/node`), and the tests glob covers `.tsx`.
- **Docs**: new [JSX Authoring](https://brepjs.dev/families/jsx) page (setup, imported intrinsics, children idioms, when to prefer the function form), wired into the sidebar.

## Validation

brepjs-families: 55/55 tests (5 new through the real compiler path), both typecheck configs, lint, and build clean. `npm run docs:build` (dead-link validation) passes.

Not in this PR: playground JSX examples (the worker's sucrase pipeline would need per-example `.tsx` flagging so the jsx transform doesn't misparse generics in plain-TS examples), and the create-brepjs template's `jsx` tsconfig keys (follows once #2186 merges to avoid a template conflict).
