### PR TITLE
feat(families): route BIM export on a declared archetype, not the family name

### DIFF
--- a/apps/docs/families/copy-in.md
+++ b/apps/docs/families/copy-in.md
@@ -56,6 +56,16 @@ npx brepjs diff wall
 
 `diff` compares your copy against the registry: stale version markers are called out (`local wall@1, registry wall@2`), content drift renders as a git diff, and the exit code is 1 on any difference, which makes it usable as a CI guard for teams that want to know when their copies diverge from upstream.
 
+## Renaming what you copied
+
+A copied family is yours, including its name, and `Storey` in particular is the IFC spelling rather than the one every team uses. Rename it freely; the `archetype` in the file is what a BIM export routes on, not the name:
+
+```typescript
+export const Level = family('Level', render, { archetype: 'storey', props: storeySchema });
+```
+
+Keep the `// brepjs-family: storey@2` marker on the first line whatever you call the family. `diff` anchors on it, and it is how you find out the upstream file moved on.
+
 ## Self-hosting a registry
 
 The registry is data: a `manifest.json` plus source files, no server logic.

--- a/apps/docs/families/ifc-export.md
+++ b/apps/docs/families/ifc-export.md
@@ -60,6 +60,8 @@ family('Level', render, { archetype: 'storey' }); // still IfcBuildingStorey
 family('Partition', render, { archetype: 'wall' }); // still IfcWall
 ```
 
+Fillers route the same way: `archetype: 'door'` or `'window'` on a `role: 'fill'` family picks the IFC entity, so a `Glazing` family still becomes an `IfcWindow`. The mapped archetypes are `storey`, `wall`, `slab`, `column`, `beam`, `roof`, `stair`, `door`, and `window`.
+
 `archetype` is a plain string that brepjs-families never interprets: the vocabulary belongs to the adapter, which is what keeps the family layer free of IFC.
 
 A family that declares none falls back to matching its display name, so families written before `archetype` existed keep working. The fallback carries the original trap, though: rename an undeclared family and it quietly stops routing. Without `proxyEvaluator` that is a hard `FAMILIES_UNSUPPORTED_TYPE` error, but with one set it becomes an `IfcBuildingElementProxy` instead of the element you meant, which is a valid file that is wrong. Every proxied element is reported so you can catch it:

--- a/apps/docs/families/ifc-export.md
+++ b/apps/docs/families/ifc-export.md
@@ -44,6 +44,31 @@ The adapter returns a `Result`; the model it produces owns kernel geometry, so h
 
 Every mapped element must sit under a `Storey` ancestor: IFC requires spatial containment, and the adapter returns `FAMILIES_NO_STOREY` rather than emit an uncontained element. Fillers are contained in their wall's storey, openings are related to their wall through `IfcRelVoidsElement` alone, exactly as the schema intends. Openings are a wall-only mapping; a fill-role element hosted by anything else returns `FAMILIES_OPENING_OUTSIDE_WALL`.
 
+## Routing is by archetype, not by name
+
+The left column above lists the starter registry's names, but the adapter does not match on them. Each family declares an `archetype`, and that is what selects the mapping:
+
+```typescript
+family('Storey', render, { archetype: 'storey' });
+family('Wall', render, { archetype: 'wall' });
+```
+
+The registry files are yours once copied, so renaming them is expected. Keep the archetype and the mapping follows:
+
+```typescript
+family('Level', render, { archetype: 'storey' }); // still IfcBuildingStorey
+family('Partition', render, { archetype: 'wall' }); // still IfcWall
+```
+
+`archetype` is a plain string that brepjs-families never interprets: the vocabulary belongs to the adapter, which is what keeps the family layer free of IFC.
+
+A family that declares none falls back to matching its display name, so families written before `archetype` existed keep working. The fallback carries the original trap, though: rename an undeclared family and it quietly stops routing. Without `proxyEvaluator` that is a hard `FAMILIES_UNSUPPORTED_TYPE` error, but with one set it becomes an `IfcBuildingElementProxy` instead of the element you meant, which is a valid file that is wrong. Every proxied element is reported so you can catch it:
+
+```typescript
+const { model, proxied } = unwrap(familiesToBim(tree, { project, proxyEvaluator: ev }));
+// proxied: [{ keyPath: 'l1/p1', type: 'Partition', archetype: undefined }]
+```
+
 ## Two sources, one element
 
 The adapter reads each element twice, on purpose:

--- a/apps/docs/reference/errors.md
+++ b/apps/docs/reference/errors.md
@@ -285,9 +285,9 @@ An element's archetype has no spec mapping in the adapter. Nothing is silently d
 
 ### `FAMILIES_UNSUPPORTED_FILL` / `FAMILIES_OPENING_OUTSIDE_WALL`
 
-A fill-role element other than `Door`/`Window` was placed in `voids`, or an opening was synthesized under a host that is not a `Wall` (for example a slab). Wall openings are the mapped case.
+A fill-role element whose archetype is neither `door` nor `window` was placed in `voids`, or an opening was synthesized under a host whose archetype is not `wall` (for example a slab). Wall openings are the mapped case.
 
-**Fix**: Restrict fill-role voids to doors and windows on walls; use plain voids for anonymous cuts elsewhere.
+**Fix**: Declare `archetype: 'door'` or `'window'` on the filler and `archetype: 'wall'` on the host; use plain voids for anonymous cuts elsewhere.
 
 ### `DUPLICATE_STABLE_KEY`
 

--- a/apps/docs/reference/errors.md
+++ b/apps/docs/reference/errors.md
@@ -273,15 +273,15 @@ The `cause` field carries the underlying kernel error (often a string from the O
 
 ### `FAMILIES_NO_STOREY`
 
-A wall or slab has no `Storey` ancestor. IFC requires spatial containment for building elements.
+A wall or slab has no `Storey` ancestor. IFC requires spatial containment for building elements. A container family is recognised by `archetype: 'storey'`, not by being called `Storey`, so a renamed container that declares none reads as an ordinary group.
 
-**Fix**: Nest geometry-bearing elements under a keyed `Storey`.
+**Fix**: Nest geometry-bearing elements under a keyed storey container, and declare `archetype: 'storey'` on it.
 
 ### `FAMILIES_UNSUPPORTED_TYPE`
 
-An element's type has no spec mapping in the adapter. Nothing is silently dropped from the file.
+An element's archetype has no spec mapping in the adapter. Nothing is silently dropped from the file. The message reports the archetype it resolved, which is `none` when the family declares one neither directly nor by display-name fallback.
 
-**Fix**: Use a mapped type (`Storey`, `Wall`, `Slab`, fill-role `Door`/`Window`), or keep the element out of the projected subtree.
+**Fix**: Declare a mapped `archetype` (`storey`, `wall`, `slab`, `column`, `beam`, `roof`, `stair`) or use a fill-role `Door`/`Window`, add a spec route, or keep the element out of the projected subtree.
 
 ### `FAMILIES_UNSUPPORTED_FILL` / `FAMILIES_OPENING_OUTSIDE_WALL`
 

--- a/apps/docs/reference/glossary.md
+++ b/apps/docs/reference/glossary.md
@@ -13,6 +13,8 @@ Terms used throughout brepjs documentation, in alphabetical order. Where a term 
 
 **Adapter** (kernel adapter): a class implementing `KernelInterface` that bridges brepjs to a specific geometry kernel. Two ship: OCCT and brepkit. See [Writing a Custom Kernel](../extending/custom-kernel).
 
+**Archetype**: `archetype: 'wall'` on a family. The domain-neutral kind a BIM export routes on, so a copied registry family keeps its IFC mapping after being renamed. Undeclared families fall back to matching their display name. See [IFC Export](../families/ifc-export).
+
 ## B
 
 **B-Rep** (Boundary Representation): a 3D shape representation as a set of mathematical surfaces (faces) bounded by curves (edges) connected at points (vertices). Contrast with mesh (triangles). See [B-Rep vs Mesh](../concepts/brep-vs-mesh).

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -2175,10 +2175,25 @@ interface FamiliesToBimOptions {
     readonly proxyEvaluator?: csg.Evaluator | undefined;
 }
 
+interface ProxiedElement {
+    readonly keyPath: string;
+    /** The family's display name, as resolved. */
+    readonly type: string;
+    readonly archetype: string | undefined;
+}
+
 interface FamiliesBimResult {
     readonly model: BimModel;
     /** LocalId per geometry-bearing families key path. */
     readonly idByKeyPath: ReadonlyMap<string, LocalId>;
+    /**
+     * Elements exported as IfcBuildingElementProxy because no spec route
+     * matched, in walk order. Only ever non-empty when `proxyEvaluator` is set:
+     * without it an unrouted element is a hard error instead. A renamed family
+     * that has lost its routing lands here rather than in the file as the type
+     * you meant, so check this before trusting an export.
+     */
+    readonly proxied: readonly ProxiedElement[];
 }
 
 /**

--- a/apps/playground/src/types/brepjs-families-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-families-ambient.d.ts
@@ -54,11 +54,23 @@ interface FamilyComponent<P, I = P> {
     /** `'fill'` marks a family whose instances fill an opening when placed in a
      *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
     readonly role: 'fill' | undefined;
+    /** Domain-neutral kind an adapter dispatches on, decoupled from the display
+     *  name so a renamed copy of a registry family keeps its mapping. */
+    readonly archetype: string | undefined;
     readonly renderErased: (props: object) => Element;
 }
 
 interface FamilyOptions<P = unknown, I = P> {
     readonly role?: 'fill' | undefined;
+    /**
+     * What kind of thing this family is, independent of what it is called.
+     * Adapters route on this instead of `familyName`, so copy-in families
+     * survive being renamed (`Storey` -> `Level` -> `Etage`). Values are the
+     * adapter's vocabulary, not this layer's: brepjs-families never interprets
+     * one, which is what keeps it domain-neutral. The starter registry uses its
+     * own manifest names (`'wall'`, `'storey'`, ...).
+     */
+    readonly archetype?: string | undefined;
     /** Optional Zod schema validated at element construction (the earliest
      *  point with a useful stack). Schema output replaces the props, so
      *  defaults and transforms apply before render — the output type must be
@@ -135,6 +147,9 @@ interface Relationship {
 
 interface ResolvedElement {
     readonly type: string;
+    /** The family's declared `archetype`, or undefined for intrinsics. Adapters
+     *  route on this so a renamed family keeps its mapping. */
+    readonly archetype: string | undefined;
     /** Ancestor chain joined with '/'; prop-embedded elements use
      *  `${hostPath}/${propName}:${slotKey}`. */
     readonly keyPath: string;

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -44,10 +44,25 @@ export interface FamiliesToBimOptions {
   readonly proxyEvaluator?: csg.Evaluator | undefined;
 }
 
+export interface ProxiedElement {
+  readonly keyPath: string;
+  /** The family's display name, as resolved. */
+  readonly type: string;
+  readonly archetype: string | undefined;
+}
+
 export interface FamiliesBimResult {
   readonly model: BimModel;
   /** LocalId per geometry-bearing families key path. */
   readonly idByKeyPath: ReadonlyMap<string, LocalId>;
+  /**
+   * Elements exported as IfcBuildingElementProxy because no spec route
+   * matched, in walk order. Only ever non-empty when `proxyEvaluator` is set:
+   * without it an unrouted element is a hard error instead. A renamed family
+   * that has lost its routing lands here rather than in the file as the type
+   * you meant, so check this before trusting an export.
+   */
+  readonly proxied: readonly ProxiedElement[];
 }
 
 const SPEC_DEFAULTS = {
@@ -60,28 +75,28 @@ const SPEC_DEFAULTS = {
 const GEOMETRY_PROPS = new Set(['voids', 'fuse', 'transform', 'psets']);
 
 const SPEC_ROUTES = {
-  Wall: {
+  wall: {
     parse: parseWallSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addWall(spec as never, { stableKey: key }),
   },
-  Slab: {
+  slab: {
     parse: parseSlabSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addSlab(spec as never, { stableKey: key }),
   },
-  Column: {
+  column: {
     parse: parseColumnSpec,
     add: (m: BimModel, spec: unknown, key: string) =>
       m.addColumn(spec as never, { stableKey: key }),
   },
-  Beam: {
+  beam: {
     parse: parseBeamSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addBeam(spec as never, { stableKey: key }),
   },
-  Roof: {
+  roof: {
     parse: parseRoofSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addRoof(spec as never, { stableKey: key }),
   },
-  Stair: {
+  stair: {
     parse: parseStairSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addStair(spec as never, { stableKey: key }),
     input: stairSpecInput,
@@ -105,9 +120,31 @@ function stairSpecInput(el: ResolvedElement): Record<string, unknown> {
   };
 }
 
-function specRoute(type: string): (typeof SPEC_ROUTES)[keyof typeof SPEC_ROUTES] | undefined {
-  return Object.hasOwn(SPEC_ROUTES, type)
-    ? SPEC_ROUTES[type as keyof typeof SPEC_ROUTES]
+/**
+ * Families predating `archetype` are routed by their display name. Keeping
+ * this fallback makes the declaration purely additive, at the cost of the
+ * original trap surviving for undeclared families: rename one and it stops
+ * routing.
+ */
+const NAME_ARCHETYPES: Readonly<Record<string, string>> = {
+  Storey: 'storey',
+  Wall: 'wall',
+  Slab: 'slab',
+  Column: 'column',
+  Beam: 'beam',
+  Roof: 'roof',
+  Stair: 'stair',
+};
+
+function archetypeFor(el: ResolvedElement): string | undefined {
+  return el.archetype ?? NAME_ARCHETYPES[el.type];
+}
+
+function specRoute(
+  archetype: string | undefined
+): (typeof SPEC_ROUTES)[keyof typeof SPEC_ROUTES] | undefined {
+  return archetype !== undefined && Object.hasOwn(SPEC_ROUTES, archetype)
+    ? SPEC_ROUTES[archetype as keyof typeof SPEC_ROUTES]
     : undefined;
 }
 
@@ -435,6 +472,7 @@ export function familiesToBim(
   model.aggregate(siteResult.value, buildingId);
 
   const idByKeyPath = new Map<string, LocalId>();
+  const proxied: ProxiedElement[] = [];
   const walk = (
     el: ResolvedElement,
     storeyId: LocalId | null,
@@ -443,10 +481,11 @@ export function familiesToBim(
     // A rotate op anywhere on the ancestor chain taints every routed
     // descendant: inherited transforms carry it into their geometry.
     const rotatedHere = rotated || hasRotateOp(el);
-    let proxied = false;
+    let proxiedHere = false;
     let containerId = storeyId;
-    const route = specRoute(el.type);
-    if (el.type === 'Storey') {
+    const archetype = archetypeFor(el);
+    const route = specRoute(archetype);
+    if (archetype === 'storey') {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
       const storeyResult = model.addStorey(
@@ -495,7 +534,7 @@ export function familiesToBim(
         return err(
           specError(
             'FAMILIES_NO_STOREY',
-            `familiesToBim: '${el.keyPath}' has no Storey ancestor — IFC elements need spatial containment`
+            `familiesToBim: '${el.keyPath}' has no Storey ancestor — IFC elements need spatial containment; a container family needs archetype: 'storey' to be recognised under any name`
           )
         );
       }
@@ -516,7 +555,7 @@ export function familiesToBim(
         return err(
           specError(
             'FAMILIES_UNSUPPORTED_TYPE',
-            `familiesToBim: no spec mapping for element type '${el.type}' at '${el.keyPath}' — add a spec route, or pass proxyEvaluator to export it as an IfcBuildingElementProxy`
+            `familiesToBim: no spec mapping for element type '${el.type}' at '${el.keyPath}' (archetype: ${el.archetype ?? 'none'}) — routing is by archetype, so declare one on the family, add a spec route, or pass proxyEvaluator to export it as an IfcBuildingElementProxy`
           )
         );
       }
@@ -526,7 +565,7 @@ export function familiesToBim(
         return err(
           specError(
             'FAMILIES_NO_STOREY',
-            `familiesToBim: '${el.keyPath}' has no Storey ancestor — IFC elements need spatial containment`
+            `familiesToBim: '${el.keyPath}' has no Storey ancestor — IFC elements need spatial containment; a container family needs archetype: 'storey' to be recognised under any name`
           )
         );
       }
@@ -534,13 +573,14 @@ export function familiesToBim(
       if (!added.ok) return added;
       model.placeIn(added.value, containerId);
       idByKeyPath.set(el.keyPath, added.value);
-      proxied = true;
+      proxied.push({ keyPath: el.keyPath, type: el.type, archetype: el.archetype });
+      proxiedHere = true;
     }
     for (const child of el.children) {
       // A wall's openings were mapped by addOpenings; a proxy's are baked
       // into its authoritative tessellated body — neither wants the
       // outside-wall rejection on the synthesized Opening child.
-      if ((el.type === 'Wall' || proxied) && child.type === 'Opening') continue;
+      if ((archetype === 'wall' || proxiedHere) && child.type === 'Opening') continue;
       const r = walk(child, containerId, rotatedHere);
       if (!r.ok) return r;
     }
@@ -552,5 +592,5 @@ export function familiesToBim(
     model[Symbol.dispose]();
     return walked;
   }
-  return ok({ model, idByKeyPath });
+  return ok({ model, idByKeyPath, proxied });
 }

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -134,6 +134,8 @@ const NAME_ARCHETYPES: Readonly<Record<string, string>> = {
   Beam: 'beam',
   Roof: 'roof',
   Stair: 'stair',
+  Door: 'door',
+  Window: 'window',
 };
 
 function archetypeFor(el: ResolvedElement): string | undefined {
@@ -281,12 +283,13 @@ function addFill(
   input: Record<string, unknown>,
   identity: OpeningIdentityOptions
 ): Result<LocalId, BimError> {
-  if (fill.type === 'Door') {
+  const archetype = archetypeFor(fill);
+  if (archetype === 'door') {
     const parsed = parseDoorSpec(input);
     if (!parsed.ok) return parsed;
     return model.addDoor(parsed.value, identity);
   }
-  if (fill.type === 'Window') {
+  if (archetype === 'window') {
     const parsed = parseWindowSpec(input);
     if (!parsed.ok) return parsed;
     return model.addWindow(parsed.value, identity);
@@ -294,7 +297,7 @@ function addFill(
   return err(
     specError(
       'FAMILIES_UNSUPPORTED_FILL',
-      `familiesToBim: no fill mapping for element type '${fill.type}' at '${fill.keyPath}'`
+      `familiesToBim: no fill mapping for element type '${fill.type}' at '${fill.keyPath}' (archetype: ${archetype ?? 'none'}) — a filler needs archetype: 'door' or 'window'`
     )
   );
 }
@@ -539,7 +542,7 @@ export function familiesToBim(
         );
       }
       model.placeIn(added.value, containerId);
-      if (el.type === 'Wall') {
+      if (archetype === 'wall') {
         const opened = addOpenings(model, el, added.value, containerId, idByKeyPath);
         if (!opened.ok) return opened;
       }

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -274,4 +274,5 @@ export {
   familiesToBim,
   type FamiliesToBimOptions,
   type FamiliesBimResult,
+  type ProxiedElement,
 } from './familiesAdapter.js';

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -523,3 +523,81 @@ describe('familiesToBim openings', () => {
     expect(isOk(selfCollision)).toBe(false);
   });
 });
+
+/**
+ * Routing is keyed on the declared archetype, not the family's display name.
+ * The copy-in registry hands people a file they own, so renaming a family is
+ * expected; without a declaration the rename silently costs the IFC mapping.
+ */
+describe('archetype routing', () => {
+  const DIMS = { length: 3000, height: 2700, thickness: 200 };
+
+  const Level = family<{ readonly items: readonly Element[] }>(
+    'Level',
+    (p) => el('Group', {}, p.items),
+    { archetype: 'storey' }
+  );
+  const Partition = family<WallProps>(
+    'Partition',
+    (p) => el('Box', { size: [p.length, p.thickness, p.height] }),
+    { archetype: 'wall' }
+  );
+
+  it('renamed families still reach IfcBuildingStorey and IfcWall', async () => {
+    const tree = resolve(Level({ key: 'l1', items: [Partition({ key: 'p1', ...DIMS })] }));
+
+    const projected = familiesToBim(tree, { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    const result = unwrap(projected);
+    using model = result.model;
+
+    expect(result.idByKeyPath.has('l1')).toBe(true);
+    expect(result.idByKeyPath.has('l1/p1')).toBe(true);
+    expect(result.proxied).toEqual([]);
+
+    const text = await ifcText(model);
+    expect(text).toContain('IFCBUILDINGSTOREY');
+    expect(text).toContain('IFCWALL');
+    expect(text).not.toContain('IFCBUILDINGELEMENTPROXY');
+  });
+
+  it('an undeclared rename loses its route and is reported as proxied', () => {
+    const Undeclared = family<WallProps>('Partition', (p) =>
+      el('Box', { size: [p.length, p.thickness, p.height] })
+    );
+    const tree = resolve(Level({ key: 'l1', items: [Undeclared({ key: 'p1', ...DIMS })] }));
+
+    // Without an evaluator the lost route is a hard error, as before.
+    const strict = familiesToBim(tree, { project: PROJECT });
+    expect(isOk(strict)).toBe(false);
+    if (!strict.ok) expect(strict.error.code).toBe('FAMILIES_UNSUPPORTED_TYPE');
+
+    using ev = new csg.Evaluator();
+    const result = unwrap(familiesToBim(tree, { project: PROJECT, proxyEvaluator: ev }));
+    using model = result.model;
+    expect(model.getProxies()).toHaveLength(1);
+    expect(result.proxied).toEqual([{ keyPath: 'l1/p1', type: 'Partition', archetype: undefined }]);
+  });
+
+  it('an archetype overrides a display name that would route elsewhere', () => {
+    // Named 'Wall' (which the legacy fallback routes), declared a column.
+    const Confusing = family<{
+      readonly height: number;
+      readonly profile: { readonly kind: 'CIRCULAR'; readonly radius: number };
+    }>('Wall', (p) => el('Cylinder', { radius: p.profile.radius, height: p.height }), {
+      archetype: 'column',
+    });
+    const tree = resolve(
+      Level({
+        key: 'l1',
+        items: [Confusing({ key: 'c1', height: 3000, profile: { kind: 'CIRCULAR', radius: 150 } })],
+      })
+    );
+    const result = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = result.model;
+    expect(result.idByKeyPath.has('l1/c1')).toBe(true);
+    expect(result.proxied).toEqual([]);
+    expect(model.getColumns()).toHaveLength(1);
+    expect(model.getWalls()).toHaveLength(0);
+  });
+});

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -579,6 +579,75 @@ describe('archetype routing', () => {
     expect(result.proxied).toEqual([{ keyPath: 'l1/p1', type: 'Partition', archetype: undefined }]);
   });
 
+  it('a renamed wall keeps its openings, filler and relationships', async () => {
+    const Entrance = family<{ readonly width: number; readonly height: number }>(
+      'Entrance',
+      (p) => el('Box', { size: [p.width, 300, p.height], transform: [tTranslate([500, 0, 0])] }),
+      { role: 'fill', archetype: 'door' }
+    );
+    const VoidedPartition = family<WallProps & { readonly voids: readonly Element[] }>(
+      'Partition',
+      (p) => el('Box', { size: [p.length, p.thickness, p.height], voids: p.voids }),
+      { archetype: 'wall' }
+    );
+
+    const tree = resolve(
+      Level({
+        key: 'l1',
+        items: [
+          VoidedPartition({
+            key: 'p1',
+            ...DIMS,
+            voids: [Entrance({ key: 'entry', width: 1000, height: 2100 })],
+          }),
+        ],
+      })
+    );
+
+    const result = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = result.model;
+
+    // Both halves of the opening path must agree on the archetype: addOpenings
+    // is gated on it, and the child walk suppresses the synthesized Opening on
+    // the same condition. Disagree and the door vanishes from a valid file.
+    expect(result.idByKeyPath.has('l1/p1/voids:entry')).toBe(true);
+    expect(result.idByKeyPath.has('l1/p1/voids:entry/fill')).toBe(true);
+
+    const text = await ifcText(model);
+    expect(text).toContain('IFCOPENINGELEMENT');
+    expect(text).toContain('IFCDOOR');
+    expect(text).toContain('IFCRELVOIDSELEMENT');
+    expect(text).toContain('IFCRELFILLSELEMENT');
+  });
+
+  it('a renamed window filler still reaches IfcWindow', async () => {
+    const Glazing = family<{ readonly width: number; readonly height: number }>(
+      'Glazing',
+      (p) => el('Box', { size: [p.width, 300, p.height], transform: [tTranslate([500, 0, 900])] }),
+      { role: 'fill', archetype: 'window' }
+    );
+    const VoidedPartition = family<WallProps & { readonly voids: readonly Element[] }>(
+      'Partition',
+      (p) => el('Box', { size: [p.length, p.thickness, p.height], voids: p.voids }),
+      { archetype: 'wall' }
+    );
+    const tree = resolve(
+      Level({
+        key: 'l1',
+        items: [
+          VoidedPartition({
+            key: 'p1',
+            ...DIMS,
+            voids: [Glazing({ key: 'w', width: 1000, height: 1200 })],
+          }),
+        ],
+      })
+    );
+    const result = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = result.model;
+    expect(await ifcText(model)).toContain('IFCWINDOW');
+  });
+
   it('an archetype overrides a display name that would route elsewhere', () => {
     // Named 'Wall' (which the legacy fallback routes), declared a column.
     const Confusing = family<{

--- a/packages/brepjs-cad/skills/implement/references/families-bim.md
+++ b/packages/brepjs-cad/skills/implement/references/families-bim.md
@@ -21,10 +21,16 @@ const Wall = family<{
   height: number;
   thickness: number;
   voids?: readonly ReturnType<typeof Door>[];
-}>('Wall', (p) => el('Box', { size: [p.length, p.thickness, p.height], voids: p.voids ?? [] }));
+}>(
+  'Wall',
+  (p) => el('Box', { size: [p.length, p.thickness, p.height], voids: p.voids ?? [] }),
+  { archetype: 'wall' } // archetype routes it to IfcWall, whatever the family is named
+);
 
-const Storey = family<{ items: readonly unknown[] }>('Storey', (p) =>
-  el('Group', {}, p.items as never)
+const Storey = family<{ items: readonly unknown[] }>(
+  'Storey',
+  (p) => el('Group', {}, p.items as never),
+  { archetype: 'storey' }
 );
 
 const tree = resolve(
@@ -64,9 +70,11 @@ const bytes = unwrap(await toIfc(bim, { applicationName: 'agent', applicationVer
 - **Openings are fill-role families in the host's `voids`** — never a bare cut. An anonymous
   (non-fill) void is rejected (`FAMILIES_ANONYMOUS_VOID`): it would cut the viewport solid while the
   parametric IFC body stays solid.
-- **Routed element types:** `Wall`, `Slab`, `Column`, `Beam`, `Roof`, `Stair`, `Storey`, plus
-  `Door`/`Window` as fills. The family's **name string** routes it (`family('Wall', …)`). Anything
-  else with geometry → `FAMILIES_UNSUPPORTED_TYPE`; drop to the imperative `BimModel` adders
+- **Routed archetypes:** `wall`, `slab`, `column`, `beam`, `roof`, `stair`, `storey`, plus
+  `Door`/`Window` as fills. The family's **archetype** routes it
+  (`family('Wall', …, { archetype: 'wall' })`), so a renamed family keeps its mapping; declare none
+  and it falls back to matching the family name. Anything else with geometry →
+  `FAMILIES_UNSUPPORTED_TYPE`; drop to the imperative `BimModel` adders
   (`addSpace`, `addFooting`, `addRailing`, …) for the rest.
 - **Placement frame:** an element's thickness extrudes along `axisZ × axisX`, so a wall running +Y
   (`axisX: [0,1,0]`) grows its thickness toward **−X**. Probe placement with `getBounds`, not by eye.

--- a/packages/brepjs-cad/skills/implement/references/families-bim.md
+++ b/packages/brepjs-cad/skills/implement/references/families-bim.md
@@ -13,7 +13,7 @@ import { familiesToBim, toIfc } from 'brepjs-bim';
 const Door = family<{ width: number; height: number; at: number }>(
   'Door',
   (p) => el('Box', { size: [p.width, 300, p.height], transform: [tTranslate([p.at, 0, 0])] }),
-  { role: 'fill' } // fill-role: placed in a host's voids, becomes a real IfcOpening + IfcDoor
+  { role: 'fill', archetype: 'door' } // placed in a host's voids, becomes a real IfcOpening + IfcDoor
 );
 
 const Wall = family<{
@@ -71,7 +71,7 @@ const bytes = unwrap(await toIfc(bim, { applicationName: 'agent', applicationVer
   (non-fill) void is rejected (`FAMILIES_ANONYMOUS_VOID`): it would cut the viewport solid while the
   parametric IFC body stays solid.
 - **Routed archetypes:** `wall`, `slab`, `column`, `beam`, `roof`, `stair`, `storey`, plus
-  `Door`/`Window` as fills. The family's **archetype** routes it
+  `door`/`window` as fills. The family's **archetype** routes it
   (`family('Wall', …, { archetype: 'wall' })`), so a renamed family keeps its mapping; declare none
   and it falls back to matching the family name. Anything else with geometry →
   `FAMILIES_UNSUPPORTED_TYPE`; drop to the imperative `BimModel` adders

--- a/packages/brepjs-families/README.md
+++ b/packages/brepjs-families/README.md
@@ -59,6 +59,7 @@ What the pieces buy you:
 - **Key paths** (`ground/south/voids:entry`) are order-independent identity. Reorder siblings and every element keeps its identity; a BIM projection derives stable IFC GlobalIds from them.
 - **The CSG IR** is content-addressed: two identical walls evaluate once and share one materialization, while each keeps its own identity.
 - **Fill roles** make openings real: a `role: 'fill'` family inside a wall's `voids` synthesizes an `Opening` element with a `Fills` relationship, which a BIM export turns into `IfcOpeningElement` + `IfcRelFillsElement` rather than an anonymous boolean hole.
+- **Archetypes** decouple routing from naming: `family('Level', render, { archetype: 'storey' })` still exports as `IfcBuildingStorey`. The value is an opaque string here (this layer never interprets one), which is what lets the registry's copy-in files be renamed without losing their BIM mapping.
 - **JSX optional**: `jsxImportSource: "brepjs-families"` lets you write the same trees as JSX. The plain-function API is primary.
 
 ## Starter registry

--- a/packages/brepjs-families/registry/families/beam.ts
+++ b/packages/brepjs-families/registry/families/beam.ts
@@ -1,4 +1,4 @@
-// brepjs-family: beam@1
+// brepjs-family: beam@2
 /**
  * Beam — a linear member (cross-section centred on the beam axis, extruded
  * along `axisX` by `length`). Props feed the IFC beam spec 1:1 in a BIM
@@ -138,5 +138,5 @@ export const Beam = family(
     }
     return el('Geometry', { node, transform: [tTranslate(p.at)] });
   },
-  { props: beamSchema }
+  { archetype: 'beam', props: beamSchema }
 );

--- a/packages/brepjs-families/registry/families/column.ts
+++ b/packages/brepjs-families/registry/families/column.ts
@@ -1,4 +1,4 @@
-// brepjs-family: column@2
+// brepjs-family: column@3
 /**
  * Column — a vertical column (cross-section centred on `at`, extruded up by
  * `height`). Props feed the IFC column spec 1:1 in a BIM projection. The
@@ -117,5 +117,5 @@ export const Column = family(
       transform: [tTranslate(p.at)],
     });
   },
-  { props: columnSchema }
+  { archetype: 'column', props: columnSchema }
 );

--- a/packages/brepjs-families/registry/families/door.ts
+++ b/packages/brepjs-families/registry/families/door.ts
@@ -1,4 +1,4 @@
-// brepjs-family: door@1
+// brepjs-family: door@2
 /**
  * Door — a fill-role family: placed in a wall's `voids`, resolution
  * synthesizes an Opening (IfcRelVoidsElement + IfcRelFillsElement in a BIM
@@ -29,5 +29,5 @@ export const Door = family(
       size: p.alongY ? [p.depth, p.width, p.height] : [p.width, p.depth, p.height],
       transform: [tTranslate(p.alongY ? [0, p.at[0], p.at[1]] : [p.at[0], 0, p.at[1]])],
     }),
-  { role: 'fill', props: doorSchema }
+  { role: 'fill', archetype: 'door', props: doorSchema }
 );

--- a/packages/brepjs-families/registry/families/roof.ts
+++ b/packages/brepjs-families/registry/families/roof.ts
@@ -1,4 +1,4 @@
-// brepjs-family: roof@2
+// brepjs-family: roof@3
 /**
  * Roof — a rectangular roof over a corner-origin length × width footprint.
  * Props feed the IFC roof spec 1:1 in a BIM projection. Presence of `pitch`
@@ -123,5 +123,5 @@ export const Roof = family(
   'Roof',
   (p: z.output<typeof roofSchema>) =>
     el('Geometry', { node: roofNode(p), transform: [tTranslate(p.at)] }),
-  { props: roofSchema }
+  { archetype: 'roof', props: roofSchema }
 );

--- a/packages/brepjs-families/registry/families/slab.ts
+++ b/packages/brepjs-families/registry/families/slab.ts
@@ -1,4 +1,4 @@
-// brepjs-family: slab@1
+// brepjs-family: slab@2
 /**
  * Slab — a horizontal plate (floor, roof, landing, base slab). Props feed
  * the IFC slab spec 1:1 in a BIM projection.
@@ -27,5 +27,5 @@ export const Slab = family(
       size: [p.length, p.width, p.thickness],
       transform: [tTranslate(p.at)],
     }),
-  { props: slabSchema }
+  { archetype: 'slab', props: slabSchema }
 );

--- a/packages/brepjs-families/registry/families/stair.ts
+++ b/packages/brepjs-families/registry/families/stair.ts
@@ -1,4 +1,4 @@
-// brepjs-family: stair@1
+// brepjs-family: stair@2
 /**
  * Stair — one or more straight flights, each a stepped sawtooth solid. Props
  * feed the IFC stair spec 1:1: every flight carries its own spec-shaped
@@ -104,5 +104,5 @@ export const Stair = family(
     const node = flights.length === 1 && flights[0] ? flights[0] : csg.compound(flights);
     return el('Geometry', { node, transform: [tTranslate(p.at)] });
   },
-  { props: stairPropsSchema }
+  { archetype: 'stair', props: stairPropsSchema }
 );

--- a/packages/brepjs-families/registry/families/storey.ts
+++ b/packages/brepjs-families/registry/families/storey.ts
@@ -1,4 +1,4 @@
-// brepjs-family: storey@1
+// brepjs-family: storey@2
 /**
  * Storey — a pure spatial container: no geometry of its own, maps onto
  * IfcBuildingStorey in a BIM projection. Children are the storey's elements.
@@ -17,5 +17,5 @@ export type StoreyProps = z.input<typeof storeySchema>;
 export const Storey = family(
   'Storey',
   (p: z.output<typeof storeySchema>) => el('Group', {}, p.items),
-  { props: storeySchema }
+  { archetype: 'storey', props: storeySchema }
 );

--- a/packages/brepjs-families/registry/families/wall.ts
+++ b/packages/brepjs-families/registry/families/wall.ts
@@ -1,4 +1,4 @@
-// brepjs-family: wall@1
+// brepjs-family: wall@2
 /**
  * Wall — a solid wall running along `axisX` with optional fill-role voids
  * (doors, windows). Props feed the IFC wall spec 1:1 when projected through
@@ -31,14 +31,10 @@ export const Wall = family(
   (p: z.output<typeof wallSchema>) => {
     const alongY = p.axisX[1] !== 0;
     return el('Box', {
-      size: alongY
-        ? [p.thickness, p.length, p.height]
-        : [p.length, p.thickness, p.height],
+      size: alongY ? [p.thickness, p.length, p.height] : [p.length, p.thickness, p.height],
       voids: p.voids,
-      transform: [
-        tTranslate(alongY ? [p.at[0] - p.thickness, p.at[1], p.at[2]] : p.at),
-      ],
+      transform: [tTranslate(alongY ? [p.at[0] - p.thickness, p.at[1], p.at[2]] : p.at)],
     });
   },
-  { props: wallSchema }
+  { archetype: 'wall', props: wallSchema }
 );

--- a/packages/brepjs-families/registry/families/window.ts
+++ b/packages/brepjs-families/registry/families/window.ts
@@ -1,4 +1,4 @@
-// brepjs-family: window@1
+// brepjs-family: window@2
 /**
  * Window — a fill-role family: placed in a wall's `voids`, resolution
  * synthesizes an Opening. `at` is [along-wall, sill] in the host wall's
@@ -28,5 +28,5 @@ export const Window = family(
       size: p.alongY ? [p.depth, p.width, p.height] : [p.width, p.depth, p.height],
       transform: [tTranslate(p.alongY ? [0, p.at[0], p.at[1]] : [p.at[0], 0, p.at[1]])],
     }),
-  { role: 'fill', props: windowSchema }
+  { role: 'fill', archetype: 'window', props: windowSchema }
 );

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -4,7 +4,7 @@
   "families": [
     {
       "name": "storey",
-      "version": 1,
+      "version": 2,
       "description": "Spatial container mapping onto IfcBuildingStorey",
       "files": ["families/storey.ts"],
       "npmDeps": ["brepjs-families", "zod"],
@@ -12,7 +12,7 @@
     },
     {
       "name": "wall",
-      "version": 1,
+      "version": 2,
       "description": "Solid wall along a configurable axis with fill-role voids",
       "files": ["families/wall.ts"],
       "npmDeps": ["brepjs-families", "zod"],
@@ -20,7 +20,7 @@
     },
     {
       "name": "slab",
-      "version": 1,
+      "version": 2,
       "description": "Horizontal plate: floor, roof, landing, or base slab",
       "files": ["families/slab.ts"],
       "npmDeps": ["brepjs-families", "zod"],
@@ -28,7 +28,7 @@
     },
     {
       "name": "column",
-      "version": 2,
+      "version": 3,
       "description": "Vertical column (rectangular / circular / I-shape) mapping onto IfcColumn",
       "files": ["families/column.ts"],
       "npmDeps": ["brepjs", "brepjs-families", "zod"],
@@ -36,7 +36,7 @@
     },
     {
       "name": "beam",
-      "version": 1,
+      "version": 2,
       "description": "Linear beam (rectangular / circular / I-shape) mapping onto IfcBeam",
       "files": ["families/beam.ts"],
       "npmDeps": ["brepjs", "brepjs-families", "zod"],
@@ -44,7 +44,7 @@
     },
     {
       "name": "roof",
-      "version": 2,
+      "version": 3,
       "description": "Rectangular roof (flat / shed / gable / hip / dome) mapping onto IfcRoof",
       "files": ["families/roof.ts"],
       "npmDeps": ["brepjs", "brepjs-families", "zod"],
@@ -52,7 +52,7 @@
     },
     {
       "name": "stair",
-      "version": 1,
+      "version": 2,
       "description": "Multi-flight stair (stepped sawtooth flights) mapping onto IfcStair",
       "files": ["families/stair.ts"],
       "npmDeps": ["brepjs", "brepjs-families", "zod"],

--- a/packages/brepjs-families/registry/manifest.json
+++ b/packages/brepjs-families/registry/manifest.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "door",
-      "version": 1,
+      "version": 2,
       "description": "Fill-role void: synthesizes an Opening with IfcRelVoids/Fills",
       "files": ["families/door.ts"],
       "npmDeps": ["brepjs-families", "zod"],
@@ -68,7 +68,7 @@
     },
     {
       "name": "window",
-      "version": 1,
+      "version": 2,
       "description": "Fill-role void: synthesizes an Opening with IfcRelVoids/Fills",
       "files": ["families/window.ts"],
       "npmDeps": ["brepjs-families", "zod"],

--- a/packages/brepjs-families/src/element.ts
+++ b/packages/brepjs-families/src/element.ts
@@ -77,11 +77,23 @@ export interface FamilyComponent<P, I = P> {
   /** `'fill'` marks a family whose instances fill an opening when placed in a
    *  host's `voids` (doors, windows): resolution synthesizes the Opening. */
   readonly role: 'fill' | undefined;
+  /** Domain-neutral kind an adapter dispatches on, decoupled from the display
+   *  name so a renamed copy of a registry family keeps its mapping. */
+  readonly archetype: string | undefined;
   readonly renderErased: (props: object) => Element;
 }
 
 export interface FamilyOptions<P = unknown, I = P> {
   readonly role?: 'fill' | undefined;
+  /**
+   * What kind of thing this family is, independent of what it is called.
+   * Adapters route on this instead of `familyName`, so copy-in families
+   * survive being renamed (`Storey` -> `Level` -> `Etage`). Values are the
+   * adapter's vocabulary, not this layer's: brepjs-families never interprets
+   * one, which is what keeps it domain-neutral. The starter registry uses its
+   * own manifest names (`'wall'`, `'storey'`, ...).
+   */
+  readonly archetype?: string | undefined;
   /** Optional Zod schema validated at element construction (the earliest
    *  point with a useful stack). Schema output replaces the props, so
    *  defaults and transforms apply before render — the output type must be
@@ -123,6 +135,7 @@ export function family<P extends object, I extends object = P>(
   const component: FamilyComponent<P, I> = Object.assign(make, {
     familyName: name,
     role: options?.role,
+    archetype: options?.archetype,
     renderErased: (props: object) => render(props as P),
   });
   return component;
@@ -146,4 +159,8 @@ export function isFamily(t: Element['type']): t is FamilyComponent<never> {
 
 export function typeNameOf(e: Element): string {
   return isFamily(e.type) ? e.type.familyName : e.type;
+}
+
+export function archetypeOf(e: Element): string | undefined {
+  return isFamily(e.type) ? e.type.archetype : undefined;
 }

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -10,7 +10,7 @@
  */
 
 import { csg } from 'brepjs';
-import { IDENTITY_PROPS, isFamily, typeNameOf, type Element } from './element.js';
+import { archetypeOf, IDENTITY_PROPS, isFamily, typeNameOf, type Element } from './element.js';
 
 export type TransformOp =
   | { readonly op: 'translate'; readonly v: readonly [number, number, number] }
@@ -46,6 +46,9 @@ export interface Relationship {
 
 export interface ResolvedElement {
   readonly type: string;
+  /** The family's declared `archetype`, or undefined for intrinsics. Adapters
+   *  route on this so a renamed family keeps its mapping. */
+  readonly archetype: string | undefined;
   /** Ancestor chain joined with '/'; prop-embedded elements use
    *  `${hostPath}/${propName}:${slotKey}`. */
   readonly keyPath: string;
@@ -76,15 +79,20 @@ function identityAttributes(elem: Element): Readonly<Record<string, unknown>> {
  *  outermost family supplies the resolved type name. An element's children
  *  reach the render function as `props.children` (the React contract), so a
  *  container family decides where they land in its intrinsic tree. */
-function renderToIntrinsic(elem: Element): { intrinsic: Element; typeName: string } {
+function renderToIntrinsic(elem: Element): {
+  intrinsic: Element;
+  typeName: string;
+  archetype: string | undefined;
+} {
   const typeName = typeNameOf(elem);
+  const archetype = archetypeOf(elem);
   let cur = elem;
   while (isFamily(cur.type)) {
     cur = cur.type.renderErased(
       cur.children.length > 0 ? { ...cur.props, children: cur.children } : cur.props
     );
   }
-  return { intrinsic: cur, typeName };
+  return { intrinsic: cur, typeName, archetype };
 }
 
 /** Fragments inline: their children join the parent's child list and the
@@ -196,6 +204,7 @@ function desugar(intrinsic: Element, hostPath: string | null): DesugarOut {
       const fill = resolveAt(v, `${openingPath}/fill`, v.key !== undefined, []);
       openings.push({
         type: 'Opening',
+        archetype: 'opening',
         keyPath: openingPath,
         keyed: v.key !== undefined,
         geometry: fill.geometry,
@@ -245,7 +254,7 @@ function resolveAt(
   keyed: boolean,
   inherited: readonly TransformOp[]
 ): ResolvedElement {
-  const { intrinsic, typeName } = renderToIntrinsic(elem);
+  const { intrinsic, typeName, archetype } = renderToIntrinsic(elem);
   const d = desugar(intrinsic, path);
   // The element's own transform is applied inside desugar (local frame, after
   // voids/fuse); ancestor transforms compose outside it, and thread down so
@@ -275,6 +284,7 @@ function resolveAt(
   children.push(...openings);
   return {
     type: typeName,
+    archetype,
     keyPath: path,
     keyed,
     geometry,

--- a/packages/brepjs-families/tests/families.test.ts
+++ b/packages/brepjs-families/tests/families.test.ts
@@ -544,3 +544,48 @@ describe('composition (children, hierarchical transforms, rotation)', () => {
     expect(tree.children.map((c) => c.keyPath)).toEqual(['l/w1', 'l/w2']);
   });
 });
+
+describe('archetype', () => {
+  const Door = family<{ readonly w: number }>(
+    'Door',
+    (p) => el('Box', { size: [p.w, 300, 2100] }),
+    {
+      role: 'fill',
+      archetype: 'door',
+    }
+  );
+
+  it('rides from the family declaration onto the resolved element', () => {
+    const Level = family<{ readonly items: readonly Element[] }>(
+      'Level',
+      (p) => el('Group', {}, p.items),
+      { archetype: 'storey' }
+    );
+    const tree = resolve(Level({ key: 'l', items: [] }));
+    expect(tree.type).toBe('Level');
+    expect(tree.archetype).toBe('storey');
+  });
+
+  it('is undefined for families that declare none, and for intrinsics', () => {
+    const Plain = family('Plain', () => el('Box', { size: [1, 1, 1] }));
+    expect(resolve(Plain({ key: 'p' })).archetype).toBeUndefined();
+    expect(resolve(el('Box', { key: 'b', size: [1, 1, 1] })).archetype).toBeUndefined();
+  });
+
+  it('comes from the outermost family when one wraps another', () => {
+    const Inner = family('Inner', () => el('Box', { size: [1, 1, 1] }), { archetype: 'inner' });
+    const Outer = family('Outer', () => Inner({}), { archetype: 'outer' });
+    expect(resolve(Outer({ key: 'o' })).archetype).toBe('outer');
+  });
+
+  it('marks synthesized openings, and fills keep their own', () => {
+    const Wall = family<{ readonly voids: readonly Element[] }>('Wall', (p) =>
+      el('Box', { size: [4000, 200, 2700], voids: p.voids })
+    );
+    const tree = resolve(Wall({ key: 'w', voids: [Door({ key: 'd', w: 1000 })] }));
+    const opening = tree.children[0];
+    expect(opening?.type).toBe('Opening');
+    expect(opening?.archetype).toBe('opening');
+    expect(opening?.children[0]?.archetype).toBe('door');
+  });
+});


### PR DESCRIPTION
## The problem

`familiesAdapter.ts` keyed the entire IFC mapping on the family's **display name**. `SPEC_ROUTES` was `{ Wall, Slab, Column, Beam, Roof, Stair }`, the spatial container was a literal `el.type === 'Storey'`, and `ResolvedElement.type` is just `familyName`. So every starter-registry family name was an undeclared API contract with a different package.

That sits badly with copy-in distribution. `registry/families/storey.ts` carries `// brepjs-family: storey@1` and is explicitly handed over for the user to own, and renaming a file you own is the obvious thing to do, especially with `Storey` (the IFC spelling, not the one most teams use).

