### PR TITLE
fix(ci): stop executing workflow_run head_sha in docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,15 +19,18 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-    # workflow_dispatch bypasses CI gate (intentional for emergency redeploys, restricted to main)
+    # workflow_dispatch bypasses CI gate (intentional for emergency redeploys, restricted to main).
+    # The workflow_run leg requires event == 'push' because the branches filter matches the
+    # triggering run's head-branch NAME, which a fork branch named "main" would satisfy.
     if: >-
       (github.event_name == 'workflow_dispatch' &&
         github.ref == 'refs/heads/main') ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push')
     steps:
+      # no ref: the default checkout is the repo's main tip, never workflow_run.head_sha
+      # (untrusted for fork-triggered CI runs)
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24


### PR DESCRIPTION
Resolves the four open code scanning alerts (90-93, `actions/cache-poisoning/poisonable-step`) on `.github/workflows/docs.yml`.

## Problem

The docs deploy job checked out `github.event.workflow_run.head_sha || github.sha` and then executed code from that checkout (`npm ci`, `tsx`, `npm run docs:api`) with npm caching enabled.

Beyond the scanner's cache-poisoning framing, the `workflow_run` leg was genuinely exploitable: the `branches: [main]` filter on a `workflow_run` trigger matches the **head-branch name** of the triggering run, not the repo's own branch. CI runs on `pull_request`, so a fork PR opened from a branch the attacker named `main` that passes CI would fire this workflow, which then:

1. checks out the fork's `head_sha` and runs its `npm ci` install scripts in the base repo's default-branch context, and
2. deploys the fork-built `docs-api` artifact to GitHub Pages.

## Fix

- Checkout no longer passes a `ref` — the default for both trigger paths is the repo's own `main` tip, never `workflow_run.head_sha`.
- The `workflow_run` gate additionally requires `github.event.workflow_run.event == 'push'`, so PR-triggered CI completions can't fire the deploy at all.

Behavior change: a `workflow_run`-triggered deploy now builds the latest `main` tip rather than the exact commit CI validated. For docs this is fine (concurrency already serializes deploys, and every push's CI completion triggers a fresh deploy).
