### PR TITLE
docs(families): document voids in JSX authoring; fix vite config warnings

### DIFF
--- a/apps/docs/families/jsx.md
+++ b/apps/docs/families/jsx.md
@@ -73,6 +73,55 @@ Children reach the render function as `props.children`, already flattened and cl
 
 Conditionals that evaluate to `false`/`null` disappear, nested arrays flatten, and fragments inline without contributing a key-path segment. Declare a children prop as `FamilyChildren` to accept all of that; resolution hands your render a flat `Element[]`.
 
+## Voids and openings
+
+`voids`, `fuse`, and `transform` are props on every intrinsic, so the whole [openings model](/families/openings) is available in JSX with no change of meaning. A plain element in `voids` is an anonymous cut, geometry with no identity:
+
+```tsx
+import { Box, family, resolve, tTranslate, type Element } from 'brepjs-families';
+
+const Bin = family<{ length: number; width: number; height: number; wall: number }>('Bin', (p) => (
+  <Box
+    size={[p.length, p.width, p.height]}
+    voids={[
+      <Box
+        size={[p.length - 2 * p.wall, p.width - 2 * p.wall, p.height - p.wall]}
+        transform={[tTranslate([p.wall, p.wall, p.wall])]}
+      />,
+    ]}
+  />
+));
+```
+
+`voids` is a prop rather than children, and the split is semantic: children are contained by the host and carry their own key paths, voids are subtracted from it. Put an instance of a `role: 'fill'` family in `voids` and you get both, because resolution synthesizes an `Opening` between host and filler:
+
+```tsx
+const Door = family<{ width: number; height: number; at: number }>(
+  'Door',
+  (p) => <Box size={[p.width, 300, p.height]} transform={[tTranslate([p.at, 0, 0])]} />,
+  { role: 'fill' }
+);
+
+const Wall = family<{ voids?: readonly Element[] }>('Wall', (p) => (
+  <Box size={[4000, 200, 2700]} voids={p.voids ?? []} />
+));
+
+resolve(<Wall key="south" voids={[<Door key="entry" width={1000} height={2100} at={1500} />]} />);
+```
+
+```
+south                     the wall      Voids -> south/voids:entry
+south/voids:entry         the opening   Fills -> south/voids:entry/fill
+south/voids:entry/fill    the door
+```
+
+One children idiom does not carry over. `voids` takes a plain `Element[]` and is not run through children normalization, so a bare `{show && <Door … />}` entry is a type error rather than a node that disappears. Build the array instead:
+
+```tsx
+const openings = show ? [<Door key="entry" width={1000} height={2100} at={1500} />] : [];
+resolve(<Wall key="south" voids={openings} />);
+```
+
 ## When to prefer the function form
 
 The two forms produce hash-identical trees, so this is style, not capability. Reach for plain calls when you're generating elements programmatically (loops over data, builders), and JSX when a human reviews the model shape: a storey of keyed walls reads like the building it describes.

