### PR TITLE
feat(brepjs-bim): route footing, pile, railing, ramp, covering, curtain wall, and space through familiesToBim

### DIFF
--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -5,7 +5,8 @@
  * while the IR path serves the viewport and dedup. GlobalIds derive from
  * families key paths (stable under reordering), not insertion order.
  *
- * Scope: Storey containers, Wall/Slab/Column/Beam/Roof/Stair elements, and wall openings — a
+ * Scope: Storey containers; Wall/Slab/Column/Beam/Roof/Stair, Footing/Pile,
+ * Railing/Ramp, Covering/CurtainWall, and Space elements; and wall openings — a
  * fill-role void (Door/Window family) maps onto addDoor/addWindow, which cut
  * the wall and wire IfcRelVoidsElement + IfcRelFillsElement; the opening and
  * filler GlobalIds derive from the synthesized key paths. Anonymous (non-fill)
@@ -23,6 +24,12 @@ import { parseColumnSpec } from './specs/columnSpec.js';
 import { parseBeamSpec } from './specs/beamSpec.js';
 import { parseRoofSpec } from './specs/roofSpec.js';
 import { parseStairSpec } from './specs/stairSpec.js';
+import { parseFootingSpec, parsePileSpec } from './specs/foundationSpec.js';
+import { parseRailingSpec } from './specs/railingSpec.js';
+import { parseRampSpec } from './specs/rampSpec.js';
+import { parseCoveringSpec } from './specs/coveringSpec.js';
+import { parseCurtainWallSpec } from './specs/curtainWallSpec.js';
+import { parseSpaceSpec } from './specs/spaceSpec.js';
 import { parseDoorSpec, parseWindowSpec } from './specs/openingSpec.js';
 import type { ProxySpec } from './specs/proxySpec.js';
 import type { ProjectSpec } from './specs/spatialSpec.js';
@@ -99,13 +106,46 @@ const SPEC_ROUTES = {
   stair: {
     parse: parseStairSpec,
     add: (m: BimModel, spec: unknown, key: string) => m.addStair(spec as never, { stableKey: key }),
-    input: stairSpecInput,
+    input: flightsSpecInput,
+  },
+  footing: {
+    parse: parseFootingSpec,
+    add: (m: BimModel, spec: unknown, key: string) =>
+      m.addFooting(spec as never, { stableKey: key }),
+  },
+  pile: {
+    parse: parsePileSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addPile(spec as never, { stableKey: key }),
+  },
+  railing: {
+    parse: parseRailingSpec,
+    add: (m: BimModel, spec: unknown, key: string) =>
+      m.addRailing(spec as never, { stableKey: key }),
+  },
+  ramp: {
+    parse: parseRampSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addRamp(spec as never, { stableKey: key }),
+    input: flightsSpecInput,
+  },
+  covering: {
+    parse: parseCoveringSpec,
+    add: (m: BimModel, spec: unknown, key: string) =>
+      m.addCovering(spec as never, undefined, { stableKey: key }),
+  },
+  curtainWall: {
+    parse: parseCurtainWallSpec,
+    add: (m: BimModel, spec: unknown, key: string) =>
+      m.addCurtainWall(spec as never, { stableKey: key }),
+  },
+  space: {
+    parse: parseSpaceSpec,
+    add: (m: BimModel, spec: unknown, key: string) => m.addSpace(spec as never, { stableKey: key }),
   },
 } as const;
 
