### PR TITLE
fix(bim)!: preserve authoritative exact Product Bodies

### DIFF
--- a/apps/docs/bim/elements.md
+++ b/apps/docs/bim/elements.md
@@ -47,7 +47,11 @@ On the brepjs side, `extendedProfileToFace` builds the section face for the soli
 
 ## Placement and display
 
-Element geometry is **unplaced template geometry**. A wall's solid starts at the local origin and runs along local +X regardless of where the wall stands; `origin` / `axisX` / `axisZ` live in the spec and become `IfcLocalPlacement`. `placedSolids(element)` returns fresh, caller-owned solids transformed by the element's own placement. For an element beneath a placed spatial structure, pass its cumulative frame as `placedSolids(element, { parentFrame })` to obtain world coordinates for display or clash checks. Most elements return one solid; stairs and ramps return one per flight, and curtain walls return their panels and mullions. Elements that are purely relational (doors, windows, groups, spatial containers) return an empty list rather than an error.
+Element geometry is **unplaced template geometry**. A wall's Body starts at the local origin and runs along local +X regardless of where the wall stands; `origin` / `axisX` / `axisZ` live in the spec and become `IfcLocalPlacement`. Wall and railing `.geometry` is a `ProductBody`: narrow `geometry.kind` to distinguish one `PARAMETRIC` solid from a non-empty `EXACT` solid collection. `bodySolids()` borrows Product-local handles from either branch. Do not dispose them.
+
+Use `takeExactProductBody()` to replace a parametric wall or railing Body. A successful call transfers ownership of every supplied solid to the model; a failed call leaves the model and caller ownership unchanged. Register wall openings first. Once a wall has an exact Body, later `addDoor()` and `addWindow()` calls return `EXACT_WALL_BODY_IMMUTABLE`.
+
+`placedSolids(element)` returns fresh, caller-owned solids transformed by the element's own placement. For an element beneath a placed spatial structure, pass its cumulative frame as `placedSolids(element, { parentFrame })` to obtain world coordinates for display or clash checks. Exact Product Bodies return one placed copy per Body item. Stairs and ramps return one per flight, and curtain walls return their panels and mullions. Elements that are purely relational (doors, windows, groups, spatial containers) return an empty list rather than an error.
 
 ## Data layers
 

