### PR TITLE
chore(playground): regenerate bim and families ambient types

### DIFF
--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -5,7 +5,7 @@
  * Ambient type declarations for brepjs-bim available in the playground editor.
  */
 
-import type { BrepError, OrientedFace, PlanarFace, Result, ValidSolid } from 'brepjs';
+import type { BrepError, OrientedFace, PlanarFace, Result, ValidSolid, csg } from 'brepjs';
 
 /** Optional identity override for created elements: a stable key (e.g. a
  *  families key path) that replaces the positional GlobalId derivation. */
@@ -179,10 +179,12 @@ interface BimTreeSummary {
  * failure the solids already built for this call are disposed before the error is
  * returned, so no partial array is leaked.
  *
- * Stairs carry no element solid (`.geometry` is null), so flight solids are built
- * from `spec.flights` and placed per flight. Curtain walls return placed panels +
- * mullions. Elements with no solid geometry (doors/windows/ramps/groups/spatial)
- * return an empty array.
+ * Stairs and ramps carry no element solid (`.geometry` is null), so flight
+ * solids are built from `spec.flights` and placed per flight. Curtain walls
+ * return placed panels + mullions. Proxies are authored in world coordinates
+ * (no placement frame), so their solid is returned as a fresh identity-placed
+ * copy. Elements with no solid geometry (doors/windows/groups/spatial) return
+ * an empty array.
  */
 declare function placedSolids(el: AnyBimElement): Result<readonly ValidSolid[], BimError>;
 
@@ -2162,6 +2164,15 @@ interface FamiliesToBimOptions {
     readonly project: ProjectSpec;
     readonly siteName?: string | undefined;
     readonly buildingName?: string | undefined;
+    /**
+     * Enables the proxy route: an unrouted geometry-bearing element is
+     * materialized through this evaluator and exported as an
+     * IfcBuildingElementProxy (tessellated, world-frame body). Without it,
+     * unrouted types stay a hard FAMILIES_UNSUPPORTED_TYPE error. The
+     * evaluator's handles stay borrowed; the adapter clones what it hands the
+     * model.
+     */
+    readonly proxyEvaluator?: csg.Evaluator | undefined;
 }
 
 interface FamiliesBimResult {

--- a/apps/playground/src/types/brepjs-families-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-families-ambient.d.ts
@@ -14,6 +14,30 @@ interface Element {
     readonly children: readonly Element[];
 }
 
+/** What a caller (JSX or direct) may pass as children: single, nested arrays,
+ *  and conditional results. Normalized to a flat Element[] before render. */
+type FamilyChildren = Element | boolean | null | undefined | readonly FamilyChildren[];
+
+/**
+ * Identity-side props accepted by every family invocation, beside the
+ * family's own schema. Zod object schemas strip undeclared keys, so these are
+ * re-attached after validation — a semantic component carries IFC-facing data
+ * without every schema declaring it. `resolve()` captures them into
+ * `ResolvedElement.attributes`.
+ */
+declare const IDENTITY_PROPS: readonly ["name", "psets", "material", "classification"];
+
+interface IdentityProps {
+    /** Display name an exporter may adopt (e.g. IfcBuildingStorey.Name). */
+    readonly name?: string | undefined;
+    /** Property sets keyed by pset name (e.g. `Pset_WallCommon`). */
+    readonly psets?: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined;
+    /** Material name an exporter may adopt when the family declares none. */
+    readonly material?: string | undefined;
+    /** Classification reference (system/code/...); the exporter defines the shape. */
+    readonly classification?: Readonly<Record<string, unknown>> | undefined;
+}
+
 /**
  * A family component: a callable that constructs Elements, carrying its
  * declared name and render function. The component REFERENCE is the identity
@@ -25,7 +49,7 @@ interface Element {
  * output `P`. Schema-less families use one type for both.
  */
 interface FamilyComponent<P, I = P> {
-    (props: I & WithKey): Element;
+    (props: I & WithKey & IdentityProps & WithChildren): Element;
     readonly familyName: string;
     /** `'fill'` marks a family whose instances fill an opening when placed in a
      *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
@@ -52,15 +76,57 @@ declare function jsx(type: string | FamilyComponent<never>, props: Readonly<Reco
 
 declare const jsxs: typeof jsx;
 
-/** Fragment renders nothing itself; its children inline into the parent. */
+/** Development-runtime entry (`jsx: "react-jsxdev"`): same construction, the
+ *  extra dev metadata (source/self) is not used. */
+declare function jsxDEV(type: string | FamilyComponent<never>, props: Readonly<Record<string, unknown>>, key?: string): Element;
+
+/** Fragment renders nothing itself; resolution inlines its children into the
+ *  parent, so it never contributes a key-path segment. */
 declare const Fragment = "Fragment";
 
-interface TransformOp {
-    readonly op: 'translate';
-    readonly v: readonly [number, number, number];
+interface IntrinsicProps {
+    readonly key?: string | undefined;
+    readonly voids?: readonly Element[] | undefined;
+    readonly fuse?: readonly Element[] | undefined;
+    readonly transform?: readonly TransformOp[] | undefined;
+    readonly children?: FamilyChildren;
 }
 
+declare function Box(props: IntrinsicProps & {
+    readonly size: readonly [number, number, number];
+}): Element;
+
+declare function Cylinder(props: IntrinsicProps & {
+    readonly radius: number;
+    readonly height: number;
+}): Element;
+
+declare function Geometry(props: IntrinsicProps & {
+    readonly node: csg.IRNode;
+}): Element;
+
+declare function Group(props?: IntrinsicProps): Element;
+
+type TransformOp = {
+    readonly op: 'translate';
+    readonly v: readonly [number, number, number];
+} | {
+    readonly op: 'rotate';
+    readonly angleDeg: number;
+    readonly axis?: readonly [number, number, number] | undefined;
+    readonly at?: readonly [number, number, number] | undefined;
+};
+
 declare function tTranslate(v: readonly [number, number, number]): TransformOp;
+
+/** Rotation in degrees about `axis` (default Z) through `at` (default origin).
+ *  Viewport-first: a parametric BIM projection folds only translations into
+ *  IfcLocalPlacement and rejects rotated routed elements (walls orient via
+ *  `axisX` instead). */
+declare function tRotate(angleDeg: number, options?: {
+    readonly axis?: readonly [number, number, number] | undefined;
+    readonly at?: readonly [number, number, number] | undefined;
+}): TransformOp;
 
 interface Relationship {
     readonly kind: 'Voids' | 'Fills' | 'Contains';


### PR DESCRIPTION
The generated playground declarations lagged the merged bim proxy escape hatch (#2212) and the families composition/JSX work (#2207): FamilyChildren, the identity-prop docs, and the updated placedSolids proxy/ramp documentation were missing. Regenerated with npm run generate-types from freshly built package dist. No source changes.