-/** StairSpec has no top-level origin — placement lives per flight — so the
- *  element's folded translate lands on every flight's origin instead. */
-function stairSpecInput(el: ResolvedElement): Record<string, unknown> {
+/** Stair and ramp specs have no top-level origin — placement lives per flight —
+ *  so the element's folded translate lands on every flight's origin instead. */
+function flightsSpecInput(el: ResolvedElement): Record<string, unknown> {
   const base = specInput(el);
   const fold = (base['origin'] as readonly [number, number, number] | undefined) ?? [0, 0, 0];
   const flights = Array.isArray(base['flights'])
@@ -136,6 +176,13 @@ const NAME_ARCHETYPES: Readonly<Record<string, string>> = {
   Stair: 'stair',
   Door: 'door',
   Window: 'window',
+  Footing: 'footing',
+  Pile: 'pile',
+  Railing: 'railing',
+  Ramp: 'ramp',
+  Covering: 'covering',
+  CurtainWall: 'curtainWall',
+  Space: 'space',
 };
 
 function archetypeFor(el: ResolvedElement): string | undefined {

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -670,3 +670,146 @@ describe('archetype routing', () => {
     expect(model.getWalls()).toHaveLength(0);
   });
 });
+
+describe('familiesToBim route breadth', () => {
+  const inStorey = (child: Element): ReturnType<typeof resolve> =>
+    resolve(Storey({ key: 's', walls: [child] }));
+
+  async function project(
+    child: Element
+  ): Promise<{ ifc: string; ids: ReadonlyMap<string, unknown> }> {
+    const projected = familiesToBim(inStorey(child), { project: PROJECT });
+    expect(isOk(projected)).toBe(true);
+    using model = unwrap(projected).model;
+    expect(checkReferentialIntegrity(model).issues.filter((i) => i.severity === 'error')).toEqual(
+      []
+    );
+    return { ifc: await ifcText(model), ids: unwrap(projected).idByKeyPath };
+  }
+
+  it('maps a footing onto IfcFooting with base quantities and folded placement', async () => {
+    const Footing = family<{
+      readonly length: number;
+      readonly width: number;
+      readonly thickness: number;
+      readonly at: readonly [number, number, number];
+    }>('Footing', (p) =>
+      el('Box', { size: [p.length, p.width, p.thickness], transform: [tTranslate(p.at)] })
+    );
+    const { ifc, ids } = await project(
+      Footing({ key: 'f1', length: 2000, width: 1500, thickness: 500, at: [1000, 0, 0] })
+    );
+    expect(ids.has('s/f1')).toBe(true);
+    expect(ifc).toContain('IFCFOOTING');
+    expect(ifc).toContain('Qto_FootingBaseQuantities');
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/f1'));
+    expect(ifc).toContain('(1.,0.,0.)');
+  });
+
+  it('maps a pile onto IfcPile', async () => {
+    const Pile = family<{
+      readonly length: number;
+      readonly profile: { readonly kind: 'CIRCULAR'; readonly radius: number };
+    }>('Pile', (p) => el('Cylinder', { radius: p.profile.radius, height: p.length }));
+    const { ifc, ids } = await project(
+      Pile({ key: 'p1', length: 12000, profile: { kind: 'CIRCULAR', radius: 300 } })
+    );
+    expect(ids.has('s/p1')).toBe(true);
+    expect(ifc).toContain('IFCPILE');
+    expect(ifc).toContain('Qto_PileBaseQuantities');
+  });
+
+  it('maps a railing onto IfcRailing', async () => {
+    const Railing = family<{
+      readonly length: number;
+      readonly height: number;
+      readonly thickness: number;
+    }>('Railing', (p) => el('Box', { size: [p.length, p.thickness, p.height] }));
+    const { ifc, ids } = await project(
+      Railing({ key: 'r1', length: 3000, height: 1100, thickness: 100 })
+    );
+    expect(ids.has('s/r1')).toBe(true);
+    expect(ifc).toContain('IFCRAILING');
+  });
+
+  it('maps a ramp onto IfcRamp and folds the element translate into flight origins', async () => {
+    const Ramp = family<{
+      readonly flights: ReadonlyArray<Record<string, unknown>>;
+      readonly at: readonly [number, number, number];
+    }>('Ramp', (p) => el('Box', { size: [6000, 1200, 500], transform: [tTranslate(p.at)] }));
+    const flight = {
+      width: 1200,
+      length: 6000,
+      slope: 1 / 12,
+      thickness: 200,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    };
+    const { ifc, ids } = await project(Ramp({ key: 'ra1', flights: [flight], at: [1000, 0, 0] }));
+    expect(ids.has('s/ra1')).toBe(true);
+    expect(ifc).toContain('IFCRAMP');
+    expect(ifc).toContain('IFCRAMPFLIGHT');
+    expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/ra1'));
+    expect(ifc).toContain('(1.,0.,0.)');
+  });
+
+  it('maps a covering onto IfcCovering', async () => {
+    const Covering = family<{
+      readonly length: number;
+      readonly width: number;
+      readonly thickness: number;
+    }>('Covering', (p) => el('Box', { size: [p.length, p.width, p.thickness] }));
+    const { ifc, ids } = await project(
+      Covering({
+        key: 'c1',
+        length: 4000,
+        width: 3000,
+        thickness: 20,
+        predefinedType: 'FLOORING',
+      } as never)
+    );
+    expect(ids.has('s/c1')).toBe(true);
+    expect(ifc).toContain('IFCCOVERING');
+  });
+
+  it('maps a curtain wall onto IfcCurtainWall with plate/member parts', async () => {
+    const CurtainWall = family<{
+      readonly width: number;
+      readonly height: number;
+    }>('CurtainWall', (p) => el('Box', { size: [p.width, 30, p.height] }));
+    const { ifc, ids } = await project(
+      CurtainWall({
+        key: 'cw1',
+        width: 6000,
+        height: 3000,
+        columns: 3,
+        rows: 2,
+        panelThickness: 30,
+        mullionWidth: 60,
+        mullionDepth: 100,
+      } as never)
+    );
+    expect(ids.has('s/cw1')).toBe(true);
+    expect(ifc).toContain('IFCCURTAINWALL');
+    expect(ifc).toContain('IFCPLATE');
+    expect(ifc).toContain('IFCMEMBER');
+  });
+
+  it('maps a space onto IfcSpace with base quantities', async () => {
+    const Space = family<{
+      readonly name: string;
+      readonly length: number;
+      readonly width: number;
+      readonly height: number;
+    }>('Space', (p) => el('Box', { size: [p.length, p.width, p.height] }));
+    const { ifc, ids } = await project(
+      Space({ key: 'sp1', name: 'Office 101', length: 4000, width: 3000, height: 2700 })
+    );
+    expect(ids.has('s/sp1')).toBe(true);
+    expect(ifc).toContain('IFCSPACE');
+    expect(ifc).toContain('Qto_SpaceBaseQuantities');
+    expect(ifc).toContain('Office 101');
+  });
+});

--- a/packages/brepjs-bim/tests/familiesAdapter.test.ts
+++ b/packages/brepjs-bim/tests/familiesAdapter.test.ts
@@ -697,13 +697,14 @@ describe('familiesToBim route breadth', () => {
       el('Box', { size: [p.length, p.width, p.thickness], transform: [tTranslate(p.at)] })
     );
     const { ifc, ids } = await project(
-      Footing({ key: 'f1', length: 2000, width: 1500, thickness: 500, at: [1000, 0, 0] })
+      Footing({ key: 'f1', length: 2000, width: 1500, thickness: 500, at: [1234, 0, 0] })
     );
     expect(ids.has('s/f1')).toBe(true);
     expect(ifc).toContain('IFCFOOTING');
     expect(ifc).toContain('Qto_FootingBaseQuantities');
     expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/f1'));
-    expect(ifc).toContain('(1.,0.,0.)');
+    // 1234 mm folds to a 1.234 m placement point — a value no axis tuple can emit.
+    expect(ifc).toContain('(1.234,0.,0.)');
   });
 
   it('maps a pile onto IfcPile', async () => {
@@ -747,12 +748,13 @@ describe('familiesToBim route breadth', () => {
       axisZ: [0, 0, 1],
       materialName: 'Concrete',
     };
-    const { ifc, ids } = await project(Ramp({ key: 'ra1', flights: [flight], at: [1000, 0, 0] }));
+    const { ifc, ids } = await project(Ramp({ key: 'ra1', flights: [flight], at: [1234, 0, 0] }));
     expect(ids.has('s/ra1')).toBe(true);
     expect(ifc).toContain('IFCRAMP');
     expect(ifc).toContain('IFCRAMPFLIGHT');
     expect(ifc).toContain(deriveIfcGuidSync('elem:gate-project:s/ra1'));
-    expect(ifc).toContain('(1.,0.,0.)');
+    // 1234 mm folds onto the flight origin as 1.234 m — unambiguous vs axis tuples.
+    expect(ifc).toContain('(1.234,0.,0.)');
   });
 
   it('maps a covering onto IfcCovering', async () => {


### PR DESCRIPTION
Third of the discussion #2020 follow-ups (viktar-b): BIM breadth. This is the actual defect behind his quantity delta — `SPEC_ROUTES` covered 6 of the element types brepjs-bim already implements, so everything else exported as `IfcBuildingElementProxy` (whose Qto defines only NetSurfaceArea/NetVolume, both typed `IFCQUANTITYCOUNT` — no typed dimensions possible) or failed hard without a proxy evaluator.

## What changed

Wire the already-implemented, previously unreachable spec parsers and `add*` methods into `SPEC_ROUTES` + `NAME_ARCHETYPES` for seven types: **footing, pile, railing, ramp, covering, curtainWall, space**. Each route is the same uniform shape the existing six use (`parse*Spec` → `add*` → `placeIn`), so authored props flow 1:1 into typed IFC entities with their base-quantity sets (`Qto_FootingBaseQuantities`, `Qto_PileBaseQuantities`, `Qto_SpaceBaseQuantities`, …) — no new quantity channel, no non-standard IFC.

- **Ramp** shares the stair placement shape (no top-level origin; placement lives per flight), so the stair fold generalizes to `flightsSpecInput` and both routes use it — the element-level translate chain lands on every flight's origin.
- **Zone / system / elementAssembly** were attempted and deliberately left out: they are pure grouping objects (no geometry, no placement) whose membership needs `ASSIGNS_TO_GROUP` / `aggregate` relationship wiring — that doesn't fit the uniform spec-parser shape and deserves its own design.

Honest scoping: this does **not** on its own close the deletion gates in viktar-b's downstream projector — his model routes through his adapter's civil archetypes (Bridge/BridgePart/Earthworks), which were never upstream. Those still proxy until his civil vocabulary lands here (invited as a PR). What this does close: every standard-building element type brepjs-bim implements now routes.

## Tests

Per-route round trips (families element → typed IFC entity, key-path GUID, clean referential integrity, Qto presence, placement folding for footing and ramp). The existing regression tests already guard that unrouted types still proxy (or error without a proxy evaluator) — 671 package tests pass.