--- a/apps/playground/src/types/brepjs-bim-ambient.d.ts
+++ b/apps/playground/src/types/brepjs-bim-ambient.d.ts
@@ -61,6 +61,20 @@ declare class BimModel {
   addRamp(spec: RampSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
   addRailing(spec: RailingSpec, options?: ElementIdentityOptions): Result<LocalId, BimError>;
   /**
+   * Atomically replaces a parametric wall or railing Body with authoritative,
+   * caller-owned exact solids. Success transfers every supplied handle to this
+   * model. Failure leaves both the model and all supplied handles unchanged.
+   */
+  takeExactProductBody(
+    localId: LocalId,
+    body: Extract<
+      ProductBody,
+      {
+        readonly kind: 'EXACT';
+      }
+    >
+  ): Result<void, BimError>;
+  /**
    * Adds an IfcCovering. When `hostLocalId` is supplied, an
    * IfcRelCoversBldgElements linking the covering to its host (e.g. a slab it
    * finishes) is recorded for export.
@@ -247,6 +261,21 @@ declare function placedSolids(
   el: AnyBimElement,
   options?: PlacedSolidsOptions
 ): Result<readonly ValidSolid[], BimError>;
+
+type NonEmpty<T> = readonly [T, ...T[]];
+
+type ProductBody =
+  | {
+      readonly kind: 'PARAMETRIC';
+      readonly solid: ValidSolid;
+    }
+  | {
+      readonly kind: 'EXACT';
+      readonly solids: NonEmpty<ValidSolid>;
+    };
+
+/** Returns borrowed Product-local solids. The model retains ownership. */
+declare function bodySolids(body: ProductBody): NonEmpty<ValidSolid>;
 
 /** An (origin, axisX, axisZ) frame in mm — the authoring/display side of a placement. */
 interface FrameInput {
@@ -1848,7 +1877,12 @@ interface BimError {
 
 declare function specError(code: string, message: string, cause?: unknown): BimError;
 
-declare function ifcError(code: string, message: string, cause?: unknown): BimError;
+declare function ifcError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Readonly<Record<string, unknown>>
+): BimError;
 
 declare function geometryError(code: string, message: string, cause?: unknown): BimError;
 

--- a/packages/brepjs-bim/README.md
+++ b/packages/brepjs-bim/README.md
@@ -25,14 +25,25 @@ the low-level path (and covers elements the declarative route doesn't yet). See 
 
 Parametric authoring of the common IFC4 building elements plus the data layers that make a model
 useful downstream (psets, classification, materials, quantities), with import, export, and
-validation. Geometry is produced by brepjs (OCCT); each element carries a `ValidSolid` (or, for
-curtain walls, a panel/mullion grid). Element geometry is **unplaced template geometry** in local
-coordinates — placement (`origin` / `axisX` / `axisZ`) is applied by the IFC layer via
-`IfcLocalPlacement`, not baked into the brepjs solid. Use `placedSolids(element)` to read fresh,
-caller-owned solids transformed by the element's own placement (stairs and ramps return one solid
-per flight, curtain walls their panels and mullions). When an element is beneath a placed spatial
-structure, pass its cumulative frame as `placedSolids(element, { parentFrame })` to obtain world
-coordinates. This is especially important for parent-local Proxy and Earthworks Fill bodies.
+validation. Geometry is produced by brepjs (OCCT). Walls and railings carry a `ProductBody`, either
+a parametric solid or a non-empty collection of authoritative exact solids. Use `bodySolids()` to
+borrow their Product-local model handles and narrow `geometry.kind` when a caller specifically
+needs the parametric branch. Other solid-bearing categories continue to expose their existing
+geometry types.
+
+`takeExactProductBody(localId, { kind: 'EXACT', solids })` installs an authoritative wall or
+railing Body atomically. Success transfers every supplied handle to the model and disposes the
+superseded parametric Body; failure transfers nothing. Add wall openings before takeover, because
+an exact wall rejects later `addDoor()` and `addWindow()` mutations.
+
+Element geometry is **unplaced template geometry** in local coordinates. Placement (`origin` /
+`axisX` / `axisZ`) is applied by the IFC layer via `IfcLocalPlacement`, not baked into the brepjs
+solid. Use `placedSolids(element)` to read fresh, caller-owned solids transformed by the element's
+own placement. Stairs and ramps return one solid per flight, curtain walls return their panels and
+mullions, and an exact Product Body returns one placed copy per Body item. When an element is
+beneath a placed spatial structure, pass its cumulative frame as
+`placedSolids(element, { parentFrame })` to obtain world coordinates. This is especially important
+for parent-local Proxy and Earthworks Fill bodies.
 
 IFC import reconstructs every supported Body item independently. `ImportedGeometry.solids` owns
 the resulting World-placed handles and `completeness` reports `COMPLETE`, `PARTIAL`, or `NONE`.

--- a/packages/brepjs-bim/src/elementFns/placedGeometry.ts
+++ b/packages/brepjs-bim/src/elementFns/placedGeometry.ts
@@ -1,23 +1,44 @@
-import { applyMatrix, ok, err } from 'brepjs';
+import { ok, err } from 'brepjs';
 import type { ValidSolid, Result } from 'brepjs';
 import type { AnyBimElement } from '../types/bimTypes.js';
 import type { BimError } from '../errors/bimError.js';
-import { fromBrepError } from '../errors/bimError.js';
-import { placementToMatrix, type FrameInput } from '../import/placement.js';
+import { geometryError } from '../errors/bimError.js';
+import type { FrameInput } from '../import/placement.js';
 import { stairFlightToSolid } from './stairFns.js';
 import { rampFlightToSolid } from './rampFns.js';
+import { bodySolids } from '../types/productBody.js';
+import { locateShapeInFrame } from '../rigidPlacement.js';
+
+export interface PlacedGeometryTestHooks {
+  readonly afterPlaced?: ((solid: ValidSolid) => void) | undefined;
+}
+
+let testHooks: PlacedGeometryTestHooks | null = null;
+
+/** Package-internal deterministic failure seam for placement ownership tests. */
+export function setPlacedGeometryTestHooksForTesting(hooks: PlacedGeometryTestHooks | null): void {
+  testHooks = hooks;
+}
 
 // Applies an (origin, axisX, axisZ) frame to a local solid, returning a fresh
 // caller-owned solid. Orthonormal frames use the validity-preserving transform
 // path, so the result is a ValidSolid.
 function place(solid: ValidSolid, frame: FrameInput): Result<ValidSolid, BimError> {
-  const result = applyMatrix(solid, placementToMatrix(frame));
-  if (!result.ok) {
+  let placed: ValidSolid | null = null;
+  try {
+    placed = locateShapeInFrame(solid, frame);
+    testHooks?.afterPlaced?.(placed);
+    return ok(placed);
+  } catch (cause) {
+    placed?.[Symbol.dispose]();
     return err(
-      fromBrepError(result.error, 'PLACED_GEOMETRY_FAILED', 'Failed to place element geometry')
+      geometryError(
+        'PLACED_GEOMETRY_FAILED',
+        'Element placement threw while transforming geometry',
+        cause
+      )
     );
   }
-  return ok(result.value);
 }
 
 function disposeAll(solids: readonly ValidSolid[]): void {
@@ -69,6 +90,18 @@ export function placedSolids(
   const parentFrame = options.parentFrame;
   switch (el.category) {
     case 'WALL':
+    case 'RAILING': {
+      const out: ValidSolid[] = [];
+      for (const solid of bodySolids(el.geometry)) {
+        const placed = placeWithinParent(solid, el.spec, parentFrame);
+        if (!placed.ok) {
+          disposeAll(out);
+          return placed;
+        }
+        out.push(placed.value);
+      }
+      return ok(out);
+    }
     case 'SLAB':
     case 'BEAM':
     case 'COLUMN':
@@ -76,8 +109,7 @@ export function placedSolids(
     case 'ROOF':
     case 'FOOTING':
     case 'PILE':
-    case 'COVERING':
-    case 'RAILING': {
+    case 'COVERING': {
       const placed = placeWithinParent(el.geometry, el.spec, parentFrame);
       if (!placed.ok) return placed;
       return ok([placed.value]);

--- a/packages/brepjs-bim/src/errors/bimError.ts
+++ b/packages/brepjs-bim/src/errors/bimError.ts
@@ -15,8 +15,19 @@ export function specError(code: string, message: string, cause?: unknown): BimEr
   return { kind: 'BIM_SPEC', code, message, cause };
 }
 
-export function ifcError(code: string, message: string, cause?: unknown): BimError {
-  return { kind: 'BIM_IFC', code, message, cause };
+export function ifcError(
+  code: string,
+  message: string,
+  cause?: unknown,
+  metadata?: Readonly<Record<string, unknown>>
+): BimError {
+  return {
+    kind: 'BIM_IFC',
+    code,
+    message,
+    cause,
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
 }
 
 export function geometryError(code: string, message: string, cause?: unknown): BimError {

--- a/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
@@ -9,6 +9,24 @@ import { initIfcApi } from '../ifcRuntime.js';
 import type { Result } from 'brepjs';
 import { ok, err } from 'brepjs';
 
+export interface IfcWriterApiForTesting {
+  WriteLine(modelId: number, entity: unknown): void;
+  CreateIfcType(modelId: number, type: number, value: unknown): Record<string, unknown>;
+  SaveModel(modelId: number): Uint8Array;
+  CloseModel(modelId: number): void;
+}
+
+export interface IfcWriterTestHooks {
+  readonly afterClose?: (() => void) | undefined;
+}
+
+let testHooks: IfcWriterTestHooks | null = null;
+
+/** Package-internal deterministic lifecycle observation seam. */
+export function setIfcWriterTestHooksForTesting(hooks: IfcWriterTestHooks | null): void {
+  testHooks = hooks;
+}
+
 /** Default MVD ViewDefinition declared in the STEP FILE_DESCRIPTION header. */
 export const DEFAULT_MVD_VIEW_DEFINITION = 'ReferenceView_v1.2';
 
@@ -54,7 +72,7 @@ function normalizeStepReals(bytes: Uint8Array): Uint8Array {
 }
 
 export class IfcWriter {
-  readonly #api: IfcAPI;
+  readonly #api: IfcWriterApiForTesting;
   readonly #modelId: number;
   readonly #mvdViewDefinition: string;
   readonly #author: string;
@@ -66,7 +84,7 @@ export class IfcWriter {
   #modelScope = '';
 
   private constructor(
-    api: IfcAPI,
+    api: IfcWriterApiForTesting,
     modelId: number,
     mvdViewDefinition: string,
     header: IfcHeaderMeta
@@ -93,6 +111,11 @@ export class IfcWriter {
     }
   }
 
+  /** Package-internal lifecycle seam for deterministic writer cleanup tests. */
+  static fromApiForTesting(api: IfcWriterApiForTesting, modelId = 0): IfcWriter {
+    return new IfcWriter(api, modelId, DEFAULT_MVD_VIEW_DEFINITION, {});
+  }
+
   nextId(): number {
     return this.#nextExpressId++;
   }
@@ -112,8 +135,7 @@ export class IfcWriter {
   }
 
   writeLine(entity: { expressID: number } & Record<string, unknown>): number {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- web-ifc WASM type gap
-    this.#api.WriteLine(this.#modelId, entity as any);
+    this.#api.WriteLine(this.#modelId, entity);
     return entity.expressID;
   }
 
@@ -125,8 +147,18 @@ export class IfcWriter {
   }
 
   mkType(type: number, value: unknown): Record<string, unknown> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- web-ifc WASM type gap
-    return this.#api.CreateIfcType(this.#modelId, type, value as any) as Record<string, unknown>;
+    return this.#api.CreateIfcType(this.#modelId, type, value);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#api.CloseModel(this.#modelId);
+    testHooks?.afterClose?.();
+  }
+
+  [Symbol.dispose](): void {
+    this.close();
   }
 
   save(): Result<Uint8Array, BimError> {
@@ -139,9 +171,9 @@ export class IfcWriter {
     } catch (e) {
       return err(ifcError('IFC_SAVE_FAILED', 'Failed to serialize IFC model', e));
     } finally {
-      // CloseModel always runs to prevent WASM handle leaks; a failed save is therefore terminal.
-      this.#api.CloseModel(this.#modelId);
-      this.#closed = true;
+      // A failed save is terminal, and close() remains safe when the surrounding
+      // using scope runs afterward.
+      this.close();
     }
   }
 

--- a/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/ifcWriter.ts
@@ -17,6 +17,7 @@ export interface IfcWriterApiForTesting {
 }
 
 export interface IfcWriterTestHooks {
+  readonly afterWriteLine?: (() => void) | undefined;
   readonly afterClose?: (() => void) | undefined;
 }
 
@@ -136,6 +137,7 @@ export class IfcWriter {
 
   writeLine(entity: { expressID: number } & Record<string, unknown>): number {
     this.#api.WriteLine(this.#modelId, entity);
+    testHooks?.afterWriteLine?.();
     return entity.expressID;
   }
 

--- a/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/psetWriter.ts
@@ -375,6 +375,27 @@ export function writeWallBaseQuantities(
   writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, qtoId);
 }
 
+export function writeExactWallBaseQuantities(
+  w: IfcWriter,
+  ownerHistoryId: number,
+  wallExpressId: number,
+  values: {
+    readonly lengthM: number;
+    readonly widthM: number;
+    readonly heightM: number;
+    readonly netVolumeM3: number;
+  }
+): void {
+  const qtyIds = [
+    writeQtyLength(w, 'Length', values.lengthM),
+    writeQtyLength(w, 'Width', values.widthM),
+    writeQtyLength(w, 'Height', values.heightM),
+    writeQtyVolume(w, 'NetVolume', values.netVolumeM3),
+  ];
+  const qtoId = writeElementQuantity(w, ownerHistoryId, 'Qto_WallBaseQuantities', qtyIds);
+  writeRelDefinesByProperties(w, ownerHistoryId, wallExpressId, qtoId);
+}
+
 export function writeSlabCommonPset(
   w: IfcWriter,
   ownerHistoryId: number,

--- a/packages/brepjs-bim/src/ifc-writer/tessellationWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/tessellationWriter.ts
@@ -5,6 +5,7 @@ import type { IfcWriter } from './ifcWriter.js';
 import { toIfcLengthM } from '../units/units.js';
 import { writeAxis2Placement3D } from './headerWriter.js';
 import type { FrameInput } from '../import/placement.js';
+import type { NonEmpty } from '../types/productBody.js';
 
 export interface TessellationResult {
   readonly productDefinitionShapeId: number;
@@ -125,7 +126,7 @@ export function writeTessellation(
 
 export function writePreparedTessellationBody(
   w: IfcWriter,
-  items: readonly PreparedTessellation[],
+  items: NonEmpty<PreparedTessellation>,
   geomSubContextId: number
 ): { readonly productDefinitionShapeId: number; readonly bodyItemIds: readonly number[] } {
   const bodyItemIds = items.map((item) => writePreparedTessellationItem(w, item));
@@ -153,7 +154,7 @@ export function writePreparedTessellationBody(
 export function writeExactBodyGeometry(
   w: IfcWriter,
   placement: FrameInput,
-  items: readonly PreparedTessellation[],
+  items: NonEmpty<PreparedTessellation>,
   geomSubContextId: number,
   parentPlacementId: number | null
 ): ExactBodyRepresentationIds {

--- a/packages/brepjs-bim/src/ifc-writer/tessellationWriter.ts
+++ b/packages/brepjs-bim/src/ifc-writer/tessellationWriter.ts
@@ -3,6 +3,8 @@ import { mesh } from 'brepjs';
 import type { ValidSolid } from 'brepjs';
 import type { IfcWriter } from './ifcWriter.js';
 import { toIfcLengthM } from '../units/units.js';
+import { writeAxis2Placement3D } from './headerWriter.js';
+import type { FrameInput } from '../import/placement.js';
 
 export interface TessellationResult {
   readonly productDefinitionShapeId: number;
@@ -22,6 +24,65 @@ export type TessellationOutput = TessellationResult | TessellationFallbackResult
 // validators do not require fine meshes; finer values bloat the SPF file.
 const IFC_MESH_TOLERANCE_MM = 5;
 const IFC_MESH_ANGULAR_TOLERANCE_RAD = 0.3;
+
+export interface PreparedTessellation {
+  readonly coordList: readonly (readonly [number, number, number])[];
+  readonly coordIndex: readonly (readonly [number, number, number])[];
+}
+
+export type TessellationPreparation =
+  | { readonly ok: true; readonly value: PreparedTessellation }
+  | { readonly ok: false; readonly reason: string; readonly cause?: unknown };
+
+export interface ExactBodyRepresentationIds {
+  readonly localPlacementId: number;
+  readonly productDefinitionShapeId: number;
+  readonly bodyItemIds: readonly number[];
+}
+
+export function prepareTessellation(
+  solid: ValidSolid,
+  toleranceMm: number = IFC_MESH_TOLERANCE_MM
+): TessellationPreparation {
+  let meshData;
+  try {
+    meshData = mesh(solid, {
+      tolerance: toleranceMm,
+      angularTolerance: IFC_MESH_ANGULAR_TOLERANCE_RAD,
+    });
+  } catch (cause) {
+    return {
+      ok: false,
+      reason: cause instanceof Error ? cause.message : String(cause),
+      cause,
+    };
+  }
+
+  const { vertices, triangles } = meshData;
+  if (vertices.length === 0 || triangles.length === 0) {
+    return { ok: false, reason: 'mesh() returned an empty triangle set' };
+  }
+
+  const coordList: Array<readonly [number, number, number]> = [];
+  for (let i = 0; i + 2 < vertices.length; i += 3) {
+    coordList.push([
+      toIfcLengthM(vertices[i] ?? 0),
+      toIfcLengthM(vertices[i + 1] ?? 0),
+      toIfcLengthM(vertices[i + 2] ?? 0),
+    ]);
+  }
+
+  const coordIndex: Array<readonly [number, number, number]> = [];
+  for (let i = 0; i + 2 < triangles.length; i += 3) {
+    coordIndex.push([
+      (triangles[i] ?? 0) + 1,
+      (triangles[i + 1] ?? 0) + 1,
+      (triangles[i + 2] ?? 0) + 1,
+    ]);
+  }
+
+  return { ok: true, value: { coordList, coordIndex } };
+}
 
 /**
  * Writes an IfcTriangulatedFaceSet (preferred IFC4 tessellation) from a brepjs
@@ -47,66 +108,27 @@ export function writeTessellation(
   _localPlacementId: number | null,
   toleranceMm: number = IFC_MESH_TOLERANCE_MM
 ): TessellationOutput {
-  let meshData;
-  try {
-    meshData = mesh(solid, {
-      tolerance: toleranceMm,
-      angularTolerance: IFC_MESH_ANGULAR_TOLERANCE_RAD,
-    });
-  } catch (e) {
-    const reason = e instanceof Error ? e.message : String(e);
+  const prepared = prepareTessellation(solid, toleranceMm);
+  if (!prepared.ok) {
+    const reason = prepared.reason;
     console.warn(`writeTessellation: mesh() failed, using IfcFacetedBrep fallback: ${reason}`);
     return writeFacetedBrepFallback(w, geomSubContextId, reason);
   }
+  const { productDefinitionShapeId } = writePreparedTessellationBody(
+    w,
+    [prepared.value],
+    geomSubContextId
+  );
 
-  const { vertices, triangles } = meshData;
-  if (vertices.length === 0 || triangles.length === 0) {
-    const reason = 'mesh() returned an empty triangle set';
-    console.warn(`writeTessellation: ${reason}, using IfcFacetedBrep fallback`);
-    return writeFacetedBrepFallback(w, geomSubContextId, reason);
-  }
+  return { productDefinitionShapeId, usedFallback: false };
+}
 
-  // Build the coordinate list (metres) as [x, y, z] triples. vertices is a
-  // flat Float32Array of interleaved positions in mm.
-  const coordList: number[][] = [];
-  for (let i = 0; i + 2 < vertices.length; i += 3) {
-    coordList.push([
-      toIfcLengthM(vertices[i] ?? 0),
-      toIfcLengthM(vertices[i + 1] ?? 0),
-      toIfcLengthM(vertices[i + 2] ?? 0),
-    ]);
-  }
-
-  const pointListId = w.nextId();
-  w.writeLine({
-    expressID: pointListId,
-    type: WebIFC.IFCCARTESIANPOINTLIST3D,
-    CoordList: coordList.map((pt) => pt.map((v) => w.mkType(WebIFC.IFCLENGTHMEASURE, v))),
-    TagList: null,
-  });
-
-  // Build 1-based 3-tuple coordinate indices directly from the Uint32Array to
-  // avoid an intermediate flat allocation. triangles holds 0-based vertex ids.
-  const coordIndex: number[][] = [];
-  for (let i = 0; i + 2 < triangles.length; i += 3) {
-    coordIndex.push([
-      (triangles[i] ?? 0) + 1,
-      (triangles[i + 1] ?? 0) + 1,
-      (triangles[i + 2] ?? 0) + 1,
-    ]);
-  }
-
-  const faceSetId = w.nextId();
-  w.writeLine({
-    expressID: faceSetId,
-    type: WebIFC.IFCTRIANGULATEDFACESET,
-    Coordinates: w.ref(pointListId),
-    Normals: null,
-    Closed: w.mkType(WebIFC.IFCBOOLEAN, true),
-    CoordIndex: coordIndex.map((tri) => tri.map((idx) => w.mkType(WebIFC.IFCPOSITIVEINTEGER, idx))),
-    PnIndex: null,
-  });
-
+export function writePreparedTessellationBody(
+  w: IfcWriter,
+  items: readonly PreparedTessellation[],
+  geomSubContextId: number
+): { readonly productDefinitionShapeId: number; readonly bodyItemIds: readonly number[] } {
+  const bodyItemIds = items.map((item) => writePreparedTessellationItem(w, item));
   const shapeRepId = w.nextId();
   w.writeLine({
     expressID: shapeRepId,
@@ -114,7 +136,7 @@ export function writeTessellation(
     ContextOfItems: w.ref(geomSubContextId),
     RepresentationIdentifier: w.mkType(WebIFC.IFCLABEL, 'Body'),
     RepresentationType: w.mkType(WebIFC.IFCLABEL, 'Tessellation'),
-    Items: [w.ref(faceSetId)],
+    Items: bodyItemIds.map((id) => w.ref(id)),
   });
 
   const productDefinitionShapeId = w.nextId();
@@ -125,8 +147,64 @@ export function writeTessellation(
     Description: null,
     Representations: [w.ref(shapeRepId)],
   });
+  return { productDefinitionShapeId, bodyItemIds };
+}
 
-  return { productDefinitionShapeId, usedFallback: false };
+export function writeExactBodyGeometry(
+  w: IfcWriter,
+  placement: FrameInput,
+  items: readonly PreparedTessellation[],
+  geomSubContextId: number,
+  parentPlacementId: number | null
+): ExactBodyRepresentationIds {
+  const placement3DId = writeAxis2Placement3D(
+    w,
+    [
+      toIfcLengthM(placement.origin[0]),
+      toIfcLengthM(placement.origin[1]),
+      toIfcLengthM(placement.origin[2]),
+    ],
+    [placement.axisZ[0], placement.axisZ[1], placement.axisZ[2]],
+    [placement.axisX[0], placement.axisX[1], placement.axisX[2]]
+  );
+  const localPlacementId = w.nextId();
+  w.writeLine({
+    expressID: localPlacementId,
+    type: WebIFC.IFCLOCALPLACEMENT,
+    PlacementRelTo: parentPlacementId === null ? null : w.ref(parentPlacementId),
+    RelativePlacement: w.ref(placement3DId),
+  });
+  const body = writePreparedTessellationBody(w, items, geomSubContextId);
+  return { localPlacementId, ...body };
+}
+
+export function writePreparedTessellationItem(
+  w: IfcWriter,
+  prepared: PreparedTessellation
+): number {
+  const pointListId = w.nextId();
+  w.writeLine({
+    expressID: pointListId,
+    type: WebIFC.IFCCARTESIANPOINTLIST3D,
+    CoordList: prepared.coordList.map((point) =>
+      point.map((value) => w.mkType(WebIFC.IFCLENGTHMEASURE, value))
+    ),
+    TagList: null,
+  });
+
+  const faceSetId = w.nextId();
+  w.writeLine({
+    expressID: faceSetId,
+    type: WebIFC.IFCTRIANGULATEDFACESET,
+    Coordinates: w.ref(pointListId),
+    Normals: null,
+    Closed: w.mkType(WebIFC.IFCBOOLEAN, true),
+    CoordIndex: prepared.coordIndex.map((triangle) =>
+      triangle.map((index) => w.mkType(WebIFC.IFCPOSITIVEINTEGER, index))
+    ),
+    PnIndex: null,
+  });
+  return faceSetId;
 }
 
 /**

--- a/packages/brepjs-bim/src/index.ts
+++ b/packages/brepjs-bim/src/index.ts
@@ -5,6 +5,8 @@ export {
 } from './model/bimModel.js';
 export type { BimTreeNode, BimTreeSummary } from './model/treeSummary.js';
 export { placedSolids } from './elementFns/placedGeometry.js';
+export { bodySolids } from './types/productBody.js';
+export type { NonEmpty, ProductBody } from './types/productBody.js';
 export type { PlacedSolidsOptions } from './elementFns/placedGeometry.js';
 export type { FrameInput } from './import/placement.js';
 export { toIfc, toIfcValidated } from './serialize/toIfc.js';

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -1,5 +1,5 @@
 import type { Result, ValidSolid } from 'brepjs';
-import { ok, err, cut } from 'brepjs';
+import { ok, err, cut, isValidSolid } from 'brepjs';
 import type { IfcGuid } from '../identity/ifcGuid.js';
 import { deriveIfcGuidSync, makeElementKey, makeRelKey } from '../identity/guidDerivation.js';
 import type { LocalId } from '../identity/localId.js';
@@ -66,6 +66,7 @@ import { curtainWallToGrid } from '../elementFns/curtainWallFns.js';
 import { footingToSolid, pileToSolid } from '../elementFns/foundationFns.js';
 import { railingToSolid } from '../elementFns/railingFns.js';
 import { coveringToSolid } from '../elementFns/coveringFns.js';
+import { disposeProductBody, type ProductBody } from '../types/productBody.js';
 
 /** Optional identity override for created elements: a stable key (e.g. a
  *  families key path) that replaces the positional GlobalId derivation. */
@@ -77,6 +78,15 @@ export interface ElementIdentityOptions {
  *  the filler (door/window), `openingStableKey` the synthesized opening. */
 export interface OpeningIdentityOptions extends ElementIdentityOptions {
   readonly openingStableKey?: string | undefined;
+}
+
+function exactWallBodyImmutable(): Result<never, BimError> {
+  return err(
+    specError(
+      'EXACT_WALL_BODY_IMMUTABLE',
+      'Cannot add an opening after a wall has taken an exact Product Body'
+    )
+  );
 }
 
 export class BimModel {
@@ -110,7 +120,6 @@ export class BimModel {
   [Symbol.dispose](): void {
     for (const el of this.#elements.values()) {
       if (
-        el.category === 'WALL' ||
         el.category === 'SLAB' ||
         el.category === 'BEAM' ||
         el.category === 'COLUMN' ||
@@ -120,10 +129,11 @@ export class BimModel {
         el.category === 'ROOF' ||
         el.category === 'FOOTING' ||
         el.category === 'PILE' ||
-        el.category === 'RAILING' ||
         el.category === 'COVERING'
       ) {
         el.geometry[Symbol.dispose]();
+      } else if (el.category === 'WALL' || el.category === 'RAILING') {
+        disposeProductBody(el.geometry);
       } else if (el.category === 'CURTAIN_WALL') {
         // Curtain wall geometry is a grid of component solids (panels + mullions).
         for (const panel of el.geometry.panels) panel.solid[Symbol.dispose]();
@@ -209,7 +219,12 @@ export class BimModel {
     if (!keyCheck.ok) return keyCheck;
     const geomResult = wallToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('WALL', spec, geomResult.value, options?.stableKey);
+    const id = this.#makeElement(
+      'WALL',
+      spec,
+      { kind: 'PARAMETRIC', solid: geomResult.value },
+      options?.stableKey
+    );
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);
@@ -338,10 +353,98 @@ export class BimModel {
     if (!keyCheck.ok) return keyCheck;
     const geomResult = railingToSolid(spec);
     if (!geomResult.ok) return err(geomResult.error);
-    const id = this.#makeElement('RAILING', spec, geomResult.value, options?.stableKey);
+    const id = this.#makeElement(
+      'RAILING',
+      spec,
+      { kind: 'PARAMETRIC', solid: geomResult.value },
+      options?.stableKey
+    );
     this.#associateMaterial(id, spec);
     this.#associateClassification(id, spec);
     return ok(id);
+  }
+
+  /**
+   * Atomically replaces a parametric wall or railing Body with authoritative,
+   * caller-owned exact solids. Success transfers every supplied handle to this
+   * model. Failure leaves both the model and all supplied handles unchanged.
+   */
+  takeExactProductBody(
+    localId: LocalId,
+    body: Extract<ProductBody, { readonly kind: 'EXACT' }>
+  ): Result<void, BimError> {
+    const target = this.#elements.get(localId);
+    if (target === undefined) {
+      return err(
+        specError('EXACT_BODY_TARGET_NOT_FOUND', `No element found for localId ${localId}`)
+      );
+    }
+    if (target.category !== 'WALL' && target.category !== 'RAILING') {
+      return err(
+        specError(
+          'EXACT_BODY_UNSUPPORTED_CATEGORY',
+          `Exact Product Bodies are supported only for walls and railings, not ${target.category}`
+        )
+      );
+    }
+    if (target.geometry.kind === 'EXACT') {
+      return err(
+        specError(
+          'EXACT_BODY_ALREADY_EXACT',
+          `Element ${localId} already has an exact Product Body`
+        )
+      );
+    }
+
+    const solids: readonly ValidSolid[] = body.solids;
+    if (solids.length === 0) {
+      return err(
+        specError('EXACT_BODY_EMPTY', 'An exact Product Body must contain at least one solid')
+      );
+    }
+    const identities = new Set<ValidSolid>();
+    for (const [itemIndex, solid] of solids.entries()) {
+      if (identities.has(solid)) {
+        return err(
+          specError(
+            'EXACT_BODY_DUPLICATE_SOLID',
+            `Exact Product Body item ${itemIndex} duplicates an earlier handle`
+          )
+        );
+      }
+      identities.add(solid);
+      if (solid.disposed) {
+        return err(
+          specError(
+            'EXACT_BODY_SOLID_DISPOSED',
+            `Exact Product Body item ${itemIndex} is already disposed`
+          )
+        );
+      }
+      try {
+        if (!isValidSolid(solid)) {
+          return err(
+            specError(
+              'EXACT_BODY_SOLID_INVALID',
+              `Exact Product Body item ${itemIndex} is not a valid solid`
+            )
+          );
+        }
+      } catch (cause) {
+        return err(
+          specError(
+            'EXACT_BODY_SOLID_INVALID',
+            `Exact Product Body item ${itemIndex} could not be validated`,
+            cause
+          )
+        );
+      }
+    }
+
+    const replaced = { ...target, geometry: body } as BimElement<'WALL'> | BimElement<'RAILING'>;
+    this.#elements.set(localId, replaced);
+    disposeProductBody(target.geometry);
+    return ok(undefined);
   }
 
   /**
@@ -601,12 +704,13 @@ export class BimModel {
   }
 
   addDoor(spec: DoorSpec, options?: OpeningIdentityOptions): Result<LocalId, BimError> {
-    const keyCheck = this.#checkOpeningKeys(options);
-    if (!keyCheck.ok) return keyCheck;
     const wall = this.#elements.get(spec.wallLocalId);
     if (wall === undefined || wall.category !== 'WALL') {
       return err(specError('DOOR_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`));
     }
+    if (wall.geometry.kind === 'EXACT') return exactWallBodyImmutable();
+    const keyCheck = this.#checkOpeningKeys(options);
+    if (!keyCheck.ok) return keyCheck;
     if (spec.offsetAlongWall + spec.width > wall.spec.length) {
       return err(
         specError('DOOR_EXCEEDS_WALL_BOUNDS', 'Door (offsetAlongWall + width) exceeds wall length')
@@ -650,14 +754,15 @@ export class BimModel {
   }
 
   addWindow(spec: WindowSpec, options?: OpeningIdentityOptions): Result<LocalId, BimError> {
-    const keyCheck = this.#checkOpeningKeys(options);
-    if (!keyCheck.ok) return keyCheck;
     const wall = this.#elements.get(spec.wallLocalId);
     if (wall === undefined || wall.category !== 'WALL') {
       return err(
         specError('WINDOW_WALL_NOT_FOUND', `No wall found for localId ${spec.wallLocalId}`)
       );
     }
+    if (wall.geometry.kind === 'EXACT') return exactWallBodyImmutable();
+    const keyCheck = this.#checkOpeningKeys(options);
+    if (!keyCheck.ok) return keyCheck;
     if (spec.offsetAlongWall + spec.width > wall.spec.length) {
       return err(
         specError(
@@ -784,10 +889,13 @@ export class BimModel {
     wall: BimElement<'WALL'>,
     openingSpec: WallOpeningSpec
   ): Result<ValidSolid, BimError> {
+    if (wall.geometry.kind === 'EXACT') {
+      return exactWallBodyImmutable();
+    }
     const toolResult = openingToSolid(openingSpec, wall.spec.thickness);
     if (!toolResult.ok) return err(toolResult.error);
     using tool = toolResult.value;
-    const cutResult = cut(wall.geometry, tool);
+    const cutResult = cut(wall.geometry.solid, tool);
     if (!cutResult.ok) {
       return err(
         fromBrepError(cutResult.error, 'WALL_CUT_FAILED', 'Boolean cut of wall with opening failed')
@@ -798,9 +906,12 @@ export class BimModel {
 
   #replaceWallGeometry(wall: BimElement<'WALL'>, newGeometry: ValidSolid): void {
     const oldGeometry = wall.geometry;
-    const replaced: BimElement<'WALL'> = { ...wall, geometry: newGeometry };
+    const replaced: BimElement<'WALL'> = {
+      ...wall,
+      geometry: { kind: 'PARAMETRIC', solid: newGeometry },
+    };
     this.#elements.set(wall.localId, replaced);
-    oldGeometry[Symbol.dispose]();
+    disposeProductBody(oldGeometry);
   }
 
   #cutSlabGeometry(

--- a/packages/brepjs-bim/src/model/bimModel.ts
+++ b/packages/brepjs-bim/src/model/bimModel.ts
@@ -402,6 +402,14 @@ export class BimModel {
         specError('EXACT_BODY_EMPTY', 'An exact Product Body must contain at least one solid')
       );
     }
+    if (solids.includes(target.geometry.solid)) {
+      return err(
+        specError(
+          'EXACT_BODY_SOLID_OWNERSHIP_CONFLICT',
+          `Exact Product Body for ${localId} reuses the target parametric solid`
+        )
+      );
+    }
     const identities = new Set<ValidSolid>();
     for (const [itemIndex, solid] of solids.entries()) {
       if (identities.has(solid)) {

--- a/packages/brepjs-bim/src/rigidPlacement.ts
+++ b/packages/brepjs-bim/src/rigidPlacement.ts
@@ -1,0 +1,74 @@
+import { locate, type AnyShape, type Dimension, type TransformOp } from 'brepjs';
+import { placementToMatrix, type FrameInput, type Vec3 } from './import/placement.js';
+
+const RAD_TO_DEG = 180 / Math.PI;
+const ROTATION_EPSILON = 1e-12;
+
+/** Applies a rigid placement as a location so the source BRep is not rebuilt. */
+export function locateShapeInFrame<T extends AnyShape<Dimension>>(shape: T, frame: FrameInput): T {
+  return locate(shape, placementOps(frame));
+}
+
+function placementOps(frame: FrameInput): readonly TransformOp[] {
+  const matrix = placementToMatrix(frame);
+  const rotation = rotationOp(matrix.linear);
+  const translation: TransformOp = { type: 'translate', v: matrix.translation };
+  return rotation === null ? [translation] : [rotation, translation];
+}
+
+function rotationOp(
+  matrix: readonly [number, number, number, number, number, number, number, number, number]
+): TransformOp | null {
+  const [m00, m01, m02, m10, m11, m12, m20, m21, m22] = matrix;
+  const trace = m00 + m11 + m22;
+  let w: number;
+  let x: number;
+  let y: number;
+  let z: number;
+
+  if (trace > 0) {
+    const scale = 2 * Math.sqrt(trace + 1);
+    w = scale / 4;
+    x = (m21 - m12) / scale;
+    y = (m02 - m20) / scale;
+    z = (m10 - m01) / scale;
+  } else if (m00 > m11 && m00 > m22) {
+    const scale = 2 * Math.sqrt(1 + m00 - m11 - m22);
+    w = (m21 - m12) / scale;
+    x = scale / 4;
+    y = (m01 + m10) / scale;
+    z = (m02 + m20) / scale;
+  } else if (m11 > m22) {
+    const scale = 2 * Math.sqrt(1 + m11 - m00 - m22);
+    w = (m02 - m20) / scale;
+    x = (m01 + m10) / scale;
+    y = scale / 4;
+    z = (m12 + m21) / scale;
+  } else {
+    const scale = 2 * Math.sqrt(1 + m22 - m00 - m11);
+    w = (m10 - m01) / scale;
+    x = (m02 + m20) / scale;
+    y = (m12 + m21) / scale;
+    z = scale / 4;
+  }
+
+  const length = Math.hypot(w, x, y, z);
+  const sign = w < 0 ? -1 : 1;
+  const normalizedW = (sign * w) / length;
+  const normalizedX = (sign * x) / length;
+  const normalizedY = (sign * y) / length;
+  const normalizedZ = (sign * z) / length;
+  const sinHalfAngle = Math.hypot(normalizedX, normalizedY, normalizedZ);
+  if (sinHalfAngle < ROTATION_EPSILON) return null;
+
+  const axis: Vec3 = [
+    normalizedX / sinHalfAngle,
+    normalizedY / sinHalfAngle,
+    normalizedZ / sinHalfAngle,
+  ];
+  return {
+    type: 'rotate',
+    angle: 2 * Math.atan2(sinHalfAngle, normalizedW) * RAD_TO_DEG,
+    axis,
+  };
+}

--- a/packages/brepjs-bim/src/serialize/exactBodyPreflight.ts
+++ b/packages/brepjs-bim/src/serialize/exactBodyPreflight.ts
@@ -1,6 +1,7 @@
 import { err, ok, type Result, type ValidSolid } from 'brepjs';
 import { ifcError, type BimError } from '../errors/bimError.js';
 import type { LocalId } from '../identity/localId.js';
+import type { NonEmpty } from '../types/productBody.js';
 import {
   prepareTessellation,
   type PreparedTessellation,
@@ -20,17 +21,19 @@ export function setExactBodyItemPreparerForTesting(
 
 export interface ExactBodyPreflightInput {
   readonly localId: LocalId;
-  readonly solids: readonly ValidSolid[];
+  readonly solids: NonEmpty<ValidSolid>;
   readonly prepareItem?: ExactBodyItemPreparer | undefined;
 }
 
 /** Prepares every exact Body item without writing IFC lines. Source solids remain borrowed. */
 export function preflightExactBody(
   input: ExactBodyPreflightInput
-): Result<readonly PreparedTessellation[], BimError> {
-  const prepared: PreparedTessellation[] = [];
+): Result<NonEmpty<PreparedTessellation>, BimError> {
   const prepareItem = input.prepareItem ?? testItemPreparer ?? prepareTessellation;
-  for (const [itemIndex, solid] of input.solids.entries()) {
+  const prepareAt = (
+    solid: ValidSolid,
+    itemIndex: number
+  ): Result<PreparedTessellation, BimError> => {
     const item = prepareItem(solid);
     if (!item.ok) {
       return err(
@@ -42,7 +45,18 @@ export function preflightExactBody(
         )
       );
     }
-    prepared.push(item.value);
+    return ok(item.value);
+  };
+
+  const [firstSolid, ...remainingSolids] = input.solids;
+  const first = prepareAt(firstSolid, 0);
+  if (!first.ok) return first;
+
+  const remainingPrepared: PreparedTessellation[] = [];
+  for (const [remainingIndex, solid] of remainingSolids.entries()) {
+    const item = prepareAt(solid, remainingIndex + 1);
+    if (!item.ok) return item;
+    remainingPrepared.push(item.value);
   }
-  return ok(prepared);
+  return ok([first.value, ...remainingPrepared]);
 }

--- a/packages/brepjs-bim/src/serialize/exactBodyPreflight.ts
+++ b/packages/brepjs-bim/src/serialize/exactBodyPreflight.ts
@@ -1,0 +1,48 @@
+import { err, ok, type Result, type ValidSolid } from 'brepjs';
+import { ifcError, type BimError } from '../errors/bimError.js';
+import type { LocalId } from '../identity/localId.js';
+import {
+  prepareTessellation,
+  type PreparedTessellation,
+  type TessellationPreparation,
+} from '../ifc-writer/tessellationWriter.js';
+
+export type ExactBodyItemPreparer = (solid: ValidSolid) => TessellationPreparation;
+
+let testItemPreparer: ExactBodyItemPreparer | null = null;
+
+/** Package-internal deterministic failure seam for serialization cleanup tests. */
+export function setExactBodyItemPreparerForTesting(
+  prepareItem: ExactBodyItemPreparer | null
+): void {
+  testItemPreparer = prepareItem;
+}
+
+export interface ExactBodyPreflightInput {
+  readonly localId: LocalId;
+  readonly solids: readonly ValidSolid[];
+  readonly prepareItem?: ExactBodyItemPreparer | undefined;
+}
+
+/** Prepares every exact Body item without writing IFC lines. Source solids remain borrowed. */
+export function preflightExactBody(
+  input: ExactBodyPreflightInput
+): Result<readonly PreparedTessellation[], BimError> {
+  const prepared: PreparedTessellation[] = [];
+  const prepareItem = input.prepareItem ?? testItemPreparer ?? prepareTessellation;
+  for (const [itemIndex, solid] of input.solids.entries()) {
+    const item = prepareItem(solid);
+    if (!item.ok) {
+      return err(
+        ifcError(
+          'EXACT_BODY_TESSELLATION_FAILED',
+          `Exact Product Body item ${itemIndex} for ${input.localId} could not be tessellated: ${item.reason}`,
+          item.cause,
+          { localId: input.localId, itemIndex }
+        )
+      );
+    }
+    prepared.push(item.value);
+  }
+  return ok(prepared);
+}

--- a/packages/brepjs-bim/src/serialize/exactWallQuantities.ts
+++ b/packages/brepjs-bim/src/serialize/exactWallQuantities.ts
@@ -29,9 +29,13 @@ export function deriveExactWallQuantities(
   let volumeMm3: number;
 
   if (input.solids.length === 1) {
-    const measured = measure(input.solids[0]);
-    if (!measured.ok) return exactVolumeError(measured.error);
-    volumeMm3 = measured.value;
+    try {
+      const measured = measure(input.solids[0]);
+      if (!measured.ok) return exactVolumeError(measured.error);
+      volumeMm3 = measured.value;
+    } catch (cause) {
+      return exactVolumeError(cause);
+    }
   } else {
     const fuse = input.dependencies?.fuse ?? fuseAll;
     let union: ValidSolid | null = null;

--- a/packages/brepjs-bim/src/serialize/exactWallQuantities.ts
+++ b/packages/brepjs-bim/src/serialize/exactWallQuantities.ts
@@ -1,0 +1,72 @@
+import { err, fuseAll, measureVolume, ok, type Result, type ValidSolid } from 'brepjs';
+import { ifcError, type BimError } from '../errors/bimError.js';
+import type { WallSpec } from '../specs/wallSpec.js';
+import type { NonEmpty } from '../types/productBody.js';
+import { toIfcLengthM } from '../units/units.js';
+
+export interface ExactWallQuantityValues {
+  readonly lengthM: number;
+  readonly widthM: number;
+  readonly heightM: number;
+  readonly netVolumeM3: number;
+}
+
+export interface ExactWallQuantityDependencies {
+  readonly fuse?: typeof fuseAll | undefined;
+  readonly measure?: typeof measureVolume | undefined;
+}
+
+export interface ExactWallQuantityInput {
+  readonly spec: WallSpec;
+  readonly solids: NonEmpty<ValidSolid>;
+  readonly dependencies?: ExactWallQuantityDependencies | undefined;
+}
+
+export function deriveExactWallQuantities(
+  input: ExactWallQuantityInput
+): Result<ExactWallQuantityValues, BimError> {
+  const measure = input.dependencies?.measure ?? measureVolume;
+  let volumeMm3: number;
+
+  if (input.solids.length === 1) {
+    const measured = measure(input.solids[0]);
+    if (!measured.ok) return exactVolumeError(measured.error);
+    volumeMm3 = measured.value;
+  } else {
+    const fuse = input.dependencies?.fuse ?? fuseAll;
+    let union: ValidSolid | null = null;
+    try {
+      const fused = fuse([...input.solids]);
+      if (!fused.ok) return exactVolumeError(fused.error);
+      union = fused.value;
+      const measured = measure(union);
+      if (!measured.ok) return exactVolumeError(measured.error);
+      volumeMm3 = measured.value;
+    } catch (cause) {
+      return exactVolumeError(cause);
+    } finally {
+      union?.[Symbol.dispose]();
+    }
+  }
+
+  if (!Number.isFinite(volumeMm3) || volumeMm3 <= 0) {
+    return exactVolumeError(new Error(`Measured exact wall volume was ${volumeMm3}`));
+  }
+
+  return ok({
+    lengthM: toIfcLengthM(input.spec.length),
+    widthM: toIfcLengthM(input.spec.thickness),
+    heightM: toIfcLengthM(input.spec.height),
+    netVolumeM3: volumeMm3 / 1_000_000_000,
+  });
+}
+
+function exactVolumeError(cause: unknown): Result<never, BimError> {
+  return err(
+    ifcError(
+      'IFC_EXACT_WALL_QUANTITY_DERIVATION_FAILED',
+      'Failed to derive a positive finite NetVolume for an exact wall Product Body',
+      cause
+    )
+  );
+}

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -34,7 +34,11 @@ import {
   writePileEntity,
 } from '../ifc-writer/foundationWriter.js';
 import { writeStairAssembly, writeRampAssembly } from '../ifc-writer/stairWriter.js';
-import { writeRailingGeometry, writeRailingEntity } from '../ifc-writer/railingWriter.js';
+import {
+  writeRailingGeometry,
+  writeRailingEntity,
+  type RailingRepresentationIds,
+} from '../ifc-writer/railingWriter.js';
 import {
   writeCoveringGeometry,
   writeCoveringEntity,
@@ -70,6 +74,7 @@ import {
   writeManufacturerPset,
   writeCustomPsets,
   writeWallBaseQuantities,
+  writeExactWallBaseQuantities,
   writeSlabCommonPset,
   writeSlabBaseQuantities,
   writeBeamCommonPset,
@@ -126,6 +131,10 @@ import {
   type ValidationReport,
   type ValidationIssue,
 } from '../validation/severity.js';
+import { bodySolids } from '../types/productBody.js';
+import { preflightExactBody } from './exactBodyPreflight.js';
+import { deriveExactWallQuantities } from './exactWallQuantities.js';
+import { writeExactBodyGeometry } from '../ifc-writer/tessellationWriter.js';
 
 export async function toIfc(
   model: BimModel,
@@ -157,7 +166,7 @@ export async function toIfc(
     organization: meta.organizationName,
   });
   if (!writerResult.ok) return writerResult;
-  const w = writerResult.value;
+  using w = writerResult.value;
   // Scope writer-minted GUIDs (psets/quantities/rels) to this model.
   w.setModelScope(project.guid);
 
@@ -321,12 +330,26 @@ export async function toIfc(
     const containingId = findContainerOf(wall.localId, relationships);
     const storeyPlacementId =
       containingId !== null ? (placementMap.get(containingId) ?? null) : null;
-    const { localPlacementId, productDefinitionShapeId } = writeWallGeometry(
-      w,
-      wall.spec,
-      geomSubContextId,
-      storeyPlacementId
-    );
+    const exactPrepared =
+      wall.geometry.kind === 'EXACT'
+        ? preflightExactBody({ localId: wall.localId, solids: wall.geometry.solids })
+        : null;
+    if (exactPrepared !== null && !exactPrepared.ok) return err(exactPrepared.error);
+    const exactQuantities =
+      wall.geometry.kind === 'EXACT'
+        ? deriveExactWallQuantities({ spec: wall.spec, solids: wall.geometry.solids })
+        : null;
+
+    const { localPlacementId, productDefinitionShapeId } =
+      wall.geometry.kind === 'EXACT' && exactPrepared !== null && exactPrepared.ok
+        ? writeExactBodyGeometry(
+            w,
+            wall.spec,
+            exactPrepared.value,
+            geomSubContextId,
+            storeyPlacementId
+          )
+        : writeWallGeometry(w, wall.spec, geomSubContextId, storeyPlacementId);
     const wallExpressId = writeWallEntity(
       w,
       wall.guid,
@@ -342,14 +365,20 @@ export async function toIfc(
     if (wall.spec.customProperties !== undefined) {
       writeCustomPsets(w, ownerHistoryId, wallExpressId, wall.spec.customProperties);
     }
-    writeWallBaseQuantities(
-      w,
-      ownerHistoryId,
-      wallExpressId,
-      wall.spec,
-      openingsByWall.get(wall.localId) ?? [],
-      densityByElement.get(wall.localId)
-    );
+    if (wall.geometry.kind === 'EXACT') {
+      if (exactQuantities !== null && exactQuantities.ok) {
+        writeExactWallBaseQuantities(w, ownerHistoryId, wallExpressId, exactQuantities.value);
+      }
+    } else {
+      writeWallBaseQuantities(
+        w,
+        ownerHistoryId,
+        wallExpressId,
+        wall.spec,
+        openingsByWall.get(wall.localId) ?? [],
+        densityByElement.get(wall.localId)
+      );
+    }
   }
 
   for (const [i, slab] of slabs.entries()) {
@@ -721,8 +750,35 @@ export async function toIfc(
     const containingId = findContainerOf(railing.localId, relationships);
     const storeyPlacementId =
       containingId !== null ? (placementMap.get(containingId) ?? null) : null;
-    const { localPlacementId, productDefinitionShapeId, bodyItemId, usedFallback } =
-      writeRailingGeometry(w, railing.spec, railing.geometry, geomSubContextId, storeyPlacementId);
+    const exactPrepared =
+      railing.geometry.kind === 'EXACT'
+        ? preflightExactBody({ localId: railing.localId, solids: railing.geometry.solids })
+        : null;
+    if (exactPrepared !== null && !exactPrepared.ok) return err(exactPrepared.error);
+    let representation: RailingRepresentationIds;
+    let exactBodyItemIds: readonly number[] = [];
+    if (railing.geometry.kind === 'EXACT' && exactPrepared !== null && exactPrepared.ok) {
+      const exact = writeExactBodyGeometry(
+        w,
+        railing.spec,
+        exactPrepared.value,
+        geomSubContextId,
+        storeyPlacementId
+      );
+      exactBodyItemIds = exact.bodyItemIds;
+      representation = { ...exact, bodyItemId: null, usedFallback: false };
+    } else {
+      representation = writeRailingGeometry(
+        w,
+        railing.spec,
+        railing.geometry.kind === 'PARAMETRIC'
+          ? railing.geometry.solid
+          : railing.geometry.solids[0],
+        geomSubContextId,
+        storeyPlacementId
+      );
+    }
+    const { localPlacementId, productDefinitionShapeId, bodyItemId, usedFallback } = representation;
     if (usedFallback) {
       console.warn(`Railing ${i + 1} tessellation failed; IFC body is a degenerate fallback.`);
     }
@@ -743,7 +799,13 @@ export async function toIfc(
       writeCustomPsets(w, ownerHistoryId, railingExpressId, railing.spec.customProperties);
     }
     // POSTED railings tessellate and have no single styleable body item.
-    if (bodyItemId !== null) applySurfaceStyle(w, model, railing.localId, bodyItemId);
+    if (railing.geometry.kind === 'EXACT') {
+      for (const itemId of exactBodyItemIds) {
+        applySurfaceStyle(w, model, railing.localId, itemId);
+      }
+    } else if (bodyItemId !== null) {
+      applySurfaceStyle(w, model, railing.localId, bodyItemId);
+    }
   }
 
   for (const [i, covering] of coverings.entries()) {
@@ -1222,7 +1284,6 @@ export async function toIfcValidated(
 function collectGeometryIssues(model: BimModel): ValidationReport {
   const issues: ValidationIssue[] = [];
   const groups: ReadonlyArray<readonly [string, ReadonlyArray<{ geometry: ValidSolid }>]> = [
-    ['Wall', model.getWalls()],
     ['Slab', model.getSlabs()],
     ['Beam', model.getBeams()],
     ['Column', model.getColumns()],
@@ -1232,13 +1293,28 @@ function collectGeometryIssues(model: BimModel): ValidationReport {
     ['Roof', model.getRoofs()],
     ['Footing', model.getFootings()],
     ['Pile', model.getPiles()],
-    ['Railing', model.getRailings()],
     ['Covering', model.getCoverings()],
   ];
   for (const [label, elements] of groups) {
     elements.forEach((el, index) => {
       const report = checkGeometryValidity(el.geometry, `${label} ${index + 1}`);
       issues.push(...report.issues);
+    });
+  }
+
+  const productGroups = [
+    ['Wall', model.getWalls()],
+    ['Railing', model.getRailings()],
+  ] as const;
+  for (const [label, elements] of productGroups) {
+    elements.forEach((el, index) => {
+      bodySolids(el.geometry).forEach((solid, itemIndex) => {
+        const report = checkGeometryValidity(
+          solid,
+          `${label} ${index + 1} Body item ${itemIndex + 1}`
+        );
+        issues.push(...report.issues);
+      });
     });
   }
 

--- a/packages/brepjs-bim/src/serialize/toIfc.ts
+++ b/packages/brepjs-bim/src/serialize/toIfc.ts
@@ -132,9 +132,50 @@ import {
   type ValidationIssue,
 } from '../validation/severity.js';
 import { bodySolids } from '../types/productBody.js';
+import type { NonEmpty } from '../types/productBody.js';
 import { preflightExactBody } from './exactBodyPreflight.js';
 import { deriveExactWallQuantities } from './exactWallQuantities.js';
-import { writeExactBodyGeometry } from '../ifc-writer/tessellationWriter.js';
+import {
+  writeExactBodyGeometry,
+  type PreparedTessellation,
+} from '../ifc-writer/tessellationWriter.js';
+
+type ExactBodyCapableElement = BimElement<'WALL'> | BimElement<'RAILING'>;
+
+type PreflightedProductElement<E extends ExactBodyCapableElement> =
+  | {
+      readonly kind: 'PARAMETRIC';
+      readonly element: E;
+      readonly solid: ValidSolid;
+    }
+  | {
+      readonly kind: 'EXACT';
+      readonly element: E;
+      readonly solids: NonEmpty<ValidSolid>;
+      readonly items: NonEmpty<PreparedTessellation>;
+    };
+
+function preflightProductBodies<E extends ExactBodyCapableElement>(
+  elements: readonly E[]
+): Result<readonly PreflightedProductElement<E>[], BimError> {
+  const preflighted: PreflightedProductElement<E>[] = [];
+  for (const element of elements) {
+    const body = element.geometry;
+    if (body.kind === 'PARAMETRIC') {
+      preflighted.push({ kind: 'PARAMETRIC', element, solid: body.solid });
+      continue;
+    }
+    const prepared = preflightExactBody({ localId: element.localId, solids: body.solids });
+    if (!prepared.ok) return err(prepared.error);
+    preflighted.push({
+      kind: 'EXACT',
+      element,
+      solids: body.solids,
+      items: prepared.value,
+    });
+  }
+  return ok(preflighted);
+}
 
 export async function toIfc(
   model: BimModel,
@@ -194,6 +235,13 @@ export async function toIfc(
   const assemblies = model.getElementAssemblies();
   const zones = model.getZones();
   const systems = model.getSystems();
+
+  const preflightedWallsResult = preflightProductBodies(walls);
+  if (!preflightedWallsResult.ok) return err(preflightedWallsResult.error);
+  const preflightedRailingsResult = preflightProductBodies(railings);
+  if (!preflightedRailingsResult.ok) return err(preflightedRailingsResult.error);
+  const preflightedWalls = preflightedWallsResult.value;
+  const preflightedRailings = preflightedRailingsResult.value;
 
   const { ownerHistoryId, geomContextId, geomSubContextId, unitAssignmentId, lengthUnitId } =
     writeHeader(w, meta);
@@ -326,26 +374,22 @@ export async function toIfc(
     openingsBySlab.set(rel.slabLocalId, list);
   }
 
-  for (const [i, wall] of walls.entries()) {
+  for (const [i, preflighted] of preflightedWalls.entries()) {
+    const wall = preflighted.element;
     const containingId = findContainerOf(wall.localId, relationships);
     const storeyPlacementId =
       containingId !== null ? (placementMap.get(containingId) ?? null) : null;
-    const exactPrepared =
-      wall.geometry.kind === 'EXACT'
-        ? preflightExactBody({ localId: wall.localId, solids: wall.geometry.solids })
-        : null;
-    if (exactPrepared !== null && !exactPrepared.ok) return err(exactPrepared.error);
     const exactQuantities =
-      wall.geometry.kind === 'EXACT'
-        ? deriveExactWallQuantities({ spec: wall.spec, solids: wall.geometry.solids })
+      preflighted.kind === 'EXACT'
+        ? deriveExactWallQuantities({ spec: wall.spec, solids: preflighted.solids })
         : null;
 
     const { localPlacementId, productDefinitionShapeId } =
-      wall.geometry.kind === 'EXACT' && exactPrepared !== null && exactPrepared.ok
+      preflighted.kind === 'EXACT'
         ? writeExactBodyGeometry(
             w,
             wall.spec,
-            exactPrepared.value,
+            preflighted.items,
             geomSubContextId,
             storeyPlacementId
           )
@@ -365,7 +409,7 @@ export async function toIfc(
     if (wall.spec.customProperties !== undefined) {
       writeCustomPsets(w, ownerHistoryId, wallExpressId, wall.spec.customProperties);
     }
-    if (wall.geometry.kind === 'EXACT') {
+    if (preflighted.kind === 'EXACT') {
       if (exactQuantities !== null && exactQuantities.ok) {
         writeExactWallBaseQuantities(w, ownerHistoryId, wallExpressId, exactQuantities.value);
       }
@@ -746,22 +790,18 @@ export async function toIfc(
     writeRampCommonPset(w, ownerHistoryId, result.value.assemblyExpressId, ramp.spec);
   }
 
-  for (const [i, railing] of railings.entries()) {
+  for (const [i, preflighted] of preflightedRailings.entries()) {
+    const railing = preflighted.element;
     const containingId = findContainerOf(railing.localId, relationships);
     const storeyPlacementId =
       containingId !== null ? (placementMap.get(containingId) ?? null) : null;
-    const exactPrepared =
-      railing.geometry.kind === 'EXACT'
-        ? preflightExactBody({ localId: railing.localId, solids: railing.geometry.solids })
-        : null;
-    if (exactPrepared !== null && !exactPrepared.ok) return err(exactPrepared.error);
     let representation: RailingRepresentationIds;
     let exactBodyItemIds: readonly number[] = [];
-    if (railing.geometry.kind === 'EXACT' && exactPrepared !== null && exactPrepared.ok) {
+    if (preflighted.kind === 'EXACT') {
       const exact = writeExactBodyGeometry(
         w,
         railing.spec,
-        exactPrepared.value,
+        preflighted.items,
         geomSubContextId,
         storeyPlacementId
       );
@@ -771,9 +811,7 @@ export async function toIfc(
       representation = writeRailingGeometry(
         w,
         railing.spec,
-        railing.geometry.kind === 'PARAMETRIC'
-          ? railing.geometry.solid
-          : railing.geometry.solids[0],
+        preflighted.solid,
         geomSubContextId,
         storeyPlacementId
       );
@@ -799,7 +837,7 @@ export async function toIfc(
       writeCustomPsets(w, ownerHistoryId, railingExpressId, railing.spec.customProperties);
     }
     // POSTED railings tessellate and have no single styleable body item.
-    if (railing.geometry.kind === 'EXACT') {
+    if (preflighted.kind === 'EXACT') {
       for (const itemId of exactBodyItemIds) {
         applySurfaceStyle(w, model, railing.localId, itemId);
       }

--- a/packages/brepjs-bim/src/types/bimTypes.ts
+++ b/packages/brepjs-bim/src/types/bimTypes.ts
@@ -24,6 +24,7 @@ import type {
   BridgeSpec,
   EarthworksFillSpec,
 } from '../specs/infrastructureSpec.js';
+import type { ProductBody } from './productBody.js';
 
 export type BimCategory =
   | 'WALL'
@@ -138,21 +139,21 @@ export type BimSpecFor<C extends BimCategory> = C extends 'WALL'
 
 export type BimGeometryFor<C extends BimCategory> = C extends 'CURTAIN_WALL'
   ? CurtainWallGrid
-  : C extends
-        | 'WALL'
-        | 'SLAB'
-        | 'BEAM'
-        | 'COLUMN'
-        | 'PROXY'
-        | 'EARTHWORKS_FILL'
-        | 'SPACE'
-        | 'ROOF'
-        | 'FOOTING'
-        | 'PILE'
-        | 'RAILING'
-        | 'COVERING'
-    ? ValidSolid
-    : null;
+  : C extends 'WALL' | 'RAILING'
+    ? ProductBody
+    : C extends
+          | 'SLAB'
+          | 'BEAM'
+          | 'COLUMN'
+          | 'PROXY'
+          | 'EARTHWORKS_FILL'
+          | 'SPACE'
+          | 'ROOF'
+          | 'FOOTING'
+          | 'PILE'
+          | 'COVERING'
+      ? ValidSolid
+      : null;
 
 export interface BimElement<C extends BimCategory> {
   readonly guid: IfcGuid;

--- a/packages/brepjs-bim/src/types/productBody.ts
+++ b/packages/brepjs-bim/src/types/productBody.ts
@@ -1,0 +1,28 @@
+import type { ValidSolid } from 'brepjs';
+
+export type NonEmpty<T> = readonly [T, ...T[]];
+
+export type ProductBody =
+  | {
+      readonly kind: 'PARAMETRIC';
+      readonly solid: ValidSolid;
+    }
+  | {
+      readonly kind: 'EXACT';
+      readonly solids: NonEmpty<ValidSolid>;
+    };
+
+/** Returns borrowed Product-local solids. The model retains ownership. */
+export function bodySolids(body: ProductBody): NonEmpty<ValidSolid> {
+  switch (body.kind) {
+    case 'PARAMETRIC':
+      return [body.solid];
+    case 'EXACT':
+      return body.solids;
+  }
+}
+
+/** Model-owner cleanup. Borrowers must use {@link bodySolids} without disposing its items. */
+export function disposeProductBody(body: ProductBody): void {
+  for (const solid of bodySolids(body)) solid[Symbol.dispose]();
+}

--- a/packages/brepjs-bim/tests/bimModel.test.ts
+++ b/packages/brepjs-bim/tests/bimModel.test.ts
@@ -162,8 +162,10 @@ describe('BimModel', () => {
     if (!result.ok) throw new Error(result.error.message);
     const wall = model.getElement(result.value);
     if (!wall || wall.category !== 'WALL') throw new Error('Expected wall element');
+    expect(wall.geometry.kind).toBe('PARAMETRIC');
+    if (wall.geometry.kind !== 'PARAMETRIC') throw new Error('Expected parametric wall Body');
     model[Symbol.dispose]();
-    expect(wall.geometry.disposed).toBe(true);
+    expect(wall.geometry.solid.disposed).toBe(true);
   });
 
   it('addEarthworksFill keeps a rejected duplicate body caller-owned', () => {
@@ -357,7 +359,8 @@ describe('BimModel — wall geometry is cut by openings (M4)', () => {
   function wallVolume(model: BimModel): number {
     const wall = model.getWalls()[0];
     if (!wall) throw new Error('Expected one wall');
-    return unwrap(measureVolume(wall.geometry));
+    if (wall.geometry.kind !== 'PARAMETRIC') throw new Error('Expected parametric wall Body');
+    return unwrap(measureVolume(wall.geometry.solid));
   }
 
   it('wall volume drops by door volume after addDoor', () => {

--- a/packages/brepjs-bim/tests/exactProductBodyIfc.test.ts
+++ b/packages/brepjs-bim/tests/exactProductBodyIfc.test.ts
@@ -112,6 +112,25 @@ describe('exact wall quantities', () => {
     });
     expect(quantities.ok).toBe(true);
   });
+
+  it('maps a thrown singleton measurement to the omission error', () => {
+    using solid = box(100, 100, 100);
+    const quantities = deriveExactWallQuantities({
+      spec: WALL_SPEC,
+      solids: [solid],
+      dependencies: {
+        measure: () => {
+          throw new Error('injected singleton measurement failure');
+        },
+      },
+    });
+
+    expect(quantities.ok).toBe(false);
+    if (!quantities.ok) {
+      expect(quantities.error.code).toBe('IFC_EXACT_WALL_QUANTITY_DERIVATION_FAILED');
+    }
+    expect(solid.disposed).toBe(false);
+  });
 });
 
 describe('IfcWriter cleanup', () => {

--- a/packages/brepjs-bim/tests/exactProductBodyIfc.test.ts
+++ b/packages/brepjs-bim/tests/exactProductBodyIfc.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { box, fuseAll, measureVolume, translate } from 'brepjs';
 import { initKernel } from '../../../tests/setup.js';
 import { makeLocalIdCounter } from '../src/identity/localId.js';
@@ -11,6 +11,10 @@ import type { WallSpec } from '../src/specs/wallSpec.js';
 beforeAll(async () => {
   await initKernel();
 }, 30_000);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const WALL_SPEC: WallSpec = {
   length: 1_000,
@@ -145,7 +149,6 @@ describe('IfcWriter cleanup', () => {
     writer[Symbol.dispose]();
     expect(result.ok).toBe(!failSave);
     expect(api.closeCalls).toBe(1);
-    vi.restoreAllMocks();
   });
 
   it('closes exactly once when a write throws before save', () => {

--- a/packages/brepjs-bim/tests/exactProductBodyIfc.test.ts
+++ b/packages/brepjs-bim/tests/exactProductBodyIfc.test.ts
@@ -1,0 +1,171 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { box, fuseAll, measureVolume, translate } from 'brepjs';
+import { initKernel } from '../../../tests/setup.js';
+import { makeLocalIdCounter } from '../src/identity/localId.js';
+import { IfcWriter, type IfcWriterApiForTesting } from '../src/ifc-writer/ifcWriter.js';
+import { prepareTessellation } from '../src/ifc-writer/tessellationWriter.js';
+import { preflightExactBody } from '../src/serialize/exactBodyPreflight.js';
+import { deriveExactWallQuantities } from '../src/serialize/exactWallQuantities.js';
+import type { WallSpec } from '../src/specs/wallSpec.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30_000);
+
+const WALL_SPEC: WallSpec = {
+  length: 1_000,
+  height: 500,
+  thickness: 100,
+  origin: [0, 0, 0],
+  axisX: [1, 0, 0],
+  axisZ: [0, 0, 1],
+  materialName: 'Concrete',
+};
+
+describe('exact Product Body IFC preparation', () => {
+  it('reports the failed later item without disposing borrowed source solids', () => {
+    using first = box(100, 100, 100);
+    using second = box(50, 50, 50);
+    const result = preflightExactBody({
+      localId: makeLocalIdCounter().next(),
+      solids: [first, second],
+      prepareItem: (solid) =>
+        solid === second
+          ? { ok: false, reason: 'injected mesh failure' }
+          : prepareTessellation(solid),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('EXACT_BODY_TESSELLATION_FAILED');
+    expect(result.error.metadata?.['itemIndex']).toBe(1);
+    expect(first.disposed).toBe(false);
+    expect(second.disposed).toBe(false);
+  });
+});
+
+describe('exact wall quantities', () => {
+  it('uses a temporary union so overlapping solids are not double-counted', () => {
+    using first = box(100, 100, 100);
+    using source = box(100, 100, 100);
+    using second = translate(source, [50, 0, 0]);
+    let unionDisposals = 0;
+    const quantities = deriveExactWallQuantities({
+      spec: WALL_SPEC,
+      solids: [first, second],
+      dependencies: {
+        fuse: (solids, options) => {
+          const result = fuseAll(solids, options);
+          if (result.ok) result.value.onDispose(() => unionDisposals++);
+          return result;
+        },
+      },
+    });
+
+    expect(quantities.ok).toBe(true);
+    if (!quantities.ok) return;
+    expect(quantities.value.netVolumeM3).toBeCloseTo(1_500_000 / 1_000_000_000, 12);
+    expect(unionDisposals).toBe(1);
+    expect(first.disposed).toBe(false);
+    expect(second.disposed).toBe(false);
+  });
+
+  it('disposes the temporary union when measurement throws', () => {
+    using first = box(100, 100, 100);
+    using second = box(100, 100, 100);
+    let unionDisposals = 0;
+    const quantities = deriveExactWallQuantities({
+      spec: WALL_SPEC,
+      solids: [first, second],
+      dependencies: {
+        fuse: (solids, options) => {
+          const result = fuseAll(solids, options);
+          if (result.ok) result.value.onDispose(() => unionDisposals++);
+          return result;
+        },
+        measure: () => {
+          throw new Error('injected measurement failure');
+        },
+      },
+    });
+
+    expect(quantities.ok).toBe(false);
+    if (!quantities.ok) {
+      expect(quantities.error.code).toBe('IFC_EXACT_WALL_QUANTITY_DERIVATION_FAILED');
+    }
+    expect(unionDisposals).toBe(1);
+    expect(first.disposed).toBe(false);
+    expect(second.disposed).toBe(false);
+  });
+
+  it('measures a singleton directly without calling fuseAll', () => {
+    using solid = box(100, 100, 100);
+    const quantities = deriveExactWallQuantities({
+      spec: WALL_SPEC,
+      solids: [solid],
+      dependencies: {
+        fuse: () => {
+          throw new Error('singleton must not fuse');
+        },
+        measure: measureVolume,
+      },
+    });
+    expect(quantities.ok).toBe(true);
+  });
+});
+
+describe('IfcWriter cleanup', () => {
+  it.each([
+    ['save success', false],
+    ['save failure', true],
+  ])('closes exactly once after %s', (_name, failSave) => {
+    const api = new FakeWriterApi({ failSave });
+    const writer = IfcWriter.fromApiForTesting(api);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const result = writer.save();
+    writer[Symbol.dispose]();
+    expect(result.ok).toBe(!failSave);
+    expect(api.closeCalls).toBe(1);
+    vi.restoreAllMocks();
+  });
+
+  it('closes exactly once when a write throws before save', () => {
+    const api = new FakeWriterApi({ failWrite: true });
+    const writer = IfcWriter.fromApiForTesting(api);
+    try {
+      expect(() => writer.writeLine({ expressID: 1 })).toThrow('injected write failure');
+    } finally {
+      writer[Symbol.dispose]();
+      writer[Symbol.dispose]();
+    }
+    expect(api.closeCalls).toBe(1);
+  });
+});
+
+class FakeWriterApi implements IfcWriterApiForTesting {
+  closeCalls = 0;
+  readonly #failSave: boolean;
+  readonly #failWrite: boolean;
+
+  constructor(options: { readonly failSave?: boolean; readonly failWrite?: boolean }) {
+    this.#failSave = options.failSave ?? false;
+    this.#failWrite = options.failWrite ?? false;
+  }
+
+  WriteLine(): void {
+    if (this.#failWrite) throw new Error('injected write failure');
+  }
+
+  CreateIfcType(_modelId: number, type: number, value: unknown): Record<string, unknown> {
+    return { type, value };
+  }
+
+  SaveModel(): Uint8Array {
+    if (this.#failSave) throw new Error('injected save failure');
+    return new Uint8Array();
+  }
+
+  CloseModel(): void {
+    this.closeCalls++;
+  }
+}

--- a/packages/brepjs-bim/tests/exactProductBodyTakeover.test.ts
+++ b/packages/brepjs-bim/tests/exactProductBodyTakeover.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { box, cut, cylinder, measureVolume, translate, type ValidSolid } from 'brepjs';
+import { initKernel } from '../../../tests/setup.js';
+import { BimModel } from '../src/model/bimModel.js';
+import {
+  placedSolids,
+  setPlacedGeometryTestHooksForTesting,
+} from '../src/elementFns/placedGeometry.js';
+import { bodySolids, type ProductBody } from '../src/types/productBody.js';
+import type { LocalId } from '../src/identity/localId.js';
+import { toIfc } from '../src/serialize/toIfc.js';
+import {
+  setExactBodyItemPreparerForTesting,
+  type ExactBodyItemPreparer,
+} from '../src/serialize/exactBodyPreflight.js';
+import { setIfcWriterTestHooksForTesting } from '../src/ifc-writer/ifcWriter.js';
+import { fromIfc } from '../src/import/fromIfc.js';
+import { disposeImportedModel } from '../src/import/importedModel.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30_000);
+
+afterEach(() => {
+  setPlacedGeometryTestHooksForTesting(null);
+  setExactBodyItemPreparerForTesting(null);
+  setIfcWriterTestHooksForTesting(null);
+});
+
+const FRAME = {
+  origin: [0, 0, 0] as [number, number, number],
+  axisX: [1, 0, 0] as [number, number, number],
+  axisZ: [0, 0, 1] as [number, number, number],
+};
+
+const WALL_SPEC = {
+  length: 1_000,
+  height: 500,
+  thickness: 100,
+  ...FRAME,
+  materialName: 'Concrete',
+};
+
+const RAILING_SPEC = {
+  length: 1_000,
+  height: 500,
+  thickness: 100,
+  ...FRAME,
+  materialName: 'Steel',
+};
+
+type ExactProductBody = Extract<ProductBody, { readonly kind: 'EXACT' }>;
+
+describe('BimModel.takeExactProductBody', () => {
+  it('atomically transfers every exact handle and disposes the superseded Body once', () => {
+    const model = new BimModel();
+    const wallId = required(model.addWall(WALL_SPEC));
+    const wallBefore = requiredElement(model, wallId, 'WALL');
+    const oldSolid = bodySolids(wallBefore.geometry)[0];
+    let oldDisposals = 0;
+    oldSolid.onDispose(() => oldDisposals++);
+
+    const first = box(100, 100, 100);
+    const source = box(50, 50, 50);
+    const second = translate(source, [200, 0, 0]);
+    source[Symbol.dispose]();
+    const exactDisposals = [0, 0];
+    first.onDispose(() => exactDisposals[0]++);
+    second.onDispose(() => exactDisposals[1]++);
+
+    const takeover = model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [first, second] });
+    expect(takeover.ok).toBe(true);
+    expect(oldDisposals).toBe(1);
+    expect(first.disposed).toBe(false);
+    expect(second.disposed).toBe(false);
+    expect(requiredElement(model, wallId, 'WALL').geometry).toEqual({
+      kind: 'EXACT',
+      solids: [first, second],
+    });
+
+    model[Symbol.dispose]();
+    expect(exactDisposals).toEqual([1, 1]);
+  });
+
+  it('rejects missing and unsupported targets without taking caller inputs', () => {
+    const model = new BimModel();
+    const slabId = required(
+      model.addSlab({
+        length: 1_000,
+        width: 500,
+        thickness: 100,
+        ...FRAME,
+        predefinedType: 'FLOOR',
+        materialName: 'Concrete',
+      })
+    );
+    using missingInput = box(10, 10, 10);
+    using categoryInput = box(20, 20, 20);
+
+    const missing = model.takeExactProductBody(localIdBeyondModel(), {
+      kind: 'EXACT',
+      solids: [missingInput],
+    });
+    const wrongCategory = model.takeExactProductBody(slabId, {
+      kind: 'EXACT',
+      solids: [categoryInput],
+    });
+
+    expect(errorCode(missing)).toBe('EXACT_BODY_TARGET_NOT_FOUND');
+    expect(errorCode(wrongCategory)).toBe('EXACT_BODY_UNSUPPORTED_CATEGORY');
+    expect(missingInput.disposed).toBe(false);
+    expect(categoryInput.disposed).toBe(false);
+    model[Symbol.dispose]();
+  });
+
+  it('rejects empty, duplicate, disposed, and invalid collections before mutation', () => {
+    const model = new BimModel();
+    const wallId = required(model.addWall(WALL_SPEC));
+    const original = requiredElement(model, wallId, 'WALL').geometry;
+
+    const emptyBody = { kind: 'EXACT', solids: [] } as unknown as ExactProductBody;
+    expect(errorCode(model.takeExactProductBody(wallId, emptyBody))).toBe('EXACT_BODY_EMPTY');
+
+    using duplicate = box(30, 30, 30);
+    expect(
+      errorCode(
+        model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [duplicate, duplicate] })
+      )
+    ).toBe('EXACT_BODY_DUPLICATE_SOLID');
+
+    const disposed = box(40, 40, 40);
+    let disposedCalls = 0;
+    disposed.onDispose(() => disposedCalls++);
+    disposed[Symbol.dispose]();
+    expect(
+      errorCode(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [disposed] }))
+    ).toBe('EXACT_BODY_SOLID_DISPOSED');
+    expect(disposedCalls).toBe(1);
+
+    const invalid = { disposed: false } as unknown as ValidSolid;
+    expect(
+      errorCode(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [invalid] }))
+    ).toBe('EXACT_BODY_SOLID_INVALID');
+    expect(requiredElement(model, wallId, 'WALL').geometry).toBe(original);
+    model[Symbol.dispose]();
+  });
+
+  it('rejects replacement of an already exact Body and leaves both collections owned correctly', () => {
+    const model = new BimModel();
+    const railingId = required(model.addRailing(RAILING_SPEC));
+    const selected = box(100, 20, 20);
+    const rejected = box(100, 30, 30);
+    let selectedDisposals = 0;
+    let rejectedDisposals = 0;
+    selected.onDispose(() => selectedDisposals++);
+    rejected.onDispose(() => rejectedDisposals++);
+    expect(model.takeExactProductBody(railingId, { kind: 'EXACT', solids: [selected] }).ok).toBe(
+      true
+    );
+
+    const second = model.takeExactProductBody(railingId, {
+      kind: 'EXACT',
+      solids: [rejected],
+    });
+    expect(errorCode(second)).toBe('EXACT_BODY_ALREADY_EXACT');
+    expect(selected.disposed).toBe(false);
+    expect(rejected.disposed).toBe(false);
+
+    model[Symbol.dispose]();
+    expect(selectedDisposals).toBe(1);
+    expect(rejectedDisposals).toBe(0);
+    rejected[Symbol.dispose]();
+    expect(rejectedDisposals).toBe(1);
+  });
+});
+
+describe('exact wall mutation and multi-solid placement', () => {
+  it('rejects later doors and windows without changing Body or relationships', () => {
+    const model = new BimModel();
+    const wallId = required(model.addWall(WALL_SPEC));
+    const exact = box(1_000, 100, 500);
+    required(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [exact] }));
+    const bodyBefore = requiredElement(model, wallId, 'WALL').geometry;
+    const relationshipsBefore = model.getAllRelationships();
+    const elementsBefore = model.getAllElements();
+
+    const door = model.addDoor({
+      wallLocalId: wallId,
+      width: 100,
+      height: 200,
+      offsetAlongWall: 100,
+      offsetFromFloor: 0,
+      materialName: 'Wood',
+    });
+    const window = model.addWindow({
+      wallLocalId: wallId,
+      width: 100,
+      height: 100,
+      offsetAlongWall: 300,
+      offsetFromFloor: 200,
+      materialName: 'Glass',
+    });
+
+    expect(errorCode(door)).toBe('EXACT_WALL_BODY_IMMUTABLE');
+    expect(errorCode(window)).toBe('EXACT_WALL_BODY_IMMUTABLE');
+    expect(requiredElement(model, wallId, 'WALL').geometry).toBe(bodyBefore);
+    expect(model.getAllRelationships()).toEqual(relationshipsBefore);
+    expect(model.getAllElements()).toEqual(elementsBefore);
+    model[Symbol.dispose]();
+  });
+
+  it('returns one independent caller-owned placed copy per exact Body item', () => {
+    const model = new BimModel();
+    const railingId = required(model.addRailing(RAILING_SPEC));
+    const first = box(100, 20, 20);
+    const second = box(100, 30, 30);
+    required(model.takeExactProductBody(railingId, { kind: 'EXACT', solids: [first, second] }));
+
+    const placed = required(placedSolids(requiredElement(model, railingId, 'RAILING')));
+    expect(placed).toHaveLength(2);
+    expect(placed[0]).not.toBe(first);
+    expect(placed[1]).not.toBe(second);
+    for (const solid of placed) solid[Symbol.dispose]();
+    expect(first.disposed).toBe(false);
+    expect(second.disposed).toBe(false);
+    model[Symbol.dispose]();
+  });
+
+  it('preserves curved exact-Body volume through rotated placement', () => {
+    const model = new BimModel();
+    const angle = Math.PI / 6;
+    const wallId = required(
+      model.addWall({
+        ...WALL_SPEC,
+        origin: [1_000, 2_000, 3_000],
+        axisX: [Math.cos(angle), Math.sin(angle), 0],
+      })
+    );
+    using outer = box(1_200, 100, 500);
+    using cutter = cylinder(125, 200, { at: [300, -50, 250], axis: [0, 1, 0] });
+    const exact = required(cut(outer, cutter));
+    const localVolume = required(measureVolume(exact));
+    required(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [exact] }));
+
+    const placed = required(placedSolids(requiredElement(model, wallId, 'WALL')));
+    try {
+      expect(placed).toHaveLength(1);
+      const placedSolid = placed[0];
+      if (placedSolid === undefined) throw new Error('Expected one placed wall Body item');
+      expect(required(measureVolume(placedSolid))).toBeCloseTo(localVolume, 6);
+    } finally {
+      for (const solid of placed) solid[Symbol.dispose]();
+      model[Symbol.dispose]();
+    }
+  });
+
+  it('disposes all partial placement outputs while preserving stored exact inputs', () => {
+    const model = new BimModel();
+    const railingId = required(model.addRailing(RAILING_SPEC));
+    const first = box(100, 20, 20);
+    const second = box(100, 30, 30);
+    required(model.takeExactProductBody(railingId, { kind: 'EXACT', solids: [first, second] }));
+    const placedDisposals = [0, 0];
+    let placedIndex = 0;
+    setPlacedGeometryTestHooksForTesting({
+      afterPlaced: (solid) => {
+        const current = placedIndex++;
+        solid.onDispose(() => placedDisposals[current]++);
+        if (current === 1) throw new Error('injected later placement failure');
+      },
+    });
+
+    const placed = placedSolids(requiredElement(model, railingId, 'RAILING'));
+    expect(errorCode(placed)).toBe('PLACED_GEOMETRY_FAILED');
+    expect(placedDisposals).toEqual([1, 1]);
+    expect(first.disposed).toBe(false);
+    expect(second.disposed).toBe(false);
+    model[Symbol.dispose]();
+  });
+});
+
+describe('exact Product Body IFC integration', () => {
+  it('round-trips a two-item exact railing without changing IFC classification', async () => {
+    const model = initializedModel();
+    const railingId = required(model.addRailing(RAILING_SPEC));
+    const first = box(1_000, 20, 20);
+    const source = box(1_000, 20, 20);
+    const second = translate(source, [0, 0, 480]);
+    source[Symbol.dispose]();
+    required(model.takeExactProductBody(railingId, { kind: 'EXACT', solids: [first, second] }));
+
+    const serialized = required(await toIfc(model, META));
+    const text = new TextDecoder().decode(serialized);
+    expect(text.match(/IFCTRIANGULATEDFACESET\(/g)).toHaveLength(2);
+    expect(text).toContain('IFCRAILING(');
+
+    const imported = required(await fromIfc(serialized));
+    const railing = imported.elements.find((element) => element.category === 'RAILING');
+    expect(railing?.geometry.completeness).toBe('COMPLETE');
+    expect(railing?.geometry.solids).toHaveLength(2);
+    disposeImportedModel(imported);
+    model[Symbol.dispose]();
+  });
+
+  it('keeps overlapping exact wall items separate and writes union NetVolume', async () => {
+    const model = initializedModel();
+    const wallId = required(model.addWall(WALL_SPEC));
+    const first = box(100, 100, 100);
+    const source = box(100, 100, 100);
+    const second = translate(source, [50, 0, 0]);
+    source[Symbol.dispose]();
+    required(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [first, second] }));
+
+    const serialized = required(await toIfc(model, META));
+    const text = new TextDecoder().decode(serialized);
+    expect(text.match(/IFCTRIANGULATEDFACESET\(/g)).toHaveLength(2);
+
+    const imported = required(await fromIfc(serialized));
+    const wall = imported.elements.find((element) => element.category === 'WALL');
+    expect(wall?.geometry.solids).toHaveLength(2);
+    const qto = wall?.psets.find((pset) => pset.name === 'Qto_WallBaseQuantities');
+    expect(Object.keys(qto?.properties ?? {}).sort()).toEqual([
+      'Height',
+      'Length',
+      'NetVolume',
+      'Width',
+    ]);
+    expect(qto?.properties['NetVolume']).toBeCloseTo(0.0015, 10);
+    disposeImportedModel(imported);
+    model[Symbol.dispose]();
+  });
+
+  it('closes the IFC writer on a returned exact-item preflight error', async () => {
+    const model = initializedModel();
+    const wallId = required(model.addWall(WALL_SPEC));
+    const exact = box(100, 100, 100);
+    required(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [exact] }));
+    const failingPreparer: ExactBodyItemPreparer = () => ({
+      ok: false,
+      reason: 'injected preflight failure',
+    });
+    setExactBodyItemPreparerForTesting(failingPreparer);
+    let closeCalls = 0;
+    setIfcWriterTestHooksForTesting({ afterClose: () => closeCalls++ });
+
+    const serialized = await toIfc(model, META);
+    expect(errorCode(serialized)).toBe('EXACT_BODY_TESSELLATION_FAILED');
+    expect(closeCalls).toBe(1);
+    expect(exact.disposed).toBe(false);
+    model[Symbol.dispose]();
+  });
+});
+
+const META = { applicationName: 'exact-body-test', applicationVersion: '1' };
+
+function initializedModel(): BimModel {
+  const model = new BimModel();
+  required(model.init({ name: 'Exact Body Test', projectId: 'exact-body-test' }));
+  return model;
+}
+
+function required<T, E extends { readonly message: string }>(
+  result: { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: E }
+): T {
+  if (!result.ok) throw new Error(result.error.message);
+  return result.value;
+}
+
+function errorCode(result: {
+  readonly ok: boolean;
+  readonly error?: { readonly code: string };
+}): string {
+  if (result.ok || result.error === undefined) throw new Error('Expected an error Result');
+  return result.error.code;
+}
+
+function requiredElement<C extends 'WALL' | 'RAILING'>(
+  model: BimModel,
+  localId: LocalId,
+  category: C
+): Extract<ReturnType<BimModel['getAllElements']>[number], { readonly category: C }> {
+  const element = model.getElement(localId);
+  if (element === null || element.category !== category) {
+    throw new Error(`Expected ${category} element ${localId}`);
+  }
+  return element;
+}
+
+function localIdBeyondModel(): LocalId {
+  return 1_000_000 as LocalId;
+}

--- a/packages/brepjs-bim/tests/exactProductBodyTakeover.test.ts
+++ b/packages/brepjs-bim/tests/exactProductBodyTakeover.test.ts
@@ -172,6 +172,26 @@ describe('BimModel.takeExactProductBody', () => {
     rejected[Symbol.dispose]();
     expect(rejectedDisposals).toBe(1);
   });
+
+  it('rejects reuse of the model-owned parametric solid', () => {
+    const model = new BimModel();
+    const wallId = required(model.addWall(WALL_SPEC));
+    const original = requiredElement(model, wallId, 'WALL').geometry;
+    if (original.kind !== 'PARAMETRIC') throw new Error('Expected a parametric wall Body');
+    let originalDisposals = 0;
+    original.solid.onDispose(() => originalDisposals++);
+
+    const takeover = model.takeExactProductBody(wallId, {
+      kind: 'EXACT',
+      solids: [original.solid],
+    });
+
+    expect(errorCode(takeover)).toBe('EXACT_BODY_SOLID_OWNERSHIP_CONFLICT');
+    expect(requiredElement(model, wallId, 'WALL').geometry).toBe(original);
+    expect(original.solid.disposed).toBe(false);
+    model[Symbol.dispose]();
+    expect(originalDisposals).toBe(1);
+  });
 });
 
 describe('exact wall mutation and multi-solid placement', () => {

--- a/packages/brepjs-bim/tests/exactProductBodyTakeover.test.ts
+++ b/packages/brepjs-bim/tests/exactProductBodyTakeover.test.ts
@@ -14,6 +14,7 @@ import {
   type ExactBodyItemPreparer,
 } from '../src/serialize/exactBodyPreflight.js';
 import { setIfcWriterTestHooksForTesting } from '../src/ifc-writer/ifcWriter.js';
+import { prepareTessellation } from '../src/ifc-writer/tessellationWriter.js';
 import { fromIfc } from '../src/import/fromIfc.js';
 import { disposeImportedModel } from '../src/import/importedModel.js';
 
@@ -350,23 +351,36 @@ describe('exact Product Body IFC integration', () => {
     model[Symbol.dispose]();
   });
 
-  it('closes the IFC writer on a returned exact-item preflight error', async () => {
+  it('preflights every exact Body before writing IFC lines', async () => {
     const model = initializedModel();
     const wallId = required(model.addWall(WALL_SPEC));
-    const exact = box(100, 100, 100);
-    required(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [exact] }));
-    const failingPreparer: ExactBodyItemPreparer = () => ({
-      ok: false,
-      reason: 'injected preflight failure',
-    });
+    const railingId = required(model.addRailing(RAILING_SPEC));
+    const exactWall = box(100, 100, 100);
+    const exactRailing = box(200, 20, 20);
+    required(model.takeExactProductBody(wallId, { kind: 'EXACT', solids: [exactWall] }));
+    required(model.takeExactProductBody(railingId, { kind: 'EXACT', solids: [exactRailing] }));
+    let prepareCalls = 0;
+    const failingPreparer: ExactBodyItemPreparer = (solid) => {
+      prepareCalls++;
+      return prepareCalls === 2
+        ? { ok: false, reason: 'injected later preflight failure' }
+        : prepareTessellation(solid);
+    };
     setExactBodyItemPreparerForTesting(failingPreparer);
     let closeCalls = 0;
-    setIfcWriterTestHooksForTesting({ afterClose: () => closeCalls++ });
+    let writeCalls = 0;
+    setIfcWriterTestHooksForTesting({
+      afterClose: () => closeCalls++,
+      afterWriteLine: () => writeCalls++,
+    });
 
     const serialized = await toIfc(model, META);
     expect(errorCode(serialized)).toBe('EXACT_BODY_TESSELLATION_FAILED');
+    expect(prepareCalls).toBe(2);
+    expect(writeCalls).toBe(0);
     expect(closeCalls).toBe(1);
-    expect(exact.disposed).toBe(false);
+    expect(exactWall.disposed).toBe(false);
+    expect(exactRailing.disposed).toBe(false);
     model[Symbol.dispose]();
   });
 });

--- a/packages/brepjs-bim/tests/exactWallQuantityOmission.test.ts
+++ b/packages/brepjs-bim/tests/exactWallQuantityOmission.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { box } from 'brepjs';
+import { initKernel } from '../../../tests/setup.js';
+import { BimModel } from '../src/model/bimModel.js';
+
+const quantityMocks = vi.hoisted(() => ({
+  derive: vi.fn(() => ({
+    ok: false,
+    error: {
+      kind: 'BIM_IFC',
+      code: 'IFC_EXACT_WALL_QUANTITY_DERIVATION_FAILED',
+      message: 'injected exact wall quantity failure',
+    },
+  })),
+}));
+
+vi.mock('../src/serialize/exactWallQuantities.js', () => ({
+  deriveExactWallQuantities: quantityMocks.derive,
+}));
+
+import { toIfc } from '../src/serialize/toIfc.js';
+
+beforeAll(async () => {
+  await initKernel();
+}, 30_000);
+
+describe('exact wall quantity omission', () => {
+  it('exports the exact Body without an envelope quantity when derivation fails', async () => {
+    using model = new BimModel();
+    const initialized = model.init({ name: 'Exact wall quantity omission', projectId: 'qto-omit' });
+    if (!initialized.ok) throw new Error(initialized.error.message);
+
+    const wall = model.addWall({
+      length: 1_000,
+      height: 500,
+      thickness: 100,
+      origin: [0, 0, 0],
+      axisX: [1, 0, 0],
+      axisZ: [0, 0, 1],
+      materialName: 'Concrete',
+    });
+    if (!wall.ok) throw new Error(wall.error.message);
+
+    const exact = box(900, 100, 400);
+    const takeover = model.takeExactProductBody(wall.value, { kind: 'EXACT', solids: [exact] });
+    if (!takeover.ok) {
+      exact[Symbol.dispose]();
+      throw new Error(takeover.error.message);
+    }
+
+    const serialized = await toIfc(model, {
+      applicationName: 'exact-wall-quantity-omission-test',
+      applicationVersion: '1',
+    });
+    expect(serialized.ok).toBe(true);
+    if (!serialized.ok) return;
+
+    const text = new TextDecoder().decode(serialized.value);
+    expect(quantityMocks.derive).toHaveBeenCalledOnce();
+    expect(text).toContain('IFCWALL(');
+    expect(text).toContain('IFCTRIANGULATEDFACESET(');
+    expect(text).not.toContain('Qto_WallBaseQuantities');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Part of #2272.

Adds a shared `ProductBody` contract for walls and railings that distinguishes parametric geometry from an authoritative exact Body.

- Adds `BimModel.takeExactProductBody()` with atomic ownership transfer.
- Preserves multiple exact solids as separate IFC Body representation items.
- Keeps exact walls as `IfcWall` and exact railings as `IfcRailing`.
- Updates placement, validation, surface styling, and disposal to handle every Body item.
- Derives exact wall `NetVolume` from the authoritative geometry. If reliable measurement fails, the quantity set is omitted instead of using the semantic envelope.
- Preflights all exact Body items before writing IFC data.
- Documents the new ownership and migration rules.

The multi-item importer was merged separately in #2278.

This PR does not yet connect evaluated Family Bodies to the new contract. That remains in the follow-up Families adapter PR, which will complete and close #2272.

### Breaking change

Wall and railing `.geometry` is now a `ProductBody` union. Consumers must narrow `geometry.kind`, use `bodySolids()` for borrowed Product-local solids, or use `placedSolids()` for caller-owned placed copies.

## How to test

```bash
npm run test:coverage --workspace=brepjs-bim
npm run typecheck --workspace=brepjs-bim
npm run lint --workspace=brepjs-bim
npm run build --workspace=brepjs-bim
npm run check:boundaries
npm run check:patterns
npm run typecheck --workspace=brepjs-playground
npm run check:examples --workspace=brepjs-playground
```

## Checklist

- [x] Tests pass (`npm run test`)
- [x] BIM coverage suite passes: 741 tests across 76 files
- [x] Lint passes (`npm run lint`)
- [x] Layer boundaries checked (`npm run check:boundaries`)
- [x] Pattern checks pass (`npm run check:patterns`)
- [x] Package build passes
- [x] Changed files pass Prettier
- [x] Packed build validated against downstream fixtures
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
