### PR TITLE
feat(bim): fold tRotate into IFC placement for typed products and civil nodes

### DIFF
--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -970,8 +970,11 @@ function rotatedRoutedInput(
 ): Record<string, unknown> {
   const toSpatial = frameInverse(spatialFrame);
   if (Array.isArray(flatInput['flights'])) {
-    // Flights place per-flight (no element-level origin); compose each flight's
-    // authored frame under the element's world transform.
+    // The spec has no top-level placement, so each flight's authored frame
+    // composes under the element's full body frame — cumulative transforms plus
+    // the element's own `origin`/`axisX`/`axisZ` props, matching what
+    // flightsSpecInput folds into flight origins on the unrotated path.
+    const elementFrame = elementBodyFrame(el, cumulativeFrame);
     const flights: readonly unknown[] = flatInput['flights'];
     return {
       ...flatInput,
@@ -982,7 +985,7 @@ function rotatedRoutedInput(
         if (typeof flight !== 'object' || flight === null) return flight;
         const f = flight as Record<string, unknown>;
         const world = frameMul(
-          cumulativeFrame,
+          elementFrame,
           frameFromPlacement({
             origin: (f['origin'] as Vec3 | undefined) ?? [0, 0, 0],
             axisX: (f['axisX'] as Vec3 | undefined) ?? DEFAULT_AXIS_X,

--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  applyMatrix,
   clone,
   err,
   getSolids,
@@ -29,6 +30,19 @@ import {
   type csg,
 } from 'brepjs';
 import type { ResolvedElement } from 'brepjs-families';
+import { placementToMatrix, type Vec3 } from './import/placement.js';
+import {
+  IDENTITY_FRAME,
+  decomposeFrame,
+  frameFromOps,
+  frameFromPlacement,
+  frameInverse,
+  frameMul,
+  frameOrigin,
+  isPureTranslation,
+  translationFrame,
+  type Frame,
+} from './placementFrame.js';
 import { BimModel, type OpeningIdentityOptions } from './model/bimModel.js';
 import type { LocalId } from './identity/localId.js';
 import { parseWallSpec } from './specs/wallSpec.js';
@@ -281,6 +295,36 @@ function centreOrigin(
   return [origin[0] + shift[0], origin[1] + shift[1], origin[2] + shift[2]];
 }
 
+/** A cross-section synthesized from civil envelope dimensions, plus the
+ *  placement shift that centres it on the beam/column axis. Shared by the
+ *  translation path (which bakes the shift into `origin`) and the rotation path
+ *  (which folds it into the placement frame), so the two never drift. */
+interface SynthesizedProfile {
+  readonly profile: {
+    readonly kind: 'RECTANGULAR';
+    readonly width: number;
+    readonly height: number;
+  };
+  readonly shift: readonly [number, number, number];
+}
+
+function synthesizedProfile(el: ResolvedElement): SynthesizedProfile | undefined {
+  if (el.semantics?.kind !== 'product' || el.props['profile'] !== undefined) return undefined;
+  const length = semanticDimension(el, 'length');
+  const width = semanticDimension(el, 'width');
+  const height = semanticDimension(el, 'height');
+  if (el.semantics.category === 'beam' && width !== undefined && height !== undefined) {
+    return { profile: { kind: 'RECTANGULAR', width, height }, shift: [0, width / 2, height / 2] };
+  }
+  if (el.semantics.category === 'column' && length !== undefined && width !== undefined) {
+    return {
+      profile: { kind: 'RECTANGULAR', width: length, height: width },
+      shift: [length / 2, width / 2, 0],
+    };
+  }
+  return undefined;
+}
+
 /**
  * Adapts target-independent civil envelope dimensions onto existing typed BIM
  * spec inputs. Reference infrastructure Families intentionally author domain
@@ -295,13 +339,7 @@ function civilProductSpecInput(el: ResolvedElement): Record<string, unknown> {
   const height = semanticDimension(el, 'height');
   switch (el.semantics.category) {
     case 'beam': {
-      const synthesized =
-        base['profile'] === undefined && width !== undefined && height !== undefined
-          ? {
-              profile: { kind: 'RECTANGULAR', width, height },
-              shift: [0, width / 2, height / 2] as const,
-            }
-          : undefined;
+      const synthesized = synthesizedProfile(el);
       return {
         ...base,
         ...(synthesized !== undefined
@@ -312,13 +350,7 @@ function civilProductSpecInput(el: ResolvedElement): Record<string, unknown> {
       };
     }
     case 'column': {
-      const synthesized =
-        base['profile'] === undefined && length !== undefined && width !== undefined
-          ? {
-              profile: { kind: 'RECTANGULAR', width: length, height: width },
-              shift: [length / 2, width / 2, 0] as const,
-            }
-          : undefined;
+      const synthesized = synthesizedProfile(el);
       return {
         ...base,
         ...(synthesized !== undefined
@@ -387,12 +419,12 @@ function peelTranslates(node: csg.IRNode): {
   return { total, moved };
 }
 
-/** True when the element's rendered local transform carries a rotation. The spec path
- *  folds only translations into IfcLocalPlacement (walls orient via `axisX`),
- *  so a tRotate placement would export un-rotated while the viewport shows it
- *  rotated — reject instead of diverging. Rotations a family render bakes
- *  into its own body geometry (e.g. a circular beam oriented along axisX) are
- *  fine: the spec rebuilds that body parametrically from props. */
+/** True when the element's rendered local transform carries a rotation, which
+ *  switches the walk to the rigid-frame placement path (the composed rotation
+ *  folds into origin + axisX + axisZ). Only authored `transform` rotations
+ *  count: a rotation a family render bakes into its own body geometry (e.g. a
+ *  circular beam oriented along axisX) stays in the body, which the spec
+ *  rebuilds parametrically from props. */
 function hasRotateOp(el: ResolvedElement): boolean {
   return el.localTransforms.some((op) => op.op === 'rotate');
 }
@@ -593,7 +625,7 @@ function addProxyElement(
   model: BimModel,
   el: ResolvedElement,
   evaluator: csg.Evaluator,
-  projectedSpatialTranslation: Translation
+  spatialFrame: Frame
 ): Result<LocalId, BimError> {
   const body = materializeOwnedSolid(el, evaluator, {
     evalCode: 'FAMILIES_PROXY_EVAL_FAILED',
@@ -602,10 +634,10 @@ function addProxyElement(
     routeName: 'proxy',
   });
   if (!body.ok) return body;
-  const localized = localizeOwnedSolid(
+  const localized = localizeBodyToFrame(
     el,
     body.value,
-    projectedSpatialTranslation,
+    spatialFrame,
     'FAMILIES_PROXY_LOCALIZE_FAILED',
     'spatial parent'
   );
@@ -825,8 +857,9 @@ function axisEquals(value: unknown, axis: Translation): boolean {
   );
 }
 
-/** Civil descendant relativization is translation-only, so a civil frame with
- *  non-default axes would rotate the exported hierarchy away from the IR. */
+/** True when a civil node authors non-default `axisX`/`axisZ` props: like a
+ *  tRotate, this puts the node (and its subtree) on the rigid-frame placement
+ *  path so descendants relativize against the rotated parent frame. */
 function hasRotatedAxes(el: ResolvedElement): boolean {
   const axisX = el.props['axisX'];
   const axisZ = el.props['axisZ'];
@@ -882,6 +915,129 @@ function authoredTranslation(el: ResolvedElement): Translation {
   return total;
 }
 
+function authoredAxisX(el: ResolvedElement): Vec3 {
+  const v = el.props['axisX'];
+  return Array.isArray(v) && v.length === 3 ? (v as unknown as Vec3) : DEFAULT_AXIS_X;
+}
+
+function authoredAxisZ(el: ResolvedElement): Vec3 {
+  const v = el.props['axisZ'];
+  return Array.isArray(v) && v.length === 3 ? (v as unknown as Vec3) : DEFAULT_AXIS_Z;
+}
+
+/** The placement shift that centres a synthesized beam/column cross-section on
+ *  its axis, in the element's own (body) frame. Zero for every other route. */
+function specLocalShift(el: ResolvedElement): Vec3 {
+  return synthesizedProfile(el)?.shift ?? [0, 0, 0];
+}
+
+/** World frame of an element's own body: the walk's cumulative frame (all
+ *  authored transforms, ancestors + own) composed with the body's authored axes
+ *  (`axisX`/`axisZ` props) and its local origin (`origin` prop + centring
+ *  shift). Under no rotation this reduces to `composedOrigin` + shift. */
+function elementBodyFrame(el: ResolvedElement, cumulativeFrame: Frame): Frame {
+  const axes = frameFromPlacement({
+    origin: authoredSpecOrigin(el),
+    axisX: authoredAxisX(el),
+    axisZ: authoredAxisZ(el),
+  });
+  return frameMul(frameMul(cumulativeFrame, axes), translationFrame(specLocalShift(el)));
+}
+
+/** World frame of a civil spatial node: cumulative transforms composed with any
+ *  authored `origin`/`axisX`/`axisZ` props (identity when default). */
+function civilNodeFrame(el: ResolvedElement, cumulativeFrame: Frame): Frame {
+  return frameMul(
+    cumulativeFrame,
+    frameFromPlacement({
+      origin: authoredSpecOrigin(el),
+      axisX: authoredAxisX(el),
+      axisZ: authoredAxisZ(el),
+    })
+  );
+}
+
+/** Places a routed element's spec input through the composed placement frame:
+ *  the flat spec input keeps its dimensions/profile/psets, but `origin`/`axisX`/
+ *  `axisZ` are recomputed from the element's world frame relative to its spatial
+ *  container. Stair/ramp flights, which carry their own per-flight frame, are
+ *  each re-placed the same way. */
+function rotatedRoutedInput(
+  flatInput: Record<string, unknown>,
+  el: ResolvedElement,
+  cumulativeFrame: Frame,
+  spatialFrame: Frame
+): Record<string, unknown> {
+  const toSpatial = frameInverse(spatialFrame);
+  if (Array.isArray(flatInput['flights'])) {
+    // Flights place per-flight (no element-level origin); compose each flight's
+    // authored frame under the element's world transform.
+    const flights: readonly unknown[] = flatInput['flights'];
+    return {
+      ...flatInput,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      flights: flights.map((flight): unknown => {
+        if (typeof flight !== 'object' || flight === null) return flight;
+        const f = flight as Record<string, unknown>;
+        const world = frameMul(
+          cumulativeFrame,
+          frameFromPlacement({
+            origin: (f['origin'] as Vec3 | undefined) ?? [0, 0, 0],
+            axisX: (f['axisX'] as Vec3 | undefined) ?? DEFAULT_AXIS_X,
+            axisZ: (f['axisZ'] as Vec3 | undefined) ?? DEFAULT_AXIS_Z,
+          })
+        );
+        const placed = decomposeFrame(frameMul(toSpatial, world));
+        return { ...f, origin: placed.origin, axisX: placed.axisX, axisZ: placed.axisZ };
+      }),
+    };
+  }
+  const placed = decomposeFrame(frameMul(toSpatial, elementBodyFrame(el, cumulativeFrame)));
+  return { ...flatInput, origin: placed.origin, axisX: placed.axisX, axisZ: placed.axisZ };
+}
+
+/** Moves an owned world-baked body into its spatial container's local frame.
+ *  A pure translation keeps the fast `translate` path (identical to the prior
+ *  behaviour); a rotated container applies the inverse frame via `applyMatrix`. */
+function localizeBodyToFrame(
+  el: ResolvedElement,
+  body: ValidSolid,
+  spatialFrame: Frame,
+  errorCode: string,
+  frameName: string
+): Result<ValidSolid, BimError> {
+  if (isPureTranslation(spatialFrame)) {
+    return localizeOwnedSolid(el, body, frameOrigin(spatialFrame), errorCode, frameName);
+  }
+  const inverse = decomposeFrame(frameInverse(spatialFrame));
+  try {
+    const localized = applyMatrix(body, placementToMatrix(inverse));
+    if (!localized.ok) {
+      body[Symbol.dispose]();
+      return err(
+        specError(
+          errorCode,
+          `familiesToBim: '${el.keyPath}' could not move its body into the ${frameName} frame`,
+          localized.error
+        )
+      );
+    }
+    body[Symbol.dispose]();
+    return ok(localized.value);
+  } catch (cause) {
+    body[Symbol.dispose]();
+    return err(
+      specError(
+        errorCode,
+        `familiesToBim: '${el.keyPath}' could not move its body into the ${frameName} frame`,
+        cause
+      )
+    );
+  }
+}
+
 function civilSpatialInput(
   el: ResolvedElement,
   localTranslation: Translation
@@ -902,6 +1058,28 @@ function civilSpatialInput(
   };
 }
 
+/** Relativizes a civil node's world frame against its parent civil frame into
+ *  the origin/axisX/axisZ the spatial specs consume. */
+function civilSpatialFrameInput(
+  el: ResolvedElement,
+  nodeFrame: Frame,
+  parentFrame: Frame
+): Record<string, unknown> {
+  const semantics = el.semantics;
+  const composition =
+    semantics !== undefined && 'composition' in semantics
+      ? CIVIL_COMPOSITION[semantics.composition]
+      : undefined;
+  const local = decomposeFrame(frameMul(frameInverse(parentFrame), nodeFrame));
+  return {
+    name: semanticName(el),
+    origin: local.origin,
+    axisX: local.axisX,
+    axisZ: local.axisZ,
+    ...(composition !== undefined ? { compositionType: composition } : {}),
+  };
+}
+
 function civilParentAccepts(kind: CivilSpatialKind, parent: CivilParentKind): boolean {
   if (kind === 'site') return parent === 'project';
   if (kind === 'bridge') return parent === 'site';
@@ -912,27 +1090,24 @@ function addCivilSpatialOccurrence(
   model: BimModel,
   el: ResolvedElement,
   kind: CivilSpatialKind,
-  localTranslation: Translation
+  input: Record<string, unknown>
 ): Result<LocalId, BimError> {
   if (kind === 'site') {
     if (el.semantics?.role !== 'transport-site') return unsupportedCivilRole(el, 'Site');
-    const parsed = parseSiteSpec(civilSpatialInput(el, localTranslation));
+    const parsed = parseSiteSpec(input);
     return parsed.ok ? model.addSite(parsed.value, { stableKey: el.keyPath }) : parsed;
   }
   if (kind === 'bridge') {
     const predefinedType = lookup(BRIDGE_ROLE, el.semantics?.role ?? '');
     if (predefinedType === undefined) return unsupportedCivilRole(el, 'Bridge');
-    const parsed = parseBridgeSpec({
-      ...civilSpatialInput(el, localTranslation),
-      predefinedType,
-    });
+    const parsed = parseBridgeSpec({ ...input, predefinedType });
     return parsed.ok ? model.addBridge(parsed.value, { stableKey: el.keyPath }) : parsed;
   }
   const subdivision = el.semantics?.kind === 'spatial-part' ? el.semantics.subdivision : undefined;
   const predefinedType = lookup(BRIDGE_PART_ROLE, el.semantics?.role ?? '');
   if (predefinedType === undefined) return unsupportedCivilRole(el, 'Bridge Part');
   const parsed = parseBridgePartSpec({
-    ...civilSpatialInput(el, localTranslation),
+    ...input,
     predefinedType,
     usageType: subdivision !== undefined ? CIVIL_USAGE[subdivision] : 'NOTDEFINED',
   });
@@ -970,7 +1145,7 @@ function addEarthworksFillElement(
   model: BimModel,
   el: ResolvedElement,
   evaluator: csg.Evaluator,
-  projectedSpatialTranslation: Translation
+  spatialFrame: Frame
 ): Result<LocalId, BimError> {
   if (el.semantics?.kind !== 'product') {
     return err(
@@ -990,10 +1165,10 @@ function addEarthworksFillElement(
   });
   if (!body.ok) return body;
 
-  const localized = localizeOwnedSolid(
+  const localized = localizeBodyToFrame(
     el,
     body.value,
-    projectedSpatialTranslation,
+    spatialFrame,
     'FAMILIES_EARTHWORKS_LOCALIZE_FAILED',
     'Bridge Part'
   );
@@ -1024,6 +1199,14 @@ interface ProjectionWalkState {
   readonly rotated: boolean;
   readonly cumulativeTranslation: Translation;
   readonly projectedSpatialTranslation: Translation;
+  /** World frame of the current element's parent: every authored transform
+   *  (ancestors, composed) as a rigid motion. Drives the rotation-aware
+   *  placement path; its translation column equals `cumulativeTranslation`. */
+  readonly cumulativeFrame: Frame;
+  /** World frame of the nearest enclosing spatial container (Storey / Site /
+   *  Bridge / Bridge Part). A routed element's IfcLocalPlacement is its world
+   *  frame relative to this. Pure translation on the building path. */
+  readonly spatialFrame: Frame;
 }
 
 /**
@@ -1083,10 +1266,14 @@ export function familiesToBim(
       state.cumulativeTranslation,
       authoredTranslation(el)
     );
+    const cumulativeFrameHere = frameMul(state.cumulativeFrame, frameFromOps(el.localTransforms));
     let proxiedHere = false;
+    let nextRotated = rotatedHere;
     let nextSpatialStructureId = state.spatialStructureId;
     let nextCivilParent = state.civilParent;
     let nextProjectedSpatialTranslation = state.projectedSpatialTranslation;
+    let nextCumulativeFrame = cumulativeFrameHere;
+    let nextSpatialFrame = state.spatialFrame;
     const archetype = archetypeFor(el);
     // An explicitly authored civil Product is routed by its semantic category.
     // Do not let a coincidental legacy archetype silently change its IFC class.
@@ -1109,14 +1296,6 @@ export function familiesToBim(
       }
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
-      if (rotatedHere || hasRotatedAxes(el)) {
-        return err(
-          specError(
-            'FAMILIES_UNSUPPORTED_TRANSFORM',
-            `familiesToBim: civil spatial element '${el.keyPath}' carries a rotated frame — descendants are relativized by translation only, so bake the orientation into child geometry`
-          )
-        );
-      }
       if (el.geometry.kind !== 'Empty') {
         return err(
           specError(
@@ -1125,18 +1304,33 @@ export function familiesToBim(
           )
         );
       }
-      const localTranslation = subtractTranslation(
-        cumulativeTranslationHere,
-        state.projectedSpatialTranslation
-      );
-      const added = addCivilSpatialOccurrence(model, el, civilKind, localTranslation);
+      const nodeFrame = civilNodeFrame(el, cumulativeFrameHere);
+      // A rotated frame (from a tRotate ancestor/self or authored axisX/axisZ)
+      // relativizes this node against its parent civil frame; a pure translation
+      // keeps the exact-subtraction path. Either way descendants inherit the full
+      // frame, so a rotated Site/Bridge/Bridge Part orients its children.
+      const rotatedFrame = rotatedHere || hasRotatedAxes(el);
+      const input = rotatedFrame
+        ? civilSpatialFrameInput(el, nodeFrame, state.spatialFrame)
+        : civilSpatialInput(
+            el,
+            subtractTranslation(cumulativeTranslationHere, state.projectedSpatialTranslation)
+          );
+      const added = addCivilSpatialOccurrence(model, el, civilKind, input);
       if (!added.ok) return added;
       model.aggregate(state.spatialStructureId, added.value);
       idByKeyPath.set(el.keyPath, added.value);
       nextSpatialStructureId = added.value;
       nextCivilParent = civilKind;
+      nextRotated = rotatedFrame;
+      // Descendants inherit the node's full frame (transforms + authored axes +
+      // origin prop), so their own transforms compose in the node's coordinate
+      // system and relativize against it.
+      nextCumulativeFrame = nodeFrame;
+      nextSpatialFrame = nodeFrame;
       // The frame's IfcLocalPlacement origin includes the spec `origin` prop on
-      // top of the walk's translates, so descendants relativize by both.
+      // top of the walk's translates, so translation-path descendants relativize
+      // by both.
       nextProjectedSpatialTranslation = addTranslation(
         cumulativeTranslationHere,
         authoredSpecOrigin(el)
@@ -1194,26 +1388,13 @@ export function familiesToBim(
       }
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
-      const added = addEarthworksFillElement(
-        model,
-        el,
-        bodyEvaluator,
-        state.projectedSpatialTranslation
-      );
+      const added = addEarthworksFillElement(model, el, bodyEvaluator, state.spatialFrame);
       if (!added.ok) return added;
       model.placeIn(added.value, nextSpatialStructureId);
       idByKeyPath.set(el.keyPath, added.value);
     } else if (route !== undefined) {
       const keyed = requireKeyed(el);
       if (!keyed.ok) return keyed;
-      if (rotatedHere) {
-        return err(
-          specError(
-            'FAMILIES_UNSUPPORTED_TRANSFORM',
-            `familiesToBim: '${el.keyPath}' carries a rotated placement — the spec path folds only translations into IfcLocalPlacement; orient walls via axisX instead of tRotate`
-          )
-        );
-      }
       // The spec path rebuilds the body parametrically: an anonymous
       // (non-fill) void cuts only the IR/viewport geometry, so exporting it
       // silently would diverge the IFC body from what the user sees.
@@ -1233,11 +1414,18 @@ export function familiesToBim(
         el.semantics?.kind === 'product'
           ? civilProductSpecInput(el)
           : ('input' in route ? route.input : specInput)(el);
-      const parsed = route.parse(
-        usesAuthoredCivilHierarchy
+      // A tRotate on the element or its ancestors folds into the IfcLocalPlacement
+      // frame (origin + axisX + axisZ); the translation-only path stays the exact
+      // subtraction so unrotated placements are byte-identical. Flight routes
+      // re-place off the UNFOLDED flights (specInput): flightsSpecInput already
+      // adds the element origin to each flight, which the frame would double-count.
+      const rotatedBase = Array.isArray(routedInput['flights']) ? specInput(el) : routedInput;
+      const placedInput = rotatedHere
+        ? rotatedRoutedInput(rotatedBase, el, cumulativeFrameHere, state.spatialFrame)
+        : usesAuthoredCivilHierarchy
           ? relativeSpecInput(routedInput, state.projectedSpatialTranslation)
-          : routedInput
-      );
+          : routedInput;
+      const parsed = route.parse(placedInput);
       if (!parsed.ok) return parsed;
       const added = route.add(model, parsed.value, el.keyPath);
       if (!added.ok) return added;
@@ -1291,12 +1479,7 @@ export function familiesToBim(
           )
         );
       }
-      const added = addProxyElement(
-        model,
-        el,
-        options.proxyEvaluator,
-        state.projectedSpatialTranslation
-      );
+      const added = addProxyElement(model, el, options.proxyEvaluator, state.spatialFrame);
       if (!added.ok) return added;
       model.placeIn(added.value, nextSpatialStructureId);
       idByKeyPath.set(el.keyPath, added.value);
@@ -1311,9 +1494,11 @@ export function familiesToBim(
       const r = walk(child, {
         spatialStructureId: nextSpatialStructureId,
         civilParent: nextCivilParent,
-        rotated: rotatedHere,
+        rotated: nextRotated,
         cumulativeTranslation: cumulativeTranslationHere,
         projectedSpatialTranslation: nextProjectedSpatialTranslation,
+        cumulativeFrame: nextCumulativeFrame,
+        spatialFrame: nextSpatialFrame,
       });
       if (!r.ok) return r;
     }
@@ -1326,6 +1511,8 @@ export function familiesToBim(
     rotated: false,
     cumulativeTranslation: ZERO_TRANSLATION,
     projectedSpatialTranslation: ZERO_TRANSLATION,
+    cumulativeFrame: IDENTITY_FRAME,
+    spatialFrame: IDENTITY_FRAME,
   });
   if (!walked.ok) {
     model[Symbol.dispose]();

--- a/packages/brepjs-bim/src/placementFrame.ts
+++ b/packages/brepjs-bim/src/placementFrame.ts
@@ -1,0 +1,193 @@
+/**
+ * Rigid-body frame algebra for the families -> BIM placement fold. A `Frame` is
+ * a column-major 4x4 (the same layout as {@link Mat4x4}): columns 0-2 are the
+ * basis vectors (axisX, axisY, axisZ), column 3 is the translation, and the
+ * bottom row is [0,0,0,1]. Every frame produced here is a proper rigid motion
+ * (rotation + translation, no scale/shear), so it is fully described by its
+ * origin + IFC axes and inverts by transpose.
+ *
+ * The adapter composes a families `TransformOp` chain into one frame, then reads
+ * an element's IfcLocalPlacement off it: a local placement relative to a spatial
+ * container is `decompose(inverse(containerFrame) . elementWorldFrame)`.
+ */
+
+import type { TransformOp } from 'brepjs-families';
+import {
+  decomposePlacement,
+  type FrameInput,
+  type Mat4x4,
+  type Vec3,
+  type WorldPlacement,
+} from './import/placement.js';
+
+export type Frame = Mat4x4;
+
+export const IDENTITY_FRAME: Frame = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+const DEFAULT_AXIS: Vec3 = [0, 0, 1];
+const ORIGIN: Vec3 = [0, 0, 0];
+
+/** Column-major 4x4 multiply: `a . b` (apply b first, then a). */
+export function frameMul(a: Frame, b: Frame): Frame {
+  const out = new Array<number>(16).fill(0);
+  for (let col = 0; col < 4; col++) {
+    for (let row = 0; row < 4; row++) {
+      let sum = 0;
+      for (let k = 0; k < 4; k++) sum += (a[k * 4 + row] ?? 0) * (b[col * 4 + k] ?? 0);
+      out[col * 4 + row] = sum;
+    }
+  }
+  return out as unknown as Frame;
+}
+
+export function translationFrame(v: Vec3): Frame {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, v[0], v[1], v[2], 1];
+}
+
+function normalizeAxis(axis: Vec3): Vec3 {
+  const len = Math.sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
+  if (len < 1e-12) return DEFAULT_AXIS;
+  return [axis[0] / len, axis[1] / len, axis[2] / len];
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+}
+
+/**
+ * Builds a frame from an authored `(origin, axisX, axisZ)` placement, using the
+ * same IFC orthonormalization as `placementToMatrix`/`readAxis2Placement3D`:
+ * z = normalize(axisZ); x = normalize(axisX projected perpendicular to z);
+ * y = z x. Lets a civil node authored with explicit axis props enter the same
+ * frame pipeline as a `tRotate` chain.
+ */
+export function frameFromPlacement(f: FrameInput): Frame {
+  const z = normalizeAxis(f.axisZ);
+  const dot = z[0] * f.axisX[0] + z[1] * f.axisX[1] + z[2] * f.axisX[2];
+  const projX: Vec3 = [f.axisX[0] - dot * z[0], f.axisX[1] - dot * z[1], f.axisX[2] - dot * z[2]];
+  const x = normalizeAxis(projX);
+  const y = cross(z, x);
+  return [
+    x[0],
+    x[1],
+    x[2],
+    0,
+    y[0],
+    y[1],
+    y[2],
+    0,
+    z[0],
+    z[1],
+    z[2],
+    0,
+    f.origin[0],
+    f.origin[1],
+    f.origin[2],
+    1,
+  ];
+}
+
+/**
+ * Rotation by `angleDeg` about `axis` (default +Z) through pivot `at` (default
+ * origin), matching `csg.rotate` (Rodrigues; right-handed about the axis). With
+ * a pivot the motion is `T(at) . R . T(-at)`, i.e. `p -> at + R(p - at)`.
+ */
+export function rotationFrame(
+  angleDeg: number,
+  axis: Vec3 = DEFAULT_AXIS,
+  at: Vec3 = ORIGIN
+): Frame {
+  const [x, y, z] = normalizeAxis(axis);
+  const t = (angleDeg * Math.PI) / 180;
+  const c = Math.cos(t);
+  const s = Math.sin(t);
+  const C = 1 - c;
+  // Row-major rotation matrix entries (standard Rodrigues form).
+  const r00 = c + x * x * C;
+  const r01 = x * y * C - z * s;
+  const r02 = x * z * C + y * s;
+  const r10 = y * x * C + z * s;
+  const r11 = c + y * y * C;
+  const r12 = y * z * C - x * s;
+  const r20 = z * x * C - y * s;
+  const r21 = z * y * C + x * s;
+  const r22 = c + z * z * C;
+  // Pivot: translation = at - R.at.
+  const rat0 = r00 * at[0] + r01 * at[1] + r02 * at[2];
+  const rat1 = r10 * at[0] + r11 * at[1] + r12 * at[2];
+  const rat2 = r20 * at[0] + r21 * at[1] + r22 * at[2];
+  // Column-major: columns are R.e0, R.e1, R.e2; translation in column 3.
+  return [
+    r00,
+    r10,
+    r20,
+    0,
+    r01,
+    r11,
+    r21,
+    0,
+    r02,
+    r12,
+    r22,
+    0,
+    at[0] - rat0,
+    at[1] - rat1,
+    at[2] - rat2,
+    1,
+  ];
+}
+
+function opFrame(op: TransformOp): Frame {
+  if (op.op === 'translate') return translationFrame(op.v);
+  return rotationFrame(op.angleDeg, op.axis ?? DEFAULT_AXIS, op.at ?? ORIGIN);
+}
+
+/**
+ * Composes an authored `TransformOp` chain into one frame, matching families'
+ * `applyOps`: `ops[0]` is innermost (applied first). For `[A, B]` the composed
+ * motion is `B . A`, so a point transforms as `B(A(p))`.
+ */
+export function frameFromOps(ops: readonly TransformOp[]): Frame {
+  let m: Frame = IDENTITY_FRAME;
+  for (const op of ops) m = frameMul(opFrame(op), m);
+  return m;
+}
+
+/** Rigid inverse of `[R | t]`: `[R^T | -R^T t]`. */
+export function frameInverse(f: Frame): Frame {
+  // Column-major: R column c is [f[c], f[4+c], f[8+c]]; transpose swaps to rows.
+  const t0 = f[12] ?? 0;
+  const t1 = f[13] ?? 0;
+  const t2 = f[14] ?? 0;
+  // -R^T t: row i of R^T is column i of R = [f[i], f[4+i], f[8+i]].
+  const inv0 = -(f[0] * t0 + f[1] * t1 + f[2] * t2);
+  const inv1 = -(f[4] * t0 + f[5] * t1 + f[6] * t2);
+  const inv2 = -(f[8] * t0 + f[9] * t1 + f[10] * t2);
+  return [f[0], f[4], f[8], 0, f[1], f[5], f[9], 0, f[2], f[6], f[10], 0, inv0, inv1, inv2, 1];
+}
+
+/** Decomposes a frame into origin (mm) + IFC axes (axisX, axisZ). */
+export function decomposeFrame(f: Frame): WorldPlacement {
+  return decomposePlacement(f);
+}
+
+/** Translation column of a frame. */
+export function frameOrigin(f: Frame): Vec3 {
+  return [f[12] ?? 0, f[13] ?? 0, f[14] ?? 0];
+}
+
+/** True when the rotation part is the identity (within tolerance): a pure
+ *  translation, so the existing translation-only placement path suffices. */
+export function isPureTranslation(f: Frame, eps = 1e-9): boolean {
+  return (
+    Math.abs((f[0] ?? 1) - 1) < eps &&
+    Math.abs((f[5] ?? 1) - 1) < eps &&
+    Math.abs((f[10] ?? 1) - 1) < eps &&
+    Math.abs(f[1] ?? 0) < eps &&
+    Math.abs(f[2] ?? 0) < eps &&
+    Math.abs(f[4] ?? 0) < eps &&
+    Math.abs(f[6] ?? 0) < eps &&
+    Math.abs(f[8] ?? 0) < eps &&
+    Math.abs(f[9] ?? 0) < eps
+  );
+}

--- a/packages/brepjs-bim/tests/familiesCivil.test.ts
+++ b/packages/brepjs-bim/tests/familiesCivil.test.ts
@@ -371,15 +371,31 @@ describe('civil Families Projection', () => {
     });
   });
 
-  it('rejects a rotated civil frame before projecting descendants', () => {
+  it('folds an authored civil Site frame (axisX) into its placement and subtree', () => {
+    const projected = unwrap(
+      familiesToBim(civilModel({ axisX: [0, 1, 0] }), {
+        project: { name: 'Civil gate', projectId: 'civil-gate' },
+      })
+    );
+    using model = projected.model;
+    const site = model.getAllElements().find(({ category }) => category === 'SITE');
+    const spec = site?.spec as { origin: number[]; axisX: number[]; axisZ: number[] };
+    // The authored axisX yaws the Site frame; the same frame relativizes its
+    // subtree, which still projects.
+    expect(spec.axisX[0]).toBeCloseTo(0, 6);
+    expect(spec.axisX[1]).toBeCloseTo(1, 6);
+    expect(spec.axisX[2]).toBeCloseTo(0, 6);
+    expect(spec.origin[0]).toBeCloseTo(1_000, 6);
+    expect(model.getBeams()).toHaveLength(1);
+  });
+
+  it('rejects a degenerate civil frame (axisX parallel to axisZ)', () => {
     const result = familiesToBim(civilModel({ axisX: [0, 0, 1] }), {
       project: { name: 'Civil gate', projectId: 'civil-gate' },
     });
 
-    expect(result).toMatchObject({
-      ok: false,
-      error: { kind: 'BIM_SPEC', code: 'FAMILIES_UNSUPPORTED_TRANSFORM' },
-    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('BIM_SPEC');
   });
 
   it('projects a root-level Site without colliding with the Project stableKey', () => {

--- a/packages/brepjs-bim/tests/familiesRegistry.test.ts
+++ b/packages/brepjs-bim/tests/familiesRegistry.test.ts
@@ -147,7 +147,7 @@ describe('registry families through familiesToBim', () => {
     expect(model.getBeams()).toHaveLength(1);
   });
 
-  it('rejects a rotated routed element instead of exporting a diverged body', () => {
+  it('folds a rotated wing into the wall IfcLocalPlacement axisX', () => {
     const tree = resolve(
       Storey({
         key: 'g',
@@ -158,9 +158,22 @@ describe('registry families through familiesToBim', () => {
         ],
       })
     );
-    const projected = familiesToBim(tree, { project: PROJECT });
-    expect(isOk(projected)).toBe(false);
-    if (!projected.ok) expect(projected.error.code).toBe('FAMILIES_UNSUPPORTED_TRANSFORM');
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    const wall = model.getWalls()[0];
+    expect(wall).toBeDefined();
+    // The inherited tRotate(30) about Z lands on the wall's placement axes, not
+    // on a diverged (un-rotated) body: axisX = [cos30, sin30, 0].
+    const spec = wall?.spec as { origin: number[]; axisX: number[]; axisZ: number[] };
+    expect(spec.axisX[0]).toBeCloseTo(0.866025, 5);
+    expect(spec.axisX[1]).toBeCloseTo(0.5, 5);
+    expect(spec.axisX[2]).toBeCloseTo(0, 5);
+    expect(spec.axisZ[0]).toBeCloseTo(0, 5);
+    expect(spec.axisZ[1]).toBeCloseTo(0, 5);
+    expect(spec.axisZ[2]).toBeCloseTo(1, 5);
+    expect(spec.origin[0]).toBeCloseTo(0, 5);
+    expect(spec.origin[1]).toBeCloseTo(0, 5);
+    expect(spec.origin[2]).toBeCloseTo(0, 5);
   });
 
   it('routes unrouted geometry through the proxy escape hatch when enabled', async () => {

--- a/packages/brepjs-bim/tests/familiesRotation.test.ts
+++ b/packages/brepjs-bim/tests/familiesRotation.test.ts
@@ -211,6 +211,46 @@ describe('familiesToBim rotation fold', () => {
     expectVec(placed.origin, [0, 1000, 0]);
     expectVec(placed.axisX, [0, 1, 0]);
   });
+
+  it('folds a stair element-level origin prop into rotated flight placements', () => {
+    const Stair = family<{
+      readonly flights: ReadonlyArray<Record<string, unknown>>;
+      readonly origin: readonly [number, number, number];
+    }>('Stair', () => el('Box', { size: [2240, 1200, 1400] }), { archetype: 'stair' });
+    const flight = {
+      width: 1200,
+      riserHeight: 175,
+      treadLength: 280,
+      numberOfRisers: 8,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    };
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          el('Group', { key: 'wing', transform: [tRotate(90)] }, [
+            Stair({ key: 'st', flights: [flight], origin: [1000, 0, 0] }),
+          ]),
+        ],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    const localId = projected.idByKeyPath.get('g/wing/st');
+    if (localId === undefined) throw new Error('stair not projected');
+    const spec = model.getElement(localId)?.spec as {
+      flights: ReadonlyArray<{ origin: number[]; axisX: number[] }>;
+    };
+    const placed = spec.flights[0];
+    if (placed === undefined) throw new Error('no flight');
+    // The origin PROP places the element like flightsSpecInput does unrotated:
+    // +1000x under the wing's 90deg yaw -> +1000y, on the flight, once.
+    expectVec(placed.origin, [0, 1000, 0]);
+    expectVec(placed.axisX, [0, 1, 0]);
+  });
 });
 
 // --- civil spatial nodes -----------------------------------------------------

--- a/packages/brepjs-bim/tests/familiesRotation.test.ts
+++ b/packages/brepjs-bim/tests/familiesRotation.test.ts
@@ -1,0 +1,383 @@
+/**
+ * familiesToBim rotation fold: a tRotate on a typed Product or a civil spatial
+ * node lands in its IfcLocalPlacement (origin + axisX + axisZ), so the exported
+ * IFC world placement matches the viewport transform. Every expectation here is
+ * hand-computed from the authored rotation and verified through the full
+ * pipeline (families -> adapter -> IFC text -> SpfReader -> composeWorldPlacement),
+ * independent of the adapter's own frame math.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { csg, getBounds, measureVolume, unwrap } from 'brepjs';
+import {
+  civilSemantics,
+  el,
+  family,
+  resolve,
+  tRotate,
+  tTranslate,
+  type Element,
+  type TransformOp,
+} from 'brepjs-families';
+import { initOCCT } from '../../../tests/setup.js';
+import { familiesToBim } from '../src/familiesAdapter.js';
+import { placedSolids } from '../src/elementFns/placedGeometry.js';
+import { toIfc } from '../src/serialize/toIfc.js';
+import { SpfReader } from '../src/import/spfReader.js';
+import {
+  composeWorldPlacement,
+  readLengthScale,
+  type WorldPlacement,
+} from '../src/import/placement.js';
+import type { BimModel } from '../src/model/bimModel.js';
+
+beforeAll(async () => {
+  await initOCCT();
+}, 30_000);
+
+const PROJECT = { name: 'Rotation', projectId: 'rot' };
+const META = { applicationName: 'rotation-test', applicationVersion: '1' };
+const COS30 = Math.cos(Math.PI / 6);
+const SIN30 = Math.sin(Math.PI / 6);
+
+interface PadProps {
+  readonly length: number;
+  readonly width: number;
+  readonly thickness: number;
+  readonly transform?: readonly TransformOp[] | undefined;
+}
+
+const Pad = family<PadProps>(
+  'Pad',
+  ({ length, width, thickness, transform }) =>
+    el('Box', { size: [length, width, thickness], transform: transform ?? [] }),
+  { archetype: 'footing' }
+);
+
+const Storey = family<{ readonly items: readonly Element[] }>(
+  'Storey',
+  ({ items }) => el('Group', {}, items),
+  { archetype: 'storey' }
+);
+
+/** Serializes to IFC and recovers an element's composed world placement in mm. */
+async function worldPlacement(
+  model: BimModel,
+  guid: string,
+  ifcSchema: 'IFC4' | 'IFC4X3' = 'IFC4'
+): Promise<WorldPlacement> {
+  const bytes = unwrap(await toIfc(model, { ...META, ifcSchema }));
+  const reader = unwrap(await SpfReader.create(bytes));
+  try {
+    reader.buildGuidMap();
+    const id = reader.expressIdFromGuid(guid);
+    if (id === undefined) throw new Error(`no express id for guid ${guid}`);
+    const scale = readLengthScale(reader);
+    const line = reader.getLine<Record<string, unknown>>(id);
+    const placementRef = line?.['ObjectPlacement'] as { value?: number } | undefined;
+    if (placementRef?.value === undefined) throw new Error('ObjectPlacement missing');
+    const world = composeWorldPlacement(reader, placementRef.value, scale);
+    if (world === null) throw new Error('world placement null');
+    return world;
+  } finally {
+    reader.close();
+  }
+}
+
+function guidOf(model: BimModel, localId: number): string {
+  const guid = model.getElement(localId as never)?.guid;
+  if (guid === undefined) throw new Error('element guid missing');
+  return guid;
+}
+
+async function padWorldPlacement(transform: readonly TransformOp[]): Promise<WorldPlacement> {
+  const tree = resolve(
+    Storey({
+      key: 'g',
+      items: [Pad({ key: 'p', length: 1000, width: 800, thickness: 400, transform })],
+    })
+  );
+  const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+  using model = projected.model;
+  const localId = projected.idByKeyPath.get('g/p');
+  if (localId === undefined) throw new Error('pad not projected');
+  return worldPlacement(model, guidOf(model, localId));
+}
+
+function expectVec(actual: readonly number[], expected: readonly number[], precision = 4): void {
+  for (let i = 0; i < expected.length; i++)
+    expect(actual[i]).toBeCloseTo(expected[i] ?? 0, precision);
+}
+
+describe('familiesToBim rotation fold', () => {
+  it('folds a typed Product local tRotate(30) into IFC axisX (issue repro)', async () => {
+    const world = await padWorldPlacement([tRotate(30)]);
+    expectVec(world.axisX, [COS30, SIN30, 0]);
+    expectVec(world.axisZ, [0, 0, 1]);
+    expectVec(world.origin, [0, 0, 0]);
+  });
+
+  it('folds a rotation inherited from a rotated ancestor Group', async () => {
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          el('Group', { key: 'wing', transform: [tRotate(90)] }, [
+            Pad({
+              key: 'p',
+              length: 1000,
+              width: 800,
+              thickness: 400,
+              transform: [tTranslate([1000, 0, 0])],
+            }),
+          ]),
+        ],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    const localId = projected.idByKeyPath.get('g/wing/p');
+    if (localId === undefined) throw new Error('pad not projected');
+    const world = await worldPlacement(model, guidOf(model, localId));
+    // Pad sits at local +1000x, then the wing rotates 90deg about Z: +1000x -> +1000y.
+    expectVec(world.origin, [0, 1000, 0]);
+    expectVec(world.axisX, [0, 1, 0]);
+    expectVec(world.axisZ, [0, 0, 1]);
+  });
+
+  it('respects authored transform order [tRotate, tTranslate] vs [tTranslate, tRotate]', async () => {
+    // Rotate in place, then move +1000x -> origin stays on the world X axis.
+    const rotateThenMove = await padWorldPlacement([tRotate(90), tTranslate([1000, 0, 0])]);
+    expectVec(rotateThenMove.origin, [1000, 0, 0]);
+    expectVec(rotateThenMove.axisX, [0, 1, 0]);
+
+    // Move +1000x, then rotate 90deg about the origin -> origin swings to +1000y.
+    const moveThenRotate = await padWorldPlacement([tTranslate([1000, 0, 0]), tRotate(90)]);
+    expectVec(moveThenRotate.origin, [0, 1000, 0]);
+    expectVec(moveThenRotate.axisX, [0, 1, 0]);
+  });
+
+  it('folds a rotation about a non-default axis', async () => {
+    // 90deg about world X: local Z (Axis) points along world -Y.
+    const world = await padWorldPlacement([tRotate(90, { axis: [1, 0, 0] })]);
+    expectVec(world.axisX, [1, 0, 0]);
+    expectVec(world.axisZ, [0, -1, 0]);
+  });
+
+  it('folds a rotation about a non-origin pivot', async () => {
+    // 90deg about Z through [500,0,0]: the pivot is the fixed point.
+    const world = await padWorldPlacement([tRotate(90, { at: [500, 0, 0] })]);
+    expectVec(world.origin, [500, -500, 0]);
+    expectVec(world.axisX, [0, 1, 0]);
+  });
+
+  it('places each stair flight through the rotated frame without double-folding', () => {
+    const Stair = family<{
+      readonly flights: ReadonlyArray<Record<string, unknown>>;
+      readonly at: readonly [number, number, number];
+    }>('Stair', (p) => el('Box', { size: [2240, 1200, 1400], transform: [tTranslate(p.at)] }), {
+      archetype: 'stair',
+    });
+    const flight = {
+      width: 1200,
+      riserHeight: 175,
+      treadLength: 280,
+      numberOfRisers: 8,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    };
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          el('Group', { key: 'wing', transform: [tRotate(90)] }, [
+            Stair({ key: 'st', flights: [flight], at: [1000, 0, 0] }),
+          ]),
+        ],
+      })
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+    const localId = projected.idByKeyPath.get('g/wing/st');
+    if (localId === undefined) throw new Error('stair not projected');
+    const spec = model.getElement(localId)?.spec as {
+      flights: ReadonlyArray<{ origin: number[]; axisX: number[] }>;
+    };
+    const placed = spec.flights[0];
+    if (placed === undefined) throw new Error('no flight');
+    // Element +1000x, then the wing's 90deg yaw -> flight origin at +1000y, once.
+    expectVec(placed.origin, [0, 1000, 0]);
+    expectVec(placed.axisX, [0, 1, 0]);
+  });
+});
+
+// --- civil spatial nodes -----------------------------------------------------
+
+interface CivilProps {
+  readonly children?: readonly Element[] | undefined;
+  readonly transform?: readonly TransformOp[] | undefined;
+}
+
+function civilGroup(props: CivilProps): Element {
+  return el('Group', { transform: props.transform ?? [] }, props.children);
+}
+
+const Site = family<CivilProps>('TransportSite', civilGroup, {
+  semantics: civilSemantics({
+    kind: 'site',
+    category: 'site',
+    role: 'transport-site',
+    composition: 'element',
+  }),
+});
+const Bridge = family<CivilProps>('RoadBridge', civilGroup, {
+  semantics: civilSemantics({
+    kind: 'facility',
+    category: 'bridge',
+    role: 'girder',
+    composition: 'element',
+  }),
+});
+const BridgePart = family<CivilProps>('BridgeDeck', civilGroup, {
+  semantics: civilSemantics({
+    kind: 'spatial-part',
+    category: 'bridge-part',
+    role: 'deck',
+    composition: 'element',
+    subdivision: 'longitudinal',
+  }),
+});
+
+// A civil footing places with the standard IfcAxis2Placement3D convention
+// (Axis = axisZ, RefDirection = axisX), so its world axes read back directly —
+// unlike beams/columns, which the writer places along their length axis.
+const CivilFooting = family('DeckFooting', () => el('Box', { size: [1_000, 800, 400] }), {
+  archetype: 'footing',
+  semantics: civilSemantics({
+    kind: 'product',
+    category: 'footing',
+    role: 'pad',
+    material: 'Concrete',
+    dimensionsMm: { length: 1_000, width: 800, height: 400 },
+  }),
+});
+
+const EarthFill = family(
+  'EarthFill',
+  () =>
+    el('Geometry', {
+      node: csg.fuse(
+        csg.box(4_000, 3_000, 1_000),
+        csg.translate(csg.box(2_000, 3_000, 1_000), [1_000, 0, 1_000])
+      ),
+    }),
+  {
+    semantics: civilSemantics({
+      kind: 'product',
+      category: 'earthworks-fill',
+      role: 'embankment',
+      material: 'Compacted soil',
+      dimensionsMm: { length: 4_000, width: 3_000, height: 2_000 },
+    }),
+  }
+);
+
+describe('familiesToBim rotation fold — civil spatial nodes', () => {
+  it('exports a rotated Bridge and orients a contained footing in world space', async () => {
+    const tree = resolve(
+      el('Group', { key: 'root' }, [
+        Site({
+          key: 'site',
+          children: [
+            Bridge({
+              key: 'bridge',
+              transform: [tRotate(90)],
+              children: [
+                BridgePart({
+                  key: 'deck',
+                  children: [CivilFooting({ key: 'pad' })],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ])
+    );
+    const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+    using model = projected.model;
+
+    const padId = projected.idByKeyPath.get('root/site/bridge/deck/pad');
+    if (padId === undefined) throw new Error('footing not projected');
+    const world = await worldPlacement(model, guidOf(model, padId), 'IFC4X3');
+    // The bridge's 90deg yaw carries down to the footing's world placement axes.
+    expectVec(world.axisX, [0, 1, 0], 3);
+    expectVec(world.axisZ, [0, 0, 1], 3);
+  });
+
+  it('localizes an Earthworks Fill body under a rotated Bridge Part', () => {
+    const fillTree = resolve(
+      el('Group', { key: 'root' }, [
+        Site({
+          key: 'site',
+          children: [
+            Bridge({
+              key: 'bridge',
+              children: [
+                BridgePart({
+                  key: 'deck',
+                  transform: [tRotate(90)],
+                  children: [EarthFill({ key: 'fill' })],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ])
+    );
+    const fillOccurrence = findFill(fillTree, 'root/site/bridge/deck/fill');
+
+    using evaluator = new csg.Evaluator();
+    // The resolved fill body is world-baked (carries the deck's 90deg yaw).
+    using source = unwrap(evaluator.evaluate(fillOccurrence.geometry));
+    const sourceVolume = unwrap(measureVolume(source));
+    const sourceBounds = getBounds(source);
+
+    const projected = unwrap(
+      familiesToBim(fillTree, { project: PROJECT, bodyEvaluator: evaluator })
+    );
+    using model = projected.model;
+    const fill = model.getEarthworksFills()[0];
+    expect(fill).toBeDefined();
+    // Rotation preserves volume; the stored (parent-local) body is intact.
+    expect(unwrap(measureVolume(fill?.geometry ?? source))).toBeCloseTo(sourceVolume, 3);
+
+    // Reconstruct the world body through the rotated parent frame; bounds match
+    // the world-baked source, proving the applyMatrix localization is exact.
+    const placed = unwrap(
+      placedSolids(fill as never, {
+        parentFrame: { origin: [0, 0, 0], axisX: [0, 1, 0], axisZ: [0, 0, 1] },
+      })
+    );
+    const worldBody = placed[0];
+    if (worldBody === undefined) throw new Error('no placed body');
+    using disposeWorld = worldBody;
+    const worldBounds = getBounds(disposeWorld);
+    expect(worldBounds.xMin).toBeCloseTo(sourceBounds.xMin, 4);
+    expect(worldBounds.xMax).toBeCloseTo(sourceBounds.xMax, 4);
+    expect(worldBounds.yMin).toBeCloseTo(sourceBounds.yMin, 4);
+    expect(worldBounds.yMax).toBeCloseTo(sourceBounds.yMax, 4);
+  });
+});
+
+function findFill(root: ReturnType<typeof resolve>, keyPath: string): ReturnType<typeof resolve> {
+  const stack: Array<ReturnType<typeof resolve>> = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node === undefined) continue;
+    if (node.keyPath === keyPath) return node;
+    stack.push(...node.children);
+  }
+  throw new Error(`no resolved element at ${keyPath}`);
+}

--- a/packages/brepjs-bim/tests/placementFrame.test.ts
+++ b/packages/brepjs-bim/tests/placementFrame.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { tRotate, tTranslate } from 'brepjs-families';
+import {
+  IDENTITY_FRAME,
+  decomposeFrame,
+  frameFromOps,
+  frameInverse,
+  frameMul,
+  isPureTranslation,
+  rotationFrame,
+  translationFrame,
+  type Frame,
+} from '../src/placementFrame.js';
+
+function expectVecClose(
+  actual: readonly number[],
+  expected: readonly number[],
+  precision = 6
+): void {
+  for (let i = 0; i < expected.length; i++)
+    expect(actual[i]).toBeCloseTo(expected[i] ?? 0, precision);
+}
+
+function expectFrameClose(actual: Frame, expected: Frame, precision = 6): void {
+  for (let i = 0; i < 16; i++) expect(actual[i]).toBeCloseTo(expected[i] ?? 0, precision);
+}
+
+describe('placementFrame', () => {
+  it('folds tRotate(30) about Z into axisX/axisZ per the issue', () => {
+    const f = frameFromOps([tRotate(30)]);
+    const { origin, axisX, axisZ } = decomposeFrame(f);
+    expectVecClose(axisX, [0.866025, 0.5, 0]);
+    expectVecClose(axisZ, [0, 0, 1]);
+    expectVecClose(origin, [0, 0, 0]);
+  });
+
+  it('composes [tRotate, tTranslate] and [tTranslate, tRotate] in authored order', () => {
+    // applyOps runs ops[0] first: [rotate, translate] rotates in place then moves.
+    const rotateThenMove = decomposeFrame(frameFromOps([tRotate(90), tTranslate([10, 0, 0])]));
+    expectVecClose(rotateThenMove.axisX, [0, 1, 0]);
+    expectVecClose(rotateThenMove.origin, [10, 0, 0]);
+
+    // [translate, rotate] moves +10x then rotates about origin -> lands at +10y.
+    const moveThenRotate = decomposeFrame(frameFromOps([tTranslate([10, 0, 0]), tRotate(90)]));
+    expectVecClose(moveThenRotate.axisX, [0, 1, 0]);
+    expectVecClose(moveThenRotate.origin, [0, 10, 0]);
+  });
+
+  it('honours a rotation pivot (at)', () => {
+    const f = rotationFrame(90, [0, 0, 1], [5, 0, 0]);
+    // The pivot is a fixed point.
+    const { origin } = decomposeFrame(f);
+    expectVecClose(origin, [5, -5, 0]);
+    // A point at [6,0,0] maps to [5,1,0] (unit arm rotated 90deg about [5,0,0]).
+    const p = applyFrame(f, [6, 0, 0]);
+    expectVecClose(p, [5, 1, 0]);
+  });
+
+  it('handles a non-default rotation axis', () => {
+    const { axisX, axisZ } = decomposeFrame(rotationFrame(90, [1, 0, 0]));
+    expectVecClose(axisX, [1, 0, 0]);
+    expectVecClose(axisZ, [0, -1, 0]);
+  });
+
+  it('inverts a rigid frame (f . f^-1 = I)', () => {
+    const f = frameMul(translationFrame([3, -4, 5]), rotationFrame(37, [0.2, 0.6, 1]));
+    expectFrameClose(frameMul(f, frameInverse(f)), IDENTITY_FRAME);
+    expectFrameClose(frameMul(frameInverse(f), f), IDENTITY_FRAME);
+  });
+
+  it('relativizes a world frame against a parent frame', () => {
+    const parent = frameFromOps([tTranslate([100, 0, 0]), tRotate(90)]);
+    const world = frameFromOps([tTranslate([100, 0, 0]), tRotate(90), tTranslate([0, 0, 50])]);
+    const local = frameMul(frameInverse(parent), world);
+    // The child sits +50 along the parent's local Z from the parent origin.
+    const { origin, axisX, axisZ } = decomposeFrame(local);
+    expectVecClose(origin, [0, 0, 50]);
+    expectVecClose(axisX, [1, 0, 0]);
+    expectVecClose(axisZ, [0, 0, 1]);
+  });
+
+  it('classifies pure translations vs rotations', () => {
+    expect(isPureTranslation(translationFrame([1, 2, 3]))).toBe(true);
+    expect(isPureTranslation(IDENTITY_FRAME)).toBe(true);
+    expect(isPureTranslation(rotationFrame(5))).toBe(false);
+  });
+});
+
+function applyFrame(f: Frame, p: readonly [number, number, number]): [number, number, number] {
+  return [
+    f[0] * p[0] + f[4] * p[1] + f[8] * p[2] + f[12],
+    f[1] * p[0] + f[5] * p[1] + f[9] * p[2] + f[13],
+    f[2] * p[0] + f[6] * p[1] + f[10] * p[2] + f[14],
+  ];
+}

--- a/packages/brepjs-families/src/resolve.ts
+++ b/packages/brepjs-families/src/resolve.ts
@@ -27,9 +27,9 @@ export function tTranslate(v: readonly [number, number, number]): TransformOp {
 }
 
 /** Rotation in degrees about `axis` (default Z) through `at` (default origin).
- *  Viewport-first: a parametric BIM projection folds only translations into
- *  IfcLocalPlacement and rejects rotated routed elements (walls orient via
- *  `axisX` instead). */
+ *  A parametric BIM projection folds the composed rotation into the
+ *  IfcLocalPlacement frame (origin + axisX + axisZ), so the IFC placement
+ *  matches the viewport transform. */
 export function tRotate(
   angleDeg: number,
   options?: {


### PR DESCRIPTION
Closes #2259.

## What

`familiesToBim` now folds a `tRotate` (composed with `tTranslate`, in authored order) into a real IFC placement instead of rejecting it with `FAMILIES_UNSUPPORTED_TRANSFORM`. The composed rotation is written as `origin` + `axisX` + `axisZ` on the typed spec / civil spatial entity, so the exported `IfcLocalPlacement` matches the viewport transform.

Every typed spec (`wallSpec`, `beamSpec`, `foundationSpec`, `spatialSpec`, `infrastructureSpec`, ...) and the IFC writer already accepted a full frame; the gap was entirely in the adapter, which threaded only a translation.

## How

- **`placementFrame.ts`** (new): column-major rigid-frame algebra built on the existing `Mat4x4` from `import/placement.ts` — Rodrigues rotation (any axis, any pivot), compose, rigid inverse, decompose, plus `frameFromPlacement` for authored `axisX`/`axisZ`.
- **The walk threads a rigid frame.** It carries the element's world frame and its enclosing spatial-container frame. A routed product's local placement is `decompose(inverse(container) · world)`; in the no-rotation case this reduces exactly to the previous `composedOrigin − projectedSpatialTranslation`, so unrotated placements are byte-identical (dual path).
- **Materialized bodies** (`IfcBuildingElementProxy`, Earthworks Fill) localize into a rotated container via `applyMatrix(inverse frame)` rather than a plain translate.
- **Civil Site / Bridge / Bridge Part** fold a `tRotate` (or authored `axisX`/`axisZ`) into their own placement and relativize the whole subtree by the full parent frame, so a rotated spatial node orients its children.
- Any axis and any pivot are representable (a proper rotation is fully captured by `axisX`/`axisZ`); a degenerate/non-orthonormal frame is rejected downstream by the spec's orthogonality check.

## Acceptance criteria

- [x] A typed Product with a local `tRotate` exports.
- [x] A typed Product below a rotated ancestor exports.
- [x] A rotated Site / Bridge / Bridge Part exports.
- [x] IFC and viewport world placements agree.
- [x] Transform order covered for `[tRotate, tTranslate]` and `[tTranslate, tRotate]`.
- [x] Non-default axis and pivot handled (folded into the frame, not rejected).

## Testing

- `placementFrame.test.ts`: unit coverage of the frame algebra (compose, order, pivot, non-Z axis, inverse, relativize).
- `familiesRotation.test.ts`: full round-trip (families → adapter → IFC text → `SpfReader` → `composeWorldPlacement`) with hand-computed expectations — local rotate (the issue repro), inherited rotation, both transform orders, non-Z axis, pivot, rotated civil Bridge → footing, rotated stair flights (no double-fold), and an Earthworks Fill under a rotated Bridge Part.
- Full `brepjs-bim` suite green (2812 tests) across kernels; the two previously-rejecting tests now assert the folded placement.
