### PR TITLE
feat(brepjs-cad): brep export --3dm — element-aware Rhino export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,7 +1213,6 @@
       "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
@@ -12139,6 +12138,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rhino3dm": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/rhino3dm/-/rhino3dm-8.32.2.tgz",
+      "integrity": "sha512-Q3/5iHIKJeoE5doXrRy7C1vJer4F8uMYe8K6B8VQHqhGj5BCS1L3EkqNpKyUTERoHyKh7rMmiiZpw9iEUkCnPQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
@@ -15147,7 +15153,7 @@
       }
     },
     "packages/brepjs-bim": {
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "brepjs-families": ">=0.1.0 <1.0.0"
@@ -15172,13 +15178,14 @@
       }
     },
     "packages/brepjs-cad": {
-      "version": "0.174.0",
+      "version": "0.175.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",
         "brepjs": ">=18.122.0",
         "commander": "^15.0.0",
         "occt-wasm": "^3.0.0 || ^4.0.0",
+        "rhino3dm": "^8.17.0",
         "typescript": "^6.0.3"
       },
       "bin": {
@@ -15214,7 +15221,8 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "puppeteer": "^25.0.4"
+        "puppeteer": "^25.0.4",
+        "rhino3dm": "8.32.2"
       }
     },
     "packages/brepjs-cad/node_modules/@react-three/drei": {

--- a/packages/brepjs-cad/package.json
+++ b/packages/brepjs-cad/package.json
@@ -63,7 +63,8 @@
     "typescript": "^6.0.3"
   },
   "optionalDependencies": {
-    "puppeteer": "^25.0.4"
+    "puppeteer": "^25.0.4",
+    "rhino3dm": "^8.32.2"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.117.1",

--- a/packages/brepjs-cad/skills/implement/references/families-bim.md
+++ b/packages/brepjs-cad/skills/implement/references/families-bim.md
@@ -70,12 +70,13 @@ const bytes = unwrap(await toIfc(bim, { applicationName: 'agent', applicationVer
 - **Openings are fill-role families in the host's `voids`** — never a bare cut. An anonymous
   (non-fill) void is rejected (`FAMILIES_ANONYMOUS_VOID`): it would cut the viewport solid while the
   parametric IFC body stays solid.
-- **Routed archetypes:** `wall`, `slab`, `column`, `beam`, `roof`, `stair`, `storey`, plus
-  `door`/`window` as fills. The family's **archetype** routes it
-  (`family('Wall', …, { archetype: 'wall' })`), so a renamed family keeps its mapping; declare none
-  and it falls back to matching the family name. Anything else with geometry →
-  `FAMILIES_UNSUPPORTED_TYPE`; drop to the imperative `BimModel` adders
-  (`addSpace`, `addFooting`, `addRailing`, …) for the rest.
+- **Routed archetypes:** `wall`, `slab`, `column`, `beam`, `roof`, `stair`, `storey`, `footing`,
+  `pile`, `railing`, `ramp`, `covering`, `curtainWall`, `space`, plus `door`/`window` as fills. The
+  family's **archetype** routes it (`family('Wall', …, { archetype: 'wall' })`), so a renamed family
+  keeps its mapping; declare none and it falls back to matching the family name. Anything else with
+  geometry → `FAMILIES_UNSUPPORTED_TYPE` (or an `IfcBuildingElementProxy` when a proxy evaluator is
+  passed); drop to the imperative `BimModel` adders (`addZone`, `addSystem`,
+  `addElementAssembly`, …) for pure grouping objects.
 - **Placement frame:** an element's thickness extrudes along `axisZ × axisX`, so a wall running +Y
   (`axisX: [0,1,0]`) grows its thickness toward **−X**. Probe placement with `getBounds`, not by eye.
 - **Wall/slab dims must contain their openings** — a door wider than the wall fails with
@@ -96,6 +97,22 @@ own. `npx brepjs diff room` shows upstream drift. Registry props feed the IFC sp
 `el('Geometry', { node })` accepts any `csg` IR node (profile→extrude, revolve, loft, booleans), so
 a family can own real modeling while keeping key-path identity for the viewport. Only routed types
 reach IFC — a custom-geometry family is viewport-only until you add it imperatively.
+
+## Project workflow (scaffolded projects)
+
+A `npm create brepjs` project default-exports the element tree from `src/main.tsx`; the tools own
+evaluation — never put top-level kernel work in the model module.
+
+- `npm run preview` (→ `brep preview src/main.tsx`): element-aware live viewer. Clicking an element
+  reports its key path; failed elements are listed. Add `-- --watch` to re-evaluate on save (the
+  kernel stays warm — edits to any project source or tsconfig re-render). `--write-only` +
+  `--json`/`--glb` for CI.
+- `npm run export:ifc`: `resolve()` → `familiesToBim` → `toIfc` → `dist/model.ifc`. Check
+  `projected.proxied` — a key path there means the element lost its typed route.
+- `brep export src/main.tsx --3dm`: Rhino export, one named mesh object per element (name = key
+  path), layered by archetype/key-path prefix. Needs the optional `rhino3dm` install.
+- The `brep` CLI transpiles TS/TSX itself (tsconfig-driven JSX) and maps `./x.js` specifiers onto
+  `.ts`/`.tsx` sources — multi-file TSX projects run without a bundler, in ONE kernel realm.
 
 ## Scale
 

--- a/packages/brepjs-cad/src/cli/main.ts
+++ b/packages/brepjs-cad/src/cli/main.ts
@@ -21,6 +21,7 @@ import { exportPart } from './exportPart.js';
 import { openBrowser, shouldAutoOpen } from './openBrowser.js';
 import { disposeShape } from '../disposeShape.js';
 import type { shoot as ShootFn } from '../snapshot/shoot.js';
+import type { export3dm as Export3dmFn } from '../export3dm/export3dm.js';
 import { aimedSection, featureMarks } from '../snapshot/aiming.js';
 
 // OCCT's WASM STEP writer emits a "Statistics on Transfer" banner via console.log
@@ -390,21 +391,64 @@ program
   .option('--glb', 'write a GLB artifact')
   .option('--stl', 'write an STL artifact')
   .option('--all', 'write STEP + GLB + STL')
+  .option('--3dm', 'write a Rhino .3dm (element-aware: one named object per element, layered)')
   .option('--out <dir>', 'output directory', '.')
   .action(
     async (
       file: string,
-      opts: { step?: boolean; glb?: boolean; stl?: boolean; all?: boolean; out: string }
+      opts: {
+        step?: boolean;
+        glb?: boolean;
+        stl?: boolean;
+        all?: boolean;
+        '3dm'?: boolean;
+        out: string;
+      }
     ) => {
+      const path = resolve(file);
+      if (opts['3dm']) {
+        // Lazy: rhino3dm is an optionalDependency; a missing install must fail with an
+        // actionable message, not a resolution stack.
+        let run: typeof Export3dmFn;
+        try {
+          ({ export3dm: run } = await import('../export3dm/export3dm.js'));
+        } catch {
+          process.stderr.write('.3dm export needs rhino3dm — run: npm i rhino3dm\n');
+          process.exitCode = 1;
+          return;
+        }
+        const outPath = join(resolve(opts.out), basename(path).replace(/\.[^.]+$/, '') + '.3dm');
+        try {
+          const r = await run(path, outPath);
+          process.stderr.write(`wrote: ${outPath}\n`);
+          process.stdout.write(
+            JSON.stringify(
+              {
+                ok: r.failed.length === 0,
+                written: [outPath],
+                elements: r.elements,
+                failed: r.failed,
+              },
+              null,
+              2
+            ) + '\n'
+          );
+          if (r.failed.length > 0) process.exitCode = 1;
+        } catch (e) {
+          process.stderr.write(`3dm export failed: ${(e as Error).message}\n`);
+          process.exitCode = 1;
+        }
+        return;
+      }
       const formats = opts.all
         ? { step: true, glb: true, stl: true }
         : { step: Boolean(opts.step), glb: Boolean(opts.glb), stl: Boolean(opts.stl) };
       if (!formats.step && !formats.glb && !formats.stl) {
-        process.stderr.write('no formats requested — pass --step/--glb/--stl or --all\n');
+        process.stderr.write('no formats requested — pass --step/--glb/--stl/--3dm or --all\n');
         process.exitCode = 1;
         return;
       }
-      const result = await exportPart(resolve(file), formats, resolve(opts.out));
+      const result = await exportPart(path, formats, resolve(opts.out));
       for (const p of result.written) process.stderr.write(`wrote: ${p}\n`);
       for (const e of result.errors) process.stderr.write(`error: ${e}\n`);
       process.stdout.write(

--- a/packages/brepjs-cad/src/export3dm/export3dm.ts
+++ b/packages/brepjs-cad/src/export3dm/export3dm.ts
@@ -1,0 +1,93 @@
+import { writeFileSync } from 'node:fs';
+import rhino3dm from 'rhino3dm';
+import type { PreviewTreeNode } from 'brepjs-viewer';
+import { evaluateElements } from '../preview/evaluate.js';
+
+// Distinct-but-stable layer colors: index into a small palette, wrapping.
+const LAYER_COLORS: readonly { r: number; g: number; b: number; a: number }[] = [
+  { r: 204, g: 92, b: 74, a: 255 },
+  { r: 74, g: 144, b: 204, a: 255 },
+  { r: 96, g: 178, b: 110, a: 255 },
+  { r: 224, g: 172, b: 70, a: 255 },
+  { r: 158, g: 108, b: 196, a: 255 },
+  { r: 92, g: 184, b: 186, a: 255 },
+];
+
+export interface Export3dmResult {
+  readonly elements: number;
+  readonly failed: readonly string[];
+}
+
+interface ElementIdentity {
+  readonly archetype?: string | undefined;
+  readonly type: string;
+}
+
+function identityByKeyPath(tree: PreviewTreeNode): Map<string, ElementIdentity> {
+  const map = new Map<string, ElementIdentity>();
+  const walk = (node: PreviewTreeNode): void => {
+    map.set(node.keyPath, { archetype: node.archetype, type: node.type });
+    for (const child of node.children) walk(child);
+  };
+  walk(tree);
+  return map;
+}
+
+/** Layer name: the element's archetype when declared, else the key path's first
+ *  segment (the containing family/group), else the element type. */
+function layerNameFor(keyPath: string, identity: ElementIdentity | undefined): string {
+  if (identity?.archetype !== undefined) return identity.archetype;
+  const prefix = keyPath.split('/')[0];
+  if (prefix !== undefined && prefix !== keyPath) return prefix;
+  return identity?.type ?? 'default';
+}
+
+/**
+ * Export the evaluated model as a Rhino .3dm: one named mesh object per element
+ * (ObjectAttributes.name = key path), layered by archetype/key-path prefix. The
+ * loaded-module contract is preview's: element tree, resolved tree, or plain shape.
+ */
+export async function export3dm(entryPath: string, outPath: string): Promise<Export3dmResult> {
+  const { nodes, tree } = await evaluateElements(entryPath);
+  const rh = await rhino3dm();
+  const doc = new rh.File3dm();
+  const layerIndexByName = new Map<string, number>();
+  const identities = identityByKeyPath(tree);
+  const failed: string[] = [];
+  let elements = 0;
+  for (const [keyPath, node] of nodes) {
+    if (!node.mesh.ok) {
+      failed.push(keyPath);
+      continue;
+    }
+    const layerName = layerNameFor(keyPath, identities.get(keyPath));
+    let layerIndex = layerIndexByName.get(layerName);
+    if (layerIndex === undefined) {
+      const color = LAYER_COLORS[layerIndexByName.size % LAYER_COLORS.length];
+      layerIndex = doc.layers().addLayer(layerName, color ?? { r: 128, g: 128, b: 128, a: 255 });
+      layerIndexByName.set(layerName, layerIndex);
+    }
+    const m = node.mesh.value;
+    const mesh = new rh.Mesh();
+    const vertices = mesh.vertices();
+    for (let i = 0; i + 2 < m.vertices.length; i += 3) {
+      vertices.add(m.vertices[i] ?? 0, m.vertices[i + 1] ?? 0, m.vertices[i + 2] ?? 0);
+    }
+    const normals = mesh.normals();
+    for (let i = 0; i + 2 < m.normals.length; i += 3) {
+      normals.add(m.normals[i] ?? 0, m.normals[i + 1] ?? 0, m.normals[i + 2] ?? 0);
+    }
+    const faces = mesh.faces();
+    for (let i = 0; i + 2 < m.triangles.length; i += 3) {
+      faces.addTriFace(m.triangles[i] ?? 0, m.triangles[i + 1] ?? 0, m.triangles[i + 2] ?? 0);
+    }
+    const attrs = new rh.ObjectAttributes();
+    attrs.name = keyPath;
+    attrs.layerIndex = layerIndex;
+    // addMesh(mesh) has no attributes overload — the generic add carries them.
+    doc.objects().add(mesh, attrs);
+    elements += 1;
+  }
+  writeFileSync(outPath, doc.toByteArray());
+  return { elements, failed };
+}

--- a/packages/brepjs-cad/src/export3dm/export3dm.ts
+++ b/packages/brepjs-cad/src/export3dm/export3dm.ts
@@ -1,4 +1,5 @@
-import { writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 import rhino3dm from 'rhino3dm';
 import type { PreviewTreeNode } from 'brepjs-viewer';
 import { evaluateElements } from '../preview/evaluate.js';
@@ -35,6 +36,14 @@ function identityByKeyPath(tree: PreviewTreeNode): Map<string, ElementIdentity> 
 
 /** Layer name: the element's archetype when declared, else the key path's first
  *  segment (the containing family/group), else the element type. */
+// rhino3dm objects are Emscripten-bound wasm allocations; the typings do not declare
+// the embind delete(), so release through a guarded probe. File3dm.objects().add copies
+// into the document, which makes the staging objects safe to free immediately.
+function release(obj: unknown): void {
+  const d = (obj as { delete?: () => void }).delete;
+  if (typeof d === 'function') d.call(obj);
+}
+
 function layerNameFor(keyPath: string, identity: ElementIdentity | undefined): string {
   if (identity?.archetype !== undefined) return identity.archetype;
   const prefix = keyPath.split('/')[0];
@@ -86,8 +95,16 @@ export async function export3dm(entryPath: string, outPath: string): Promise<Exp
     attrs.layerIndex = layerIndex;
     // addMesh(mesh) has no attributes overload — the generic add carries them.
     doc.objects().add(mesh, attrs);
+    release(vertices);
+    release(normals);
+    release(faces);
+    release(mesh);
+    release(attrs);
     elements += 1;
   }
-  writeFileSync(outPath, doc.toByteArray());
+  const bytes = doc.toByteArray();
+  release(doc);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, bytes);
   return { elements, failed };
 }

--- a/packages/brepjs-cad/src/export3dm/export3dm.ts
+++ b/packages/brepjs-cad/src/export3dm/export3dm.ts
@@ -60,51 +60,76 @@ export async function export3dm(entryPath: string, outPath: string): Promise<Exp
   const { nodes, tree } = await evaluateElements(entryPath);
   const rh = await rhino3dm();
   const doc = new rh.File3dm();
-  const layerIndexByName = new Map<string, number>();
-  const identities = identityByKeyPath(tree);
-  const failed: string[] = [];
-  let elements = 0;
-  for (const [keyPath, node] of nodes) {
-    if (!node.mesh.ok) {
-      failed.push(keyPath);
-      continue;
+  try {
+    const layerIndexByName = new Map<string, number>();
+    const identities = identityByKeyPath(tree);
+    const failed: string[] = [];
+    let elements = 0;
+    for (const [keyPath, node] of nodes) {
+      if (!node.mesh.ok) {
+        failed.push(keyPath);
+        continue;
+      }
+      const layerName = layerNameFor(keyPath, identities.get(keyPath));
+      let layerIndex = layerIndexByName.get(layerName);
+      if (layerIndex === undefined) {
+        const color = LAYER_COLORS[layerIndexByName.size % LAYER_COLORS.length];
+        layerIndex = doc.layers().addLayer(layerName, color ?? { r: 128, g: 128, b: 128, a: 255 });
+        layerIndexByName.set(layerName, layerIndex);
+      }
+      addElementMesh(rh, doc, node.mesh.value, keyPath, layerIndex);
+      elements += 1;
     }
-    const layerName = layerNameFor(keyPath, identities.get(keyPath));
-    let layerIndex = layerIndexByName.get(layerName);
-    if (layerIndex === undefined) {
-      const color = LAYER_COLORS[layerIndexByName.size % LAYER_COLORS.length];
-      layerIndex = doc.layers().addLayer(layerName, color ?? { r: 128, g: 128, b: 128, a: 255 });
-      layerIndexByName.set(layerName, layerIndex);
-    }
-    const m = node.mesh.value;
-    const mesh = new rh.Mesh();
-    const vertices = mesh.vertices();
+    const bytes = doc.toByteArray();
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, bytes);
+    return { elements, failed };
+  } finally {
+    release(doc);
+  }
+}
+
+type RhinoModule = Awaited<ReturnType<typeof rhino3dm>>;
+
+function addElementMesh(
+  rh: RhinoModule,
+  doc: InstanceType<RhinoModule['File3dm']>,
+  m: { vertices: Float32Array; normals: Float32Array; triangles: Uint32Array },
+  keyPath: string,
+  layerIndex: number
+): void {
+  const mesh = new rh.Mesh();
+  const attrs = new rh.ObjectAttributes();
+  let vertices: unknown;
+  let normals: unknown;
+  let faces: unknown;
+  try {
+    const v = mesh.vertices();
+    vertices = v;
     for (let i = 0; i + 2 < m.vertices.length; i += 3) {
-      vertices.add(m.vertices[i] ?? 0, m.vertices[i + 1] ?? 0, m.vertices[i + 2] ?? 0);
+      v.add(m.vertices[i] ?? 0, m.vertices[i + 1] ?? 0, m.vertices[i + 2] ?? 0);
     }
-    const normals = mesh.normals();
+    const n = mesh.normals();
+    normals = n;
     for (let i = 0; i + 2 < m.normals.length; i += 3) {
-      normals.add(m.normals[i] ?? 0, m.normals[i + 1] ?? 0, m.normals[i + 2] ?? 0);
+      n.add(m.normals[i] ?? 0, m.normals[i + 1] ?? 0, m.normals[i + 2] ?? 0);
     }
-    const faces = mesh.faces();
+    const f = mesh.faces();
+    faces = f;
     for (let i = 0; i + 2 < m.triangles.length; i += 3) {
-      faces.addTriFace(m.triangles[i] ?? 0, m.triangles[i + 1] ?? 0, m.triangles[i + 2] ?? 0);
+      f.addTriFace(m.triangles[i] ?? 0, m.triangles[i + 1] ?? 0, m.triangles[i + 2] ?? 0);
     }
-    const attrs = new rh.ObjectAttributes();
     attrs.name = keyPath;
     attrs.layerIndex = layerIndex;
     // addMesh(mesh) has no attributes overload — the generic add carries them.
     doc.objects().add(mesh, attrs);
+  } finally {
+    // The doc copied what it needs; the staging wasm objects are freed on every
+    // path, including a throw mid-construction.
     release(vertices);
     release(normals);
     release(faces);
     release(mesh);
     release(attrs);
-    elements += 1;
   }
-  const bytes = doc.toByteArray();
-  release(doc);
-  mkdirSync(dirname(outPath), { recursive: true });
-  writeFileSync(outPath, bytes);
-  return { elements, failed };
 }

--- a/packages/brepjs-cad/src/preview/evaluate.ts
+++ b/packages/brepjs-cad/src/preview/evaluate.ts
@@ -92,30 +92,9 @@ export async function evaluatePreview(
   entryPath: string,
   opts: { fresh?: boolean } = {}
 ): Promise<PreviewBuild> {
-  const brep = await loadBrep();
-  await initOcctWasm(brep);
-  const mod = await loadPart(entryPath, opts.fresh ?? false);
-  if (mod.default === undefined) {
-    throw new Error(
-      'module has no default export (expected a shape, a families element tree, or a function returning one)'
-    );
-  }
-  const produced: unknown = await Promise.resolve(
-    typeof mod.default === 'function' ? (mod.default as () => unknown)() : mod.default
-  );
-  let value = produced;
-  if (isResultLike(value)) {
-    if (!value.ok) {
-      throw new Error(
-        `model returned Err: ${String((value.error as Error)?.message ?? value.error)}`
-      );
-    }
-    value = value.value;
-  }
-  if (isResolvedElementLike(value) || isElementLike(value)) {
-    return evaluateTree(brep, value, entryPath);
-  }
-  return evaluateShape(brep, value as AnyShape);
+  const { nodes, tree } = await evaluateElements(entryPath, opts);
+  const { data, elements, failed } = modelToMeshData({ byKeyPath: nodes });
+  return finish(data, elements, failed, tree);
 }
 
 /**
@@ -176,11 +155,48 @@ async function importFamilies(entryPath: string): Promise<FamiliesNs | undefined
   }
 }
 
-async function evaluateTree(
+/** Per-element stage shared by preview (which merges) and the .3dm exporter
+ *  (which needs each element separately, named and layered). */
+export interface EvaluatedElements {
+  readonly nodes: ReadonlyMap<string, EvaluatedNodeLike>;
+  readonly tree: PreviewTreeNode;
+}
+
+export async function evaluateElements(
+  entryPath: string,
+  opts: { fresh?: boolean } = {}
+): Promise<EvaluatedElements> {
+  const brep = await loadBrep();
+  await initOcctWasm(brep);
+  const mod = await loadPart(entryPath, opts.fresh ?? false);
+  if (mod.default === undefined) {
+    throw new Error(
+      'module has no default export (expected a shape, a families element tree, or a function returning one)'
+    );
+  }
+  const produced: unknown = await Promise.resolve(
+    typeof mod.default === 'function' ? (mod.default as () => unknown)() : mod.default
+  );
+  let value = produced;
+  if (isResultLike(value)) {
+    if (!value.ok) {
+      throw new Error(
+        `model returned Err: ${String((value.error as Error)?.message ?? value.error)}`
+      );
+    }
+    value = value.value;
+  }
+  if (isResolvedElementLike(value) || isElementLike(value)) {
+    return treeElements(brep, value, entryPath);
+  }
+  return shapeElements(brep, value as AnyShape);
+}
+
+async function treeElements(
   brep: BrepNs,
   value: unknown,
   entryPath: string
-): Promise<PreviewBuild> {
+): Promise<EvaluatedElements> {
   const fam = await importFamilies(entryPath);
   if (fam === undefined) {
     throw new Error(
@@ -221,11 +237,10 @@ async function evaluateTree(
       },
     });
   }
-  const { data, elements, failed } = modelToMeshData({ byKeyPath: nodes });
-  return finish(data, elements, failed, toTree(model.root));
+  return { nodes, tree: toTree(model.root) };
 }
 
-function evaluateShape(brep: BrepNs, shape: AnyShape): PreviewBuild {
+function shapeElements(brep: BrepNs, shape: AnyShape): EvaluatedElements {
   try {
     const m = brep.mesh(shape);
     let edges: Float32Array | undefined;
@@ -246,14 +261,13 @@ function evaluateShape(brep: BrepNs, shape: AnyShape): PreviewBuild {
         },
       },
     };
-    const { data, elements, failed } = modelToMeshData({ byKeyPath: new Map([['part', node]]) });
     const tree: PreviewTreeNode = {
       keyPath: 'part',
       type: 'Shape',
       hasGeometry: true,
       children: [],
     };
-    return finish(data, elements, failed, tree);
+    return { nodes: new Map([['part', node]]), tree };
   } finally {
     // A plain-shape module hands ownership to the caller — verify's contract too.
     disposeShape(shape);

--- a/packages/brepjs-cad/tests/export3dm.test.ts
+++ b/packages/brepjs-cad/tests/export3dm.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import rhino3dm from 'rhino3dm';
+
+const pkgRoot = fileURLToPath(new URL('..', import.meta.url));
+const cli = fileURLToPath(new URL('../src/cli/main.ts', import.meta.url));
+const fixtureDir = fileURLToPath(new URL('./fixtures/tsxProject', import.meta.url));
+
+interface Export3dmSummary {
+  ok: boolean;
+  written: string[];
+  elements: number;
+  failed: string[];
+}
+
+function run3dm(entry: string, outDir: string): Export3dmSummary {
+  const stdout = execFileSync('npx', ['tsx', cli, 'export', entry, '--3dm', '--out', outDir], {
+    encoding: 'utf8',
+    cwd: pkgRoot,
+  });
+  return JSON.parse(stdout) as Export3dmSummary;
+}
+
+describe('brep export --3dm', () => {
+  it('writes one named, layered mesh object per element of a families tree', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-3dm-'));
+    try {
+      const summary = run3dm(join(fixtureDir, 'model.tsx'), dir);
+      expect(summary.ok).toBe(true);
+      expect(summary.elements).toBe(1);
+      const rh = await rhino3dm();
+      const doc = rh.File3dm.fromByteArray(readFileSync(join(dir, 'model.3dm')));
+      expect(doc.objects().count).toBe(1);
+      const obj = doc.objects().get(0);
+      expect(obj.attributes().name).toBe('assembly/panel');
+      const layer = doc.layers().get(obj.attributes().layerIndex);
+      expect(layer.name).toBe('assembly');
+      const mesh = obj.geometry() as InstanceType<typeof rh.Mesh>;
+      expect(mesh.faces().count).toBeGreaterThan(0);
+      expect(mesh.vertices().count).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  it('exports a plain-shape module as a single object', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-3dm-shape-'));
+    try {
+      const summary = run3dm(join(fixtureDir, 'main.tsx'), dir);
+      expect(summary.ok).toBe(true);
+      expect(summary.elements).toBe(1);
+      const rh = await rhino3dm();
+      const doc = rh.File3dm.fromByteArray(readFileSync(join(dir, 'main.3dm')));
+      expect(doc.objects().count).toBe(1);
+      expect(doc.objects().get(0).attributes().name).toBe('part');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+});

--- a/packages/brepjs-cad/tests/export3dm.test.ts
+++ b/packages/brepjs-cad/tests/export3dm.test.ts
@@ -29,11 +29,12 @@ describe('brep export --3dm', () => {
   it('writes one named, layered mesh object per element of a families tree', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'brepjs-cad-3dm-'));
     try {
-      const summary = run3dm(join(fixtureDir, 'model.tsx'), dir);
+      // A nested, not-yet-existing out dir: the exporter must create it.
+      const summary = run3dm(join(fixtureDir, 'model.tsx'), join(dir, 'nested', 'out'));
       expect(summary.ok).toBe(true);
       expect(summary.elements).toBe(1);
       const rh = await rhino3dm();
-      const doc = rh.File3dm.fromByteArray(readFileSync(join(dir, 'model.3dm')));
+      const doc = rh.File3dm.fromByteArray(readFileSync(join(dir, 'nested', 'out', 'model.3dm')));
       expect(doc.objects().count).toBe(1);
       const obj = doc.objects().get(0);
       expect(obj.attributes().name).toBe('assembly/panel');

--- a/packages/brepjs-cad/vite.config.ts
+++ b/packages/brepjs-cad/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         'snapshot/shoot': resolve(import.meta.dirname, 'src/snapshot/shoot.ts'),
         'snapshot/serve': resolve(import.meta.dirname, 'src/snapshot/serve.ts'),
         'preview/preview': resolve(import.meta.dirname, 'src/preview/preview.ts'),
+        'export3dm/export3dm': resolve(import.meta.dirname, 'src/export3dm/export3dm.ts'),
         'mcp/server': resolve(import.meta.dirname, 'src/mcp/server.ts'),
       },
       formats: ['es', 'cjs'],
@@ -50,6 +51,7 @@ export default defineConfig({
         'occt-wasm',
         'commander',
         'puppeteer',
+        'rhino3dm',
         'typescript',
         /^@modelcontextprotocol\/sdk/,
         // Optional MCP telemetry — kept external so src/mcp/telemetry.ts can dynamic-import them at

--- a/packages/create-brepjs/templates/AGENTS.md
+++ b/packages/create-brepjs/templates/AGENTS.md
@@ -7,6 +7,7 @@ Parametric building model on brepjs. Units are mm end to end.
 - `npm run preview` — live viewer (`-- --watch` re-evaluates on save; clicking an element shows its key path; failed elements are listed)
 - `npm start` — per-element mesh stats
 - `npm run export:ifc` — write `dist/model.ifc`
+- `npm run export:3dm` — Rhino export, one named object per element (needs the optional `rhino3dm` install)
 - `npm test` / `npm run typecheck`
 
 ## Model contract

--- a/packages/create-brepjs/templates/CLAUDE.md
+++ b/packages/create-brepjs/templates/CLAUDE.md
@@ -7,6 +7,7 @@ Parametric building model on brepjs. Units are mm end to end.
 - `npm run preview` — live viewer (`-- --watch` re-evaluates on save; clicking an element shows its key path; failed elements are listed)
 - `npm start` — per-element mesh stats
 - `npm run export:ifc` — write `dist/model.ifc`
+- `npm run export:3dm` — Rhino export, one named object per element (needs the optional `rhino3dm` install)
 - `npm test` / `npm run typecheck`
 
 ## Model contract

--- a/packages/create-brepjs/templates/README.md
+++ b/packages/create-brepjs/templates/README.md
@@ -7,6 +7,7 @@ npm install
 npm run preview                    # live viewer; add -- --watch to re-render on save
 npm start                          # evaluate src/main.tsx and print mesh stats
 npm run export:ifc                 # write dist/model.ifc
+npm run export:3dm                 # write dist/main.3dm (needs: npm i rhino3dm)
 npm test                           # resolve + mesh every element
 npx brepjs add room storey slab    # copy starter families into src/families/
 npx brepjs diff room               # compare a copied family against the registry

--- a/packages/create-brepjs/templates/package.json.tpl
+++ b/packages/create-brepjs/templates/package.json.tpl
@@ -9,6 +9,7 @@
     "start": "tsx scripts/report.ts",
     "preview": "brep preview src/main.tsx",
     "export:ifc": "tsx scripts/exportIfc.ts",
+    "export:3dm": "brep export src/main.tsx --3dm --out dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },


### PR DESCRIPTION
Discussion #2020 follow-up (viktar-b asked about `--rhino`): `brep export --3dm`, an element-aware Rhino export.

## What it does

`brep export src/main.tsx --3dm` evaluates the model through the same loaded-module contract as `brep preview` (families element tree, resolved tree, or plain shape — single kernel realm via the registered hook) and writes a Rhino `.3dm`:

- **One named mesh object per element** — `ObjectAttributes.name` carries the families key path, so objects stay addressable in Rhino.
- **Layers** from the element's `archetype` when declared, else the key path's first segment (the containing family/group), with stable palette colors.
- `objects().add(mesh, attrs)` is used deliberately — `addMesh(mesh)` has no attributes overload in rhino3dm.
- Failed elements are listed in the JSON summary and fail the exit code, mirroring preview.

## Mechanics

- `rhino3dm` is an **optionalDependency**, dynamically imported only when `--3dm` is passed (the same lazy pattern as puppeteer in `snapshot/shoot.ts`); a missing install fails with `run: npm i rhino3dm`, not a resolution stack. It lives in brepjs-cad, not brepjs core `src/io/` (the core budget is capped at 380 kB total JS).
- The preview evaluation refactors into a shared per-element stage (`evaluateElements`): preview merges it into one payload, the 3dm exporter consumes elements individually. One evaluation path, two consumers.

## Tests

Child-process CLI runs on both module kinds, with the written `.3dm` read back via `rhino3dm.File3dm.fromByteArray` asserting object count, names (key paths), layer naming, and mesh content. Built-CLI smoke under plain node passes locally.

Note: intended to merge after the create-brepjs template PR; the template's `npm run export:3dm` script rides with that sequencing.
