### PR TITLE
feat(bim): proxy escape hatch for unrouted families geometry

### DIFF
--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -308,15 +308,6 @@ function addProxyElement(
       )
     );
   }
-  if (!isSolid(copy.value)) {
-    copy.value[Symbol.dispose]();
-    return err(
-      specError(
-        'FAMILIES_PROXY_NOT_SOLID',
-        `familiesToBim: '${el.keyPath}' materialized to a non-solid — a proxy body must be a solid`
-      )
-    );
-  }
   const valid = validSolid(copy.value);
   if (!valid.ok) {
     copy.value[Symbol.dispose]();

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -13,7 +13,7 @@
  * the uncut spec body would silently diverge from what the user sees.
  */
 
-import { ok, err, type Result, type csg } from 'brepjs';
+import { clone, err, isSolid, ok, validSolid, type Result, type csg } from 'brepjs';
 import type { ResolvedElement } from 'brepjs-families';
 import { BimModel, type OpeningIdentityOptions } from './model/bimModel.js';
 import type { LocalId } from './identity/localId.js';
@@ -24,6 +24,7 @@ import { parseBeamSpec } from './specs/beamSpec.js';
 import { parseRoofSpec } from './specs/roofSpec.js';
 import { parseStairSpec } from './specs/stairSpec.js';
 import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
+import type { ProxySpec } from './specs/proxySpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
 import { specError, type BimError } from './errors/bimError.js';
 import type { FillsOpeningRel } from './types/relationships.js';
@@ -32,6 +33,15 @@ export interface FamiliesToBimOptions {
   readonly project: ProjectSpec;
   readonly siteName?: string | undefined;
   readonly buildingName?: string | undefined;
+  /**
+   * Enables the proxy route: an unrouted geometry-bearing element is
+   * materialized through this evaluator and exported as an
+   * IfcBuildingElementProxy (tessellated, world-frame body). Without it,
+   * unrouted types stay a hard FAMILIES_UNSUPPORTED_TYPE error. The
+   * evaluator's handles stay borrowed; the adapter clones what it hands the
+   * model.
+   */
+  readonly proxyEvaluator?: csg.Evaluator | undefined;
 }
 
 export interface FamiliesBimResult {
@@ -252,6 +262,72 @@ function addFill(
   );
 }
 
+/** Materialize an unrouted element's IR and add it as a proxy. The body is
+ *  authoritative for a proxy (no parametric spec to diverge from), so baked
+ *  transforms — rotations included — are fine here. */
+function addProxyElement(
+  model: BimModel,
+  el: ResolvedElement,
+  evaluator: csg.Evaluator
+): Result<LocalId, BimError> {
+  const evaluated = evaluator.evaluate(el.geometry);
+  if (!evaluated.ok) {
+    return err(
+      specError(
+        'FAMILIES_PROXY_EVAL_FAILED',
+        `familiesToBim: '${el.keyPath}' failed to materialize for the proxy route: ${evaluated.error.message}`,
+        evaluated.error
+      )
+    );
+  }
+  // The evaluator owns its handles and addProxy takes ownership of the solid,
+  // so hand the model an independent copy.
+  const copy = clone(evaluated.value);
+  if (!copy.ok) {
+    return err(
+      specError(
+        'FAMILIES_PROXY_EVAL_FAILED',
+        `familiesToBim: '${el.keyPath}' could not copy the materialized body`,
+        copy.error
+      )
+    );
+  }
+  if (!isSolid(copy.value)) {
+    copy.value[Symbol.dispose]();
+    return err(
+      specError(
+        'FAMILIES_PROXY_NOT_SOLID',
+        `familiesToBim: '${el.keyPath}' materialized to a non-solid — a proxy body must be a solid`
+      )
+    );
+  }
+  const valid = validSolid(copy.value);
+  if (!valid.ok) {
+    copy.value[Symbol.dispose]();
+    return err(
+      specError(
+        'FAMILIES_PROXY_INVALID',
+        `familiesToBim: '${el.keyPath}' materialized to an invalid solid: ${valid.error}`
+      )
+    );
+  }
+  const nameAttr = el.attributes['name'];
+  const materialProp = el.props['materialName'];
+  const specProps = collectSpecProps(el);
+  return model.addProxy(
+    {
+      name: typeof nameAttr === 'string' ? nameAttr : el.type,
+      solid: valid.value,
+      materialName:
+        typeof materialProp === 'string'
+          ? materialProp
+          : (specProps['materialName'] as string | undefined),
+      customProperties: specProps['customProperties'] as ProxySpec['customProperties'],
+    },
+    { stableKey: el.keyPath }
+  );
+}
+
 /** Map a wall's synthesized Opening children onto addDoor/addWindow. The
  *  wall-relative offsets come from the void geometry's frame minus the host's:
  *  exact because both carry the same outer host transform. */
@@ -428,12 +504,28 @@ export function familiesToBim(
         )
       );
     } else if (el.type !== 'Group' && el.geometry.kind !== 'Empty') {
-      return err(
-        specError(
-          'FAMILIES_UNSUPPORTED_TYPE',
-          `familiesToBim: no spec mapping for element type '${el.type}' at '${el.keyPath}'`
-        )
-      );
+      if (options.proxyEvaluator === undefined) {
+        return err(
+          specError(
+            'FAMILIES_UNSUPPORTED_TYPE',
+            `familiesToBim: no spec mapping for element type '${el.type}' at '${el.keyPath}' — add a spec route, or pass proxyEvaluator to export it as an IfcBuildingElementProxy`
+          )
+        );
+      }
+      const keyed = requireKeyed(el);
+      if (!keyed.ok) return keyed;
+      if (containerId === null) {
+        return err(
+          specError(
+            'FAMILIES_NO_STOREY',
+            `familiesToBim: '${el.keyPath}' has no Storey ancestor — IFC elements need spatial containment`
+          )
+        );
+      }
+      const added = addProxyElement(model, el, options.proxyEvaluator);
+      if (!added.ok) return added;
+      model.placeIn(added.value, containerId);
+      idByKeyPath.set(el.keyPath, added.value);
     }
     for (const child of el.children) {
       if (el.type === 'Wall' && child.type === 'Opening') continue;

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -13,7 +13,7 @@
  * the uncut spec body would silently diverge from what the user sees.
  */
 
-import { clone, err, isSolid, ok, validSolid, type Result, type csg } from 'brepjs';
+import { clone, err, getSolids, isSolid, ok, validSolid, type Result, type csg } from 'brepjs';
 import type { ResolvedElement } from 'brepjs-families';
 import { BimModel, type OpeningIdentityOptions } from './model/bimModel.js';
 import type { LocalId } from './identity/localId.js';
@@ -280,9 +280,25 @@ function addProxyElement(
       )
     );
   }
