### PR TITLE
fix(create-brepjs): track brepjs 19 in the scaffold template

### DIFF
--- a/packages/create-brepjs/templates/package.json.tpl
+++ b/packages/create-brepjs/templates/package.json.tpl
@@ -14,7 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "brepjs": "^18.0.0",
+    "brepjs": "^19.0.0",
     "brepjs-bim": ">=0.21.0 <1.0.0",
     "brepjs-families": ">=0.10.0 <1.0.0",
     "occt-wasm": "^4.0.0",


### PR DESCRIPTION
## Why

Main CI is red on the brepjs 19.0.0 release commits: `packages-create` and `test (1)` both fail the create-brepjs scaffold test "declares ranges the current workspace versions satisfy". The template pinned `brepjs: ^18.0.0`, which excludes the new 19.0.0 workspace version.

The 19.0.0 major came from `fix(bim)!` (#2286), a bim-only diff. Root's `exclude-paths` in `release-please-config.json` does not list `packages/brepjs-bim`, so the breaking marker was attributed to the root train.

## What

- `packages/create-brepjs/templates/package.json.tpl`: `brepjs` range `^18.0.0` -> `^19.0.0`.

The bim, families, and cad ranges already cover their current workspace versions and are unchanged.

## Verification

- `npm run test --workspace=create-brepjs`: 5 passed, 1 skipped.
- Root `vitest run packages/create-brepjs/tests/scaffold.test.ts` (what shard 1 runs): passed.
- `SCAFFOLD_SMOKE=1 npm run test --workspace=create-brepjs` (what the `packages-create` job runs, installs from the live registry): 6 passed. brepjs 19.0.0 is published.

https://claude.ai/code/session_01T4Aws9ZCAmPvcoCYaCnMzY
