### PR TITLE
ci: skip benchmark comment on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,12 @@ jobs:
         run: |
           echo "[]" > /tmp/main-results.json
           echo "::warning::main branch dependency install failed — skipping benchmark baseline (no comparison this run)"
+      # Fork PRs run with a read-only GITHUB_TOKEN (the job's pull-requests: write
+      # is ignored for public-fork pull_request runs), so posting the comment 403s
+      # and fails the required ci-pass gate. The benchmark still runs on both sides;
+      # only the comment is skipped for forks.
       - name: Compare results and post PR comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Guard the benchmark job's "post PR comment" step so it only runs for same-repo PRs.

## Why

Fork PRs run with a read-only `GITHUB_TOKEN`. GitHub ignores a job's `permissions: pull-requests: write` for `pull_request` runs from public forks, so the `github.rest.issues.createComment` call returns:

```
HttpError: Resource not accessible by integration ... status: 403
```

That fails the whole `benchmark` job, which turns the required `ci-pass` gate red and blocks every external contribution, even though the benchmark itself ran fine and is informational only (it never fails on an actual regression).

Surfaced on #2257 (external fork contributor): all real checks green, only benchmark red on the comment 403.

## Change

One `if:` guard on the comment step:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

The benchmark still runs both passes for forks; only the comment it could never post is skipped.