-  // The evaluator owns its handles and addProxy takes ownership of the solid,
-  // so hand the model an independent copy.
-  const copy = clone(evaluated.value);
+  // Booleans can materialize as a compound wrapping one solid; accept that,
+  // reject anything that is not exactly one solid body.
+  let source = evaluated.value;
+  if (!isSolid(source)) {
+    const solids = getSolids(source);
+    const only = solids.length === 1 ? solids[0] : undefined;
+    if (only === undefined) {
+      return err(
+        specError(
+          'FAMILIES_PROXY_NOT_SOLID',
+          `familiesToBim: '${el.keyPath}' materialized to ${solids.length} solids — a proxy body must be exactly one`
+        )
+      );
+    }
+    source = only;
+  }
+  // The evaluator (or its topology cache) owns `source`; addProxy takes
+  // ownership of what it is handed, so give the model an independent copy.
+  const copy = clone(source);
   if (!copy.ok) {
     return err(
       specError(
@@ -436,6 +452,7 @@ export function familiesToBim(
     // A rotate op anywhere on the ancestor chain taints every routed
     // descendant: inherited transforms carry it into their geometry.
     const rotatedHere = rotated || hasRotateOp(el);
+    let proxied = false;
     let containerId = storeyId;
     const route = specRoute(el.type);
     if (el.type === 'Storey') {
@@ -526,9 +543,13 @@ export function familiesToBim(
       if (!added.ok) return added;
       model.placeIn(added.value, containerId);
       idByKeyPath.set(el.keyPath, added.value);
+      proxied = true;
     }
     for (const child of el.children) {
-      if (el.type === 'Wall' && child.type === 'Opening') continue;
+      // A wall's openings were mapped by addOpenings; a proxy's are baked
+      // into its authoritative tessellated body — neither wants the
+      // outside-wall rejection on the synthesized Opening child.
+      if ((el.type === 'Wall' || proxied) && child.type === 'Opening') continue;
       const r = walk(child, containerId, rotatedHere);
       if (!r.ok) return r;
     }

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -202,6 +202,30 @@ describe('registry families through familiesToBim', () => {
     expect(text).toContain('Granite');
   });
 
+  it('a proxied element with a fill-role void keeps its baked opening', () => {
+    const Slot = family<{ readonly w: number }>(
+      'Slot',
+      (p) => el('Box', { size: [p.w, 400, 400] }),
+      {
+        role: 'fill',
+      }
+    );
+    const Cabin = family<{ readonly size: number }>('Cabin', (p) =>
+      el('Geometry', {
+        node: csg.box(p.size, p.size, p.size),
+        voids: [Slot({ key: 'hatch', w: 600 })],
+      })
+    );
+    const tree = resolve(Storey({ key: 'g', items: [Cabin({ key: 'cabin', size: 2000 })] }));
+    using ev = new csg.Evaluator();
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT, proxyEvaluator: ev }));
+    using model = projected.model;
+    // The body is authoritative: the hole is baked into the tessellated proxy,
+    // and the synthesized Opening child must not trip the wall-only mapping.
+    expect(model.getProxies()).toHaveLength(1);
+    expect(projected.idByKeyPath.has('g/cabin')).toBe(true);
+  });
+
   it('rejects an anonymous void instead of silently diverging the IFC body', () => {
     const Hole = family<{ readonly size?: number }>('Hole', () =>
       el('Box', { size: [500, 500, 500] })

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initOCCT } from '../../../tests/setup.js';
-import { isOk, unwrap } from 'brepjs';
+import { csg, isOk, unwrap } from 'brepjs';
 import { z } from 'zod';
 import { family, el, resolve, tRotate } from 'brepjs-families';
 import { Beam } from '../../brepjs-families/registry/families/beam.js';
@@ -161,6 +161,45 @@ describe('registry families through familiesToBim', () => {
     const projected = familiesToBim(tree, { project: PROJECT });
     expect(isOk(projected)).toBe(false);
     if (!projected.ok) expect(projected.error.code).toBe('FAMILIES_UNSUPPORTED_TRANSFORM');
+  });
+
+  it('routes unrouted geometry through the proxy escape hatch when enabled', async () => {
+    const Plinth = family<{ readonly radius: number; readonly height: number }>('Plinth', (p) => {
+      const pts: Array<[number, number, number]> = [];
+      for (let i = 0; i < 6; i++) {
+        const a = (2 * Math.PI * i) / 6;
+        pts.push([p.radius * Math.cos(a), p.radius * Math.sin(a), 0]);
+      }
+      return el('Geometry', { node: csg.extrude(csg.polygon(pts), [0, 0, p.height]) });
+    });
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          Plinth({
+            key: 'plinth',
+            name: 'Hex plinth',
+            material: 'Granite',
+            radius: 400,
+            height: 900,
+          }),
+        ],
+      })
+    );
+
+    const withoutHatch = familiesToBim(tree, { project: PROJECT });
+    expect(isOk(withoutHatch)).toBe(false);
+    if (!withoutHatch.ok) expect(withoutHatch.error.code).toBe('FAMILIES_UNSUPPORTED_TYPE');
+
+    using ev = new csg.Evaluator();
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT, proxyEvaluator: ev }));
+    using model = projected.model;
+    expect(projected.idByKeyPath.has('g/plinth')).toBe(true);
+    expect(model.getProxies()).toHaveLength(1);
+    const text = new TextDecoder().decode(unwrap(await toIfc(model, META)));
+    expect(text).toContain('IFCBUILDINGELEMENTPROXY');
+    expect(text).toContain('Hex plinth');
+    expect(text).toContain('Granite');
   });
 
   it('rejects an anonymous void instead of silently diverging the IFC body', () => {


### PR DESCRIPTION
From the audit's deferred queue: a custom-geometry family (`el('Geometry', ...)`) could not reach IFC at all — `familiesToBim` hard-failed with `FAMILIES_UNSUPPORTED_TYPE` even though `BimModel.addProxy` exists and the writer tessellates proxies.

New opt-in `proxyEvaluator` option: unrouted geometry-bearing elements are materialized through the caller's evaluator and exported as `IfcBuildingElementProxy` with the key-path-derived GlobalId, spatial containment, `name`/`material` identity props, and custom psets. The tessellated body is authoritative for a proxy (no parametric spec to diverge from), so baked rotations are legal on this route, unlike the parametric ones. Without the option the hard error stands and now names the escape hatch. Ownership is clean: the evaluator's handles stay borrowed and the adapter clones the solid it hands the model (which takes ownership per `ProxySpec`).

Validation: new registry test (hex plinth through the Geometry hatch) asserts the hard error without the option and, with it, the proxy element, GlobalId map entry, and `IFCBUILDINGELEMENTPROXY` + name + material in the IFC text. Full brepjs-bim suite green, typecheck + lint clean.