### PR TITLE
chore: drop jsdelivr from playground csp

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -34,7 +34,7 @@
         { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://va.vercel-scripts.com https://us-assets.i.posthog.com; worker-src 'self' blob:; connect-src 'self' https://cdn.jsdelivr.net https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net"
+          "value": "default-src 'self'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://va.vercel-scripts.com https://us-assets.i.posthog.com; worker-src 'self' blob:; connect-src 'self' https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:"
         }
       ]
     },


### PR DESCRIPTION
Removes `https://cdn.jsdelivr.net` from all four playground CSP directives (script-src, connect-src, style-src, font-src) in `vercel.json`.

The allowlist has been dead weight since #1923 bundled Monaco from npm (`monacoLoader.ts` passes the bundled instance to `@monaco-editor/react`'s `loader.config`, so the CDN fallback never fires). `rg jsdelivr` across `apps/` finds no other consumer.

Verification: `site-build` runs the exact Vercel build in CI; `playground-smoke` validates WASM init under the tightened CSP on the production deployment after merge.
