### PR TITLE
fix: playground example permalinks 404 on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -16,8 +16,8 @@
       "destination": "https://us-assets.i.posthog.com/array/:path"
     },
     { "source": "/ingest/:path(.*)", "destination": "https://us.i.posthog.com/:path" },
-    { "source": "/playground/examples", "destination": "/playground/index.html" },
-    { "source": "/playground/examples/:path(.*)", "destination": "/playground/index.html" }
+    { "source": "/playground/examples", "destination": "/playground" },
+    { "source": "/playground/examples/:path(.*)", "destination": "/playground" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Production probe: `/playground` serves 200, but `/playground/examples` and `/playground/examples/<id>` return the docs 404 page, and `/playground/index.html` 308-redirects. With `cleanUrls: true` Vercel refuses to serve `.html` destinations directly, so the SPA-fallback rewrites resolved to nothing. Pointing them at the clean URL `/playground` fixes both routes.

Verification after merge: `curl -s -o /dev/null -w '%{http_code}' https://brepjs.dev/playground/examples/axial-fan` should return 200 once the production deploy completes (and #2249's static shells will then shadow known ids filesystem-first).
