### PR TITLE
feat(brepjs-cad): brep preview — element-aware model viewer with live watch

### DIFF
--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -10,6 +10,7 @@ import { runMeasure } from '../verify/measure.js';
 import { runDiff } from '../verify/diff.js';
 import { scaffoldPart } from './scaffold.js';
 import {
+  createSerialRunner,
   debounce,
   DEFAULT_DEBOUNCE_MS,
   isWatchRelevant,
@@ -328,31 +329,10 @@ program
         process.stderr.write(`watch run failed: ${(e as Error).message}\n`);
       }
     };
-    // Serialize runs: a save landing mid-verify must not start a second runPart on the
-    // shared kernel (reports would interleave out of order). Edits during a run coalesce
-    // into exactly one trailing rerun.
-    let inFlight = false;
-    let rerunQueued = false;
-    const start = (fresh: boolean): void => {
-      inFlight = true;
-      void run(fresh).finally(() => {
-        inFlight = false;
-        if (rerunQueued) {
-          rerunQueued = false;
-          start(true);
-        }
-      });
-    };
-    const schedule = (): void => {
-      if (inFlight) {
-        rerunQueued = true;
-        return;
-      }
-      start(true);
-    };
-    const { trigger } = debounce(schedule, DEFAULT_DEBOUNCE_MS);
+    const runner = createSerialRunner(run);
+    const { trigger } = debounce(runner.trigger, DEFAULT_DEBOUNCE_MS);
     process.stderr.write(`watching ${path} (Ctrl-C to stop)\n`);
-    start(false); // initial verify
+    runner.start(false); // initial verify
     // Watch the whole project tree (nearest package.json/tsconfig.json above the entry):
     // editors often replace a file (rename) on save, which drops a watcher bound to the
     // inode itself — and a multi-file project must re-verify when any source OR the root
@@ -367,6 +347,41 @@ program
     process.on('SIGINT', stop);
     process.on('SIGTERM', stop); // supervisors (docker stop, systemctl) send SIGTERM
   });
+
+program
+  .command('preview')
+  .argument(
+    '<file>',
+    'path to a model module (.ts/.tsx); a families element tree renders per element'
+  )
+  .option('--watch', 're-evaluate on save and push updates to the open viewer tab')
+  .option('--write-only', 'write artifacts and exit without starting the viewer server')
+  .option('--glb <out>', 'write a merged GLB of the whole model')
+  .option('--json <out>', 'write the JSON summary to this path')
+  .option('--port <n>', 'viewer server port (default: OS-assigned)', (v: string) => parseInt(v, 10))
+  .option('--no-open', 'do not auto-open the browser')
+  .action(
+    async (
+      file: string,
+      opts: {
+        watch?: boolean;
+        writeOnly?: boolean;
+        glb?: string;
+        json?: string;
+        port?: number;
+        open?: boolean;
+      }
+    ) => {
+      // Lazy: keeps the viewer server + evaluation graph off the default CLI path.
+      const { runPreview } = await import('../preview/preview.js');
+      try {
+        await runPreview(resolve(file), opts);
+      } catch (e) {
+        process.stderr.write(`preview failed: ${(e as Error).message}\n`);
+        process.exitCode = 1;
+      }
+    }
+  );
 
 program
   .command('export')

--- a/packages/brepjs-cad/src/cli/watch.ts
+++ b/packages/brepjs-cad/src/cli/watch.ts
@@ -109,3 +109,34 @@ export function watchTree(
     watchers.clear();
   };
 }
+
+/**
+ * Serialize an async job: while one run is in flight, triggers coalesce into exactly
+ * one trailing rerun (verify/preview runs share one kernel — overlapping runs would
+ * interleave output and reorder reports).
+ */
+export function createSerialRunner(run: (fresh: boolean) => Promise<void>): {
+  start: (fresh: boolean) => void;
+  trigger: () => void;
+} {
+  let inFlight = false;
+  let rerunQueued = false;
+  const start = (fresh: boolean): void => {
+    inFlight = true;
+    void run(fresh).finally(() => {
+      inFlight = false;
+      if (rerunQueued) {
+        rerunQueued = false;
+        start(true);
+      }
+    });
+  };
+  const trigger = (): void => {
+    if (inFlight) {
+      rerunQueued = true;
+      return;
+    }
+    start(true);
+  };
+  return { start, trigger };
+}

