### PR TITLE
feat(brepjs-cad): transpiling loader for multi-file TS/TSX projects + working watch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,10 @@ jobs:
   packages-verify:
     # brepjs-cad skill runtime (verify CLI + WASM viewer). Build root brepjs and
     # brepjs-viewer dist first so the package typecheck/viewer build resolve their
-    # types (brepjs-viewer is a runtime dep, not externalized). The setup
-    # composite restores the OCCT WASM the viewer build copies.
+    # types (brepjs-viewer is a runtime dep, not externalized). brepjs-families dist
+    # is needed too: the TSX loader tests resolve brepjs-families/jsx-runtime through
+    # the workspace symlink. The setup composite restores the OCCT WASM the viewer
+    # build copies.
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
@@ -210,6 +212,7 @@ jobs:
       - uses: ./.github/actions/setup
       - run: npm run build
       - run: npm run build --workspace=brepjs-viewer
+      - run: npm run build --workspace=brepjs-families
       - run: npm run typecheck --workspace=brepjs-cad
       - run: npm run lint --workspace=brepjs-cad
       - run: npm run test --workspace=brepjs-cad

--- a/packages/brepjs-cad/eslint.config.js
+++ b/packages/brepjs-cad/eslint.config.js
@@ -6,7 +6,10 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   // Never lint build output — `eslint src tests viewer` walks viewer/ which contains the emitted
   // viewer/dist after a build; type-checked rules choke on those un-projected .js chunks.
