### PR TITLE
feat(topology): scale-relative default mesh deflection on the eager path

### DIFF
--- a/apps/playground/src/types/brepjs-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-ambient.d.ts
@@ -4773,7 +4773,9 @@ interface EdgeMesh {
 
 /** Shared options for meshing operations. */
 interface MeshOptions {
-    /** Linear deflection tolerance. Smaller = finer mesh. Defaults to the active quality level. */
+    /** Linear deflection tolerance. Smaller = finer mesh. Defaults to the active
+     *  quality level, scaled with the shape's bounding-box diagonal beyond 10
+     *  model units so default meshes stay scale-invariant. */
     tolerance?: number;
     /** Angular deflection tolerance in radians. Smaller = finer mesh on curved surfaces. Defaults to the active quality level. */
     angularTolerance?: number;

--- a/src/csg/evaluate.ts
+++ b/src/csg/evaluate.ts
@@ -14,9 +14,14 @@ import { BrepErrorCode, kernelError } from '@/core/errors.js';
 import type { AnyShape, Dimension } from '@/core/shapeTypes.js';
 import type { Vec3 } from '@/utils/vec3.js';
 import { quatFromAxisAngle, quatMultiply, quatRotate, type Quat } from '@/utils/quaternion.js';
-import { getBounds, getFaces } from '@/topology/topologyQueryFns.js';
+import { getFaces } from '@/topology/topologyQueryFns.js';
 import { getHashCode } from '@/topology/shapeFns.js';
-import { mesh, type ShapeMesh, type MeshOptions } from '@/topology/meshFns.js';
+import {
+  mesh,
+  scaleDefaultTolerance,
+  type ShapeMesh,
+  type MeshOptions,
+} from '@/topology/meshFns.js';
 import { buildMeshCacheKey } from '@/topology/meshCache.js';
 import { evalScalar, evalVec3, projectEnv, type Env, type ExprValue } from './expressions.js';
 import { fnvInit, fnvMixString, fnvMixNumber, fnvMixBool, fnvMixInt32, toHex } from './hash.js';
@@ -401,28 +406,6 @@ function relocateFaceGroups(
     if (a !== undefined && b !== undefined) remap.set(a, b);
   }
   return faceGroups.map((g) => ({ ...g, faceId: remap.get(g.faceId) ?? g.faceId }));
-}
-
-// Beyond this bounding-box diagonal (model units) the default deflection grows
-// linearly with size, keeping default meshes scale-invariant; below it the
-// absolute tier default applies unchanged. Quality deflections are absolute
-// model units tuned for ~unit-scale parts: adopting them unscaled at BIM
-// (mm) scale explodes a curved surface into 10^5-10^6 triangles and can
-// exhaust the WASM heap.
-const SCALE_INVARIANT_DIAGONAL = 10;
-
-function scaleDefaultTolerance(base: number, shape: AnyShape<Dimension>): number {
-  let diagonal: number;
-  try {
-    const b = getBounds(shape);
-    const dx = b.xMax - b.xMin;
-    const dy = b.yMax - b.yMin;
-    const dz = b.zMax - b.zMin;
-    diagonal = Math.sqrt(dx * dx + dy * dy + dz * dz);
-  } catch {
-    return base;
-  }
-  return base * Math.max(1, diagonal / SCALE_INVARIANT_DIAGONAL);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/topology/meshFns.ts
+++ b/src/topology/meshFns.ts
@@ -47,12 +47,36 @@ export interface EdgeMesh {
 
 /** Shared options for meshing operations. */
 export interface MeshOptions {
-  /** Linear deflection tolerance. Smaller = finer mesh. Defaults to the active quality level. */
+  /** Linear deflection tolerance. Smaller = finer mesh. Defaults to the active
+   *  quality level, scaled with the shape's bounding-box diagonal beyond 10
+   *  model units so default meshes stay scale-invariant. */
   tolerance?: number;
   /** Angular deflection tolerance in radians. Smaller = finer mesh on curved surfaces. Defaults to the active quality level. */
   angularTolerance?: number;
   /** Abort signal to cancel mesh generation between face iterations. */
   signal?: AbortSignal;
+}
+
+// Beyond this bounding-box diagonal (model units) the default deflection grows
+// linearly with size, keeping default meshes scale-invariant; below it the
+// absolute tier default applies unchanged. Quality deflections are absolute
+// model units tuned for ~unit-scale parts: adopting them unscaled at BIM
+// (mm) scale explodes a curved surface into 10^5-10^6 triangles and can
+// exhaust the WASM heap.
+const SCALE_INVARIANT_DIAGONAL = 10;
+
+export function scaleDefaultTolerance(base: number, shape: AnyShape<Dimension>): number {
+  let diagonal: number;
+  try {
+    const b = getBounds(shape);
+    const dx = b.xMax - b.xMin;
+    const dy = b.yMax - b.yMin;
+    const dz = b.zMax - b.zMin;
+    diagonal = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  } catch {
+    return base;
+  }
+  return base * Math.max(1, diagonal / SCALE_INVARIANT_DIAGONAL);
 }
 
 // ---------------------------------------------------------------------------
@@ -73,10 +97,12 @@ export function mesh(
   opts: MeshOptions & { skipNormals?: boolean; includeUVs?: boolean; cache?: boolean } = {}
 ): ShapeMesh {
   // Unspecified deflection defaults to the active quality level (see
-  // withQuality / withTier). 'standard' reproduces the historical 1e-3 / 0.1.
+  // withQuality / withTier), scaled with the shape's size beyond a 10-unit
+  // bounding diagonal (see scaleDefaultTolerance). The resolved value is a
+  // pure function of the shape, so it keys the cache like an explicit one.
   const quality = qualityDeflection();
   const {
-    tolerance = quality.tolerance,
+    tolerance = scaleDefaultTolerance(quality.tolerance, shape),
     angularTolerance = quality.angularTolerance,
     skipNormals = false,
     includeUVs = false,
@@ -137,10 +163,10 @@ export function meshEdges(
   shape: AnyShape<Dimension>,
   opts: MeshOptions & { cache?: boolean } = {}
 ): EdgeMesh {
-  // Default deflection follows the active quality level (see mesh()).
+  // Default deflection follows mesh(): quality level, scale-relative.
   const quality = qualityDeflection();
   const {
-    tolerance = quality.tolerance,
+    tolerance = scaleDefaultTolerance(quality.tolerance, shape),
     angularTolerance = quality.angularTolerance,
     cache = true,
   } = opts;
@@ -285,10 +311,10 @@ export function exportSTL(
   shape: AnyShape<Dimension>,
   opts: MeshOptions & { binary?: boolean } = {}
 ): Result<Blob> {
-  // Default deflection follows the active quality level (see mesh()).
+  // Default deflection follows mesh(): quality level, scale-relative.
   const quality = qualityDeflection();
   const {
-    tolerance = quality.tolerance,
+    tolerance = scaleDefaultTolerance(quality.tolerance, shape),
     angularTolerance = quality.angularTolerance,
     binary = false,
   } = opts;

--- a/tests/helpers/kernelDivergences.ts
+++ b/tests/helpers/kernelDivergences.ts
@@ -365,6 +365,11 @@ export const divergences: DivergenceMap = {
       kind: 'not-implemented',
       reason: 'Mesh deflection control uses OCCT-specific API',
     },
+    'meshFns.deflectionDensity': {
+      kind: 'skip',
+      reason:
+        'brepkit tessellation/wireframe density is not driven by linear deflection, so relative-vs-absolute density comparisons do not hold',
+    },
 
     // -----------------------------------------------------------------------
     // Whole-suite OCCT-only (describe.skipIf)
@@ -541,6 +546,11 @@ export const divergences: DivergenceMap = {
     'meshFns.meshDeflection': {
       kind: 'not-implemented',
       reason: 'STL read-error test patches oc.FS.readFile — not exposed by occt-wasm',
+    },
+    'meshFns.edgeDeflection': {
+      kind: 'skip',
+      reason:
+        "occt-wasm's wireframe() passes the linear deflection into GCPnts_TangentialDeflection's angular slot (the curvature deflection is a fixed 0.5), so edge density does not follow linear tolerance. Remove when occt-wasm ships the wireframe parameter-order fix.",
     },
     'cast.garbageInput': {
       kind: 'not-implemented',

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, vi } from 'vitest';
-import { initKernel } from './setup.js';
+import { initKernel, currentKernel } from './setup.js';
 import { shouldSkipSuite } from './helpers/kernelDivergences.js';
 import {
   box,
@@ -70,6 +70,60 @@ describe('meshFns', () => {
       const mesh2 = mesh(b, { tolerance: 0.1, cache: false });
       // Not cached — different object
       expect(mesh2).not.toBe(mesh1);
+    });
+  });
+
+  describe('scale-relative default deflection', () => {
+    // The manifold preview kernel tessellates from build-time segments and
+    // ignores extract-time deflection, so density comparisons only hold on
+    // B-rep kernels.
+    const itBrep = it.skipIf(currentKernel === 'manifold');
+
+    itBrep('meshes a BIM-scale sphere with a bounded triangle count', () => {
+      const m = mesh(sphere(2000), { cache: false });
+      expect(m.triangles.length / 3).toBeGreaterThan(100);
+      expect(m.triangles.length / 3).toBeLessThan(100_000);
+    });
+
+    itBrep('leaves small shapes on the absolute tier default', () => {
+      // Diagonal below 10 model units: the resolved default must equal the
+      // absolute standard-tier deflection, triangle for triangle. Separate
+      // instances so neither call re-uses the other's triangulation.
+      const byDefault = mesh(sphere(2), { cache: false });
+      const explicit = mesh(sphere(2), { tolerance: 1e-3, cache: false });
+      expect(byDefault.triangles.length).toBe(explicit.triangles.length);
+    });
+
+    it.skipIf(currentKernel === 'manifold' || shouldSkipSuite('meshFns.deflectionDensity'))(
+      'an explicit tolerance still overrides the relative default',
+      () => {
+        const byDefault = mesh(sphere(2000), { cache: false });
+        const coarse = mesh(sphere(2000), { tolerance: 40, angularTolerance: 0.5, cache: false });
+        expect(coarse.triangles.length).toBeLessThan(byDefault.triangles.length);
+      }
+    );
+
+    it.skipIf(currentKernel === 'manifold' || shouldSkipSuite('meshFns.edgeDeflection'))(
+      'meshEdges edge density is scale-invariant at the relative default',
+      () => {
+        // Segments per edge go as sqrt(r / deflection); the relative default's
+        // deflection grows linearly with r, so the count is scale-invariant.
+        // Under the absolute tier default the 10x larger sphere would carry
+        // ~sqrt(10) times the segments.
+        const small = meshEdges(sphere(2000), { cache: false });
+        const large = meshEdges(sphere(20000), { cache: false });
+        expect(small.lines.length).toBeGreaterThan(0);
+        const ratio = large.lines.length / small.lines.length;
+        expect(ratio).toBeGreaterThan(0.7);
+        expect(ratio).toBeLessThan(1.4);
+      }
+    );
+
+    itBrep('exportSTL tessellates large shapes at the relative default', () => {
+      const blob = unwrap(exportSTL(sphere(2000), { binary: true }));
+      // Binary STL is 84 header bytes + 50 per triangle: a bounded blob proves
+      // the absolute tier default did not apply at this scale.
+      expect(blob.size).toBeLessThan(84 + 50 * 100_000);
     });
   });
 

--- a/tests/meshFns.test.ts
+++ b/tests/meshFns.test.ts
@@ -80,7 +80,8 @@ describe('meshFns', () => {
     const itBrep = it.skipIf(currentKernel === 'manifold');
 
     itBrep('meshes a BIM-scale sphere with a bounded triangle count', () => {
-      const m = mesh(sphere(2000), { cache: false });
+      using s = sphere(2000);
+      const m = mesh(s, { cache: false });
       expect(m.triangles.length / 3).toBeGreaterThan(100);
       expect(m.triangles.length / 3).toBeLessThan(100_000);
     });
@@ -89,16 +90,20 @@ describe('meshFns', () => {
       // Diagonal below 10 model units: the resolved default must equal the
       // absolute standard-tier deflection, triangle for triangle. Separate
       // instances so neither call re-uses the other's triangulation.
-      const byDefault = mesh(sphere(2), { cache: false });
-      const explicit = mesh(sphere(2), { tolerance: 1e-3, cache: false });
+      using a = sphere(2);
+      using b = sphere(2);
+      const byDefault = mesh(a, { cache: false });
+      const explicit = mesh(b, { tolerance: 1e-3, cache: false });
       expect(byDefault.triangles.length).toBe(explicit.triangles.length);
     });
 
     it.skipIf(currentKernel === 'manifold' || shouldSkipSuite('meshFns.deflectionDensity'))(
       'an explicit tolerance still overrides the relative default',
       () => {
-        const byDefault = mesh(sphere(2000), { cache: false });
-        const coarse = mesh(sphere(2000), { tolerance: 40, angularTolerance: 0.5, cache: false });
+        using a = sphere(2000);
+        using b = sphere(2000);
+        const byDefault = mesh(a, { cache: false });
+        const coarse = mesh(b, { tolerance: 40, angularTolerance: 0.5, cache: false });
         expect(coarse.triangles.length).toBeLessThan(byDefault.triangles.length);
       }
     );
@@ -110,8 +115,10 @@ describe('meshFns', () => {
         // deflection grows linearly with r, so the count is scale-invariant.
         // Under the absolute tier default the 10x larger sphere would carry
         // ~sqrt(10) times the segments.
-        const small = meshEdges(sphere(2000), { cache: false });
-        const large = meshEdges(sphere(20000), { cache: false });
+        using a = sphere(2000);
+        using b = sphere(20000);
+        const small = meshEdges(a, { cache: false });
+        const large = meshEdges(b, { cache: false });
         expect(small.lines.length).toBeGreaterThan(0);
         const ratio = large.lines.length / small.lines.length;
         expect(ratio).toBeGreaterThan(0.7);
@@ -120,7 +127,8 @@ describe('meshFns', () => {
     );
 
     itBrep('exportSTL tessellates large shapes at the relative default', () => {
-      const blob = unwrap(exportSTL(sphere(2000), { binary: true }));
+      using s = sphere(2000);
+      const blob = unwrap(exportSTL(s, { binary: true }));
       // Binary STL is 84 header bytes + 50 per triangle: a bounded blob proves
       // the absolute tier default did not apply at this scale.
       expect(blob.size).toBeLessThan(84 + 50 * 100_000);


### PR DESCRIPTION
## What

The eager meshing path adopts the scale-relative default deflection that `Evaluator.evaluateMesh` has used since #2187. `mesh()`, `meshEdges()`, and `exportSTL()` with no explicit `tolerance` now resolve the quality tier's absolute value scaled linearly with the shape's bounding-box diagonal beyond 10 model units. Explicit tolerances behave exactly as before.

## Why

The quality tiers' deflections are absolute model units tuned for unit-scale parts. Adopted unscaled at BIM (mm) scale they explode a curved surface into 10^5 to 10^6 triangles and can exhaust the WASM heap. #2187 fixed this for the evaluator; the eager path was the deferred remainder (callers needed an explicit `tolerance` at mm scale).

## How

- `scaleDefaultTolerance` moves from `csg/evaluate.ts` into `topology/meshFns.ts` as the single implementation (the evaluator imports it; layer direction is fine, csg already imports meshFns).
- The three defaulting sites resolve it lazily in the destructuring default, so explicit-tolerance calls never pay the `getBounds` probe.
- The resolved default is a pure function of the shape, so it keys the WeakMap mesh caches like an explicit value; no cache-key marker needed (unlike the evaluator, the shape is already in hand).

## occt-wasm bug surfaced by the tests

The edge-density test exposed a real kernel bug: occt-wasm's `wireframe()` passes the linear deflection into `GCPnts_TangentialDeflection`'s **angular** parameter (first slot) and hardcodes 0.5 as the curvature deflection. Confirmed empirically: on a unit sphere, segments go 3144 → 317 → 34 as tolerance goes 1e-3 → 1e-2 → 1e-1 (exactly π/angle), and at r=2000 the fixed 0.5 dominates (predicted ~70 segments, observed 73). Practical effect today: every unit-scale circle edge gets ~3000 wireframe segments under the standard tier.

The test skips occt-wasm via a new `meshFns.edgeDeflection` divergence entry with the removal trigger documented (lift when occt-wasm ships the parameter-order fix, which I'm preparing separately). A `meshFns.deflectionDensity` divergence also skips the explicit-override comparison on brepkit, whose density is not deflection-driven.

## Tests

New `scale-relative default deflection` block in `tests/meshFns.test.ts`: bounded triangle count on a BIM-scale sphere; small shapes identical to the absolute tier default; explicit tolerance still overrides; edge segment count scale-invariant between r=2000 and r=20000 (segments go as sqrt(r/d), and d scaling linearly with r cancels — under the old absolute default the ratio is sqrt(10), observed 3.08 on occt-wasm before the skip); bounded binary STL blob. All five pass on the occt kernel; occt-wasm passes all but the divergence-skipped edge test.

Size gate: main bundle 67.55 kB / 68 kB (down 0.09 kB), total 372.15 kB / 380 kB.
