### PR TITLE
ci: disable vercel preview deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "vitepress",
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in *components--brepjs-cad) exit 0 ;; *) exit 1 ;; esac",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main) exit 1 ;; *) exit 0 ;; esac",
   "installCommand": "npm ci",
   "buildCommand": "npm run build:site",
   "outputDirectory": "apps/docs/.vitepress/dist",


### PR DESCRIPTION
Vercel builds only from `main` now. The `ignoreCommand` becomes an allowlist (exit 0 = skip): every PR and topic branch is skipped, which also subsumes the old `*components--brepjs-cad` release-please skip.

Nothing loses coverage:

- The `site-build` CI job runs Vercel's exact `buildCommand` (`npm run build:site`) on every PR, so deploy-breaking changes are still caught pre-merge.
- `playground-smoke` triggers on any successful Vercel deployment and keeps running against production deploys from `main`.
- The `Vercel` / `Vercel Preview Comments` statuses were never required checks, so branch protection is unaffected.