-  { ignores: ['dist/**', 'viewer/dist/**'] },
+  // tests/fixtures/tsxProject is runtime-loaded test data for the TS/TSX loader hook —
+  // deliberately outside every tsconfig project (it carries its own), so type-aware rules
+  // can't run on it.
+  { ignores: ['dist/**', 'viewer/dist/**', 'tests/fixtures/tsxProject/**'] },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
@@ -16,7 +19,7 @@ export default tseslint.config(
     files: ['src/loader/*.mjs'],
     ...tseslint.configs.disableTypeChecked,
     languageOptions: {
-      globals: { console: 'readonly' },
+      globals: { console: 'readonly', URL: 'readonly' },
     },
   },
   {

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { writeFileSync, realpathSync, globSync } from 'node:fs';
-import { resolve, join, basename, dirname } from 'node:path';
+import { resolve, join, basename } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { runPart } from '../verify/runPart.js';
@@ -9,7 +9,13 @@ import { pushError, reportOk, serializeReport, type VerifyReport } from '../veri
 import { runMeasure } from '../verify/measure.js';
 import { runDiff } from '../verify/diff.js';
 import { scaffoldPart } from './scaffold.js';
-import { debounce, DEFAULT_DEBOUNCE_MS, isWatchRelevant, watchTree } from './watch.js';
+import {
+  debounce,
+  DEFAULT_DEBOUNCE_MS,
+  isWatchRelevant,
+  watchRootFor,
+  watchTree,
+} from './watch.js';
 import { exportPart } from './exportPart.js';
 import { openBrowser, shouldAutoOpen } from './openBrowser.js';
 import { disposeShape } from '../disposeShape.js';
@@ -347,10 +353,11 @@ program
     const { trigger } = debounce(schedule, DEFAULT_DEBOUNCE_MS);
     process.stderr.write(`watching ${path} (Ctrl-C to stop)\n`);
     start(false); // initial verify
-    // Watch the entry's whole directory tree: editors often replace a file (rename) on
-    // save, which drops a watcher bound to the inode itself — and a multi-file project
-    // must re-verify when any of its source files changes, not just the entry.
-    const stopWatching = watchTree(dirname(path), (filename) => {
+    // Watch the whole project tree (nearest package.json/tsconfig.json above the entry):
+    // editors often replace a file (rename) on save, which drops a watcher bound to the
+    // inode itself — and a multi-file project must re-verify when any source OR the root
+    // tsconfig changes, not just files beside the entry.
+    const stopWatching = watchTree(watchRootFor(path), (filename) => {
       if (isWatchRelevant(filename)) trigger();
     });
     const stop = () => {

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -322,9 +322,31 @@ program
         process.stderr.write(`watch run failed: ${(e as Error).message}\n`);
       }
     };
-    const { trigger } = debounce(() => run(true), DEFAULT_DEBOUNCE_MS);
+    // Serialize runs: a save landing mid-verify must not start a second runPart on the
+    // shared kernel (reports would interleave out of order). Edits during a run coalesce
+    // into exactly one trailing rerun.
+    let inFlight = false;
+    let rerunQueued = false;
+    const start = (fresh: boolean): void => {
+      inFlight = true;
+      void run(fresh).finally(() => {
+        inFlight = false;
+        if (rerunQueued) {
+          rerunQueued = false;
+          start(true);
+        }
+      });
+    };
+    const schedule = (): void => {
+      if (inFlight) {
+        rerunQueued = true;
+        return;
+      }
+      start(true);
+    };
+    const { trigger } = debounce(schedule, DEFAULT_DEBOUNCE_MS);
     process.stderr.write(`watching ${path} (Ctrl-C to stop)\n`);
-    void run(false); // initial verify
+    start(false); // initial verify
     // Watch the entry's whole directory tree: editors often replace a file (rename) on
     // save, which drops a watcher bound to the inode itself — and a multi-file project
     // must re-verify when any of its source files changes, not just the entry.

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { writeFileSync, watch as fsWatch, realpathSync, globSync } from 'node:fs';
+import { writeFileSync, realpathSync, globSync } from 'node:fs';
 import { resolve, join, basename, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -9,7 +9,7 @@ import { pushError, reportOk, serializeReport, type VerifyReport } from '../veri
 import { runMeasure } from '../verify/measure.js';
 import { runDiff } from '../verify/diff.js';
 import { scaffoldPart } from './scaffold.js';
-import { debounce, DEFAULT_DEBOUNCE_MS } from './watch.js';
+import { debounce, DEFAULT_DEBOUNCE_MS, isWatchRelevant, watchTree } from './watch.js';
 import { exportPart } from './exportPart.js';
 import { openBrowser, shouldAutoOpen } from './openBrowser.js';
 import { disposeShape } from '../disposeShape.js';
@@ -308,9 +308,11 @@ program
   .argument('<file>', 'path to a .brep.ts module; re-verifies on each save until Ctrl-C')
   .action((file: string) => {
     const path = resolve(file);
-    const run = async () => {
+    // Reruns import with a fresh cache-busting query — the ESM cache is keyed by URL, so
+    // without it every rerun would re-execute the first version of the part forever.
+    const run = async (fresh: boolean) => {
       try {
-        const { report, shape } = await runPart(path);
+        const { report, shape } = await runPart(path, { freshImport: fresh });
         try {
           process.stdout.write(serializeReport(report) + '\n');
         } finally {
@@ -320,20 +322,17 @@ program
         process.stderr.write(`watch run failed: ${(e as Error).message}\n`);
       }
     };
-    const { trigger } = debounce(run, DEFAULT_DEBOUNCE_MS);
+    const { trigger } = debounce(() => run(true), DEFAULT_DEBOUNCE_MS);
     process.stderr.write(`watching ${path} (Ctrl-C to stop)\n`);
-    void run(); // initial verify
-    // Watch the parent dir: editors often replace the file (rename) on save,
-    // which drops a watcher bound to the file inode itself.
-    const watcher = fsWatch(dirname(path), (_event, filename) => {
-      if (filename === undefined || filename === null) {
-        trigger();
-        return;
-      }
-      if (basename(path) === filename.toString()) trigger();
+    void run(false); // initial verify
+    // Watch the entry's whole directory tree: editors often replace a file (rename) on
+    // save, which drops a watcher bound to the inode itself — and a multi-file project
+    // must re-verify when any of its source files changes, not just the entry.
+    const stopWatching = watchTree(dirname(path), (filename) => {
+      if (isWatchRelevant(filename)) trigger();
     });
     const stop = () => {
-      watcher.close();
+      stopWatching();
       process.exit(0);
     };
     process.on('SIGINT', stop);

--- a/packages/brepjs-cad/src/cli/watch.ts
+++ b/packages/brepjs-cad/src/cli/watch.ts
@@ -33,7 +33,10 @@ const SOURCE_FILE_RE = /\.(?:m?[jt]s|[jt]sx)$/;
 // "something changed" — treat it as relevant rather than dropping the event.
 export function isWatchRelevant(filename: string | Buffer | null | undefined): boolean {
   if (filename === undefined || filename === null) return true;
-  return SOURCE_FILE_RE.test(filename.toString());
+  const name = filename.toString();
+  // tsconfig edits change how sources transpile (JSX dialect), so they re-verify too.
+  if (/(?:^|[\\/])tsconfig(?:\..+)?\.json$/.test(name)) return true;
+  return SOURCE_FILE_RE.test(name);
 }
 
 const IGNORED_DIR_NAMES = new Set(['node_modules', 'dist', '.git']);

--- a/packages/brepjs-cad/src/cli/watch.ts
+++ b/packages/brepjs-cad/src/cli/watch.ts
@@ -1,9 +1,13 @@
+import { watch, readdirSync } from 'node:fs';
+import type { FSWatcher } from 'node:fs';
+import { join } from 'node:path';
+
 export const DEFAULT_DEBOUNCE_MS = 150;
 
 // fs.watch fires twice per save on many platforms; debounce collapses bursts to one trailing call.
 export function debounce(
   fn: () => void | Promise<void>,
-  delayMs: number = DEFAULT_DEBOUNCE_MS,
+  delayMs: number = DEFAULT_DEBOUNCE_MS
 ): { trigger: () => void; cancel: () => void } {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const cancel = () => {
@@ -20,4 +24,66 @@ export function debounce(
     }, delayMs);
   };
   return { trigger, cancel };
+}
+
+const SOURCE_FILE_RE = /\.(?:m?[jt]s|[jt]sx)$/;
+
+// Filter for the project watcher: react to source edits, not to build output or written
+// artifacts (.step/.glb land next to the entry). A null filename is platform-dependent
+// "something changed" — treat it as relevant rather than dropping the event.
+export function isWatchRelevant(filename: string | Buffer | null | undefined): boolean {
+  if (filename === undefined || filename === null) return true;
+  return SOURCE_FILE_RE.test(filename.toString());
+}
+
+const IGNORED_DIR_NAMES = new Set(['node_modules', 'dist', '.git']);
+
+/**
+ * Watch a directory tree with one non-recursive `fs.watch` per directory, skipping
+ * node_modules/dist/.git and never following symlinks. `fs.watch({recursive})` has no
+ * exclusion API, so on a real project it would descend into node_modules — tens of
+ * thousands of inotify watches. Whenever an event fires in a directory it is re-scanned,
+ * which picks up newly created subdirectories. Returns a stop function.
+ */
+export function watchTree(
+  root: string,
+  onEvent: (filename: string | Buffer | null | undefined) => void
+): () => void {
+  const watchers = new Map<string, FSWatcher>();
+  const add = (dir: string): void => {
+    if (watchers.has(dir)) return;
+    try {
+      watchers.set(
+        dir,
+        watch(dir, (_event, filename) => {
+          scan(dir);
+          onEvent(filename);
+        })
+      );
+    } catch {
+      // directory vanished between scan and watch
+    }
+  };
+  const scan = (dir: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      // Dirent.isDirectory() is false for symlinks, so symlinked trees are never entered.
+      if (!entry.isDirectory() || IGNORED_DIR_NAMES.has(entry.name)) continue;
+      const child = join(dir, entry.name);
+      if (watchers.has(child)) continue;
+      add(child);
+      scan(child);
+    }
+  };
+  add(root);
+  scan(root);
+  return () => {
+    for (const watcher of watchers.values()) watcher.close();
+    watchers.clear();
+  };
 }

--- a/packages/brepjs-cad/src/cli/watch.ts
+++ b/packages/brepjs-cad/src/cli/watch.ts
@@ -1,6 +1,6 @@
-import { watch, readdirSync } from 'node:fs';
+import { watch, readdirSync, existsSync } from 'node:fs';
 import type { FSWatcher } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 export const DEFAULT_DEBOUNCE_MS = 150;
 
@@ -37,6 +37,25 @@ export function isWatchRelevant(filename: string | Buffer | null | undefined): b
   // tsconfig edits change how sources transpile (JSX dialect), so they re-verify too.
   if (/(?:^|[\\/])tsconfig(?:\..+)?\.json$/.test(name)) return true;
   return SOURCE_FILE_RE.test(name);
+}
+
+/**
+ * Root the watcher at the project, not the entry's own directory: with the common
+ * `src/main.ts` layout, tsconfig.json (whose JSX options change how sources transpile)
+ * and `../` imports live one level up. Nearest package.json or tsconfig.json walking up
+ * wins; entries with no project marker fall back to their own directory.
+ */
+export function watchRootFor(entryPath: string): string {
+  const start = dirname(entryPath);
+  let dir = start;
+  for (;;) {
+    if (existsSync(join(dir, 'package.json')) || existsSync(join(dir, 'tsconfig.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return start;
+    dir = parent;
+  }
 }
 
 const IGNORED_DIR_NAMES = new Set(['node_modules', 'dist', '.git']);

--- a/packages/brepjs-cad/src/loader/brepjsResolve.mjs
+++ b/packages/brepjs-cad/src/loader/brepjsResolve.mjs
@@ -1,4 +1,6 @@
-import { pathToFileURL } from 'node:url';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 // Prefer-local resolution hook for the bundled `brep` CLI.
 //
@@ -12,6 +14,13 @@ import { pathToFileURL } from 'node:url';
 // Critical single-instance property: the bundled fallback always resolves against the
 // SAME tool directory regardless of who imports, so the CLI's own `brepjs` and the
 // part's `import 'brepjs'` collapse to one module URL — one initialized kernel realm.
+//
+// The same hook also carries a `load` hook that transpiles `.ts`/`.mts`/`.tsx` sources
+// (Node's native type-stripping cannot load `.tsx` at all), and a relative-specifier
+// fallback that maps `./dep.js` onto an on-disk `dep.ts`/`dep.tsx` (house style writes
+// `.js` specifiers over TS sources; Node does not do this mapping). Keeping all of this
+// in the ONE registered hook — instead of reaching for tsx — is what preserves the
+// single-realm property above.
 
 let toolBaseUrl;
 
@@ -35,23 +44,137 @@ function isManagedSpecifier(specifier) {
   );
 }
 
-export async function resolve(specifier, context, nextResolve) {
-  if (!isManagedSpecifier(specifier)) {
-    return nextResolve(specifier, context);
-  }
+// Watch/preview cache-busting: the ESM module cache is keyed by full URL, so a rerun
+// that re-imports the same file URL re-executes the FIRST version forever. The watch
+// loop imports the entry with `?v=N`; propagating that query to every user-space file
+// the entry (transitively) imports makes each rerun a fresh module graph. Bare and
+// managed specifiers are never versioned, so `brepjs`/`occt-wasm` keep their stable
+// URLs and the initialized kernel realm survives across reruns.
+function versionParam(parentURL) {
+  if (!parentURL || !parentURL.startsWith('file:')) return undefined;
   try {
-    // Default resolution: finds a LOCAL brepjs/occt-wasm in the consumer's project.
+    return new URL(parentURL).searchParams.get('v') ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function withInheritedVersion(resolution, version) {
+  const url = resolution && resolution.url;
+  if (!version || !url || !url.startsWith('file:') || url.includes('/node_modules/')) {
+    return resolution;
+  }
+  const u = new URL(url);
+  u.searchParams.set('v', version);
+  return { ...resolution, url: u.href };
+}
+
+async function resolveWithTsFallback(specifier, context, nextResolve) {
+  try {
     return await nextResolve(specifier, context);
   } catch (err) {
-    if (!toolBaseUrl) throw err;
-    // Re-run the DEFAULT resolver, but as if the import came from inside the tool's package
-    // (parentURL = the tool's package.json) so it walks the tool's node_modules and honors
-    // package "exports" for subpaths. `import.meta.resolve` is unavailable in the hooks
-    // thread, so this nextResolve-with-rebased-parent is the resolver we have.
+    if (specifier.endsWith('.js')) {
+      const stem = specifier.slice(0, -'.js'.length);
+      for (const ext of ['.ts', '.tsx']) {
+        try {
+          return await nextResolve(stem + ext, context);
+        } catch {
+          // keep trying
+        }
+      }
+    }
+    throw err;
+  }
+}
+
+export async function resolve(specifier, context, nextResolve) {
+  if (isManagedSpecifier(specifier)) {
     try {
-      return await nextResolve(specifier, { ...context, parentURL: toolBaseUrl });
-    } catch {
-      throw err;
+      // Default resolution: finds a LOCAL brepjs/occt-wasm in the consumer's project.
+      return await nextResolve(specifier, context);
+    } catch (err) {
+      if (!toolBaseUrl) throw err;
+      // Re-run the DEFAULT resolver, but as if the import came from inside the tool's package
+      // (parentURL = the tool's package.json) so it walks the tool's node_modules and honors
+      // package "exports" for subpaths. `import.meta.resolve` is unavailable in the hooks
+      // thread, so this nextResolve-with-rebased-parent is the resolver we have.
+      try {
+        return await nextResolve(specifier, { ...context, parentURL: toolBaseUrl });
+      } catch {
+        throw err;
+      }
     }
   }
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return nextResolve(specifier, context);
+  }
+  const version = versionParam(context.parentURL);
+  return withInheritedVersion(
+    await resolveWithTsFallback(specifier, context, nextResolve),
+    version
+  );
+}
+
+// --- TypeScript loading ---------------------------------------------------------------
+
+// `typescript` is already a runtime dependency (the `--check` path imports it on the main
+// thread); here it loads lazily in the hooks thread only when a TS source is actually
+// imported, so pure-JS projects never pay for it.
+let tsPromise;
+
+function loadTypescript() {
+  tsPromise ??= import('typescript').then((mod) => mod.default ?? mod);
+  return tsPromise;
+}
+
+// JSX cannot be transpiled without knowing the project's dialect (families projects set
+// `jsx: react-jsx` + `jsxImportSource: brepjs-families`), so read it from the nearest
+// tsconfig.json — the same file the author's editor uses. Cached per directory; config
+// parsing honors `extends`.
+const jsxOptionsCache = new Map();
+
+function jsxOptionsFor(ts, filePath) {
+  const dir = dirname(filePath);
+  const cached = jsxOptionsCache.get(dir);
+  if (cached) return cached;
+  const options = {};
+  const configPath = ts.findConfigFile(dir, ts.sys.fileExists);
+  if (configPath) {
+    const host = { ...ts.sys, onUnRecoverableConfigFileDiagnostic: () => {} };
+    const parsed = ts.getParsedCommandLineOfConfigFile(configPath, undefined, host);
+    if (parsed) {
+      for (const key of ['jsx', 'jsxImportSource', 'jsxFactory', 'jsxFragmentFactory']) {
+        if (parsed.options[key] !== undefined) options[key] = parsed.options[key];
+      }
+    }
+  }
+  jsxOptionsCache.set(dir, options);
+  return options;
+}
+
+const TS_SOURCE_RE = /\.(?:ts|mts|tsx)$/;
+const DECLARATION_RE = /\.d\.(?:ts|mts)$/;
+
+export async function load(url, context, nextLoad) {
+  if (!url.startsWith('file:')) return nextLoad(url, context);
+  const parsed = new URL(url);
+  if (!TS_SOURCE_RE.test(parsed.pathname) || DECLARATION_RE.test(parsed.pathname)) {
+    return nextLoad(url, context);
+  }
+  const filePath = fileURLToPath(parsed);
+  const source = readFileSync(filePath, 'utf8');
+  const ts = await loadTypescript();
+  const { outputText } = ts.transpileModule(source, {
+    fileName: filePath,
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+      // A .tsx with no configured dialect still needs SOME emit mode; the automatic
+      // runtime is TS's modern default recommendation and what the scaffold ships.
+      ...(parsed.pathname.endsWith('.tsx') ? { jsx: ts.JsxEmit.ReactJSX } : {}),
+      ...jsxOptionsFor(ts, filePath),
+      inlineSourceMap: true,
+    },
+  });
+  return { format: 'module', source: outputText, shortCircuit: true };
 }

--- a/packages/brepjs-cad/src/loader/brepjsResolve.mjs
+++ b/packages/brepjs-cad/src/loader/brepjsResolve.mjs
@@ -133,6 +133,17 @@ function loadTypescript() {
 // parsing honors `extends`.
 const jsxOptionsCache = new Map();
 
+// Each watch rerun imports with a fresh `?v=N`; treat a new generation as a config
+// epoch so tsconfig edits made between reruns are picked up instead of served stale.
+let jsxOptionsGeneration;
+
+function bumpJsxOptionsGeneration(version) {
+  if (version !== null && version !== jsxOptionsGeneration) {
+    jsxOptionsGeneration = version;
+    jsxOptionsCache.clear();
+  }
+}
+
 function jsxOptionsFor(ts, filePath) {
   const dir = dirname(filePath);
   const cached = jsxOptionsCache.get(dir);
@@ -164,6 +175,7 @@ export async function load(url, context, nextLoad) {
   const filePath = fileURLToPath(parsed);
   const source = readFileSync(filePath, 'utf8');
   const ts = await loadTypescript();
+  bumpJsxOptionsGeneration(parsed.searchParams.get('v'));
   const { outputText } = ts.transpileModule(source, {
     fileName: filePath,
     compilerOptions: {

--- a/packages/brepjs-cad/src/verify/brepjsRuntime.ts
+++ b/packages/brepjs-cad/src/verify/brepjsRuntime.ts
@@ -43,10 +43,15 @@ export function toolDir(): string {
 }
 
 function loaderUrl(dir: string): string {
-  // Hand-authored ESM hook. The build copies it to dist/loader/; in dev/test it lives in
-  // src/loader/. Probe both so the same module works built and from source.
-  const built = resolvePath(dir, 'dist', 'loader', 'brepjsResolve.mjs');
+  // Hand-authored ESM hook. The build copies it to dist/loader/; in dev/test this module
+  // runs from src/. Pick by where THIS module runs — probing dist first would let a stale
+  // dist/ from an earlier build shadow the live source in dev.
   const source = resolvePath(dir, 'src', 'loader', 'brepjsResolve.mjs');
+  const built = resolvePath(dir, 'dist', 'loader', 'brepjsResolve.mjs');
+  const runningFromSrc = import.meta.url.startsWith(
+    pathToFileURL(resolvePath(dir, 'src') + '/').href
+  );
+  if (runningFromSrc) return pathToFileURL(source).href;
   return pathToFileURL(existsSync(built) ? built : source).href;
 }
 

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -54,15 +54,20 @@ function buildMaterialMap(
   return map.size > 0 ? { map } : {};
 }
 
-// Author parts are `.brep.ts`. Node strips types natively (engines requires >=24),
-// but only in an ESM context — so a part loaded under a CommonJS project fails. A
-// transpiler fallback (tsx) is NOT viable: it loads `brepjs` in a separate module
-// realm, so the part gets an uninitialized kernel. Surface a clear fix instead.
+// TS/TSX parts load through the registered hook (transpile + `.js`->`.ts` fallback), all
+// in ONE module realm — a transpiler runner like tsx would give the part an uninitialized
+// kernel in a second realm. `fresh` busts the ESM module cache with a `?v=N` query (the
+// hook propagates it across the part's own imports) so watch reruns pick up edits.
+let importGeneration = 0;
+
 async function loadPart(
-  modulePath: string
+  modulePath: string,
+  fresh = false
 ): Promise<{ default?: PartFn; expected?: unknown; materials?: unknown }> {
+  const url = new URL(pathToFileURL(modulePath).href);
+  if (fresh) url.searchParams.set('v', String(++importGeneration));
   try {
-    return (await import(pathToFileURL(modulePath).href)) as {
+    return (await import(url.href)) as {
       default?: PartFn;
       expected?: unknown;
       materials?: unknown;
@@ -74,7 +79,7 @@ async function loadPart(
     if (/\.[mc]?tsx?$/.test(modulePath) && /import statement|file extension/i.test(msg)) {
       throw new Error(
         `cannot load TypeScript part "${modulePath}": author parts in an ESM project ` +
-          `(set "type": "module" in package.json) or rename the file to .mts. (${msg})`,
+          `(set "type": "module" in package.json). (${msg})`,
         { cause: e }
       );
     }
@@ -104,7 +109,8 @@ function toErrorInfo(prefix: string, e: unknown): ErrorInfo {
     // Anchor on the literal `[KIND] CODE:` shape so a stray `]…:` elsewhere can't be mistaken
     // for the code.
     const code =
-      e.message.match(/\[[A-Z][A-Z0-9_]*\]\s+([A-Z][A-Z0-9_]+):/)?.[1] ?? classifyKernelMessage(e.message);
+      e.message.match(/\[[A-Z][A-Z0-9_]*\]\s+([A-Z][A-Z0-9_]+):/)?.[1] ??
+      classifyKernelMessage(e.message);
     return code
       ? { message: `${prefix}: ${e.message}`, code }
       : { message: `${prefix}: ${e.message}` };
@@ -135,6 +141,11 @@ export interface RunPartOptions {
    * judge/snapshot path opts in; the author `--check` loop stays fast.
    */
   metrics?: boolean;
+  /**
+   * Bust the ESM module cache for the part and its own imports (watch reruns pick up
+   * edits). The kernel realm (`brepjs`/`occt-wasm`) keeps its stable URLs either way.
+   */
+  freshImport?: boolean;
 }
 
 export interface RunPartResult {
@@ -182,7 +193,7 @@ export async function runPart(
   const { isOk, mesh, exportGlb, exportSTEP } = brep;
   let mod: { default?: PartFn; expected?: unknown; materials?: unknown };
   try {
-    mod = await loadPart(modulePath);
+    mod = await loadPart(modulePath, opts.freshImport);
   } catch (e) {
     pushError(report, toErrorInfo('import failed', e));
     return finalize({ shape: null, report });

--- a/packages/brepjs-cad/src/verify/typecheck.ts
+++ b/packages/brepjs-cad/src/verify/typecheck.ts
@@ -78,6 +78,31 @@ function packageRootOf(startDir: string, name: string): string | undefined {
   }
 }
 
+/**
+ * JSX options for a part come from the nearest tsconfig.json — the same source the
+ * runtime load hook reads — so `--check` and execution agree on the dialect
+ * (families projects set `jsx: react-jsx` + `jsxImportSource: brepjs-families`).
+ * A `.tsx` part with nothing configured defaults to the automatic runtime.
+ */
+function jsxCompilerOptions(partPath: string): ts.CompilerOptions {
+  const out: ts.CompilerOptions = {};
+  const configPath = ts.findConfigFile(dirname(partPath), (f) => ts.sys.fileExists(f));
+  if (configPath) {
+    const host: ts.ParseConfigFileHost = {
+      ...ts.sys,
+      onUnRecoverableConfigFileDiagnostic: () => {},
+    };
+    const parsed = ts.getParsedCommandLineOfConfigFile(configPath, undefined, host);
+    if (parsed) {
+      for (const key of ['jsx', 'jsxImportSource', 'jsxFactory', 'jsxFragmentFactory']) {
+        if (parsed.options[key] !== undefined) out[key] = parsed.options[key];
+      }
+    }
+  }
+  if (partPath.endsWith('.tsx') && out.jsx === undefined) out.jsx = ts.JsxEmit.ReactJSX;
+  return out;
+}
+
 const COMPILER_OPTIONS: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES2022,
   module: ts.ModuleKind.ESNext,
@@ -138,7 +163,7 @@ export interface TypecheckResult {
  */
 export function typecheckPart(partPath: string, toolDir?: string): TypecheckResult {
   const dts = resolveBrepjsTypes(partPath, toolDir);
-  const options: ts.CompilerOptions = { ...COMPILER_OPTIONS };
+  const options: ts.CompilerOptions = { ...COMPILER_OPTIONS, ...jsxCompilerOptions(partPath) };
   if (dts) {
     options.paths = { brepjs: [dts] };
   }

--- a/packages/brepjs-cad/tests/fixtures/tsxProject/dims.ts
+++ b/packages/brepjs-cad/tests/fixtures/tsxProject/dims.ts
@@ -1,0 +1,1 @@
+export const panelSize: readonly [number, number, number] = [20, 10, 4];

--- a/packages/brepjs-cad/tests/fixtures/tsxProject/main.tsx
+++ b/packages/brepjs-cad/tests/fixtures/tsxProject/main.tsx
@@ -1,0 +1,15 @@
+import { box } from 'brepjs';
+import { Group, resolve } from 'brepjs-families';
+import { Panel } from './panel.js';
+
+export default function part() {
+  const model = resolve(
+    <Group key="assembly">
+      <Panel />
+    </Group>
+  );
+  const panel = model.children[0];
+  if (!panel) throw new Error('resolve produced no children');
+  const size = panel.props['size'] as readonly [number, number, number];
+  return box(size[0], size[1], size[2]);
+}

--- a/packages/brepjs-cad/tests/fixtures/tsxProject/panel.tsx
+++ b/packages/brepjs-cad/tests/fixtures/tsxProject/panel.tsx
@@ -1,0 +1,6 @@
+import { Box, type Element } from 'brepjs-families';
+import { panelSize } from './dims.js';
+
+export function Panel(): Element {
+  return <Box key="panel" size={panelSize} />;
+}

--- a/packages/brepjs-cad/tests/fixtures/tsxProject/tsconfig.json
+++ b/packages/brepjs-cad/tests/fixtures/tsxProject/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "brepjs-families"
+  }
+}

--- a/packages/brepjs-cad/tests/loader.test.ts
+++ b/packages/brepjs-cad/tests/loader.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawn } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { VerifyReport } from '@/verify/report.js';
+
+type SerializedReport = VerifyReport & { ok: boolean };
+
+const pkgRoot = fileURLToPath(new URL('..', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const cli = fileURLToPath(new URL('../src/cli/main.ts', import.meta.url));
+const fixtureDir = fileURLToPath(new URL('./fixtures/tsxProject', import.meta.url));
+
+// The node:module hooks only govern real ESM resolution, which vitest's module runner
+// bypasses in-process — so every loader test runs the CLI in a child process, the same
+// way a user does.
+describe('TSX loader', () => {
+  it('verifies a multi-file TSX families project (with --check) through the hook', () => {
+    const stdout = execFileSync('npx', ['tsx', cli, join(fixtureDir, 'main.tsx'), '--check'], {
+      encoding: 'utf8',
+      cwd: pkgRoot,
+    });
+    const json = JSON.parse(stdout) as SerializedReport;
+    expect(json.errors, json.errors.join('; ')).toEqual([]);
+    expect(json.ok).toBe(true);
+    // 20x10x4 from dims.ts, threaded through JSX props and resolve() — proves the .tsx
+    // transform, the automatic jsx-runtime import, and the .js -> .ts/.tsx fallback all
+    // executed in the one kernel realm.
+    expect(json.measurements.volume).toBeCloseTo(800, 1);
+  }, 120000);
+});
+
+describe('brep watch', () => {
+  it('re-verifies with fresh module state when a dependency file changes', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-watch-'));
+    const reports: SerializedReport[] = [];
+    const child = spawnWatch(dir, reports);
+    try {
+      await waitFor(() => reports.length >= 1, 90000, 'first watch report');
+      expect(reports[0]?.measurements.volume).toBeCloseTo(800, 1);
+      // Edit a DEPENDENCY, not the entry: proves the tree watcher sees it AND that the
+      // rerun imports fresh module state instead of the first version cached by URL.
+      writeFileSync(
+        join(dir, 'dims.ts'),
+        'export const panelSize: readonly [number, number, number] = [20, 10, 8];\n'
+      );
+      await waitFor(() => reports.length >= 2, 90000, 'post-edit watch report');
+      expect(reports[1]?.measurements.volume).toBeCloseTo(1600, 1);
+    } finally {
+      child.kill('SIGTERM');
+      await new Promise((res) => child.once('exit', res));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 240000);
+});
+
+function spawnWatch(dir: string, reports: SerializedReport[]) {
+  cpSync(fixtureDir, dir, { recursive: true });
+  // Bare imports (brepjs-families) must resolve from the tmp copy; link the repo's
+  // installed tree rather than paying for an install.
+  symlinkSync(join(repoRoot, 'node_modules'), join(dir, 'node_modules'), 'dir');
+  const child = spawn('npx', ['tsx', cli, 'watch', join(dir, 'main.tsx')], { cwd: pkgRoot });
+  let buffer = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString();
+    // serializeReport pretty-prints, so each report is a multi-line JSON object; the
+    // top-level close brace on its own line is the report boundary.
+    for (let end = buffer.indexOf('\n}\n'); end >= 0; end = buffer.indexOf('\n}\n')) {
+      const chunkText = buffer.slice(0, end + 2);
+      buffer = buffer.slice(end + 3);
+      reports.push(JSON.parse(chunkText) as SerializedReport);
+    }
+  });
+  return child;
+}
+
+function waitFor(cond: () => boolean, timeoutMs: number, what: string): Promise<void> {
+  const started = Date.now();
+  return new Promise((res, rej) => {
+    const tick = () => {
+      if (cond()) return res();
+      if (Date.now() - started > timeoutMs) return rej(new Error(`timed out waiting for ${what}`));
+      setTimeout(tick, 250);
+    };
+    tick();
+  });
+}

--- a/packages/brepjs-cad/tests/loader.test.ts
+++ b/packages/brepjs-cad/tests/loader.test.ts
@@ -48,6 +48,23 @@ describe('brep watch', () => {
       );
       await waitFor(() => reports.length >= 2, 90000, 'post-edit watch report');
       expect(reports[1]?.measurements.volume).toBeCloseTo(1600, 1);
+      // Edit tsconfig.json: the rerun must read the NEW jsx config (per-generation cache
+      // invalidation in the hook), so a bogus jsxImportSource now fails the import.
+      writeFileSync(
+        join(dir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            module: 'esnext',
+            moduleResolution: 'bundler',
+            target: 'es2022',
+            strict: true,
+            jsx: 'react-jsx',
+            jsxImportSource: 'brepjs-families/bogus',
+          },
+        })
+      );
+      await waitFor(() => reports.length >= 3, 90000, 'post-tsconfig-edit watch report');
+      expect(reports[2]?.ok).toBe(false);
     } finally {
       child.kill('SIGTERM');
       await new Promise((res) => child.once('exit', res));

--- a/packages/brepjs-cad/tests/watch.test.ts
+++ b/packages/brepjs-cad/tests/watch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { debounce, DEFAULT_DEBOUNCE_MS } from '@/cli/watch.js';
+import { debounce, DEFAULT_DEBOUNCE_MS, isWatchRelevant, watchTree } from '@/cli/watch.js';
 
 describe('debounce', () => {
   beforeEach(() => vi.useFakeTimers());
@@ -40,5 +40,47 @@ describe('debounce', () => {
 
   it('exposes a sane default debounce window', () => {
     expect(DEFAULT_DEBOUNCE_MS).toBe(150);
+  });
+});
+
+describe('isWatchRelevant', () => {
+  it('accepts source files and a null filename', () => {
+    for (const name of ['main.tsx', 'dims.ts', 'dep.mts', 'lib/helper.js', 'a.jsx', 'b.mjs']) {
+      expect(isWatchRelevant(name)).toBe(true);
+    }
+    expect(isWatchRelevant(null)).toBe(true);
+    expect(isWatchRelevant(undefined)).toBe(true);
+  });
+
+  it('ignores written artifacts and non-source noise', () => {
+    for (const name of ['out.step', 'preview.glb', 'report.json', 'notes.md', 'main.tsx~']) {
+      expect(isWatchRelevant(name)).toBe(false);
+    }
+  });
+});
+
+describe('watchTree', () => {
+  it('fires for edits in nested directories but not under node_modules', async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    vi.useRealTimers();
+    const root = mkdtempSync(join(tmpdir(), 'brepjs-cad-watchtree-'));
+    const events: string[] = [];
+    mkdirSync(join(root, 'lib'));
+    mkdirSync(join(root, 'node_modules', 'dep'), { recursive: true });
+    const stop = watchTree(root, (filename) => {
+      if (filename) events.push(filename.toString());
+    });
+    try {
+      writeFileSync(join(root, 'lib', 'helper.ts'), 'export const x = 1;\n');
+      writeFileSync(join(root, 'node_modules', 'dep', 'index.js'), '// dep\n');
+      await new Promise((res) => setTimeout(res, 300));
+      expect(events).toContain('helper.ts');
+      expect(events).not.toContain('index.js');
+    } finally {
+      stop();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/brepjs-cad/tests/watch.test.ts
+++ b/packages/brepjs-cad/tests/watch.test.ts
@@ -57,6 +57,12 @@ describe('isWatchRelevant', () => {
       expect(isWatchRelevant(name)).toBe(false);
     }
   });
+
+  it('accepts tsconfig edits (they change how sources transpile)', () => {
+    for (const name of ['tsconfig.json', 'tsconfig.test.json', 'sub/tsconfig.json']) {
+      expect(isWatchRelevant(name)).toBe(true);
+    }
+  });
 });
 
 describe('watchTree', () => {

--- a/packages/brepjs-cad/tests/watch.test.ts
+++ b/packages/brepjs-cad/tests/watch.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { debounce, DEFAULT_DEBOUNCE_MS, isWatchRelevant, watchTree } from '@/cli/watch.js';
+import {
+  debounce,
+  DEFAULT_DEBOUNCE_MS,
+  isWatchRelevant,
+  watchRootFor,
+  watchTree,
+} from '@/cli/watch.js';
 
 describe('debounce', () => {
   beforeEach(() => vi.useFakeTimers());
@@ -86,6 +92,26 @@ describe('watchTree', () => {
       expect(events).not.toContain('index.js');
     } finally {
       stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('watchRootFor', () => {
+  it('roots at the nearest project marker above the entry, else the entry dir', async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const root = mkdtempSync(join(tmpdir(), 'brepjs-cad-watchroot-'));
+    try {
+      mkdirSync(join(root, 'proj', 'src'), { recursive: true });
+      writeFileSync(join(root, 'proj', 'tsconfig.json'), '{}\n');
+      expect(watchRootFor(join(root, 'proj', 'src', 'main.tsx'))).toBe(join(root, 'proj'));
+      mkdirSync(join(root, 'bare', 'deep'), { recursive: true });
+      expect(watchRootFor(join(root, 'bare', 'deep', 'part.brep.ts'))).toBe(
+        join(root, 'bare', 'deep')
+      );
+    } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
First of the discussion #2020 follow-ups (viktar-b): make `brep verify` / `brep watch` work on real multi-file TS/TSX families projects. Today Node cannot load `.tsx` at all (`ERR_UNKNOWN_FILE_EXTENSION`) and never maps a `./dep.js` specifier onto an on-disk `dep.ts`, so any project beyond a single self-contained `.ts` file was unloadable without `tsx` — which the CLI rejects because it splits the module realm and hands the part an uninitialized kernel.

## What changed

All inside the one registered `node:module` hook, so the single-realm property (one initialized kernel shared by the CLI and the part) is preserved:

- **`load` hook**: transpiles `.ts`/`.mts`/`.tsx` with `ts.transpileModule` (typescript was already a runtime dependency). The JSX dialect comes from the nearest `tsconfig.json` — `jsx`, `jsxImportSource`, `jsxFactory`, `jsxFragmentFactory` — so families projects (`jsx: react-jsx`, `jsxImportSource: brepjs-families`) just work. No type-check here; that stays `--check`'s job.
- **`resolve` hook**: relative `./x.js` specifiers that miss fall back to `./x.ts` then `./x.tsx` (house style writes `.js` specifiers over TS sources).
- **`brep watch` actually picks up edits now.** The ESM module cache is keyed by URL, so re-importing the same file re-ran the first version forever. Watch reruns import with a `?v=N` query that the hook propagates across user-space imports only; `brepjs`/`occt-wasm` keep stable URLs, so the initialized kernel survives reruns (no per-save kernel init).
- **Watch covers the whole project tree**, not just the entry file: bounded per-directory watchers (skipping `node_modules`/`dist`/`.git`, never following symlinks). `fs.watch({recursive})` was rejected deliberately — it has no exclusion API and would descend into `node_modules` (inotify watch exhaustion).
- **`verify --check` reads the same tsconfig JSX options**, so type-checking `.tsx` parts works and agrees with the runtime dialect.
- **Stale-dist fix**: `loaderUrl` picked `dist/loader/` whenever it existed, letting an old build shadow the live hook in dev/test. It now picks by where the running module lives.
- Dropped the wrong "rename the file to `.mts`" hint for `.tsx` parts.

## Tests

- Child-process integration tests (the hooks only govern real ESM resolution, which vitest's runner bypasses in-process): a multi-file TSX families fixture (`main.tsx` → `./panel.js` (.tsx) → `./dims.js` (.ts), `jsxImportSource: brepjs-families`) verified end-to-end with `--check`, dims threaded through JSX props and `resolve()` into real geometry.
- A live `brep watch` test that edits a **dependency** file (not the entry) and asserts the re-verify reports the new volume — proving both the tree watcher and the cache-bust.
- Unit tests for the watch filter and the tree watcher (fires for nested source edits, silent under `node_modules`).
- Also verified against the **built** CLI under plain node (no tsx anywhere in play).

CI: `packages-verify` now builds `brepjs-families` before the brepjs-cad tests, since the fixture resolves `brepjs-families/jsx-runtime` through the workspace symlink.

Next in the sequence: `brep preview` (element-aware viewer) building on this loader.
