### PR TITLE
ci(release): merge a release PR directly when auto-merge is rejected as clean

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -97,6 +97,15 @@ jobs:
           # Leaf branches carry a `-<pkg>` suffix, so this matches root exactly.
           ROOT_BRANCH: release-please--branches--main--components--brepjs
         run: |
+          # GitHub rejects enablePullRequestAutoMerge on a PR that is already
+          # mergeable ("Pull request is in clean status"), which is exactly the
+          # state a held leaf reaches once its checks finish while it waits for
+          # root. Merge such a PR directly; branch protection still gates it.
+          merge_release_pr() {
+            gh pr merge "$1" --auto --squash --repo "$GH_REPO" \
+              || gh pr merge "$1" --squash --repo "$GH_REPO"
+          }
+
           # Query the live set of open release PRs (release-please labels every
           # one `autorelease: pending`) rather than trusting the action outputs,
           # so a held leaf is picked up on whichever later run unblocks it.
@@ -131,7 +140,7 @@ jobs:
                 ;;
               "$ROOT_BRANCH")
                 echo "MERGE #$number ($title) — root brepjs release goes first"
-                gh pr merge "$number" --auto --squash --repo "$GH_REPO"
+                merge_release_pr "$number"
                 continue
                 ;;
             esac
@@ -150,7 +159,7 @@ jobs:
               echo "HOLD #$number ($title) — waiting for brepjs-families release to merge first"
             else
               echo "MERGE #$number ($title) — no root brepjs release pending"
-              gh pr merge "$number" --auto --squash --repo "$GH_REPO"
+              merge_release_pr "$number"
             fi
           done
 


### PR DESCRIPTION
## Why

The Release Please `auto-merge` job failed on the 19.0.1 release push with:

```
MERGE #2290 (chore(main): release create-brepjs 0.4.1) — no root brepjs release pending
GraphQL: Pull request Pull request is in clean status (enablePullRequestAutoMerge)
```

GitHub refuses to enable auto-merge on a PR that is already mergeable. A leaf release PR held while the root release is open finishes its checks during the hold, so by the time the serializer releases it the PR is already clean and `gh pr merge --auto` is rejected. The job exits non-zero and the leaf stays open until an unrelated push makes release-please refresh the branch. Today that push was #2293, which is the only reason #2290 merged.

## What

`.github/workflows/release-please.yml`: a `merge_release_pr` helper tries `--auto` first and falls back to a direct squash merge when GitHub rejects the auto-merge. Both the root and leaf call sites use it. Branch protection still gates the direct merge.

## Verification

- YAML parses and the extracted `run` script passes `bash -n`.
- The run 33772052838 log shows the exact rejection above; the follow-up run 33772322070 succeeded only because the branch had been refreshed.

https://claude.ai/code/session_01T4Aws9ZCAmPvcoCYaCnMzY