The two failure modes:

- **Renamed `Storey`** → `FAMILIES_NO_STOREY`, naming the thing you just renamed away.
- **Renamed `Wall`** → falls out of `SPEC_ROUTES`. Without `proxyEvaluator` that is a hard `FAMILIES_UNSUPPORTED_TYPE`; with one set it becomes an `IfcBuildingElementProxy`, so you get a valid IFC file full of proxies where walls should be, and no signal.

## The change

Families declare an `archetype`, and the adapter routes on that:

```ts
family('Storey', render, { archetype: 'storey' })
family('Level',  render, { archetype: 'storey' })  // same mapping, different name
```

`archetype` is an opaque string that brepjs-families never interprets. The vocabulary belongs to the adapter, which is what keeps the family layer free of IFC (`src/index.ts`: "Domain-neutral: no BIM imports here"). It sits beside `role: 'fill'`, which already decoupled "fills an opening" from the family's name; this extends the same idea to the routed element types and the spatial container.

`SPEC_ROUTES` is rekeyed to archetypes, and every name check on the routing path goes through `archetypeFor(el)`: the route lookup, the storey container, the wall-opening gate, the synthesized-`Opening` suppression in the child walk, and `addFill`'s `IfcDoor`-vs-`IfcWindow` choice. Mapped archetypes are `storey`, `wall`, `slab`, `column`, `beam`, `roof`, `stair`, `door`, `window`.