--- a/packages/brepjs-cad/src/preview/evaluate.ts
+++ b/packages/brepjs-cad/src/preview/evaluate.ts
@@ -1,0 +1,259 @@
+import type { AnyShape, ShapeMesh } from 'brepjs';
+import {
+  modelToMeshData,
+  type ElementRange,
+  type EvaluatedNodeLike,
+  type MeshData,
+  type PreviewMeasurements,
+  type PreviewModelPayload,
+  type PreviewTreeNode,
+} from 'brepjs-viewer';
+import { loadBrep, initOcctWasm, type BrepNs } from '../verify/brepjsRuntime.js';
+import { loadPart } from '../verify/runPart.js';
+import { disposeShape } from '../disposeShape.js';
+
+// Structural views of brepjs-families — the package is dynamically imported from the
+// USER's project (the CLI walks up into the project's node_modules), so brepjs-cad
+// carries no dependency on it and previews plain shapes without it installed.
+interface ResolvedElementLike {
+  readonly keyPath: string;
+  readonly type: string;
+  readonly archetype?: string | undefined;
+  readonly geometry: { readonly kind: string };
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly children: readonly ResolvedElementLike[];
+}
+
+interface FamiliesEvaluatedNode {
+  readonly keyPath: string;
+  readonly mesh: { readonly ok: boolean; readonly value?: ShapeMesh | undefined };
+  readonly shape?: { readonly ok: boolean; readonly value?: AnyShape | undefined } | undefined;
+}
+
+interface FamiliesNs {
+  resolve(el: unknown): ResolvedElementLike;
+  evaluateModel(
+    root: ResolvedElementLike,
+    evaluator: unknown,
+    env: Record<string, unknown>,
+    options: { shapes?: boolean }
+  ): { root: ResolvedElementLike; byKeyPath: ReadonlyMap<string, FamiliesEvaluatedNode> };
+}
+
+export interface PreviewBuild {
+  readonly payload: PreviewModelPayload;
+  /** Whole-model merge in ShapeMesh form — the GLB export input, derived from the
+   *  same single merge the viewer payload uses. */
+  readonly merged: ShapeMesh;
+  readonly ok: boolean;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function isResultLike(v: unknown): v is { ok: boolean; value?: unknown; error?: unknown } {
+  return isRecord(v) && typeof v['ok'] === 'boolean' && ('value' in v || 'error' in v);
+}
+
+function isResolvedElementLike(v: unknown): v is ResolvedElementLike {
+  return (
+    isRecord(v) &&
+    typeof v['keyPath'] === 'string' &&
+    isRecord(v['geometry']) &&
+    Array.isArray(v['children'])
+  );
+}
+
+function isElementLike(v: unknown): boolean {
+  return (
+    isRecord(v) &&
+    typeof v['type'] === 'string' &&
+    isRecord(v['props']) &&
+    Array.isArray(v['children']) &&
+    !('keyPath' in v)
+  );
+}
+
+/**
+ * Load the module through the registered hook (same realm/kernel as verify) and
+ * evaluate it into a preview payload. Contract: `export default` a value or a
+ * (possibly async) function returning one — a families element tree, an already
+ * resolved tree, or a plain shape; `Result` wrappers are unwrapped.
+ */
+export async function evaluatePreview(
+  entryPath: string,
+  opts: { fresh?: boolean } = {}
+): Promise<PreviewBuild> {
+  const brep = await loadBrep();
+  await initOcctWasm(brep);
+  const mod = await loadPart(entryPath, opts.fresh ?? false);
+  if (mod.default === undefined) {
+    throw new Error(
+      'module has no default export (expected a shape, a families element tree, or a function returning one)'
+    );
+  }
+  const produced: unknown = await Promise.resolve(
+    typeof mod.default === 'function' ? (mod.default as () => unknown)() : mod.default
+  );
+  let value = produced;
+  if (isResultLike(value)) {
+    if (!value.ok) {
+      throw new Error(
+        `model returned Err: ${String((value.error as Error)?.message ?? value.error)}`
+      );
+    }
+    value = value.value;
+  }
+  if (isResolvedElementLike(value) || isElementLike(value)) {
+    return evaluateTree(brep, value);
+  }
+  return evaluateShape(brep, value as AnyShape);
+}
+
+async function evaluateTree(brep: BrepNs, value: unknown): Promise<PreviewBuild> {
+  let fam: FamiliesNs;
+  try {
+    fam = (await import('brepjs-families')) as unknown as FamiliesNs;
+  } catch {
+    throw new Error(
+      "the model is a families element tree, but 'brepjs-families' is not installed in this project"
+    );
+  }
+  const resolved = isResolvedElementLike(value) ? value : fam.resolve(value);
+  using evaluator = new brep.csg.Evaluator();
+  const model = fam.evaluateModel(resolved, evaluator, {}, { shapes: true });
+  const nodes = new Map<string, EvaluatedNodeLike>();
+  for (const [keyPath, node] of model.byKeyPath) {
+    const m = node.mesh.ok ? node.mesh.value : undefined;
+    if (!m) {
+      nodes.set(keyPath, { mesh: { ok: false } });
+      continue;
+    }
+    // Shapes are borrowed from the Evaluator's cache (do not dispose); edges are
+    // cosmetic, so a meshEdges failure must not fail the element.
+    let edges: Float32Array | undefined;
+    const shape = node.shape?.ok ? node.shape.value : undefined;
+    if (shape) {
+      try {
+        edges = brep.meshEdges(shape).lines;
+      } catch {
+        edges = undefined;
+      }
+    }
+    nodes.set(keyPath, {
+      mesh: {
+        ok: true,
+        value: {
+          triangles: m.triangles,
+          vertices: m.vertices,
+          normals: m.normals,
+          faceGroups: m.faceGroups,
+          ...(edges ? { edges } : {}),
+        },
+      },
+    });
+  }
+  const { data, elements, failed } = modelToMeshData({ byKeyPath: nodes });
+  return finish(data, elements, failed, toTree(model.root));
+}
+
+function evaluateShape(brep: BrepNs, shape: AnyShape): PreviewBuild {
+  try {
+    const m = brep.mesh(shape);
+    let edges: Float32Array | undefined;
+    try {
+      edges = brep.meshEdges(shape).lines;
+    } catch {
+      edges = undefined;
+    }
+    const node: EvaluatedNodeLike = {
+      mesh: {
+        ok: true,
+        value: {
+          triangles: m.triangles,
+          vertices: m.vertices,
+          normals: m.normals,
+          faceGroups: m.faceGroups,
+          ...(edges ? { edges } : {}),
+        },
+      },
+    };
+    const { data, elements, failed } = modelToMeshData({ byKeyPath: new Map([['part', node]]) });
+    const tree: PreviewTreeNode = {
+      keyPath: 'part',
+      type: 'Shape',
+      hasGeometry: true,
+      children: [],
+    };
+    return finish(data, elements, failed, tree);
+  } finally {
+    // A plain-shape module hands ownership to the caller — verify's contract too.
+    disposeShape(shape);
+  }
+}
+
+function toTree(el: ResolvedElementLike): PreviewTreeNode {
+  const name = el.attributes['name'];
+  return {
+    keyPath: el.keyPath,
+    type: el.type,
+    ...(el.archetype !== undefined ? { archetype: el.archetype } : {}),
+    ...(typeof name === 'string' ? { name } : {}),
+    hasGeometry: el.geometry.kind !== 'Empty',
+    children: el.children.map(toTree),
+  };
+}
+
+function measure(data: MeshData, elementCount: number, failedCount: number): PreviewMeasurements {
+  const p = data.position;
+  const counts = {
+    elementCount,
+    failedCount,
+    triangleCount: data.index.length / 3,
+  };
+  if (p.length < 3) return counts;
+  const b = {
+    xMin: Infinity,
+    xMax: -Infinity,
+    yMin: Infinity,
+    yMax: -Infinity,
+    zMin: Infinity,
+    zMax: -Infinity,
+  };
+  for (let i = 0; i + 2 < p.length; i += 3) {
+    const x = p[i] ?? 0;
+    const y = p[i + 1] ?? 0;
+    const z = p[i + 2] ?? 0;
+    if (x < b.xMin) b.xMin = x;
+    if (x > b.xMax) b.xMax = x;
+    if (y < b.yMin) b.yMin = y;
+    if (y > b.yMax) b.yMax = y;
+    if (z < b.zMin) b.zMin = z;
+    if (z > b.zMax) b.zMax = z;
+  }
+  return { ...counts, bounds: b };
+}
+
+function finish(
+  data: MeshData,
+  elements: readonly ElementRange[],
+  failed: readonly string[],
+  tree: PreviewTreeNode
+): PreviewBuild {
+  const payload: PreviewModelPayload = {
+    data,
+    elements,
+    failed,
+    tree,
+    measurements: measure(data, elements.length, failed.length),
+  };
+  const merged: ShapeMesh = {
+    triangles: data.index,
+    vertices: data.position,
+    normals: data.normal,
+    uvs: new Float32Array(0),
+    faceGroups: (data.faceGroups ?? []).map((g) => ({ ...g, origin: 0 })),
+  };
+  return { payload, merged, ok: failed.length === 0 };
+}

--- a/packages/brepjs-cad/src/preview/evaluate.ts
+++ b/packages/brepjs-cad/src/preview/evaluate.ts
@@ -1,3 +1,7 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { AnyShape, ShapeMesh } from 'brepjs';
 import {
   modelToMeshData,
@@ -10,6 +14,7 @@ import {
 } from 'brepjs-viewer';
 import { loadBrep, initOcctWasm, type BrepNs } from '../verify/brepjsRuntime.js';
 import { loadPart } from '../verify/runPart.js';
+import { packageRootOf } from '../verify/typecheck.js';
 import { disposeShape } from '../disposeShape.js';
 
 // Structural views of brepjs-families — the package is dynamically imported from the
@@ -66,9 +71,11 @@ function isResolvedElementLike(v: unknown): v is ResolvedElementLike {
 }
 
 function isElementLike(v: unknown): boolean {
+  // A families Element's type is an intrinsic name OR a family component function
+  // (a tree rooted at <MyFamily/> arrives un-rendered — resolve() renders it).
   return (
     isRecord(v) &&
-    typeof v['type'] === 'string' &&
+    (typeof v['type'] === 'string' || typeof v['type'] === 'function') &&
     isRecord(v['props']) &&
     Array.isArray(v['children']) &&
     !('keyPath' in v)
@@ -106,16 +113,76 @@ export async function evaluatePreview(
     value = value.value;
   }
   if (isResolvedElementLike(value) || isElementLike(value)) {
-    return evaluateTree(brep, value);
+    return evaluateTree(brep, value, entryPath);
   }
   return evaluateShape(brep, value as AnyShape);
 }
 
-async function evaluateTree(brep: BrepNs, value: unknown): Promise<PreviewBuild> {
-  let fam: FamiliesNs;
+/**
+ * Resolve the ESM entry of the PROJECT's brepjs-families install, walking from the
+ * entry module. A globally installed CLI is not inside the project's node_modules, so
+ * a bare import would miss (or load the wrong copy); resolving from the entry lands on
+ * the same file URL the model itself imports — one module instance, matching runtime
+ * identities.
+ */
+export function resolveFamiliesEntry(entryPath: string): string | undefined {
+  let requireEntry: string;
   try {
-    fam = (await import('brepjs-families')) as unknown as FamiliesNs;
+    requireEntry = createRequire(pathToFileURL(entryPath).href).resolve('brepjs-families');
   } catch {
+    return undefined;
+  }
+  const pkgDir = packageRootOf(dirname(requireEntry), 'brepjs-families');
+  if (pkgDir === undefined) return requireEntry;
+  try {
+    const pkg = JSON.parse(readFileSync(resolvePath(pkgDir, 'package.json'), 'utf8')) as {
+      exports?: unknown;
+      module?: unknown;
+    };
+    const rel = esmEntryOf(pkg);
+    return rel === undefined ? requireEntry : resolvePath(pkgDir, rel);
+  } catch {
+    return requireEntry;
+  }
+}
+
+function esmEntryOf(pkg: { exports?: unknown; module?: unknown }): string | undefined {
+  const root = (pkg.exports as Record<string, unknown> | undefined)?.['.'];
+  if (root && typeof root === 'object') {
+    const imp = (root as Record<string, unknown>)['import'];
+    if (imp && typeof imp === 'object') {
+      const d = (imp as Record<string, unknown>)['default'];
+      if (typeof d === 'string') return d;
+    }
+    const d = (root as Record<string, unknown>)['default'];
+    if (typeof d === 'string') return d;
+  }
+  return typeof pkg.module === 'string' ? pkg.module : undefined;
+}
+
+async function importFamilies(entryPath: string): Promise<FamiliesNs | undefined> {
+  try {
+    // Dev-dependency install: the CLI lives inside the project's node_modules, so the
+    // bare specifier resolves to the project's copy.
+    return (await import('brepjs-families')) as unknown as FamiliesNs;
+  } catch {
+    const abs = resolveFamiliesEntry(entryPath);
+    if (abs === undefined) return undefined;
+    try {
+      return (await import(pathToFileURL(abs).href)) as FamiliesNs;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+async function evaluateTree(
+  brep: BrepNs,
+  value: unknown,
+  entryPath: string
+): Promise<PreviewBuild> {
+  const fam = await importFamilies(entryPath);
+  if (fam === undefined) {
     throw new Error(
       "the model is a families element tree, but 'brepjs-families' is not installed in this project"
     );

--- a/packages/brepjs-cad/src/preview/preview.ts
+++ b/packages/brepjs-cad/src/preview/preview.ts
@@ -1,0 +1,101 @@
+import { writeFileSync } from 'node:fs';
+import { encodePreviewPayload } from 'brepjs-viewer';
+import { evaluatePreview, type PreviewBuild } from './evaluate.js';
+import { startPreviewServer, type PreviewServer } from './server.js';
+import {
+  createSerialRunner,
+  debounce,
+  DEFAULT_DEBOUNCE_MS,
+  isWatchRelevant,
+  watchRootFor,
+  watchTree,
+} from '../cli/watch.js';
+import { loadBrep } from '../verify/brepjsRuntime.js';
+import { openBrowser, shouldAutoOpen } from '../cli/openBrowser.js';
+
+export interface PreviewOptions {
+  watch?: boolean;
+  writeOnly?: boolean;
+  glb?: string;
+  json?: string;
+  port?: number;
+  open?: boolean;
+}
+
+interface PreviewSummary {
+  ok: boolean;
+  elements: number;
+  failed: readonly string[];
+  measurements: PreviewBuild['payload']['measurements'];
+  viewer?: string;
+}
+
+function summarize(build: PreviewBuild, viewerUrl?: string): PreviewSummary {
+  return {
+    ok: build.ok,
+    elements: build.payload.elements.length,
+    failed: build.payload.failed,
+    measurements: build.payload.measurements,
+    ...(viewerUrl ? { viewer: viewerUrl } : {}),
+  };
+}
+
+async function writeArtifacts(build: PreviewBuild, opts: PreviewOptions): Promise<void> {
+  if (opts.glb) {
+    const brep = await loadBrep();
+    writeFileSync(opts.glb, Buffer.from(brep.exportGlb(build.merged)));
+  }
+  if (opts.json && opts.json !== '-') {
+    writeFileSync(opts.json, JSON.stringify(summarize(build), null, 2));
+  }
+}
+
+export async function runPreview(entryPath: string, opts: PreviewOptions): Promise<void> {
+  const initial = await evaluatePreview(entryPath);
+  await writeArtifacts(initial, opts);
+
+  if (opts.writeOnly && !opts.watch) {
+    process.stdout.write(JSON.stringify(summarize(initial), null, 2) + '\n');
+    if (!initial.ok) process.exitCode = 1;
+    return;
+  }
+
+  let server: PreviewServer | undefined;
+  if (!opts.writeOnly) {
+    server = await startPreviewServer(encodePreviewPayload(initial.payload), {
+      ...(opts.port !== undefined ? { port: opts.port } : {}),
+    });
+    process.stderr.write(`viewer: ${server.url}\n`);
+    if (opts.open !== false && shouldAutoOpen()) openBrowser(server.url);
+  }
+  process.stdout.write(JSON.stringify(summarize(initial, server?.url), null, 2) + '\n');
+
+  if (opts.watch) {
+    const runner = createSerialRunner(async (fresh) => {
+      try {
+        const build = await evaluatePreview(entryPath, { fresh });
+        server?.update(encodePreviewPayload(build.payload));
+        await writeArtifacts(build, opts);
+        const failedNote =
+          build.payload.failed.length > 0 ? `, ${build.payload.failed.length} failed` : '';
+        process.stderr.write(`preview: ${build.payload.elements.length} elements${failedNote}\n`);
+      } catch (e) {
+        // Keep serving the last good payload; the next save gets another chance.
+        process.stderr.write(`preview rebuild failed: ${(e as Error).message}\n`);
+      }
+    });
+    const { trigger } = debounce(runner.trigger, DEFAULT_DEBOUNCE_MS);
+    const stopWatching = watchTree(watchRootFor(entryPath), (filename) => {
+      if (isWatchRelevant(filename)) trigger();
+    });
+    process.stderr.write(`watching ${entryPath} (Ctrl-C to stop)\n`);
+    const stop = (): void => {
+      stopWatching();
+      void server?.close().finally(() => process.exit(0));
+      if (!server) process.exit(0);
+    };
+    process.on('SIGINT', stop);
+    process.on('SIGTERM', stop);
+  }
+  // Without --watch the server (if any) still runs until Ctrl-C, matching --serve.
+}

--- a/packages/brepjs-cad/src/preview/server.ts
+++ b/packages/brepjs-cad/src/preview/server.ts
@@ -1,0 +1,87 @@
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import { join } from 'node:path';
+import { sendFile, safeJoin, VIEWER_DIST } from '../snapshot/static.js';
+
+export interface PreviewServer {
+  readonly url: string;
+  readonly port: number;
+  /** Swap the served payload and notify subscribed viewer tabs via SSE. */
+  update(payload: ArrayBuffer): void;
+  close(): Promise<void>;
+}
+
+/**
+ * Preview-owned server: serves the built viewer app statically plus two in-memory
+ * routes — `/__preview/model` (the current binary payload) and `/__preview/events`
+ * (SSE reload pings for `--watch`). Unlike the shared snapshot server there is no
+ * `?dir=` dynamic root here, so the filesystem-traversal surface that `/__model/`
+ * has to guard never exists on this server. Loopback only.
+ */
+export function startPreviewServer(
+  initial: ArrayBuffer,
+  opts: { port?: number } = {}
+): Promise<PreviewServer> {
+  let current = Buffer.from(initial);
+  let seq = 1;
+  const clients = new Set<ServerResponse>();
+
+  const handle = async (pathname: string, res: ServerResponse): Promise<void> => {
+    if (pathname === '/__preview/model') {
+      res.writeHead(200, {
+        'content-type': 'application/octet-stream',
+        'content-length': current.length,
+        'cache-control': 'no-store',
+      });
+      res.end(current);
+      return;
+    }
+    if (pathname === '/__preview/events') {
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-store',
+        connection: 'keep-alive',
+      });
+      res.write(`data: {"seq":${seq}}\n\n`);
+      clients.add(res);
+      res.on('close', () => clients.delete(res));
+      return;
+    }
+    const abs = safeJoin(VIEWER_DIST, pathname === '/' ? 'index.html' : pathname);
+    if (!abs) {
+      res.writeHead(403).end('forbidden');
+      return;
+    }
+    await sendFile(res, abs).catch(() =>
+      sendFile(res, join(VIEWER_DIST, 'index.html')).catch(() =>
+        res.writeHead(404).end('not found')
+      )
+    );
+  };
+
+  return new Promise((resolvePromise, reject) => {
+    const server: Server = createServer((req, res) => {
+      const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname;
+      void handle(pathname, res);
+    });
+    server.on('error', reject);
+    server.listen(opts.port ?? 0, '127.0.0.1', () => {
+      const port = (server.address() as { port: number }).port;
+      resolvePromise({
+        port,
+        url: `http://127.0.0.1:${port}/?preview=1`,
+        update(payload) {
+          current = Buffer.from(payload);
+          seq += 1;
+          for (const res of clients) res.write(`data: {"seq":${seq}}\n\n`);
+        },
+        close: () =>
+          new Promise<void>((done, fail) => {
+            for (const res of clients) res.end();
+            clients.clear();
+            server.closeAllConnections();
+            server.close((e) => (e ? fail(e) : done()));
+          }),
+      });
+    });
+  });
+}

--- a/packages/brepjs-cad/src/snapshot/static.ts
+++ b/packages/brepjs-cad/src/snapshot/static.ts
@@ -6,7 +6,7 @@ import { dirname, join, normalize, resolve, sep, extname } from 'node:path';
 
 export const SERVER_API_VERSION = 1;
 const moduleDir = dirname(fileURLToPath(import.meta.url));
-const VIEWER_DIST = resolve(moduleDir, '../../viewer/dist');
+export const VIEWER_DIST = resolve(moduleDir, '../../viewer/dist');
 const MIME: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
   '.js': 'text/javascript; charset=utf-8',
@@ -40,7 +40,7 @@ export interface ServerDescriptor {
   serverApiVersion: number;
 }
 
-async function sendFile(res: ServerResponse, absPath: string): Promise<void> {
+export async function sendFile(res: ServerResponse, absPath: string): Promise<void> {
   const info = await stat(absPath);
   if (!info.isFile()) {
     res.writeHead(404).end('not found');
@@ -50,7 +50,7 @@ async function sendFile(res: ServerResponse, absPath: string): Promise<void> {
   createReadStream(absPath).pipe(res);
 }
 
-function safeJoin(root: string, rel: string): string | null {
+export function safeJoin(root: string, rel: string): string | null {
   const abs = resolve(root, normalize(decodeURIComponent(rel.replace(/^\/+/, ''))));
   if (abs !== root && !abs.startsWith(root + sep)) return null;
   return abs;
@@ -59,7 +59,12 @@ function safeJoin(root: string, rel: string): string | null {
 async function handle(req: IncomingMessage, res: ServerResponse, port: number): Promise<void> {
   const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
   if (url.pathname === '/__cad/server') {
-    const d: ServerDescriptor = { app: 'brepjs-viewer', port, dynamicRoot: true, serverApiVersion: SERVER_API_VERSION };
+    const d: ServerDescriptor = {
+      app: 'brepjs-viewer',
+      port,
+      dynamicRoot: true,
+      serverApiVersion: SERVER_API_VERSION,
+    };
     res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(d));
     return;
@@ -93,7 +98,7 @@ async function handle(req: IncomingMessage, res: ServerResponse, port: number): 
   }
   // SPA fallback so ?dir=&file= bare paths still serve index.html.
   await sendFile(res, abs).catch(() =>
-    sendFile(res, join(VIEWER_DIST, 'index.html')).catch(() => res.writeHead(404).end('not found')),
+    sendFile(res, join(VIEWER_DIST, 'index.html')).catch(() => res.writeHead(404).end('not found'))
   );
 }
 

--- a/packages/brepjs-cad/src/verify/runPart.ts
+++ b/packages/brepjs-cad/src/verify/runPart.ts
@@ -60,15 +60,15 @@ function buildMaterialMap(
 // hook propagates it across the part's own imports) so watch reruns pick up edits.
 let importGeneration = 0;
 
-async function loadPart(
+export async function loadPart(
   modulePath: string,
   fresh = false
-): Promise<{ default?: PartFn; expected?: unknown; materials?: unknown }> {
+): Promise<{ default?: unknown; expected?: unknown; materials?: unknown }> {
   const url = new URL(pathToFileURL(modulePath).href);
   if (fresh) url.searchParams.set('v', String(++importGeneration));
   try {
     return (await import(url.href)) as {
-      default?: PartFn;
+      default?: unknown;
       expected?: unknown;
       materials?: unknown;
     };
@@ -191,7 +191,7 @@ export async function runPart(
     return finalize({ shape: null, report });
   }
   const { isOk, mesh, exportGlb, exportSTEP } = brep;
-  let mod: { default?: PartFn; expected?: unknown; materials?: unknown };
+  let mod: { default?: unknown; expected?: unknown; materials?: unknown };
   try {
     mod = await loadPart(modulePath, opts.freshImport);
   } catch (e) {
@@ -204,7 +204,7 @@ export async function runPart(
   }
   let out: unknown;
   try {
-    out = await mod.default();
+    out = await (mod.default as PartFn)();
   } catch (e) {
     pushError(report, toErrorInfo('part threw', e));
     return finalize({ shape: null, report });

--- a/packages/brepjs-cad/src/verify/typecheck.ts
+++ b/packages/brepjs-cad/src/verify/typecheck.ts
@@ -60,7 +60,7 @@ function typesEntryOf(pkg: { types?: unknown; exports?: unknown }): string | und
   return typeof pkg.types === 'string' ? pkg.types : undefined;
 }
 
-function packageRootOf(startDir: string, name: string): string | undefined {
+export function packageRootOf(startDir: string, name: string): string | undefined {
   let dir = startDir;
   const root = parsePath(dir).root;
   for (;;) {

--- a/packages/brepjs-cad/tests/fixtures/tsxProject/component.tsx
+++ b/packages/brepjs-cad/tests/fixtures/tsxProject/component.tsx
@@ -1,0 +1,5 @@
+import { Panel } from './panel.js';
+
+export default function model() {
+  return <Panel />;
+}

--- a/packages/brepjs-cad/tests/fixtures/tsxProject/model.tsx
+++ b/packages/brepjs-cad/tests/fixtures/tsxProject/model.tsx
@@ -1,0 +1,10 @@
+import { Group } from 'brepjs-families';
+import { Panel } from './panel.js';
+
+export default function model() {
+  return (
+    <Group key="assembly">
+      <Panel />
+    </Group>
+  );
+}

--- a/packages/brepjs-cad/tests/preview.test.ts
+++ b/packages/brepjs-cad/tests/preview.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { decodePreviewPayload, type PreviewModelPayload } from 'brepjs-viewer';
+import { resolveFamiliesEntry } from '@/preview/evaluate.js';
 
 interface PreviewSummary {
   ok: boolean;
@@ -51,6 +52,26 @@ describe('brep preview --write-only', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   }, 120000);
+});
+
+describe('brep preview module contract', () => {
+  it('previews a tree rooted at a family component (function-typed element)', () => {
+    const stdout = execFileSync(
+      'npx',
+      ['tsx', cli, 'preview', join(fixtureDir, 'component.tsx'), '--write-only'],
+      { encoding: 'utf8', cwd: pkgRoot }
+    );
+    const summary = JSON.parse(stdout) as PreviewSummary;
+    expect(summary.ok).toBe(true);
+    expect(summary.elements).toBe(1);
+  }, 120000);
+
+  it('resolves the project-local brepjs-families ESM entry from the model path', () => {
+    const abs = resolveFamiliesEntry(join(fixtureDir, 'main.tsx'));
+    expect(abs).toBeDefined();
+    expect(abs).toMatch(/brepjs-families[\\/]dist[\\/]/);
+    expect(abs?.endsWith('.js')).toBe(true);
+  });
 });
 
 describe('brep preview server', () => {

--- a/packages/brepjs-cad/tests/preview.test.ts
+++ b/packages/brepjs-cad/tests/preview.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { decodePreviewPayload, type PreviewModelPayload } from 'brepjs-viewer';
+
+interface PreviewSummary {
+  ok: boolean;
+  elements: number;
+  failed: string[];
+  measurements: { triangleCount: number; bounds?: { zMax: number } };
+  viewer?: string;
+}
+
+const pkgRoot = fileURLToPath(new URL('..', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const cli = fileURLToPath(new URL('../src/cli/main.ts', import.meta.url));
+const fixtureDir = fileURLToPath(new URL('./fixtures/tsxProject', import.meta.url));
+
+describe('brep preview --write-only', () => {
+  it('evaluates a families TSX model into summary + GLB artifacts', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-preview-'));
+    try {
+      const glb = join(dir, 'model.glb');
+      const json = join(dir, 'model.json');
+      const stdout = execFileSync(
+        'npx',
+        [
+          'tsx',
+          cli,
+          'preview',
+          join(fixtureDir, 'main.tsx'),
+          '--write-only',
+          '--glb',
+          glb,
+          '--json',
+          json,
+        ],
+        { encoding: 'utf8', cwd: pkgRoot }
+      );
+      const summary = JSON.parse(stdout) as PreviewSummary;
+      expect(summary.ok).toBe(true);
+      expect(summary.elements).toBe(1);
+      expect(summary.failed).toEqual([]);
+      expect(summary.measurements.triangleCount).toBeGreaterThan(0);
+      expect(existsSync(glb)).toBe(true);
+      expect(existsSync(json)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+});
+
+describe('brep preview server', () => {
+  it('serves the payload and pushes updates on watched edits', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-preview-watch-'));
+    cpSync(fixtureDir, dir, { recursive: true });
+    symlinkSync(join(repoRoot, 'node_modules'), join(dir, 'node_modules'), 'dir');
+    const child = spawn(
+      'npx',
+      ['tsx', cli, 'preview', join(dir, 'model.tsx'), '--watch', '--no-open'],
+      { cwd: pkgRoot }
+    );
+    let stdout = '';
+    child.stdout.on('data', (c: Buffer) => (stdout += c.toString()));
+    try {
+      const summary = await waitFor(
+        () => {
+          const text = stdout.trim();
+          if (!text.startsWith('{') || !text.endsWith('}')) return undefined;
+          return JSON.parse(text) as PreviewSummary;
+        },
+        90000,
+        'preview summary on stdout'
+      );
+      expect(summary.ok).toBe(true);
+      expect(summary.viewer).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/\?preview=1$/);
+      const origin = new URL(summary.viewer as string).origin;
+
+      const first = await fetchPayload(origin);
+      expect(first.elements).toHaveLength(1);
+      expect(first.elements[0]?.keyPath).toBe('assembly/panel');
+      expect(first.data.index.length).toBeGreaterThan(0);
+      expect(first.data.edges.length).toBeGreaterThan(0);
+      expect(first.tree?.type).toBe('Group');
+      expect(first.tree?.children).toHaveLength(1);
+      expect(first.measurements.bounds?.zMax).toBeCloseTo(4, 5);
+
+      const events = await fetch(`${origin}/__preview/events`);
+      expect(events.headers.get('content-type')).toBe('text/event-stream');
+      await events.body?.cancel();
+
+      writeFileSync(
+        join(dir, 'dims.ts'),
+        'export const panelSize: readonly [number, number, number] = [20, 10, 8];\n'
+      );
+      await waitFor(
+        async () => {
+          const p = await fetchPayload(origin);
+          return p.measurements.bounds?.zMax === 8 ? p : undefined;
+        },
+        90000,
+        'updated payload after dependency edit'
+      );
+    } finally {
+      await shutdown(child);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 240000);
+});
+
+async function fetchPayload(origin: string): Promise<PreviewModelPayload> {
+  const r = await fetch(`${origin}/__preview/model`);
+  if (!r.ok) throw new Error(`fetch payload: ${r.status}`);
+  return decodePreviewPayload(await r.arrayBuffer());
+}
+
+async function waitFor<T>(
+  probe: () => T | undefined | Promise<T | undefined>,
+  timeoutMs: number,
+  what: string
+): Promise<T> {
+  const started = Date.now();
+  for (;;) {
+    let result: T | undefined;
+    try {
+      result = await probe();
+    } catch {
+      result = undefined;
+    }
+    if (result !== undefined) return result;
+    if (Date.now() - started > timeoutMs) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((res) => setTimeout(res, 250));
+  }
+}
+
+function shutdown(child: ChildProcess): Promise<void> {
+  return new Promise((res) => {
+    child.once('exit', () => res());
+    child.kill('SIGTERM');
+    setTimeout(() => child.kill('SIGKILL'), 5000).unref();
+  });
+}

--- a/packages/brepjs-cad/viewer/main.tsx
+++ b/packages/brepjs-cad/viewer/main.tsx
@@ -12,6 +12,7 @@ import {
   meshSize,
   meshBounds,
   sectionPlane,
+  findElementAt,
   type FaceInfo,
   type Projection,
   type SectionAxis,
@@ -19,7 +20,7 @@ import {
   type ViewName,
 } from 'brepjs-viewer';
 import { Html } from '@react-three/drei';
-import { useModel } from './src/useModel.js';
+import { useModel, type PreviewInfo } from './src/useModel.js';
 import { installScreenshotApi, onScene, markReady, type Mark } from './src/screenshotApi.js';
 
 // Kernel-anchored Set-of-Marks: numbered badges drawn at 3D feature points (drei <Html> projects them
@@ -68,6 +69,43 @@ function downloadCanvasPng(): void {
   a.click();
 }
 
+// Element identity panel for `brep preview`: counts, the picked element's key path,
+// and every failed key path (failed elements are absent from the merged mesh, so the
+// list is the only place they surface visually).
+function PreviewPanel({ preview, selected }: { preview: PreviewInfo; selected: string | null }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 12,
+        left: 12,
+        maxWidth: 340,
+        maxHeight: '60vh',
+        overflowY: 'auto',
+        background: 'rgba(16, 20, 24, 0.85)',
+        color: '#cfd6dc',
+        font: '12px monospace',
+        padding: '8px 10px',
+        borderRadius: 6,
+        pointerEvents: 'auto',
+      }}
+    >
+      <div>
+        elements: {preview.elements.length}
+        {preview.failed.length > 0 && (
+          <span style={{ color: '#e88' }}> · {preview.failed.length} failed</span>
+        )}
+      </div>
+      {selected && <div style={{ color: '#ffd479' }}>selected: {selected}</div>}
+      {preview.failed.map((keyPath) => (
+        <div key={keyPath} style={{ color: '#e88' }}>
+          ✗ {keyPath}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function App() {
   const state = useModel({ inspect: showControls });
   const [view, setView] = useState<ViewName>('iso');
@@ -84,6 +122,15 @@ function App() {
   const [sectionPos, setSectionPos] = useState(0);
   const [sectionFlip, setSectionFlip] = useState(false);
   const [marks, setMarks] = useState<readonly Mark[]>([]);
+  const [selectedElement, setSelectedElement] = useState<string | null>(null);
+  const preview: PreviewInfo | undefined = state.status === 'ready' ? state.preview : undefined;
+  const handleTrianglePick = useCallback(
+    (triangleIndex: number) => {
+      if (!preview) return;
+      setSelectedElement(findElementAt(preview.elements, triangleIndex)?.keyPath ?? null);
+    },
+    [preview]
+  );
   const handleFit = useCallback(() => {
     setFitSignal((n) => n + 1);
   }, []);
@@ -167,6 +214,7 @@ function App() {
           viewMode={viewMode}
           {...(clippingPlanes ? { clippingPlanes } : {})}
           {...(showControls ? { onFacePick: handleFacePick, onFaceHover: handleFaceHover } : {})}
+          {...(preview ? { onTrianglePick: handleTrianglePick } : {})}
         />
         {showEdges && viewMode !== 'wireframe' && state.data.edges.length > 0 && (
           <EdgeRenderer edges={state.data.edges} {...(clippingPlanes ? { clippingPlanes } : {})} />
@@ -214,6 +262,7 @@ function App() {
         />
       )}
       {!showControls && showDims && <ViewerInfoPanel dims={meshSize(state.data)} />}
+      {preview && <PreviewPanel preview={preview} selected={selectedElement} />}
       {showControls && (
         <ViewerControls
           viewMode={viewMode}

--- a/packages/brepjs-cad/viewer/src/useModel.ts
+++ b/packages/brepjs-cad/viewer/src/useModel.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import type { MeshData } from 'brepjs-viewer';
+import { decodePreviewPayload } from 'brepjs-viewer';
+import type { ElementRange, MeshData, PreviewTreeNode } from 'brepjs-viewer';
 import type { FromWorker, LoadRequest } from './kernelWorker.js';
 import type { ModelMeasurements } from './loaders.js';
 
@@ -17,10 +18,17 @@ export function extOf(file: string): string {
   return d === -1 ? '' : file.slice(d).toLowerCase();
 }
 
+/** Element identity riding on a preview payload (brep preview). */
+export interface PreviewInfo {
+  elements: readonly ElementRange[];
+  failed: readonly string[];
+  tree: PreviewTreeNode | null;
+}
+
 export type ModelState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'ready'; data: MeshData; measurements: ModelMeasurements }
+  | { status: 'ready'; data: MeshData; measurements: ModelMeasurements; preview?: PreviewInfo }
   | { status: 'error'; error: string };
 
 export interface UseModelOptions {
@@ -30,6 +38,40 @@ export interface UseModelOptions {
 export function useModel({ inspect = false }: UseModelOptions = {}): ModelState {
   const [state, setState] = useState<ModelState>({ status: 'idle' });
   useEffect(() => {
+    // Preview mode (`brep preview`): the payload is server-evaluated — fetch it and
+    // re-fetch on each SSE ping. No kernel worker, no ?dir=/?file= routes involved.
+    if (new URLSearchParams(window.location.search).has('preview')) {
+      setState({ status: 'loading' });
+      let cancelled = false;
+      const load = async (): Promise<void> => {
+        try {
+          const r = await fetch('/__preview/model');
+          if (!r.ok) throw new Error(`fetch preview model: ${r.status}`);
+          const payload = decodePreviewPayload(await r.arrayBuffer());
+          if (cancelled) return;
+          setState({
+            status: 'ready',
+            data: payload.data,
+            measurements: { valid: payload.failed.length === 0 },
+            preview: {
+              elements: payload.elements,
+              failed: payload.failed,
+              tree: payload.tree,
+            },
+          });
+        } catch (err) {
+          if (!cancelled)
+            setState({ status: 'error', error: err instanceof Error ? err.message : String(err) });
+        }
+      };
+      void load();
+      const events = new EventSource('/__preview/events');
+      events.onmessage = () => void load();
+      return () => {
+        cancelled = true;
+        events.close();
+      };
+    }
     const params = parseModelParams(window.location.search);
     if (!params) {
       setState({ status: 'error', error: 'missing ?file= parameter' });

--- a/packages/brepjs-cad/vite.config.ts
+++ b/packages/brepjs-cad/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         'snapshot/registry': resolve(import.meta.dirname, 'src/snapshot/registry.ts'),
         'snapshot/shoot': resolve(import.meta.dirname, 'src/snapshot/shoot.ts'),
         'snapshot/serve': resolve(import.meta.dirname, 'src/snapshot/serve.ts'),
+        'preview/preview': resolve(import.meta.dirname, 'src/preview/preview.ts'),
         'mcp/server': resolve(import.meta.dirname, 'src/mcp/server.ts'),
       },
       formats: ['es', 'cjs'],
@@ -44,6 +45,8 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'brepjs',
+        // Resolved at runtime from the USER's project (preview element trees); never bundled.
+        'brepjs-families',
         'occt-wasm',
         'commander',
         'puppeteer',

--- a/packages/brepjs-cad/vitest.config.ts
+++ b/packages/brepjs-cad/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     // `@/utils`/`@/kernel` imports and breaks any test that imports `brepjs`.
     alias: [
       { find: /^@viewer\//, replacement: `${viewerSrc}/` },
-      { find: /^@\/(verify|snapshot|cli|sandbox|mcp)\//, replacement: `${pkgSrc}/$1/` },
+      { find: /^@\/(verify|snapshot|cli|sandbox|mcp|preview)\//, replacement: `${pkgSrc}/$1/` },
       { find: /^@\//, replacement: `${rootSrc}/` },
       { find: 'brepjs', replacement: resolve(rootSrc, 'index.ts') },
     ],

--- a/packages/brepjs-viewer/src/Renderer.tsx
+++ b/packages/brepjs-viewer/src/Renderer.tsx
@@ -12,6 +12,9 @@ export interface RendererProps {
   onFacePick?: (info: FaceInfo, additive: boolean, pos: ScreenPos) => void;
   onFaceHover?: (info: FaceInfo | null, pos?: ScreenPos) => void;
   onFaceContextMenu?: (info: FaceInfo, pos: ScreenPos) => void;
+  /** Raw triangle-index pick — works without faceInfos (element-identity payloads
+   *  map it back to a key path via findElementAt). */
+  onTrianglePick?: (triangleIndex: number, pos: ScreenPos) => void;
 }
 
 export function Renderer({
@@ -21,9 +24,11 @@ export function Renderer({
   onFacePick,
   onFaceHover,
   onFaceContextMenu,
+  onTrianglePick,
 }: RendererProps) {
   const pickable = Boolean(
-    data.faceGroups && data.faceInfos && (onFacePick || onFaceHover || onFaceContextMenu)
+    (data.faceGroups && data.faceInfos && (onFacePick || onFaceHover || onFaceContextMenu)) ||
+    onTrianglePick
   );
   const geometry = useMemo(() => buildGeometry(data), [data.position, data.normal, data.index]);
   useEffect(() => () => geometry.dispose(), [geometry]);
@@ -61,12 +66,16 @@ export function Renderer({
       // Swallow the tap the browser synthesizes when a touch long-press just
       // opened the context menu, so it doesn't also select the entity.
       if (longPress.consumeFired()) return;
+      if (onTrianglePick && e.faceIndex !== undefined && e.faceIndex !== null) {
+        e.stopPropagation();
+        onTrianglePick(e.faceIndex, { x: e.clientX, y: e.clientY });
+      }
       const info = resolveFace(e);
       if (!info) return;
       e.stopPropagation();
       onFacePick?.(info, e.shiftKey, { x: e.clientX, y: e.clientY });
     },
-    [resolveFace, onFacePick, longPress]
+    [resolveFace, onFacePick, onTrianglePick, longPress]
   );
   const onCtx = useCallback(
     (e: ThreeEvent<MouseEvent>) => {

--- a/packages/brepjs-viewer/src/index.ts
+++ b/packages/brepjs-viewer/src/index.ts
@@ -31,3 +31,13 @@ export {
   type EvaluatedNodeLike,
   type ModelMeshResult,
 } from './model.js';
+export {
+  encodePreviewPayload,
+  decodePreviewPayload,
+  PREVIEW_PAYLOAD_MAGIC,
+  PREVIEW_PAYLOAD_VERSION,
+  type PreviewModelPayload,
+  type PreviewTreeNode,
+  type PreviewBounds,
+  type PreviewMeasurements,
+} from './payload.js';

--- a/packages/brepjs-viewer/src/model.ts
+++ b/packages/brepjs-viewer/src/model.ts
@@ -16,6 +16,9 @@ export interface ElementMesh {
   readonly vertices: Float32Array;
   readonly normals: Float32Array;
   readonly faceGroups?: readonly { start: number; count: number; faceId: number }[] | undefined;
+  /** Optional edge line segments (x,y,z interleaved, 2 vertices per segment) —
+   *  merged into `MeshData.edges` so the EdgeRenderer has real wireframe data. */
+  readonly edges?: Float32Array | undefined;
 }
 
 export interface EvaluatedNodeLike {
@@ -55,11 +58,13 @@ export function modelToMeshData(model: EvaluatedModelLike): ModelMeshResult {
   const failed: string[] = [];
   let floats = 0;
   let indices = 0;
+  let edgeFloats = 0;
   for (const [keyPath, node] of model.byKeyPath) {
     if (node.mesh.ok) {
       parts.push({ keyPath, mesh: node.mesh.value });
       floats += node.mesh.value.vertices.length;
       indices += node.mesh.value.triangles.length;
+      edgeFloats += node.mesh.value.edges?.length ?? 0;
     } else {
       failed.push(keyPath);
     }
@@ -68,11 +73,17 @@ export function modelToMeshData(model: EvaluatedModelLike): ModelMeshResult {
   const position = new Float32Array(floats);
   const normal = new Float32Array(floats);
   const index = new Uint32Array(indices);
+  const edges = new Float32Array(edgeFloats);
   const faceGroups: FaceGroup[] = [];
   const elements: ElementRange[] = [];
   let floatOffset = 0;
   let indexOffset = 0;
+  let edgeOffset = 0;
   for (const { keyPath, mesh } of parts) {
+    if (mesh.edges) {
+      edges.set(mesh.edges, edgeOffset);
+      edgeOffset += mesh.edges.length;
+    }
     position.set(mesh.vertices, floatOffset);
     normal.set(mesh.normals, floatOffset);
     const vertexBase = floatOffset / 3;
@@ -91,7 +102,7 @@ export function modelToMeshData(model: EvaluatedModelLike): ModelMeshResult {
     position,
     normal,
     index,
-    edges: new Float32Array(0),
+    edges,
     ...(faceGroups.length > 0 ? { faceGroups } : {}),
   };
   return { data, elements, failed };

--- a/packages/brepjs-viewer/src/payload.ts
+++ b/packages/brepjs-viewer/src/payload.ts
@@ -1,0 +1,137 @@
+/**
+ * Binary framing for the preview model payload: a fixed prelude, a JSON header,
+ * then the raw typed-array buffers back to back. Buffers stay out of JSON so
+ * multi-megabyte meshes cross HTTP without base64 or per-float text.
+ *
+ * Layout (little-endian):
+ *   [u32 magic 'BPRV'][u32 headerByteLength][header JSON utf8, padded to 4][buffers…]
+ *
+ * The header's `buffers` entries give each array's element length in payload
+ * order: position, normal, index, edges.
+ */
+import type { FaceGroup, MeshData } from './types.js';
+import type { ElementRange } from './model.js';
+
+export const PREVIEW_PAYLOAD_MAGIC = 0x42505256;
+export const PREVIEW_PAYLOAD_VERSION = 1;
+
+export interface PreviewTreeNode {
+  readonly keyPath: string;
+  readonly type: string;
+  readonly archetype?: string | undefined;
+  readonly name?: string | undefined;
+  readonly hasGeometry: boolean;
+  readonly children: readonly PreviewTreeNode[];
+}
+
+export interface PreviewBounds {
+  readonly xMin: number;
+  readonly xMax: number;
+  readonly yMin: number;
+  readonly yMax: number;
+  readonly zMin: number;
+  readonly zMax: number;
+}
+
+export interface PreviewMeasurements {
+  readonly bounds?: PreviewBounds | undefined;
+  readonly elementCount: number;
+  readonly failedCount: number;
+  readonly triangleCount: number;
+}
+
+export interface PreviewModelPayload {
+  readonly data: MeshData;
+  readonly elements: readonly ElementRange[];
+  readonly failed: readonly string[];
+  readonly tree: PreviewTreeNode | null;
+  readonly measurements: PreviewMeasurements;
+}
+
+interface PayloadHeader {
+  version: number;
+  elements: readonly ElementRange[];
+  failed: readonly string[];
+  tree: PreviewTreeNode | null;
+  measurements: PreviewMeasurements;
+  faceGroups?: readonly FaceGroup[] | undefined;
+  buffers: { position: number; normal: number; index: number; edges: number };
+}
+
+const pad4 = (n: number): number => (n + 3) & ~3;
+
+export function encodePreviewPayload(payload: PreviewModelPayload): ArrayBuffer {
+  const { data } = payload;
+  const header: PayloadHeader = {
+    version: PREVIEW_PAYLOAD_VERSION,
+    elements: payload.elements,
+    failed: payload.failed,
+    tree: payload.tree,
+    measurements: payload.measurements,
+    ...(data.faceGroups ? { faceGroups: data.faceGroups } : {}),
+    buffers: {
+      position: data.position.length,
+      normal: data.normal.length,
+      index: data.index.length,
+      edges: data.edges.length,
+    },
+  };
+  const headerBytes = new TextEncoder().encode(JSON.stringify(header));
+  const headerSpan = pad4(headerBytes.length);
+  const bodyBytes =
+    (data.position.length + data.normal.length + data.edges.length + data.index.length) * 4;
+  const out = new ArrayBuffer(8 + headerSpan + bodyBytes);
+  const view = new DataView(out);
+  view.setUint32(0, PREVIEW_PAYLOAD_MAGIC, true);
+  view.setUint32(4, headerBytes.length, true);
+  new Uint8Array(out, 8, headerBytes.length).set(headerBytes);
+  let offset = 8 + headerSpan;
+  for (const arr of [data.position, data.normal, data.index, data.edges]) {
+    new Uint8Array(out, offset, arr.byteLength).set(
+      new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength)
+    );
+    offset += arr.byteLength;
+  }
+  return out;
+}
+
+export function decodePreviewPayload(buffer: ArrayBuffer): PreviewModelPayload {
+  const view = new DataView(buffer);
+  if (buffer.byteLength < 8 || view.getUint32(0, true) !== PREVIEW_PAYLOAD_MAGIC) {
+    throw new Error('not a preview payload (bad magic)');
+  }
+  const headerLength = view.getUint32(4, true);
+  const header = JSON.parse(
+    new TextDecoder().decode(new Uint8Array(buffer, 8, headerLength))
+  ) as PayloadHeader;
+  if (header.version !== PREVIEW_PAYLOAD_VERSION) {
+    throw new Error(`unsupported preview payload version ${header.version}`);
+  }
+  let offset = 8 + pad4(headerLength);
+  const take = <T extends Float32Array | Uint32Array>(
+    ctor: new (b: ArrayBuffer, o: number, l: number) => T,
+    length: number
+  ): T => {
+    const arr = new ctor(buffer, offset, length);
+    offset += length * 4;
+    return arr;
+  };
+  const position = take(Float32Array, header.buffers.position);
+  const normal = take(Float32Array, header.buffers.normal);
+  const index = take(Uint32Array, header.buffers.index);
+  const edges = take(Float32Array, header.buffers.edges);
+  const data: MeshData = {
+    position,
+    normal,
+    index,
+    edges,
+    ...(header.faceGroups ? { faceGroups: [...header.faceGroups] } : {}),
+  };
+  return {
+    data,
+    elements: header.elements,
+    failed: header.failed,
+    tree: header.tree,
+    measurements: header.measurements,
+  };
+}

--- a/packages/brepjs-viewer/tests/model.test.ts
+++ b/packages/brepjs-viewer/tests/model.test.ts
@@ -39,6 +39,28 @@ describe('modelToMeshData', () => {
     expect(data.edges.length).toBe(0);
   });
 
+  it('merges per-element edge segments into MeshData.edges', () => {
+    const withEdges = (offset: number): EvaluatedNodeLike => {
+      const base = tri(offset);
+      if (!base.mesh.ok) throw new Error('unreachable');
+      return {
+        mesh: {
+          ok: true,
+          value: { ...base.mesh.value, edges: new Float32Array([offset, 0, 0, offset + 1, 0, 0]) },
+        },
+      };
+    };
+    const model = {
+      byKeyPath: new Map([
+        ['a', withEdges(0)],
+        ['b', withEdges(10)],
+        ['c', tri(20)],
+      ]),
+    };
+    const { data } = modelToMeshData(model);
+    expect(Array.from(data.edges)).toEqual([0, 0, 0, 1, 0, 0, 10, 0, 0, 11, 0, 0]);
+  });
+
   it('collects failed elements instead of dropping them silently', () => {
     const model = {
       byKeyPath: new Map<string, EvaluatedNodeLike>([

--- a/packages/brepjs-viewer/tests/payload.test.ts
+++ b/packages/brepjs-viewer/tests/payload.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { encodePreviewPayload, decodePreviewPayload, type PreviewModelPayload } from '@/payload.js';
+
+function samplePayload(): PreviewModelPayload {
+  return {
+    data: {
+      position: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normal: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      index: new Uint32Array([0, 1, 2]),
+      edges: new Float32Array([0, 0, 0, 1, 0, 0]),
+      faceGroups: [{ start: 0, count: 3, faceId: 7 }],
+    },
+    elements: [{ keyPath: 'assembly/panel', start: 0, count: 3 }],
+    failed: ['assembly/broken'],
+    tree: {
+      keyPath: 'assembly',
+      type: 'Group',
+      hasGeometry: false,
+      children: [
+        { keyPath: 'assembly/panel', type: 'Box', name: 'panel', hasGeometry: true, children: [] },
+      ],
+    },
+    measurements: {
+      bounds: { xMin: 0, xMax: 1, yMin: 0, yMax: 1, zMin: 0, zMax: 0 },
+      elementCount: 1,
+      failedCount: 1,
+      triangleCount: 1,
+    },
+  };
+}
+
+describe('preview payload codec', () => {
+  it('round-trips data, identity, tree, and measurements', () => {
+    const original = samplePayload();
+    const decoded = decodePreviewPayload(encodePreviewPayload(original));
+    expect(Array.from(decoded.data.position)).toEqual(Array.from(original.data.position));
+    expect(Array.from(decoded.data.normal)).toEqual(Array.from(original.data.normal));
+    expect(Array.from(decoded.data.index)).toEqual(Array.from(original.data.index));
+    expect(Array.from(decoded.data.edges)).toEqual(Array.from(original.data.edges));
+    expect(decoded.data.faceGroups).toEqual(original.data.faceGroups);
+    expect(decoded.elements).toEqual(original.elements);
+    expect(decoded.failed).toEqual(original.failed);
+    expect(decoded.tree).toEqual(original.tree);
+    expect(decoded.measurements).toEqual(original.measurements);
+  });
+
+  it('survives a non-4-aligned header length', () => {
+    const p = { ...samplePayload(), failed: ['x'] };
+    const decoded = decodePreviewPayload(encodePreviewPayload(p));
+    expect(decoded.failed).toEqual(['x']);
+    expect(Array.from(decoded.data.index)).toEqual([0, 1, 2]);
+  });
+
+  it('rejects garbage and version drift', () => {
+    expect(() => decodePreviewPayload(new ArrayBuffer(4))).toThrow(/magic/);
+    const buf = encodePreviewPayload(samplePayload());
+    const bad = buf.slice(0);
+    new DataView(bad).setUint32(0, 0xdeadbeef, true);
+    expect(() => decodePreviewPayload(bad)).toThrow(/magic/);
+  });
+});


### PR DESCRIPTION
Second of the discussion #2020 follow-ups (viktar-b), building on #2228's loader: `brep preview` — an element-aware model viewer with a live edit loop. `npm run preview` in the upcoming scaffold template shells to this.

## What it does

`brep preview src/main.tsx` loads the module through the registered single-realm hook (same kernel as verify), evaluates it, and opens the viewer:

- **Module contract**: `export default` a value or a (possibly async) function returning one — a families element tree, an already-resolved tree, or a plain shape; `Result` wrappers are unwrapped. Detection is structural, so brepjs-cad carries no dependency on brepjs-families: it dynamic-imports the USER project's install (the CLI resolves from inside the project's `node_modules`), and plain shapes preview without families entirely.
- **Element-aware**: families trees evaluate per element (`shapes: true`), preserving key-path identity through the merged mesh as index ranges. Clicking the model reports the element's key path; failed elements are listed in the panel (they're absent from the merge, so the list is the only place they surface). The containment tree comes from walking `model.root`, since `byKeyPath` holds geometry-bearing elements only.
- **Real edges**: `modelToMeshData` now merges per-element edge segments (`meshEdges` on each borrowed element shape; the Evaluator's `using` scope is the whole disposal story). The viewer's EdgeRenderer previously rendered nothing for evaluated models (`edges: new Float32Array(0)`).
- **Binary payload**: a JSON header + raw typed-array buffers (`encode/decodePreviewPayload` in brepjs-viewer) — no base64, no per-float JSON.
- **Preview-owned server**: `/__preview/model` and `/__preview/events` (SSE) serve in-memory data plus the static viewer assets, loopback only. There is no `?dir=` dynamic root on this server, so the traversal surface `/__model/` has to guard never exists here. `verify --serve` is untouched.
- **`--watch`**: re-evaluates on save (serialized runs, cache-busted imports — the #2228 machinery) and pushes to the open tab over SSE. `--write-only` (CI), `--glb <out>` (merged GLB derived from the same single merge as the viewer payload), `--json <out>`, `--port`, `--no-open`.

## Viewer changes (brepjs-viewer)

`ElementMesh.edges` + merge, payload codec, and an additive `Renderer.onTrianglePick` (raw triangle-index pick that works without `faceInfos`, mapped to elements via `findElementAt`). No external callers of `modelToMeshData` existed, and brepjs-cad bundles brepjs-viewer from the workspace at build time, so no brepjs-viewer publish is required.

## Tests

- payload codec round-trip (incl. alignment + garbage/version rejection), edge merging, `createSerialRunner` extraction reused by watch + preview
- child-process integration: `--write-only` on a plain-shape TSX module (summary + GLB artifacts), and a full server test on a families element-tree module — fetches and decodes the binary payload (element key paths, tree, edges, bounds), checks the SSE endpoint, edits a dependency file, and asserts the served payload updates
- built-CLI smoke under plain node passes locally
