### PR TITLE
fix(bim): import every Product Body representation item

### DIFF
--- a/apps/docs/bim/ifc.md
+++ b/apps/docs/bim/ifc.md
@@ -45,11 +45,13 @@ if (imported.ok) {
 
 Imported geometry pins kernel memory; call `disposeImportedModel` when done. `geometry.solids` owns
 every reconstructed, World-placed Body item. `geometry.completeness` reports `COMPLETE`, `PARTIAL`,
-or `NONE`. The `geometry.solid` compatibility property borrows the same handle only when a
-`COMPLETE` Body contains one solid; it is `null` for multi-item, partial, and missing Bodies. Never
-dispose the alias separately. Complete Bodies expose the component-wise aggregate `bounds` and the
-sum of item volumes as `volumeMm3`; both are `null` when completeness is `PARTIAL` or `NONE`. For
-header-level inspection without geometry, `SpfReader` parses the STEP structure directly.
+or `NONE`. `geometry.fidelity` reports the least faithful retained item. Raw mesh siblings are
+combined in `meshVertices` and `meshIndices`. The `geometry.solid` compatibility property borrows
+the same handle only when a `COMPLETE` Body contains one solid; it is `null` for multi-item, partial,
+and missing Bodies. Never dispose the alias separately. Complete Bodies expose the component-wise
+aggregate `bounds` and the sum of item volumes as `volumeMm3`. Both become `null` when aggregate
+measurement fails. Both are also `null` when completeness is `PARTIAL` or `NONE`. For header-level
+inspection without geometry, `SpfReader` parses the STEP structure directly.
 
 The IFC4X3 importer recognizes Bridge and Bridge Part nodes in `spatialTree` and imports
 `IfcEarthworksFill` as `EARTHWORKS_FILL`. Each imported product exposes

--- a/apps/docs/bim/ifc.md
+++ b/apps/docs/bim/ifc.md
@@ -43,7 +43,13 @@ if (imported.ok) {
 }
 ```
 
-Imported geometry pins kernel memory; call `disposeImportedModel` when done. For header-level inspection without geometry, `SpfReader` parses the STEP structure directly.
+Imported geometry pins kernel memory; call `disposeImportedModel` when done. `geometry.solids` owns
+every reconstructed, World-placed Body item. `geometry.completeness` reports `COMPLETE`, `PARTIAL`,
+or `NONE`. The `geometry.solid` compatibility property borrows the same handle only when a
+`COMPLETE` Body contains one solid; it is `null` for multi-item, partial, and missing Bodies. Never
+dispose the alias separately. Complete Bodies expose the component-wise aggregate `bounds` and the
+sum of item volumes as `volumeMm3`; both are `null` when completeness is `PARTIAL` or `NONE`. For
+header-level inspection without geometry, `SpfReader` parses the STEP structure directly.
 
 The IFC4X3 importer recognizes Bridge and Bridge Part nodes in `spatialTree` and imports
 `IfcEarthworksFill` as `EARTHWORKS_FILL`. Each imported product exposes

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -314,12 +314,12 @@ declare function fromIfc(
 type ImportedSchema = 'IFC2X3' | 'IFC4' | 'IFC4X3';
 
 /**
- * How faithfully a product's body geometry was reconstructed:
+ * How faithfully the least faithful retained Body item was reconstructed:
  * - `PARAMETRIC` — rebuilt losslessly from a swept solid (extrude/revolve).
  * - `TESSELLATED_MANIFOLD` — a tessellated mesh was recovered as a closed solid
  *   by sewing its triangles; geometrically faithful but topology was re-derived.
- * - `TESSELLATED_LOSSY` — geometry exists only as raw triangles (mesh did not
- *   close into a solid); `solid` is null, `meshVertices`/`meshIndices` carry it.
+ * - `TESSELLATED_LOSSY` — at least one item exists only as raw triangles because
+ *   its mesh did not close into a solid. More faithful siblings may remain in `solids`.
  * - `NONE` — no recognised body representation was found.
  */
 type GeometryFidelity = 'PARAMETRIC' | 'TESSELLATED_MANIFOLD' | 'TESSELLATED_LOSSY' | 'NONE';
@@ -334,13 +334,13 @@ interface ImportedGeometry {
   readonly solids: readonly ValidSolid[];
   /** Borrowed alias for a COMPLETE one-solid Body. Otherwise null. */
   readonly solid: ValidSolid | null;
-  /** Component-wise union of all item bounds for a COMPLETE Body. Otherwise null. */
+  /** Component-wise union of all item bounds for a COMPLETE Body. Null if measurement fails. */
   readonly bounds: Bounds3D | null;
-  /** Sum of item volumes in mm³ for a COMPLETE Body. Otherwise null. */
+  /** Sum of item volumes in mm³ for a COMPLETE Body. Null if measurement fails. */
   readonly volumeMm3: number | null;
-  /** Raw triangle vertices (interleaved xyz), present only for `TESSELLATED_LOSSY`. */
+  /** Combined raw triangle vertices (interleaved xyz), present for `TESSELLATED_LOSSY`. */
   readonly meshVertices?: Float32Array | undefined;
-  /** Raw triangle indices, present only for `TESSELLATED_LOSSY`. */
+  /** Combined raw triangle indices, present for `TESSELLATED_LOSSY`. */
   readonly meshIndices?: Uint32Array | undefined;
 }
 

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -5,7 +5,15 @@
  * Ambient type declarations for brepjs-bim available in the playground editor.
  */
 
-import type { BrepError, OrientedFace, PlanarFace, Result, ValidSolid, csg } from 'brepjs';
+import type {
+  Bounds3D,
+  BrepError,
+  OrientedFace,
+  PlanarFace,
+  Result,
+  ValidSolid,
+  csg,
+} from 'brepjs';
 
 /** Optional identity override for created elements: a stable key (e.g. a
  *  families key path) that replaces the positional GlobalId derivation. */
@@ -309,17 +317,27 @@ type ImportedSchema = 'IFC2X3' | 'IFC4' | 'IFC4X3';
  * How faithfully a product's body geometry was reconstructed:
  * - `PARAMETRIC` — rebuilt losslessly from a swept solid (extrude/revolve).
  * - `TESSELLATED_MANIFOLD` — a tessellated mesh was recovered as a closed solid
- *   via an STL round-trip; geometrically faithful but topology was re-derived.
+ *   by sewing its triangles; geometrically faithful but topology was re-derived.
  * - `TESSELLATED_LOSSY` — geometry exists only as raw triangles (mesh did not
  *   close into a solid); `solid` is null, `meshVertices`/`meshIndices` carry it.
  * - `NONE` — no recognised body representation was found.
  */
 type GeometryFidelity = 'PARAMETRIC' | 'TESSELLATED_MANIFOLD' | 'TESSELLATED_LOSSY' | 'NONE';
 
+type ImportedBodyCompleteness = 'COMPLETE' | 'PARTIAL' | 'NONE';
+
 interface ImportedGeometry {
   readonly fidelity: GeometryFidelity;
-  /** The reconstructed solid; null when fidelity is `NONE` or `TESSELLATED_LOSSY`. */
+  /** Whether every IFC Body item reconstructed into an owned solid. */
+  readonly completeness: ImportedBodyCompleteness;
+  /** Owned World-placed reconstructed handles. Dispose them through disposeImportedModel(). */
+  readonly solids: readonly ValidSolid[];
+  /** Borrowed alias for a COMPLETE one-solid Body. Otherwise null. */
   readonly solid: ValidSolid | null;
+  /** Component-wise union of all item bounds for a COMPLETE Body. Otherwise null. */
+  readonly bounds: Bounds3D | null;
+  /** Sum of item volumes in mm³ for a COMPLETE Body. Otherwise null. */
+  readonly volumeMm3: number | null;
   /** Raw triangle vertices (interleaved xyz), present only for `TESSELLATED_LOSSY`. */
   readonly meshVertices?: Float32Array | undefined;
   /** Raw triangle indices, present only for `TESSELLATED_LOSSY`. */

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -34,6 +34,12 @@ per flight, curtain walls their panels and mullions). When an element is beneath
 structure, pass its cumulative frame as `placedSolids(element, { parentFrame })` to obtain world
 coordinates. This is especially important for parent-local Proxy and Earthworks Fill bodies.
 
+IFC import reconstructs every supported Body item independently. `ImportedGeometry.solids` owns
+the resulting World-placed handles and `completeness` reports `COMPLETE`, `PARTIAL`, or `NONE`.
+The legacy `.solid` property is a borrowed alias only for a complete one-solid Body. Dispose import
+geometry through `disposeImportedModel()` rather than through either property. Complete Bodies
+also expose aggregate `bounds` and `volumeMm3`; both are `null` for partial or missing Bodies.
+
 - Units default to mm; IFC export emits SI metres.
 - Stable identity: deterministic IFC GUIDs (`deriveIfcGuid`) and local id counters.
 - Shaped geometry: roofs build real shed/gable/hip/dome solids when `pitch` is set (flat slab

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -36,9 +36,11 @@ coordinates. This is especially important for parent-local Proxy and Earthworks 
 
 IFC import reconstructs every supported Body item independently. `ImportedGeometry.solids` owns
 the resulting World-placed handles and `completeness` reports `COMPLETE`, `PARTIAL`, or `NONE`.
-The legacy `.solid` property is a borrowed alias only for a complete one-solid Body. Dispose import
-geometry through `disposeImportedModel()` rather than through either property. Complete Bodies
-also expose aggregate `bounds` and `volumeMm3`; both are `null` for partial or missing Bodies.
+`fidelity` reports the least faithful retained item. Raw mesh siblings are combined in
+`meshVertices` and `meshIndices`. The legacy `.solid` property is a borrowed alias only for a
+complete one-solid Body. Dispose import geometry through `disposeImportedModel()` rather than
+through either property. Complete Bodies also expose aggregate `bounds` and `volumeMm3`; both are
+`null` when aggregate measurement fails or when the Body is partial or missing.
 
 - Units default to mm; IFC export emits SI metres.
 - Stable identity: deterministic IFC GUIDs (`deriveIfcGuid`) and local id counters.

--- a/packages/brepjs-bim/src/import/fromIfc.ts
+++ b/packages/brepjs-bim/src/import/fromIfc.ts
@@ -282,42 +282,45 @@ function reconstructGeometry(
   diagnostics: ValidationIssue[]
 ): ImportedGeometry {
   const base = toImportedGeometry(reader, expressId, scale, diagnostics);
-  if (
-    base.fidelity !== 'PARAMETRIC' ||
-    base.completeness !== 'COMPLETE' ||
-    base.solid === null ||
-    voidedBy.length === 0
-  ) {
+  if (base.fidelity !== 'PARAMETRIC' || base.completeness !== 'COMPLETE' || voidedBy.length === 0) {
     return base;
   }
+
+  const firstHost = base.solids[0];
+  if (firstHost === undefined) return base;
+  const hosts: [ValidSolid, ...ValidSolid[]] = [firstHost, ...base.solids.slice(1)];
 
   // cut<ValidSolid> preserves the base's solid type; the kernel may wrap the
   // result in a single-solid compound, so we trust the typed Result rather than
   // re-running isSolid (which rejects the compound wrapper) — mirroring how
   // BimModel applies opening cuts on the write side.
-  let host: ValidSolid = base.solid;
   for (const openingId of voidedBy) {
     const opening = readBodyGeometry(reader, openingId, scale, diagnostics);
     if (opening.kind !== 'SOLID') continue;
-    const cutResult = cut<ValidSolid>(host, opening.solid);
-    // cut() consumes neither input; free the opening tool every iteration.
-    opening.solid[Symbol.dispose]();
-    if (!cutResult.ok) {
-      diagnostics.push(
-        issue(
-          'warning',
-          'VOID_SUBTRACTION_FAILED',
-          `Opening ${openingId} could not be subtracted from element ${expressId}: ${cutResult.error.message}`,
-          expressId
-        )
-      );
-      continue;
+    try {
+      for (let hostIndex = 0; hostIndex < hosts.length; hostIndex++) {
+        const host = hosts[hostIndex];
+        if (host === undefined) continue;
+        const cutResult = cut<ValidSolid>(host, opening.solid);
+        if (!cutResult.ok) {
+          diagnostics.push(
+            issue(
+              'warning',
+              'VOID_SUBTRACTION_FAILED',
+              `Opening ${openingId} could not be subtracted from element ${expressId}: ${cutResult.error.message}`,
+              expressId
+            )
+          );
+          continue;
+        }
+        host[Symbol.dispose]();
+        hosts[hostIndex] = cutResult.value;
+      }
+    } finally {
+      opening.solid[Symbol.dispose]();
     }
-    // Free the prior host (the base body on the first cut) before adopting the result.
-    host[Symbol.dispose]();
-    host = cutResult.value;
   }
-  return completeImportedGeometry('PARAMETRIC', [host], expressId, diagnostics);
+  return completeImportedGeometry('PARAMETRIC', hosts, expressId, diagnostics);
 }
 
 function toImportedGeometry(
@@ -329,13 +332,18 @@ function toImportedGeometry(
   const body = readBodyItems(reader, expressId, scale, diagnostics);
   const solids: ValidSolid[] = [];
   let hasTessellatedSolid = false;
-  let lossyMesh: { readonly vertices: Float32Array; readonly indices: Uint32Array } | null = null;
+  let lossyMesh: { readonly vertices: number[]; readonly indices: number[] } | null = null;
   for (const item of body.items) {
     if (item.kind === 'SOLID') {
       solids.push(item.solid);
       hasTessellatedSolid ||= item.lossy;
-    } else if (item.kind === 'MESH' && lossyMesh === null) {
-      lossyMesh = { vertices: item.vertices, indices: item.indices };
+    } else if (item.kind === 'MESH') {
+      const meshAccumulator: { readonly vertices: number[]; readonly indices: number[] } =
+        lossyMesh ?? { vertices: [], indices: [] };
+      lossyMesh = meshAccumulator;
+      const vertexOffset = meshAccumulator.vertices.length / 3;
+      for (const vertex of item.vertices) meshAccumulator.vertices.push(vertex);
+      for (const index of item.indices) meshAccumulator.indices.push(vertexOffset + index);
     }
   }
 
@@ -368,13 +376,13 @@ function toImportedGeometry(
   }
 
   const fidelity =
-    solids.length > 0
-      ? hasTessellatedSolid
+    lossyMesh !== null
+      ? 'TESSELLATED_LOSSY'
+      : hasTessellatedSolid
         ? 'TESSELLATED_MANIFOLD'
-        : 'PARAMETRIC'
-      : lossyMesh !== null
-        ? 'TESSELLATED_LOSSY'
-        : 'NONE';
+        : solids.length > 0
+          ? 'PARAMETRIC'
+          : 'NONE';
   const aggregate =
     completeness === 'COMPLETE'
       ? measureCompleteBody(solids, expressId, diagnostics)
@@ -386,7 +394,10 @@ function toImportedGeometry(
     solid: completeness === 'COMPLETE' && solids.length === 1 ? (solids[0] ?? null) : null,
     ...aggregate,
     ...(lossyMesh !== null
-      ? { meshVertices: lossyMesh.vertices, meshIndices: lossyMesh.indices }
+      ? {
+          meshVertices: new Float32Array(lossyMesh.vertices),
+          meshIndices: new Uint32Array(lossyMesh.indices),
+        }
       : {}),
   };
 }

--- a/packages/brepjs-bim/src/import/fromIfc.ts
+++ b/packages/brepjs-bim/src/import/fromIfc.ts
@@ -1,6 +1,6 @@
 import * as WebIFC from 'web-ifc';
-import type { Result, ValidSolid } from 'brepjs';
-import { ok, err, cut } from 'brepjs';
+import type { Bounds3D, Result, ValidSolid } from 'brepjs';
+import { ok, err, cut, getBounds, measureVolume } from 'brepjs';
 import type { BimError } from '../errors/bimError.js';
 import { importError } from '../errors/bimError.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
@@ -14,7 +14,7 @@ import {
 import { SpfReader, type SpfReaderSettings } from './spfReader.js';
 import { readLengthScale } from './placement.js';
 import { buildSpatialTree, buildElementContainmentMap, type SpatialNode } from './spatialTree.js';
-import { readBodyGeometry, type GeometryResult } from './geometryRead.js';
+import { readBodyGeometry, readBodyItems } from './geometryRead.js';
 import {
   readPsets,
   readMaterial,
@@ -39,6 +39,19 @@ export interface FromIfcOptions {
   readonly coordinateToOrigin?: boolean | undefined;
   /** Skip body-geometry reconstruction for fast metadata-only reads. Default false. */
   readonly skipGeometry?: boolean | undefined;
+}
+
+export interface FromIfcTestHooks {
+  readonly afterGeometry?: ((expressId: number, geometry: ImportedGeometry) => void) | undefined;
+  readonly afterElement?:
+    ((element: ImportedElement, accumulatedCount: number) => void) | undefined;
+}
+
+let testHooks: FromIfcTestHooks | null = null;
+
+/** Package-internal deterministic failure seam for import ownership tests. */
+export function setFromIfcTestHooksForTesting(hooks: FromIfcTestHooks | null): void {
+  testHooks = hooks;
 }
 
 /**
@@ -95,6 +108,7 @@ export async function fromIfc(
   const readerResult = await SpfReader.create(bytes, settings);
   if (!readerResult.ok) return err(readerResult.error);
   const reader = readerResult.value;
+  const elements: ImportedElement[] = [];
 
   try {
     reader.buildGuidMap();
@@ -115,7 +129,6 @@ export async function fromIfc(
     const containment = buildElementContainmentMap(reader);
     const typeEnums = buildTypePredefinedMap(reader);
 
-    const elements: ImportedElement[] = [];
     const byExpressId = new Map<number, ImportedElement>();
     for (const [type, category] of ELEMENT_TYPES) {
       for (const expressId of reader.getLinesOfType(type)) {
@@ -132,6 +145,7 @@ export async function fromIfc(
         if (element === null) continue;
         elements.push(element);
         byExpressId.set(element.expressId, element);
+        testHooks?.afterElement?.(element, elements.length);
       }
     }
 
@@ -148,6 +162,7 @@ export async function fromIfc(
     };
     return ok(model);
   } catch (e) {
+    disposeElements(elements);
     return err(importError('IMPORT_FAILED', 'Unexpected failure during IFC import', e));
   } finally {
     reader.close();
@@ -169,6 +184,7 @@ function readElement(
   skipGeometry: boolean,
   diagnostics: ValidationIssue[]
 ): ImportedElement | null {
+  let geometry: ImportedGeometry | null = null;
   try {
     const line = reader.getLine<Record<string, unknown>>(expressId);
     if (line === null) {
@@ -193,9 +209,17 @@ function readElement(
     const voidedBy = voids.map((v) => v.openingExpressId);
     const fills = findFills(reader, expressId);
 
-    const geometry: ImportedGeometry = skipGeometry
-      ? { fidelity: 'NONE', solid: null }
+    geometry = skipGeometry
+      ? {
+          fidelity: 'NONE',
+          completeness: 'NONE',
+          solids: [],
+          solid: null,
+          bounds: null,
+          volumeMm3: null,
+        }
       : reconstructGeometry(reader, expressId, scale, voidedBy, diagnostics);
+    testHooks?.afterGeometry?.(expressId, geometry);
 
     const psets = readPsets(reader, expressId).map(toImportedPset);
     const material = readMaterial(reader, expressId, scale);
@@ -219,6 +243,7 @@ function readElement(
       ...(fills !== undefined ? { fills } : {}),
     };
   } catch (e) {
+    if (geometry !== null) disposeGeometry(geometry);
     diagnostics.push(
       issue(
         'error',
@@ -256,8 +281,13 @@ function reconstructGeometry(
   voidedBy: readonly number[],
   diagnostics: ValidationIssue[]
 ): ImportedGeometry {
-  const base = toImportedGeometry(readBodyGeometry(reader, expressId, scale, diagnostics));
-  if (base.fidelity !== 'PARAMETRIC' || base.solid === null || voidedBy.length === 0) {
+  const base = toImportedGeometry(reader, expressId, scale, diagnostics);
+  if (
+    base.fidelity !== 'PARAMETRIC' ||
+    base.completeness !== 'COMPLETE' ||
+    base.solid === null ||
+    voidedBy.length === 0
+  ) {
     return base;
   }
 
@@ -287,25 +317,144 @@ function reconstructGeometry(
     host[Symbol.dispose]();
     host = cutResult.value;
   }
-  return { fidelity: 'PARAMETRIC', solid: host };
+  return completeImportedGeometry('PARAMETRIC', [host], expressId, diagnostics);
 }
 
-function toImportedGeometry(result: GeometryResult): ImportedGeometry {
-  if (result.kind === 'SOLID') {
-    return {
-      fidelity: result.lossy ? 'TESSELLATED_MANIFOLD' : 'PARAMETRIC',
-      solid: result.solid,
-    };
+function toImportedGeometry(
+  reader: SpfReader,
+  expressId: number,
+  scale: number,
+  diagnostics: ValidationIssue[]
+): ImportedGeometry {
+  const body = readBodyItems(reader, expressId, scale, diagnostics);
+  const solids: ValidSolid[] = [];
+  let hasTessellatedSolid = false;
+  let lossyMesh: { readonly vertices: Float32Array; readonly indices: Uint32Array } | null = null;
+  for (const item of body.items) {
+    if (item.kind === 'SOLID') {
+      solids.push(item.solid);
+      hasTessellatedSolid ||= item.lossy;
+    } else if (item.kind === 'MESH' && lossyMesh === null) {
+      lossyMesh = { vertices: item.vertices, indices: item.indices };
+    }
   }
-  if (result.kind === 'MESH') {
-    return {
-      fidelity: 'TESSELLATED_LOSSY',
-      solid: null,
-      meshVertices: result.vertices,
-      meshIndices: result.indices,
-    };
+
+  const completeness =
+    body.hasBody && body.itemCount > 0 && solids.length === body.itemCount
+      ? 'COMPLETE'
+      : solids.length > 0
+        ? 'PARTIAL'
+        : 'NONE';
+  if (completeness === 'PARTIAL') {
+    diagnostics.push(
+      issue(
+        'warning',
+        'PARTIAL_BODY_RECONSTRUCTION',
+        `Reconstructed ${solids.length} of ${body.itemCount} Body items`,
+        expressId,
+        { reconstructedItems: solids.length, bodyItems: body.itemCount }
+      )
+    );
+  } else if (completeness === 'NONE' && body.hasBody) {
+    diagnostics.push(
+      issue(
+        'warning',
+        'BODY_RECONSTRUCTION_NONE',
+        `The Product has ${body.itemCount} Body item(s), but none reconstructed as solids`,
+        expressId,
+        { bodyItems: body.itemCount }
+      )
+    );
   }
-  return { fidelity: 'NONE', solid: null };
+
+  const fidelity =
+    solids.length > 0
+      ? hasTessellatedSolid
+        ? 'TESSELLATED_MANIFOLD'
+        : 'PARAMETRIC'
+      : lossyMesh !== null
+        ? 'TESSELLATED_LOSSY'
+        : 'NONE';
+  const aggregate =
+    completeness === 'COMPLETE'
+      ? measureCompleteBody(solids, expressId, diagnostics)
+      : { bounds: null, volumeMm3: null };
+  return {
+    fidelity,
+    completeness,
+    solids,
+    solid: completeness === 'COMPLETE' && solids.length === 1 ? (solids[0] ?? null) : null,
+    ...aggregate,
+    ...(lossyMesh !== null
+      ? { meshVertices: lossyMesh.vertices, meshIndices: lossyMesh.indices }
+      : {}),
+  };
+}
+
+function completeImportedGeometry(
+  fidelity: ImportedGeometry['fidelity'],
+  solids: readonly [ValidSolid, ...ValidSolid[]],
+  expressId: number,
+  diagnostics: ValidationIssue[]
+): ImportedGeometry {
+  return {
+    fidelity,
+    completeness: 'COMPLETE',
+    solids,
+    solid: solids.length === 1 ? solids[0] : null,
+    ...measureCompleteBody(solids, expressId, diagnostics),
+  };
+}
+
+function measureCompleteBody(
+  solids: readonly ValidSolid[],
+  expressId: number,
+  diagnostics: ValidationIssue[]
+): { readonly bounds: Bounds3D | null; readonly volumeMm3: number | null } {
+  try {
+    const first = solids[0];
+    if (first === undefined) return { bounds: null, volumeMm3: null };
+    const initial = getBounds(first);
+    let xMin = initial.xMin;
+    let xMax = initial.xMax;
+    let yMin = initial.yMin;
+    let yMax = initial.yMax;
+    let zMin = initial.zMin;
+    let zMax = initial.zMax;
+    let volumeMm3 = 0;
+    for (const solid of solids) {
+      const measured = measureVolume(solid);
+      if (!measured.ok) throw new Error(measured.error.message);
+      volumeMm3 += measured.value;
+      const itemBounds = getBounds(solid);
+      xMin = Math.min(xMin, itemBounds.xMin);
+      xMax = Math.max(xMax, itemBounds.xMax);
+      yMin = Math.min(yMin, itemBounds.yMin);
+      yMax = Math.max(yMax, itemBounds.yMax);
+      zMin = Math.min(zMin, itemBounds.zMin);
+      zMax = Math.max(zMax, itemBounds.zMax);
+    }
+    const bounds: Bounds3D = { xMin, xMax, yMin, yMax, zMin, zMax };
+    return { bounds, volumeMm3 };
+  } catch (cause) {
+    diagnostics.push(
+      issue(
+        'warning',
+        'BODY_AGGREGATE_MEASUREMENT_FAILED',
+        `Complete Body aggregate measurement failed: ${errMsg(cause)}`,
+        expressId
+      )
+    );
+    return { bounds: null, volumeMm3: null };
+  }
+}
+
+function disposeGeometry(geometry: ImportedGeometry): void {
+  for (const solid of geometry.solids) solid[Symbol.dispose]();
+}
+
+function disposeElements(elements: readonly ImportedElement[]): void {
+  for (const element of elements) disposeGeometry(element.geometry);
 }
 
 function toImportedPset(pset: DataPset): ImportedPset {

--- a/packages/brepjs-bim/src/import/geometryRead.ts
+++ b/packages/brepjs-bim/src/import/geometryRead.ts
@@ -2,9 +2,11 @@ import * as WebIFC from 'web-ifc';
 import {
   applyMatrix,
   castShape,
+  clone,
   err,
   extrude,
   getKernel,
+  getSolids,
   isSolid,
   ok,
   polygon,
@@ -32,7 +34,7 @@ import { readPlaneAngleScale } from './placement.js';
  * Outcome of reconstructing a single product's body geometry.
  *
  * - `SOLID` — a brepjs ValidSolid was rebuilt (parametrically from a swept
- *   solid, or by a manifold STL round-trip of a tessellated mesh).
+ *   solid, or by sewing a manifold tessellated mesh).
  * - `MESH` — geometry exists but could not be turned into a closed solid;
  *   raw triangle data is returned and flagged lossy via `diagnostic`.
  * - `NONE` — the product carries no recognised body representation.
@@ -47,6 +49,12 @@ export type GeometryResult =
     }
   | { readonly kind: 'NONE' };
 
+export interface BodyGeometryItems {
+  readonly hasBody: boolean;
+  readonly itemCount: number;
+  readonly items: readonly GeometryResult[];
+}
+
 // web-ifc wraps measure/real values as { value | _representationValue } and
 // references as { value: expressId }. Both are read via `.value`/`._representationValue`.
 interface IfcRef {
@@ -54,6 +62,17 @@ interface IfcRef {
 }
 
 const NONE: GeometryResult = { kind: 'NONE' };
+
+export interface GeometryReadTestHooks {
+  readonly afterItemSolid?: ((itemExpressId: number, solid: ValidSolid) => void) | undefined;
+}
+
+let testHooks: GeometryReadTestHooks | null = null;
+
+/** Package-internal deterministic failure seam for import ownership tests. */
+export function setGeometryReadTestHooksForTesting(hooks: GeometryReadTestHooks | null): void {
+  testHooks = hooks;
+}
 
 /**
  * Reconstructs the `Body` (SweptSolid) representation of a product into a brepjs
@@ -70,53 +89,98 @@ export function readBodyGeometry(
   scale: number,
   diagnostics: ValidationIssue[]
 ): GeometryResult {
+  const body = readBodyItems(reader, productExpressId, scale, diagnostics);
+  const selected = body.items.find((item) => item.kind !== 'NONE') ?? NONE;
+  for (const item of body.items) {
+    if (item !== selected && item.kind === 'SOLID') item.solid[Symbol.dispose]();
+  }
+  return selected;
+}
+
+/** Reconstructs each supported IFC Body item independently in representation order. */
+export function readBodyItems(
+  reader: SpfReader,
+  productExpressId: number,
+  scale: number,
+  diagnostics: ValidationIssue[]
+): BodyGeometryItems {
   const product = reader.getLine<Record<string, unknown>>(productExpressId);
-  if (product === null) return NONE;
+  if (product === null) return { hasBody: false, itemCount: 0, items: [] };
   const representationRef = asRef(product['Representation']);
-  if (representationRef === undefined) return NONE;
+  if (representationRef === undefined) return { hasBody: false, itemCount: 0, items: [] };
 
   const productShape = reader.getLine<Record<string, unknown>>(representationRef.value);
   const representations =
     productShape === null ? undefined : asRefArray(productShape['Representations']);
-  if (representations === undefined) return NONE;
+  if (representations === undefined) return { hasBody: false, itemCount: 0, items: [] };
 
-  const bodyItemId = findBodyItem(reader, representations);
-  if (bodyItemId === undefined) return NONE;
+  const bodyItemIds = findBodyItems(reader, representations);
+  if (bodyItemIds === null) return { hasBody: false, itemCount: 0, items: [] };
 
   const worldTransform = readWorldTransform(reader, product, scale);
+  const itemTypes = new Map(bodyItemIds.map((id) => [id, reader.getLineType(id)]));
+  const streamedItemIds = new Set(
+    bodyItemIds.filter((id) => isStreamedTessellatedType(itemTypes.get(id)))
+  );
+  let streamedMeshes: ReadonlyMap<number, MeshData> = new Map();
+  if (streamedItemIds.size > 0) {
+    try {
+      streamedMeshes = collectItemMeshes(reader, productExpressId, streamedItemIds);
+    } catch (cause) {
+      diagnostics.push(
+        issue(
+          'warning',
+          'GEOMETRY_RECONSTRUCTION_FAILED',
+          `Body tessellation stream failed: ${errMsg(cause)}`,
+          productExpressId
+        )
+      );
+    }
+  }
+  const items = bodyItemIds.map((bodyItemId): GeometryResult => {
+    const itemType = itemTypes.get(bodyItemId);
+    try {
+      if (itemType === WebIFC.IFCEXTRUDEDAREASOLID) {
+        return reconstructExtrusion(reader, bodyItemId, scale, worldTransform, diagnostics);
+      }
+      if (itemType === WebIFC.IFCREVOLVEDAREASOLID) {
+        return reconstructRevolution(reader, bodyItemId, scale, worldTransform, diagnostics);
+      }
+      if (itemType === WebIFC.IFCTRIANGULATEDFACESET) {
+        return reconstructTriangulatedItem(reader, bodyItemId, scale, worldTransform, diagnostics);
+      }
+      if (isStreamedTessellatedType(itemType)) {
+        return reconstructStreamedTessellatedItem(
+          streamedMeshes.get(bodyItemId),
+          bodyItemId,
+          diagnostics
+        );
+      }
+    } catch (cause) {
+      diagnostics.push(
+        issue(
+          'warning',
+          'GEOMETRY_RECONSTRUCTION_FAILED',
+          `Body item ${bodyItemId} reconstruction threw: ${errMsg(cause)}`,
+          bodyItemId,
+          { productExpressId }
+        )
+      );
+      return NONE;
+    }
 
-  const itemType = reader.getLineType(bodyItemId);
-  try {
-    if (itemType === WebIFC.IFCEXTRUDEDAREASOLID) {
-      return reconstructExtrusion(reader, bodyItemId, scale, worldTransform, diagnostics);
-    }
-    if (itemType === WebIFC.IFCREVOLVEDAREASOLID) {
-      return reconstructRevolution(reader, bodyItemId, scale, worldTransform, diagnostics);
-    }
-    if (isTessellatedType(itemType)) {
-      return reconstructTessellated(reader, productExpressId, diagnostics);
-    }
-  } catch (e) {
     diagnostics.push(
       issue(
         'warning',
-        'GEOMETRY_RECONSTRUCTION_FAILED',
-        `Body geometry reconstruction threw: ${errMsg(e)}`,
-        productExpressId
+        'UNSUPPORTED_REPRESENTATION_ITEM',
+        `Unsupported Body item ${bodyItemId} type ${itemType}; geometry skipped`,
+        bodyItemId,
+        { productExpressId }
       )
     );
     return NONE;
-  }
-
-  diagnostics.push(
-    issue(
-      'warning',
-      'UNSUPPORTED_REPRESENTATION_ITEM',
-      `Unsupported body representation item type ${itemType}; geometry skipped`,
-      productExpressId
-    )
-  );
-  return NONE;
+  });
+  return { hasBody: true, itemCount: bodyItemIds.length, items };
 }
 
 // ---------------------------------------------------------------------------
@@ -292,36 +356,102 @@ function reconstructRevolution(
 }
 
 // ---------------------------------------------------------------------------
-// Tessellated fallback (STL round-trip; lossy when not manifold)
+// Tessellated reconstruction (direct sewing with an STL fallback)
 // ---------------------------------------------------------------------------
 
-function reconstructTessellated(
+function reconstructTriangulatedItem(
   reader: SpfReader,
-  productExpressId: number,
+  itemExpressId: number,
+  scale: number,
+  worldTransform: MatrixTransform | null,
   diagnostics: ValidationIssue[]
 ): GeometryResult {
-  const mesh = collectMesh(reader, productExpressId);
+  const faceSet = reader.getLine<Record<string, unknown>>(itemExpressId);
+  const coordinatesRef = faceSet === null ? undefined : asRef(faceSet['Coordinates']);
+  const pointList =
+    coordinatesRef === undefined
+      ? null
+      : reader.getLine<Record<string, unknown>>(coordinatesRef.value);
+  const rawPoints = pointList?.['CoordList'];
+  const rawTriangles = faceSet?.['CoordIndex'];
+  const mesh = readTriangulatedMesh(rawPoints, rawTriangles, scale, worldTransform);
+  return reconstructTessellatedMesh(mesh, 1, itemExpressId, diagnostics);
+}
+
+function reconstructStreamedTessellatedItem(
+  mesh: MeshData | undefined,
+  itemExpressId: number,
+  diagnostics: ValidationIssue[]
+): GeometryResult {
+  return reconstructTessellatedMesh(mesh ?? null, 1000, itemExpressId, diagnostics);
+}
+
+function reconstructTessellatedMesh(
+  mesh: MeshData | null,
+  scaleToMm: number,
+  itemExpressId: number,
+  diagnostics: ValidationIssue[]
+): GeometryResult {
   if (mesh === null || mesh.indices.length === 0) {
     diagnostics.push(
       issue(
         'warning',
         'GEOMETRY_RECONSTRUCTION_FAILED',
         'Tessellated geometry yielded no triangles',
-        productExpressId
+        itemExpressId
       )
     );
     return NONE;
   }
 
-  // web-ifc emits geometry in metres; the parametric path works in mm.
-  const solid = sewMeshToSolid(mesh, 1000, productExpressId, diagnostics);
+  const stl = packBinaryStl(mesh.vertices, mesh.indices, scaleToMm);
+  let solid = sewMeshToSolid(mesh, scaleToMm, itemExpressId, diagnostics);
+  try {
+    // getKernel().importSTL returns the kernel's KernelShape (typed `any` at the
+    // WASM boundary); castShape brands it back into a brepjs handle.
+    if (solid === null) {
+      const cast = castFreshResult(getKernel().importSTL(new Uint8Array(stl).buffer));
+      if (isSolid(cast)) {
+        const valid = validSolid(cast);
+        if (valid.ok) solid = valid.value;
+        else cast[Symbol.dispose]();
+      } else {
+        const solids = getSolids(cast);
+        if (solids.length === 1 && solids[0] !== undefined) {
+          const copied = clone(solids[0]);
+          if (copied.ok) {
+            const valid = validSolid(copied.value);
+            if (valid.ok) solid = valid.value;
+            else copied.value[Symbol.dispose]();
+          }
+        }
+        cast[Symbol.dispose]();
+      }
+    }
+  } catch (e) {
+    diagnostics.push(
+      issue(
+        'info',
+        'TESSELLATION_NOT_MANIFOLD',
+        `STL round-trip failed: ${errMsg(e)}`,
+        itemExpressId
+      )
+    );
+  }
+
   if (solid !== null) {
+    try {
+      testHooks?.afterItemSolid?.(itemExpressId, solid);
+    } catch (cause) {
+      solid[Symbol.dispose]();
+      throw cause;
+    }
     diagnostics.push(
       issue(
         'info',
         'TESSELLATED_MANIFOLD',
-        'Tessellated mesh recovered as a closed solid by sewing its triangles',
-        productExpressId
+        'Tessellated mesh recovered as a closed solid',
+        itemExpressId
       )
     );
     return { kind: 'SOLID', solid, lossy: true };
@@ -332,7 +462,7 @@ function reconstructTessellated(
       'info',
       'TESSELLATION_NOT_MANIFOLD',
       'Tessellated mesh is not closed/manifold; returning raw triangle data (lossy)',
-      productExpressId
+      itemExpressId
     )
   );
   return {
@@ -348,16 +478,15 @@ interface MeshData {
   readonly indices: Uint32Array;
 }
 
-/** Kernel handles are `any` at the WASM boundary; the dispose contract is the honest shape. */
+/** Kernel handles are untyped at the WASM boundary; disposal is the stable contract. */
 type KernelHandle = Parameters<ReturnType<typeof getKernel>['dispose']>[0];
 
-/** Loose enough to weld float32 vertices web-ifc emits per face, in mm. */
+/** Loose enough to weld float32 vertices emitted per face, expressed in millimetres. */
 const MESH_SEW_TOLERANCE_MM = 1e-3;
 
 /**
  * Brands a fresh kernel result and releases its pre-downcast arena slot when
- * the cast moved to a new one (occt-wasm); in-place kernels share the slot and
- * are left alone. Mirrors brepjs's internal castResultShape.
+ * the cast moved to a new one. In-place kernels share the slot.
  */
 function castFreshResult(raw: unknown): ReturnType<typeof castShape> {
   const cast = castShape(raw);
@@ -369,15 +498,10 @@ function castFreshResult(raw: unknown): ReturnType<typeof castShape> {
   return cast;
 }
 
-/**
- * Sews the streamed triangles into a closed solid through the kernel's mesh
- * builder, the same path brepjs's mesh importers use. Null when the mesh is
- * open or the kernel rejects it.
- */
 function sewMeshToSolid(
   mesh: MeshData,
   scaleToMm: number,
-  productExpressId: number,
+  itemExpressId: number,
   diagnostics: ValidationIssue[]
 ): ValidSolid | null {
   const kernel = getKernel();
@@ -388,31 +512,29 @@ function sewMeshToSolid(
     (vertices[index * 3 + 2] ?? 0) * scaleToMm,
   ];
   const triangles: KernelHandle[] = [];
-  for (let t = 0; t + 2 < indices.length; t += 3) {
+  for (let index = 0; index + 2 < indices.length; index += 3) {
     const face: unknown = kernel.buildTriFace(
-      point(indices[t] ?? 0),
-      point(indices[t + 1] ?? 0),
-      point(indices[t + 2] ?? 0)
+      point(indices[index] ?? 0),
+      point(indices[index + 1] ?? 0),
+      point(indices[index + 2] ?? 0)
     );
     if (face !== null) triangles.push(face as KernelHandle);
   }
   if (triangles.length === 0) return null;
   try {
-    // sewAndSolidify copies the faces into a fresh solid, so the triangle
-    // slots are released in `finally` on every path.
     const sewn: unknown = kernel.sewAndSolidify(triangles, MESH_SEW_TOLERANCE_MM);
     const cast = castFreshResult(sewn);
     const valid = isSolid(cast) ? validSolid(cast) : null;
     if (valid !== null && valid.ok) return valid.value;
     cast[Symbol.dispose]();
     return null;
-  } catch (e) {
+  } catch (cause) {
     diagnostics.push(
       issue(
         'info',
         'TESSELLATION_NOT_MANIFOLD',
-        `Mesh sewing failed: ${errMsg(e)}`,
-        productExpressId
+        `Mesh sewing failed: ${errMsg(cause)}`,
+        itemExpressId
       )
     );
     return null;
@@ -421,53 +543,163 @@ function sewMeshToSolid(
   }
 }
 
-function collectMesh(reader: SpfReader, productExpressId: number): MeshData | null {
-  const vertices: number[] = [];
-  const indices: number[] = [];
-  let base = 0;
+interface MeshAccumulator {
+  readonly vertices: number[];
+  readonly indices: number[];
+}
 
+/** Streams a product once, then separates web-ifc geometry by Body item express ID. */
+function collectItemMeshes(
+  reader: SpfReader,
+  productExpressId: number,
+  itemExpressIds: ReadonlySet<number>
+): ReadonlyMap<number, MeshData> {
+  const byItem = new Map<number, MeshAccumulator>();
+  const soleItemExpressId = itemExpressIds.size === 1 ? [...itemExpressIds][0] : undefined;
   reader.streamMeshes([productExpressId], (flatMesh) => {
     try {
       const geometries = flatMesh.geometries;
-      for (let g = 0; g < geometries.size(); g++) {
-        const placed = geometries.get(g);
-        const geom = reader.getGeometry(placed.geometryExpressID);
+      for (let geometryIndex = 0; geometryIndex < geometries.size(); geometryIndex++) {
+        const placed = geometries.get(geometryIndex);
+        const itemExpressId = itemExpressIds.has(placed.geometryExpressID)
+          ? placed.geometryExpressID
+          : soleItemExpressId;
+        if (itemExpressId === undefined) continue;
+        const accumulator = byItem.get(itemExpressId) ?? { vertices: [], indices: [] };
+        byItem.set(itemExpressId, accumulator);
+        const geometry = reader.getGeometry(placed.geometryExpressID);
         try {
-          const verts = reader.getVertexArray(geom.GetVertexData(), geom.GetVertexDataSize());
-          const idx = reader.getIndexArray(geom.GetIndexData(), geom.GetIndexDataSize());
-          const m = placed.flatTransformation;
-          // web-ifc vertex stride is 6 floats: position(3) + normal(3).
-          const vertexCount = verts.length / 6;
-          for (let v = 0; v < vertexCount; v++) {
-            const x = verts[v * 6] ?? 0;
-            const y = verts[v * 6 + 1] ?? 0;
-            const z = verts[v * 6 + 2] ?? 0;
-            // Apply the 4x4 column-major placement transform.
-            vertices.push(
-              (m[0] ?? 1) * x + (m[4] ?? 0) * y + (m[8] ?? 0) * z + (m[12] ?? 0),
-              (m[1] ?? 0) * x + (m[5] ?? 1) * y + (m[9] ?? 0) * z + (m[13] ?? 0),
-              (m[2] ?? 0) * x + (m[6] ?? 0) * y + (m[10] ?? 1) * z + (m[14] ?? 0)
+          const vertices = reader.getVertexArray(
+            geometry.GetVertexData(),
+            geometry.GetVertexDataSize()
+          );
+          const indices = reader.getIndexArray(
+            geometry.GetIndexData(),
+            geometry.GetIndexDataSize()
+          );
+          const transform = placed.flatTransformation;
+          const base = accumulator.vertices.length / 3;
+          const vertexCount = vertices.length / 6;
+          for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
+            const x = vertices[vertexIndex * 6] ?? 0;
+            const y = vertices[vertexIndex * 6 + 1] ?? 0;
+            const z = vertices[vertexIndex * 6 + 2] ?? 0;
+            accumulator.vertices.push(
+              (transform[0] ?? 1) * x +
+                (transform[4] ?? 0) * y +
+                (transform[8] ?? 0) * z +
+                (transform[12] ?? 0),
+              (transform[1] ?? 0) * x +
+                (transform[5] ?? 1) * y +
+                (transform[9] ?? 0) * z +
+                (transform[13] ?? 0),
+              (transform[2] ?? 0) * x +
+                (transform[6] ?? 0) * y +
+                (transform[10] ?? 1) * z +
+                (transform[14] ?? 0)
             );
           }
-          for (let i = 0; i < idx.length; i++) {
-            indices.push(base + (idx[i] ?? 0));
+          for (let index = 0; index < indices.length; index++) {
+            accumulator.indices.push(base + (indices[index] ?? 0));
           }
-          base += vertexCount;
         } finally {
-          geom.delete();
+          geometry.delete();
         }
       }
     } finally {
-      // web-ifc streams IfcFlatMesh as an embind value object: the nested
-      // geometries vector is the WASM-owned handle, and neither is guaranteed
-      // to expose delete().
       releaseEmbind(flatMesh.geometries);
       releaseEmbind(flatMesh);
     }
   });
 
-  if (vertices.length === 0) return null;
+  return new Map(
+    [...byItem].map(([itemExpressId, mesh]) => [
+      itemExpressId,
+      {
+        vertices: new Float32Array(mesh.vertices),
+        indices: new Uint32Array(mesh.indices),
+      },
+    ])
+  );
+}
+
+function readTriangulatedMesh(
+  rawPoints: unknown,
+  rawTriangles: unknown,
+  scale: number,
+  worldTransform: MatrixTransform | null
+): MeshData | null {
+  if (!Array.isArray(rawPoints) || !Array.isArray(rawTriangles)) return null;
+  const vertices: number[] = [];
+  const indices: number[] = [];
+  const lengthFactor = scale * 1000;
+  for (const rawPoint of rawPoints) {
+    if (!Array.isArray(rawPoint) || rawPoint.length < 3) return null;
+    const local: Vec3 = [
+      (readMeasure(rawPoint[0]) ?? 0) * lengthFactor,
+      (readMeasure(rawPoint[1]) ?? 0) * lengthFactor,
+      (readMeasure(rawPoint[2]) ?? 0) * lengthFactor,
+    ];
+    const placed = transformPoint(local, worldTransform);
+    vertices.push(placed[0], placed[1], placed[2]);
+  }
+  for (const rawTriangle of rawTriangles) {
+    if (!Array.isArray(rawTriangle) || rawTriangle.length < 3) return null;
+    indices.push(
+      (readMeasure(rawTriangle[0]) ?? 1) - 1,
+      (readMeasure(rawTriangle[1]) ?? 1) - 1,
+      (readMeasure(rawTriangle[2]) ?? 1) - 1
+    );
+  }
   return { vertices: new Float32Array(vertices), indices: new Uint32Array(indices) };
+}
+
+function transformPoint(point: Vec3, transform: MatrixTransform | null): Vec3 {
+  if (transform === null) return point;
+  const m = transform.linear;
+  return [
+    (m[0] ?? 1) * point[0] +
+      (m[1] ?? 0) * point[1] +
+      (m[2] ?? 0) * point[2] +
+      transform.translation[0],
+    (m[3] ?? 0) * point[0] +
+      (m[4] ?? 1) * point[1] +
+      (m[5] ?? 0) * point[2] +
+      transform.translation[1],
+    (m[6] ?? 0) * point[0] +
+      (m[7] ?? 0) * point[1] +
+      (m[8] ?? 1) * point[2] +
+      transform.translation[2],
+  ];
+}
+
+// Packs interleaved triangle data into a binary STL buffer. `scaleToMm` converts
+// the source units (metres) to millimetres so the imported solid matches the
+// parametric reconstruction's coordinate space.
+function packBinaryStl(
+  vertices: Float32Array,
+  indices: Uint32Array,
+  scaleToMm: number
+): Uint8Array {
+  const triCount = Math.floor(indices.length / 3);
+  const buffer = new ArrayBuffer(84 + triCount * 50);
+  const view = new DataView(buffer);
+  view.setUint32(80, triCount, true);
+
+  let offset = 84;
+  for (let t = 0; t < triCount; t++) {
+    // Normal left as zero; OCCT recomputes face normals on import.
+    offset += 12;
+    for (let c = 0; c < 3; c++) {
+      const vi = (indices[t * 3 + c] ?? 0) * 3;
+      view.setFloat32(offset, (vertices[vi] ?? 0) * scaleToMm, true);
+      view.setFloat32(offset + 4, (vertices[vi + 1] ?? 0) * scaleToMm, true);
+      view.setFloat32(offset + 8, (vertices[vi + 2] ?? 0) * scaleToMm, true);
+      offset += 12;
+    }
+    offset += 2; // attribute byte count
+  }
+  return new Uint8Array(buffer);
 }
 
 // ---------------------------------------------------------------------------
@@ -898,17 +1130,17 @@ function isIdentity(t: MatrixTransform): boolean {
 // Line / value extraction helpers
 // ---------------------------------------------------------------------------
 
-function findBodyItem(reader: SpfReader, representations: readonly IfcRef[]): number | undefined {
+function findBodyItems(reader: SpfReader, representations: readonly IfcRef[]): number[] | null {
   for (const repRef of representations) {
     const rep = reader.getLine<Record<string, unknown>>(repRef.value);
     if (rep === null) continue;
     const repId = readLabel(rep['RepresentationIdentifier']);
     if (repId !== 'Body') continue;
     const items = asRefArray(rep['Items']);
-    if (items === undefined || items.length === 0) continue;
-    return items[0]?.value;
+    if (items === undefined) return [];
+    return items.map((item) => item.value);
   }
-  return undefined;
+  return null;
 }
 
 function readPolylinePoints(
@@ -1034,12 +1266,8 @@ function readLabel(value: unknown): string | undefined {
   return undefined;
 }
 
-function isTessellatedType(type: number): boolean {
-  return (
-    type === WebIFC.IFCTRIANGULATEDFACESET ||
-    type === WebIFC.IFCPOLYGONALFACESET ||
-    type === WebIFC.IFCFACEBASEDSURFACEMODEL
-  );
+function isStreamedTessellatedType(type: number | undefined): boolean {
+  return type === WebIFC.IFCPOLYGONALFACESET || type === WebIFC.IFCFACEBASEDSURFACEMODEL;
 }
 
 function normalize(v: Vec3): Vec3 {

--- a/packages/brepjs-bim/src/import/importedModel.ts
+++ b/packages/brepjs-bim/src/import/importedModel.ts
@@ -6,12 +6,12 @@ import type { ImportedSchema } from './spfReader.js';
 export type { ImportedSchema } from './spfReader.js';
 
 /**
- * How faithfully a product's body geometry was reconstructed:
+ * How faithfully the least faithful retained Body item was reconstructed:
  * - `PARAMETRIC` — rebuilt losslessly from a swept solid (extrude/revolve).
  * - `TESSELLATED_MANIFOLD` — a tessellated mesh was recovered as a closed solid
  *   by sewing its triangles; geometrically faithful but topology was re-derived.
- * - `TESSELLATED_LOSSY` — geometry exists only as raw triangles (mesh did not
- *   close into a solid); `solid` is null, `meshVertices`/`meshIndices` carry it.
+ * - `TESSELLATED_LOSSY` — at least one item exists only as raw triangles because
+ *   its mesh did not close into a solid. More faithful siblings may remain in `solids`.
  * - `NONE` — no recognised body representation was found.
  */
 export type GeometryFidelity = 'PARAMETRIC' | 'TESSELLATED_MANIFOLD' | 'TESSELLATED_LOSSY' | 'NONE';
@@ -25,13 +25,13 @@ export interface ImportedGeometry {
   readonly solids: readonly ValidSolid[];
   /** Borrowed alias for a COMPLETE one-solid Body. Otherwise null. */
   readonly solid: ValidSolid | null;
-  /** Component-wise union of all item bounds for a COMPLETE Body. Otherwise null. */
+  /** Component-wise union of all item bounds for a COMPLETE Body. Null if measurement fails. */
   readonly bounds: Bounds3D | null;
-  /** Sum of item volumes in mm³ for a COMPLETE Body. Otherwise null. */
+  /** Sum of item volumes in mm³ for a COMPLETE Body. Null if measurement fails. */
   readonly volumeMm3: number | null;
-  /** Raw triangle vertices (interleaved xyz), present only for `TESSELLATED_LOSSY`. */
+  /** Combined raw triangle vertices (interleaved xyz), present for `TESSELLATED_LOSSY`. */
   readonly meshVertices?: Float32Array | undefined;
-  /** Raw triangle indices, present only for `TESSELLATED_LOSSY`. */
+  /** Combined raw triangle indices, present for `TESSELLATED_LOSSY`. */
   readonly meshIndices?: Uint32Array | undefined;
 }
 

--- a/packages/brepjs-bim/src/import/importedModel.ts
+++ b/packages/brepjs-bim/src/import/importedModel.ts
@@ -1,4 +1,4 @@
-import type { ValidSolid } from 'brepjs';
+import type { Bounds3D, ValidSolid } from 'brepjs';
 import type { ValidationReport } from '../validation/severity.js';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import type { ImportedSchema } from './spfReader.js';
@@ -9,17 +9,26 @@ export type { ImportedSchema } from './spfReader.js';
  * How faithfully a product's body geometry was reconstructed:
  * - `PARAMETRIC` — rebuilt losslessly from a swept solid (extrude/revolve).
  * - `TESSELLATED_MANIFOLD` — a tessellated mesh was recovered as a closed solid
- *   via an STL round-trip; geometrically faithful but topology was re-derived.
+ *   by sewing its triangles; geometrically faithful but topology was re-derived.
  * - `TESSELLATED_LOSSY` — geometry exists only as raw triangles (mesh did not
  *   close into a solid); `solid` is null, `meshVertices`/`meshIndices` carry it.
  * - `NONE` — no recognised body representation was found.
  */
 export type GeometryFidelity = 'PARAMETRIC' | 'TESSELLATED_MANIFOLD' | 'TESSELLATED_LOSSY' | 'NONE';
+export type ImportedBodyCompleteness = 'COMPLETE' | 'PARTIAL' | 'NONE';
 
 export interface ImportedGeometry {
   readonly fidelity: GeometryFidelity;
-  /** The reconstructed solid; null when fidelity is `NONE` or `TESSELLATED_LOSSY`. */
+  /** Whether every IFC Body item reconstructed into an owned solid. */
+  readonly completeness: ImportedBodyCompleteness;
+  /** Owned World-placed reconstructed handles. Dispose them through disposeImportedModel(). */
+  readonly solids: readonly ValidSolid[];
+  /** Borrowed alias for a COMPLETE one-solid Body. Otherwise null. */
   readonly solid: ValidSolid | null;
+  /** Component-wise union of all item bounds for a COMPLETE Body. Otherwise null. */
+  readonly bounds: Bounds3D | null;
+  /** Sum of item volumes in mm³ for a COMPLETE Body. Otherwise null. */
+  readonly volumeMm3: number | null;
   /** Raw triangle vertices (interleaved xyz), present only for `TESSELLATED_LOSSY`. */
   readonly meshVertices?: Float32Array | undefined;
   /** Raw triangle indices, present only for `TESSELLATED_LOSSY`. */
@@ -110,7 +119,7 @@ export interface ImportedSpatialNode {
  */
 export function disposeImportedModel(model: ImportedModel): void {
   for (const el of model.elements) {
-    el.geometry.solid?.[Symbol.dispose]();
+    for (const solid of el.geometry.solids) solid[Symbol.dispose]();
   }
 }
 

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -208,6 +208,7 @@ export type {
   ImportedElement,
   ImportedElementCategory,
   ImportedGeometry,
+  ImportedBodyCompleteness,
   GeometryFidelity,
   ImportedPset,
   ImportedMaterial,

--- a/packages/brepjs-bim/tests/importedBodyItems.test.ts
+++ b/packages/brepjs-bim/tests/importedBodyItems.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import * as WebIFC from 'web-ifc';
-import { getBounds } from 'brepjs';
+import { getBounds, measureVolume } from 'brepjs';
 import { initKernel } from '../../../tests/setup.js';
 import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
 import { writeWallEntity } from '../src/ifc-writer/entityWriter.js';
-import { writeAxis2Placement3D, writeHeader } from '../src/ifc-writer/headerWriter.js';
+import {
+  writeAxis2Placement3D,
+  writeDirection,
+  writeHeader,
+} from '../src/ifc-writer/headerWriter.js';
 import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
+import { writeOpeningGeometry, writeRelVoidsElement } from '../src/ifc-writer/openingWriter.js';
 import { fromIfc, setFromIfcTestHooksForTesting } from '../src/import/fromIfc.js';
 import { setGeometryReadTestHooksForTesting } from '../src/import/geometryRead.js';
 import { disposeImportedModel } from '../src/import/importedModel.js';
@@ -25,43 +30,103 @@ describe('imported Body completeness and ownership', () => {
     const imported = await fromIfc(await bodyFixture({ polygonalCubes: 1 }));
     expect(imported.ok).toBe(true);
     if (!imported.ok) return;
-    const wall = imported.value.elements.find((element) => element.category === 'WALL');
-    expect(wall?.geometry.completeness).toBe('COMPLETE');
-    expect(wall?.geometry.solids).toHaveLength(1);
-    expect(wall?.geometry.solid).toBe(wall?.geometry.solids[0]);
-    expect((wall?.geometry.volumeMm3 ?? 0) / 1_000_000).toBeCloseTo(1, 5);
-    disposeImportedModel(imported.value);
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.completeness).toBe('COMPLETE');
+      expect(wall?.geometry.solids).toHaveLength(1);
+      expect(wall?.geometry.solid).toBe(wall?.geometry.solids[0]);
+      expect((wall?.geometry.volumeMm3 ?? 0) / 1_000_000).toBeCloseTo(1, 5);
+    } finally {
+      disposeImportedModel(imported.value);
+    }
   });
 
   it('owns every item in a COMPLETE multi-item World-placed Body', async () => {
     const imported = await fromIfc(await bodyFixture({ polygonalCubes: 2 }));
     expect(imported.ok).toBe(true);
     if (!imported.ok) return;
-    const wall = imported.value.elements.find((element) => element.category === 'WALL');
-    expect(wall?.geometry.completeness).toBe('COMPLETE');
-    expect(wall?.geometry.solids).toHaveLength(2);
-    expect(wall?.geometry.solid).toBeNull();
-    const bounds = wall?.geometry.solids.map(getBounds) ?? [];
-    expect(bounds[0]?.xMin).toBeCloseTo(1_000, 2);
-    expect(bounds[0]?.yMin).toBeCloseTo(2_000, 2);
-    expect(bounds[0]?.zMin).toBeCloseTo(3_000, 2);
-    expect(bounds[1]?.xMin).toBeCloseTo(1_200, 2);
-    expect((wall?.geometry.volumeMm3 ?? 0) / 1_125_000).toBeCloseTo(1, 5);
-    expect(wall?.geometry.bounds?.xMin).toBeCloseTo(1_000, 2);
-    expect(wall?.geometry.bounds?.xMax).toBeCloseTo(1_250, 2);
-    expect(wall?.geometry.bounds?.yMin).toBeCloseTo(2_000, 2);
-    expect(wall?.geometry.bounds?.yMax).toBeCloseTo(2_100, 2);
-    expect(wall?.geometry.bounds?.zMin).toBeCloseTo(3_000, 2);
-    expect(wall?.geometry.bounds?.zMax).toBeCloseTo(3_100, 2);
+    const disposals: number[] = [];
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.completeness).toBe('COMPLETE');
+      expect(wall?.geometry.solids).toHaveLength(2);
+      expect(wall?.geometry.solid).toBeNull();
+      const bounds = wall?.geometry.solids.map(getBounds) ?? [];
+      expect(bounds[0]?.xMin).toBeCloseTo(1_000, 2);
+      expect(bounds[0]?.yMin).toBeCloseTo(2_000, 2);
+      expect(bounds[0]?.zMin).toBeCloseTo(3_000, 2);
+      expect(bounds[1]?.xMin).toBeCloseTo(1_200, 2);
+      expect((wall?.geometry.volumeMm3 ?? 0) / 1_125_000).toBeCloseTo(1, 5);
+      expect(wall?.geometry.bounds?.xMin).toBeCloseTo(1_000, 2);
+      expect(wall?.geometry.bounds?.xMax).toBeCloseTo(1_250, 2);
+      expect(wall?.geometry.bounds?.yMin).toBeCloseTo(2_000, 2);
+      expect(wall?.geometry.bounds?.yMax).toBeCloseTo(2_100, 2);
+      expect(wall?.geometry.bounds?.zMin).toBeCloseTo(3_000, 2);
+      expect(wall?.geometry.bounds?.zMax).toBeCloseTo(3_100, 2);
 
-    const disposals = wall?.geometry.solids.map(() => 0) ?? [];
-    wall?.geometry.solids.forEach((solid, index) => {
-      solid.onDispose(() => {
-        disposals[index] = (disposals[index] ?? 0) + 1;
+      disposals.push(...(wall?.geometry.solids.map(() => 0) ?? []));
+      wall?.geometry.solids.forEach((solid, index) => {
+        solid.onDispose(() => {
+          disposals[index] = (disposals[index] ?? 0) + 1;
+        });
       });
-    });
-    disposeImportedModel(imported.value);
+    } finally {
+      disposeImportedModel(imported.value);
+    }
     expect(disposals).toEqual([1, 1]);
+  });
+
+  it('cuts openings from every solid in a COMPLETE multi-item Body', async () => {
+    const imported = await fromIfc(await bodyFixture({ extrudedCubes: 2, withOpening: true }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.fidelity).toBe('PARAMETRIC');
+      expect(wall?.geometry.completeness).toBe('COMPLETE');
+      expect(wall?.geometry.solids).toHaveLength(2);
+      expect(wall?.geometry.solid).toBeNull();
+      const volumes =
+        wall?.geometry.solids.map((solid) => {
+          const volume = measureVolume(solid);
+          if (!volume.ok) throw new Error(volume.error.message);
+          return volume.value;
+        }) ?? [];
+      expect(volumes[0]).toBeCloseTo(750_000, 2);
+      expect(volumes[1]).toBeCloseTo(62_500, 2);
+      expect(wall?.geometry.volumeMm3).toBeCloseTo(812_500, 2);
+    } finally {
+      disposeImportedModel(imported.value);
+    }
+  });
+
+  it('combines every lossy mesh item into the raw mesh aggregate', async () => {
+    const imported = await fromIfc(await bodyFixture({ openTriangles: 2 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.fidelity).toBe('TESSELLATED_LOSSY');
+      expect(wall?.geometry.meshVertices).toHaveLength(18);
+      expect(wall?.geometry.meshIndices).toEqual(new Uint32Array([0, 1, 2, 3, 4, 5]));
+    } finally {
+      disposeImportedModel(imported.value);
+    }
+  });
+
+  it('reports the least faithful item for a mixed PARTIAL Body', async () => {
+    const imported = await fromIfc(await bodyFixture({ extrudedCubes: 1, openTriangles: 1 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.fidelity).toBe('TESSELLATED_LOSSY');
+      expect(wall?.geometry.completeness).toBe('PARTIAL');
+      expect(wall?.geometry.solids).toHaveLength(1);
+      expect(wall?.geometry.meshVertices).toHaveLength(9);
+    } finally {
+      disposeImportedModel(imported.value);
+    }
   });
 
   it('imports multiple polygonal Body items with one product mesh stream', async () => {
@@ -107,16 +172,19 @@ describe('imported Body completeness and ownership', () => {
     const imported = await fromIfc(await bodyFixture({ unsupportedItems: 1 }));
     expect(imported.ok).toBe(true);
     if (!imported.ok) return;
-    const wall = imported.value.elements.find((element) => element.category === 'WALL');
-    expect(wall?.geometry.completeness).toBe('NONE');
-    expect(wall?.geometry.solids).toEqual([]);
-    expect(wall?.geometry.solid).toBeNull();
-    expect(wall?.geometry.bounds).toBeNull();
-    expect(wall?.geometry.volumeMm3).toBeNull();
-    expect(imported.value.diagnostics.issues.map((diagnostic) => diagnostic.code)).toContain(
-      'BODY_RECONSTRUCTION_NONE'
-    );
-    disposeImportedModel(imported.value);
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.completeness).toBe('NONE');
+      expect(wall?.geometry.solids).toEqual([]);
+      expect(wall?.geometry.solid).toBeNull();
+      expect(wall?.geometry.bounds).toBeNull();
+      expect(wall?.geometry.volumeMm3).toBeNull();
+      expect(imported.value.diagnostics.issues.map((diagnostic) => diagnostic.code)).toContain(
+        'BODY_RECONSTRUCTION_NONE'
+      );
+    } finally {
+      disposeImportedModel(imported.value);
+    }
   });
 
   it('disposes a later item intermediate while retaining an earlier sibling', async () => {
@@ -135,11 +203,14 @@ describe('imported Body completeness and ownership', () => {
     const imported = await fromIfc(await bodyFixture({ polygonalCubes: 2 }));
     expect(imported.ok).toBe(true);
     if (!imported.ok) return;
-    const wall = imported.value.elements.find((element) => element.category === 'WALL');
-    expect(wall?.geometry.completeness).toBe('PARTIAL');
-    expect(wall?.geometry.solids).toHaveLength(1);
-    expect(disposals).toEqual([0, 1]);
-    disposeImportedModel(imported.value);
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.completeness).toBe('PARTIAL');
+      expect(wall?.geometry.solids).toHaveLength(1);
+      expect(disposals).toEqual([0, 1]);
+    } finally {
+      disposeImportedModel(imported.value);
+    }
     expect(disposals).toEqual([1, 1]);
   });
 
@@ -175,8 +246,11 @@ describe('imported Body completeness and ownership', () => {
 });
 
 interface BodyFixtureOptions {
+  readonly extrudedCubes?: number | undefined;
+  readonly openTriangles?: number | undefined;
   readonly polygonalCubes?: number | undefined;
   readonly unsupportedItems?: number | undefined;
+  readonly withOpening?: boolean | undefined;
 }
 
 async function bodyFixture(options: BodyFixtureOptions): Promise<Uint8Array> {
@@ -195,6 +269,12 @@ async function bodyFixture(options: BodyFixtureOptions): Promise<Uint8Array> {
   });
 
   const itemIds: number[] = [];
+  for (let index = 0; index < (options.extrudedCubes ?? 0); index++) {
+    itemIds.push(writeExtrudedCube(writer, index));
+  }
+  for (let index = 0; index < (options.openTriangles ?? 0); index++) {
+    itemIds.push(writeOpenTriangle(writer, index));
+  }
   for (let index = 0; index < (options.polygonalCubes ?? 0); index++) {
     itemIds.push(writePolygonalCube(writer, index));
   }
@@ -229,7 +309,7 @@ async function bodyFixture(options: BodyFixtureOptions): Promise<Uint8Array> {
     Description: null,
     Representations: [writer.ref(shapeRepresentationId)],
   });
-  writeWallEntity(
+  const wallEntityId = writeWallEntity(
     writer,
     deriveIfcGuidSync('imported-body-items-fixture'),
     'Imported Body items wall',
@@ -237,9 +317,112 @@ async function bodyFixture(options: BodyFixtureOptions): Promise<Uint8Array> {
     localPlacementId,
     productDefinitionShapeId
   );
+  if (options.withOpening === true) {
+    const { openingEntityId } = writeOpeningGeometry(
+      writer,
+      deriveIfcGuidSync('imported-body-items-opening'),
+      {
+        kind: 'WALL_OPENING',
+        width: 175,
+        height: 50,
+        offsetAlongWall: 50,
+        offsetFromFloor: 0,
+      },
+      {
+        length: 250,
+        height: 100,
+        thickness: 100,
+        origin: [1_000, 2_000, 3_000],
+        axisX: [1, 0, 0],
+        axisZ: [0, 0, 1],
+        materialName: 'Test',
+      },
+      localPlacementId,
+      geomSubContextId,
+      ownerHistoryId
+    );
+    writeRelVoidsElement(
+      writer,
+      deriveIfcGuidSync('imported-body-items-void-relation'),
+      ownerHistoryId,
+      wallEntityId,
+      openingEntityId
+    );
+  }
   const saved = writer.save();
   if (!saved.ok) throw new Error(saved.error.message);
   return saved.value;
+}
+
+function writeExtrudedCube(writer: IfcWriter, index: number): number {
+  const size = index === 0 ? 0.1 : 0.05;
+  const x = index === 0 ? 0 : 0.2;
+  const profilePositionId = writeAxis2Placement2D(writer, [size / 2, size / 2]);
+  const profileId = writer.nextId();
+  writer.writeLine({
+    expressID: profileId,
+    type: WebIFC.IFCRECTANGLEPROFILEDEF,
+    ProfileType: { type: 3, value: 'AREA' },
+    ProfileName: null,
+    Position: writer.ref(profilePositionId),
+    XDim: writer.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, size),
+    YDim: writer.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, size),
+  });
+  const positionId = writeAxis2Placement3D(writer, [x, 0, 0]);
+  const directionId = writeDirection(writer, [0, 0, 1]);
+  const extrusionId = writer.nextId();
+  writer.writeLine({
+    expressID: extrusionId,
+    type: WebIFC.IFCEXTRUDEDAREASOLID,
+    SweptArea: writer.ref(profileId),
+    Position: writer.ref(positionId),
+    ExtrudedDirection: writer.ref(directionId),
+    Depth: writer.mkType(WebIFC.IFCPOSITIVELENGTHMEASURE, size),
+  });
+  return extrusionId;
+}
+
+function writeOpenTriangle(writer: IfcWriter, index: number): number {
+  const x = index * 0.2;
+  const pointListId = writer.nextId();
+  writer.writeLine({
+    expressID: pointListId,
+    type: WebIFC.IFCCARTESIANPOINTLIST3D,
+    CoordList: [
+      [x, 0, 0],
+      [x + 0.1, 0, 0],
+      [x, 0.1, 0],
+    ].map((point) => point.map((coordinate) => writer.mkType(WebIFC.IFCLENGTHMEASURE, coordinate))),
+    TagList: null,
+  });
+  const faceSetId = writer.nextId();
+  writer.writeLine({
+    expressID: faceSetId,
+    type: WebIFC.IFCTRIANGULATEDFACESET,
+    Coordinates: writer.ref(pointListId),
+    Normals: null,
+    Closed: writer.mkType(WebIFC.IFCBOOLEAN, false),
+    CoordIndex: [[1, 2, 3].map((value) => writer.mkType(WebIFC.IFCPOSITIVEINTEGER, value))],
+    PnIndex: null,
+  });
+  return faceSetId;
+}
+
+function writeAxis2Placement2D(writer: IfcWriter, location: readonly [number, number]): number {
+  const pointId = writer.nextId();
+  writer.writeLine({
+    expressID: pointId,
+    type: WebIFC.IFCCARTESIANPOINT,
+    Coordinates: location.map((coordinate) => writer.mkType(WebIFC.IFCLENGTHMEASURE, coordinate)),
+  });
+  const placementId = writer.nextId();
+  writer.writeLine({
+    expressID: placementId,
+    type: WebIFC.IFCAXIS2PLACEMENT2D,
+    Location: writer.ref(pointId),
+    RefDirection: null,
+  });
+  return placementId;
 }
 
 function writePolygonalCube(writer: IfcWriter, index: number): number {

--- a/packages/brepjs-bim/tests/importedBodyItems.test.ts
+++ b/packages/brepjs-bim/tests/importedBodyItems.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import * as WebIFC from 'web-ifc';
+import { getBounds } from 'brepjs';
+import { initKernel } from '../../../tests/setup.js';
+import { deriveIfcGuidSync } from '../src/identity/guidDerivation.js';
+import { writeWallEntity } from '../src/ifc-writer/entityWriter.js';
+import { writeAxis2Placement3D, writeHeader } from '../src/ifc-writer/headerWriter.js';
+import { IfcWriter } from '../src/ifc-writer/ifcWriter.js';
+import { fromIfc, setFromIfcTestHooksForTesting } from '../src/import/fromIfc.js';
+import { setGeometryReadTestHooksForTesting } from '../src/import/geometryRead.js';
+import { disposeImportedModel } from '../src/import/importedModel.js';
+import { SpfReader } from '../src/import/spfReader.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30_000);
+
+afterEach(() => {
+  setGeometryReadTestHooksForTesting(null);
+  setFromIfcTestHooksForTesting(null);
+});
+
+describe('imported Body completeness and ownership', () => {
+  it('keeps .solid as a borrowed alias for a COMPLETE one-solid Body', async () => {
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 1 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    const wall = imported.value.elements.find((element) => element.category === 'WALL');
+    expect(wall?.geometry.completeness).toBe('COMPLETE');
+    expect(wall?.geometry.solids).toHaveLength(1);
+    expect(wall?.geometry.solid).toBe(wall?.geometry.solids[0]);
+    expect((wall?.geometry.volumeMm3 ?? 0) / 1_000_000).toBeCloseTo(1, 5);
+    disposeImportedModel(imported.value);
+  });
+
+  it('owns every item in a COMPLETE multi-item World-placed Body', async () => {
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 2 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    const wall = imported.value.elements.find((element) => element.category === 'WALL');
+    expect(wall?.geometry.completeness).toBe('COMPLETE');
+    expect(wall?.geometry.solids).toHaveLength(2);
+    expect(wall?.geometry.solid).toBeNull();
+    const bounds = wall?.geometry.solids.map(getBounds) ?? [];
+    expect(bounds[0]?.xMin).toBeCloseTo(1_000, 2);
+    expect(bounds[0]?.yMin).toBeCloseTo(2_000, 2);
+    expect(bounds[0]?.zMin).toBeCloseTo(3_000, 2);
+    expect(bounds[1]?.xMin).toBeCloseTo(1_200, 2);
+    expect((wall?.geometry.volumeMm3 ?? 0) / 1_125_000).toBeCloseTo(1, 5);
+    expect(wall?.geometry.bounds?.xMin).toBeCloseTo(1_000, 2);
+    expect(wall?.geometry.bounds?.xMax).toBeCloseTo(1_250, 2);
+    expect(wall?.geometry.bounds?.yMin).toBeCloseTo(2_000, 2);
+    expect(wall?.geometry.bounds?.yMax).toBeCloseTo(2_100, 2);
+    expect(wall?.geometry.bounds?.zMin).toBeCloseTo(3_000, 2);
+    expect(wall?.geometry.bounds?.zMax).toBeCloseTo(3_100, 2);
+
+    const disposals = wall?.geometry.solids.map(() => 0) ?? [];
+    wall?.geometry.solids.forEach((solid, index) => {
+      solid.onDispose(() => {
+        disposals[index] = (disposals[index] ?? 0) + 1;
+      });
+    });
+    disposeImportedModel(imported.value);
+    expect(disposals).toEqual([1, 1]);
+  });
+
+  it('imports multiple polygonal Body items with one product mesh stream', async () => {
+    const streamMeshes = vi.spyOn(SpfReader.prototype, 'streamMeshes');
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 2 }));
+    try {
+      expect(imported.ok).toBe(true);
+      if (!imported.ok) return;
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.completeness).toBe('COMPLETE');
+      expect(wall?.geometry.solids).toHaveLength(2);
+      expect(wall?.geometry.solid).toBeNull();
+      expect((wall?.geometry.volumeMm3 ?? 0) / 1_125_000).toBeCloseTo(1, 5);
+      expect(wall?.geometry.bounds?.xMin).toBeCloseTo(1_000, 2);
+      expect(wall?.geometry.bounds?.xMax).toBeCloseTo(1_250, 2);
+      expect(streamMeshes).toHaveBeenCalledTimes(1);
+    } finally {
+      if (imported.ok) disposeImportedModel(imported.value);
+      streamMeshes.mockRestore();
+    }
+  });
+
+  it('retains supported siblings and item diagnostics for a PARTIAL Body', async () => {
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 1, unsupportedItems: 1 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    try {
+      const wall = imported.value.elements.find((element) => element.category === 'WALL');
+      expect(wall?.geometry.completeness).toBe('PARTIAL');
+      expect(wall?.geometry.solids).toHaveLength(1);
+      expect(wall?.geometry.solid).toBeNull();
+      expect(wall?.geometry.bounds).toBeNull();
+      expect(wall?.geometry.volumeMm3).toBeNull();
+      const codes = imported.value.diagnostics.issues.map((diagnostic) => diagnostic.code);
+      expect(codes).toContain('UNSUPPORTED_REPRESENTATION_ITEM');
+      expect(codes).toContain('PARTIAL_BODY_RECONSTRUCTION');
+    } finally {
+      disposeImportedModel(imported.value);
+    }
+  });
+
+  it('distinguishes an existing Body whose items all fail as NONE', async () => {
+    const imported = await fromIfc(await bodyFixture({ unsupportedItems: 1 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    const wall = imported.value.elements.find((element) => element.category === 'WALL');
+    expect(wall?.geometry.completeness).toBe('NONE');
+    expect(wall?.geometry.solids).toEqual([]);
+    expect(wall?.geometry.solid).toBeNull();
+    expect(wall?.geometry.bounds).toBeNull();
+    expect(wall?.geometry.volumeMm3).toBeNull();
+    expect(imported.value.diagnostics.issues.map((diagnostic) => diagnostic.code)).toContain(
+      'BODY_RECONSTRUCTION_NONE'
+    );
+    disposeImportedModel(imported.value);
+  });
+
+  it('disposes a later item intermediate while retaining an earlier sibling', async () => {
+    const disposals = [0, 0];
+    let itemIndex = 0;
+    setGeometryReadTestHooksForTesting({
+      afterItemSolid: (_expressId, solid) => {
+        const current = itemIndex++;
+        solid.onDispose(() => {
+          disposals[current] = (disposals[current] ?? 0) + 1;
+        });
+        if (current === 1) throw new Error('injected later item failure');
+      },
+    });
+
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 2 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    const wall = imported.value.elements.find((element) => element.category === 'WALL');
+    expect(wall?.geometry.completeness).toBe('PARTIAL');
+    expect(wall?.geometry.solids).toHaveLength(1);
+    expect(disposals).toEqual([0, 1]);
+    disposeImportedModel(imported.value);
+    expect(disposals).toEqual([1, 1]);
+  });
+
+  it('disposes reconstructed geometry when later element metadata throws', async () => {
+    let disposals = 0;
+    setFromIfcTestHooksForTesting({
+      afterGeometry: (_expressId, geometry) => {
+        geometry.solids[0]?.onDispose(() => disposals++);
+        throw new Error('injected metadata failure');
+      },
+    });
+
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 1 }));
+    expect(imported.ok).toBe(true);
+    if (!imported.ok) return;
+    expect(imported.value.elements).toHaveLength(0);
+    expect(disposals).toBe(1);
+  });
+
+  it('disposes accumulated element geometry on a fatal model-level failure', async () => {
+    let disposals = 0;
+    setFromIfcTestHooksForTesting({
+      afterElement: (element) => {
+        element.geometry.solids[0]?.onDispose(() => disposals++);
+        throw new Error('injected model failure');
+      },
+    });
+
+    const imported = await fromIfc(await bodyFixture({ polygonalCubes: 1 }));
+    expect(imported.ok).toBe(false);
+    expect(disposals).toBe(1);
+  });
+});
+
+interface BodyFixtureOptions {
+  readonly polygonalCubes?: number | undefined;
+  readonly unsupportedItems?: number | undefined;
+}
+
+async function bodyFixture(options: BodyFixtureOptions): Promise<Uint8Array> {
+  const writer = requiredWriter(await IfcWriter.create());
+  const { ownerHistoryId, geomSubContextId } = writeHeader(writer, {
+    applicationName: 'imported-body-items-test',
+    applicationVersion: '1',
+  });
+  const placement3DId = writeAxis2Placement3D(writer, [1, 2, 3]);
+  const localPlacementId = writer.nextId();
+  writer.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: null,
+    RelativePlacement: writer.ref(placement3DId),
+  });
+
+  const itemIds: number[] = [];
+  for (let index = 0; index < (options.polygonalCubes ?? 0); index++) {
+    itemIds.push(writePolygonalCube(writer, index));
+  }
+  for (let index = 0; index < (options.unsupportedItems ?? 0); index++) {
+    const unsupportedId = writer.nextId();
+    writer.writeLine({
+      expressID: unsupportedId,
+      type: WebIFC.IFCCARTESIANPOINT,
+      Coordinates: [
+        writer.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+        writer.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+        writer.mkType(WebIFC.IFCLENGTHMEASURE, 0),
+      ],
+    });
+    itemIds.push(unsupportedId);
+  }
+
+  const shapeRepresentationId = writer.nextId();
+  writer.writeLine({
+    expressID: shapeRepresentationId,
+    type: WebIFC.IFCSHAPEREPRESENTATION,
+    ContextOfItems: writer.ref(geomSubContextId),
+    RepresentationIdentifier: writer.mkType(WebIFC.IFCLABEL, 'Body'),
+    RepresentationType: writer.mkType(WebIFC.IFCLABEL, 'Tessellation'),
+    Items: itemIds.map((itemId) => writer.ref(itemId)),
+  });
+  const productDefinitionShapeId = writer.nextId();
+  writer.writeLine({
+    expressID: productDefinitionShapeId,
+    type: WebIFC.IFCPRODUCTDEFINITIONSHAPE,
+    Name: null,
+    Description: null,
+    Representations: [writer.ref(shapeRepresentationId)],
+  });
+  writeWallEntity(
+    writer,
+    deriveIfcGuidSync('imported-body-items-fixture'),
+    'Imported Body items wall',
+    ownerHistoryId,
+    localPlacementId,
+    productDefinitionShapeId
+  );
+  const saved = writer.save();
+  if (!saved.ok) throw new Error(saved.error.message);
+  return saved.value;
+}
+
+function writePolygonalCube(writer: IfcWriter, index: number): number {
+  const size = index === 0 ? 0.1 : 0.05;
+  const x = index === 0 ? 0 : 0.2;
+  const points = [
+    [x, 0, 0],
+    [x + size, 0, 0],
+    [x + size, size, 0],
+    [x, size, 0],
+    [x, 0, size],
+    [x + size, 0, size],
+    [x + size, size, size],
+    [x, size, size],
+  ] as const;
+  const pointListId = writer.nextId();
+  writer.writeLine({
+    expressID: pointListId,
+    type: WebIFC.IFCCARTESIANPOINTLIST3D,
+    CoordList: points.map((point) =>
+      point.map((coordinate) => writer.mkType(WebIFC.IFCLENGTHMEASURE, coordinate))
+    ),
+    TagList: null,
+  });
+  const faces = [
+    [1, 4, 3, 2],
+    [5, 6, 7, 8],
+    [1, 2, 6, 5],
+    [2, 3, 7, 6],
+    [3, 4, 8, 7],
+    [4, 1, 5, 8],
+  ] as const;
+  const faceIds = faces.map((face) => {
+    const faceId = writer.nextId();
+    writer.writeLine({
+      expressID: faceId,
+      type: WebIFC.IFCINDEXEDPOLYGONALFACE,
+      CoordIndex: face.map((coordinate) => writer.mkType(WebIFC.IFCPOSITIVEINTEGER, coordinate)),
+    });
+    return faceId;
+  });
+  const faceSetId = writer.nextId();
+  writer.writeLine({
+    expressID: faceSetId,
+    type: WebIFC.IFCPOLYGONALFACESET,
+    Coordinates: writer.ref(pointListId),
+    Closed: writer.mkType(WebIFC.IFCBOOLEAN, true),
+    Faces: faceIds.map((faceId) => writer.ref(faceId)),
+    PnIndex: null,
+  });
+  return faceSetId;
+}
+
+function requiredWriter(result: Awaited<ReturnType<typeof IfcWriter.create>>): IfcWriter {
+  if (!result.ok) throw new Error(result.error.message);
+  return result.value;
+}


### PR DESCRIPTION
## What does this PR do?

This PR removes the IFC importer's first-Body-item limitation.

- Reconstructs every supported item in an IFC Product Body, preserving representation order.
- Streams tessellated geometry once per Product rather than once per item.
- Exposes all owned reconstructed solids through `ImportedGeometry.solids`.
- Reports Body reconstruction as `COMPLETE`, `PARTIAL`, or `NONE`.
- Keeps `geometry.solid` as a compatibility alias only for complete, single-solid Bodies.
- Provides aggregate bounds and volume for complete Bodies.
- Retains supported items when another item fails and reports item-level diagnostics.
- Ensures all reconstructed geometry is disposed correctly on partial and fatal failures.

This is a prerequisite for #2272 but does not close the issue by itself.

## How to test

```bash
npm run typecheck --workspace=brepjs-bim
npm run lint --workspace=brepjs-bim
npm test --workspace=brepjs-bim
npm run check:boundaries
```

Verified locally:
- Full `brepjs-bim` suite: 73 test files, 717 tests passed.
- Multi-item importer regression suite: 8 tests passed.

## Checklist
- [x] Full `brepjs-bim` suite: 73 test files, 717 tests passed
- [x] Multi-item importer regression suite: 8 tests passed
- [x] Typecheck passed
- [x] Lint passed
- [x] Layer boundary check passed