The two opening-path checks are the ones that have to agree. Greptile caught them disagreeing in the first commit: `addOpenings` was still gated on `el.type === 'Wall'` while the child walk already suppressed the `Opening` on `archetype === 'wall'`, so a renamed wall skipped the mapping *and* swallowed the child, and its door left no trace in an otherwise valid file. Following that up found the same defect in `addFill`, which picked the IFC entity off `fill.type`. `role: 'fill'` makes opening *synthesis* name-independent, which is why fillers looked like they needed no archetype; the entity choice was still name-keyed.

## Compatibility

Undeclared families fall back to matching their display name, so this is purely additive. **All 659 existing brepjs-bim tests pass unchanged.**

The fallback keeps the original trap alive for undeclared families, which is why two other things changed:

- Both error messages now name archetype as the fix, and `FAMILIES_UNSUPPORTED_TYPE` reports the archetype it resolved (`none` when neither a declaration nor the name fallback matched).
- `FamiliesBimResult` gains `proxied: readonly ProxiedElement[]`, so a lost route shows up in the result instead of only in the file. It is only ever non-empty when `proxyEvaluator` is set, since without it an unrouted element is still a hard error.

## Also in here

- Starter registry families declare their archetypes; version markers and manifest entries bump (`storey@2`, `wall@2`, `slab@2`, `column@3`, `beam@2`, `roof@3`, `stair@2`, `door@2`, `window@2`).
- Docs: a routing section in `families/ifc-export`, a renaming section in `families/copy-in`, the two error entries in `reference/errors`, a glossary entry, the brepjs-cad `families-bim` skill reference, and the families README.
- Playground ambient types regenerated.
- Prettier reflowed two pre-existing lines in `registry/families/wall.ts`; that file was already unformatted on `main` (`registry/` is outside the `format:check` globs).

## Verification

- brepjs-bim 664 tests (659 existing + 5 new), brepjs-families 59 (55 + 4)
- New tests: renamed `Level`/`Partition` still reach `IFCBUILDINGSTOREY`/`IFCWALL`; an undeclared rename is reported in `proxied`; an archetype beats a display name that would route elsewhere (family named `Wall`, `archetype: 'column'`, lands as `IfcColumn`); a renamed wall keeps its opening, filler and both relationships; a renamed window filler still reaches `IFCWINDOW`
- The two opening tests were verified RED against the previous commit and GREEN here, and only those two moved
- typecheck (root, families incl. jsx config, bim, playground), eslint, knip, boundaries, check:patterns all clean