--- a/packages/brepjs-bim/vite.config.ts
+++ b/packages/brepjs-bim/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     target: 'es2022',
     minify: false,
     lib: {
-      entry: { 'brepjs-bim': resolve(__dirname, 'src/index.ts') },
+      entry: { 'brepjs-bim': resolve(import.meta.dirname, 'src/index.ts') },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/brepjs-bim/vitest.config.ts
+++ b/packages/brepjs-bim/vitest.config.ts
@@ -4,9 +4,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
-      '@': resolve(__dirname, '../../src'),
-      brepjs: resolve(__dirname, '../../src/index.ts'),
-      'brepjs-families': resolve(__dirname, '../brepjs-families/src/index.ts'),
+      '@': resolve(import.meta.dirname, '../../src'),
+      brepjs: resolve(import.meta.dirname, '../../src/index.ts'),
+      'brepjs-families': resolve(import.meta.dirname, '../brepjs-families/src/index.ts'),
     },
   },
   test: {

--- a/packages/brepjs-cad/vite.config.ts
+++ b/packages/brepjs-cad/vite.config.ts
@@ -9,10 +9,10 @@ function copyResolveHook() {
   return {
     name: 'copy-brepjs-resolve-hook',
     closeBundle() {
-      const outDir = resolve(__dirname, 'dist/loader');
+      const outDir = resolve(import.meta.dirname, 'dist/loader');
       mkdirSync(outDir, { recursive: true });
       copyFileSync(
-        resolve(__dirname, 'src/loader/brepjsResolve.mjs'),
+        resolve(import.meta.dirname, 'src/loader/brepjsResolve.mjs'),
         resolve(outDir, 'brepjsResolve.mjs')
       );
     },
@@ -29,15 +29,15 @@ export default defineConfig({
     minify: false,
     lib: {
       entry: {
-        'brepjs-cad': resolve(__dirname, 'src/index.ts'),
-        'cli/main': resolve(__dirname, 'src/cli/main.ts'),
+        'brepjs-cad': resolve(import.meta.dirname, 'src/index.ts'),
+        'cli/main': resolve(import.meta.dirname, 'src/cli/main.ts'),
         // Pinned so the CLI's dynamic imports land on stable dist/snapshot/*.js paths
         // (preserves the ../../viewer/dist sibling-depth invariant static.ts relies on).
-        'snapshot/static': resolve(__dirname, 'src/snapshot/static.ts'),
-        'snapshot/registry': resolve(__dirname, 'src/snapshot/registry.ts'),
-        'snapshot/shoot': resolve(__dirname, 'src/snapshot/shoot.ts'),
-        'snapshot/serve': resolve(__dirname, 'src/snapshot/serve.ts'),
-        'mcp/server': resolve(__dirname, 'src/mcp/server.ts'),
+        'snapshot/static': resolve(import.meta.dirname, 'src/snapshot/static.ts'),
+        'snapshot/registry': resolve(import.meta.dirname, 'src/snapshot/registry.ts'),
+        'snapshot/shoot': resolve(import.meta.dirname, 'src/snapshot/shoot.ts'),
+        'snapshot/serve': resolve(import.meta.dirname, 'src/snapshot/serve.ts'),
+        'mcp/server': resolve(import.meta.dirname, 'src/mcp/server.ts'),
       },
       formats: ['es', 'cjs'],
     },

--- a/packages/brepjs-cad/vitest.config.ts
+++ b/packages/brepjs-cad/vitest.config.ts
@@ -1,9 +1,9 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 
-const pkgSrc = resolve(__dirname, 'src');
-const rootSrc = resolve(__dirname, '../../src');
-const viewerSrc = resolve(__dirname, 'viewer/src');
+const pkgSrc = resolve(import.meta.dirname, 'src');
+const rootSrc = resolve(import.meta.dirname, '../../src');
+const viewerSrc = resolve(import.meta.dirname, 'viewer/src');
 
 export default defineConfig({
   resolve: {

--- a/packages/brepjs-families/tests/familiesJsx.test.tsx
+++ b/packages/brepjs-families/tests/familiesJsx.test.tsx
@@ -1,4 +1,3 @@
-/** @jsxRuntime automatic @jsxImportSource brepjs-families */
 /**
  * Typed JSX authoring — the real compiler path (react-jsx transform through
  * `jsxImportSource: "brepjs-families"`), not direct jsx() calls. Pure data:
@@ -7,7 +6,15 @@
 
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { Box, Group, family, resolve, tTranslate, type FamilyChildren } from '../src/index.js';
+import {
+  Box,
+  Group,
+  family,
+  resolve,
+  tTranslate,
+  type Element,
+  type FamilyChildren,
+} from '../src/index.js';
 
 const wallSchema = z.object({
   length: z.number().positive(),
@@ -76,5 +83,27 @@ describe('typed JSX authoring', () => {
     ));
     const tree = resolve(<Bin key="b" size={10} />);
     expect(tree.geometry.kind).toBe('Translate');
+  });
+
+  it('fill-role instances in a voids prop synthesize the opening triangle', () => {
+    const Door = family<{ readonly width: number; readonly height: number }>(
+      'Door',
+      (p) => <Box size={[p.width, 300, p.height]} />,
+      { role: 'fill' }
+    );
+    const VoidedWall = family<{ readonly voids: readonly Element[] }>('Wall', (p) => (
+      <Box size={[4000, 200, 2700]} voids={p.voids} />
+    ));
+
+    const tree = resolve(
+      <VoidedWall key="south" voids={[<Door key="entry" width={1000} height={2100} />]} />
+    );
+
+    expect(tree.relationships).toEqual([{ kind: 'Voids', target: 'south/voids:entry' }]);
+    const opening = tree.children[0];
+    expect(opening?.type).toBe('Opening');
+    expect(opening?.keyPath).toBe('south/voids:entry');
+    expect(opening?.relationships).toEqual([{ kind: 'Fills', target: 'south/voids:entry/fill' }]);
+    expect(opening?.children[0]?.type).toBe('Door');
   });
 });

--- a/packages/brepjs-families/tests/familiesJsx.test.tsx
+++ b/packages/brepjs-families/tests/familiesJsx.test.tsx
@@ -1,7 +1,13 @@
+/** @jsxRuntime automatic @jsxImportSource brepjs-families */
 /**
  * Typed JSX authoring — the real compiler path (react-jsx transform through
  * `jsxImportSource: "brepjs-families"`), not direct jsx() calls. Pure data:
  * resolution builds IR nodes without a kernel, so no WASM setup here.
+ *
+ * The pragma above is required, not decorative: this file is run by two vitest
+ * configs (the package's own and the root suite), and the root one cannot set a
+ * global jsxImportSource without committing every future .tsx in it to this
+ * package's runtime.
  */
 
 import { describe, expect, it } from 'vitest';

--- a/packages/brepjs-families/vitest.config.ts
+++ b/packages/brepjs-families/vitest.config.ts
@@ -8,20 +8,19 @@ export default defineConfig({
     alias: [
       {
         find: 'brepjs-families/jsx-dev-runtime',
-        replacement: resolve(__dirname, 'src/jsxRuntime.ts'),
+        replacement: resolve(import.meta.dirname, 'src/jsxRuntime.ts'),
       },
       {
         find: 'brepjs-families/jsx-runtime',
-        replacement: resolve(__dirname, 'src/jsxRuntime.ts'),
+        replacement: resolve(import.meta.dirname, 'src/jsxRuntime.ts'),
       },
-      { find: 'brepjs-families', replacement: resolve(__dirname, 'src/index.ts') },
-      { find: 'brepjs', replacement: resolve(__dirname, '../../src/index.ts') },
-      { find: '@', replacement: resolve(__dirname, '../../src') },
+      { find: 'brepjs-families', replacement: resolve(import.meta.dirname, 'src/index.ts') },
+      { find: 'brepjs', replacement: resolve(import.meta.dirname, '../../src/index.ts') },
+      { find: '@', replacement: resolve(import.meta.dirname, '../../src') },
     ],
   },
-  esbuild: {
-    jsx: 'automatic',
-    jsxImportSource: 'brepjs-families',
+  oxc: {
+    jsx: { runtime: 'automatic', importSource: 'brepjs-families' },
   },
   test: {
     globals: true,

--- a/packages/brepjs-sheetmetal/vite.config.ts
+++ b/packages/brepjs-sheetmetal/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     target: 'es2022',
     minify: false,
     lib: {
-      entry: { 'brepjs-sheetmetal': resolve(__dirname, 'src/index.ts') },
+      entry: { 'brepjs-sheetmetal': resolve(import.meta.dirname, 'src/index.ts') },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/brepjs-sheetmetal/vitest.config.ts
+++ b/packages/brepjs-sheetmetal/vitest.config.ts
@@ -4,8 +4,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
-      '@': resolve(__dirname, '../../src'),
-      brepjs: resolve(__dirname, '../../src/index.ts'),
+      '@': resolve(import.meta.dirname, '../../src'),
+      brepjs: resolve(import.meta.dirname, '../../src/index.ts'),
     },
   },
   test: {

--- a/packages/brepjs-viewer/vite.config.ts
+++ b/packages/brepjs-viewer/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     // source instead of a stack-less synthetic `e.useCache`-style report.
     sourcemap: true,
     lib: {
-      entry: { 'brepjs-viewer': resolve(__dirname, 'src/index.ts') },
+      entry: { 'brepjs-viewer': resolve(import.meta.dirname, 'src/index.ts') },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/packages/brepjs-viewer/vitest.config.ts
+++ b/packages/brepjs-viewer/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src'),
+      '@': resolve(import.meta.dirname, 'src'),
     },
   },
   test: {

--- a/packages/brepjs-vscode/webview/vite.config.ts
+++ b/packages/brepjs-vscode/webview/vite.config.ts
@@ -1,16 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
 export default defineConfig({
-  root: __dirname,
+  root: import.meta.dirname,
   base: './',
   plugins: [react()],
   build: {
-    outDir: resolve(__dirname, '../dist/webview'),
+    outDir: resolve(import.meta.dirname, '../dist/webview'),
     emptyOutDir: true,
     rollupOptions: {
       output: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 export default defineConfig({
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src'),
+      '@': resolve(import.meta.dirname, 'src'),
     },
   },
   plugins: [
@@ -20,23 +20,23 @@ export default defineConfig({
     minify: false,
     lib: {
       entry: {
-        brepjs: resolve(__dirname, 'src/index.ts'),
-        core: resolve(__dirname, 'src/core.ts'),
-        result: resolve(__dirname, 'src/result.ts'),
-        vectors: resolve(__dirname, 'src/vectors.ts'),
-        topology: resolve(__dirname, 'src/topology.ts'),
-        operations: resolve(__dirname, 'src/operations.ts'),
-        '2d': resolve(__dirname, 'src/2d.ts'),
-        sketching: resolve(__dirname, 'src/sketching.ts'),
-        text: resolve(__dirname, 'src/text.ts'),
-        projection: resolve(__dirname, 'src/projection.ts'),
-        query: resolve(__dirname, 'src/query.ts'),
-        measurement: resolve(__dirname, 'src/measurement.ts'),
-        io: resolve(__dirname, 'src/io.ts'),
-        worker: resolve(__dirname, 'src/worker.ts'),
-        shapeRef: resolve(__dirname, 'src/shapeRef.ts'),
+        brepjs: resolve(import.meta.dirname, 'src/index.ts'),
+        core: resolve(import.meta.dirname, 'src/core.ts'),
+        result: resolve(import.meta.dirname, 'src/result.ts'),
+        vectors: resolve(import.meta.dirname, 'src/vectors.ts'),
+        topology: resolve(import.meta.dirname, 'src/topology.ts'),
+        operations: resolve(import.meta.dirname, 'src/operations.ts'),
+        '2d': resolve(import.meta.dirname, 'src/2d.ts'),
+        sketching: resolve(import.meta.dirname, 'src/sketching.ts'),
+        text: resolve(import.meta.dirname, 'src/text.ts'),
+        projection: resolve(import.meta.dirname, 'src/projection.ts'),
+        query: resolve(import.meta.dirname, 'src/query.ts'),
+        measurement: resolve(import.meta.dirname, 'src/measurement.ts'),
+        io: resolve(import.meta.dirname, 'src/io.ts'),
+        worker: resolve(import.meta.dirname, 'src/worker.ts'),
+        shapeRef: resolve(import.meta.dirname, 'src/shapeRef.ts'),
         'kernel/occtWasm/occtWasmAdapter': resolve(
-          __dirname,
+          import.meta.dirname,
           'src/kernel/occtWasm/occtWasmAdapter.ts'
         ),
       },

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -4,8 +4,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src'),
-      'brepkit-wasm': resolve(__dirname, 'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'),
+      '@': resolve(import.meta.dirname, 'src'),
+      'brepkit-wasm': resolve(
+        import.meta.dirname,
+        'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'
+      ),
     },
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,29 +49,32 @@ export default defineConfig({
       // Vite resolves the "import" exports condition by default, hitting the ESM
       // bundler entry that uses the unsupported WASM ESM integration proposal.
       // Alias to the Node CJS entry so brepkit tests run under vitest.
-      '@': resolve(__dirname, 'src'),
-      'brepkit-wasm': resolve(__dirname, 'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'),
+      '@': resolve(import.meta.dirname, 'src'),
+      'brepkit-wasm': resolve(
+        import.meta.dirname,
+        'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'
+      ),
       // The voxel engine ships as a committed wasm-pack artifact; point the bare
       // specifier at the built ESM entry so voxel tests resolve it under vitest.
-      'brepjs-voxel-wasm': resolve(__dirname, 'packages/brepjs-voxel-wasm/pkg/index.js'),
+      'brepjs-voxel-wasm': resolve(import.meta.dirname, 'packages/brepjs-voxel-wasm/pkg/index.js'),
       // node_modules/brepjs is a stale published copy; route to live src.
-      brepjs: resolve(__dirname, 'src/index.ts'),
+      brepjs: resolve(import.meta.dirname, 'src/index.ts'),
       // Same for the satellite domain packages the playground-example regression
       // test meshes: route to live src so tests run against current source (not
       // the last-published dist) and don't need a dist build in CI.
-      'brepjs-sheetmetal': resolve(__dirname, 'packages/brepjs-sheetmetal/src/index.ts'),
-      'brepjs-bim': resolve(__dirname, 'packages/brepjs-bim/src/index.ts'),
+      'brepjs-sheetmetal': resolve(import.meta.dirname, 'packages/brepjs-sheetmetal/src/index.ts'),
+      'brepjs-bim': resolve(import.meta.dirname, 'packages/brepjs-bim/src/index.ts'),
       // Subpath entries first: object-form aliases are exact-match, so the
       // automatic-JSX runtime imports need their own rows (no dist in CI).
       'brepjs-families/jsx-runtime': resolve(
-        __dirname,
+        import.meta.dirname,
         'packages/brepjs-families/src/jsxRuntime.ts'
       ),
       'brepjs-families/jsx-dev-runtime': resolve(
-        __dirname,
+        import.meta.dirname,
         'packages/brepjs-families/src/jsxRuntime.ts'
       ),
-      'brepjs-families': resolve(__dirname, 'packages/brepjs-families/src/index.ts'),
+      'brepjs-families': resolve(import.meta.dirname, 'packages/brepjs-families/src/index.ts'),
     },
   },
   test: {

--- a/vitest.stress.config.ts
+++ b/vitest.stress.config.ts
@@ -4,7 +4,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
-      'brepkit-wasm': resolve(__dirname, 'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'),
+      'brepkit-wasm': resolve(
+        import.meta.dirname,
+        'node_modules/brepkit-wasm/brepkit_wasm_node.cjs'
+      ),
     },
   },
   test: {


### PR DESCRIPTION
Two unrelated cleanups, one commit each.

## Voids and openings in the JSX docs

`apps/docs/families/jsx.md` never mentioned `voids`, so the whole openings model was only discoverable in the plain-function form, even though `IntrinsicProps` puts `voids`/`fuse`/`transform` on every intrinsic and the JSX path has always supported it. This came up in discussion #2020, where the ask was specifically in JSX.

Adds a "Voids and openings" section covering:

- the anonymous-cut case (a plain element in `voids`)
- the fill-role case, with the synthesized `Voids`/`Fills` key paths spelled out
- why `voids` is a prop rather than children (containment vs subtraction)
- the one children idiom that does not carry over: `voids` skips children normalization, so a bare `{show && <Door />}` entry is a type error rather than a node that disappears

Every snippet was typechecked verbatim against `tsconfig.jsx.json`. The doc-test extractor only reads ` ```typescript ` blocks, so ` ```tsx ` blocks get no automated syntax gate.

Also adds a test asserting the fill-role JSX path produces the full triangle (`south` -> `south/voids:entry` -> `south/voids:entry/fill`); the existing JSX test covered `voids` only in the plain-cut form.

## Vite config warnings

Every vitest/vite run printed two warnings.

**`__dirname`.** Vite warns it is unsupported under `configLoader: 'native'`, which becomes the default in a future major. All 14 configs are ESM on node >=24, so `import.meta.dirname` is a direct swap.

**esbuild vs oxc.** `packages/brepjs-families/vitest.config.ts` set `esbuild: { jsx, jsxImportSource }`, which vitest 4 ignores in favour of oxc ("Both esbuild and oxc options were set"). The package's `.tsx` transform was therefore coming entirely from the `@jsxImportSource` pragma on `familiesJsx.test.tsx`, and a new `.tsx` test in that package without the pragma would have compiled against the wrong runtime. Moved to `oxc: { jsx: { runtime, importSource } }`.

I also dropped the pragma at first, on the theory that the suite should exercise the config. That broke shard 4: `familiesJsx.test.tsx` is run by *two* vitest configs, and the root one has no jsx settings, so oxc's default runtime produced elements with no children. The root config cannot be fixed the same way either, since a global `jsxImportSource` there would bind every future `.tsx` in the root suite to this package's runtime. The pragma is per-file and correct under both, so it is restored with a comment saying why it is not decorative.

## Verification

- families 56 tests, viewer 14, bim 659, sheetmetal 233, all passing
- root `npm run build` and `npm run typecheck` clean
- eslint and prettier clean on changed files
- `familiesJsx.test.tsx` verified green under both the package config and the root suite (`vitest run --project occt-wasm`), which is the one that failed

