### PR TITLE
Fix rotated typed Body Datum placement

### DIFF
--- a/packages/brepjs-bim/src/familiesAdapter.ts
+++ b/packages/brepjs-bim/src/familiesAdapter.ts
@@ -931,13 +931,36 @@ function specLocalShift(el: ResolvedElement): Vec3 {
   return synthesizedProfile(el)?.shift ?? [0, 0, 0];
 }
 
+/** Skip the resolver occurrence wrappers already owned by `cumulativeFrame`,
+ *  then recover only the Body's outer literal Datum translations. An unexpected
+ *  wrapper shape returns zero rather than risking an occurrence transform twice. */
+function bodyLocalTranslation(
+  el: ResolvedElement,
+  occurrenceTransformDepth: number
+): Translation {
+  let body = el.geometry;
+  for (let i = 0; i < occurrenceTransformDepth; i++) {
+    if (body.kind !== 'Translate' && body.kind !== 'Rotate') return ZERO_TRANSLATION;
+    body = body.target;
+  }
+  return peelTranslates(body).total;
+}
+
 /** World frame of an element's own body: the walk's cumulative frame (all
  *  authored transforms, ancestors + own) composed with the body's authored axes
- *  (`axisX`/`axisZ` props) and its local origin (`origin` prop + centring
- *  shift). Under no rotation this reduces to `composedOrigin` + shift. */
-function elementBodyFrame(el: ResolvedElement, cumulativeFrame: Frame): Frame {
+ *  (`axisX`/`axisZ` props) and its local origin (`origin` prop + literal Body
+ *  Datum + centring shift). Under no rotation this reduces to `composedOrigin`
+ *  + shift. */
+function elementBodyFrame(
+  el: ResolvedElement,
+  cumulativeFrame: Frame,
+  occurrenceTransformDepth: number
+): Frame {
   const axes = frameFromPlacement({
-    origin: authoredSpecOrigin(el),
+    origin: addTranslation(
+      authoredSpecOrigin(el),
+      bodyLocalTranslation(el, occurrenceTransformDepth)
+    ),
     axisX: authoredAxisX(el),
     axisZ: authoredAxisZ(el),
   });
@@ -966,6 +989,7 @@ function rotatedRoutedInput(
   flatInput: Record<string, unknown>,
   el: ResolvedElement,
   cumulativeFrame: Frame,
+  occurrenceTransformDepth: number,
   spatialFrame: Frame
 ): Record<string, unknown> {
   const toSpatial = frameInverse(spatialFrame);
@@ -974,7 +998,7 @@ function rotatedRoutedInput(
     // composes under the element's full body frame — cumulative transforms plus
     // the element's own `origin`/`axisX`/`axisZ` props, matching what
     // flightsSpecInput folds into flight origins on the unrotated path.
-    const elementFrame = elementBodyFrame(el, cumulativeFrame);
+    const elementFrame = elementBodyFrame(el, cumulativeFrame, occurrenceTransformDepth);
     const flights: readonly unknown[] = flatInput['flights'];
     return {
       ...flatInput,
@@ -997,7 +1021,9 @@ function rotatedRoutedInput(
       }),
     };
   }
-  const placed = decomposeFrame(frameMul(toSpatial, elementBodyFrame(el, cumulativeFrame)));
+  const placed = decomposeFrame(
+    frameMul(toSpatial, elementBodyFrame(el, cumulativeFrame, occurrenceTransformDepth))
+  );
   return { ...flatInput, origin: placed.origin, axisX: placed.axisX, axisZ: placed.axisZ };
 }
 
@@ -1202,6 +1228,8 @@ interface ProjectionWalkState {
   readonly rotated: boolean;
   readonly cumulativeTranslation: Translation;
   readonly projectedSpatialTranslation: Translation;
+  /** Resolver transform wrappers already represented by `cumulativeFrame`. */
+  readonly occurrenceTransformDepth: number;
   /** World frame of the current element's parent: every authored transform
    *  (ancestors, composed) as a rigid motion. Drives the rotation-aware
    *  placement path; its translation column equals `cumulativeTranslation`. */
@@ -1269,6 +1297,8 @@ export function familiesToBim(
       state.cumulativeTranslation,
       authoredTranslation(el)
     );
+    const occurrenceTransformDepthHere =
+      state.occurrenceTransformDepth + el.localTransforms.length;
     const cumulativeFrameHere = frameMul(state.cumulativeFrame, frameFromOps(el.localTransforms));
     let proxiedHere = false;
     let nextRotated = rotatedHere;
@@ -1424,7 +1454,13 @@ export function familiesToBim(
       // adds the element origin to each flight, which the frame would double-count.
       const rotatedBase = Array.isArray(routedInput['flights']) ? specInput(el) : routedInput;
       const placedInput = rotatedHere
-        ? rotatedRoutedInput(rotatedBase, el, cumulativeFrameHere, state.spatialFrame)
+        ? rotatedRoutedInput(
+            rotatedBase,
+            el,
+            cumulativeFrameHere,
+            occurrenceTransformDepthHere,
+            state.spatialFrame
+          )
         : usesAuthoredCivilHierarchy
           ? relativeSpecInput(routedInput, state.projectedSpatialTranslation)
           : routedInput;
@@ -1500,6 +1536,7 @@ export function familiesToBim(
         rotated: nextRotated,
         cumulativeTranslation: cumulativeTranslationHere,
         projectedSpatialTranslation: nextProjectedSpatialTranslation,
+        occurrenceTransformDepth: occurrenceTransformDepthHere,
         cumulativeFrame: nextCumulativeFrame,
         spatialFrame: nextSpatialFrame,
       });
@@ -1514,6 +1551,7 @@ export function familiesToBim(
     rotated: false,
     cumulativeTranslation: ZERO_TRANSLATION,
     projectedSpatialTranslation: ZERO_TRANSLATION,
+    occurrenceTransformDepth: 0,
     cumulativeFrame: IDENTITY_FRAME,
     spatialFrame: IDENTITY_FRAME,
   });

--- a/packages/brepjs-bim/tests/familiesRotation.test.ts
+++ b/packages/brepjs-bim/tests/familiesRotation.test.ts
@@ -47,6 +47,24 @@ interface PadProps {
   readonly transform?: readonly TransformOp[] | undefined;
 }
 
+const DatumSlab = family<PadProps>(
+  'DatumSlab',
+  ({ length, width, thickness, transform }) =>
+    el('Geometry', {
+      node: csg.translate(csg.box(length, width, thickness), [-length, 0, -thickness]),
+      transform: transform ?? [],
+    }),
+  {
+    semantics: civilSemantics({
+      kind: 'product',
+      category: 'slab',
+      role: 'deck',
+      material: 'Concrete',
+      dimensionsMm: { length: 500, width: 300, height: 40 },
+    }),
+  }
+);
+
 const Pad = family<PadProps>(
   'Pad',
   ({ length, width, thickness, transform }) =>
@@ -109,7 +127,73 @@ function expectVec(actual: readonly number[], expected: readonly number[], preci
     expect(actual[i]).toBeCloseTo(expected[i] ?? 0, precision);
 }
 
+function projectedBounds(tree: ReturnType<typeof resolve>, keyPath: string) {
+  const projected = unwrap(familiesToBim(tree, { project: PROJECT }));
+  using model = projected.model;
+  const localId = projected.idByKeyPath.get(keyPath);
+  if (localId === undefined) throw new Error(`${keyPath} not projected`);
+  const element = model.getElement(localId);
+  if (element === null) throw new Error(`${keyPath} element missing`);
+  const solids = unwrap(placedSolids(element));
+  const solid = solids[0];
+  if (solid === undefined) throw new Error(`${keyPath} body missing`);
+  using disposeSolid = solid;
+  return getBounds(disposeSolid);
+}
+
 describe('familiesToBim rotation fold', () => {
+  it('preserves a typed Product Body Datum through rotation', () => {
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          DatumSlab({
+            key: 'slab',
+            length: 500,
+            width: 300,
+            thickness: 40,
+            transform: [tRotate(30), tTranslate([1_000, 2_000, 3_000])],
+          }),
+        ],
+      })
+    );
+    const bounds = projectedBounds(tree, 'g/slab');
+
+    expect(bounds.xMin).toBeCloseTo(416.987298, 4);
+    expect(bounds.xMax).toBeCloseTo(1_000, 4);
+    expect(bounds.yMin).toBeCloseTo(1_750, 4);
+    expect(bounds.yMax).toBeCloseTo(2_259.807621, 4);
+    expect(bounds.zMin).toBeCloseTo(2_960, 4);
+    expect(bounds.zMax).toBeCloseTo(3_000, 4);
+  });
+
+  it('preserves a Body Datum after inherited and local occurrence transforms', () => {
+    const tree = resolve(
+      Storey({
+        key: 'g',
+        items: [
+          el('Group', { key: 'wing', transform: [tRotate(90)] }, [
+            DatumSlab({
+              key: 'slab',
+              length: 500,
+              width: 300,
+              thickness: 40,
+              transform: [tTranslate([1_000, 0, 0])],
+            }),
+          ]),
+        ],
+      })
+    );
+    const bounds = projectedBounds(tree, 'g/wing/slab');
+
+    expect(bounds.xMin).toBeCloseTo(-300, 4);
+    expect(bounds.xMax).toBeCloseTo(0, 4);
+    expect(bounds.yMin).toBeCloseTo(500, 4);
+    expect(bounds.yMax).toBeCloseTo(1_000, 4);
+    expect(bounds.zMin).toBeCloseTo(-40, 4);
+    expect(bounds.zMax).toBeCloseTo(0, 4);
+  });
+
   it('folds a typed Product local tRotate(30) into IFC axisX (issue repro)', async () => {
     const world = await padWorldPlacement([tRotate(30)]);
     expectVec(world.axisX, [COS30, SIN30, 0]);


### PR DESCRIPTION
## Summary

Addresses #2270

Preserve literal Family Body Datum translations when `familiesToBim` projects a rotated typed product.

The patch keeps the existing typed semantic route. It does not replace typed products with tessellated bodies or change the public Families API.

## Root cause

Family resolution produces geometry shaped like:

`Translate(occurrence) -> Rotate(occurrence) -> Translate(Body Datum) -> Body`

The projection walk includes the occurrence transforms in `cumulativeFrame`. The rotated typed route then rebuilds the body placement from that frame, authored placement properties, and semantic dimensions.

The inner Body Datum translation was not included. This preserved classification and volume but shifted the placed body in world space.

## Fix

Track how many resolver occurrence wrappers are already represented by `cumulativeFrame`.

When constructing the rotated body frame:

1. Skip exactly those known `Translate` or `Rotate` wrappers.
2. Read only the remaining leading literal Body translations.
3. Compose the recovered Datum once into `elementBodyFrame`.
4. Return zero if the expected wrapper structure is absent, preventing an occurrence transform from being applied twice.

The translation-only route remains unchanged.

## Regression coverage

Added public regressions through `resolve`, `familiesToBim`, `placedSolids`, and `getBounds` for:

- a typed slab with a Body Datum under local rotation and translation;
- a typed slab with a Body Datum under inherited rotation and local translation.

The linked full bridge fixture was also checked locally. Both pitched `ApproachSlab` occurrences now match their authored world bounds on all six components.

## Verification

- `familiesRotation.test.ts`: 11 passed
- related Family projection suites: 76 passed
- `npm run typecheck --workspace=brepjs-bim`
- `npm run lint --workspace=brepjs-bim`
- `git diff --check`


